### PR TITLE
feat(project-tree): pinned folder menu

### DIFF
--- a/frontend/src/layout/panel-layout/PinnedFolder/PinnedFolder.tsx
+++ b/frontend/src/layout/panel-layout/PinnedFolder/PinnedFolder.tsx
@@ -4,6 +4,12 @@ import { FolderSelect } from 'lib/components/FolderSelect/FolderSelect'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from 'lib/ui/DropdownMenu/DropdownMenu'
 
 import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
 import { pinnedFolderLogic } from '~/layout/panel-layout/PinnedFolder/pinnedFolderLogic'
@@ -15,37 +21,44 @@ export function PinnedFolder(): JSX.Element {
     const { modalVisible, pinnedFolder, selectedFolder } = useValues(pinnedFolderLogic)
     const { hideModal, showModal, setPinnedFolder, setSelectedFolder } = useActions(pinnedFolderLogic)
 
+    const showDefaultHeader = pinnedFolder !== 'products://' && pinnedFolder !== 'data://'
+
+    const configMenu = (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <ButtonPrimitive iconOnly data-attr="tree-navbar-pinned-folder-change-button">
+                    <IconGear className="size-3 text-secondary" />
+                </ButtonPrimitive>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent loop align="end" side="bottom" className="max-w-[250px]">
+                <DropdownMenuItem
+                    asChild
+                    onClick={(e) => {
+                        e.stopPropagation()
+                        showModal()
+                    }}
+                    data-attr="tree-item-menu-open-link-button"
+                >
+                    <ButtonPrimitive menuItem>Change pinned folder</ButtonPrimitive>
+                </DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
+    )
+
     return (
         <>
             {!isLayoutNavCollapsed &&
-                (pinnedFolder === 'products://' ? (
-                    <ButtonPrimitive
-                        onClick={showModal}
-                        iconOnly
-                        tooltip="Change pinned folder"
-                        tooltipPlacement="right"
-                        data-attr="tree-navbar-pinned-folder-change-button"
-                        className="absolute right-1 z-10"
-                    >
-                        <IconGear className="size-3 text-secondary" />
-                    </ButtonPrimitive>
-                ) : (
+                (showDefaultHeader ? (
                     <div className="flex justify-between items-center pl-3 pr-1 relative">
                         <div className="flex items-center gap-1">
                             <span className="text-xs font-semibold text-quaternary">
                                 {formatUrlAsName(pinnedFolder)}
                             </span>
                         </div>
-                        <ButtonPrimitive
-                            onClick={showModal}
-                            iconOnly
-                            tooltip="Change pinned folder"
-                            tooltipPlacement="right"
-                            data-attr="tree-navbar-pinned-folder-change-button"
-                        >
-                            <IconGear className="size-3 text-secondary" />
-                        </ButtonPrimitive>
+                        {configMenu}
                     </div>
+                ) : (
+                    <div className="absolute right-1 z-10">{configMenu}</div>
                 ))}
             <div className="flex flex-col mt-[-0.25rem] h-full group/colorful-product-icons colorful-product-icons-true">
                 <ProjectTree root={pinnedFolder} onlyTree treeSize={isLayoutNavCollapsed ? 'narrow' : 'default'} />

--- a/frontend/src/layout/panel-layout/PinnedFolder/PinnedFolder.tsx
+++ b/frontend/src/layout/panel-layout/PinnedFolder/PinnedFolder.tsx
@@ -1,6 +1,7 @@
-import { IconGear } from '@posthog/icons'
+import { IconCheck, IconGear } from '@posthog/icons'
 import { useActions, useValues } from 'kea'
 import { FolderSelect } from 'lib/components/FolderSelect/FolderSelect'
+import { IconBlank } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
@@ -8,6 +9,8 @@ import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from 'lib/ui/DropdownMenu/DropdownMenu'
 
@@ -31,6 +34,34 @@ export function PinnedFolder(): JSX.Element {
                 </ButtonPrimitive>
             </DropdownMenuTrigger>
             <DropdownMenuContent loop align="end" side="bottom" className="max-w-[250px]">
+                <DropdownMenuLabel>Choose pinned folder</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                    asChild
+                    onClick={(e) => {
+                        e.stopPropagation()
+                        setPinnedFolder('products://')
+                    }}
+                    data-attr="tree-item-menu-open-link-button"
+                >
+                    <ButtonPrimitive menuItem>
+                        {!pinnedFolder || pinnedFolder === 'products://' ? <IconCheck /> : <IconBlank />}
+                        Products
+                    </ButtonPrimitive>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                    asChild
+                    onClick={(e) => {
+                        e.stopPropagation()
+                        setPinnedFolder('shortcuts://')
+                    }}
+                    data-attr="tree-item-menu-open-link-button"
+                >
+                    <ButtonPrimitive menuItem>
+                        {pinnedFolder === 'shortcuts://' ? <IconCheck /> : <IconBlank />}
+                        Shortcuts
+                    </ButtonPrimitive>
+                </DropdownMenuItem>
                 <DropdownMenuItem
                     asChild
                     onClick={(e) => {
@@ -39,7 +70,14 @@ export function PinnedFolder(): JSX.Element {
                     }}
                     data-attr="tree-item-menu-open-link-button"
                 >
-                    <ButtonPrimitive menuItem>Change pinned folder</ButtonPrimitive>
+                    <ButtonPrimitive menuItem>
+                        {pinnedFolder && pinnedFolder !== 'products://' && pinnedFolder !== 'shortcuts://' ? (
+                            <IconCheck />
+                        ) : (
+                            <IconBlank />
+                        )}
+                        Custom...
+                    </ButtonPrimitive>
                 </DropdownMenuItem>
             </DropdownMenuContent>
         </DropdownMenu>


### PR DESCRIPTION

## Problem

I find the modal that appears somewhat unexpected and definitely overwhelming.

![2025-06-06 11 04 01](https://github.com/user-attachments/assets/64a18518-1091-4bdd-a8ad-4543b0eb0918)

## Changes

Turn it into a menu with the two most useful options immediately clickable:

![2025-06-06 11 14 17](https://github.com/user-attachments/assets/dc47883a-39db-4086-92ca-d718a33f93b5)

