### PR TITLE
fix: show inspector panel in sharing recording

### DIFF
--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -135,10 +135,13 @@ export const urls = {
         combineUrl(
             `/shared/${token}`,
             Object.entries(exportOptions)
+                // strip falsey values
                 .filter((x) => x[1])
                 .reduce(
                     (acc, [key, val]) => ({
                         ...acc,
+                        // just sends the key and not a value
+                        // e.g., &showInspector not &showInspector=true
                         [key]: val === true ? null : val,
                     }),
                     {}


### PR DESCRIPTION
we shifted to remembering your last choice for inspector panel in recordings
which broke whether we showed the inspector panel in shared recordings

this allows the URL to override your choice when viewing shared recordings