### PR TITLE
feat(logs): make log attribute key/value lookup efficient

### DIFF
--- a/products/logs/backend/api.py
+++ b/products/logs/backend/api.py
@@ -73,13 +73,11 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
         results = sync_execute(
             """
 SELECT
-    arrayFilter(
-        x -> x like %(search)s,
-        arraySort(groupArrayDistinctArrayMerge(attribute_keys)) as keys
-    )
+    arraySort(groupArrayDistinct(attribute_key)) as keys
 FROM log_attributes
-WHERE time_bucket >= toStartOfHour(now()) AND time_bucket <= toStartOfHour(now())
+WHERE time_bucket >= toStartOfInterval(now() - interval 1 hour, interval 10 minute)
 AND team_id = %(team_id)s
+AND attribute_key LIKE %(search)s
 GROUP BY team_id
 LIMIT 1;
 """,
@@ -102,24 +100,18 @@ LIMIT 1;
 
     @action(detail=False, methods=["GET"], required_scopes=["error_tracking:read"])
     def values(self, request: Request, *args, **kwargs) -> Response:
-        search = request.GET.get("search", "")
+        search = request.GET.get("value", "")
         key = request.GET.get("key", "")
 
         results = sync_execute(
             """
 SELECT
-        arraySort(
-            arrayMap(
-                (k, v) -> v,
-                arrayFilter(
-                    (k, v) -> k == %(key)s and v like %(search)s,
-                    groupArrayDistinctArrayMerge(attribute_values)
-                )
-            )
-        ) as values
+    arraySort(groupArrayDistinct(attribute_value)) as values
 FROM log_attributes
-WHERE time_bucket >= toStartOfHour(now()) AND time_bucket <= toStartOfHour(now())
+WHERE time_bucket >= toStartOfInterval(now() - interval 1 hour, interval 10 minute)
 AND team_id = %(team_id)s
+AND attribute_key = %(key)s
+AND attribute_value LIKE %(search)s
 GROUP BY team_id
 LIMIT 1;
 """,

--- a/products/logs/backend/schema.sql
+++ b/products/logs/backend/schema.sql
@@ -53,44 +53,33 @@ CREATE TABLE default.log_attributes
     `team_id` Int32,
     `time_bucket` DateTime64(0),
     `service_name` LowCardinality(String),
-    `attribute_keys` AggregateFunction(groupArrayDistinctArray, Array(LowCardinality(String))),
-    `attribute_values` AggregateFunction(groupArrayDistinctArray, Array(Tuple(
-        String,
-        String))),
-    `resource_attribute_keys` AggregateFunction(groupArrayDistinctArray, Array(LowCardinality(String))),
-    `resource_attribute_values` AggregateFunction(groupArrayDistinctArray, Array(Tuple(
-        String,
-        String)))
+    `attribute_key` LowCardinality(String),
+    `attribute_value` String,
+
+    INDEX idx_attribute_key attribute_key TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_attribute_value attribute_value TYPE bloom_filter(0.001) GRANULARITY 1,
+    INDEX idx_attribute_key_n3 attribute_key TYPE ngrambf_v1(3, 32768, 3, 0) GRANULARITY 1,
+    INDEX idx_attribute_value_n3 attribute_value TYPE ngrambf_v1(3, 32768, 3, 0)) GRANULARITY 1,
 )
 ENGINE = SharedAggregatingMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}')
 PARTITION BY toDate(time_bucket)
-ORDER BY (team_id, service_name, time_bucket)
-SETTINGS index_granularity = 8192;
+ORDER BY (team_id, service_name, time_bucket, attribute_key, attribute_value);
 
-CREATE MATERIALIZED VIEW default.log_to_log_attributes TO default.log_attributes
+set enable_dynamic_type=1;
+CREATE MATERIALIZED VIEW default.log_to_log_attributes TO default.log_attributes2
 (
     `team_id` Int32,
-    `time_bucket` DateTime,
+    `time_bucket` DateTime64(0),
     `service_name` LowCardinality(String),
-    `attribute_keys` AggregateFunction(groupArrayDistinctArray, Array(String)),
-    `attribute_values` AggregateFunction(groupArrayDistinctArray, Array(Tuple(
-        String,
-        String))),
-    `resource_attribute_keys` AggregateFunction(groupArrayDistinctArray, Array(String)),
-    `resource_attribute_values` AggregateFunction(groupArrayDistinctArray, Array(Tuple(
-        String,
-        String)))
+    `attribute_key` LowCardinality(String),
+    `attribute_value` String,
 )
 AS SELECT
+    uuid,
     team_id AS team_id,
-    toStartOfInterval(timestamp, toIntervalHour(1)) AS time_bucket,
+    toStartOfInterval(timestamp, toIntervalMinute(10)) AS time_bucket,
     service_name AS service_name,
-    groupArrayDistinctArrayState(arrayFilter(x -> (length(x) < 256), mapKeys(attributes))) AS attribute_keys,
-    groupArrayDistinctArrayState(CAST(mapFilter((k, v) -> ((length(k) < 256) AND (length(v) < 256)), mapApply((k, v) -> (k, JSONExtract(v, 'Dynamic')::String),attributes)), 'Array(Tuple(String, String))')) AS attribute_values,
-    groupArrayDistinctArrayState(arrayFilter(x -> (length(x) < 256), mapKeys(resource_attributes))) AS resource_attribute_keys,
-    groupArrayDistinctArrayState(CAST(mapFilter((k, v) -> ((length(k) < 256) AND (length(v) < 256)), resource_attributes), 'Array(Tuple(String, String))')) AS resource_attribute_values
+    arrayJoin(arrayFilter((k,v) -> (length(k) < 256 and length(v) < 256), attributes::Array(Tuple(String, String)))) as attribute,
+    attribute.1 as attribute_key,
+    JSONExtract(attribute.2, 'Dynamic')::String as attribute_value
 FROM default.logs
-GROUP BY
-    team_id,
-    time_bucket,
-    service_name;


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
this used to get _very_ slow. Make it lightning fast

rearchitect so the aggregation table actually makes sense by splitting map elements to separate rows instead of making and merging loads of mega arrays
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
