### PR TITLE
fix(logs): don't allow unknown severity text strings

### DIFF
--- a/rust/log-capture/src/log_record.rs
+++ b/rust/log-capture/src/log_record.rs
@@ -166,8 +166,8 @@ fn normalize_severity_text(severity_text: String) -> String {
         "info" | "information" | "informational" => "info".to_string(),
         "debug" | "dbug" => "debug".to_string(),
         "trace" => "trace".to_string(),
-        "" => "info".to_string(),
-        _ => severity_text,
+        // don't allow arbitrary values in severity text. normalize unknown to info
+        _ => "info".to_string(),
     }
 }
 


### PR DESCRIPTION

> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

due to some bad otel parsing we ended up with some a bunch of garbage in severity text which really killed queries in prod

ensure we only write known values

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
