### PR TITLE
feat(alerts): show cdp destinations after saving alert

### DIFF
--- a/frontend/src/lib/components/Alerts/alertFormLogic.ts
+++ b/frontend/src/lib/components/Alerts/alertFormLogic.ts
@@ -162,6 +162,7 @@ export const alertFormLogic = kea<alertFormLogicType>([
                 throw new Error("Cannot delete alert that doesn't exist")
             }
             await api.alerts.delete(values.alertForm.id)
+            lemonToast.success('Alert deleted.')
             props.onEditSuccess(undefined)
         },
         snoozeAlert: async ({ snoozeUntil }) => {

--- a/frontend/src/lib/components/Alerts/alertFormLogic.ts
+++ b/frontend/src/lib/components/Alerts/alertFormLogic.ts
@@ -46,7 +46,7 @@ export function canCheckOngoingInterval(alert?: AlertType | AlertFormType): bool
 export interface AlertFormLogicProps {
     alert: AlertType | null
     insightId: QueryBasedInsightModel['id']
-    onEditSuccess: () => void
+    onEditSuccess: (alertId?: AlertType['id']) => void
     insightVizDataLogicProps?: InsightLogicProps
 }
 
@@ -135,7 +135,7 @@ export const alertFormLogic = kea<alertFormLogicType>([
                         const updatedAlert: AlertType = await api.alerts.create(payload)
 
                         lemonToast.success(`Alert created.`)
-                        props.onEditSuccess()
+                        props.onEditSuccess(updatedAlert.id)
 
                         return updatedAlert
                     }
@@ -143,7 +143,7 @@ export const alertFormLogic = kea<alertFormLogicType>([
                     const updatedAlert: AlertType = await api.alerts.update(alert.id, payload)
 
                     lemonToast.success(`Alert saved.`)
-                    props.onEditSuccess()
+                    props.onEditSuccess(updatedAlert.id)
 
                     return updatedAlert
                 } catch (error: any) {
@@ -162,7 +162,7 @@ export const alertFormLogic = kea<alertFormLogicType>([
                 throw new Error("Cannot delete alert that doesn't exist")
             }
             await api.alerts.delete(values.alertForm.id)
-            props.onEditSuccess()
+            props.onEditSuccess(undefined)
         },
         snoozeAlert: async ({ snoozeUntil }) => {
             // resolution only allowed on created alert (which will have alertId)
@@ -170,7 +170,7 @@ export const alertFormLogic = kea<alertFormLogicType>([
                 throw new Error("Cannot resolve alert that doesn't exist")
             }
             await api.alerts.update(values.alertForm.id, { snoozed_until: snoozeUntil })
-            props.onEditSuccess()
+            props.onEditSuccess(values.alertForm.id)
         },
         clearSnooze: async () => {
             // resolution only allowed on created alert (which will have alertId)
@@ -178,7 +178,7 @@ export const alertFormLogic = kea<alertFormLogicType>([
                 throw new Error("Cannot resolve alert that doesn't exist")
             }
             await api.alerts.update(values.alertForm.id, { snoozed_until: null })
-            props.onEditSuccess()
+            props.onEditSuccess(values.alertForm.id)
         },
     })),
 ])

--- a/frontend/src/lib/components/Alerts/alertFormLogic.ts
+++ b/frontend/src/lib/components/Alerts/alertFormLogic.ts
@@ -166,9 +166,9 @@ export const alertFormLogic = kea<alertFormLogicType>([
             props.onEditSuccess(undefined)
         },
         snoozeAlert: async ({ snoozeUntil }) => {
-            // resolution only allowed on created alert (which will have alertId)
+            // snoozing only allowed on created alert (which will have alertId)
             if (!values.alertForm.id) {
-                throw new Error("Cannot resolve alert that doesn't exist")
+                throw new Error("Cannot snooze alert that doesn't exist")
             }
             await api.alerts.update(values.alertForm.id, { snoozed_until: snoozeUntil })
             props.onEditSuccess(values.alertForm.id)

--- a/frontend/src/lib/components/Alerts/views/EditAlertModal.tsx
+++ b/frontend/src/lib/components/Alerts/views/EditAlertModal.tsx
@@ -358,9 +358,9 @@ export function EditAlertModal({
                                 </div>
                             </div>
 
-                            <div className="deprecated-space-y-2">
+                            <div>
                                 <h3>Notification</h3>
-                                <div className="flex gap-4 items-center">
+                                <div className="flex gap-4 items-center mt-2">
                                     <div>E-mail</div>
                                     <div className="flex-auto">
                                         <MemberSelectMultiple
@@ -370,10 +370,10 @@ export function EditAlertModal({
                                         />
                                     </div>
                                 </div>
-                                <h4>CDP Destinations</h4>
 
+                                <h4 className="mt-4">CDP Destinations</h4>
                                 {insightAlertsCDPFlag && (
-                                    <div className="deprecated-space-y-5">
+                                    <div className="mt-2">
                                         {alertId ? (
                                             <div className="flex flex-col">
                                                 <AlertDestinationSelector alertId={alertId} />

--- a/frontend/src/lib/components/Alerts/views/EditAlertModal.tsx
+++ b/frontend/src/lib/components/Alerts/views/EditAlertModal.tsx
@@ -106,7 +106,9 @@ export function EditAlertModal({
     // need to reload edited alert as well
     const _onEditSuccess = useCallback(
         (alertId: AlertType['id'] | undefined) => {
-            loadAlert()
+            if (alertId) {
+                loadAlert()
+            }
             onEditSuccess(alertId)
         },
         [loadAlert, onEditSuccess]

--- a/frontend/src/lib/components/Alerts/views/EditAlertModal.tsx
+++ b/frontend/src/lib/components/Alerts/views/EditAlertModal.tsx
@@ -85,7 +85,7 @@ interface EditAlertModalProps {
     alertId?: AlertType['id']
     insightId: QueryBasedInsightModel['id']
     insightShortId: InsightShortId
-    onEditSuccess: () => void
+    onEditSuccess: (alertId?: AlertType['id'] | undefined) => void
     onClose?: () => void
     insightLogicProps?: InsightLogicProps
 }
@@ -104,10 +104,13 @@ export function EditAlertModal({
     const { loadAlert } = useActions(_alertLogic)
 
     // need to reload edited alert as well
-    const _onEditSuccess = useCallback(() => {
-        loadAlert()
-        onEditSuccess()
-    }, [loadAlert, onEditSuccess])
+    const _onEditSuccess = useCallback(
+        (alertId: AlertType['id'] | undefined) => {
+            loadAlert()
+            onEditSuccess(alertId)
+        },
+        [loadAlert, onEditSuccess]
+    )
 
     const formLogicProps = {
         alert,
@@ -365,11 +368,17 @@ export function EditAlertModal({
                                         />
                                     </div>
                                 </div>
-                                {!!alertId && insightAlertsCDPFlag && (
+                                <h4>CDP Destinations</h4>
+
+                                {insightAlertsCDPFlag && (
                                     <div className="deprecated-space-y-5">
-                                        <div className="flex flex-col">
-                                            <AlertDestinationSelector alertId={alertId} />
-                                        </div>
+                                        {alertId ? (
+                                            <div className="flex flex-col">
+                                                <AlertDestinationSelector alertId={alertId} />
+                                            </div>
+                                        ) : (
+                                            <div className="text-muted-alt">Save alert first to add destinations</div>
+                                        )}
                                     </div>
                                 )}
                             </div>

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -5,6 +5,7 @@ import { AddToDashboard } from 'lib/components/AddToDashboard/AddToDashboard'
 import { AddToDashboardModal } from 'lib/components/AddToDashboard/AddToDashboardModal'
 import { AlertsButton } from 'lib/components/Alerts/AlertsButton'
 import { insightAlertsLogic } from 'lib/components/Alerts/insightAlertsLogic'
+import { AlertType } from 'lib/components/Alerts/types'
 import { EditAlertModal } from 'lib/components/Alerts/views/EditAlertModal'
 import { ManageAlertsModal } from 'lib/components/Alerts/views/ManageAlertsModal'
 import { EditableField } from 'lib/components/EditableField/EditableField'
@@ -137,9 +138,13 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                             alertId={alertId === null || alertId === 'new' ? undefined : alertId}
                             insightShortId={insight.short_id as InsightShortId}
                             insightId={insight.id!}
-                            onEditSuccess={() => {
+                            onEditSuccess={(alertId: AlertType['id'] | undefined) => {
                                 loadAlerts()
-                                push(urls.insightAlerts(insight.short_id as InsightShortId))
+                                if (alertId) {
+                                    push(urls.insightAlert(insight.short_id as InsightShortId, alertId))
+                                } else {
+                                    push(urls.insightAlerts(insight.short_id as InsightShortId))
+                                }
                             }}
                             insightLogicProps={insightLogicProps}
                         />


### PR DESCRIPTION
## Problem
Need alertId to create CDP destinatiosn

## Changes
UX updates in alerts form to show destination picker after saving alert

<img width="633" alt="image" src="https://github.com/user-attachments/assets/dabdcc6d-9808-4455-b306-1d5441655690" />

## Did you write or update any docs for this change?
Pushing separate PR on website update docs for destinations on alerts
<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?
Tested locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
