### PR TITLE
fix(cohorts): Saving cohorts with $autocapture events

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -87,7 +87,7 @@ from pydantic import ValidationError as PydanticValidationError
 
 
 class EventPropFilter(BaseModel, extra="forbid"):
-    type: Literal["event"]
+    type: Literal["event", "element"]
     key: str
     value: Any
     operator: str | None = None


### PR DESCRIPTION
When setting up an $autocapture event, `element` is a valid type for the event property filter. See `test_funnel_correlation_with_event_properties_autocapture` for an example.

## Problem

Fixes #32599

## Changes

Update the Pydantic model.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Manually.