### PR TITLE
chore: Add members_can_invite to django admin

### DIFF
--- a/posthog/admin/admins/organization_admin.py
+++ b/posthog/admin/admins/organization_admin.py
@@ -43,6 +43,7 @@ class OrganizationAdmin(admin.ModelAdmin):
         "customer_trust_scores",
         "is_hipaa",
         "is_platform",
+        "members_can_invite",
     ]
     inlines = [ProjectInline, TeamInline, OrganizationMemberInline, OrganizationInviteInline]
     readonly_fields = [


### PR DESCRIPTION
## Changes

- Add the newly added `organization.members_can_invite` flag to the admin
<img width="1014" alt="image" src="https://github.com/user-attachments/assets/ea94f28d-b221-4c15-8621-4d83f9433893" />

## How did you test this code?

- Manually
