### PR TITLE
chore: update the inclusion_only filter

### DIFF
--- a/frontend/src/scenes/billing/Billing.tsx
+++ b/frontend/src/scenes/billing/Billing.tsx
@@ -20,7 +20,7 @@ import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
-import { BillingPlanType, BillingProductV2Type, ProductKey } from '~/types'
+import { BillingProductV2Type, ProductKey } from '~/types'
 
 import { BillingHero } from './BillingHero'
 import { billingLogic } from './billingLogic'
@@ -204,7 +204,7 @@ export function Billing(): JSX.Element {
             {products
                 ?.filter(
                     (product: BillingProductV2Type) =>
-                        !product.inclusion_only || product.plans.some((plan: BillingPlanType) => !plan.included_if)
+                        !product.inclusion_only || product.addons.find((a) => !a.inclusion_only)
                 )
                 ?.map((x: BillingProductV2Type) => (
                     <div key={x.type}>


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changes

This filter no longer makes sense because it was used for platform and support with the enterprise plan. So instead moving this to look at the `inclusion_only` on products and addons.

This will make sure it only shows the product if there it and none of its addons is not inclusion only.

This was the reason for the unsub button not working and the platform addons disappearing from the billing page. 

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

Manually
