### PR TITLE
chore: limit web_analytics partitions while running the backfill

### DIFF
--- a/dags/README.md
+++ b/dags/README.md
@@ -141,7 +141,8 @@ concurrency:
 
 3. Run Dagster with the configuration:
 
-`DAGSTER_WEB_PREAGGREGATED_MAX_PARTITIONS_PER_RUN=1` Force small partitions per run to create multiple runs
+```bash
+DAGSTER_WEB_PREAGGREGATED_MAX_PARTITIONS_PER_RUN=1  # Force small partitions per run to create multiple runs
 
 ```bash
 export DAGSTER_HOME=$(pwd)/.dagster_home && DAGSTER_WEB_PREAGGREGATED_MAX_PARTITIONS_PER_RUN=1 DEBUG=1 dagster dev -m dags.definitions

--- a/dags/README.md
+++ b/dags/README.md
@@ -93,6 +93,74 @@ Add `-v` for verbose output:
 pytest -v dags/tests/test_exchange_rate.py
 ```
 
+### Web Analytics Pre-Aggregated Tables
+
+**Note:** For materializing web analytics preaggregated tables locally (e.g., during development or testing), you may want to use a higher partition count to process more data in a single run:
+
+```bash
+DAGSTER_WEB_PREAGGREGATED_MAX_PARTITIONS_PER_RUN=3000 DEBUG=1 dagster dev -m dags.definitions
+```
+
+This will allow backfills to process up to 3000 partitions per run instead of the default, significantly reducing the number of individual runs needed for large historical backfills.
+
+### Testing Concurrency Limits Locally
+
+To test job concurrency limits (useful for jobs like `web_analytics_daily_job` that use backfill policies), you need to configure a `dagster.yaml` file with concurrency settings. This is especially important for asset backfills which create `__ASSET_JOB` runs that can overwhelm your system if not properly limited.
+
+#### Setup
+
+1. Create the Dagster home directory and configuration file:
+
+```bash
+mkdir -p .dagster_home
+```
+
+2. Create `.dagster_home/dagster.yaml` with the following content:
+
+```yaml
+run_coordinator:
+  module: dagster._core.run_coordinator.queued_run_coordinator
+  class: QueuedRunCoordinator
+  config:
+    dequeue_interval_seconds: 5
+
+run_launcher:
+  module: dagster._core.launcher.default_run_launcher
+  class: DefaultRunLauncher
+
+concurrency:
+  runs:
+    max_concurrent_runs: 10  # Overall instance limit
+    tag_concurrency_limits:
+      # Limit specific job types
+      - key: 'dagster/job_name'
+        value: 'web_analytics_daily_job'
+        limit: 1
+
+```
+
+3. Run Dagster with the configuration:
+
+`DAGSTER_WEB_PREAGGREGATED_MAX_PARTITIONS_PER_RUN=1` Force small partitions per run to create multiple runs
+
+```bash
+export DAGSTER_HOME=$(pwd)/.dagster_home && DAGSTER_WEB_PREAGGREGATED_MAX_PARTITIONS_PER_RUN=1 DEBUG=1 dagster dev -m dags.definitions
+```
+
+#### Testing
+
+1. In the Dagster UI, navigate to your assets (e.g., web analytics assets)
+2. Start a backfill for several days (e.g., 3-5 days)
+3. Check the "Runs" page - you should observe:
+   - Only 1 run in `STARTED`/`STARTING` status at a time for the same concurrency group
+   - Other runs waiting in `QUEUED` status
+   - Runs progressing sequentially: `QUEUED` → `STARTED` → `SUCCESS`
+
+#### Production Configuration
+
+For production deployments, configure similar concurrency settings in your `dagster.yaml`.
+For posthog employees, it is on our charts repo: https://github.com/PostHog/charts/blob/master/config/dagster
+
 ## Additional Resources
 
 -   [Dagster Documentation](https://docs.dagster.io/)

--- a/dags/web_preaggregated_daily.py
+++ b/dags/web_preaggregated_daily.py
@@ -130,8 +130,8 @@ web_pre_aggregate_daily_job = dagster.define_asset_job(
     selection=["web_analytics_bounces_daily", "web_analytics_stats_table_daily"],
     tags={
         "owner": JobOwners.TEAM_WEB_ANALYTICS.value,
-        # This limits the job concurrency on the run queue but needs to be set on the instance level
-        # https://github.com/PostHog/charts/blob/master/config/dagster
+        # The intance level config limits the job concurrency on the run queue
+        # https://github.com/PostHog/charts/blob/chore/dagster-config/config/dagster/prod-us.yaml#L179-L181
     },
     # This limit the concurrency of the assets inside the job, so they run sequentially
     config={

--- a/dags/web_preaggregated_daily.py
+++ b/dags/web_preaggregated_daily.py
@@ -19,8 +19,10 @@ from posthog.models.web_preaggregated.sql import (
     WEB_STATS_INSERT_SQL,
 )
 
-# 14 is a sane value for production but locally we can run more partitions per run to speed up testing
-max_partitions_per_run = int(os.getenv("DAGSTER_WEB_PREAGGREGATED_MAX_PARTITIONS_PER_RUN", 14))
+# From my tests, 14 (two weeks) is a sane value for production.
+# But locally we can run more partitions per run to speed up testing (e.g: 3000 to materialize everythin on a single run)
+# TODO: I am currently setting it to 2 so the backfill can be kept running without clickinghouse getting overwhelmed
+max_partitions_per_run = int(os.getenv("DAGSTER_WEB_PREAGGREGATED_MAX_PARTITIONS_PER_RUN", 2))
 backfill_policy_def = BackfillPolicy.multi_run(max_partitions_per_run=max_partitions_per_run)
 
 partition_def = DailyPartitionsDefinition(start_date="2020-01-01")
@@ -126,7 +128,12 @@ def web_stats_daily(context: dagster.AssetExecutionContext) -> None:
 web_pre_aggregate_daily_job = dagster.define_asset_job(
     name="web_analytics_daily_job",
     selection=["web_analytics_bounces_daily", "web_analytics_stats_table_daily"],
-    tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
+    tags={
+        "owner": JobOwners.TEAM_WEB_ANALYTICS.value,
+        # This limits the job concurrency on the run queue but needs to be set on the instance level
+        # https://github.com/PostHog/charts/blob/master/config/dagster
+    },
+    # This limit the concurrency of the assets inside the job, so they run sequentially
     config={
         "execution": {
             "config": {

--- a/dags/web_preaggregated_daily.py
+++ b/dags/web_preaggregated_daily.py
@@ -20,7 +20,7 @@ from posthog.models.web_preaggregated.sql import (
 )
 
 # From my tests, 14 (two weeks) is a sane value for production.
-# But locally we can run more partitions per run to speed up testing (e.g: 3000 to materialize everythin on a single run)
+# But locally we can run more partitions per run to speed up testing (e.g: 3000 to materialize everything on a single run)
 # TODO: I am currently setting it to 2 so the backfill can be kept running without clickinghouse getting overwhelmed
 max_partitions_per_run = int(os.getenv("DAGSTER_WEB_PREAGGREGATED_MAX_PARTITIONS_PER_RUN", 2))
 backfill_policy_def = BackfillPolicy.multi_run(max_partitions_per_run=max_partitions_per_run)


### PR DESCRIPTION
## Problem

We have now limited the Dagster job concurrency with https://github.com/PostHog/charts/pull/4767. However, for running the backfill, we want to be cautious so it can be kept running without overwhelming the cluster. 

## Changes

- Lowered the max_partitions_per_run to 2
- Added some docs on how to test tag concurrency limits locally

## Did you write or update any docs for this change?

Just internal docs.

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Locally, per the docs.