### PR TITLE
fix(trends): extend execution time for insight actors queries

### DIFF
--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -22,7 +22,7 @@ from posthog.api.monitoring import Feature, monitor
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.services.query import process_query_model
 
-from posthog.api.utils import action, is_insight_query
+from posthog.api.utils import action, is_insight_actors_options_query, is_insight_actors_query, is_insight_query
 from posthog.clickhouse.client.execute_async import (
     cancel_query,
     get_query_status,
@@ -145,7 +145,12 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
                 limit_context=(
                     # QUERY_ASYNC provides extended max execution time for insight queries
                     LimitContext.QUERY_ASYNC
-                    if is_insight_query(query) and get_query_tag_value("access_method") != "personal_api_key"
+                    if (
+                        is_insight_query(query)
+                        or is_insight_actors_query(query)
+                        or is_insight_actors_options_query(query)
+                    )
+                    and get_query_tag_value("access_method") != "personal_api_key"
                     else None
                 ),
             )

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -364,6 +364,28 @@ def is_insight_query(query):
     return False
 
 
+def is_insight_actors_query(query):
+    insight_actors_kinds = {
+        "InsightActorsQuery",
+        "FunnelsActorsQuery",
+        "FunnelCorrelationActorsQuery",
+        "StickinessActorsQuery",
+    }
+    if getattr(query, "kind", None) in insight_actors_kinds:
+        return True
+    if getattr(query, "kind", None) == "ActorsQuery":
+        source = getattr(query, "source", None)
+        if source and getattr(source, "kind", None) in insight_actors_kinds:
+            return True
+    return False
+
+
+def is_insight_actors_options_query(query):
+    if getattr(query, "kind", None) == "InsightActorsQueryOptions":
+        return True
+    return False
+
+
 def parse_bool(value: Union[str, list[str]]) -> bool:
     if value == "true":
         return True


### PR DESCRIPTION
## Problem

Insight actor queries and insight actor options queries fail for a customer as they exceed the standard 60s limit. See https://posthoghelp.zendesk.com/agent/tickets/30965. (moved to PostHog: https://us.posthog.com/project/2/support/tickets/33289)

## Changes

Allows them to run for 600s, like insight queries.

## How did you test this code?

Used debugger locally