### PR TITLE
fix(project-tree): use US spelling

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
@@ -300,13 +300,13 @@ export const getDefaultTreeProducts = (): FileSystemImport[] =>
         } as FileSystemImport,
         {
             path: 'Error tracking',
-            category: 'Behaviour',
+            category: 'Behavior',
             iconType: 'errorTracking',
             href: urls.errorTracking(),
         } as FileSystemImport,
         {
             path: 'Heatmaps',
-            category: 'Behaviour',
+            category: 'Behavior',
             iconType: 'heatmap',
             href: urls.heatmaps(),
             flag: FEATURE_FLAGS.HEATMAPS_UI,

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -493,7 +493,7 @@ export const getTreeItemsNew = (): FileSystemImport[] => [
 export const getTreeItemsProducts = (): FileSystemImport[] => [
     {
         path: 'Broadcasts',
-        category: 'Behaviour',
+        category: 'Behavior',
         href: urls.messagingBroadcasts(),
         type: 'hog_function/broadcast',
         tags: ['alpha'],
@@ -501,7 +501,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
     },
     {
         path: 'Campaigns',
-        category: 'Behaviour',
+        category: 'Behavior',
         href: urls.messagingCampaigns(),
         type: 'hog_function/campaign',
         tags: ['alpha'],
@@ -536,14 +536,14 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
     },
     {
         path: 'Session replay',
-        category: 'Behaviour',
+        category: 'Behavior',
         href: urls.replay(ReplayTabs.Home),
         type: 'session_recording_playlist',
     },
-    { path: 'Surveys', category: 'Behaviour', type: 'survey', href: urls.surveys() },
+    { path: 'Surveys', category: 'Behavior', type: 'survey', href: urls.surveys() },
     {
         path: 'User interviews',
-        category: 'Behaviour',
+        category: 'Behavior',
         href: urls.userInterviews(),
         type: 'user_interview',
         flag: FEATURE_FLAGS.USER_INTERVIEWS,

--- a/products/messaging/manifest.tsx
+++ b/products/messaging/manifest.tsx
@@ -102,7 +102,7 @@ export const manifest: ProductManifest = {
     treeItemsProducts: [
         {
             path: 'Broadcasts',
-            category: 'Behaviour',
+            category: 'Behavior',
             href: urls.messagingBroadcasts(),
             type: 'hog_function/broadcast',
             tags: ['alpha'],
@@ -110,7 +110,7 @@ export const manifest: ProductManifest = {
         },
         {
             path: 'Campaigns',
-            category: 'Behaviour',
+            category: 'Behavior',
             href: urls.messagingCampaigns(),
             type: 'hog_function/campaign',
             tags: ['alpha'],

--- a/products/replay/manifest.tsx
+++ b/products/replay/manifest.tsx
@@ -42,7 +42,7 @@ export const manifest: ProductManifest = {
     treeItemsProducts: [
         {
             path: 'Session replay',
-            category: 'Behaviour',
+            category: 'Behavior',
             href: urls.replay(ReplayTabs.Home),
             type: 'session_recording_playlist',
         },

--- a/products/surveys/manifest.tsx
+++ b/products/surveys/manifest.tsx
@@ -31,7 +31,7 @@ export const manifest: ProductManifest = {
     treeItemsProducts: [
         {
             path: 'Surveys',
-            category: 'Behaviour',
+            category: 'Behavior',
             type: 'survey',
             href: urls.surveys(),
         },

--- a/products/user_interviews/manifest.tsx
+++ b/products/user_interviews/manifest.tsx
@@ -41,7 +41,7 @@ export const manifest: ProductManifest = {
     treeItemsProducts: [
         {
             path: 'User interviews',
-            category: 'Behaviour',
+            category: 'Behavior',
             href: urls.userInterviews(),
             type: 'user_interview',
             flag: FEATURE_FLAGS.USER_INTERVIEWS,


### PR DESCRIPTION
## Problem

So posh, so British:

<img width="265" alt="image" src="https://github.com/user-attachments/assets/dca71241-28e8-461a-864b-d8d64a009237" />

## Changes

🇺🇸 🦅 in accordance with the book of hands.

<img width="285" alt="image" src="https://github.com/user-attachments/assets/0ee6979c-34cd-4194-96e0-21e596faf872" />

Now, "error tracking" should probably be moved to a different category, but that's for another PR.

## How did you test this code?

👀 