### PR TITLE
fix(data-warehouse): Raise an error if a postgres job hits a 10 min statement timeout

### DIFF
--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -72,6 +72,7 @@ Non_Retryable_Schema_Errors: dict[ExternalDataSource.Type, list[str]] = {
         "FATAL: no such database",
         "does not exist",
         "timestamp too small",
+        "QueryTimeout",
     ],
     ExternalDataSource.Type.ZENDESK: ["404 Client Error: Not Found for url", "403 Client Error: Forbidden for url"],
     ExternalDataSource.Type.MYSQL: [

--- a/posthog/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/utils.py
@@ -48,6 +48,10 @@ class DuplicatePrimaryKeysException(Exception):
     pass
 
 
+class QueryTimeout(Exception):
+    pass
+
+
 def normalize_column_name(column_name: str) -> str:
     return NamingConvention().normalize_identifier(column_name)
 

--- a/posthog/temporal/data_imports/pipelines/postgres/postgres.py
+++ b/posthog/temporal/data_imports/pipelines/postgres/postgres.py
@@ -464,7 +464,11 @@ def postgres_source(
                 incremental_field_type,
                 db_incremental_field_last_value,
             )
-            cursor.execute("SET LOCAL statement_timeout = %s", (str(1000 * 60 * 10),))  # 10 mins
+            cursor.execute(
+                sql.SQL("SET LOCAL statement_timeout = {timeout}").format(
+                    timeout=sql.Literal(1000 * 60 * 10)  # 10 mins
+                )
+            )
             try:
                 primary_keys = _get_primary_keys(cursor, schema, table_name)
                 table = _get_table(cursor, schema, table_name)


### PR DESCRIPTION
## Problem
- A handful of postgres syncs are trying to incrementally sync a lot of rows without any index on their incremental field, meaning the job is taking hours to even start processing rows

## Changes
- Add a statement timeout for the initial queries we run, 10 mins
- These statements, such as `_get_rows_to_sync`, uses the actual query we run to get rows and so this is a good place to test the timeout
- If the timeout gets hit, we then stop syncing that table and give the user a useful error message to add an appropriate index to their incremental field 

## How did you test this code?
Tested locally
