### PR TITLE
fix(project-tree): clickable pinned dashboards

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/menus/DashboardsMenu.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/menus/DashboardsMenu.tsx
@@ -1,5 +1,6 @@
 import { IconPinFilled } from '@posthog/icons'
 import { useValues } from 'kea'
+import { router } from 'kea-router'
 import { Link } from 'lib/lemon-ui/Link'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { DropdownMenuItem } from 'lib/ui/DropdownMenu/DropdownMenu'
@@ -24,6 +25,10 @@ export function DashboardsMenu({ MenuItem = DropdownMenuItem }: CustomMenuProps)
                                 menuItem: true,
                             }}
                             to={urls.dashboard(dashboard.id)}
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                router.actions.push(urls.dashboard(dashboard.id))
+                            }}
                             onKeyDown={(e) => {
                                 if (e.key === 'Enter' || e.key === ' ') {
                                     // small delay to fight dropdown menu from taking focus


### PR DESCRIPTION
## Problem

Clicking pinned dashboard items opens the dashboards index.

## Changes

No longer:

![2025-06-04 09 42 38](https://github.com/user-attachments/assets/d59fd588-c7a6-479f-800a-3914c3d79c14)

If it feels like a hacky quick fix... then that's because it is :D

## How did you test this code?

👀 