### PR TITLE
fix: replace remaining betweens in usage reports with >= and <

### DIFF
--- a/posthog/tasks/test/__snapshots__/test_usage_report.ambr
+++ b/posthog/tasks/test/__snapshots__/test_usage_report.ambr
@@ -33,7 +33,8 @@
   SELECT team_id,
          count(1) as count
   FROM events
-  WHERE timestamp between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+  WHERE timestamp >= '2022-01-10 00:00:00'
+    AND timestamp < '2022-01-10 23:59:59'
     AND ($group_0 != ''
          OR $group_1 != ''
          OR $group_2 != ''
@@ -51,13 +52,15 @@
     (SELECT any(team_id) as team_id,
             session_id
      FROM session_replay_events
-     WHERE min_first_timestamp BETWEEN '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+     WHERE min_first_timestamp >= '2022-01-10 00:00:00'
+       AND min_first_timestamp < '2022-01-10 23:59:59'
      GROUP BY session_id
      HAVING ifNull(argMinMerge(snapshot_source), 'web') == 'web')
   WHERE session_id NOT IN
       (SELECT DISTINCT session_id
        FROM session_replay_events
-       WHERE min_first_timestamp BETWEEN '2022-01-09 00:00:00' AND '2022-01-10 00:00:00'
+       WHERE min_first_timestamp >= '2022-01-09 00:00:00'
+         AND min_first_timestamp < '2022-01-10 00:00:00'
        GROUP BY session_id)
   GROUP BY team_id
   '''
@@ -72,13 +75,15 @@
             session_id,
             sum(size) as total_size
      FROM session_replay_events
-     WHERE min_first_timestamp BETWEEN '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+     WHERE min_first_timestamp >= '2022-01-10 00:00:00'
+       AND min_first_timestamp < '2022-01-10 23:59:59'
      GROUP BY session_id
      HAVING ifNull(argMinMerge(snapshot_source), 'web') == 'web')
   WHERE session_id NOT IN
       (SELECT DISTINCT session_id
        FROM session_replay_events
-       WHERE min_first_timestamp BETWEEN '2022-01-09 00:00:00' AND '2022-01-10 00:00:00'
+       WHERE min_first_timestamp >= '2022-01-09 00:00:00'
+         AND min_first_timestamp < '2022-01-10 00:00:00'
        GROUP BY session_id)
   GROUP BY team_id
   '''
@@ -92,13 +97,15 @@
     (SELECT any(team_id) as team_id,
             session_id
      FROM session_replay_events
-     WHERE min_first_timestamp BETWEEN '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+     WHERE min_first_timestamp >= '2022-01-10 00:00:00'
+       AND min_first_timestamp < '2022-01-10 23:59:59'
      GROUP BY session_id
      HAVING ifNull(argMinMerge(snapshot_source), 'web') == 'mobile')
   WHERE session_id NOT IN
       (SELECT DISTINCT session_id
        FROM session_replay_events
-       WHERE min_first_timestamp BETWEEN '2022-01-09 00:00:00' AND '2022-01-10 00:00:00'
+       WHERE min_first_timestamp >= '2022-01-09 00:00:00'
+         AND min_first_timestamp < '2022-01-10 00:00:00'
        GROUP BY session_id)
   GROUP BY team_id
   '''
@@ -113,13 +120,15 @@
             session_id,
             sum(size) as total_size
      FROM session_replay_events
-     WHERE min_first_timestamp BETWEEN '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+     WHERE min_first_timestamp >= '2022-01-10 00:00:00'
+       AND min_first_timestamp < '2022-01-10 23:59:59'
      GROUP BY session_id
      HAVING ifNull(argMinMerge(snapshot_source), 'web') == 'mobile')
   WHERE session_id NOT IN
       (SELECT DISTINCT session_id
        FROM session_replay_events
-       WHERE min_first_timestamp BETWEEN '2022-01-09 00:00:00' AND '2022-01-10 00:00:00'
+       WHERE min_first_timestamp >= '2022-01-09 00:00:00'
+         AND min_first_timestamp < '2022-01-10 00:00:00'
        GROUP BY session_id)
   GROUP BY team_id
   '''
@@ -133,7 +142,8 @@
     (SELECT any(team_id) as team_id,
             session_id
      FROM session_replay_events
-     WHERE min_first_timestamp BETWEEN '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+     WHERE min_first_timestamp >= '2022-01-10 00:00:00'
+       AND min_first_timestamp < '2022-01-10 23:59:59'
      GROUP BY session_id
      HAVING (ifNull(argMinMerge(snapshot_source), '') == 'mobile'
              AND ifNull(argMinMerge(snapshot_library), '') IN ('posthog-ios',
@@ -143,7 +153,8 @@
   WHERE session_id NOT IN
       (SELECT DISTINCT session_id
        FROM session_replay_events
-       WHERE min_first_timestamp BETWEEN '2022-01-09 00:00:00' AND '2022-01-10 00:00:00'
+       WHERE min_first_timestamp >= '2022-01-09 00:00:00'
+         AND min_first_timestamp < '2022-01-10 00:00:00'
        GROUP BY session_id)
   GROUP BY team_id
   '''
@@ -156,7 +167,8 @@
   FROM events
   WHERE team_id = 99999
     AND event='decide usage'
-    AND timestamp between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND timestamp >= '2022-01-10 00:00:00'
+    AND timestamp < '2022-01-10 23:59:59'
     AND has(['correct'], replaceRegexpAll(JSONExtractRaw(properties, 'token'), '^"|"$', ''))
   GROUP BY team
   '''
@@ -169,7 +181,8 @@
   FROM events
   WHERE team_id = 99999
     AND event='local evaluation usage'
-    AND timestamp between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND timestamp >= '2022-01-10 00:00:00'
+    AND timestamp < '2022-01-10 23:59:59'
     AND has(['correct'], replaceRegexpAll(JSONExtractRaw(properties, 'token'), '^"|"$', ''))
   GROUP BY team
   '''
@@ -185,7 +198,8 @@
   WHERE (type = 'QueryFinish'
          OR type = 'ExceptionWhileProcessing')
     AND is_initial_query = 1
-    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND query_start_time >= '2022-01-10 00:00:00'
+    AND query_start_time < '2022-01-10 23:59:59'
     AND access_method = ''
   GROUP BY team_id
   '''
@@ -201,7 +215,8 @@
   WHERE (type = 'QueryFinish'
          OR type = 'ExceptionWhileProcessing')
     AND is_initial_query = 1
-    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND query_start_time >= '2022-01-10 00:00:00'
+    AND query_start_time < '2022-01-10 23:59:59'
     AND access_method = ''
   GROUP BY team_id
   '''
@@ -231,7 +246,8 @@
   WHERE (type = 'QueryFinish'
          OR type = 'ExceptionWhileProcessing')
     AND is_initial_query = 1
-    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND query_start_time >= '2022-01-10 00:00:00'
+    AND query_start_time < '2022-01-10 23:59:59'
     AND access_method = ''
   GROUP BY team_id
   '''
@@ -247,7 +263,8 @@
   WHERE (type = 'QueryFinish'
          OR type = 'ExceptionWhileProcessing')
     AND is_initial_query = 1
-    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND query_start_time >= '2022-01-10 00:00:00'
+    AND query_start_time < '2022-01-10 23:59:59'
     AND access_method = 'personal_api_key'
   GROUP BY team_id
   '''
@@ -263,7 +280,8 @@
   WHERE (type = 'QueryFinish'
          OR type = 'ExceptionWhileProcessing')
     AND is_initial_query = 1
-    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND query_start_time >= '2022-01-10 00:00:00'
+    AND query_start_time < '2022-01-10 23:59:59'
     AND access_method = 'personal_api_key'
   GROUP BY team_id
   '''
@@ -279,7 +297,8 @@
   WHERE (type = 'QueryFinish'
          OR type = 'ExceptionWhileProcessing')
     AND is_initial_query = 1
-    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND query_start_time >= '2022-01-10 00:00:00'
+    AND query_start_time < '2022-01-10 23:59:59'
     AND access_method = 'personal_api_key'
   GROUP BY team_id
   '''
@@ -296,7 +315,8 @@
          OR type = 'ExceptionWhileProcessing')
     AND is_initial_query = 1
     AND query_type IN (['EventsQuery'])
-    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND query_start_time >= '2022-01-10 00:00:00'
+    AND query_start_time < '2022-01-10 23:59:59'
     AND access_method = ''
   GROUP BY team_id
   '''
@@ -313,7 +333,8 @@
          OR type = 'ExceptionWhileProcessing')
     AND is_initial_query = 1
     AND query_type IN (['EventsQuery'])
-    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND query_start_time >= '2022-01-10 00:00:00'
+    AND query_start_time < '2022-01-10 23:59:59'
     AND access_method = ''
   GROUP BY team_id
   '''
@@ -330,7 +351,8 @@
          OR type = 'ExceptionWhileProcessing')
     AND is_initial_query = 1
     AND query_type IN (['EventsQuery'])
-    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND query_start_time >= '2022-01-10 00:00:00'
+    AND query_start_time < '2022-01-10 23:59:59'
     AND access_method = ''
   GROUP BY team_id
   '''
@@ -347,7 +369,8 @@
          OR type = 'ExceptionWhileProcessing')
     AND is_initial_query = 1
     AND query_type IN (['EventsQuery'])
-    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND query_start_time >= '2022-01-10 00:00:00'
+    AND query_start_time < '2022-01-10 23:59:59'
     AND access_method = 'personal_api_key'
   GROUP BY team_id
   '''
@@ -364,7 +387,8 @@
          OR type = 'ExceptionWhileProcessing')
     AND is_initial_query = 1
     AND query_type IN (['EventsQuery'])
-    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND query_start_time >= '2022-01-10 00:00:00'
+    AND query_start_time < '2022-01-10 23:59:59'
     AND access_method = 'personal_api_key'
   GROUP BY team_id
   '''
@@ -381,7 +405,8 @@
          OR type = 'ExceptionWhileProcessing')
     AND is_initial_query = 1
     AND query_type IN (['EventsQuery'])
-    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND query_start_time >= '2022-01-10 00:00:00'
+    AND query_start_time < '2022-01-10 23:59:59'
     AND access_method = 'personal_api_key'
   GROUP BY team_id
   '''
@@ -395,7 +420,8 @@
   FROM clusterAllReplicas(posthog, system.query_log)
   WHERE type = 'QueryFinish'
     AND is_initial_query
-    AND event_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND event_time >= '2022-01-10 00:00:00'
+    AND event_time < '2022-01-10 23:59:59'
     AND team_id > 0
     AND JSONExtractBool(log_comment, 'chargeable')
   GROUP BY team_id
@@ -408,11 +434,13 @@
          COUNT() as count
   FROM events
   WHERE event = 'survey sent'
-    AND timestamp BETWEEN '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND timestamp >= '2022-01-10 00:00:00'
+    AND timestamp < '2022-01-10 23:59:59'
     AND uuid IN
       (SELECT argMax(uuid, timestamp)
        FROM events
-       WHERE timestamp BETWEEN '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+       WHERE timestamp >= '2022-01-10 00:00:00'
+         AND timestamp < '2022-01-10 23:59:59'
          AND event = 'survey sent'
        GROUP BY team_id,
                 JSONExtractString(properties, '$survey_id'),
@@ -430,7 +458,8 @@
          COUNT() as count
   FROM events
   WHERE event = '$exception'
-    AND timestamp between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND timestamp >= '2022-01-10 00:00:00'
+    AND timestamp < '2022-01-10 23:59:59'
   GROUP BY team_id
   '''
 # ---
@@ -443,7 +472,8 @@
   WHERE app_source='hog_function'
     AND metric_name IN ('succeeded',
                         'failed')
-    AND timestamp between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND timestamp >= '2022-01-10 00:00:00'
+    AND timestamp < '2022-01-10 23:59:59'
   GROUP BY team_id,
            metric_name
   '''
@@ -456,7 +486,8 @@
   FROM app_metrics2
   WHERE app_source='hog_function'
     AND metric_name IN ('fetch')
-    AND timestamp between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND timestamp >= '2022-01-10 00:00:00'
+    AND timestamp < '2022-01-10 23:59:59'
   GROUP BY team_id,
            metric_name
   '''
@@ -468,7 +499,8 @@
          COUNT() as count
   FROM events
   WHERE event LIKE '$ai_%'
-    AND timestamp between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND timestamp >= '2022-01-10 00:00:00'
+    AND timestamp < '2022-01-10 23:59:59'
   GROUP BY team_id
   '''
 # ---

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -512,7 +512,7 @@ def get_teams_with_event_count_with_groups_in_period(begin: datetime, end: datet
         """
         SELECT team_id, count(1) as count
         FROM events
-        WHERE timestamp between %(begin)s AND %(end)s
+        WHERE timestamp >= %(begin)s AND timestamp < %(end)s
         AND ($group_0 != '' OR $group_1 != '' OR $group_2 != '' OR $group_3 != '' OR $group_4 != '')
         GROUP BY team_id
         """,
@@ -623,7 +623,7 @@ def get_teams_with_recording_count_in_period(
         FROM (
             SELECT any(team_id) as team_id, session_id
             FROM session_replay_events
-            WHERE min_first_timestamp BETWEEN %(begin)s AND %(end)s
+            WHERE min_first_timestamp >= %(begin)s AND min_first_timestamp < %(end)s
             GROUP BY session_id
             HAVING ifNull(argMinMerge(snapshot_source), 'web') == %(snapshot_source)s
         )
@@ -635,7 +635,7 @@ def get_teams_with_recording_count_in_period(
             -- begin is the very first instant of the period we are interested in
             -- we assume it is also the very first instant of a day
             -- so we can to subtract 1 second to get the day before
-            WHERE min_first_timestamp BETWEEN %(previous_begin)s AND %(begin)s
+            WHERE min_first_timestamp >= %(previous_begin)s AND min_first_timestamp < %(begin)s
             GROUP BY session_id
         )
         GROUP BY team_id
@@ -659,7 +659,7 @@ def get_teams_with_mobile_billable_recording_count_in_period(begin: datetime, en
         FROM (
             SELECT any(team_id) as team_id, session_id
             FROM session_replay_events
-            WHERE min_first_timestamp BETWEEN %(begin)s AND %(end)s
+            WHERE min_first_timestamp >= %(begin)s AND min_first_timestamp < %(end)s
             GROUP BY session_id
             HAVING (ifNull(argMinMerge(snapshot_source), '') == 'mobile'
             AND ifNull(argMinMerge(snapshot_library), '') IN ('posthog-ios', 'posthog-android', 'posthog-react-native', 'posthog-flutter'))
@@ -672,7 +672,7 @@ def get_teams_with_mobile_billable_recording_count_in_period(begin: datetime, en
             -- begin is the very first instant of the period we are interested in
             -- we assume it is also the very first instant of a day
             -- so we can to subtract 1 second to get the day before
-            WHERE min_first_timestamp BETWEEN %(previous_begin)s AND %(begin)s
+            WHERE min_first_timestamp >= %(previous_begin)s AND min_first_timestamp < %(begin)s
             GROUP BY session_id
         )
         GROUP BY team_id
@@ -698,7 +698,7 @@ def get_teams_with_api_queries_metrics(
         FROM clusterAllReplicas({CLICKHOUSE_CLUSTER}, system.query_log)
         WHERE type = 'QueryFinish'
         AND is_initial_query
-        AND event_time between %(begin)s AND %(end)s
+        AND event_time >= %(begin)s AND event_time < %(end)s
         AND team_id > 0
         AND JSONExtractBool(log_comment, 'chargeable')
         GROUP BY team_id
@@ -745,7 +745,7 @@ def get_teams_with_query_metric(
         WHERE (type = 'QueryFinish' OR type = 'ExceptionWhileProcessing')
         AND is_initial_query = 1
         {query_types_clause}
-        AND query_start_time between %(begin)s AND %(end)s
+        AND query_start_time >= %(begin)s AND query_start_time < %(end)s
         AND access_method = %(access_method)s
         GROUP BY team_id
     """
@@ -778,7 +778,7 @@ def get_teams_with_feature_flag_requests_count_in_period(
         """
         SELECT distinct_id as team, sum(JSONExtractInt(properties, 'count')) as sum
         FROM events
-        WHERE team_id = %(team_to_query)s AND event=%(target_event)s AND timestamp between %(begin)s AND %(end)s
+        WHERE team_id = %(team_to_query)s AND event=%(target_event)s AND timestamp >= %(begin)s AND timestamp < %(end)s
         AND has([%(validity_token)s], replaceRegexpAll(JSONExtractRaw(properties, 'token'), '^"|"$', ''))
         GROUP BY team
     """,
@@ -805,7 +805,7 @@ def get_teams_with_survey_responses_count_in_period(
     # Construct the subquery for unique event UUIDs
     unique_uuids_subquery = get_unique_survey_event_uuids_sql_subquery(
         base_conditions_sql=[
-            "timestamp BETWEEN %(begin)s AND %(end)s",
+            "timestamp >= %(begin)s AND timestamp < %(end)s",
         ],
         group_by_prefix_expressions=[
             "team_id",
@@ -820,7 +820,7 @@ def get_teams_with_survey_responses_count_in_period(
         FROM events
         WHERE
             event = 'survey sent'
-            AND timestamp BETWEEN %(begin)s AND %(end)s
+            AND timestamp >= %(begin)s AND timestamp < %(end)s
             AND uuid IN {unique_uuids_subquery}
         GROUP BY team_id
     """
@@ -845,7 +845,7 @@ def get_teams_with_ai_event_count_in_period(
         """
         SELECT team_id, COUNT() as count
         FROM events
-        WHERE event LIKE '$ai_%%' AND timestamp between %(begin)s AND %(end)s
+        WHERE event LIKE '$ai_%%' AND timestamp >= %(begin)s AND timestamp < %(end)s
         GROUP BY team_id
     """,
         {"begin": begin, "end": end},
@@ -935,7 +935,7 @@ def get_teams_with_exceptions_captured_in_period(
         """
         SELECT team_id, COUNT() as count
         FROM events
-        WHERE event = '$exception' AND timestamp between %(begin)s AND %(end)s
+        WHERE event = '$exception' AND timestamp >= %(begin)s AND timestamp < %(end)s
         GROUP BY team_id
     """,
         {"begin": begin, "end": end},
@@ -956,7 +956,7 @@ def get_teams_with_hog_function_calls_in_period(
         """
         SELECT team_id, SUM(count) as count
         FROM app_metrics2
-        WHERE app_source='hog_function' AND metric_name IN ('succeeded','failed') AND timestamp between %(begin)s AND %(end)s
+        WHERE app_source='hog_function' AND metric_name IN ('succeeded','failed') AND timestamp >= %(begin)s AND timestamp < %(end)s
         GROUP BY team_id, metric_name
     """,
         {"begin": begin, "end": end},
@@ -977,7 +977,7 @@ def get_teams_with_hog_function_fetch_calls_in_period(
         """
         SELECT team_id, SUM(count) as count
         FROM app_metrics2
-        WHERE app_source='hog_function' AND metric_name IN ('fetch') AND timestamp between %(begin)s AND %(end)s
+        WHERE app_source='hog_function' AND metric_name IN ('fetch') AND timestamp >= %(begin)s AND timestamp < %(end)s
         GROUP BY team_id, metric_name
     """,
         {"begin": begin, "end": end},
@@ -1001,7 +1001,7 @@ def get_teams_with_recording_bytes_in_period(
         FROM (
             SELECT any(team_id) as team_id, session_id, sum(size) as total_size
             FROM session_replay_events
-            WHERE min_first_timestamp BETWEEN %(begin)s AND %(end)s
+            WHERE min_first_timestamp >= %(begin)s AND min_first_timestamp < %(end)s
             GROUP BY session_id
             HAVING ifNull(argMinMerge(snapshot_source), 'web') == %(snapshot_source)s
         )
@@ -1013,7 +1013,7 @@ def get_teams_with_recording_bytes_in_period(
             -- begin is the very first instant of the period we are interested in
             -- we assume it is also the very first instant of a day
             -- so we can to subtract 1 second to get the day before
-            WHERE min_first_timestamp BETWEEN %(previous_begin)s AND %(begin)s
+            WHERE min_first_timestamp >= %(previous_begin)s AND min_first_timestamp < %(begin)s
             GROUP BY session_id
         )
         GROUP BY team_id


### PR DESCRIPTION
## Problem

We were double-counting events occurring at period end because we were using `between`, which is inclusive of start and end. This should almost never happen, but it is more accurate, and it was causing issues in tests when used with `num_splits` since the mock events were happening exactly on the hour, so they were getting double counted.

## Solution

In #33180 we fixed it for the tests that started failing after increasing `num_splits` to 3, this fixes it for remaining queries in usage reports.

## Did you write or update any docs for this change?

- [x] No docs needed for this change

## How did you test this code?

Ran existing tests