### PR TITLE
fix(err): add connect timeout

### DIFF
--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -54,6 +54,9 @@ pub struct Config {
     #[envconfig(default = "30")]
     pub sourcemap_timeout_seconds: u64,
 
+    #[envconfig(default = "5")]
+    pub sourcemap_connect_timeout_seconds: u64,
+
     #[envconfig(default = "100000000")] // 100MB - in prod, we should use closer to 1-10GB
     pub symbol_store_cache_max_bytes: usize,
 

--- a/rust/cymbal/src/symbol_store/sourcemap.rs
+++ b/rust/cymbal/src/symbol_store/sourcemap.rs
@@ -56,7 +56,10 @@ impl OwnedSourceMapCache {
 impl SourcemapProvider {
     pub fn new(config: &Config) -> Self {
         let timeout = Duration::from_secs(config.sourcemap_timeout_seconds);
-        let mut client = reqwest::Client::builder().timeout(timeout);
+        let connect_timeout = Duration::from_secs(config.sourcemap_connect_timeout_seconds);
+        let mut client = reqwest::Client::builder()
+            .timeout(timeout)
+            .connect_timeout(connect_timeout);
 
         if !config.allow_internal_ips {
             client = client.dns_resolver(Arc::new(common_dns::PublicIPv4Resolver {}));


### PR DESCRIPTION
We want lenient total request times because sometimes bodies are large or servers are slow, but sometimes we get routable addresses that just never accept a connection, and we hang in that case. Bail out earlier instead.