### PR TITLE
fix(max): bump the message content limit

### DIFF
--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -24,7 +24,7 @@ from posthog.utils import get_instance_region
 
 
 class MessageSerializer(serializers.Serializer):
-    content = serializers.CharField(required=True, max_length=6000)  ## roughly 1.5k tokens
+    content = serializers.CharField(required=True, max_length=40000)  ## roughly 10k tokens
     conversation = serializers.UUIDField(required=False)
     contextual_tools = serializers.DictField(required=False, child=serializers.JSONField())
     trace_id = serializers.UUIDField(required=True)

--- a/ee/api/test/test_conversation.py
+++ b/ee/api/test/test_conversation.py
@@ -99,7 +99,7 @@ class TestConversation(APIBaseTest):
     def test_content_too_long(self):
         response = self.client.post(
             f"/api/environments/{self.team.id}/conversations/",
-            {"content": "x" * 8000, "trace_id": str(uuid.uuid4())},  # Very long message
+            {"content": "x" * 50000, "trace_id": str(uuid.uuid4())},  # Very long message
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("detail", response.json())

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -323,7 +323,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
 
                         if (e.status === 400 && e.data?.attr === 'content') {
                             relevantErrorMessage.content =
-                                'Oops! Your message is too long. Ensure it has no more than 6000 characters.'
+                                'Oops! Your message is too long. Ensure it has no more than 40000 characters.'
                         }
                     } else {
                         posthog.captureException(e)


### PR DESCRIPTION
## Problem

Customers have a use case when they want to include multiple SQL queries in a message so Max can generate a better one. This is not possible with a 1.5k limit.

## Changes

- Bump limits
- 
## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Unit tests
