### PR TITLE
fix(project-tree): add flag for revenue analytics and campaigns

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -559,6 +559,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         href: urls.revenueAnalytics(),
         visualOrder: PRODUCT_VISUAL_ORDER.revenueAnalytics,
         tags: ['beta'],
+        flag: FEATURE_FLAGS.REVENUE_ANALYTICS,
     },
     {
         path: 'Session replay',
@@ -589,5 +590,10 @@ export const getTreeItemsGames = (): FileSystemImport[] => [{ path: '368 Hedgeho
 /** This const is auto-generated, as is the whole file */
 export const getTreeItemsMetadata = (): FileSystemImport[] => [
     { path: 'Actions', iconType: 'rocket', href: urls.actions() },
-    { path: 'Revenue settings', iconType: 'handMoney', href: urls.revenueSettings() },
+    {
+        path: 'Revenue settings',
+        iconType: 'handMoney',
+        href: urls.revenueSettings(),
+        flag: FEATURE_FLAGS.REVENUE_ANALYTICS,
+    },
 ]

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -364,7 +364,7 @@ export const fileSystemTypes = {
         href: (ref: string) => urls.messagingCampaign(ref),
         iconColor: ['var(--product-messaging-light)'],
         filterKey: 'campaign',
-        flag: FEATURE_FLAGS.MESSAGING_AUTOMATION,
+        flag: FEATURE_FLAGS.MESSAGING,
     },
     insight: {
         name: 'Insight',
@@ -425,7 +425,7 @@ export const getTreeItemsNew = (): FileSystemImport[] => [
         path: `Campaign`,
         type: 'hog_function/campaign',
         href: urls.messagingCampaignNew(),
-        flag: FEATURE_FLAGS.MESSAGING_AUTOMATION,
+        flag: FEATURE_FLAGS.MESSAGING,
     },
     { path: `Cohort`, type: 'cohort', href: urls.cohort('new') },
     { path: `Dashboard`, type: 'dashboard', href: urls.dashboards() + '#newDashboard=modal' },
@@ -503,7 +503,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         type: 'hog_function/campaign',
         visualOrder: PRODUCT_VISUAL_ORDER.messaging,
         tags: ['alpha'],
-        flag: FEATURE_FLAGS.MESSAGING_AUTOMATION,
+        flag: FEATURE_FLAGS.MESSAGING,
     },
     {
         path: 'Early access features',

--- a/products/messaging/manifest.tsx
+++ b/products/messaging/manifest.tsx
@@ -76,7 +76,7 @@ export const manifest: ProductManifest = {
             href: (ref: string) => urls.messagingCampaign(ref),
             iconColor: ['var(--product-messaging-light)'],
             filterKey: 'campaign',
-            flag: FEATURE_FLAGS.MESSAGING_AUTOMATION,
+            flag: FEATURE_FLAGS.MESSAGING,
         },
     },
     treeItemsNew: [
@@ -90,7 +90,7 @@ export const manifest: ProductManifest = {
             path: `Campaign`,
             type: 'hog_function/campaign',
             href: urls.messagingCampaignNew(),
-            flag: FEATURE_FLAGS.MESSAGING_AUTOMATION,
+            flag: FEATURE_FLAGS.MESSAGING,
         },
     ],
     treeItemsProducts: [
@@ -108,7 +108,7 @@ export const manifest: ProductManifest = {
             type: 'hog_function/campaign',
             visualOrder: PRODUCT_VISUAL_ORDER.messaging,
             tags: ['alpha'],
-            flag: FEATURE_FLAGS.MESSAGING_AUTOMATION,
+            flag: FEATURE_FLAGS.MESSAGING,
         },
     ],
 }

--- a/products/revenue_analytics/manifest.tsx
+++ b/products/revenue_analytics/manifest.tsx
@@ -1,4 +1,4 @@
-import { PRODUCT_VISUAL_ORDER } from 'lib/constants'
+import { FEATURE_FLAGS, PRODUCT_VISUAL_ORDER } from 'lib/constants'
 import { urls } from 'scenes/urls'
 
 import { ProductManifest } from '~/types'
@@ -27,6 +27,7 @@ export const manifest: ProductManifest = {
             href: urls.revenueAnalytics(),
             visualOrder: PRODUCT_VISUAL_ORDER.revenueAnalytics,
             tags: ['beta'],
+            flag: FEATURE_FLAGS.REVENUE_ANALYTICS,
         },
     ],
     treeItemsMetadata: [
@@ -34,6 +35,7 @@ export const manifest: ProductManifest = {
             path: 'Revenue settings',
             iconType: 'handMoney',
             href: urls.revenueSettings(),
+            flag: FEATURE_FLAGS.REVENUE_ANALYTICS,
         },
     ],
 }


### PR DESCRIPTION
## Problem

- The revenue analytics beta showed up even if you didn't enroll.
- The campaigns link showed up whether you had enrolled into messaging or not

## Changes

Adds a flag for the tree item.

## How did you test this code?

🤷 