### PR TITLE
fix(project-tree): remove button highlight if aria-selected

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -940,9 +940,11 @@ const LemonTree = forwardRef<LemonTreeRef, LemonTreeProps>(
                     item.onClick(willBeOpen)
                 }
 
-                setSelectedId(item?.id)
+                if (selectMode === 'folder-only') {
+                    setSelectedId(item?.id)
+                }
             },
-            [expandedItemIdsState, onFolderClick, onItemClick, focusContent]
+            [expandedItemIdsState, onFolderClick, onItemClick, focusContent, selectMode]
         )
 
         /** Focus the element from the tree item ID. */

--- a/frontend/src/lib/ui/Button/ButtonPrimitives.scss
+++ b/frontend/src/lib/ui/Button/ButtonPrimitives.scss
@@ -40,7 +40,6 @@
         &[data-current='true'],
         &[data-state='open'],
         &[data-state='checked'],
-        &[aria-selected='true'],
         &[data-highlighted],
         &.button-primitive--active {
             background-color: var(--bg-fill-button-tertiary-active);


### PR DESCRIPTION

## Problem
In lemon tree we set aria-selected=true if selectedID is true, this state is kept on navigation and therefor was confusing to users having a what looked "active" state for a route, when it was indeed just because it was clicked.

## Changes
Remove button background styling for button primitive, in the tree only set selected ID on folder select mode

## How did you test this code?
Manually, removed it and tested the component mentioned in it's originally added PR, all good.