### PR TITLE
fix: fallback for duration filters

### DIFF
--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFilters.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFilters.tsx
@@ -24,6 +24,7 @@ import { RecordingUniversalFilters, ReplayTabs, UniversalFiltersGroup } from '~/
 import { playerSettingsLogic, TimestampFormat } from '../player/playerSettingsLogic'
 import { playlistLogic } from '../playlist/playlistLogic'
 import { createPlaylist } from '../playlist/playlistUtils'
+import { defaultRecordingDurationFilter } from '../playlist/sessionRecordingsPlaylistLogic'
 import { savedSessionRecordingPlaylistsLogic } from '../saved-playlists/savedSessionRecordingPlaylistsLogic'
 import { sessionRecordingEventUsageLogic } from '../sessionRecordingEventUsageLogic'
 import { DurationFilter } from './DurationFilter'
@@ -86,7 +87,7 @@ export const RecordingsUniversalFilters = ({
     useMountedLogic(actionsModel)
     useMountedLogic(groupsModel)
 
-    const durationFilter = filters.duration[0]
+    const durationFilter = filters.duration?.length ? filters.duration[0] : defaultRecordingDurationFilter
 
     const { isFiltersExpanded, activeFilterTab } = useValues(playlistLogic)
     const { setIsFiltersExpanded, setActiveFilterTab } = useActions(playlistLogic)

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFilters.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFilters.tsx
@@ -87,7 +87,7 @@ export const RecordingsUniversalFilters = ({
     useMountedLogic(actionsModel)
     useMountedLogic(groupsModel)
 
-    const durationFilter = filters.duration?.length ? filters.duration[0] : defaultRecordingDurationFilter
+    const durationFilter = filters.duration?.[0] ?? defaultRecordingDurationFilter
 
     const { isFiltersExpanded, activeFilterTab } = useValues(playlistLogic)
     const { setIsFiltersExpanded, setActiveFilterTab } = useActions(playlistLogic)


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Attempts to fix [this exception](https://us.posthog.com/project/2/error_tracking/536f86c7-6e8e-4443-b856-352ad5300dff?dateRange=%7B%22date_from%22%3A%22-14d%22%2C%22date_to%22%3Anull%7D): Cannot read properties of undefined (reading 'key')

## Changes

- Checks if the duration filter is an array and is empty: `const durationFilter = filters.duration?.length ? filters.duration[0] : defaultRecordingDurationFilter`
- Falls back to the default duration filter in `../playlist/sessionRecordingsPlaylistLogic`

## How did you test this code?


