### PR TITLE
feat(bi): Add a total row to chart tooltips

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -380,13 +380,12 @@ export const LineGraph = (): JSX.Element => {
                             })
 
                             if (tooltipData.length > 1) {
-                                const rawData = ySeriesData.reduce(
-                                    (acc: number, cur: AxisSeries<number> | AxisBreakdownSeries<number>) => {
-                                        acc += cur.data[referenceDataPoint.dataIndex]
-                                        return acc
-                                    },
-                                    0
-                                )
+                                const rawData = (
+                                    ySeriesData as (AxisSeries<number> | AxisBreakdownSeries<number>)[]
+                                ).reduce((acc: number, cur: AxisSeries<number> | AxisBreakdownSeries<number>) => {
+                                    acc += cur.data[referenceDataPoint.dataIndex]
+                                    return acc
+                                }, 0)
 
                                 tooltipData.push({
                                     series: '',

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -375,7 +375,7 @@ export const LineGraph = (): JSX.Element => {
                                     ),
                                     rawData: series.data[referenceDataPoint.dataIndex],
                                     dataIndex: referenceDataPoint.dataIndex,
-                                    isTotalRow: true,
+                                    isTotalRow: false,
                                 }
                             })
 
@@ -390,7 +390,7 @@ export const LineGraph = (): JSX.Element => {
                                     data: rawData.toString(),
                                     rawData: rawData,
                                     dataIndex: referenceDataPoint.dataIndex,
-                                    isTotalRow: false,
+                                    isTotalRow: true,
                                 })
                             }
 
@@ -403,7 +403,7 @@ export const LineGraph = (): JSX.Element => {
                                                 title: xSeriesData.data[referenceDataPoint.dataIndex],
                                                 dataIndex: 'series',
                                                 render: (value, record) => {
-                                                    if (!record.isTotalRow) {
+                                                    if (record.isTotalRow) {
                                                         return (
                                                             <div className="datum-label-column font-extrabold">
                                                                 Total
@@ -450,7 +450,7 @@ export const LineGraph = (): JSX.Element => {
                                         ]}
                                         uppercaseHeader={false}
                                         rowRibbonColor={(_datum, index) => {
-                                            if (!_datum.isTotalRow) {
+                                            if (_datum.isTotalRow) {
                                                 return undefined
                                             }
 

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -380,10 +380,13 @@ export const LineGraph = (): JSX.Element => {
                             })
 
                             if (tooltipData.length > 1) {
-                                const rawData = ySeriesData.reduce((acc, cur) => {
-                                    acc += cur.data[referenceDataPoint.dataIndex]
-                                    return acc
-                                }, 0)
+                                const rawData = ySeriesData.reduce(
+                                    (acc: number, cur: AxisSeries<number> | AxisBreakdownSeries<number>) => {
+                                        acc += cur.data[referenceDataPoint.dataIndex]
+                                        return acc
+                                    },
+                                    0
+                                )
 
                                 tooltipData.push({
                                     series: '',


### PR DESCRIPTION
## Changes
- Add a total row to chart tooltips when theres more than a single series present 
- Tested on all chart types 

<img width="709" alt="image" src="https://github.com/user-attachments/assets/83561448-1ea6-4c81-b5b2-3a068c2a4dd4" />


## How did you test this code?
See pic
