### PR TITLE
fix: filter out legacy products for paygate

### DIFF
--- a/frontend/src/lib/components/PayGateMini/payGateMiniLogic.tsx
+++ b/frontend/src/lib/components/PayGateMini/payGateMiniLogic.tsx
@@ -52,21 +52,23 @@ export const payGateMiniLogic = kea<payGateMiniLogicType>([
                 let foundProduct: BillingProductV2Type | BillingProductV2AddonType | undefined = undefined
 
                 if (checkProductFirst.includes(props.feature)) {
-                    foundProduct = billing?.products?.find((product) =>
-                        product.features?.some((f) => f.key === props.feature)
-                    )
+                    foundProduct = billing?.products
+                        .filter((plan) => !plan.legacy_product || plan.subscribed)
+                        .find((product) => product.features?.some((f) => f.key === props.feature))
                 }
 
                 // Check addons first (if not included in checkProductFirst) since their features are rolled up into the parent
                 const allAddons = billing?.products?.map((product) => product.addons).flat() || []
                 if (!foundProduct) {
-                    foundProduct = allAddons.find((addon) => addon.features?.some((f) => f.key === props.feature))
+                    foundProduct = allAddons
+                        .filter((plan) => !plan.legacy_product || plan.subscribed)
+                        .find((addon) => addon.features?.some((f) => f.key === props.feature))
                 }
 
                 if (!foundProduct) {
-                    foundProduct = billing?.products?.find((product) =>
-                        product.features?.some((f) => f.key === props.feature)
-                    )
+                    foundProduct = billing?.products
+                        .filter((plan) => !plan.legacy_product || plan.subscribed)
+                        .find((product) => product.features?.some((f) => f.key === props.feature))
                 }
                 return foundProduct
             },


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changes

We now have the notion of legacy products so this is updating the pay gate to filter out the legacy products. 

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

Manually
