### PR TITLE
fix: endless status loading

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelStatusLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelStatusLogic.tsx
@@ -98,6 +98,7 @@ export const sidePanelStatusLogic = kea<sidePanelStatusLogicType>([
 
     actions({
         loadStatusPage: true,
+        setPageVisibility: (visible: boolean) => ({ visible }),
     }),
 
     reducers(() => ({
@@ -143,13 +144,27 @@ export const sidePanelStatusLogic = kea<sidePanelStatusLogicType>([
             clearTimeout(cache.timeout)
             cache.timeout = setTimeout(() => actions.loadStatusPage(), REFRESH_INTERVAL)
         },
+        setPageVisibility: ({ visible }) => {
+            if (visible && !cache.timeout) {
+                actions.loadStatusPage()
+            } else {
+                clearTimeout(cache.timeout)
+                cache.timeout = null
+            }
+        },
     })),
 
-    afterMount(({ actions }) => {
+    afterMount(({ actions, cache }) => {
         actions.loadStatusPage()
+        cache.onVisibilityChange = () => {
+            actions.setPageVisibility(document.visibilityState === 'visible')
+        }
+        document.addEventListener('visibilitychange', cache.onVisibilityChange)
     }),
 
     beforeUnmount(({ cache }) => {
         clearTimeout(cache.timeout)
+        cache.timeout = null
+        document.removeEventListener('visibilitychange', cache.onVisibilityChange)
     }),
 ])


### PR DESCRIPTION
since i've been looking at idle tabs so much

i realised that sometimes they're sending a request to get posthog's incident status every 5 minutes

even in the background

so instead

we track page visibility
and stop and start checking based on page/tab visibility

i don't have strong confidence this will help with the memory leak

but, a regular API call could be stopping a tab becoming idle and freeing memory... and after all it can't make it worse 🤷 
