### PR TITLE
chore: disable usage report for platform org

### DIFF
--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -1300,7 +1300,7 @@ def _get_all_usage_data_as_team_rows(period_start: datetime, period_end: datetim
 def _get_teams_for_usage_reports() -> Sequence[Team]:
     return list(
         Team.objects.select_related("organization")
-        .exclude(Q(organization__for_internal_metrics=True) | Q(is_demo=True))
+        .exclude(Q(organization__for_internal_metrics=True) | Q(is_demo=True) | Q(organization__is_platform=True))
         .only("id", "name", "organization__id", "organization__name", "organization__created_at")
     )
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We want to trial out having orgs with very large number of projects (see [here](https://github.com/PostHog/product-internal/pull/779)) - these would break the current billing logic, so for now we would like to skip usage reports all together for them and deal with them manually (there will be a low number of these orgs).

## Changes

- Filter out orgs with `is_platform=True` when getting teams for usage reports.
- Move a test from before that was in the wrong place.

## How did you test this code?

Added uni tests.
