### PR TITLE
chore: increase partition grouping and log sql statements

### DIFF
--- a/dags/web_preaggregated_daily.py
+++ b/dags/web_preaggregated_daily.py
@@ -21,8 +21,7 @@ from posthog.models.web_preaggregated.sql import (
 
 # From my tests, 14 (two weeks) is a sane value for production.
 # But locally we can run more partitions per run to speed up testing (e.g: 3000 to materialize everything on a single run)
-# TODO: I am currently setting it to 2 so the backfill can be kept running without clickinghouse getting overwhelmed
-max_partitions_per_run = int(os.getenv("DAGSTER_WEB_PREAGGREGATED_MAX_PARTITIONS_PER_RUN", 2))
+max_partitions_per_run = int(os.getenv("DAGSTER_WEB_PREAGGREGATED_MAX_PARTITIONS_PER_RUN", 14))
 backfill_policy_def = BackfillPolicy.multi_run(max_partitions_per_run=max_partitions_per_run)
 
 partition_def = DailyPartitionsDefinition(start_date="2020-01-01")
@@ -130,7 +129,7 @@ web_pre_aggregate_daily_job = dagster.define_asset_job(
     selection=["web_analytics_bounces_daily", "web_analytics_stats_table_daily"],
     tags={
         "owner": JobOwners.TEAM_WEB_ANALYTICS.value,
-        # The intance level config limits the job concurrency on the run queue
+        # The instance level config limits the job concurrency on the run queue
         # https://github.com/PostHog/charts/blob/chore/dagster-config/config/dagster/prod-us.yaml#L179-L181
     },
     # This limit the concurrency of the assets inside the job, so they run sequentially


### PR DESCRIPTION
## Problem

We can go back to our previous value, as each job now takes [~1min](https://dagster.prod-us.posthog.dev/runs/bb8066fb-5191-40d6-96f5-7056307803e4), and half of it is waiting for dagster resources to boot the subprocesses.

The reason is that the changes https://github.com/PostHog/posthog/pull/33251 were compelling enough so that we can make this one use more CH resources.

## Changes

- Rolled back the partition group to 14 (2 weeks)
- Added a small log for the SQL statements that run with `map_all_hosts` to improve the debugging experience.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [x] No docs needed for this change

## How did you test this code?

Manually
