### PR TITLE
fix(project-tree): move "sql editor"

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
@@ -294,7 +294,7 @@ export const getDefaultTreeProducts = (): FileSystemImport[] =>
         } as FileSystemImport,
         {
             path: `SQL editor`,
-            category: 'Tools',
+            category: 'Analytics',
             type: 'sql',
             href: urls.sqlEditor(),
         } as FileSystemImport,


### PR DESCRIPTION
## Changes

Move the "SQL editor" link from the "Tools" tab in the bottom, all the way up to the "Analytics" tab

![image](https://github.com/user-attachments/assets/9feb4ddd-e29c-45f1-9a4e-f930050a5f40)
