### PR TITLE
feat(data-warehouse): Added logic to resume stripe initial syncs

### DIFF
--- a/posthog/management/commands/warehouse_last_incremental_value_sync.py
+++ b/posthog/management/commands/warehouse_last_incremental_value_sync.py
@@ -4,7 +4,6 @@ from django.conf import settings
 
 import dlt
 import dlt.common
-import dlt.common.pipeline
 import dlt.common.configuration.resolve
 
 from dlt.common.configuration.specs.base_configuration import (
@@ -132,10 +131,10 @@ class Command(BaseCommand):
                 continue
 
             try:
-                schema.update_incremental_field_last_value(last_incremental_value)
+                schema.update_incremental_field_value(last_incremental_value)
             except Exception as e:
                 print(  # noqa: T201
-                    f"Cant update_incremental_field_last_value for schema: {schema.pk}. With last_incremental_value={last_incremental_value}. ERROR: {e}"
+                    f"Cant update_incremental_field_value for schema: {schema.pk}. With last_incremental_value={last_incremental_value}. ERROR: {e}"
                 )
                 pipeline.drop()
                 continue

--- a/posthog/settings/data_warehouse.py
+++ b/posthog/settings/data_warehouse.py
@@ -23,6 +23,8 @@ OLD_BIGQUERY_SOURCE_TEAM_IDS: list[str] = get_list(os.getenv("OLD_BIGQUERY_SOURC
 # After further testing this will be removed and all teams moved to new source.
 OLD_MSSQL_SOURCE_TEAM_IDS: list[str] = get_list(os.getenv("OLD_MSSQL_SOURCE_TEAM_IDS", ""))
 
+STRIPE_V2_TEAM_IDS: list[str] = get_list(os.getenv("STRIPE_V2_TEAM_IDS", ""))
+
 GOOGLE_ADS_SERVICE_ACCOUNT_CLIENT_EMAIL: str | None = os.getenv("GOOGLE_ADS_SERVICE_ACCOUNT_CLIENT_EMAIL")
 GOOGLE_ADS_SERVICE_ACCOUNT_PRIVATE_KEY: str | None = os.getenv("GOOGLE_ADS_SERVICE_ACCOUNT_PRIVATE_KEY")
 GOOGLE_ADS_SERVICE_ACCOUNT_PRIVATE_KEY_ID: str | None = os.getenv("GOOGLE_ADS_SERVICE_ACCOUNT_PRIVATE_KEY_ID")

--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -411,7 +411,7 @@ def _get_incremental_field_value(
     else:
         raise Exception(f"Unsupported aggregate function for _get_incremental_field_value: {aggregate}")
 
-    return last_value
+    return last_value.as_py()
 
 
 def should_partition_table(

--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -1,6 +1,6 @@
 import gc
 import time
-from typing import Any
+from typing import Any, Literal
 
 import deltalake as deltalake
 import posthoganalytics
@@ -268,14 +268,19 @@ class PipelineNonDLT:
         # `incremental_field_last_value` in the schema.
         # However, if the data is returned in descending order, we only want to update the
         # `incremental_field_last_value` once we have processed all of the data, otherwise if we fail halfway through,
-        # we'd not process older data the next time we retry.
-        last_value = _get_incremental_field_last_value(self._schema, pa_table)
+        # we'd not process older data the next time we retry. But we do store the earliest available value so that we
+        # can resume syncs if they stop mid way through without having to start from the beginning
+        last_value = _get_incremental_field_value(self._schema, pa_table)
         if last_value is not None:
             if (self._last_incremental_field_value is None) or (last_value > self._last_incremental_field_value):
                 self._last_incremental_field_value = last_value
             if self._resource.sort_mode == "asc":
                 self._logger.debug(f"Updating incremental_field_last_value with {self._last_incremental_field_value}")
-                self._schema.update_incremental_field_last_value(self._last_incremental_field_value)
+                self._schema.update_incremental_field_value(self._last_incremental_field_value)
+            if self._resource.sort_mode == "desc":
+                earliest_value = _get_incremental_field_value(self._schema, pa_table, aggregate="min")
+                self._logger.debug(f"Updating incremental_field_earliest_value with {earliest_value}")
+                self._schema.update_incremental_field_value(earliest_value, type="earliest")
 
         _update_job_row_count(self._job.id, pa_table.num_rows, self._logger)
         decrement_rows(self._job.team_id, self._schema.id, pa_table.num_rows)
@@ -363,7 +368,7 @@ class PipelineNonDLT:
                 f"Sort mode is 'desc' -> updating incremental_field_last_value with {self._last_incremental_field_value}"
             )
             self._schema.refresh_from_db()
-            self._schema.update_incremental_field_last_value(self._last_incremental_field_value)
+            self._schema.update_incremental_field_value(self._last_incremental_field_value)
 
         self._logger.debug("Validating schema and updating table")
         validate_schema_and_update_table_sync(
@@ -386,7 +391,9 @@ def _update_job_row_count(job_id: str, count: int, logger: FilteringBoundLogger)
     ExternalDataJob.objects.filter(id=job_id).update(rows_synced=F("rows_synced") + count)
 
 
-def _get_incremental_field_last_value(schema: ExternalDataSchema | None, table: pa.Table) -> Any:
+def _get_incremental_field_value(
+    schema: ExternalDataSchema | None, table: pa.Table, aggregate: Literal["max"] | Literal["min"] = "max"
+) -> Any:
     if schema is None or schema.sync_type != ExternalDataSchema.SyncType.INCREMENTAL:
         return
 
@@ -397,8 +404,13 @@ def _get_incremental_field_last_value(schema: ExternalDataSchema | None, table: 
     column = table[normalize_column_name(incremental_field_name)]
     numpy_arr = column.combine_chunks().to_pandas().dropna().to_numpy()
 
-    # TODO(@Gilbert09): support different operations here (e.g. min)
-    last_value = numpy_arr.max()
+    if aggregate == "max":
+        last_value = numpy_arr.max()
+    elif aggregate == "min":
+        last_value = numpy_arr.min()
+    else:
+        raise Exception(f"Unsupported aggregate function for _get_incremental_field_value: {aggregate}")
+
     return last_value
 
 

--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -5,6 +5,7 @@ from typing import Any, Literal
 import deltalake as deltalake
 import posthoganalytics
 import pyarrow as pa
+import pyarrow.compute as pc
 from django.db.models import F
 from dlt.sources import DltSource
 
@@ -402,12 +403,11 @@ def _get_incremental_field_value(
         return
 
     column = table[normalize_column_name(incremental_field_name)]
-    numpy_arr = column.combine_chunks().to_pandas().dropna().to_numpy()
 
     if aggregate == "max":
-        last_value = numpy_arr.max()
+        last_value = pc.max(column)
     elif aggregate == "min":
-        last_value = numpy_arr.min()
+        last_value = pc.min(column)
     else:
         raise Exception(f"Unsupported aggregate function for _get_incremental_field_value: {aggregate}")
 

--- a/posthog/temporal/data_imports/pipelines/stripe/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/stripe/__init__.py
@@ -377,7 +377,9 @@ def stripe_source_v2(
         if not resource:
             raise Exception(f"Stripe endpoint does not exist: {endpoint}")
 
-        if not is_incremental or (db_incremental_field_last_value is None and db_incremental_field_last_value is None):
+        if not is_incremental or (
+            db_incremental_field_last_value is None and db_incremental_field_earliest_value is None
+        ):
             stripe_objects = resource.method(params={**default_params, **resource.params})
             yield from stripe_objects.auto_paging_iter()
             return

--- a/posthog/temporal/data_imports/pipelines/stripe/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/stripe/__init__.py
@@ -1,9 +1,11 @@
+import dataclasses
 from typing import Any, Optional
+from collections.abc import Callable
 
 import dlt
 from dlt.sources.helpers.requests import Request, Response
 from dlt.sources.helpers.rest_client.paginators import BasePaginator
-from stripe import StripeClient
+from stripe import ListObject, StripeClient
 
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from posthog.temporal.data_imports.pipelines.rest_source import (
@@ -343,6 +345,79 @@ class StripePaginator(BasePaginator):
         request.params["starting_after"] = self._starting_after
 
 
+@dataclasses.dataclass
+class StripeResource:
+    method: Callable[..., ListObject[Any]]
+    params: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+
+def stripe_source_v2(
+    api_key: str,
+    account_id: Optional[str],
+    endpoint: str,
+    db_incremental_field_last_value: Optional[Any],
+    db_incremental_field_earliest_value: Optional[Any],
+    is_incremental: bool = False,
+):
+    def get_rows():
+        client = StripeClient(api_key, stripe_account=account_id, stripe_version="2024-09-30.acacia")
+        default_params = {"limit": DEFAULT_LIMIT}
+        resources: dict[str, StripeResource] = {
+            ACCOUNT_RESOURCE_NAME: StripeResource(method=client.accounts.list),
+            BALANCE_TRANSACTION_RESOURCE_NAME: StripeResource(method=client.balance_transactions.list),
+            CHARGE_RESOURCE_NAME: StripeResource(method=client.charges.list),
+            CUSTOMER_RESOURCE_NAME: StripeResource(method=client.customers.list),
+            INVOICE_RESOURCE_NAME: StripeResource(method=client.invoices.list),
+            PRICE_RESOURCE_NAME: StripeResource(method=client.prices.list, params={"expand[]": "data.tiers"}),
+            PRODUCT_RESOURCE_NAME: StripeResource(method=client.products.list),
+            SUBSCRIPTION_RESOURCE_NAME: StripeResource(method=client.subscriptions.list, params={"status": "all"}),
+        }
+
+        resource = resources.get(endpoint, None)
+        if not resource:
+            raise Exception(f"Stripe endpoint does not exist: {endpoint}")
+
+        if not is_incremental or (db_incremental_field_last_value is None and db_incremental_field_last_value is None):
+            stripe_objects = resource.method(params={**default_params, **resource.params})
+            yield from stripe_objects.auto_paging_iter()
+            return
+
+        # check for any objects less than the minimum object we already have
+        if db_incremental_field_earliest_value is not None:
+            stripe_objects = resource.method(
+                params={**default_params, **resource.params, "created[lt]": db_incremental_field_earliest_value}
+            )
+            yield from stripe_objects.auto_paging_iter()
+
+        # check for any objects more than the maximum object we already have
+        if db_incremental_field_last_value is not None:
+            stripe_objects = resource.method(
+                params={**default_params, **resource.params, "created[gt]": db_incremental_field_last_value}
+            )
+            for obj in stripe_objects.auto_paging_iter():
+                if obj["created"] < db_incremental_field_last_value:
+                    break
+
+                yield obj
+
+    column_mapping = get_dlt_mapping_for_external_table(f"stripe_{endpoint.lower()}")
+    column_hints = {key: value.get("data_type") for key, value in column_mapping.items()}
+
+    return SourceResponse(
+        items=get_rows(),
+        primary_keys=["id"],
+        name=endpoint,
+        column_hints=column_hints,
+        # Stripe data is returned in descending timestamp order
+        sort_mode="desc",
+        partition_count=1,  # this enables partitioning
+        partition_size=1,  # this enables partitioning
+        partition_mode="datetime",
+        partition_format="month",
+        partition_keys=["created"],
+    )
+
+
 @dlt.source(max_table_nesting=0)
 def stripe_dlt_source(
     api_key: str,
@@ -437,6 +512,10 @@ def validate_credentials(api_key: str) -> bool:
     - Raise Exception if the API key is invalid or there's any other error
     """
     client = StripeClient(api_key)
+
+    invoices = client.invoices.list(params={})
+    for i in invoices:
+        i.to_dict()
 
     # Test access to all resources we're pulling
     resources_to_check = [

--- a/posthog/temporal/data_imports/pipelines/stripe/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/stripe/__init__.py
@@ -395,7 +395,7 @@ def stripe_source_v2(
                 params={**default_params, **resource.params, "created[gt]": db_incremental_field_last_value}
             )
             for obj in stripe_objects.auto_paging_iter():
-                if obj["created"] < db_incremental_field_last_value:
+                if obj["created"] <= db_incremental_field_last_value:
                     break
 
                 yield obj
@@ -512,10 +512,6 @@ def validate_credentials(api_key: str) -> bool:
     - Raise Exception if the API key is invalid or there's any other error
     """
     client = StripeClient(api_key)
-
-    invoices = client.invoices.list(params={})
-    for i in invoices:
-        i.to_dict()
 
     # Test access to all resources we're pulling
     resources_to_check = [

--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -168,9 +168,7 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
                     team_id=inputs.team_id,
                     job_id=inputs.run_id,
                     is_incremental=schema.is_incremental,
-                    db_incremental_field_last_value=schema.incremental_field_earliest_value
-                    if schema.is_incremental
-                    else None,
+                    db_incremental_field_last_value=processed_incremental_last_value if schema.is_incremental else None,
                 )
 
             return _run(

--- a/posthog/temporal/tests/data_imports/stripe/conftest.py
+++ b/posthog/temporal/tests/data_imports/stripe/conftest.py
@@ -58,6 +58,12 @@ class MockStripeAPI:
         elif "created[gt]" in query:
             created_gt = int(query["created[gt]"][0])
             filtered_data = [tx for tx in filtered_data if tx["created"] > created_gt]
+        if "created[lte]" in query:
+            created_gte = int(query["created[gte]"][0])
+            filtered_data = [tx for tx in filtered_data if tx["created"] <= created_gte]
+        elif "created[lt]" in query:
+            created_gt = int(query["created[gt]"][0])
+            filtered_data = [tx for tx in filtered_data if tx["created"] < created_gt]
 
         if "starting_after" in query:
             starting_after = query["starting_after"][0]

--- a/posthog/temporal/tests/data_imports/stripe/conftest.py
+++ b/posthog/temporal/tests/data_imports/stripe/conftest.py
@@ -59,10 +59,10 @@ class MockStripeAPI:
             created_gt = int(query["created[gt]"][0])
             filtered_data = [tx for tx in filtered_data if tx["created"] > created_gt]
         if "created[lte]" in query:
-            created_gte = int(query["created[gte]"][0])
+            created_gte = int(query["created[lte]"][0])
             filtered_data = [tx for tx in filtered_data if tx["created"] <= created_gte]
         elif "created[lt]" in query:
-            created_gt = int(query["created[gt]"][0])
+            created_gt = int(query["created[lt]"][0])
             filtered_data = [tx for tx in filtered_data if tx["created"] < created_gt]
 
         if "starting_after" in query:

--- a/posthog/temporal/tests/data_imports/stripe/conftest.py
+++ b/posthog/temporal/tests/data_imports/stripe/conftest.py
@@ -59,11 +59,11 @@ class MockStripeAPI:
             created_gt = int(query["created[gt]"][0])
             filtered_data = [tx for tx in filtered_data if tx["created"] > created_gt]
         if "created[lte]" in query:
-            created_gte = int(query["created[lte]"][0])
-            filtered_data = [tx for tx in filtered_data if tx["created"] <= created_gte]
+            created_lte = int(query["created[lte]"][0])
+            filtered_data = [tx for tx in filtered_data if tx["created"] <= created_lte]
         elif "created[lt]" in query:
-            created_gt = int(query["created[lt]"][0])
-            filtered_data = [tx for tx in filtered_data if tx["created"] < created_gt]
+            created_lt = int(query["created[lt]"][0])
+            filtered_data = [tx for tx in filtered_data if tx["created"] < created_lt]
 
         if "starting_after" in query:
             starting_after = query["starting_after"][0]

--- a/posthog/temporal/tests/data_imports/stripe/test_stripe_source.py
+++ b/posthog/temporal/tests/data_imports/stripe/test_stripe_source.py
@@ -2,6 +2,7 @@ import uuid
 from unittest import mock
 from urllib.parse import parse_qs, urlparse
 
+from django.test import override_settings
 import pytest
 
 from posthog.temporal.data_imports.pipelines.pipeline.pipeline import PipelineNonDLT
@@ -142,3 +143,72 @@ async def test_stripe_source_incremental(team, mock_stripe_api, external_data_so
         "created[gt]": [f"{third_item_created}"],
         "limit": ["100"],
     }
+
+
+# mock the chunk size to 1 so we can test how iterating over chunks of data works, particularly with updating the
+# incremental field last value
+@mock.patch.object(PipelineNonDLT, "_chunk_size", 1)
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_stripe_source_v2_incremental(
+    team, mock_stripe_api, external_data_source, external_data_schema_incremental
+):
+    """Test that an incremental sync works as expected.
+
+    We set the 'max_created' value to the created timestamp of the third item in the BALANCE_TRANSACTIONS list. This
+    means on the first sync it will return all the data, except for the most recent 2 balance transactions.
+
+    Then, after resetting the 'max_created' value, we expect the incremental sync to return the most recent 2 balance
+    transactions when it is called again.
+    """
+    with override_settings(STRIPE_V2_TEAM_IDS=[str(team.id)]):
+        table_name = "stripe_balancetransaction"
+
+        # mock the API so it doesn't return all data on initial sync
+        third_item_created = BALANCE_TRANSACTIONS[2]["created"]
+        mock_stripe_api.set_max_created(third_item_created)
+        expected_rows_synced = 3
+        expected_total_rows = 3
+
+        await run_external_data_job_workflow(
+            team=team,
+            external_data_source=external_data_source,
+            external_data_schema=external_data_schema_incremental,
+            table_name=table_name,
+            expected_rows_synced=expected_rows_synced,
+            expected_total_rows=expected_total_rows,
+        )
+
+        # Check that the API was called as expected
+        api_calls_made = mock_stripe_api.get_all_api_calls()
+        assert len(api_calls_made) == 1
+        assert parse_qs(urlparse(api_calls_made[0].url).query) == {
+            "limit": ["100"],
+        }
+
+        mock_stripe_api.reset_max_created()
+        # run the incremental sync
+        # we expect this to bring in 2 more rows
+        expected_rows_synced = 2
+        expected_total_rows = len(BALANCE_TRANSACTIONS)
+
+        await run_external_data_job_workflow(
+            team=team,
+            external_data_source=external_data_source,
+            external_data_schema=external_data_schema_incremental,
+            table_name=table_name,
+            expected_rows_synced=expected_rows_synced,
+            expected_total_rows=expected_total_rows,
+        )
+
+        api_calls_made = mock_stripe_api.get_all_api_calls()
+        # Check that the API was called once more
+        assert len(api_calls_made) == 3
+        assert parse_qs(urlparse(api_calls_made[1].url).query) == {
+            "created[lt]": [str(BALANCE_TRANSACTIONS[4]["created"])],
+            "limit": ["100"],
+        }
+        assert parse_qs(urlparse(api_calls_made[2].url).query) == {
+            "created[gt]": [f"{third_item_created}"],
+            "limit": ["100"],
+        }

--- a/posthog/warehouse/api/external_data_schema.py
+++ b/posthog/warehouse/api/external_data_schema.py
@@ -166,7 +166,7 @@ class ExternalDataSchemaSerializer(serializers.ModelSerializer):
                     # Get the max_value and set it on incremental_field_last_value
                     max_value = instance.table.get_max_value_for_column(data.get("incremental_field"))
                     if max_value:
-                        instance.update_incremental_field_last_value(max_value, save=False)
+                        instance.update_incremental_field_value(max_value, save=False)
                     else:
                         # if we can't get the max value, reset the table
                         payload["incremental_field_last_value"] = None

--- a/posthog/warehouse/models/external_data_schema.py
+++ b/posthog/warehouse/models/external_data_schema.py
@@ -242,7 +242,7 @@ class ExternalDataSchema(CreatedMetaFields, UpdatedMetaFields, UUIDModel, Delete
         elif type == "earliest":
             self.sync_type_config["incremental_field_earliest_value"] = last_value_json
         else:
-            raise Exception(f"Unsupported type for update_incremental_field_value: {type}")
+            raise ValueError(f"Unsupported type for update_incremental_field_value: {type}")
 
         if save:
             self.save()

--- a/posthog/warehouse/models/external_data_schema.py
+++ b/posthog/warehouse/models/external_data_schema.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Any, Literal
 
 import numpy
 import psycopg2
@@ -66,7 +66,7 @@ class ExternalDataSchema(CreatedMetaFields, UpdatedMetaFields, UUIDModel, Delete
     status = models.CharField(max_length=400, null=True, blank=True)
     last_synced_at = models.DateTimeField(null=True, blank=True)
     sync_type = models.CharField(max_length=128, choices=SyncType.choices, null=True, blank=True)
-    # { "incremental_field": string, "incremental_field_type": string, "incremental_field_last_value": any, "reset_pipeline": bool, "partitioning_enabled": bool, "partition_count": int, "partition_size": int, "partition_mode": str, "partitioning_keys": list[str] }
+    # { "incremental_field": string, "incremental_field_type": string, "incremental_field_last_value": any, "incremental_field_earliest_value": any, "reset_pipeline": bool, "partitioning_enabled": bool, "partition_count": int, "partition_size": int, "partition_mode": str, "partitioning_keys": list[str] }
     sync_type_config = models.JSONField(
         default=dict,
         blank=True,
@@ -99,7 +99,7 @@ class ExternalDataSchema(CreatedMetaFields, UpdatedMetaFields, UUIDModel, Delete
         return None
 
     @property
-    def incremental_field_type(self) -> str | None:
+    def incremental_field_type(self) -> IncrementalFieldType | None:
         if self.sync_type_config:
             return self.sync_type_config.get("incremental_field_type", None)
 
@@ -109,6 +109,13 @@ class ExternalDataSchema(CreatedMetaFields, UpdatedMetaFields, UUIDModel, Delete
     def incremental_field_last_value(self) -> str | None:
         if self.sync_type_config:
             return self.sync_type_config.get("incremental_field_last_value", None)
+
+        return None
+
+    @property
+    def incremental_field_earliest_value(self) -> str | None:
+        if self.sync_type_config:
+            return self.sync_type_config.get("incremental_field_earliest_value", None)
 
         return None
 
@@ -189,6 +196,7 @@ class ExternalDataSchema(CreatedMetaFields, UpdatedMetaFields, UUIDModel, Delete
     def update_sync_type_config_for_reset_pipeline(self) -> None:
         self.sync_type_config.pop("reset_pipeline", None)
         self.sync_type_config.pop("incremental_field_last_value", None)
+        self.sync_type_config.pop("incremental_field_earliest_value", None)
         self.sync_type_config.pop("partitioning_enabled", None)
         self.sync_type_config.pop("partition_size", None)
         self.sync_type_config.pop("partition_count", None)
@@ -197,7 +205,9 @@ class ExternalDataSchema(CreatedMetaFields, UpdatedMetaFields, UUIDModel, Delete
 
         self.save()
 
-    def update_incremental_field_last_value(self, last_value: Any, save: bool = True) -> None:
+    def update_incremental_field_value(
+        self, last_value: Any, save: bool = True, type: Literal["last"] | Literal["earliest"] = "last"
+    ) -> None:
         incremental_field_type = self.sync_type_config.get("incremental_field_type")
 
         last_value_py = last_value.item() if isinstance(last_value, numpy.generic) else last_value
@@ -227,7 +237,12 @@ class ExternalDataSchema(CreatedMetaFields, UpdatedMetaFields, UUIDModel, Delete
         else:
             last_value_json = str(last_value_py)
 
-        self.sync_type_config["incremental_field_last_value"] = last_value_json
+        if type == "last":
+            self.sync_type_config["incremental_field_last_value"] = last_value_json
+        elif type == "earliest":
+            self.sync_type_config["incremental_field_earliest_value"] = last_value_json
+        else:
+            raise Exception(f"Unsupported type for update_incremental_field_value: {type}")
 
         if save:
             self.save()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ dependencies = [
     "sqlparse==0.4.4",
     "sshtunnel==0.4.0",
     "statshog==1.0.6",
-    "stripe==10.3.0",
+    "stripe==12.2.0",
     "structlog==23.2.0",
     "temporalio==1.7.1",
     "tiktoken==0.9.*",

--- a/uv.lock
+++ b/uv.lock
@@ -3919,7 +3919,7 @@ requires-dist = [
     { name = "sqlparse", specifier = "==0.4.4" },
     { name = "sshtunnel", specifier = "==0.4.0" },
     { name = "statshog", specifier = "==1.0.6" },
-    { name = "stripe", specifier = "==10.3.0" },
+    { name = "stripe", specifier = "==12.2.0" },
     { name = "structlog", specifier = "==23.2.0" },
     { name = "temporalio", specifier = "==1.7.1" },
     { name = "tenacity", specifier = ">=8.4.2" },
@@ -5398,15 +5398,15 @@ wheels = [
 
 [[package]]
 name = "stripe"
-version = "10.3.0"
+version = "12.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/80/6e644fbd3b671e79128850131cf8c5858f87aa4008151f17e6ff4c516773/stripe-10.3.0.tar.gz", hash = "sha256:56515faf0cbee82f27d9b066403988a107301fc80767500be9789a25d65f2bae", size = 1300786, upload-time = "2024-07-11T18:54:41.449Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/00/346d0baff3ade82faf1299262ae9c0e1a497593e9c294837abecac8c7822/stripe-12.2.0.tar.gz", hash = "sha256:1ac2a4abba371acb3f99ff1c4a8748929862ad42d0cdee488298982f1be8d56e", size = 1393146, upload-time = "2025-05-28T19:06:16.463Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/36/6fc68c96a2ef8422964ee833da963b12314bc7e44778d8a2b06504839b55/stripe-10.3.0-py2.py3-none-any.whl", hash = "sha256:95aa10d34e325cb6a19784412d6196621442c278b0c9cd3fe7be2a7ef180c2f8", size = 1539768, upload-time = "2024-07-11T18:54:36.091Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/d6/c97a38e2997c368e62443aa8f7d0f3e903a9cb686d2445a23f5d4b552894/stripe-12.2.0-py2.py3-none-any.whl", hash = "sha256:cc9086d162e65e32893e4a03c31194e36e07870653a5f30aacc62da61e548cb9", size = 1633772, upload-time = "2025-05-28T19:06:14.108Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem
- We have a handful of users who are struggling to sync Stripe tables due to how large their dataset is and how the stripe syncs work
- We get items back from Stripe in descending order, which means we can't store an `incremental_value` until the whole sync is complete, but that also means if the sync crashes out, we can restart it from when it left off and instead have to start all over again
- This is a big problem for users with Stripe tables with 100,000's rows - these syncs take hours to run

## Changes
- Extend our "descending" paging of the pipeline to also store the "earliest" incremental value we've seen
  - On each page, if the source is sorted in "descending" order, like Stripe, we store the `min()` value for that dataset
- Replaced our existing Stripe source with a V2 that uses the Stripe python library so that we can implement some custom logic as to how we scroll their API
- We now always check to see if there's any rows available "earlier" than the earliest row we've already seen
  - If there are, then we scroll the API from there onwards
- Then we scroll from the latest afterwards as we usually do now
- This does mean that every Stripe job has at least 1 extra API call to check for any rows earlier than the earliest value
- The new source is behind a flag - will be testing it with a couple of teams before figuring out a migration plan for all existing tables
  - This will likely involve a migration for existing tables to get their current minimum `created` and store that in the DB

## How did you test this code?
- Updated existing tests and added new V2 tests
