### PR TITLE
chore: handle session boundaries and epoch grouping

### DIFF
--- a/dags/web_preaggregated_daily.py
+++ b/dags/web_preaggregated_daily.py
@@ -21,8 +21,7 @@ from posthog.models.web_preaggregated.sql import (
 
 # From my tests, 14 (two weeks) is a sane value for production.
 # But locally we can run more partitions per run to speed up testing (e.g: 3000 to materialize everything on a single run)
-# TODO: I am currently setting it to 2 so the backfill can be kept running without clickinghouse getting overwhelmed
-max_partitions_per_run = int(os.getenv("DAGSTER_WEB_PREAGGREGATED_MAX_PARTITIONS_PER_RUN", 2))
+max_partitions_per_run = int(os.getenv("DAGSTER_WEB_PREAGGREGATED_MAX_PARTITIONS_PER_RUN", 14))
 backfill_policy_def = BackfillPolicy.multi_run(max_partitions_per_run=max_partitions_per_run)
 
 partition_def = DailyPartitionsDefinition(start_date="2020-01-01")

--- a/posthog/models/web_preaggregated/sql.py
+++ b/posthog/models/web_preaggregated/sql.py
@@ -300,8 +300,8 @@ def WEB_STATS_INSERT_SQL(
                 raw_sessions.session_id_v7 AS session_id_v7
             FROM raw_sessions
             WHERE {team_filter}
-                AND toTimeZone(raw_sessions.min_timestamp, '{timezone}') >= toDateTime('{date_start}', '{timezone}')
-                AND toTimeZone(raw_sessions.min_timestamp, '{timezone}') < toDateTime('{date_end}', '{timezone}')
+                AND toTimeZone(raw_sessions.min_timestamp, '{timezone}') >= toDateTime('{date_start}', '{timezone}') - INTERVAL 2 DAY
+                AND toTimeZone(raw_sessions.min_timestamp, '{timezone}') < toDateTime('{date_end}', '{timezone}') + INTERVAL 2 DAY
             GROUP BY
                 raw_sessions.session_id_v7
             SETTINGS {settings}
@@ -320,8 +320,8 @@ def WEB_STATS_INSERT_SQL(
         WHERE {events_team_filter}
             AND ((e.event = '$pageview') OR (e.event = '$screen'))
             AND (e.`$session_id` IS NOT NULL)
-            AND toTimeZone(e.timestamp, '{timezone}') >= toDateTime('{date_start}', '{timezone}')
-            AND toTimeZone(e.timestamp, '{timezone}') < toDateTime('{date_end}', '{timezone}')
+            AND toTimeZone(e.timestamp, '{timezone}') >= toDateTime('{date_start}', '{timezone}') - INTERVAL 2 DAY
+            AND toTimeZone(e.timestamp, '{timezone}') < toDateTime('{date_end}', '{timezone}') + INTERVAL 2 DAY
         GROUP BY
             events__session.session_id,
             e.team_id,
@@ -346,6 +346,8 @@ def WEB_STATS_INSERT_SQL(
             region_name
         SETTINGS {settings}
     )
+    WHERE {time_bucket_func}(start_timestamp) >= toDateTime('{date_start}', '{timezone}')
+        AND {time_bucket_func}(start_timestamp) < toDateTime('{date_end}', '{timezone}')
     GROUP BY
         period_bucket,
         team_id,
@@ -476,8 +478,8 @@ def WEB_BOUNCES_INSERT_SQL(
                 raw_sessions.session_id_v7 AS session_id_v7
             FROM raw_sessions
             WHERE {team_filter}
-                AND toTimeZone(raw_sessions.min_timestamp, '{timezone}') >= toDateTime('{date_start}', '{timezone}')
-                AND toTimeZone(raw_sessions.min_timestamp, '{timezone}') < toDateTime('{date_end}', '{timezone}')
+                AND toTimeZone(raw_sessions.min_timestamp, '{timezone}') >= toDateTime('{date_start}', '{timezone}') - INTERVAL 2 DAY
+                AND toTimeZone(raw_sessions.min_timestamp, '{timezone}') < toDateTime('{date_end}', '{timezone}') + INTERVAL 2 DAY
             GROUP BY raw_sessions.session_id_v7
         ) AS events__session ON toUInt128(accurateCastOrNull(e.`$session_id`, 'UUID')) = events__session.session_id_v7
         LEFT JOIN
@@ -493,8 +495,8 @@ def WEB_BOUNCES_INSERT_SQL(
         WHERE {events_team_filter}
             AND ((e.event = '$pageview') OR (e.event = '$screen'))
             AND (e.`$session_id` IS NOT NULL)
-            AND toTimeZone(e.timestamp, '{timezone}') >= toDateTime('{date_start}', '{timezone}')
-            AND toTimeZone(e.timestamp, '{timezone}') < toDateTime('{date_end}', '{timezone}')
+            AND toTimeZone(e.timestamp, '{timezone}') >= toDateTime('{date_start}', '{timezone}') - INTERVAL 2 DAY
+            AND toTimeZone(e.timestamp, '{timezone}') < toDateTime('{date_end}', '{timezone}') + INTERVAL 2 DAY
         GROUP BY
             session_id,
             team_id,
@@ -517,6 +519,8 @@ def WEB_BOUNCES_INSERT_SQL(
             viewport_width,
             viewport_height
     )
+    WHERE {time_bucket_func}(start_timestamp) >= toDateTime('{date_start}', '{timezone}')
+        AND {time_bucket_func}(start_timestamp) < toDateTime('{date_end}', '{timezone}')
     GROUP BY
         period_bucket,
         team_id,


### PR DESCRIPTION
## Problem

Many values are ending up on the epoch, I think those are missing JOINs with sessions, or some weird pageviews our api key ended up receiving. I am positive we can filter them out and save us some disk space.

Also, now that we're backfilling with smaller bucket groups, it showed that we need to apply the same technique as the regular queries to include session data near the date boundaries to keep our accuracy in check.

## Changes

- Added a bigger time window for session data
- Added a date filter on the outer query to just upsert the period data

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [x] No docs needed for this change

## How did you test this code?

Manually
