### PR TITLE
fix(ci): don't run docker build on external contributors PRs

### DIFF
--- a/.github/workflows/container-images-ci.yml
+++ b/.github/workflows/container-images-ci.yml
@@ -35,6 +35,8 @@ jobs:
         permissions:
             id-token: write # allow issuing OIDC tokens for this workflow run
             contents: read # allow at least reading the repo contents, add other permissions if necessary
+        # Only on PostHog/posthog, as there's no docker login on forks
+        if: ${{ github.repository == 'PostHog/posthog' }}
 
         steps:
             # If this run wasn't initiated by PostHog Bot (meaning: snapshot update),


### PR DESCRIPTION
## Problem

We can't merge external contributors PRs due to the required docker build. See e.g. https://github.com/PostHog/posthog/pull/32748

## Changes

Doesn't run it on external PRs

## How did you test this code?

n/a