### PR TITLE
fix: blob v2 list cache

### DIFF
--- a/posthog/session_recordings/session_recording_v2_service.py
+++ b/posthog/session_recordings/session_recording_v2_service.py
@@ -30,7 +30,7 @@ def listing_cache_key(recording: SessionRecording) -> str | None:
     try:
         # NB this has to be `team_id` and not `team.id` as it's called in an async context
         # and `team.id` can trigger a database query, and the Django ORM is synchronous
-        return f"@posthog/v2-blob-snapshots/recording_block_listing_{recording.team_id}_{recording.session_id}"
+        return f"@posthog/v2-blob-snapshots/v1/recording_block_listing_{recording.team_id}_{recording.session_id}"
     except Exception as e:
         posthoganalytics.capture_exception(
             e,

--- a/posthog/session_recordings/session_recording_v2_service.py
+++ b/posthog/session_recordings/session_recording_v2_service.py
@@ -82,6 +82,8 @@ def load_blocks(recording: SessionRecording) -> RecordingBlockListing | None:
             is_within_the_last_day=within_the_last_day(recording.start_time),
             now=datetime.now(),
             number_of_blocks=len(listed_blocks.block_urls) if listed_blocks else 0,
+            team_id=recording.team_id,
+            session_id=recording.session_id,
         )
         # KLUDGE: i want to be able to cache for longer but believe i'm seeing incorrect caching behaviour
         # so i'm setting it to alway be 5 seconds for now, and adding a log to see if the 24 hour cache is incorrect

--- a/posthog/session_recordings/test/test_session_recording_v2_service.py
+++ b/posthog/session_recordings/test/test_session_recording_v2_service.py
@@ -10,7 +10,6 @@ from posthog.session_recordings.session_recording_v2_service import (
     list_blocks,
     load_blocks,
     FIVE_SECONDS,
-    ONE_DAY_IN_SECONDS,
     listing_cache_key,
 )
 
@@ -160,7 +159,8 @@ class TestSessionRecordingV2Service(TestCase):
 
         self.assertEqual(result, mock_blocks)
         expected_cache_key = listing_cache_key(self.recording)
-        mock_cache.set.assert_called_once_with(expected_cache_key, mock_blocks, timeout=ONE_DAY_IN_SECONDS)
+        # cache is forced to 5 seconds always
+        mock_cache.set.assert_called_once_with(expected_cache_key, mock_blocks, timeout=FIVE_SECONDS)
 
     @freeze_time("2024-01-01T12:00:00Z")
     @patch("posthog.session_recordings.session_recording_v2_service.cache")


### PR DESCRIPTION
@marandaneto and a support ticket have said they get endlessly buffering replay

see: https://posthoghelp.zendesk.com/agent/tickets/31919 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/33444)

we recently added a cache on top of the CH query in the listing

that's the most likely cause of the bug

let's reduce the cache
and added a little metrics / logging