### PR TITLE
fix(cohorts): restart stuck cohort calculations

### DIFF
--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -1,6 +1,7 @@
 import json
 from ee.clickhouse.materialized_columns.analyze import materialize
 from datetime import datetime, timedelta
+from dateutil.relativedelta import relativedelta
 from typing import Optional, Any
 from unittest import mock
 from unittest.mock import patch
@@ -2188,6 +2189,73 @@ email@example.org,
         self.assertEqual(response.status_code, 201, response.json())
         cohort_data = response.json()
         self.assertIsNotNone(cohort_data.get("id"))
+
+    def test_get_cohort_calculation_candidates_includes_stuck_calculations(self):
+        from freezegun import freeze_time
+
+        # Test that cohorts stuck in calculating state for >24 hours are included
+        with freeze_time("2023-01-01 12:00:00"):
+            # Create a cohort that's been calculating for 25 hours (stuck)
+            stuck_cohort = Cohort.objects.create(
+                team=self.team,
+                groups=[{"properties": [{"key": "$some_prop", "value": "something", "type": "person"}]}],
+                name="stuck_cohort",
+                is_calculating=True,
+                last_calculation=timezone.now() - relativedelta(hours=25),
+                deleted=False,
+                is_static=False,
+                errors_calculating=0,
+            )
+
+            # Create a cohort that's been calculating for 10 hours (not stuck yet)
+            recent_calculating_cohort = Cohort.objects.create(
+                team=self.team,
+                groups=[{"properties": [{"key": "$some_prop", "value": "something", "type": "person"}]}],
+                name="recent_calculating_cohort",
+                is_calculating=True,
+                last_calculation=timezone.now() - relativedelta(hours=10),
+                deleted=False,
+                is_static=False,
+                errors_calculating=0,
+            )
+
+            # Create a normal cohort that's not calculating
+            normal_cohort = Cohort.objects.create(
+                team=self.team,
+                groups=[{"properties": [{"key": "$some_prop", "value": "something", "type": "person"}]}],
+                name="normal_cohort",
+                is_calculating=False,
+                last_calculation=timezone.now() - relativedelta(hours=25),
+                deleted=False,
+                is_static=False,
+                errors_calculating=0,
+            )
+
+            # Create a static cohort (should be excluded)
+            static_cohort = Cohort.objects.create(
+                team=self.team,
+                groups=[{"properties": [{"key": "$some_prop", "value": "something", "type": "person"}]}],
+                name="static_cohort",
+                is_calculating=True,
+                last_calculation=timezone.now() - relativedelta(hours=25),
+                deleted=False,
+                is_static=True,
+                errors_calculating=0,
+            )
+
+            candidates = get_cohort_calculation_candidates_queryset()
+
+            # Stuck cohort (calculating for >24h) should be included for recalculation
+            assert stuck_cohort in candidates, "Stuck cohort should be included"
+
+            # Recent calculating cohort should NOT be included (still actively calculating)
+            assert recent_calculating_cohort not in candidates, "Recent calculating cohort should not be included"
+
+            # Normal cohort should be included (not calculating and old enough)
+            assert normal_cohort in candidates, "Normal cohort should be included"
+
+            # Static cohort should NOT be included (excluded by is_static filter)
+            assert static_cohort not in candidates, "Static cohort should not be included"
 
 
 class TestCalculateCohortCommand(APIBaseTest):

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -34,16 +34,22 @@ COHORT_STALENESS_HOURS_GAUGE = Gauge(
 logger = structlog.get_logger(__name__)
 
 MAX_AGE_MINUTES = 15
+CALCULATE_COHORT_TIME_LIMIT_MINUTES = 60 * 60 * 10
 
 
 def get_cohort_calculation_candidates_queryset() -> QuerySet:
     return Cohort.objects.filter(
         Q(last_calculation__lte=timezone.now() - relativedelta(minutes=MAX_AGE_MINUTES))
         | Q(last_calculation__isnull=True),
-        deleted=False,
-        is_calculating=False,
-        errors_calculating__lte=20,
-    ).exclude(is_static=True)
+        Q(deleted=False),
+        # Include cohorts that are either not calculating,
+        # OR are calculating but stuck (>24 hours)
+        # This will help us catch cohorts where they failed to calculate and
+        # never had is_calculating set back False due to the process crashing
+        Q(is_calculating=False)
+        | Q(is_calculating=True, last_calculation__lte=timezone.now() - relativedelta(hours=24)),
+        Q(errors_calculating__lte=20),
+    ).exclude(Q(is_static=True))
 
 
 def enqueue_cohorts_to_calculate(parallel_count: int) -> None:
@@ -89,7 +95,12 @@ def increment_version_and_enqueue_calculate_cohort(cohort: Cohort, *, initiating
     calculate_cohort_ch.delay(cohort.id, cohort.pending_version, initiating_user.id if initiating_user else None)
 
 
-@shared_task(ignore_result=True, max_retries=2, queue=CeleryQueue.LONG_RUNNING.value)
+@shared_task(
+    ignore_result=True,
+    max_retries=2,
+    queue=CeleryQueue.LONG_RUNNING.value,
+    time_limit=CALCULATE_COHORT_TIME_LIMIT_MINUTES,
+)
 def calculate_cohort_ch(cohort_id: int, pending_version: int, initiating_user_id: Optional[int] = None) -> None:
     cohort: Cohort = Cohort.objects.get(pk=cohort_id)
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

We identified an issue where some cohorts remain in a "calculating" state (`is_calculating=true`) indefinitely, sometimes for weeks or months. Because of this status, our workflow does not automatically retry the calculation. For examples, please see this ticket: https://github.com/PostHog/posthog/issues/32745.

To fix a stuck cohort, we trigger a calculation by either resaving it in the UI or directly in prod.


## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

The change automatically triggers a recalculation for cohorts that are stuck in a calculating state so we don't have to do this ourselves. 

To understand the potential impact, the following query identifies how many cohorts in US currently meet this condition:
```
SELECT count(1)
FROM posthog_cohort
where deleted = false
and is_static = false
and is_calculating = true
and last_calculation < NOW() - INTERVAL '24 hours'
AND errors_calculating <= 20;

27,280
```

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
