### PR TITLE
fix: 100 blob files at a time is too many for some recorded sites

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -499,7 +499,7 @@ LIMIT 1000000
                     }) || []
 
                 if (nextSourcesToLoad.length > 0) {
-                    return actions.loadSnapshotsForSource(nextSourcesToLoad.slice(0, 100))
+                    return actions.loadSnapshotsForSource(nextSourcesToLoad.slice(0, 50))
                 }
 
                 if (!props.blobV2PollingDisabled) {

--- a/frontend/src/scenes/session-recordings/player/snapshot-processing/process-all-snapshots.ts
+++ b/frontend/src/scenes/session-recordings/player/snapshot-processing/process-all-snapshots.ts
@@ -56,10 +56,10 @@ export function processAllSnapshots(
 
         if (snapshotsBySource?.[sourceKey]?.processed) {
             // If we already processed this source, skip it
-            // doing push.apply to mutate the original array
-            // and avoid a spread on a large array
-            // eslint-disable-next-line prefer-spread
-            result.push.apply(result, snapshotsBySource[sourceKey].snapshots || [])
+            // here we loop and push one by one, to avoid a spread on a large array
+            for (const snapshot of snapshotsBySource[sourceKey].snapshots || []) {
+                result.push(snapshot)
+            }
             continue
         }
 
@@ -121,8 +121,9 @@ export function processAllSnapshots(
         snapshotsBySource[sourceKey].processed = true
         // doing push.apply to mutate the original array
         // and avoid a spread on a large array
-        // eslint-disable-next-line prefer-spread
-        result.push.apply(result, sourceResult)
+        for (const snapshot of sourceResult) {
+            result.push(snapshot)
+        }
     }
 
     // sorting is very cheap for already sorted lists


### PR DESCRIPTION
customer getting errors because their recording files are huge

* don't load 100 at a time, it's a bit too much
* gather data in such a way as to not explode the stack