### PR TITLE
fix(cohorts): deleting cohort with 'not in cohort' filter in a cohort list

### DIFF
--- a/frontend/src/scenes/cohorts/Cohorts.tsx
+++ b/frontend/src/scenes/cohorts/Cohorts.tsx
@@ -123,7 +123,13 @@ export function Cohorts(): JSX.Element {
                                     Export all columns for users
                                 </LemonButton>
                                 <LemonDivider />
-                                <LemonButton status="danger" onClick={() => deleteCohort(cohort)} fullWidth>
+                                <LemonButton
+                                    status="danger"
+                                    onClick={() => {
+                                        deleteCohort({ id: cohort.id, name: cohort.name, deleted: true })
+                                    }}
+                                    fullWidth
+                                >
                                     Delete cohort
                                 </LemonButton>
                             </>


### PR DESCRIPTION
This extracts the fix for deleting cohorts from an externally contributed PR: https://github.com/PostHog/posthog/pull/32541
Thanks to @hoppybunny for this!

## Problem

Closes #32445

## Changes

When calling the delete endpoint, send the minimal set of fields needed to delete it, rather than the whole cohort.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Manually. I also confirmed that clicking "Undo" in the success message toast brings back the cohort.