### PR TITLE
feat(alerts): show breadcrumb on cdp template config page

### DIFF
--- a/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
+++ b/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
@@ -16,7 +16,14 @@ import { HogFunctionTesting } from 'scenes/hog-functions/testing/HogFunctionTest
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
-import { ActivityScope, Breadcrumb, HogFunctionType, HogFunctionTypeType, PipelineTab } from '~/types'
+import {
+    ActivityScope,
+    Breadcrumb,
+    HogFunctionFilterPropertyFilter,
+    HogFunctionType,
+    HogFunctionTypeType,
+    PipelineTab,
+} from '~/types'
 
 import type { hogFunctionSceneLogicType } from './HogFunctionSceneType'
 import { HogFunctionSkeleton } from './misc/HogFunctionSkeleton'
@@ -58,7 +65,9 @@ export const hogFunctionSceneLogic = kea<hogFunctionSceneLogicType>([
                 if (!configuration?.filters?.properties) {
                     return undefined
                 }
-                const alertIdProp = configuration.filters.properties.find((p: any) => p.key === 'alert_id')
+                const alertIdProp = configuration.filters.properties.find(
+                    (p: HogFunctionFilterPropertyFilter) => p.key === 'alert_id'
+                )
                 const value = alertIdProp?.value
                 return value ? String(value) : undefined
             },
@@ -126,24 +135,21 @@ export const hogFunctionSceneLogic = kea<hogFunctionSceneLogicType>([
                 if (type === 'internal_destination') {
                     // Returns a Scene that is closest to the element based on the configuration.
                     // This is used to help the HogFunctionScene render correct breadcrumbs and redirections
-                    if (configuration?.type === 'internal_destination') {
-                        if (configuration?.filters?.events?.some((e) => e.id.includes('error_tracking'))) {
-                            // Error tracking scene
-                            return [
-                                {
-                                    key: Scene.ErrorTracking,
-                                    name: 'Error tracking',
-                                    path: urls.errorTracking(),
-                                },
-                                {
-                                    key: Scene.HogFunction,
-                                    name: 'Alerts',
-                                    path:
-                                        urls.errorTrackingConfiguration() + '#selectedSetting=error-tracking-alerting',
-                                },
-                                finalCrumb,
-                            ]
-                        }
+                    if (configuration?.filters?.events?.some((e) => e.id.includes('error_tracking'))) {
+                        // Error tracking scene
+                        return [
+                            {
+                                key: Scene.ErrorTracking,
+                                name: 'Error tracking',
+                                path: urls.errorTracking(),
+                            },
+                            {
+                                key: Scene.HogFunction,
+                                name: 'Alerts',
+                                path: urls.errorTrackingConfiguration() + '#selectedSetting=error-tracking-alerting',
+                            },
+                            finalCrumb,
+                        ]
                     }
 
                     return [

--- a/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
+++ b/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
@@ -16,7 +16,7 @@ import { HogFunctionTesting } from 'scenes/hog-functions/testing/HogFunctionTest
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
-import { ActivityScope, Breadcrumb, HogFunctionTypeType, PipelineTab } from '~/types'
+import { ActivityScope, Breadcrumb, HogFunctionType, HogFunctionTypeType, PipelineTab } from '~/types'
 
 import type { hogFunctionSceneLogicType } from './HogFunctionSceneType'
 import { HogFunctionSkeleton } from './misc/HogFunctionSkeleton'
@@ -52,9 +52,25 @@ export const hogFunctionSceneLogic = kea<hogFunctionSceneLogicType>([
     })),
     selectors({
         logicProps: [() => [(_, props) => props], (props) => props],
+        alertId: [
+            (s) => [s.configuration],
+            (configuration: HogFunctionType | null): string | undefined => {
+                if (!configuration?.filters?.properties) {
+                    return undefined
+                }
+                const alertIdProp = configuration.filters.properties.find((p: any) => p.key === 'alert_id')
+                const value = alertIdProp?.value
+                return value ? String(value) : undefined
+            },
+        ],
         breadcrumbs: [
-            (s) => [s.type, s.loading, s.configuration],
-            (type, loading, configuration): Breadcrumb[] => {
+            (s) => [s.type, s.loading, s.configuration, s.alertId],
+            (
+                type: HogFunctionTypeType,
+                loading: boolean,
+                configuration: HogFunctionType | null,
+                alertId: string | undefined
+            ): Breadcrumb[] => {
                 if (loading) {
                     return [
                         {
@@ -71,6 +87,22 @@ export const hogFunctionSceneLogic = kea<hogFunctionSceneLogicType>([
                 const finalCrumb: Breadcrumb = {
                     key: Scene.HogFunction,
                     name: configuration?.name || '(Untitled)',
+                }
+
+                if (type === 'internal_destination' && alertId) {
+                    return [
+                        {
+                            key: Scene.Insight,
+                            name: 'Insight',
+                            path: urls.alerts(),
+                        },
+                        {
+                            key: 'alert',
+                            name: 'Alert',
+                            path: urls.alert(alertId),
+                        },
+                        finalCrumb,
+                    ]
                 }
 
                 const pipelineTab = DataPipelinesSceneMapping[type]
@@ -94,8 +126,8 @@ export const hogFunctionSceneLogic = kea<hogFunctionSceneLogicType>([
                 if (type === 'internal_destination') {
                     // Returns a Scene that is closest to the element based on the configuration.
                     // This is used to help the HogFunctionScene render correct breadcrumbs and redirections
-                    if (configuration.type === 'internal_destination') {
-                        if (configuration.filters?.events?.some((e) => e.id.includes('error_tracking'))) {
+                    if (configuration?.type === 'internal_destination') {
+                        if (configuration?.filters?.events?.some((e) => e.id.includes('error_tracking'))) {
                             // Error tracking scene
                             return [
                                 {


### PR DESCRIPTION
## Problem
Currently when you create a CDP destination on an alert, there's no way to get back to the alert after/while creating the destination.

## Changes
Want to find out what the recommended way is to do this, currently I just implemented a breadcrumb to get back to the alert (if alert is passed in filters)
<img width="405" alt="image" src="https://github.com/user-attachments/assets/7c5b879f-2541-4efd-8c81-1a3e3b2752b4" />

Ideally, I'd like to show the insight name/alert name in the breadcrumbs as well but that would have modified a lot more logic on CDP side, so wanted to check how you guys recommend doing it. Passing some `urlParams` to `LinkedHogFunctions` would work as well, right now I'm just accessing the filters that are passed down. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?
Tested locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
