### PR TITLE
chore: allow downloading just rrweb snapshots

### DIFF
--- a/frontend/src/scenes/session-recordings/file-playback/types.ts
+++ b/frontend/src/scenes/session-recordings/file-playback/types.ts
@@ -10,6 +10,8 @@ export type ExportedSessionRecordingFileV1 = {
     }
 }
 
+export type ExportedSessionType = 'posthog' | 'rrweb'
+
 export type ExportedSessionRecordingFileV2 = {
     version: '2023-04-28'
     data: {

--- a/frontend/src/scenes/session-recordings/player/player-meta/PlayerMetaLinks.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/PlayerMetaLinks.tsx
@@ -166,11 +166,26 @@ const MenuActions = ({ size }: { size: PlayerMetaBreakpoints }): JSX.Element => 
     const items: LemonMenuItems = useMemo(() => {
         const itemsArray: LemonMenuItems = [
             isStandardMode && {
-                label: '.json',
-                status: 'default',
-                icon: <IconDownload />,
-                onClick: exportRecordingToFile,
-                tooltip: 'Export recording to a JSON file. This can be loaded later into PostHog for playback.',
+                title: 'Export',
+                key: 'export',
+                items: [
+                    {
+                        label: 'posthog .json',
+                        status: 'default',
+                        icon: <IconDownload />,
+                        onClick: () => exportRecordingToFile('posthog'),
+                        tooltip:
+                            'Export PostHog recording data to a JSON file. This can be loaded later into PostHog for playback.',
+                    },
+                    {
+                        label: 'rrweb .json',
+                        status: 'default',
+                        icon: <IconDownload />,
+                        onClick: () => exportRecordingToFile('rrweb'),
+                        tooltip:
+                            'Export rrweb snapshots to a JSON file. This can be played in rrweb compatible players like rrwebdebug.com.',
+                    },
+                ],
             },
         ]
         if (size === 'small') {

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -931,15 +931,19 @@ LIMIT 1000000
 
         createExportJSON: [
             (s) => [s.sessionPlayerMetaData, s.snapshots],
-            (sessionPlayerMetaData, snapshots): (() => ExportedSessionRecordingFileV2) => {
-                return () => ({
-                    version: '2023-04-28',
-                    data: {
-                        id: sessionPlayerMetaData?.id ?? '',
-                        person: sessionPlayerMetaData?.person,
-                        snapshots: snapshots,
-                    },
-                })
+            (sessionPlayerMetaData, snapshots): (() => ExportedSessionRecordingFileV2 | RecordingSnapshot[]) => {
+                return (type?: 'posthog' | 'rrweb') => {
+                    return type === 'rrweb'
+                        ? snapshots
+                        : {
+                              version: '2023-04-28',
+                              data: {
+                                  id: sessionPlayerMetaData?.id ?? '',
+                                  person: sessionPlayerMetaData?.person,
+                                  snapshots: snapshots,
+                              },
+                          }
+                }
             },
         ],
 

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -33,7 +33,7 @@ import {
     SnapshotSourceType,
 } from '~/types'
 
-import { ExportedSessionRecordingFileV2 } from '../file-playback/types'
+import { ExportedSessionRecordingFileV2, ExportedSessionType } from '../file-playback/types'
 import { sessionRecordingEventUsageLogic } from '../sessionRecordingEventUsageLogic'
 import type { sessionRecordingDataLogicType } from './sessionRecordingDataLogicType'
 import { getHrefFromSnapshot, ViewportResolution } from './snapshot-processing/patch-meta-event'
@@ -931,8 +931,11 @@ LIMIT 1000000
 
         createExportJSON: [
             (s) => [s.sessionPlayerMetaData, s.snapshots],
-            (sessionPlayerMetaData, snapshots): (() => ExportedSessionRecordingFileV2 | RecordingSnapshot[]) => {
-                return (type?: 'posthog' | 'rrweb') => {
+            (
+                sessionPlayerMetaData,
+                snapshots
+            ): ((type?: ExportedSessionType) => ExportedSessionRecordingFileV2 | RecordingSnapshot[]) => {
+                return (type?: ExportedSessionType) => {
                     return type === 'rrweb'
                         ? snapshots
                         : {

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -30,6 +30,7 @@ import { RefObject } from 'react'
 import { openBillingPopupModal } from 'scenes/billing/BillingPopup'
 import { ReplayIframeData } from 'scenes/heatmaps/heatmapsBrowserLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+import { ExportedSessionType } from 'scenes/session-recordings/file-playback/types'
 import {
     sessionRecordingDataLogic,
     SessionRecordingDataLogicProps,
@@ -241,7 +242,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
         incrementErrorCount: true,
         incrementWarningCount: (count: number = 1) => ({ count }),
         syncSnapshotsWithPlayer: true,
-        exportRecordingToFile: (type?: 'posthog' | 'rrweb') => ({ type }),
+        exportRecordingToFile: (type?: ExportedSessionType) => ({ type }),
         deleteRecording: true,
         openExplorer: true,
         takeScreenshot: true,

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -241,7 +241,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
         incrementErrorCount: true,
         incrementWarningCount: (count: number = 1) => ({ count }),
         syncSnapshotsWithPlayer: true,
-        exportRecordingToFile: true,
+        exportRecordingToFile: (type?: 'posthog' | 'rrweb') => ({ type }),
         deleteRecording: true,
         openExplorer: true,
         takeScreenshot: true,
@@ -1218,7 +1218,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             cache.pausedMediaElements = []
         },
 
-        exportRecordingToFile: async () => {
+        exportRecordingToFile: async ({ type }) => {
             if (!values.sessionPlayerData) {
                 return
             }
@@ -1243,11 +1243,11 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                     await delay(delayTime)
                 }
 
-                const payload = values.createExportJSON()
-
+                const payload = values.createExportJSON(type)
+                const suffix = type === 'rrweb' ? 'rrweb-recording' : 'ph-recording'
                 const recordingFile = new File(
                     [JSON.stringify(payload, null, 2)],
-                    `export-${props.sessionRecordingId}-ph-recording.json`,
+                    `export-${props.sessionRecordingId}-${suffix}.json`,
                     { type: 'application/json' }
                 )
 


### PR DESCRIPTION
I'm adding a debug player for internal use... although there is already `rrwebdebug.com`

It means when I export a json file, i then need to edit it before playing

let's just allow rrweb snapshot exporting as well as "ph" data exporting

![Screenshot 2025-06-04 at 15 11 29](https://github.com/user-attachments/assets/922c8c62-93dd-4fb2-a2f3-842a30e545c5)
![Screenshot 2025-06-04 at 15 11 25](https://github.com/user-attachments/assets/4b78fc03-5c5a-4768-95cb-e123323d33c3)
