### PR TITLE
chore: Bump start to close timeout for hourly batch exports

### DIFF
--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -698,7 +698,7 @@ async def execute_batch_export_insert_activity(
         heartbeat_timeout_seconds = settings.BATCH_EXPORT_HEARTBEAT_TIMEOUT_SECONDS
 
     if interval == "hour":
-        start_to_close_timeout = dt.timedelta(hours=2)
+        start_to_close_timeout = dt.timedelta(hours=6)
     elif interval == "day":
         start_to_close_timeout = dt.timedelta(days=1)
     elif interval.startswith("every"):


### PR DESCRIPTION
## Problem

Some larger exports are timing out.

## Changes

We have performance improvements planned for next week, but in the meantime, let's give them more time to finish.