### PR TITLE
chore: add platform flag to organization admin

### DIFF
--- a/posthog/admin/admins/organization_admin.py
+++ b/posthog/admin/admins/organization_admin.py
@@ -42,6 +42,7 @@ class OrganizationAdmin(admin.ModelAdmin):
         "usage",
         "customer_trust_scores",
         "is_hipaa",
+        "is_platform",
     ]
     inlines = [ProjectInline, TeamInline, OrganizationMemberInline, OrganizationInviteInline]
     readonly_fields = [


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We want a flag to be able to toggle this in prod so we can test exclusions there, and also to toggle an org that did not get the default value.

## Changes

Make toggle available in admin model.

## How did you test this code?

Ran locally
