### PR TITLE
fix(err): add limit to symbol set cleanup job

### DIFF
--- a/dags/symbol_set_cleanup.py
+++ b/dags/symbol_set_cleanup.py
@@ -26,7 +26,7 @@ def symbol_sets_to_delete(config: SymbolSetSelectionConfig) -> list[ErrorTrackin
     if config.delete_unused:
         query_filter = query_filter | Q(last_used__isnull=True)
 
-    symbol_sets = ErrorTrackingSymbolSet.objects.filter(query_filter).order_by("last_used")[: config.batch_size]
+    symbol_sets = ErrorTrackingSymbolSet.objects.filter(query_filter).order_by("last_used")[:config.batch_size]
 
     return list(symbol_sets)
 

--- a/dags/symbol_set_cleanup.py
+++ b/dags/symbol_set_cleanup.py
@@ -10,6 +10,7 @@ from posthog.models.error_tracking.error_tracking import ErrorTrackingSymbolSet
 class SymbolSetSelectionConfig(dagster.Config):
     days_old: int = 30
     delete_unused: bool = False  # Delete symbol sets with null last_used
+    batch_size: int = 10000  # Maximum number of sets to process, to prevent ooms
 
 
 class SymbolSetDeletionConfig(dagster.Config):
@@ -25,7 +26,7 @@ def symbol_sets_to_delete(config: SymbolSetSelectionConfig) -> list[ErrorTrackin
     if config.delete_unused:
         query_filter = query_filter | Q(last_used__isnull=True)
 
-    symbol_sets = ErrorTrackingSymbolSet.objects.filter(query_filter).order_by("last_used")
+    symbol_sets = ErrorTrackingSymbolSet.objects.filter(query_filter).order_by("last_used")[: config.batch_size]
 
     return list(symbol_sets)
 
@@ -140,6 +141,7 @@ def daily_symbol_set_cleanup_schedule():
                     "config": SymbolSetSelectionConfig(
                         days_old=30,
                         delete_unused=False,  # TODO (olly) - switch this to True eventually (any time after July 1st 2025)
+                        batch_size=10000,
                     ).model_dump()
                 },
                 "symbol_set_cleanup_results": {

--- a/dags/symbol_set_cleanup.py
+++ b/dags/symbol_set_cleanup.py
@@ -26,7 +26,7 @@ def symbol_sets_to_delete(config: SymbolSetSelectionConfig) -> list[ErrorTrackin
     if config.delete_unused:
         query_filter = query_filter | Q(last_used__isnull=True)
 
-    symbol_sets = ErrorTrackingSymbolSet.objects.filter(query_filter).order_by("last_used")[:config.batch_size]
+    symbol_sets = ErrorTrackingSymbolSet.objects.filter(query_filter).order_by("last_used")[: config.batch_size]
 
     return list(symbol_sets)
 


### PR DESCRIPTION
Particularly for the initial few runs, we can pretty easily cause the worker pods to oom right now - this will let me run the cleanup job a few times manually without ooming, then the schedule can keep us up-to-date once the initial bulk of deletion is done