### PR TITLE
feat: combine intra day and historical data

### DIFF
--- a/dags/definitions.py
+++ b/dags/definitions.py
@@ -18,6 +18,7 @@ from dags import (
     property_definitions,
     slack_alerts,
     web_preaggregated_daily,
+    web_preaggregated_ddl,
     web_preaggregated_hourly,
 )
 
@@ -55,10 +56,11 @@ defs = dagster.Definitions(
         exchange_rate.hourly_exchange_rates_in_clickhouse,
         orm_examples.pending_deletions,
         orm_examples.process_pending_deletions,
-        web_preaggregated_daily.web_analytics_preaggregated_tables,
+        web_preaggregated_ddl.web_analytics_preaggregated_tables,
+        web_preaggregated_ddl.web_analytics_preaggregated_hourly_tables,
+        web_preaggregated_ddl.web_analytics_combined_views,
         web_preaggregated_daily.web_stats_daily,
         web_preaggregated_daily.web_bounces_daily,
-        web_preaggregated_hourly.web_analytics_preaggregated_hourly_tables,
         web_preaggregated_hourly.web_stats_hourly,
         web_preaggregated_hourly.web_bounces_hourly,
     ],

--- a/dags/web_preaggregated_daily.py
+++ b/dags/web_preaggregated_daily.py
@@ -1,49 +1,29 @@
 from datetime import datetime, UTC, timedelta
 from collections.abc import Callable
-import structlog
+import os
 
 import dagster
-from dagster import DailyPartitionsDefinition, RetryPolicy, Backoff, Jitter, BackfillPolicy
-from clickhouse_driver import Client
-from dags import web_preaggregated_hourly
+from dagster import DailyPartitionsDefinition, BackfillPolicy
 from dags.common import JobOwners
 from dags.web_preaggregated_utils import (
     TEAM_IDS_WITH_WEB_PREAGGREGATED_ENABLED,
     CLICKHOUSE_SETTINGS,
     merge_clickhouse_settings,
     WEB_ANALYTICS_CONFIG_SCHEMA,
+    web_analytics_retry_policy_def,
 )
 from posthog.clickhouse.client import sync_execute
 
 from posthog.models.web_preaggregated.sql import (
-    DISTRIBUTED_WEB_BOUNCES_DAILY_SQL,
-    WEB_BOUNCES_COMBINED_VIEW_SQL,
-    WEB_BOUNCES_DAILY_SQL,
     WEB_BOUNCES_INSERT_SQL,
-    WEB_STATS_COMBINED_VIEW_SQL,
-    WEB_STATS_DAILY_SQL,
-    DISTRIBUTED_WEB_STATS_DAILY_SQL,
     WEB_STATS_INSERT_SQL,
 )
-from posthog.clickhouse.cluster import ClickhouseCluster
-
-logger = structlog.get_logger(__name__)
 
 
 partition_def = DailyPartitionsDefinition(start_date="2020-01-01")
 
