### PR TITLE
chore: Disable Slack notifications for now for `property_definitions_ingestion_job`

### DIFF
--- a/dags/property_definitions.py
+++ b/dags/property_definitions.py
@@ -291,7 +291,10 @@ def optimize_property_definitions(
 
 @dagster.job(
     name="property_definitions_ingestion",
-    tags={"owner": JobOwners.TEAM_CLICKHOUSE.value},
+    tags={
+        "owner": JobOwners.TEAM_CLICKHOUSE.value,
+        "disable_slack_notifications": True,  # NOTE: remove when enabled for production use
+    },
 )
 def property_definitions_ingestion_job():
     """

--- a/dags/slack_alerts.py
+++ b/dags/slack_alerts.py
@@ -50,6 +50,10 @@ def notify_slack_on_failure(context: dagster.RunFailureSensorContext, slack: dag
         context.log.info("Skipping Slack notification in non-prod environment")
         return
 
+    if tags.get("disable_slack_notifications"):
+        context.log.debug("Skipping Slack notification for %s, notifications are disabled", job_name)
+        return
+
     # Construct Dagster URL based on environment
     dagster_domain = (
         f"dagster.prod-{settings.CLOUD_DEPLOYMENT.lower()}.posthog.dev"


### PR DESCRIPTION
## Problem

These are not used in production yet and current EU cluster instability causes a large number of noisy alerts that do not require action: https://posthog.slack.com/archives/C076R4753Q8/p1749061280951429

## Changes

Disables the notifications for now.

## Did you write or update any docs for this change?

No docs needed for this change

## How did you test this code?

🙈 