### PR TITLE
fix(project-tree): save to feedback

### DIFF
--- a/frontend/src/lib/components/MoveTo/MoveTo.tsx
+++ b/frontend/src/lib/components/MoveTo/MoveTo.tsx
@@ -7,11 +7,15 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
 
+import { splitPath } from '~/layout/panel-layout/ProjectTree/utils'
+
 export function MoveToModal(): JSX.Element {
     const { isOpen, form, movingItems } = useValues(moveToLogic)
     const { closeMoveToModal, submitForm } = useActions(moveToLogic)
 
     const destinationFolder = form.folder || 'Project root'
+    const allFolders = splitPath(destinationFolder)
+    const lastFolder = allFolders[allFolders.length - 1]
 
     return (
         <LemonModal
@@ -31,8 +35,13 @@ export function MoveToModal(): JSX.Element {
             footer={
                 <>
                     <div className="flex-1" />
-                    <LemonButton type="primary" onClick={submitForm} data-attr="move-to-modal-move-button">
-                        Move to {destinationFolder}
+                    <LemonButton
+                        type="primary"
+                        onClick={submitForm}
+                        data-attr="move-to-modal-move-button"
+                        disabledReason={typeof lastFolder !== 'string' ? 'Please select a folder' : undefined}
+                    >
+                        Move to {lastFolder}
                     </LemonButton>
                 </>
             }

--- a/frontend/src/lib/components/SaveTo/SaveTo.tsx
+++ b/frontend/src/lib/components/SaveTo/SaveTo.tsx
@@ -50,6 +50,7 @@ export function SaveToModal(): JSX.Element {
                                 ))}
                             </>
                         }
+                        data-attr="save-to-modal-save-button"
                         disabledReason={typeof lastFolder !== 'string' ? 'Please select a folder' : undefined}
                     >
                         Save to {lastFolder || 'folder'}

--- a/frontend/src/lib/components/SaveTo/SaveTo.tsx
+++ b/frontend/src/lib/components/SaveTo/SaveTo.tsx
@@ -5,6 +5,7 @@ import { saveToLogic } from 'lib/components/SaveTo/saveToLogic'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
+import { LemonSnack } from 'lib/lemon-ui/LemonSnack'
 
 import { splitPath } from '~/layout/panel-layout/ProjectTree/utils'
 
@@ -12,16 +13,23 @@ export function SaveToModal(): JSX.Element {
     const { isOpen, form, isFeatureEnabled } = useValues(saveToLogic)
     const { closeSaveToModal, submitForm } = useActions(saveToLogic)
     const allFolders = splitPath(form.folder || '')
+    const lastFolder = form.folder === '' ? 'Project root' : allFolders[allFolders.length - 1]
 
     if (!isFeatureEnabled) {
         return <></>
     }
+    const destinationFolder = form.folder || 'Project root'
 
     return (
         <LemonModal
             onClose={closeSaveToModal}
             isOpen={isOpen}
             title="Select a folder to save to"
+            description={
+                <>
+                    Saving to: <LemonSnack>{destinationFolder}</LemonSnack>`
+                </>
+            }
             // This is a bit of a hack. Without it, the flow "insight" -> "add to dashboard button" ->
             // "new dashboard template picker modal" -> "save dashboard to modal" wouldn't work.
             // Since SaveToModal is added to the DOM earlier as part of global modals, it's below it in hierarchy.
@@ -42,8 +50,9 @@ export function SaveToModal(): JSX.Element {
                                 ))}
                             </>
                         }
+                        disabledReason={typeof lastFolder !== 'string' ? 'Please select a folder' : undefined}
                     >
-                        Save
+                        Save to {lastFolder || 'folder'}
                     </LemonButton>
                 </>
             }


### PR DESCRIPTION
## Problem

The "Save To" modal gave zero feedback if you had selected anything other than a light gray background over the item.

## Changes

Make it more obvious, copying the elements from the "Move to" modal:

![2025-06-04 09 53 01](https://github.com/user-attachments/assets/45df4f0a-5aba-495f-b0f9-ded6807b1c4b)

## How did you test this code?

👀 