### PR TITLE
fix(google-ads-dwh): Add underscore to builtin type when traversing

### DIFF
--- a/posthog/temporal/data_imports/pipelines/google_ads/source.py
+++ b/posthog/temporal/data_imports/pipelines/google_ads/source.py
@@ -175,8 +175,10 @@ def _traverse_attributes(thing: typing.Any, *path: str):
     current = thing
 
     for component in path:
-        current = getattr(current, component)
+        if component == "type":
+            component += "_"
 
+        current = getattr(current, component)
     return current
 
 


### PR DESCRIPTION
## Problem

It seems google ads adds underscores to fields that match builtins.

## Changes

Haven't seen it impact anything else other than "type" so this is just
a quick fix for that by adding the underscore in the traversal function.