### PR TITLE
fix: unsubscribe modal

### DIFF
--- a/frontend/src/scenes/billing/UnsubscribeCard.tsx
+++ b/frontend/src/scenes/billing/UnsubscribeCard.tsx
@@ -1,54 +1,59 @@
 import { LemonButton, Link } from '@posthog/lemon-ui'
-import { useActions } from 'kea'
+import { useActions, useValues } from 'kea'
 import { supportLogic } from 'lib/components/Support/supportLogic'
 import { UNSUBSCRIBE_SURVEY_ID } from 'lib/constants'
 
 import { BillingProductV2Type } from '~/types'
 
 import { billingProductLogic } from './billingProductLogic'
+import { UnsubscribeSurveyModal } from './UnsubscribeSurveyModal'
 
 export const UnsubscribeCard = ({ product }: { product: BillingProductV2Type }): JSX.Element => {
     const { reportSurveyShown, setSurveyResponse } = useActions(billingProductLogic({ product }))
+    const { surveyID } = useValues(billingProductLogic({ product }))
     const { openSupportForm } = useActions(supportLogic)
 
     return (
-        <div className="p-5 gap-4 flex">
-            <div className="">
-                <h3>Need to take a break?</h3>
-                <p className="mb-2">
-                    Downgrade to the free plan at any time. You'll lose access to platform features and usage limits
-                    will apply immediately.
-                </p>
-                <p className="">
-                    Need to control your costs? Learn about ways to{' '}
-                    <Link
-                        to="https://posthog.com/docs/billing/estimating-usage-costs#how-to-reduce-your-posthog-costs?utm_source=app-unsubscribe"
-                        target="_blank"
+        <>
+            <div className="p-5 gap-4 flex">
+                <div className="">
+                    <h3>Need to take a break?</h3>
+                    <p className="mb-2">
+                        Downgrade to the free plan at any time. You'll lose access to platform features and usage limits
+                        will apply immediately.
+                    </p>
+                    <p className="">
+                        Need to control your costs? Learn about ways to{' '}
+                        <Link
+                            to="https://posthog.com/docs/billing/estimating-usage-costs#how-to-reduce-your-posthog-costs?utm_source=app-unsubscribe"
+                            target="_blank"
+                        >
+                            reduce your bill
+                        </Link>{' '}
+                        or{' '}
+                        <Link to="" onClick={() => openSupportForm({ target_area: 'billing', isEmailFormOpen: true })}>
+                            chat with support.
+                        </Link>{' '}
+                        Check out more about our pricing on our{' '}
+                        <Link to="https://posthog.com/pricing" target="_blank">
+                            pricing page
+                        </Link>
+                        .
+                    </p>
+                    <LemonButton
+                        status="danger"
+                        type="secondary"
+                        size="small"
+                        onClick={() => {
+                            setSurveyResponse('$survey_response_1', product.type)
+                            reportSurveyShown(UNSUBSCRIBE_SURVEY_ID, product.type)
+                        }}
                     >
-                        reduce your bill
-                    </Link>{' '}
-                    or{' '}
-                    <Link to="" onClick={() => openSupportForm({ target_area: 'billing', isEmailFormOpen: true })}>
-                        chat with support.
-                    </Link>{' '}
-                    Check out more about our pricing on our{' '}
-                    <Link to="https://posthog.com/pricing" target="_blank">
-                        pricing page
-                    </Link>
-                    .
-                </p>
-                <LemonButton
-                    status="danger"
-                    type="secondary"
-                    size="small"
-                    onClick={() => {
-                        setSurveyResponse('$survey_response_1', product.type)
-                        reportSurveyShown(UNSUBSCRIBE_SURVEY_ID, product.type)
-                    }}
-                >
-                    Downgrade to free plan
-                </LemonButton>
+                        Downgrade to free plan
+                    </LemonButton>
+                </div>
             </div>
-        </div>
+            {surveyID && <UnsubscribeSurveyModal product={product} />}
+        </>
     )
 }


### PR DESCRIPTION
## Problem

`Downgrade to free plan` button isn't working
- Reported by a user here: https://posthoghelp.zendesk.com/agent/tickets/32029 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/33736)
- I was able to reproduce locally what I saw in the session recording (nothing happens when you click on downgrade button)

The reason seems to be missing `UnsubscribeSurveyModal` - but I don't see any changes on `UnsubscribeCard` - was it removed in some other file higher up in the component tree? Because currently it's only present on other components that are siblings (or children of siblings) of `UnsubscribeCard` - there's no `UnsubscribeSurveyModal` directly on the `Billing` page.

## Changes

Adds `UnsubscribeSurveyModal` to `UnsubscribeCard`

## Did you write or update any docs for this change?

- [x] No docs needed for this change

## How did you test this code?

Manually - this change allows opening the modal and I was able to unsubscribe