### PR TITLE
fix: reopened alerts

### DIFF
--- a/frontend/src/scenes/error-tracking/configuration/alerting/ErrorTrackingAlerting.tsx
+++ b/frontend/src/scenes/error-tracking/configuration/alerting/ErrorTrackingAlerting.tsx
@@ -1,12 +1,10 @@
 import { LinkedHogFunctions } from 'scenes/hog-functions/list/LinkedHogFunctions'
-import { HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES } from 'scenes/hog-functions/sub-templates/sub-templates'
 
 export function ErrorTrackingAlerting(): JSX.Element {
     return (
         <LinkedHogFunctions
             type="internal_destination"
             subTemplateIds={['error-tracking-issue-created', 'error-tracking-issue-reopened']}
-            filters={HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['error-tracking-issue-created']?.filters ?? {}}
         />
     )
 }

--- a/frontend/src/scenes/hog-functions/list/LinkedHogFunctions.tsx
+++ b/frontend/src/scenes/hog-functions/list/LinkedHogFunctions.tsx
@@ -8,7 +8,7 @@ import { HogFunctionTemplateList } from './HogFunctionTemplateList'
 
 export type LinkedHogFunctionsProps = {
     type: HogFunctionTypeType
-    filters: HogFunctionFiltersType
+    filters?: HogFunctionFiltersType
     subTemplateIds?: HogFunctionSubTemplateIdType[]
     newDisabledReason?: string
     hideFeedback?: boolean


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We were setting the filters from `error-tracking-issue-created` since https://github.com/PostHog/posthog/pull/32080. This was applying the `$error_tracking_issue_created` filter rather than not setting any filter (which would fallback to the template filter)

## Changes

- Make filters optional and remove it from the component props

Note: we cannot just set filters to `{}` because if any object is present it will override the sub template default
https://github.com/PostHog/posthog/blob/c4aa9e940085b94618dd05a64dc02cbbcfbe594e/frontend/src/scenes/hog-functions/list/hogFunctionTemplateListLogic.tsx#L182-L185