### PR TITLE
feat(dashboard): kill clickhouse insight load on abortQuery

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -421,6 +421,10 @@ export class ApiRequest {
         return this.insight(id, teamId).addPathComponent('sharing')
     }
 
+    public insightsCancel(teamId?: TeamType['id']): ApiRequest {
+        return this.insights(teamId).addPathComponent('cancel')
+    }
+
     // # File System
     public fileSystem(teamId?: TeamType['id']): ApiRequest {
         return this.environmentsDetail(teamId).addPathComponent('file_system')
@@ -1357,6 +1361,9 @@ const api = {
         },
         async update(id: number, data: any): Promise<InsightModel> {
             return await new ApiRequest().insight(id).update({ data })
+        },
+        async cancelQuery(clientQueryId: string, teamId: TeamType['id'] = ApiConfig.getCurrentTeamId()): Promise<void> {
+            await new ApiRequest().insightsCancel(teamId).create({ data: { client_query_id: clientQueryId } })
         },
     },
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1480,7 +1480,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                                         actions.setRefreshError(insight.short_id)
                                         break // Exit retry loop
                                     }
-                                    const delay = initialDelay * Math.pow(2, attempt - 1) // Exponential backoff
+                                    const delay = initialDelay * Math.pow(1.2, attempt - 1) // Exponential backoff
                                     await wait(delay)
                                     continue // Retry
                                 }
@@ -1741,9 +1741,13 @@ export const dashboardLogic = kea<dashboardLogicType>([
             }
         },
         abortQuery: async ({ queryId, queryStartTime }) => {
-            const { currentTeamId } = values
+            const { currentTeamId, featureFlags } = values
             try {
-                await api.delete(`api/environments/${currentTeamId}/query/${queryId}`)
+                if (featureFlags[FEATURE_FLAGS.DASHBOARD_SYNC_INSIGHT_LOADING]) {
+                    await api.insights.cancelQuery(queryId, currentTeamId ?? undefined)
+                } else {
+                    await api.delete(`api/environments/${currentTeamId}/query/${queryId}`)
+                }
             } catch (e) {
                 console.warn('Failed cancelling query', e)
             }


### PR DESCRIPTION
## Problem
After using /insight to load insights on dashboards, we need to send the correct kill request on navigate away/abort query

## Changes
Sending the kill requests now
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?
Tested locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
