### PR TITLE
feat(experiments): fix cached response type

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -2856,113 +2856,256 @@
             "type": "object"
         },
         "CachedExperimentQueryResponse": {
-            "additionalProperties": false,
-            "properties": {
-                "cache_key": {
-                    "type": "string"
-                },
-                "cache_target_age": {
-                    "format": "date-time",
-                    "type": "string"
-                },
-                "calculation_trigger": {
-                    "description": "What triggered the calculation of the query, leave empty if user/immediate",
-                    "type": "string"
-                },
-                "credible_intervals": {
-                    "additionalProperties": {
-                        "items": {
+            "anyOf": [
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "cache_key": {
+                            "type": "string"
+                        },
+                        "cache_target_age": {
+                            "format": "date-time",
+                            "type": "string"
+                        },
+                        "calculation_trigger": {
+                            "description": "What triggered the calculation of the query, leave empty if user/immediate",
+                            "type": "string"
+                        },
+                        "credible_intervals": {
+                            "additionalProperties": {
+                                "items": {
+                                    "type": "number"
+                                },
+                                "maxItems": 2,
+                                "minItems": 2,
+                                "type": "array"
+                            },
+                            "type": "object"
+                        },
+                        "insight": {
+                            "items": {
+                                "type": "object"
+                            },
+                            "type": "array"
+                        },
+                        "is_cached": {
+                            "type": "boolean"
+                        },
+                        "kind": {
+                            "const": "ExperimentQuery",
+                            "type": "string"
+                        },
+                        "last_refresh": {
+                            "format": "date-time",
+                            "type": "string"
+                        },
+                        "metric": {
+                            "$ref": "#/definitions/ExperimentMetric"
+                        },
+                        "next_allowed_client_refresh": {
+                            "format": "date-time",
+                            "type": "string"
+                        },
+                        "p_value": {
                             "type": "number"
                         },
-                        "maxItems": 2,
-                        "minItems": 2,
-                        "type": "array"
+                        "probability": {
+                            "additionalProperties": {
+                                "type": "number"
+                            },
+                            "type": "object"
+                        },
+                        "query_status": {
+                            "$ref": "#/definitions/QueryStatus",
+                            "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "significance_code": {
+                            "$ref": "#/definitions/ExperimentSignificanceCode"
+                        },
+                        "significant": {
+                            "type": "boolean"
+                        },
+                        "stats_version": {
+                            "$ref": "#/definitions/integer"
+                        },
+                        "timezone": {
+                            "type": "string"
+                        },
+                        "variants": {
+                            "anyOf": [
+                                {
+                                    "items": {
+                                        "$ref": "#/definitions/ExperimentVariantTrendsBaseStats"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "items": {
+                                        "$ref": "#/definitions/ExperimentVariantFunnelsBaseStats"
+                                    },
+                                    "type": "array"
+                                }
+                            ]
+                        }
                     },
+                    "required": [
+                        "cache_key",
+                        "credible_intervals",
+                        "insight",
+                        "is_cached",
+                        "kind",
+                        "last_refresh",
+                        "metric",
+                        "next_allowed_client_refresh",
+                        "p_value",
+                        "probability",
+                        "significance_code",
+                        "significant",
+                        "timezone",
+                        "variants"
+                    ],
                     "type": "object"
                 },
-                "insight": {
-                    "items": {
-                        "type": "object"
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "cache_key": {
+                            "type": "string"
+                        },
+                        "cache_target_age": {
+                            "format": "date-time",
+                            "type": "string"
+                        },
+                        "calculation_trigger": {
+                            "description": "What triggered the calculation of the query, leave empty if user/immediate",
+                            "type": "string"
+                        },
+                        "conversion_window": {
+                            "$ref": "#/definitions/integer"
+                        },
+                        "conversion_window_unit": {
+                            "$ref": "#/definitions/FunnelConversionWindowTimeUnit"
+                        },
+                        "is_cached": {
+                            "type": "boolean"
+                        },
+                        "kind": {
+                            "const": "ExperimentMetric",
+                            "type": "string"
+                        },
+                        "last_refresh": {
+                            "format": "date-time",
+                            "type": "string"
+                        },
+                        "lower_bound_percentile": {
+                            "type": "number"
+                        },
+                        "metric_type": {
+                            "const": "mean",
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "next_allowed_client_refresh": {
+                            "format": "date-time",
+                            "type": "string"
+                        },
+                        "query_status": {
+                            "$ref": "#/definitions/QueryStatus",
+                            "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "source": {
+                            "$ref": "#/definitions/ExperimentMetricSource"
+                        },
+                        "timezone": {
+                            "type": "string"
+                        },
+                        "upper_bound_percentile": {
+                            "type": "number"
+                        }
                     },
-                    "type": "array"
-                },
-                "is_cached": {
-                    "type": "boolean"
-                },
-                "kind": {
-                    "const": "ExperimentQuery",
-                    "type": "string"
-                },
-                "last_refresh": {
-                    "format": "date-time",
-                    "type": "string"
-                },
-                "metric": {
-                    "$ref": "#/definitions/ExperimentMetric"
-                },
-                "next_allowed_client_refresh": {
-                    "format": "date-time",
-                    "type": "string"
-                },
-                "p_value": {
-                    "type": "number"
-                },
-                "probability": {
-                    "additionalProperties": {
-                        "type": "number"
-                    },
+                    "required": [
+                        "cache_key",
+                        "is_cached",
+                        "kind",
+                        "last_refresh",
+                        "metric_type",
+                        "next_allowed_client_refresh",
+                        "source",
+                        "timezone"
+                    ],
                     "type": "object"
                 },
-                "query_status": {
-                    "$ref": "#/definitions/QueryStatus",
-                    "description": "Query status indicates whether next to the provided data, a query is still running."
-                },
-                "significance_code": {
-                    "$ref": "#/definitions/ExperimentSignificanceCode"
-                },
-                "significant": {
-                    "type": "boolean"
-                },
-                "stats_version": {
-                    "$ref": "#/definitions/integer"
-                },
-                "timezone": {
-                    "type": "string"
-                },
-                "variants": {
-                    "anyOf": [
-                        {
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "cache_key": {
+                            "type": "string"
+                        },
+                        "cache_target_age": {
+                            "format": "date-time",
+                            "type": "string"
+                        },
+                        "calculation_trigger": {
+                            "description": "What triggered the calculation of the query, leave empty if user/immediate",
+                            "type": "string"
+                        },
+                        "conversion_window": {
+                            "$ref": "#/definitions/integer"
+                        },
+                        "conversion_window_unit": {
+                            "$ref": "#/definitions/FunnelConversionWindowTimeUnit"
+                        },
+                        "is_cached": {
+                            "type": "boolean"
+                        },
+                        "kind": {
+                            "const": "ExperimentMetric",
+                            "type": "string"
+                        },
+                        "last_refresh": {
+                            "format": "date-time",
+                            "type": "string"
+                        },
+                        "metric_type": {
+                            "const": "funnel",
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "next_allowed_client_refresh": {
+                            "format": "date-time",
+                            "type": "string"
+                        },
+                        "query_status": {
+                            "$ref": "#/definitions/QueryStatus",
+                            "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "series": {
                             "items": {
-                                "$ref": "#/definitions/ExperimentVariantTrendsBaseStats"
+                                "$ref": "#/definitions/ExperimentFunnelMetricStep"
                             },
                             "type": "array"
                         },
-                        {
-                            "items": {
-                                "$ref": "#/definitions/ExperimentVariantFunnelsBaseStats"
-                            },
-                            "type": "array"
+                        "timezone": {
+                            "type": "string"
                         }
-                    ]
+                    },
+                    "required": [
+                        "cache_key",
+                        "is_cached",
+                        "kind",
+                        "last_refresh",
+                        "metric_type",
+                        "next_allowed_client_refresh",
+                        "series",
+                        "timezone"
+                    ],
+                    "type": "object"
                 }
-            },
-            "required": [
-                "cache_key",
-                "credible_intervals",
-                "insight",
-                "is_cached",
-                "kind",
-                "last_refresh",
-                "metric",
-                "next_allowed_client_refresh",
-                "p_value",
-                "probability",
-                "significance_code",
-                "significant",
-                "timezone",
-                "variants"
-            ],
-            "type": "object"
+            ]
         },
         "CachedExperimentTrendsQueryResponse": {
             "additionalProperties": false,
@@ -9349,6 +9492,9 @@
                 },
                 "response": {
                     "$ref": "#/definitions/ExperimentQueryResponse"
+                },
+                "stats_method": {
+                    "$ref": "#/definitions/ExperimentStatsMethod"
                 }
             },
             "required": ["kind", "metric"],
@@ -9431,6 +9577,10 @@
         },
         "ExperimentSignificanceCode": {
             "enum": ["significant", "not_enough_exposure", "low_win_probability", "high_loss", "high_p_value"],
+            "type": "string"
+        },
+        "ExperimentStatsMethod": {
+            "enum": ["bayesian", "frequentist"],
             "type": "string"
         },
         "ExperimentTrendsQuery": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -17,6 +17,7 @@ import {
     EventType,
     ExperimentHoldoutType,
     ExperimentMetricMathType,
+    ExperimentStatsMethod,
     FilterLogicalOperator,
     FilterType,
     FunnelConversionWindowTimeUnit,
@@ -2238,6 +2239,7 @@ export interface ExperimentQuery extends DataNode<ExperimentQueryResponse> {
     metric: ExperimentMetric
     experiment_id?: integer
     name?: string
+    stats_method?: ExperimentStatsMethod
 }
 
 export interface ExperimentExposureQuery extends DataNode<ExperimentExposureQueryResponse> {
@@ -2278,7 +2280,9 @@ export interface ExperimentExposureQueryResponse {
     date_range: DateRange
 }
 
-export type CachedExperimentQueryResponse = CachedQueryResponse<ExperimentQueryResponse>
+export type CachedExperimentQueryResponse =
+    | CachedQueryResponse<ExperimentQueryResponse>
+    | CachedQueryResponse<ExperimentMetric>
 
 export type CachedExperimentExposureQueryResponse = CachedQueryResponse<ExperimentExposureQueryResponse>
 

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -137,6 +137,7 @@ export interface ExperimentLogicProps {
 interface MetricLoadingConfig {
     metrics: any[]
     experimentId: Experiment['id']
+    statsMethod: ExperimentStatsMethod
     refresh?: boolean
     onSetResults: (
         results: (
@@ -153,6 +154,7 @@ interface MetricLoadingConfig {
 const loadMetrics = async ({
     metrics,
     experimentId,
+    statsMethod,
     refresh,
     onSetResults,
     onSetErrors,
@@ -176,11 +178,13 @@ const loadMetrics = async ({
                         kind: NodeKind.ExperimentQuery,
                         metric: metric,
                         experiment_id: experimentId,
+                        stats_method: statsMethod,
                     }
                 } else {
                     queryWithExperimentId = {
                         ...metric,
                         experiment_id: experimentId,
+                        stats_method: statsMethod,
                     }
                 }
                 const response = await performQuery(queryWithExperimentId, undefined, refresh ? 'force_async' : 'async')
@@ -1378,6 +1382,7 @@ export const experimentLogic = kea<experimentLogicType>([
             await loadMetrics({
                 metrics,
                 experimentId: values.experimentId,
+                statsMethod: values.statsMethod,
                 refresh,
                 onSetResults: actions.setMetricResults,
                 onSetErrors: actions.setPrimaryMetricsResultErrors,
@@ -1401,6 +1406,7 @@ export const experimentLogic = kea<experimentLogicType>([
             await loadMetrics({
                 metrics: secondaryMetrics,
                 experimentId: values.experimentId,
+                statsMethod: values.statsMethod,
                 refresh,
                 onSetResults: actions.setSecondaryMetricResults,
                 onSetErrors: actions.setSecondaryMetricsResultErrors,

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1050,6 +1050,11 @@ class ExperimentSignificanceCode(StrEnum):
     HIGH_P_VALUE = "high_p_value"
 
 
+class ExperimentStatsMethod(StrEnum):
+    BAYESIAN = "bayesian"
+    FREQUENTIST = "frequentist"
+
+
 class ExperimentVariantFunnelsBaseStats(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -9322,6 +9327,56 @@ class TrendsQuery(BaseModel):
     trendsFilter: Optional[TrendsFilter] = Field(default=None, description="Properties specific to the trends insight")
 
 
+class CachedExperimentQueryResponse2(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    cache_key: str
+    cache_target_age: Optional[datetime] = None
+    calculation_trigger: Optional[str] = Field(
+        default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
+    )
+    conversion_window: Optional[int] = None
+    conversion_window_unit: Optional[FunnelConversionWindowTimeUnit] = None
+    is_cached: bool
+    kind: Literal["ExperimentMetric"] = "ExperimentMetric"
+    last_refresh: datetime
+    lower_bound_percentile: Optional[float] = None
+    metric_type: Literal["mean"] = "mean"
+    name: Optional[str] = None
+    next_allowed_client_refresh: datetime
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    source: Union[EventsNode, ActionsNode, ExperimentDataWarehouseNode]
+    timezone: str
+    upper_bound_percentile: Optional[float] = None
+
+
+class CachedExperimentQueryResponse3(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    cache_key: str
+    cache_target_age: Optional[datetime] = None
+    calculation_trigger: Optional[str] = Field(
+        default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
+    )
+    conversion_window: Optional[int] = None
+    conversion_window_unit: Optional[FunnelConversionWindowTimeUnit] = None
+    is_cached: bool
+    kind: Literal["ExperimentMetric"] = "ExperimentMetric"
+    last_refresh: datetime
+    metric_type: Literal["funnel"] = "funnel"
+    name: Optional[str] = None
+    next_allowed_client_refresh: datetime
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    series: list[Union[EventsNode, ActionsNode]]
+    timezone: str
+
+
 class CachedExperimentTrendsQueryResponse(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -10175,7 +10230,7 @@ class CachedExperimentFunnelsQueryResponse(BaseModel):
     variants: list[ExperimentVariantFunnelsBaseStats]
 
 
-class CachedExperimentQueryResponse(BaseModel):
+class CachedExperimentQueryResponse1(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -10201,6 +10256,12 @@ class CachedExperimentQueryResponse(BaseModel):
     stats_version: Optional[int] = None
     timezone: str
     variants: Union[list[ExperimentVariantTrendsBaseStats], list[ExperimentVariantFunnelsBaseStats]]
+
+
+class CachedExperimentQueryResponse(
+    RootModel[Union[CachedExperimentQueryResponse1, CachedExperimentQueryResponse2, CachedExperimentQueryResponse3]]
+):
+    root: Union[CachedExperimentQueryResponse1, CachedExperimentQueryResponse2, CachedExperimentQueryResponse3]
 
 
 class Response17(BaseModel):
@@ -10264,6 +10325,7 @@ class ExperimentQuery(BaseModel):
     )
     name: Optional[str] = None
     response: Optional[ExperimentQueryResponse] = None
+    stats_method: Optional[ExperimentStatsMethod] = None
 
 
 class ExperimentTrendsQuery(BaseModel):


### PR DESCRIPTION
@andehen seeking a feedback on this one. Might be also in @rodrigoi wheelhouse.

## Problem
When switching experiment `stats_method` between bayesian and frequentist, I need the experiment query to return different response types based on the stats method:
`bayesian` → `ExperimentQueryResponse`
`frequentist` → `ExperimentMetricResult`

The force-refresh of experiment result works fine. But a cached request returns an error:
```
'CachedExperimentQueryResponse' object has no attribute 'calculation_trigger'
```

https://www.loom.com/share/6c52eff5842e4326bb502695f78cf171?sid=d56c84ae-4101-4d87-bbe7-72e6d72b4f26

(Note that I also added the `stats_method` field to `ExperimentMetric` to ensure a unique cache key for each stat method)

## What I did
I defined the cached response as a union type:
```
export type CachedExperimentQueryResponse = 
  CachedQueryResponse<ExperimentQueryResponse> | 
  CachedQueryResponse<ExperimentMetricResult>
```

This however breaks in `query_runner.py` when trying to access fields like `calculation_trigger` on the cached response. The error then gets stored in the cache and served on cached requests:

## What I think is happening
When the TS union type gets converted to the Pydantic schema, it creates two separate classes (CachedExperimentQueryResponse1, CachedExperimentQueryResponse2). The query_runner code expects a single CachedExperimentQueryResponse type.

## Potential solution
I think we need a single unified type like `ExperimentResultUnifiedResponse` that can handle both response formats. This would avoid the union type issue entirely since there'd be only one cached response type generated in schema.py. But this will cause type checking issues downstream.