### PR TITLE
feat(experiments): add experiment-level stats method switcher

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -283,6 +283,7 @@ export const FEATURE_FLAGS = {
     ACTIVITY_OR_EXPLORE: 'activity-or-explore', // owner: @pauldambra #team-replay
     EXPERIMENTS_NEW_QUERY_RUNNER_FOR_USERS_ON_FREE_PLAN: 'experiments-new-query-runner-for-users-on-free-plan', // owner: #team-experiments
     TRACK_MEMORY_USAGE: 'track-memory-usage', // owner: @pauldambra #team-replay
+    EXPERIMENTS_FREQUENTIST: 'experiments-frequentist', // owner: @jurajmajerik #team-experiments
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/experiments/ExperimentView/Info.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Info.tsx
@@ -1,4 +1,4 @@
-import { IconPencil, IconRefresh, IconWarning } from '@posthog/icons'
+import { IconGear, IconPencil, IconRefresh, IconWarning } from '@posthog/icons'
 import { LemonButton, Link, ProfilePicture, Tooltip } from '@posthog/lemon-ui'
 import { LemonModal } from '@posthog/lemon-ui'
 import clsx from 'clsx'
@@ -11,13 +11,14 @@ import { LemonTextArea } from 'lib/lemon-ui/LemonTextArea/LemonTextArea'
 import { useEffect, useState } from 'react'
 import { urls } from 'scenes/urls'
 
-import { ProgressStatus } from '~/types'
+import { ExperimentStatsMethod, ProgressStatus } from '~/types'
 
 import { CONCLUSION_DISPLAY_CONFIG } from '../constants'
 import { experimentLogic } from '../experimentLogic'
 import { getExperimentStatus } from '../experimentsLogic'
 import { StatusTag } from './components'
 import { ExperimentDates } from './ExperimentDates'
+import { StatsMethodModal } from './StatsMethodModal'
 
 export function Info(): JSX.Element {
     const {
@@ -27,6 +28,7 @@ export function Info(): JSX.Element {
         metricResultsLoading,
         secondaryMetricResultsLoading,
         isDescriptionModalOpen,
+        statsMethod,
     } = useValues(experimentLogic)
     const {
         updateExperiment,
@@ -35,6 +37,7 @@ export function Info(): JSX.Element {
         openDescriptionModal,
         closeDescriptionModal,
         openEditConclusionModal,
+        openStatsEngineModal,
     } = useActions(experimentLogic)
 
     const [tempDescription, setTempDescription] = useState(experiment.description || '')
@@ -99,7 +102,23 @@ export function Info(): JSX.Element {
                         <div className="text-xs font-semibold uppercase tracking-wide">
                             <span>Stats Engine</span>
                         </div>
-                        <div className="flex gap-1">Bayesian</div>
+                        <div className="inline-flex deprecated-space-x-2">
+                            <span>{statsMethod === ExperimentStatsMethod.Bayesian ? 'Bayesian' : 'Frequentist'}</span>
+                            {featureFlags[FEATURE_FLAGS.EXPERIMENTS_FREQUENTIST] && (
+                                <>
+                                    <LemonButton
+                                        type="secondary"
+                                        size="xsmall"
+                                        onClick={() => {
+                                            openStatsEngineModal()
+                                        }}
+                                        icon={<IconGear />}
+                                        tooltip="Change stats engine"
+                                    />
+                                    <StatsMethodModal />
+                                </>
+                            )}
+                        </div>
                     </div>
                     {featureFlags[FEATURE_FLAGS.EXPERIMENT_STATS_V2] && (
                         <div className="block">

--- a/frontend/src/scenes/experiments/ExperimentView/StatsMethodModal.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/StatsMethodModal.tsx
@@ -1,0 +1,99 @@
+import { IconCheckCircle } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+import { LemonModal } from '@posthog/lemon-ui'
+import { useActions, useValues } from 'kea'
+
+import { ExperimentStatsMethod } from '~/types'
+
+import { experimentLogic } from '../experimentLogic'
+
+export function StatsMethodModal(): JSX.Element {
+    const { experiment, isStatsEngineModalOpen, statsMethod } = useValues(experimentLogic)
+    const { updateExperiment, closeStatsEngineModal, setExperiment, restoreUnmodifiedExperiment } =
+        useActions(experimentLogic)
+
+    const onClose = (): void => {
+        restoreUnmodifiedExperiment()
+        closeStatsEngineModal()
+    }
+
+    return (
+        <LemonModal
+            maxWidth={600}
+            isOpen={isStatsEngineModalOpen}
+            onClose={onClose}
+            title="Change stats engine"
+            footer={
+                <div className="flex items-center gap-2 justify-end">
+                    <LemonButton type="secondary" onClick={onClose}>
+                        Cancel
+                    </LemonButton>
+                    <LemonButton
+                        type="primary"
+                        onClick={() => {
+                            updateExperiment({ stats_config: experiment.stats_config })
+                            closeStatsEngineModal()
+                        }}
+                    >
+                        Save
+                    </LemonButton>
+                </div>
+            }
+        >
+            <div className="flex gap-4 mb-4">
+                <LemonButton
+                    className={`trends-metric-form__exposure-button flex-1 cursor-pointer p-4 rounded border ${
+                        statsMethod === ExperimentStatsMethod.Bayesian
+                            ? 'border-accent bg-accent-highlight-secondary'
+                            : 'border-primary'
+                    }`}
+                    onClick={() => {
+                        setExperiment({
+                            stats_config: {
+                                ...experiment.stats_config,
+                                method: ExperimentStatsMethod.Bayesian,
+                            },
+                        })
+                    }}
+                >
+                    <div className="font-semibold flex justify-between items-center">
+                        <span>Bayesian</span>
+                        {statsMethod === ExperimentStatsMethod.Bayesian && (
+                            <IconCheckCircle fontSize={18} color="var(--accent)" />
+                        )}
+                    </div>
+                    <div className="text-secondary text-sm leading-relaxed mt-1">
+                        This approach gives you a probability-based view of results, showing how likely one variant is
+                        to be better than another, based on the observed data.
+                    </div>
+                </LemonButton>
+                <LemonButton
+                    className={`trends-metric-form__exposure-button flex-1 cursor-pointer p-4 rounded border ${
+                        statsMethod === ExperimentStatsMethod.Frequentist
+                            ? 'border-accent bg-accent-highlight-secondary'
+                            : 'border-primary'
+                    }`}
+                    onClick={() => {
+                        setExperiment({
+                            stats_config: {
+                                ...experiment.stats_config,
+                                method: ExperimentStatsMethod.Frequentist,
+                            },
+                        })
+                    }}
+                >
+                    <div className="font-semibold flex justify-between items-center">
+                        <span>Frequentist</span>
+                        {statsMethod === ExperimentStatsMethod.Frequentist && (
+                            <IconCheckCircle fontSize={18} color="var(--accent)" />
+                        )}
+                    </div>
+                    <div className="text-secondary text-sm leading-relaxed mt-1">
+                        This approach uses statistical tests to determine whether observed differences are significant.
+                        It's based on p-values and is widely used in traditional A/B testing and scientific research.
+                    </div>
+                </LemonButton>
+            </div>
+        </LemonModal>
+    )
+}

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -55,6 +55,7 @@ import {
     CountPerActorMathType,
     DashboardType,
     Experiment,
+    ExperimentStatsMethod,
     FeatureFlagType,
     FunnelExperimentVariant,
     InsightType,
@@ -307,6 +308,8 @@ export const experimentLogic = kea<experimentLogicType>([
         closeReleaseConditionsModal: true,
         openDescriptionModal: true,
         closeDescriptionModal: true,
+        openStatsEngineModal: true,
+        closeStatsEngineModal: true,
         updateExperimentVariantImages: (variantPreviewMediaIds: Record<string, string[]>) => ({
             variantPreviewMediaIds,
         }),
@@ -842,6 +845,13 @@ export const experimentLogic = kea<experimentLogicType>([
             {
                 openDescriptionModal: () => true,
                 closeDescriptionModal: () => false,
+            },
+        ],
+        isStatsEngineModalOpen: [
+            false,
+            {
+                openStatsEngineModal: () => true,
+                closeStatsEngineModal: () => false,
             },
         ],
     }),
@@ -1966,6 +1976,12 @@ export const experimentLogic = kea<experimentLogicType>([
             (s) => [s.experiment],
             (experiment: Experiment): ExperimentExposureCriteria | undefined => {
                 return experiment.exposure_criteria
+            },
+        ],
+        statsMethod: [
+            (s) => [s.experiment],
+            (experiment: Experiment): ExperimentStatsMethod => {
+                return experiment.stats_config?.method || ExperimentStatsMethod.Bayesian
             },
         ],
     }),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3625,6 +3625,11 @@ export interface ExperimentHoldoutType {
     updated_at: string | null
 }
 
+export enum ExperimentStatsMethod {
+    Bayesian = 'bayesian',
+    Frequentist = 'frequentist',
+}
+
 export interface Experiment {
     id: ExperimentIdType
     name: string
@@ -3671,6 +3676,7 @@ export interface Experiment {
     holdout?: ExperimentHoldoutType
     stats_config?: {
         version?: number
+        method?: ExperimentStatsMethod
     }
     _create_in_folder?: string | null
     conclusion?: ExperimentConclusion | null


### PR DESCRIPTION
Feature flag: `experiments-frequentist`

## Changes
Add an experiment-level switcher of the stats method.

![image](https://github.com/user-attachments/assets/82ab0ab1-302d-4075-9664-7b9f9d03e60f)

![image](https://github.com/user-attachments/assets/293c4287-3da2-4a0b-ace2-52ebec0660eb)

## How did you test this code?
👀 