### PR TITLE
refactor: Update pipelineNodeNew to use source instead of kind

### DIFF
--- a/frontend/src/scenes/data-warehouse/external/forms/DataWarehouseIntegrationChoice.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/DataWarehouseIntegrationChoice.tsx
@@ -15,7 +15,7 @@ export function DataWarehouseIntegrationChoice({
         <IntegrationChoice
             {...props}
             integration={sourceConfig.name.toLowerCase()}
-            redirectUrl={urls.pipelineNodeNew(PipelineStage.Source, { kind: sourceConfig.name.toLowerCase() })}
+            redirectUrl={urls.pipelineNodeNew(PipelineStage.Source, { source: sourceConfig.name })}
         />
     )
 }

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -3,7 +3,16 @@ import { getCurrentTeamId } from 'lib/utils/getAppContext'
 
 import type { ExportOptions } from '~/exporter/types'
 import { productUrls } from '~/products'
-import { ActivityTab, AnnotationType, PipelineNodeTab, PipelineStage, PipelineTab, ProductKey, SDKKey } from '~/types'
+import {
+    ActivityTab,
+    AnnotationType,
+    ExternalDataSourceType,
+    PipelineNodeTab,
+    PipelineStage,
+    PipelineTab,
+    ProductKey,
+    SDKKey,
+} from '~/types'
 
 import type { BillingSectionId } from './billing/types'
 import type { OnboardingStepKey } from './onboarding/onboardingLogic'
@@ -42,14 +51,16 @@ export const urls = {
 
     pipelineNodeNew: (
         stage: PipelineStage | ':stage',
-        { id, kind }: { id?: string | number; kind?: string } = {}
+        { id, source }: { id?: string | number; source?: ExternalDataSourceType } = {}
     ): string => {
         let base = `/pipeline/new/${stage}`
         if (id) {
             base += `/${id}`
         }
 
-        if (kind) {
+        if (source) {
+            // we need to lowercase the source to match the kind in the sourceWizardLogic
+            const kind: Lowercase<ExternalDataSourceType> = source.toLowerCase() as Lowercase<ExternalDataSourceType>
             return `${base}?kind=${kind}`
         }
 

--- a/products/revenue_analytics/frontend/RevenueAnalyticsScene.tsx
+++ b/products/revenue_analytics/frontend/RevenueAnalyticsScene.tsx
@@ -175,7 +175,7 @@ const RevenueAnalyticsSceneOnboarding = (): JSX.Element => {
                             sideIcon={<IconDatabase />}
                             onClick={() => {
                                 updateHasSeenProductIntroFor(ProductKey.REVENUE_ANALYTICS, true)
-                                router.actions.push(urls.pipelineNodeNew(PipelineStage.Source, { kind: 'stripe' }))
+                                router.actions.push(urls.pipelineNodeNew(PipelineStage.Source, { source: 'Stripe' }))
                             }}
                             data-attr="create-revenue-source"
                         >

--- a/products/revenue_analytics/frontend/settings/ExternalDataSourceConfiguration.tsx
+++ b/products/revenue_analytics/frontend/settings/ExternalDataSourceConfiguration.tsx
@@ -82,7 +82,9 @@ export function ExternalDataSourceConfiguration({
                                 ref={buttonRef}
                                 type="primary"
                                 onClick={() => {
-                                    router.actions.push(urls.pipelineNodeNew(PipelineStage.Source, { kind: 'stripe' }))
+                                    router.actions.push(
+                                        urls.pipelineNodeNew(PipelineStage.Source, { source: 'Stripe' })
+                                    )
                                 }}
                             >
                                 Add new source


### PR DESCRIPTION
## Problem

Currently the way to generate source link is arbitrary. And for my future implementation I want to iterate sources and create link form them.

## Changes

For that I did this refactor that allow you to use the source id in lowercase for the url parameter (kind). And updated related code.

## Did you write or update any docs for this change?

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Manually
