### PR TITLE
fix: export screenshot editor UI

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/exports/SidePanelExports.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/exports/SidePanelExports.tsx
@@ -62,7 +62,7 @@ const ExportsContent = (): JSX.Element => {
 
                         return (
                             <div
-                                className="flex justify-between mt-2 gap-2 border rounded bg-white items-center"
+                                className="flex justify-between mt-2 gap-2 border rounded bg-fill-primary items-center"
                                 key={asset.id}
                             >
                                 <div className="flex items-center justify-between flex-auto p-2">
@@ -81,8 +81,6 @@ const ExportsContent = (): JSX.Element => {
                                             <span className="text-xs text-secondary mt-1"> · not downloaded yet</span>
                                         )}
                                     </div>
-                                    <div>{stillCalculating && <Spinner />}</div>
-                                    <div>{asset.exception && <IconWarning className="text-link" />}</div>
                                 </div>
                                 <div className="flex gap-2 mr-2">
                                     <LemonButton
@@ -106,7 +104,13 @@ const ExportsContent = (): JSX.Element => {
                                             void downloadExportedAsset(asset)
                                         }}
                                         sideIcon={
-                                            asset.has_content ? <IconDownload className="text-link" /> : undefined
+                                            stillCalculating ? (
+                                                <Spinner />
+                                            ) : asset.has_content ? (
+                                                <IconDownload className="text-link" />
+                                            ) : (
+                                                <IconWarning className="text-link" />
+                                            )
                                         }
                                     />
                                 </div>


### PR DESCRIPTION
fixed there being an empty button during loading and dark mode fill being white

![Screenshot From 2025-06-04 23-07-39](https://github.com/user-attachments/assets/893010f1-4e84-45ff-bdff-6dec81c39440)
