### PR TITLE
fix(batch-exports): Cast config value to bool

### DIFF
--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -161,6 +161,9 @@ class S3BatchExportInputs(BaseBatchExportInputs):
         if self.max_file_size_mb:
             self.max_file_size_mb = int(self.max_file_size_mb)
 
+        if self.use_virtual_style_addressing and isinstance(self.use_virtual_style_addressing, str):
+            self.use_virtual_style_addressing = self.use_virtual_style_addressing.lower() == "true"
+
 
 @dataclass(kw_only=True)
 class SnowflakeBatchExportInputs(BaseBatchExportInputs):

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -162,7 +162,7 @@ class S3BatchExportInputs(BaseBatchExportInputs):
             self.max_file_size_mb = int(self.max_file_size_mb)
 
         if self.use_virtual_style_addressing and isinstance(self.use_virtual_style_addressing, str):
-            self.use_virtual_style_addressing = self.use_virtual_style_addressing.lower() == "true"
+            self.use_virtual_style_addressing = self.use_virtual_style_addressing.lower() == "true"  # type: ignore
 
 
 @dataclass(kw_only=True)


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

For some reason, refreshing from database returns value as str instead of bool.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Cast to bool if value is str.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