-retry_policy_def = RetryPolicy(
-    max_retries=3,
-    delay=60,
-    backoff=Backoff.EXPONENTIAL,
-    jitter=Jitter.PLUS_MINUS,
-)
-
-backfill_policy_def = BackfillPolicy(max_partitions_per_run=14)
-
-
-# Backfill policy to process partitions in groups of 14 days
-web_analytics_backfill_policy = BackfillPolicy.multi_run(max_partitions_per_run=14)
+max_partitions_per_run = int(os.getenv("DAGSTER_WEB_PREAGGREGATED_MAX_PARTITIONS_PER_RUN", 14))
+backfill_policy_def = BackfillPolicy.multi_run(max_partitions_per_run=max_partitions_per_run)
 
 
 def pre_aggregate_web_analytics_data(
@@ -62,17 +42,16 @@ def pre_aggregate_web_analytics_data(
     config = context.op_config
     team_ids = config.get("team_ids", TEAM_IDS_WITH_WEB_PREAGGREGATED_ENABLED)
     extra_settings = config.get("extra_clickhouse_settings", "")
-
     ch_settings = merge_clickhouse_settings(CLICKHOUSE_SETTINGS, extra_settings)
+
+    if not context.partition_time_window:
+        raise dagster.Failure("This asset should only be run with a partition_time_window")
 
     context.log.info(f"Getting ready to pre-aggregate {table_name} for {context.partition_time_window}")
 
-    if context.partition_time_window:
-        start_datetime, end_datetime = context.partition_time_window
-        date_start = start_datetime.strftime("%Y-%m-%d")
-        date_end = end_datetime.strftime("%Y-%m-%d")
-    else:
-        raise dagster.Failure("This asset should only be run with a partition_time_window")
+    start_datetime, end_datetime = context.partition_time_window
+    date_start = start_datetime.strftime("%Y-%m-%d")
+    date_end = end_datetime.strftime("%Y-%m-%d")
 
     try:
         insert_query = sql_generator(
@@ -93,47 +72,6 @@ def pre_aggregate_web_analytics_data(
 
 
 @dagster.asset(
-    name="web_analytics_preaggregated_tables",
-    group_name="web_analytics",
-    retry_policy=retry_policy_def,
-    tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
-)
-def web_analytics_preaggregated_tables(
-    cluster: dagster.ResourceParam[ClickhouseCluster],
-) -> bool:
-    """
-    Create web analytics pre-aggregated tables on all ClickHouse hosts.
-
-    This asset creates both local and distributed tables for web analytics.
-    """
-
-    def drop_tables(client: Client):
-        try:
-            client.execute("DROP TABLE IF EXISTS web_stats_daily SYNC")
-            client.execute("DROP TABLE IF EXISTS web_bounces_daily SYNC")
-            logger.info("dropped_existing_tables", host=client.connection.host)
-        except Exception as e:
-            logger.exception("failed_to_drop_tables", host=client.connection.host, error=str(e))
-            raise
-
-    def create_tables(client: Client):
-        client.execute(WEB_STATS_DAILY_SQL(table_name="web_stats_daily"))
-        client.execute(WEB_BOUNCES_DAILY_SQL(table_name="web_bounces_daily"))
-
-        client.execute(DISTRIBUTED_WEB_STATS_DAILY_SQL())
-        client.execute(DISTRIBUTED_WEB_BOUNCES_DAILY_SQL())
-
-    try:
-        cluster.map_all_hosts(drop_tables).result()
-        cluster.map_all_hosts(create_tables).result()
-        logger.info("web_analytics_tables_setup_completed")
-        return True
-    except Exception as e:
-        logger.exception("web_analytics_tables_setup_failed", error=str(e))
-        raise dagster.Failure(f"Failed to setup web analytics tables: {str(e)}") from e
-
-
-@dagster.asset(
     name="web_analytics_bounces_daily",
     group_name="web_analytics",
     config_schema=WEB_ANALYTICS_CONFIG_SCHEMA,
@@ -142,7 +80,7 @@ def web_analytics_preaggregated_tables(
     backfill_policy=backfill_policy_def,
     metadata={"table": "web_bounces_daily"},
     tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
-    retry_policy=retry_policy_def,
+    retry_policy=web_analytics_retry_policy_def,
 )
 def web_bounces_daily(
     context: dagster.AssetExecutionContext,
@@ -169,7 +107,7 @@ def web_bounces_daily(
     backfill_policy=backfill_policy_def,
     metadata={"table": "web_stats_daily"},
     tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
-    retry_policy=retry_policy_def,
+    retry_policy=web_analytics_retry_policy_def,
 )
 def web_stats_daily(context: dagster.AssetExecutionContext) -> None:
     """
@@ -183,23 +121,6 @@ def web_stats_daily(context: dagster.AssetExecutionContext) -> None:
         table_name="web_stats_daily",
         sql_generator=WEB_STATS_INSERT_SQL,
     )
-
-@dagster.asset(
-    name="web_analytics_combined_views",
-    group_name="web_analytics",
-    description="Creates combined views that automatically merge daily and hourly data using toStartOfDay(now()) boundary.",
-    deps=["web_analytics_preaggregated_tables", web_preaggregated_hourly.web_analytics_preaggregated_hourly_tables],
-    tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
-)
-def web_analytics_combined_views(
-    cluster: dagster.ResourceParam[ClickhouseCluster],
-) -> bool:
-    def create_views(client: Client):
-        client.execute(WEB_STATS_COMBINED_VIEW_SQL())
-        client.execute(WEB_BOUNCES_COMBINED_VIEW_SQL())
-
-    cluster.map_all_hosts(create_views).result()
-    return True
 
 
 # Daily incremental job with asset-level concurrency control
@@ -216,12 +137,6 @@ web_pre_aggregate_daily_job = dagster.define_asset_job(
             }
         }
     },
-)
-
-web_analytics_table_setup_job = dagster.define_asset_job(
-    name="web_analytics_table_setup",
-    selection=["web_analytics_preaggregated_tables"],
-    tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
 )
 
 

--- a/dags/web_preaggregated_ddl.py
+++ b/dags/web_preaggregated_ddl.py
@@ -62,10 +62,15 @@ def web_analytics_preaggregated_hourly_tables(
 def web_analytics_combined_views(
     cluster: dagster.ResourceParam[ClickhouseCluster],
 ) -> bool:
+    def drop_views(client: Client):
+        client.execute("DROP VIEW IF EXISTS web_stats_combined SYNC")
+        client.execute("DROP VIEW IF EXISTS web_bounces_combined SYNC")
+
     def create_views(client: Client):
         client.execute(WEB_STATS_COMBINED_VIEW_SQL())
         client.execute(WEB_BOUNCES_COMBINED_VIEW_SQL())
 
+    cluster.map_all_hosts(drop_views).result()
     cluster.map_all_hosts(create_views).result()
     return True
 

--- a/dags/web_preaggregated_ddl.py
+++ b/dags/web_preaggregated_ddl.py
@@ -1,0 +1,111 @@
+import dagster
+import structlog
+from dags.common import JobOwners
+from posthog.clickhouse.cluster import ClickhouseCluster
+from clickhouse_driver import Client
+
+from posthog.models.web_preaggregated.sql import (
+    DISTRIBUTED_WEB_BOUNCES_DAILY_SQL,
+    DISTRIBUTED_WEB_BOUNCES_HOURLY_SQL,
+    DISTRIBUTED_WEB_STATS_DAILY_SQL,
+    DISTRIBUTED_WEB_STATS_HOURLY_SQL,
+    WEB_BOUNCES_COMBINED_VIEW_SQL,
+    WEB_BOUNCES_DAILY_SQL,
+    WEB_BOUNCES_HOURLY_SQL,
+    WEB_STATS_COMBINED_VIEW_SQL,
+    WEB_STATS_DAILY_SQL,
+    WEB_STATS_HOURLY_SQL,
+)
+from dags.web_preaggregated_utils import web_analytics_retry_policy_def
+
+logger = structlog.get_logger(__name__)
+
+
+@dagster.asset(
+    name="web_analytics_preaggregated_hourly_tables",
+    group_name="web_analytics",
+    description="Creates the hourly tables needed for web analytics preaggregated data with 24h TTL for real-time analytics.",
+    tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
+)
+def web_analytics_preaggregated_hourly_tables(
+    cluster: dagster.ResourceParam[ClickhouseCluster],
+) -> bool:
+    def drop_tables(client: Client):
+        client.execute("DROP TABLE IF EXISTS web_stats_hourly SYNC")
+        client.execute("DROP TABLE IF EXISTS web_bounces_hourly SYNC")
+        client.execute("DROP TABLE IF EXISTS web_stats_hourly_staging SYNC")
+        client.execute("DROP TABLE IF EXISTS web_bounces_hourly_staging SYNC")
+
+    def create_tables(client: Client):
+        client.execute(WEB_STATS_HOURLY_SQL())
+        client.execute(WEB_BOUNCES_HOURLY_SQL())
+
+        # Create staging tables with same structure
+        client.execute(WEB_STATS_HOURLY_SQL().replace("web_stats_hourly", "web_stats_hourly_staging"))
+        client.execute(WEB_BOUNCES_HOURLY_SQL().replace("web_bounces_hourly", "web_bounces_hourly_staging"))
+
+        client.execute(DISTRIBUTED_WEB_STATS_HOURLY_SQL())
+        client.execute(DISTRIBUTED_WEB_BOUNCES_HOURLY_SQL())
+
+    cluster.map_all_hosts(drop_tables).result()
+    cluster.map_all_hosts(create_tables).result()
+    return True
+
+
+@dagster.asset(
+    name="web_analytics_combined_views",
+    group_name="web_analytics",
+    description="Creates combined views that automatically merge daily and hourly data using toStartOfDay(now()) boundary.",
+    deps=["web_analytics_preaggregated_tables", "web_analytics_preaggregated_hourly_tables"],
+    tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
+)
+def web_analytics_combined_views(
+    cluster: dagster.ResourceParam[ClickhouseCluster],
+) -> bool:
+    def create_views(client: Client):
+        client.execute(WEB_STATS_COMBINED_VIEW_SQL())
+        client.execute(WEB_BOUNCES_COMBINED_VIEW_SQL())
+
+    cluster.map_all_hosts(create_views).result()
+    return True
+
+
+@dagster.asset(
+    name="web_analytics_preaggregated_tables",
+    group_name="web_analytics",
+    retry_policy=web_analytics_retry_policy_def,
+    tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
+)
+def web_analytics_preaggregated_tables(
+    cluster: dagster.ResourceParam[ClickhouseCluster],
+) -> bool:
+    """
+    Create web analytics pre-aggregated tables on all ClickHouse hosts.
+
+    This asset creates both local and distributed tables for web analytics.
+    """
+
+    def drop_tables(client: Client):
+        try:
+            client.execute("DROP TABLE IF EXISTS web_stats_daily SYNC")
+            client.execute("DROP TABLE IF EXISTS web_bounces_daily SYNC")
+            logger.info("dropped_existing_tables", host=client.connection.host)
+        except Exception as e:
+            logger.exception("failed_to_drop_tables", host=client.connection.host, error=str(e))
+            raise
+
+    def create_tables(client: Client):
+        client.execute(WEB_STATS_DAILY_SQL(table_name="web_stats_daily"))
+        client.execute(WEB_BOUNCES_DAILY_SQL(table_name="web_bounces_daily"))
+
+        client.execute(DISTRIBUTED_WEB_STATS_DAILY_SQL())
+        client.execute(DISTRIBUTED_WEB_BOUNCES_DAILY_SQL())
+
+    try:
+        cluster.map_all_hosts(drop_tables).result()
+        cluster.map_all_hosts(create_tables).result()
+        logger.info("web_analytics_tables_setup_completed")
+        return True
+    except Exception as e:
+        logger.exception("web_analytics_tables_setup_failed", error=str(e))
+        raise dagster.Failure(f"Failed to setup web analytics tables: {str(e)}") from e

--- a/dags/web_preaggregated_utils.py
+++ b/dags/web_preaggregated_utils.py
@@ -1,8 +1,15 @@
 from typing import Optional
-from dagster import Field, Array
+from dagster import Backoff, Field, Array, Jitter, RetryPolicy
 
 # TODO: Remove this once we're fully rolled out but this is better than defaulting to all teams
 TEAM_IDS_WITH_WEB_PREAGGREGATED_ENABLED = [1, 2, 55348, 47074]
+
+web_analytics_retry_policy_def = RetryPolicy(
+    max_retries=3,
+    delay=60,
+    backoff=Backoff.EXPONENTIAL,
+    jitter=Jitter.PLUS_MINUS,
+)
 
 # Shared ClickHouse settings for web analytics pre-aggregation
 CLICKHOUSE_SETTINGS = {

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -94,10 +94,12 @@ from posthog.hogql.database.schema.sessions_v2 import (
 )
 from posthog.hogql.database.schema.static_cohort_people import StaticCohortPeople
 from posthog.hogql.database.schema.web_analytics_preaggregated import (
-    WebBouncesDailyTable,
-    WebBouncesHourlyTable,
     WebStatsDailyTable,
+    WebBouncesDailyTable,
     WebStatsHourlyTable,
+    WebBouncesHourlyTable,
+    WebStatsCombinedTable,
+    WebBouncesCombinedTable,
 )
 from posthog.hogql.errors import QueryError, ResolutionError
 from posthog.hogql.parser import parse_expr
@@ -160,6 +162,8 @@ class Database(BaseModel):
     web_bounces_daily: WebBouncesDailyTable = WebBouncesDailyTable()
     web_stats_hourly: WebStatsHourlyTable = WebStatsHourlyTable()
     web_bounces_hourly: WebBouncesHourlyTable = WebBouncesHourlyTable()
+    web_stats_combined: WebStatsCombinedTable = WebStatsCombinedTable()
+    web_bounces_combined: WebBouncesCombinedTable = WebBouncesCombinedTable()
 
     raw_session_replay_events: RawSessionReplayEventsTable = RawSessionReplayEventsTable()
     raw_person_distinct_ids: RawPersonDistinctIdsTable = RawPersonDistinctIdsTable()

--- a/posthog/hogql/database/schema/test/test_web_analytics_preaggregated.py
+++ b/posthog/hogql/database/schema/test/test_web_analytics_preaggregated.py
@@ -1,4 +1,5 @@
 from parameterized import parameterized
+from posthog.hogql.database.models import Table
 from posthog.hogql.database.schema.web_analytics_preaggregated import (
     WebStatsDailyTable,
     WebBouncesDailyTable,
@@ -54,25 +55,24 @@ class TestWebAnalyticsPreAggregatedSchema:
     ]
 
     @property
-    def all_tables(self) -> dict[str, object]:
-        """Lazy initialization of all table instances"""
+    def all_tables(self) -> dict[str, Table]:
         if not hasattr(self, "_tables"):
             self._tables = {name: cls() for name, cls, _ in self.TABLE_CONFIGS}
         return self._tables
 
     @property
-    def stats_tables(self) -> dict[str, object]:
+    def stats_tables(self) -> dict[str, Table]:
         return {k: v for k, v in self.all_tables.items() if "Stats" in k}
 
     @property
-    def bounces_tables(self) -> dict[str, object]:
+    def bounces_tables(self) -> dict[str, Table]:
         return {k: v for k, v in self.all_tables.items() if "Bounces" in k}
 
     @property
-    def non_combined_tables(self) -> dict[str, object]:
+    def non_combined_tables(self) -> dict[str, Table]:
         return {k: v for k, v in self.all_tables.items() if "Combined" not in k}
 
-    def _assert_fields_in_tables(self, field_names: list[str], tables: dict[str, object], should_contain: bool = True):
+    def _assert_fields_in_tables(self, field_names: list[str], tables: dict[str, Table], should_contain: bool = True):
         for field_name in field_names:
             for table_name, table_instance in tables.items():
                 if should_contain:
@@ -82,7 +82,7 @@ class TestWebAnalyticsPreAggregatedSchema:
                         field_name not in table_instance.fields
                     ), f"Field '{field_name}' should not be in {table_name}"
 
-    def _assert_field_groups_in_tables(self, field_groups: dict[str, list[str]], tables: dict[str, object]):
+    def _assert_field_groups_in_tables(self, field_groups: dict[str, list[str]], tables: dict[str, Table]):
         for _, field_names in field_groups.items():
             self._assert_fields_in_tables(field_names, tables)
 

--- a/posthog/hogql/database/schema/test/test_web_analytics_preaggregated.py
+++ b/posthog/hogql/database/schema/test/test_web_analytics_preaggregated.py
@@ -1,3 +1,4 @@
+from parameterized import parameterized
 from posthog.hogql.database.schema.web_analytics_preaggregated import (
     WebStatsDailyTable,
     WebBouncesDailyTable,
@@ -17,282 +18,135 @@ from posthog.hogql.database.schema.web_analytics_preaggregated import (
 
 
 class TestWebAnalyticsPreAggregatedSchema:
+    DEVICE_BROWSER_FIELD_NAMES = ["browser", "browser_version", "os", "os_version", "viewport_width", "viewport_height"]
+    GEOIP_FIELD_NAMES = ["country_code", "country_name", "city_name", "region_code", "region_name", "time_zone"]
+    UTM_FIELD_NAMES = ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content", "referring_domain"]
+    PATH_FIELD_NAMES = ["entry_pathname", "end_pathname"]
+    AGGREGATION_FIELD_NAMES = ["persons_uniq_state", "sessions_uniq_state", "pageviews_count_state"]
+    ATTRIBUTION_FIELD_NAMES = [
+        "gclid",
+        "gad_source",
+        "gclsrc",
+        "dclid",
+        "gbraid",
+        "wbraid",
+        "fbclid",
+        "msclkid",
+        "twclid",
+        "li_fat_id",
+        "mc_cid",
+        "igshid",
+        "ttclid",
+        "epik",
+        "qclid",
+        "sccid",
+        "_kx",
+        "irclid",
+    ]
+
+    TABLE_CONFIGS = [
+        ("WebStatsDailyTable", WebStatsDailyTable, "web_stats_daily"),
+        ("WebBouncesDailyTable", WebBouncesDailyTable, "web_bounces_daily"),
+        ("WebStatsHourlyTable", WebStatsHourlyTable, "web_stats_hourly"),
+        ("WebBouncesHourlyTable", WebBouncesHourlyTable, "web_bounces_hourly"),
+        ("WebStatsCombinedTable", WebStatsCombinedTable, "web_stats_combined"),
+        ("WebBouncesCombinedTable", WebBouncesCombinedTable, "web_bounces_combined"),
+    ]
+
+    @property
+    def all_tables(self) -> dict[str, object]:
+        """Lazy initialization of all table instances"""
+        if not hasattr(self, "_tables"):
+            self._tables = {name: cls() for name, cls, _ in self.TABLE_CONFIGS}
+        return self._tables
+
+    @property
+    def stats_tables(self) -> dict[str, object]:
+        return {k: v for k, v in self.all_tables.items() if "Stats" in k}
+
+    @property
+    def bounces_tables(self) -> dict[str, object]:
+        return {k: v for k, v in self.all_tables.items() if "Bounces" in k}
+
+    @property
+    def non_combined_tables(self) -> dict[str, object]:
+        return {k: v for k, v in self.all_tables.items() if "Combined" not in k}
+
+    def _assert_fields_in_tables(self, field_names: list[str], tables: dict[str, object], should_contain: bool = True):
+        for field_name in field_names:
+            for table_name, table_instance in tables.items():
+                if should_contain:
+                    assert field_name in table_instance.fields, f"Field '{field_name}' missing from {table_name}"
+                else:
+                    assert (
+                        field_name not in table_instance.fields
+                    ), f"Field '{field_name}' should not be in {table_name}"
+
+    def _assert_field_groups_in_tables(self, field_groups: dict[str, list[str]], tables: dict[str, object]):
+        for _, field_names in field_groups.items():
+            self._assert_fields_in_tables(field_names, tables)
+
     def test_shared_fields_present_in_all_tables(self):
-        stats_daily_table = WebStatsDailyTable()
-        bounces_daily_table = WebBouncesDailyTable()
-        stats_hourly_table = WebStatsHourlyTable()
-        bounces_hourly_table = WebBouncesHourlyTable()
-        stats_combined_table = WebStatsCombinedTable()
-        bounces_combined_table = WebBouncesCombinedTable()
+        shared_field_names = list(SHARED_SCHEMA_FIELDS.keys())
+        self._assert_fields_in_tables(shared_field_names, self.all_tables)
 
-        for field_name in SHARED_SCHEMA_FIELDS.keys():
-            assert (
-                field_name in stats_daily_table.fields
-            ), f"Shared field '{field_name}' missing from WebStatsDailyTable"
-            assert (
-                field_name in bounces_daily_table.fields
-            ), f"Shared field '{field_name}' missing from WebBouncesDailyTable"
-            assert (
-                field_name in stats_hourly_table.fields
-            ), f"Shared field '{field_name}' missing from WebStatsHourlyTable"
-            assert (
-                field_name in bounces_hourly_table.fields
-            ), f"Shared field '{field_name}' missing from WebBouncesHourlyTable"
-            assert (
-                field_name in stats_combined_table.fields
-            ), f"Shared field '{field_name}' missing from WebStatsCombinedTable"
-            assert (
-                field_name in bounces_combined_table.fields
-            ), f"Shared field '{field_name}' missing from WebBouncesCombinedTable"
-
-    def test_table_specific_fields(self):
-        stats_daily_table = WebStatsDailyTable()
-        bounces_daily_table = WebBouncesDailyTable()
-        stats_hourly_table = WebStatsHourlyTable()
-        bounces_hourly_table = WebBouncesHourlyTable()
-
-        # Stats table specific fields
-        for field_name in WEB_STATS_SPECIFIC_FIELDS.keys():
-            assert (
-                field_name in stats_daily_table.fields
-            ), f"Stats-specific field '{field_name}' missing from WebStatsDailyTable"
-            assert (
-                field_name in stats_hourly_table.fields
-            ), f"Stats-specific field '{field_name}' missing from WebStatsHourlyTable"
-
-        # Bounces table specific fields
-        for field_name in WEB_BOUNCES_SPECIFIC_FIELDS.keys():
-            assert (
-                field_name in bounces_daily_table.fields
-            ), f"Bounces-specific field '{field_name}' missing from WebBouncesDailyTable"
-            assert (
-                field_name in bounces_hourly_table.fields
-            ), f"Bounces-specific field '{field_name}' missing from WebBouncesHourlyTable"
-
-        # Verify pathname is only in stats tables
-        assert "pathname" in stats_daily_table.fields
-        assert "pathname" not in bounces_daily_table.fields
-        assert "pathname" in stats_hourly_table.fields
-        assert "pathname" not in bounces_hourly_table.fields
-
-        # Verify bounce-specific fields are only in bounces tables
-        assert "bounces_count_state" not in stats_daily_table.fields
-        assert "total_session_duration_state" not in stats_daily_table.fields
-        assert "bounces_count_state" not in stats_hourly_table.fields
-        assert "total_session_duration_state" not in stats_hourly_table.fields
-        assert "bounces_count_state" in bounces_daily_table.fields
-        assert "total_session_duration_state" in bounces_daily_table.fields
-        assert "bounces_count_state" in bounces_hourly_table.fields
-        assert "total_session_duration_state" in bounces_hourly_table.fields
-
-    def test_device_browser_fields(self):
-        stats_daily_table = WebStatsDailyTable()
-        bounces_daily_table = WebBouncesDailyTable()
-        stats_hourly_table = WebStatsHourlyTable()
-        bounces_hourly_table = WebBouncesHourlyTable()
-
-        expected_fields = ["browser", "browser_version", "os", "os_version", "viewport_width", "viewport_height"]
-
-        for field in expected_fields:
-            assert field in stats_daily_table.fields, f"Device/browser field '{field}' missing from WebStatsDailyTable"
-            assert (
-                field in bounces_daily_table.fields
-            ), f"Device/browser field '{field}' missing from WebBouncesDailyTable"
-            assert (
-                field in stats_hourly_table.fields
-            ), f"Device/browser field '{field}' missing from WebStatsHourlyTable"
-            assert (
-                field in bounces_hourly_table.fields
-            ), f"Device/browser field '{field}' missing from WebBouncesHourlyTable"
-
-    def test_geoip_fields(self):
-        stats_daily_table = WebStatsDailyTable()
-        bounces_daily_table = WebBouncesDailyTable()
-        stats_hourly_table = WebStatsHourlyTable()
-        bounces_hourly_table = WebBouncesHourlyTable()
-
-        expected_fields = ["country_code", "country_name", "city_name", "region_code", "region_name", "time_zone"]
-
-        for field in expected_fields:
-            assert field in stats_daily_table.fields, f"GeoIP field '{field}' missing from WebStatsDailyTable"
-            assert field in bounces_daily_table.fields, f"GeoIP field '{field}' missing from WebBouncesDailyTable"
-            assert field in stats_hourly_table.fields, f"GeoIP field '{field}' missing from WebStatsHourlyTable"
-            assert field in bounces_hourly_table.fields, f"GeoIP field '{field}' missing from WebBouncesHourlyTable"
-
-    def test_attribution_tracking_fields(self):
-        stats_daily_table = WebStatsDailyTable()
-        bounces_daily_table = WebBouncesDailyTable()
-        stats_hourly_table = WebStatsHourlyTable()
-        bounces_hourly_table = WebBouncesHourlyTable()
-
-        expected_fields = [
-            "gclid",
-            "gad_source",
-            "gclsrc",
-            "dclid",
-            "gbraid",
-            "wbraid",
-            "fbclid",
-            "msclkid",
-            "twclid",
-            "li_fat_id",
-            "mc_cid",
-            "igshid",
-            "ttclid",
-            "epik",
-            "qclid",
-            "sccid",
-            "_kx",
-            "irclid",
+    @parameterized.expand(
+        [
+            ("device_browser", "DEVICE_BROWSER_FIELD_NAMES"),
+            ("geoip", "GEOIP_FIELD_NAMES"),
+            ("utm", "UTM_FIELD_NAMES"),
+            ("attribution", "ATTRIBUTION_FIELD_NAMES"),
+            ("path", "PATH_FIELD_NAMES"),
+            ("aggregation", "AGGREGATION_FIELD_NAMES"),
         ]
+    )
+    def test_field_groups_present_in_all_tables(self, group_name: str, field_attr_name: str):
+        field_names = getattr(self, field_attr_name)
+        self._assert_fields_in_tables(field_names, self.all_tables)
 
-        for field in expected_fields:
-            assert field in stats_daily_table.fields, f"Attribution field '{field}' missing from WebStatsDailyTable"
-            assert field in bounces_daily_table.fields, f"Attribution field '{field}' missing from WebBouncesDailyTable"
-            assert field in stats_hourly_table.fields, f"Attribution field '{field}' missing from WebStatsHourlyTable"
-            assert (
-                field in bounces_hourly_table.fields
-            ), f"Attribution field '{field}' missing from WebBouncesHourlyTable"
+    def test_table_specific_fields_separation(self):
+        stats_field_names = list(WEB_STATS_SPECIFIC_FIELDS.keys())
+        self._assert_fields_in_tables(stats_field_names, self.stats_tables, should_contain=True)
+        self._assert_fields_in_tables(stats_field_names, self.bounces_tables, should_contain=False)
 
-    def test_utm_fields(self):
-        stats_daily_table = WebStatsDailyTable()
-        bounces_daily_table = WebBouncesDailyTable()
-        stats_hourly_table = WebStatsHourlyTable()
-        bounces_hourly_table = WebBouncesHourlyTable()
+        bounces_field_names = list(WEB_BOUNCES_SPECIFIC_FIELDS.keys())
+        self._assert_fields_in_tables(bounces_field_names, self.bounces_tables, should_contain=True)
+        self._assert_fields_in_tables(bounces_field_names, self.stats_tables, should_contain=False)
 
-        expected_fields = ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content", "referring_domain"]
+    def test_specific_field_presence_rules(self):
+        # pathname should only be in stats tables
+        self._assert_fields_in_tables(["pathname"], self.stats_tables, should_contain=True)
+        self._assert_fields_in_tables(["pathname"], self.bounces_tables, should_contain=False)
 
-        for field in expected_fields:
-            assert field in stats_daily_table.fields, f"UTM field '{field}' missing from WebStatsDailyTable"
-            assert field in bounces_daily_table.fields, f"UTM field '{field}' missing from WebBouncesDailyTable"
-            assert field in stats_hourly_table.fields, f"UTM field '{field}' missing from WebStatsHourlyTable"
-            assert field in bounces_hourly_table.fields, f"UTM field '{field}' missing from WebBouncesHourlyTable"
-
-    def test_path_fields(self):
-        stats_daily_table = WebStatsDailyTable()
-        bounces_daily_table = WebBouncesDailyTable()
-        stats_hourly_table = WebStatsHourlyTable()
-        bounces_hourly_table = WebBouncesHourlyTable()
-
-        expected_fields = ["entry_pathname", "end_pathname"]
-
-        for field in expected_fields:
-            assert field in stats_daily_table.fields, f"Path field '{field}' missing from WebStatsDailyTable"
-            assert field in bounces_daily_table.fields, f"Path field '{field}' missing from WebBouncesDailyTable"
-            assert field in stats_hourly_table.fields, f"Path field '{field}' missing from WebStatsHourlyTable"
-            assert field in bounces_hourly_table.fields, f"Path field '{field}' missing from WebBouncesHourlyTable"
+        bounce_specific_agg_fields = ["bounces_count_state", "total_session_duration_state"]
+        self._assert_fields_in_tables(bounce_specific_agg_fields, self.bounces_tables, should_contain=True)
+        self._assert_fields_in_tables(bounce_specific_agg_fields, self.stats_tables, should_contain=False)
 
     def test_shared_schema_fields_composition(self):
-        expected_field_count = (
-            len(DEVICE_BROWSER_FIELDS)
-            + len(GEOIP_FIELDS)
-            + len(UTM_FIELDS)
-            + len(ATTRIBUTION_TRACKING_FIELDS)
-            + len(PATH_FIELDS)
+        expected_field_count = sum(
+            [
+                len(DEVICE_BROWSER_FIELDS),
+                len(GEOIP_FIELDS),
+                len(UTM_FIELDS),
+                len(ATTRIBUTION_TRACKING_FIELDS),
+                len(PATH_FIELDS),
+            ]
         )
 
         assert (
             len(SHARED_SCHEMA_FIELDS) == expected_field_count
         ), f"SHARED_SCHEMA_FIELDS has {len(SHARED_SCHEMA_FIELDS)} fields, expected {expected_field_count}"
 
-        # Verify all fields from each group are present
-        for field in DEVICE_BROWSER_FIELDS:
-            assert field in SHARED_SCHEMA_FIELDS, f"Device/browser field '{field}' missing from SHARED_SCHEMA_FIELDS"
-        for field in GEOIP_FIELDS:
-            assert field in SHARED_SCHEMA_FIELDS, f"GeoIP field '{field}' missing from SHARED_SCHEMA_FIELDS"
-        for field in UTM_FIELDS:
-            assert field in SHARED_SCHEMA_FIELDS, f"UTM field '{field}' missing from SHARED_SCHEMA_FIELDS"
-        for field in ATTRIBUTION_TRACKING_FIELDS:
-            assert field in SHARED_SCHEMA_FIELDS, f"Attribution field '{field}' missing from SHARED_SCHEMA_FIELDS"
-        for field in PATH_FIELDS:
-            assert field in SHARED_SCHEMA_FIELDS, f"Path field '{field}' missing from SHARED_SCHEMA_FIELDS"
+        field_groups = {
+            "device_browser": list(DEVICE_BROWSER_FIELDS.keys()),
+            "geoip": list(GEOIP_FIELDS.keys()),
+            "utm": list(UTM_FIELDS.keys()),
+            "attribution": list(ATTRIBUTION_TRACKING_FIELDS.keys()),
+            "path": list(PATH_FIELDS.keys()),
+        }
 
-    def test_table_methods(self):
-        stats_daily_table = WebStatsDailyTable()
-        bounces_daily_table = WebBouncesDailyTable()
-        stats_hourly_table = WebStatsHourlyTable()
-        bounces_hourly_table = WebBouncesHourlyTable()
-        stats_combined_table = WebStatsCombinedTable()
-        bounces_combined_table = WebBouncesCombinedTable()
-
-        assert stats_daily_table.to_printed_clickhouse(None) == "web_stats_daily"
-        assert stats_daily_table.to_printed_hogql() == "web_stats_daily"
-
-        assert bounces_daily_table.to_printed_clickhouse(None) == "web_bounces_daily"
-        assert bounces_daily_table.to_printed_hogql() == "web_bounces_daily"
-
-        assert stats_hourly_table.to_printed_clickhouse(None) == "web_stats_hourly"
-        assert stats_hourly_table.to_printed_hogql() == "web_stats_hourly"
-
-        assert bounces_hourly_table.to_printed_clickhouse(None) == "web_bounces_hourly"
-        assert bounces_hourly_table.to_printed_hogql() == "web_bounces_hourly"
-
-        assert stats_combined_table.to_printed_clickhouse(None) == "web_stats_combined"
-        assert stats_combined_table.to_printed_hogql() == "web_stats_combined"
-
-        assert bounces_combined_table.to_printed_clickhouse(None) == "web_bounces_combined"
-        assert bounces_combined_table.to_printed_hogql() == "web_bounces_combined"
-
-    def test_aggregation_fields_present(self):
-        stats_daily_table = WebStatsDailyTable()
-        bounces_daily_table = WebBouncesDailyTable()
-        stats_hourly_table = WebStatsHourlyTable()
-        bounces_hourly_table = WebBouncesHourlyTable()
-        stats_combined_table = WebStatsCombinedTable()
-        bounces_combined_table = WebBouncesCombinedTable()
-
-        expected_agg_fields = ["persons_uniq_state", "sessions_uniq_state", "pageviews_count_state"]
-
-        for field in expected_agg_fields:
-            assert field in stats_daily_table.fields, f"Aggregation field '{field}' missing from WebStatsDailyTable"
-            assert field in bounces_daily_table.fields, f"Aggregation field '{field}' missing from WebBouncesDailyTable"
-            assert field in stats_hourly_table.fields, f"Aggregation field '{field}' missing from WebStatsHourlyTable"
-            assert (
-                field in bounces_hourly_table.fields
-            ), f"Aggregation field '{field}' missing from WebBouncesHourlyTable"
-            assert (
-                field in stats_combined_table.fields
-            ), f"Aggregation field '{field}' missing from WebStatsCombinedTable"
-            assert (
-                field in bounces_combined_table.fields
-            ), f"Aggregation field '{field}' missing from WebBouncesCombinedTable"
-
-    def test_updated_at_field_present(self):
-        stats_daily_table = WebStatsDailyTable()
-        bounces_daily_table = WebBouncesDailyTable()
-        stats_hourly_table = WebStatsHourlyTable()
-        bounces_hourly_table = WebBouncesHourlyTable()
-
-        assert "updated_at" in stats_daily_table.fields, "updated_at field missing from WebStatsDailyTable"
-        assert "updated_at" in bounces_daily_table.fields, "updated_at field missing from WebBouncesDailyTable"
-        assert "updated_at" in stats_hourly_table.fields, "updated_at field missing from WebStatsHourlyTable"
-        assert "updated_at" in bounces_hourly_table.fields, "updated_at field missing from WebBouncesHourlyTable"
-
-    def test_bucket_fields_present(self):
-        stats_daily_table = WebStatsDailyTable()
-        bounces_daily_table = WebBouncesDailyTable()
-        stats_hourly_table = WebStatsHourlyTable()
-        bounces_hourly_table = WebBouncesHourlyTable()
-
-        # All tables should have period_bucket
-        assert "period_bucket" in stats_daily_table.fields, "period_bucket field missing from WebStatsDailyTable"
-        assert "period_bucket" in bounces_daily_table.fields, "period_bucket field missing from WebBouncesDailyTable"
-        assert "period_bucket" in stats_hourly_table.fields, "period_bucket field missing from WebStatsHourlyTable"
-        assert "period_bucket" in bounces_hourly_table.fields, "period_bucket field missing from WebBouncesHourlyTable"
-
-        # No tables should have the old bucket fields
-        assert "day_bucket" not in stats_daily_table.fields, "day_bucket field should not be in WebStatsDailyTable"
-        assert "day_bucket" not in bounces_daily_table.fields, "day_bucket field should not be in WebBouncesDailyTable"
-        assert "day_bucket" not in stats_hourly_table.fields, "day_bucket field should not be in WebStatsHourlyTable"
-        assert (
-            "day_bucket" not in bounces_hourly_table.fields
-        ), "day_bucket field should not be in WebBouncesHourlyTable"
-
-        assert "hour_bucket" not in stats_daily_table.fields, "hour_bucket field should not be in WebStatsDailyTable"
-        assert (
-            "hour_bucket" not in bounces_daily_table.fields
-        ), "hour_bucket field should not be in WebBouncesDailyTable"
-        assert "hour_bucket" not in stats_hourly_table.fields, "hour_bucket field should not be in WebStatsHourlyTable"
-        assert (
-            "hour_bucket" not in bounces_hourly_table.fields
-        ), "hour_bucket field should not be in WebBouncesHourlyTable"
+        for group_name, field_names in field_groups.items():
+            for field_name in field_names:
+                assert (
+                    field_name in SHARED_SCHEMA_FIELDS
+                ), f"{group_name.title()} field '{field_name}' missing from SHARED_SCHEMA_FIELDS"

--- a/posthog/hogql/database/schema/test/test_web_analytics_preaggregated.py
+++ b/posthog/hogql/database/schema/test/test_web_analytics_preaggregated.py
@@ -1,6 +1,10 @@
 from posthog.hogql.database.schema.web_analytics_preaggregated import (
     WebStatsDailyTable,
     WebBouncesDailyTable,
+    WebStatsHourlyTable,
+    WebBouncesHourlyTable,
+    WebStatsCombinedTable,
+    WebBouncesCombinedTable,
     SHARED_SCHEMA_FIELDS,
     DEVICE_BROWSER_FIELDS,
     GEOIP_FIELDS,
@@ -13,63 +17,113 @@ from posthog.hogql.database.schema.web_analytics_preaggregated import (
 
 
 class TestWebAnalyticsPreAggregatedSchema:
-    def test_shared_fields_present_in_both_tables(self):
-        stats_table = WebStatsDailyTable()
-        bounces_table = WebBouncesDailyTable()
+    def test_shared_fields_present_in_all_tables(self):
+        stats_daily_table = WebStatsDailyTable()
+        bounces_daily_table = WebBouncesDailyTable()
+        stats_hourly_table = WebStatsHourlyTable()
+        bounces_hourly_table = WebBouncesHourlyTable()
+        stats_combined_table = WebStatsCombinedTable()
+        bounces_combined_table = WebBouncesCombinedTable()
 
         for field_name in SHARED_SCHEMA_FIELDS.keys():
-            assert field_name in stats_table.fields, f"Shared field '{field_name}' missing from WebStatsDailyTable"
-            assert field_name in bounces_table.fields, f"Shared field '{field_name}' missing from WebBouncesDailyTable"
+            assert (
+                field_name in stats_daily_table.fields
+            ), f"Shared field '{field_name}' missing from WebStatsDailyTable"
+            assert (
+                field_name in bounces_daily_table.fields
+            ), f"Shared field '{field_name}' missing from WebBouncesDailyTable"
+            assert (
+                field_name in stats_hourly_table.fields
+            ), f"Shared field '{field_name}' missing from WebStatsHourlyTable"
+            assert (
+                field_name in bounces_hourly_table.fields
+            ), f"Shared field '{field_name}' missing from WebBouncesHourlyTable"
+            assert (
+                field_name in stats_combined_table.fields
+            ), f"Shared field '{field_name}' missing from WebStatsCombinedTable"
+            assert (
+                field_name in bounces_combined_table.fields
+            ), f"Shared field '{field_name}' missing from WebBouncesCombinedTable"
 
     def test_table_specific_fields(self):
-        stats_table = WebStatsDailyTable()
-        bounces_table = WebBouncesDailyTable()
+        stats_daily_table = WebStatsDailyTable()
+        bounces_daily_table = WebBouncesDailyTable()
+        stats_hourly_table = WebStatsHourlyTable()
+        bounces_hourly_table = WebBouncesHourlyTable()
 
         # Stats table specific fields
         for field_name in WEB_STATS_SPECIFIC_FIELDS.keys():
             assert (
-                field_name in stats_table.fields
+                field_name in stats_daily_table.fields
             ), f"Stats-specific field '{field_name}' missing from WebStatsDailyTable"
+            assert (
+                field_name in stats_hourly_table.fields
+            ), f"Stats-specific field '{field_name}' missing from WebStatsHourlyTable"
 
         # Bounces table specific fields
         for field_name in WEB_BOUNCES_SPECIFIC_FIELDS.keys():
             assert (
-                field_name in bounces_table.fields
+                field_name in bounces_daily_table.fields
             ), f"Bounces-specific field '{field_name}' missing from WebBouncesDailyTable"
+            assert (
+                field_name in bounces_hourly_table.fields
+            ), f"Bounces-specific field '{field_name}' missing from WebBouncesHourlyTable"
 
-        # Verify pathname is only in stats table
-        assert "pathname" in stats_table.fields
-        assert "pathname" not in bounces_table.fields
+        # Verify pathname is only in stats tables
+        assert "pathname" in stats_daily_table.fields
+        assert "pathname" not in bounces_daily_table.fields
+        assert "pathname" in stats_hourly_table.fields
+        assert "pathname" not in bounces_hourly_table.fields
 
-        # Verify bounce-specific fields are only in bounces table
-        assert "bounces_count_state" not in stats_table.fields
-        assert "total_session_duration_state" not in stats_table.fields
-        assert "bounces_count_state" in bounces_table.fields
-        assert "total_session_duration_state" in bounces_table.fields
+        # Verify bounce-specific fields are only in bounces tables
+        assert "bounces_count_state" not in stats_daily_table.fields
+        assert "total_session_duration_state" not in stats_daily_table.fields
+        assert "bounces_count_state" not in stats_hourly_table.fields
+        assert "total_session_duration_state" not in stats_hourly_table.fields
+        assert "bounces_count_state" in bounces_daily_table.fields
+        assert "total_session_duration_state" in bounces_daily_table.fields
+        assert "bounces_count_state" in bounces_hourly_table.fields
+        assert "total_session_duration_state" in bounces_hourly_table.fields
 
     def test_device_browser_fields(self):
-        stats_table = WebStatsDailyTable()
-        bounces_table = WebBouncesDailyTable()
+        stats_daily_table = WebStatsDailyTable()
+        bounces_daily_table = WebBouncesDailyTable()
+        stats_hourly_table = WebStatsHourlyTable()
+        bounces_hourly_table = WebBouncesHourlyTable()
 
         expected_fields = ["browser", "browser_version", "os", "os_version", "viewport_width", "viewport_height"]
 
         for field in expected_fields:
-            assert field in stats_table.fields, f"Device/browser field '{field}' missing from WebStatsDailyTable"
-            assert field in bounces_table.fields, f"Device/browser field '{field}' missing from WebBouncesDailyTable"
+            assert field in stats_daily_table.fields, f"Device/browser field '{field}' missing from WebStatsDailyTable"
+            assert (
+                field in bounces_daily_table.fields
+            ), f"Device/browser field '{field}' missing from WebBouncesDailyTable"
+            assert (
+                field in stats_hourly_table.fields
+            ), f"Device/browser field '{field}' missing from WebStatsHourlyTable"
+            assert (
+                field in bounces_hourly_table.fields
+            ), f"Device/browser field '{field}' missing from WebBouncesHourlyTable"
 
     def test_geoip_fields(self):
-        stats_table = WebStatsDailyTable()
-        bounces_table = WebBouncesDailyTable()
+        stats_daily_table = WebStatsDailyTable()
+        bounces_daily_table = WebBouncesDailyTable()
+        stats_hourly_table = WebStatsHourlyTable()
+        bounces_hourly_table = WebBouncesHourlyTable()
 
         expected_fields = ["country_code", "country_name", "city_name", "region_code", "region_name", "time_zone"]
 
         for field in expected_fields:
-            assert field in stats_table.fields, f"GeoIP field '{field}' missing from WebStatsDailyTable"
-            assert field in bounces_table.fields, f"GeoIP field '{field}' missing from WebBouncesDailyTable"
+            assert field in stats_daily_table.fields, f"GeoIP field '{field}' missing from WebStatsDailyTable"
+            assert field in bounces_daily_table.fields, f"GeoIP field '{field}' missing from WebBouncesDailyTable"
+            assert field in stats_hourly_table.fields, f"GeoIP field '{field}' missing from WebStatsHourlyTable"
+            assert field in bounces_hourly_table.fields, f"GeoIP field '{field}' missing from WebBouncesHourlyTable"
 
     def test_attribution_tracking_fields(self):
-        stats_table = WebStatsDailyTable()
-        bounces_table = WebBouncesDailyTable()
+        stats_daily_table = WebStatsDailyTable()
+        bounces_daily_table = WebBouncesDailyTable()
+        stats_hourly_table = WebStatsHourlyTable()
+        bounces_hourly_table = WebBouncesHourlyTable()
 
         expected_fields = [
             "gclid",
@@ -93,28 +147,40 @@ class TestWebAnalyticsPreAggregatedSchema:
         ]
 
         for field in expected_fields:
-            assert field in stats_table.fields, f"Attribution field '{field}' missing from WebStatsDailyTable"
-            assert field in bounces_table.fields, f"Attribution field '{field}' missing from WebBouncesDailyTable"
+            assert field in stats_daily_table.fields, f"Attribution field '{field}' missing from WebStatsDailyTable"
+            assert field in bounces_daily_table.fields, f"Attribution field '{field}' missing from WebBouncesDailyTable"
+            assert field in stats_hourly_table.fields, f"Attribution field '{field}' missing from WebStatsHourlyTable"
+            assert (
+                field in bounces_hourly_table.fields
+            ), f"Attribution field '{field}' missing from WebBouncesHourlyTable"
 
     def test_utm_fields(self):
-        stats_table = WebStatsDailyTable()
-        bounces_table = WebBouncesDailyTable()
+        stats_daily_table = WebStatsDailyTable()
+        bounces_daily_table = WebBouncesDailyTable()
+        stats_hourly_table = WebStatsHourlyTable()
+        bounces_hourly_table = WebBouncesHourlyTable()
 
         expected_fields = ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content", "referring_domain"]
 
         for field in expected_fields:
-            assert field in stats_table.fields, f"UTM field '{field}' missing from WebStatsDailyTable"
-            assert field in bounces_table.fields, f"UTM field '{field}' missing from WebBouncesDailyTable"
+            assert field in stats_daily_table.fields, f"UTM field '{field}' missing from WebStatsDailyTable"
+            assert field in bounces_daily_table.fields, f"UTM field '{field}' missing from WebBouncesDailyTable"
+            assert field in stats_hourly_table.fields, f"UTM field '{field}' missing from WebStatsHourlyTable"
+            assert field in bounces_hourly_table.fields, f"UTM field '{field}' missing from WebBouncesHourlyTable"
 
     def test_path_fields(self):
-        stats_table = WebStatsDailyTable()
-        bounces_table = WebBouncesDailyTable()
+        stats_daily_table = WebStatsDailyTable()
+        bounces_daily_table = WebBouncesDailyTable()
+        stats_hourly_table = WebStatsHourlyTable()
+        bounces_hourly_table = WebBouncesHourlyTable()
 
         expected_fields = ["entry_pathname", "end_pathname"]
 
         for field in expected_fields:
-            assert field in stats_table.fields, f"Path field '{field}' missing from WebStatsDailyTable"
-            assert field in bounces_table.fields, f"Path field '{field}' missing from WebBouncesDailyTable"
+            assert field in stats_daily_table.fields, f"Path field '{field}' missing from WebStatsDailyTable"
+            assert field in bounces_daily_table.fields, f"Path field '{field}' missing from WebBouncesDailyTable"
+            assert field in stats_hourly_table.fields, f"Path field '{field}' missing from WebStatsHourlyTable"
+            assert field in bounces_hourly_table.fields, f"Path field '{field}' missing from WebBouncesHourlyTable"
 
     def test_shared_schema_fields_composition(self):
         expected_field_count = (
@@ -142,28 +208,91 @@ class TestWebAnalyticsPreAggregatedSchema:
             assert field in SHARED_SCHEMA_FIELDS, f"Path field '{field}' missing from SHARED_SCHEMA_FIELDS"
 
     def test_table_methods(self):
-        stats_table = WebStatsDailyTable()
-        bounces_table = WebBouncesDailyTable()
+        stats_daily_table = WebStatsDailyTable()
+        bounces_daily_table = WebBouncesDailyTable()
+        stats_hourly_table = WebStatsHourlyTable()
+        bounces_hourly_table = WebBouncesHourlyTable()
+        stats_combined_table = WebStatsCombinedTable()
+        bounces_combined_table = WebBouncesCombinedTable()
 
-        assert stats_table.to_printed_clickhouse(None) == "web_stats_daily"
-        assert stats_table.to_printed_hogql() == "web_stats_daily"
+        assert stats_daily_table.to_printed_clickhouse(None) == "web_stats_daily"
+        assert stats_daily_table.to_printed_hogql() == "web_stats_daily"
 
-        assert bounces_table.to_printed_clickhouse(None) == "web_bounces_daily"
-        assert bounces_table.to_printed_hogql() == "web_bounces_daily"
+        assert bounces_daily_table.to_printed_clickhouse(None) == "web_bounces_daily"
+        assert bounces_daily_table.to_printed_hogql() == "web_bounces_daily"
+
+        assert stats_hourly_table.to_printed_clickhouse(None) == "web_stats_hourly"
+        assert stats_hourly_table.to_printed_hogql() == "web_stats_hourly"
+
+        assert bounces_hourly_table.to_printed_clickhouse(None) == "web_bounces_hourly"
+        assert bounces_hourly_table.to_printed_hogql() == "web_bounces_hourly"
+
+        assert stats_combined_table.to_printed_clickhouse(None) == "web_stats_combined"
+        assert stats_combined_table.to_printed_hogql() == "web_stats_combined"
+
+        assert bounces_combined_table.to_printed_clickhouse(None) == "web_bounces_combined"
+        assert bounces_combined_table.to_printed_hogql() == "web_bounces_combined"
 
     def test_aggregation_fields_present(self):
-        stats_table = WebStatsDailyTable()
-        bounces_table = WebBouncesDailyTable()
+        stats_daily_table = WebStatsDailyTable()
+        bounces_daily_table = WebBouncesDailyTable()
+        stats_hourly_table = WebStatsHourlyTable()
+        bounces_hourly_table = WebBouncesHourlyTable()
+        stats_combined_table = WebStatsCombinedTable()
+        bounces_combined_table = WebBouncesCombinedTable()
 
         expected_agg_fields = ["persons_uniq_state", "sessions_uniq_state", "pageviews_count_state"]
 
         for field in expected_agg_fields:
-            assert field in stats_table.fields, f"Aggregation field '{field}' missing from WebStatsDailyTable"
-            assert field in bounces_table.fields, f"Aggregation field '{field}' missing from WebBouncesDailyTable"
+            assert field in stats_daily_table.fields, f"Aggregation field '{field}' missing from WebStatsDailyTable"
+            assert field in bounces_daily_table.fields, f"Aggregation field '{field}' missing from WebBouncesDailyTable"
+            assert field in stats_hourly_table.fields, f"Aggregation field '{field}' missing from WebStatsHourlyTable"
+            assert (
+                field in bounces_hourly_table.fields
+            ), f"Aggregation field '{field}' missing from WebBouncesHourlyTable"
+            assert (
+                field in stats_combined_table.fields
+            ), f"Aggregation field '{field}' missing from WebStatsCombinedTable"
+            assert (
+                field in bounces_combined_table.fields
+            ), f"Aggregation field '{field}' missing from WebBouncesCombinedTable"
 
     def test_updated_at_field_present(self):
-        stats_table = WebStatsDailyTable()
-        bounces_table = WebBouncesDailyTable()
+        stats_daily_table = WebStatsDailyTable()
+        bounces_daily_table = WebBouncesDailyTable()
+        stats_hourly_table = WebStatsHourlyTable()
+        bounces_hourly_table = WebBouncesHourlyTable()
 
-        assert "updated_at" in stats_table.fields, "updated_at field missing from WebStatsDailyTable"
-        assert "updated_at" in bounces_table.fields, "updated_at field missing from WebBouncesDailyTable"
+        assert "updated_at" in stats_daily_table.fields, "updated_at field missing from WebStatsDailyTable"
+        assert "updated_at" in bounces_daily_table.fields, "updated_at field missing from WebBouncesDailyTable"
+        assert "updated_at" in stats_hourly_table.fields, "updated_at field missing from WebStatsHourlyTable"
+        assert "updated_at" in bounces_hourly_table.fields, "updated_at field missing from WebBouncesHourlyTable"
+
+    def test_bucket_fields_present(self):
+        stats_daily_table = WebStatsDailyTable()
+        bounces_daily_table = WebBouncesDailyTable()
+        stats_hourly_table = WebStatsHourlyTable()
+        bounces_hourly_table = WebBouncesHourlyTable()
+
+        # All tables should have period_bucket
+        assert "period_bucket" in stats_daily_table.fields, "period_bucket field missing from WebStatsDailyTable"
+        assert "period_bucket" in bounces_daily_table.fields, "period_bucket field missing from WebBouncesDailyTable"
+        assert "period_bucket" in stats_hourly_table.fields, "period_bucket field missing from WebStatsHourlyTable"
+        assert "period_bucket" in bounces_hourly_table.fields, "period_bucket field missing from WebBouncesHourlyTable"
+
+        # No tables should have the old bucket fields
+        assert "day_bucket" not in stats_daily_table.fields, "day_bucket field should not be in WebStatsDailyTable"
+        assert "day_bucket" not in bounces_daily_table.fields, "day_bucket field should not be in WebBouncesDailyTable"
+        assert "day_bucket" not in stats_hourly_table.fields, "day_bucket field should not be in WebStatsHourlyTable"
+        assert (
+            "day_bucket" not in bounces_hourly_table.fields
+        ), "day_bucket field should not be in WebBouncesHourlyTable"
+
+        assert "hour_bucket" not in stats_daily_table.fields, "hour_bucket field should not be in WebStatsDailyTable"
+        assert (
+            "hour_bucket" not in bounces_daily_table.fields
+        ), "hour_bucket field should not be in WebBouncesDailyTable"
+        assert "hour_bucket" not in stats_hourly_table.fields, "hour_bucket field should not be in WebStatsHourlyTable"
+        assert (
+            "hour_bucket" not in bounces_hourly_table.fields
+        ), "hour_bucket field should not be in WebBouncesHourlyTable"

--- a/posthog/hogql/database/schema/web_analytics_preaggregated.py
+++ b/posthog/hogql/database/schema/web_analytics_preaggregated.py
@@ -1,4 +1,3 @@
-from typing import Literal
 from posthog.hogql.database.models import (
     DatabaseField,
     IntegerDatabaseField,
@@ -81,16 +80,14 @@ WEB_BOUNCES_SPECIFIC_FIELDS = {
 }
 
 
-def web_preaggregated_base_fields(granularity: Literal["daily", "hourly"]):
-    bucket_name = "day_bucket" if granularity == "daily" else "hour_bucket"
-
-    return {
-        "team_id": IntegerDatabaseField(name="team_id"),
-        bucket_name: DateTimeDatabaseField(name=bucket_name),
-        "host": StringDatabaseField(name="host", nullable=True),
-        "device_type": StringDatabaseField(name="device_type", nullable=True),
-        "updated_at": DateTimeDatabaseField(name="updated_at"),
-    }
+# Base table fields present in all tables
+web_preaggregated_base_fields = {
+    "period_bucket": DateTimeDatabaseField(name="period_bucket"),
+    "team_id": IntegerDatabaseField(name="team_id"),
+    "host": StringDatabaseField(name="host"),
+    "device_type": StringDatabaseField(name="device_type"),
+    "updated_at": DateTimeDatabaseField(name="updated_at"),
+}
 
 
 web_preaggregated_base_aggregation_fields = {
@@ -102,7 +99,7 @@ web_preaggregated_base_aggregation_fields = {
 
 class WebStatsDailyTable(Table):
     fields: dict[str, FieldOrTable] = {
-        **web_preaggregated_base_fields("daily"),
+        **web_preaggregated_base_fields,
         **web_preaggregated_base_aggregation_fields,
         **SHARED_SCHEMA_FIELDS,
         **WEB_STATS_SPECIFIC_FIELDS,
@@ -117,7 +114,7 @@ class WebStatsDailyTable(Table):
 
 class WebBouncesDailyTable(Table):
     fields: dict[str, FieldOrTable] = {
-        **web_preaggregated_base_fields("daily"),
+        **web_preaggregated_base_fields,
         **web_preaggregated_base_aggregation_fields,
         **SHARED_SCHEMA_FIELDS,
         **WEB_BOUNCES_SPECIFIC_FIELDS,
@@ -132,7 +129,7 @@ class WebBouncesDailyTable(Table):
 
 class WebStatsHourlyTable(Table):
     fields: dict[str, FieldOrTable] = {
-        **web_preaggregated_base_fields("hourly"),
+        **web_preaggregated_base_fields,
         **web_preaggregated_base_aggregation_fields,
         **SHARED_SCHEMA_FIELDS,
         **WEB_STATS_SPECIFIC_FIELDS,
@@ -147,7 +144,7 @@ class WebStatsHourlyTable(Table):
 
 class WebBouncesHourlyTable(Table):
     fields: dict[str, FieldOrTable] = {
-        **web_preaggregated_base_fields("hourly"),
+        **web_preaggregated_base_fields,
         **web_preaggregated_base_aggregation_fields,
         **SHARED_SCHEMA_FIELDS,
         **WEB_BOUNCES_SPECIFIC_FIELDS,
@@ -158,3 +155,33 @@ class WebBouncesHourlyTable(Table):
 
     def to_printed_hogql(self):
         return "web_bounces_hourly"
+
+
+class WebStatsCombinedTable(Table):
+    fields: dict[str, FieldOrTable] = {
+        **web_preaggregated_base_fields,
+        **web_preaggregated_base_aggregation_fields,
+        **SHARED_SCHEMA_FIELDS,
+        **WEB_STATS_SPECIFIC_FIELDS,
+    }
+
+    def to_printed_clickhouse(self, context):
+        return "web_stats_combined"
+
+    def to_printed_hogql(self):
+        return "web_stats_combined"
+
+
+class WebBouncesCombinedTable(Table):
+    fields: dict[str, FieldOrTable] = {
+        **web_preaggregated_base_fields,
+        **web_preaggregated_base_aggregation_fields,
+        **SHARED_SCHEMA_FIELDS,
+        **WEB_BOUNCES_SPECIFIC_FIELDS,
+    }
+
+    def to_printed_clickhouse(self, context):
+        return "web_bounces_combined"
+
+    def to_printed_hogql(self):
+        return "web_bounces_combined"

--- a/posthog/hogql/database/schema/web_analytics_preaggregated.py
+++ b/posthog/hogql/database/schema/web_analytics_preaggregated.py
@@ -77,6 +77,7 @@ WEB_STATS_SPECIFIC_FIELDS = {
 WEB_BOUNCES_SPECIFIC_FIELDS = {
     "bounces_count_state": DatabaseField(name="bounces_count_state"),
     "total_session_duration_state": DatabaseField(name="total_session_duration_state"),
+    "total_session_count_state": DatabaseField(name="total_session_count_state"),
 }
 
 

--- a/posthog/hogql_queries/web_analytics/pre_aggregated/query_builder.py
+++ b/posthog/hogql_queries/web_analytics/pre_aggregated/query_builder.py
@@ -32,7 +32,7 @@ class WebAnalyticsPreAggregatedQueryBuilder:
         filter_exprs: list[ast.Expr] = [
             ast.CompareOperation(
                 op=ast.CompareOperationOp.GtEq,
-                left=ast.Field(chain=[table_name, "day_bucket"]),
+                left=ast.Field(chain=[table_name, "period_bucket"]),
                 right=ast.Constant(
                     value=(
                         self.runner.query_compare_to_date_range.date_from()
@@ -43,7 +43,7 @@ class WebAnalyticsPreAggregatedQueryBuilder:
             ),
             ast.CompareOperation(
                 op=ast.CompareOperationOp.LtEq,
-                left=ast.Field(chain=[table_name, "day_bucket"]),
+                left=ast.Field(chain=[table_name, "period_bucket"]),
                 right=ast.Constant(value=self.runner.query_date_range.date_to()),
             ),
         ]
@@ -78,19 +78,19 @@ class WebAnalyticsPreAggregatedQueryBuilder:
             previous_date_from = current_date_from
             previous_date_to = current_date_to
 
-        # Create the field reference for day_bucket
-        day_bucket_field = ast.Field(chain=[table_name, "day_bucket"] if table_name else ["day_bucket"])
+        # Create the field reference for period_bucket
+        period_bucket_field = ast.Field(chain=[table_name, "period_bucket"] if table_name else ["period_bucket"])
 
         current_period_filter = ast.And(
             exprs=[
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.GtEq,
-                    left=day_bucket_field,
+                    left=period_bucket_field,
                     right=ast.Constant(value=current_date_from),
                 ),
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.LtEq,
-                    left=day_bucket_field,
+                    left=period_bucket_field,
                     right=ast.Constant(value=current_date_to),
                 ),
             ]
@@ -100,12 +100,12 @@ class WebAnalyticsPreAggregatedQueryBuilder:
             exprs=[
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.GtEq,
-                    left=day_bucket_field,
+                    left=period_bucket_field,
                     right=ast.Constant(value=previous_date_from),
                 ),
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.LtEq,
-                    left=day_bucket_field,
+                    left=period_bucket_field,
                     right=ast.Constant(value=previous_date_to),
                 ),
             ]

--- a/posthog/hogql_queries/web_analytics/pre_aggregated/query_builder.py
+++ b/posthog/hogql_queries/web_analytics/pre_aggregated/query_builder.py
@@ -1,5 +1,4 @@
 from typing import Optional
-from datetime import datetime, UTC
 
 from posthog.hogql import ast
 from posthog.hogql.property import property_to_expr
@@ -19,11 +18,6 @@ class WebAnalyticsPreAggregatedQueryBuilder:
                 return False
 
         if query.conversionGoal:
-            return False
-
-        # Only work for fixed-dates that don't include current-date in the filters while we test the pre-aggregated tables
-        today = datetime.now(UTC).date()
-        if self.runner.query_date_range.date_to().date() >= today:
             return False
 
         return True

--- a/posthog/hogql_queries/web_analytics/test/test_web_overview.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_overview.py
@@ -961,7 +961,7 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
 
     @freeze_time("2023-12-15T12:00:00Z")
-    def test_cannot_use_preaggregated_tables_with_current_date(self):
+    def test_can_use_preaggregated_tables_with_current_date(self):
         today = datetime.now(UTC).date().isoformat()
         query = WebOverviewQuery(
             dateRange=DateRange(date_from="2023-11-01", date_to=today),
@@ -969,9 +969,9 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
         runner = WebOverviewQueryRunner(team=self.team, query=query)
         pre_agg_builder = WebOverviewPreAggregatedQueryBuilder(runner)
-        self.assertFalse(
+        self.assertTrue(
             pre_agg_builder.can_use_preaggregated_tables(),
-            "Should not use pre-aggregated tables when date range includes current date",
+            "Should use pre-aggregated tables when date range includes current date (using UNION ALL with hourly tables)",
         )
 
     @freeze_time("2023-12-15T12:00:00Z")

--- a/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
@@ -1,4 +1,3 @@
-import random
 import typing
 from abc import ABC
 from datetime import timedelta, datetime
@@ -475,7 +474,7 @@ WHERE
 
     def get_cache_key(self) -> str:
         original = super().get_cache_key()
-        return f"{original}_{self.team.path_cleaning_filters}_{random.randint(0, 1000000)}"
+        return f"{original}_{self.team.path_cleaning_filters}"
 
     @cached_property
     def events_session_property(self):

--- a/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
@@ -1,3 +1,4 @@
+import random
 import typing
 from abc import ABC
 from datetime import timedelta, datetime
@@ -474,7 +475,7 @@ WHERE
 
     def get_cache_key(self) -> str:
         original = super().get_cache_key()
-        return f"{original}_{self.team.path_cleaning_filters}"
+        return f"{original}_{self.team.path_cleaning_filters}_{random.randint(0, 1000000)}"
 
     @cached_property
     def events_session_property(self):

--- a/posthog/hogql_queries/web_analytics/web_overview_pre_aggregated.py
+++ b/posthog/hogql_queries/web_analytics/web_overview_pre_aggregated.py
@@ -46,13 +46,17 @@ class WebOverviewPreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder
                 "unique_sessions_current": self._uniq_merge_if("sessions_uniq_state", current_period_filter),
                 "unique_sessions_previous": self._uniq_merge_if("sessions_uniq_state", previous_period_filter),
                 "avg_session_duration_current": self._safe_avg_sessions(
-                    "total_session_duration_state", current_period_filter
+                    "total_session_duration_state", "total_session_count_state", current_period_filter
                 ),
                 "avg_session_duration_previous": self._safe_avg_sessions(
-                    "total_session_duration_state", previous_period_filter
+                    "total_session_duration_state", "total_session_count_state", previous_period_filter
                 ),
-                "bounce_rate_current": self._safe_avg_sessions("bounces_count_state", current_period_filter),
-                "bounce_rate_previous": self._safe_avg_sessions("bounces_count_state", previous_period_filter),
+                "bounce_rate_current": self._safe_avg_sessions(
+                    "bounces_count_state", "sessions_uniq_state", current_period_filter
+                ),
+                "bounce_rate_previous": self._safe_avg_sessions(
+                    "bounces_count_state", "sessions_uniq_state", previous_period_filter
+                ),
             },
         )
 
@@ -82,21 +86,25 @@ class WebOverviewPreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder
             ],
         )
 
-    def _safe_avg_sessions(self, metric_state: str, period_filter: ast.Expr) -> ast.Call:
-        sessions_count = self._uniq_merge_if("sessions_uniq_state", period_filter)
+    def _safe_avg_sessions(self, metric_state: str, denominator_state: str, period_filter: ast.Expr) -> ast.Call:
         metric_sum = self._sum_merge_if(metric_state, period_filter)
+
+        if denominator_state == "sessions_uniq_state":
+            denominator_count = self._uniq_merge_if(denominator_state, period_filter)
+        else:
+            denominator_count = self._sum_merge_if(denominator_state, period_filter)
 
         return ast.Call(
             name="if",
             args=[
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.Gt,
-                    left=sessions_count,
+                    left=denominator_count,
                     right=ast.Constant(value=0),
                 ),
                 ast.Call(
                     name="divide",
-                    args=[metric_sum, sessions_count],
+                    args=[metric_sum, denominator_count],
                 ),
                 ast.Constant(value=0),
             ],

--- a/posthog/hogql_queries/web_analytics/web_overview_pre_aggregated.py
+++ b/posthog/hogql_queries/web_analytics/web_overview_pre_aggregated.py
@@ -36,7 +36,7 @@ class WebOverviewPreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder
 
                 NULL AS revenue,
                 NULL AS previous_revenue
-        FROM web_bounces_daily FINAL
+        FROM web_bounces_combined FINAL
         """,
             placeholders={
                 "unique_persons_current": self._uniq_merge_if("persons_uniq_state", current_period_filter),
@@ -58,7 +58,7 @@ class WebOverviewPreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder
 
         assert isinstance(query, ast.SelectQuery)
 
-        filters = self._get_filters(table_name="web_bounces_daily")
+        filters = self._get_filters(table_name="web_bounces_combined")
         if filters:
             query.where = filters
 

--- a/posthog/models/web_preaggregated/sql.py
+++ b/posthog/models/web_preaggregated/sql.py
@@ -825,18 +825,18 @@ def WEB_BOUNCES_INSERT_SQL(
     """
 
 
-def create_combined_view_sql(table_name, on_cluster=True):
+def create_combined_view_sql(table_prefix, on_cluster=True):
     return f"""
-    CREATE VIEW IF NOT EXISTS {table_name} {ON_CLUSTER_CLAUSE(on_cluster)} AS
-    SELECT * FROM {table_name}_daily WHERE period_bucket < toStartOfDay(now(), 'UTC')
+    CREATE VIEW IF NOT EXISTS {table_prefix}_combined {ON_CLUSTER_CLAUSE(on_cluster)} AS
+    SELECT * FROM {table_prefix}_daily WHERE period_bucket < toStartOfDay(now(), 'UTC')
     UNION ALL
-    SELECT * FROM {table_name}_hourly WHERE period_bucket >= toStartOfDay(now(), 'UTC')
+    SELECT * FROM {table_prefix}_hourly WHERE period_bucket >= toStartOfDay(now(), 'UTC')
     """
 
 
 def WEB_STATS_COMBINED_VIEW_SQL():
-    return create_combined_view_sql("web_stats_combined")
+    return create_combined_view_sql("web_stats")
 
 
 def WEB_BOUNCES_COMBINED_VIEW_SQL():
-    return create_combined_view_sql("web_bounces_combined")
+    return create_combined_view_sql("web_bounces")

--- a/posthog/models/web_preaggregated/sql.py
+++ b/posthog/models/web_preaggregated/sql.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 
+from posthog.clickhouse.cluster import ON_CLUSTER_CLAUSE
 from posthog.clickhouse.table_engines import ReplacingMergeTree, ReplicationScheme
 
 CLICKHOUSE_CLUSTER = settings.CLICKHOUSE_CLUSTER
@@ -13,14 +14,14 @@ def TABLE_TEMPLATE(table_name, columns, order_by, on_cluster=True):
     return f"""
     CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     (
-        day_bucket DateTime,
+        period_bucket DateTime,
         team_id UInt64,
         host String,
         device_type String,
         updated_at DateTime64(6, 'UTC') DEFAULT now(),
         {columns}
     ) ENGINE = {engine}
-    PARTITION BY toYYYYMM(day_bucket)
+    PARTITION BY toYYYYMM(period_bucket)
     ORDER BY {order_by}
     """
 
@@ -29,12 +30,12 @@ def HOURLY_TABLE_TEMPLATE(table_name, columns, order_by, on_cluster=True, ttl=No
     engine = ReplacingMergeTree(table_name, replication_scheme=ReplicationScheme.REPLICATED, ver="updated_at")
     on_cluster_clause = f"ON CLUSTER '{CLICKHOUSE_CLUSTER}'" if on_cluster else ""
 
-    ttl_clause = f"TTL hour_bucket + INTERVAL {ttl} DELETE" if ttl else ""
+    ttl_clause = f"TTL period_bucket + INTERVAL {ttl} DELETE" if ttl else ""
 
     return f"""
     CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     (
-        hour_bucket DateTime,
+        period_bucket DateTime,
         team_id UInt64,
         host String,
         device_type String,
@@ -47,12 +48,10 @@ def HOURLY_TABLE_TEMPLATE(table_name, columns, order_by, on_cluster=True, ttl=No
 
 
 def DISTRIBUTED_TABLE_TEMPLATE(dist_table_name, base_table_name, columns, granularity="daily"):
-    bucket_name = "day_bucket" if granularity == "daily" else "hour_bucket"
-
     return f"""
     CREATE TABLE IF NOT EXISTS {dist_table_name} ON CLUSTER '{CLICKHOUSE_CLUSTER}'
     (
-        {bucket_name} DateTime,
+        period_bucket DateTime,
         team_id UInt64,
         host String,
         device_type String,
@@ -147,7 +146,7 @@ WEB_BOUNCES_COLUMNS = """
 """
 
 
-def WEB_STATS_ORDER_BY_FUNC(bucket_column="day_bucket"):
+def WEB_STATS_ORDER_BY_FUNC(bucket_column="period_bucket"):
     return f"""(
     team_id,
     {bucket_column},
@@ -191,7 +190,7 @@ def WEB_STATS_ORDER_BY_FUNC(bucket_column="day_bucket"):
 )"""
 
 
-def WEB_BOUNCES_ORDER_BY_FUNC(bucket_column="day_bucket"):
+def WEB_BOUNCES_ORDER_BY_FUNC(bucket_column="period_bucket"):
     return f"""(
     team_id,
     {bucket_column},
@@ -244,7 +243,7 @@ def create_table_pair(base_table_name, columns, order_by, on_cluster=True):
 
 
 def WEB_STATS_DAILY_SQL(table_name="web_stats_daily", on_cluster=True):
-    return TABLE_TEMPLATE(table_name, WEB_STATS_COLUMNS, WEB_STATS_ORDER_BY_FUNC("day_bucket"), on_cluster)
+    return TABLE_TEMPLATE(table_name, WEB_STATS_COLUMNS, WEB_STATS_ORDER_BY_FUNC("period_bucket"), on_cluster)
 
 
 def DISTRIBUTED_WEB_STATS_DAILY_SQL():
@@ -254,7 +253,7 @@ def DISTRIBUTED_WEB_STATS_DAILY_SQL():
 
 
 def WEB_BOUNCES_DAILY_SQL(table_name="web_bounces_daily", on_cluster=True):
-    return TABLE_TEMPLATE(table_name, WEB_BOUNCES_COLUMNS, WEB_BOUNCES_ORDER_BY_FUNC("day_bucket"), on_cluster)
+    return TABLE_TEMPLATE(table_name, WEB_BOUNCES_COLUMNS, WEB_BOUNCES_ORDER_BY_FUNC("period_bucket"), on_cluster)
 
 
 def DISTRIBUTED_WEB_BOUNCES_DAILY_SQL():
@@ -265,7 +264,7 @@ def DISTRIBUTED_WEB_BOUNCES_DAILY_SQL():
 
 def WEB_STATS_HOURLY_SQL(on_cluster=True):
     return HOURLY_TABLE_TEMPLATE(
-        "web_stats_hourly", WEB_STATS_COLUMNS, WEB_STATS_ORDER_BY_FUNC("hour_bucket"), on_cluster, ttl="24 HOUR"
+        "web_stats_hourly", WEB_STATS_COLUMNS, WEB_STATS_ORDER_BY_FUNC("period_bucket"), on_cluster, ttl="24 HOUR"
     )
 
 
@@ -277,7 +276,7 @@ def DISTRIBUTED_WEB_STATS_HOURLY_SQL():
 
 def WEB_BOUNCES_HOURLY_SQL(on_cluster=True):
     return HOURLY_TABLE_TEMPLATE(
-        "web_bounces_hourly", WEB_BOUNCES_COLUMNS, WEB_BOUNCES_ORDER_BY_FUNC("hour_bucket"), on_cluster, ttl="24 HOUR"
+        "web_bounces_hourly", WEB_BOUNCES_COLUMNS, WEB_BOUNCES_ORDER_BY_FUNC("period_bucket"), on_cluster, ttl="24 HOUR"
     )
 
 
@@ -307,10 +306,10 @@ def get_insert_params(team_ids, granularity="daily"):
 
     if granularity == "hourly":
         time_bucket_func = "toStartOfHour"
-        bucket_column = "hour_bucket"
+        bucket_column = "period_bucket"
     else:
         time_bucket_func = "toStartOfDay"
-        bucket_column = "day_bucket"
+        bucket_column = "period_bucket"
 
     return {
         "team_filter": filters["raw_sessions"],
@@ -329,12 +328,11 @@ def WEB_STATS_INSERT_SQL(
     person_team_filter = params["person_team_filter"]
     events_team_filter = params["events_team_filter"]
     time_bucket_func = params["time_bucket_func"]
-    bucket_column = params["bucket_column"]
 
     return f"""
     INSERT INTO {table_name}
     SELECT
-        {time_bucket_func}(start_timestamp) AS {bucket_column},
+        {time_bucket_func}(start_timestamp) AS period_bucket,
         team_id,
         host,
         device_type,
@@ -527,7 +525,7 @@ def WEB_STATS_INSERT_SQL(
         SETTINGS {settings}
     )
     GROUP BY
-        {bucket_column},
+        period_bucket,
         team_id,
         host,
         device_type,
@@ -585,12 +583,11 @@ def WEB_BOUNCES_INSERT_SQL(
     person_team_filter = params["person_team_filter"]
     events_team_filter = params["events_team_filter"]
     time_bucket_func = params["time_bucket_func"]
-    bucket_column = params["bucket_column"]
 
     return f"""
     INSERT INTO {table_name}
     SELECT
-        {time_bucket_func}(start_timestamp) AS {bucket_column},
+        {time_bucket_func}(start_timestamp) AS period_bucket,
         team_id,
         host,
         device_type,
@@ -786,7 +783,7 @@ def WEB_BOUNCES_INSERT_SQL(
             viewport_height
     )
     GROUP BY
-        {bucket_column},
+        period_bucket,
         team_id,
         entry_pathname,
         end_pathname,
@@ -826,3 +823,20 @@ def WEB_BOUNCES_INSERT_SQL(
         viewport_height
     SETTINGS {settings}
     """
+
+
+def create_combined_view_sql(table_name, on_cluster=True):
+    return f"""
+    CREATE VIEW IF NOT EXISTS {table_name} {ON_CLUSTER_CLAUSE(on_cluster)} AS
+    SELECT * FROM {table_name}_daily WHERE period_bucket < toStartOfDay(now(), 'UTC')
+    UNION ALL
+    SELECT * FROM {table_name}_hourly WHERE period_bucket >= toStartOfDay(now(), 'UTC')
+    """
+
+
+def WEB_STATS_COMBINED_VIEW_SQL():
+    return create_combined_view_sql("web_stats_combined")
+
+
+def WEB_BOUNCES_COMBINED_VIEW_SQL():
+    return create_combined_view_sql("web_bounces_combined")

--- a/posthog/models/web_preaggregated/sql.py
+++ b/posthog/models/web_preaggregated/sql.py
@@ -142,7 +142,8 @@ WEB_BOUNCES_COLUMNS = """
     sessions_uniq_state AggregateFunction(uniq, String),
     pageviews_count_state AggregateFunction(sum, UInt64),
     bounces_count_state AggregateFunction(sum, UInt64),
-    total_session_duration_state AggregateFunction(sum, Int64)
+    total_session_duration_state AggregateFunction(sum, Int64),
+    total_session_count_state AggregateFunction(sum, UInt64)
 """
 
 
@@ -630,7 +631,8 @@ def WEB_BOUNCES_INSERT_SQL(
         uniqState(assumeNotNull(session_id)) AS sessions_uniq_state,
         sumState(pageview_count) AS pageviews_count_state,
         sumState(toUInt64(ifNull(is_bounce, 0))) AS bounces_count_state,
-        sumState(session_duration) AS total_session_duration_state
+        sumState(session_duration) AS total_session_duration_state,
+        sumState(total_session_count_state) AS total_session_count_state
     FROM
     (
         SELECT
@@ -675,6 +677,7 @@ def WEB_BOUNCES_INSERT_SQL(
             events__session.session_id AS session_id,
             any(events__session.is_bounce) AS is_bounce,
             any(events__session.session_duration) AS session_duration,
+            sum(toUInt64(1)) AS total_session_count_state,
             e.team_id AS team_id,
             min(events__session.start_timestamp) AS start_timestamp
         FROM events AS e

--- a/posthog/models/web_preaggregated/test_web_preaggregated_sql.py
+++ b/posthog/models/web_preaggregated/test_web_preaggregated_sql.py
@@ -95,7 +95,7 @@ class TestWebPreAggregatedReplacingMergeTree(ClickhouseTestMixin, APIBaseTest):
         context = HogQLContext(team_id=self.team.pk, enable_select_queries=True)
         sql = print_ast(hogql_query, context=context, dialect="clickhouse")
 
-        assert "web_bounces_daily FINAL" in sql
+        assert "web_bounces_combined FINAL" in sql
 
     def test_replacing_merge_tree_version_column(self):
         table_sql = WEB_STATS_DAILY_SQL(table_name="test_web_stats_daily", on_cluster=False)

--- a/posthog/models/web_preaggregated/test_web_preaggregated_sql.py
+++ b/posthog/models/web_preaggregated/test_web_preaggregated_sql.py
@@ -1,11 +1,8 @@
 from unittest.mock import patch
+from parameterized import parameterized
 from posthog.models.web_preaggregated.sql import (
     WEB_STATS_DAILY_SQL,
     WEB_BOUNCES_DAILY_SQL,
-    WEB_STATS_INSERT_SQL,
-    WEB_BOUNCES_INSERT_SQL,
-    DISTRIBUTED_WEB_STATS_DAILY_SQL,
-    DISTRIBUTED_WEB_BOUNCES_DAILY_SQL,
 )
 from posthog.test.base import ClickhouseTestMixin, APIBaseTest
 from posthog.hogql_queries.web_analytics.web_overview_pre_aggregated import WebOverviewPreAggregatedQueryBuilder
@@ -16,82 +13,79 @@ from posthog.hogql.context import HogQLContext
 
 
 class TestWebPreAggregatedReplacingMergeTree(ClickhouseTestMixin, APIBaseTest):
-    """Test the new ReplacingMergeTree implementation for web analytics pre-aggregated tables"""
+    TEST_TABLE_STATS = "test_web_stats_daily"
+    TEST_TABLE_BOUNCES = "test_web_bounces_daily"
+    TEST_DATE_START = "2023-01-01"
+    TEST_DATE_END = "2023-01-02"
+    TEST_TEAM_IDS = [1]
 
-    def test_web_stats_table_creation_with_replacing_merge_tree(self):
-        table_sql = WEB_STATS_DAILY_SQL(table_name="test_web_stats_daily", on_cluster=False)
+    REPLACING_MERGE_TREE_PATTERNS = [
+        "ReplacingMergeTree",
+        "updated_at DateTime64(6, 'UTC') DEFAULT now()",
+    ]
 
-        assert "ReplacingMergeTree" in table_sql
-        assert "updated_at" in table_sql
-        assert "updated_at DateTime64(6, 'UTC') DEFAULT now()" in table_sql
+    AGGREGATE_FUNCTION_PATTERNS = {
+        "persons_uniq_state": "AggregateFunction(uniq, UUID)",
+        "sessions_uniq_state": "AggregateFunction(uniq, String)",
+        "pageviews_count_state": "AggregateFunction(sum, UInt64)",
+        "bounces_count_state": "AggregateFunction(sum, UInt64)",
+        "total_session_duration_state": "AggregateFunction(sum, Int64)",
+        "total_session_count_state": "AggregateFunction(sum, UInt64)",
+    }
 
-        assert "AggregatingMergeTree" not in table_sql
+    def _assert_sql_contains_patterns(self, sql: str, patterns: list[str], should_contain: bool = True):
+        for pattern in patterns:
+            if should_contain:
+                assert pattern in sql, f"Expected '{pattern}' in SQL"
+            else:
+                assert pattern not in sql, f"Did not expect '{pattern}' in SQL"
 
-    def test_web_bounces_table_creation_with_replacing_merge_tree(self):
-        table_sql = WEB_BOUNCES_DAILY_SQL(table_name="test_web_bounces_daily", on_cluster=False)
+    def _assert_sql_contains_aggregate_functions(self, sql: str, function_names: list[str]):
+        for func_name in function_names:
+            expected_pattern = f"{func_name} {self.AGGREGATE_FUNCTION_PATTERNS[func_name]}"
+            assert expected_pattern in sql, f"Expected aggregate function '{expected_pattern}' in SQL"
 
-        assert "ReplacingMergeTree" in table_sql
-        assert "updated_at" in table_sql
-        assert "updated_at DateTime64(6, 'UTC') DEFAULT now()" in table_sql
+    def _get_web_stats_sql(self, table_name: str | None = None) -> str:
+        return WEB_STATS_DAILY_SQL(table_name=table_name or self.TEST_TABLE_STATS, on_cluster=False)
 
-        assert "AggregatingMergeTree" not in table_sql
+    def _get_web_bounces_sql(self, table_name: str | None = None) -> str:
+        return WEB_BOUNCES_DAILY_SQL(table_name=table_name or self.TEST_TABLE_BOUNCES, on_cluster=False)
 
-    def test_web_bounces_columns_with_aggregate_functions(self):
-        table_sql = WEB_BOUNCES_DAILY_SQL(table_name="test_web_bounces_daily", on_cluster=False)
+    @parameterized.expand(
+        [
+            ("web_stats", _get_web_stats_sql),
+            ("web_bounces", _get_web_bounces_sql),
+        ]
+    )
+    def test_table_creation_uses_replacing_merge_tree(self, table_type: str, sql_generator):
+        table_sql = sql_generator(self)
 
-        assert "persons_uniq_state AggregateFunction(uniq, UUID)" in table_sql
-        assert "sessions_uniq_state AggregateFunction(uniq, String)" in table_sql
-        assert "pageviews_count_state AggregateFunction(sum, UInt64)" in table_sql
-        assert "bounces_count_state AggregateFunction(sum, UInt64)" in table_sql
-        assert "total_session_duration_state AggregateFunction(sum, Int64)" in table_sql
+        self._assert_sql_contains_patterns(table_sql, self.REPLACING_MERGE_TREE_PATTERNS)
+        self._assert_sql_contains_patterns(table_sql, ["AggregatingMergeTree"], should_contain=False)
 
-    def test_web_stats_insert_sql_uses_state_functions(self):
-        insert_sql = WEB_STATS_INSERT_SQL(
-            date_start="2023-01-01", date_end="2023-01-02", team_ids=[1], table_name="test_web_stats_daily"
-        )
+    def test_web_bounces_has_required_aggregate_functions(self):
+        table_sql = self._get_web_bounces_sql()
 
-        assert "uniqState(assumeNotNull(session_person_id)) AS persons_uniq_state" in insert_sql
-        assert "uniqState(assumeNotNull(session_id)) AS sessions_uniq_state" in insert_sql
-        assert "sumState(pageview_count) AS pageviews_count_state" in insert_sql
-        assert "now() AS updated_at" in insert_sql
+        bounces_specific_functions = [
+            "persons_uniq_state",
+            "sessions_uniq_state",
+            "pageviews_count_state",
+            "bounces_count_state",
+            "total_session_duration_state",
+            "total_session_count_state",
+        ]
 
-        assert "uniq(assumeNotNull(session_person_id)) AS persons_uniq" not in insert_sql
-        assert "uniq(assumeNotNull(session_id)) AS sessions_uniq" not in insert_sql
-        assert "sum(pageview_count) AS pageviews_count" not in insert_sql
-
-    def test_web_bounces_insert_sql_uses_state_functions(self):
-        insert_sql = WEB_BOUNCES_INSERT_SQL(
-            date_start="2023-01-01", date_end="2023-01-02", team_ids=[1], table_name="test_web_bounces_daily"
-        )
-
-        assert "uniqState(assumeNotNull(person_id)) AS persons_uniq_state" in insert_sql
-        assert "uniqState(assumeNotNull(session_id)) AS sessions_uniq_state" in insert_sql
-        assert "sumState(pageview_count) AS pageviews_count_state" in insert_sql
-        assert "sumState(toUInt64(ifNull(is_bounce, 0))) AS bounces_count_state" in insert_sql
-        assert "sumState(session_duration) AS total_session_duration_state" in insert_sql
-        assert "now() AS updated_at" in insert_sql
-
-    def test_distributed_tables_creation(self):
-        stats_dist_sql = DISTRIBUTED_WEB_STATS_DAILY_SQL()
-        bounces_dist_sql = DISTRIBUTED_WEB_BOUNCES_DAILY_SQL()
-
-        assert "persons_uniq_state AggregateFunction(uniq, UUID)" in stats_dist_sql
-        assert "sessions_uniq_state AggregateFunction(uniq, String)" in stats_dist_sql
-        assert "pageviews_count_state AggregateFunction(sum, UInt64)" in stats_dist_sql
-        assert "updated_at DateTime64(6, 'UTC') DEFAULT now()" in stats_dist_sql
-
-        assert "bounces_count_state AggregateFunction(sum, UInt64)" in bounces_dist_sql
-        assert "total_session_duration_state AggregateFunction(sum, Int64)" in bounces_dist_sql
-        assert "updated_at DateTime64(6, 'UTC') DEFAULT now()" in bounces_dist_sql
+        self._assert_sql_contains_aggregate_functions(table_sql, bounces_specific_functions)
 
     @patch("posthog.clickhouse.client.sync_execute")
-    def test_table_creation_with_final_keyword_in_queries(self, mock_sync_execute):
-        query = WebOverviewQuery(dateRange=DateRange(date_from="2023-01-01", date_to="2023-01-31"), properties=[])
+    def test_queries_use_final_keyword(self, mock_sync_execute):
+        query = WebOverviewQuery(
+            dateRange=DateRange(date_from=self.TEST_DATE_START, date_to="2023-01-31"), properties=[]
+        )
         runner = WebOverviewQueryRunner(team=self.team, query=query)
         builder = WebOverviewPreAggregatedQueryBuilder(runner)
 
         hogql_query = builder.get_query()
-
         context = HogQLContext(team_id=self.team.pk, enable_select_queries=True)
         sql = print_ast(hogql_query, context=context, dialect="clickhouse")
 
@@ -103,10 +97,3 @@ class TestWebPreAggregatedReplacingMergeTree(ClickhouseTestMixin, APIBaseTest):
         assert "updated_at" in table_sql
 
         assert "updated_at DateTime64(6, 'UTC') DEFAULT now()" in table_sql
-
-    def test_insert_sql_includes_updated_at_timestamp(self):
-        insert_sql = WEB_STATS_INSERT_SQL(
-            date_start="2023-01-01", date_end="2023-01-02", team_ids=[1], table_name="test_web_stats_daily"
-        )
-
-        assert "now() AS updated_at" in insert_sql


### PR DESCRIPTION
## Changes

This PR utilizes our new hourly tables to easily combine historical and current day's data, relying on a regular `VIEW` to accomplish this instead of the approach in https://github.com/PostHog/posthog/pull/32985, which uses the existing queries to do so. 

The reason for doing that is that we will have those intra-day hourly tables anyway for other purposes, and although they may not be the freshest data, we can improve upon that now that we have all the moving pieces in place.

- Changed all tables to use `period_bucket` as this makes our queries easier
- Worked around a `Session Duration` bug using weighted averages, which is not really a definitive fix, but should be better to keep as a known issue than the option before
- Moved the existing DAGs around to keep them under the same `web_analytics` group as we now have more crossed dependencies.

<img width="619" alt="Screenshot 2025-06-04 at 01 29 50" src="https://github.com/user-attachments/assets/ac75e0ac-021f-4f94-9d1f-c0e2f77ce930" />

<img width="1399" alt="image" src="https://github.com/user-attachments/assets/073635e9-09ca-4766-a890-6765da8913bb" />


## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Manually and some production clickhouse tests