### PR TITLE
fix: rely on IAM for dag export in prod

### DIFF
--- a/dags/web_preaggregated_daily.py
+++ b/dags/web_preaggregated_daily.py
@@ -22,6 +22,7 @@ from posthog.models.web_preaggregated.sql import (
     WEB_STATS_INSERT_SQL,
 )
 from posthog.settings.base_variables import DEBUG
+from posthog.settings.dagster import DAGSTER_DATA_EXPORT_S3_BUCKET
 from posthog.settings.object_storage import (
     OBJECT_STORAGE_BUCKET,
     OBJECT_STORAGE_ENDPOINT,
@@ -149,7 +150,7 @@ def export_web_analytics_data(
     if DEBUG:
         s3_path = f"{OBJECT_STORAGE_ENDPOINT}/{OBJECT_STORAGE_BUCKET}/{OBJECT_STORAGE_PREAGGREGATED_WEB_ANALYTICS_FOLDER}/{export_prefix}.native"
     else:
-        s3_path = f"https://{OBJECT_STORAGE_BUCKET}.s3.amazonaws.com/{OBJECT_STORAGE_PREAGGREGATED_WEB_ANALYTICS_FOLDER}/{export_prefix}.native"
+        s3_path = f"https://{DAGSTER_DATA_EXPORT_S3_BUCKET}.s3.amazonaws.com/{OBJECT_STORAGE_PREAGGREGATED_WEB_ANALYTICS_FOLDER}/{export_prefix}.native"
 
     export_query = sql_generator(
         date_start="2020-01-01",

--- a/posthog/models/web_preaggregated/sql.py
+++ b/posthog/models/web_preaggregated/sql.py
@@ -6,6 +6,7 @@ from posthog.settings.object_storage import (
     OBJECT_STORAGE_ACCESS_KEY_ID,
     OBJECT_STORAGE_SECRET_ACCESS_KEY,
 )
+from posthog.settings.base_variables import DEBUG
 
 CLICKHOUSE_CLUSTER = settings.CLICKHOUSE_CLUSTER
 CLICKHOUSE_DATABASE = settings.CLICKHOUSE_DATABASE
@@ -187,6 +188,13 @@ def DISTRIBUTED_WEB_BOUNCES_HOURLY_SQL():
 
 def format_team_ids(team_ids):
     return ", ".join(str(team_id) for team_id in team_ids)
+
+
+def get_s3_function_args(s3_path):
+    if DEBUG:
+        return f"'{s3_path}', '{OBJECT_STORAGE_ACCESS_KEY_ID}', '{OBJECT_STORAGE_SECRET_ACCESS_KEY}', 'Native'"
+    else:
+        return f"'{s3_path}', 'Native'"
 
 
 def get_team_filters(team_ids):
@@ -557,13 +565,10 @@ def WEB_STATS_EXPORT_SQL(
     if not s3_path:
         raise ValueError("s3_path is required")
 
+    s3_function_args = get_s3_function_args(s3_path)
+
     return f"""
-    INSERT INTO FUNCTION s3(
-        '{s3_path}',
-        '{OBJECT_STORAGE_ACCESS_KEY_ID}',
-        '{OBJECT_STORAGE_SECRET_ACCESS_KEY}',
-        'Native'
-    )
+    INSERT INTO FUNCTION s3({s3_function_args})
     SELECT
         day_bucket,
         team_id,
@@ -591,13 +596,10 @@ def WEB_BOUNCES_EXPORT_SQL(
     if not s3_path:
         raise ValueError("s3_path is required")
 
+    s3_function_args = get_s3_function_args(s3_path)
+
     return f"""
-    INSERT INTO FUNCTION s3(
-        '{s3_path}',
-        '{OBJECT_STORAGE_ACCESS_KEY_ID}',
-        '{OBJECT_STORAGE_SECRET_ACCESS_KEY}',
-        'Native'
-    )
+    INSERT INTO FUNCTION s3({s3_function_args})
     SELECT
         day_bucket,
         team_id,


### PR DESCRIPTION
We don't want to log secrets, and this pattern is used on the query_log exports.


- Rely on IAM to export values on dagster prod.
- Currently, it will use the same data-export bucket with a different prefix. We can change this later, but we should create the buckets on Terraform first.

