### PR TITLE
feat(err): support custom platforms via CustomFrame

### DIFF
--- a/rust/cymbal/src/frames/mod.rs
+++ b/rust/cymbal/src/frames/mod.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 use crate::{
     error::UnhandledError,
     fingerprinting::{FingerprintBuilder, FingerprintComponent, FingerprintRecordPart},
-    langs::{js::RawJSFrame, node::RawNodeFrame, python::RawPythonFrame},
+    langs::{custom::CustomFrame, js::RawJSFrame, node::RawNodeFrame, python::RawPythonFrame},
     metric_consts::PER_FRAME_TIME,
     sanitize_string,
     symbol_store::Catalog,
@@ -31,6 +31,8 @@ pub enum RawFrame {
     // TODO - remove once we're happy no clients are using this anymore
     #[serde(rename = "javascript")]
     LegacyJS(RawJSFrame),
+    #[serde(rename = "custom")]
+    Custom(CustomFrame),
 }
 
 impl RawFrame {
@@ -44,6 +46,7 @@ impl RawFrame {
                 (frame.resolve(team_id, catalog).await, "javascript")
             }
             RawFrame::Python(frame) => (Ok(frame.into()), "python"),
+            RawFrame::Custom(frame) => (Ok(frame.into()), "custom"),
         };
 
         // The raw id of the frame is set after it's resolved
@@ -71,6 +74,7 @@ impl RawFrame {
             // to associate a given frame with a given release (basically, a symbol set with no data, just some id,
             // which we'd then use to do a join on the releases table to get release information)
             RawFrame::Python(_) => None,
+            RawFrame::Custom(_) => None,
         }
     }
 
@@ -79,6 +83,7 @@ impl RawFrame {
             RawFrame::JavaScriptWeb(raw) | RawFrame::LegacyJS(raw) => raw.frame_id(),
             RawFrame::JavaScriptNode(raw) => raw.frame_id(),
             RawFrame::Python(raw) => raw.frame_id(),
+            RawFrame::Custom(raw) => raw.frame_id(),
         }
     }
 }

--- a/rust/cymbal/src/langs/custom.rs
+++ b/rust/cymbal/src/langs/custom.rs
@@ -1,0 +1,102 @@
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha512};
+
+use crate::frames::{Context, ContextLine, Frame};
+
+// Generic frame layout, meant for users hacking up their own implementations
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CustomFrame {
+    pub platform: String,             // The platform/language, e.g. "elixir"
+    pub function: String,             // The name of the function
+    pub filename: Option<String>,     // The path of the file the context line is in
+    pub lineno: Option<u32>,          // The line number of the frame/function
+    pub colno: Option<u32>,           // The column number of the frame/function
+    pub module: Option<String>,       // Whatever language-specific "module" name the function is in
+    pub context_line: Option<String>, // The line of code the exception came from
+
+    // The lines of code before the context line
+    // The first line prior to the context line is at index 0
+    #[serde(default)]
+    pub pre_context: Vec<String>,
+    #[serde(default)]
+    pub post_context: Vec<String>, // The lines of code after the context line
+    #[serde(default)]
+    pub in_app: bool, // Whether the frame is in the user's code
+    #[serde(default)]
+    pub resolved: bool, // Whether the frame has been resolved, or is minified/mangled
+}
+
+impl CustomFrame {
+    pub fn frame_id(&self) -> String {
+        let mut hasher = Sha512::new();
+
+        self.context_line
+            .as_ref()
+            .inspect(|c| hasher.update(c.as_bytes()));
+        self.filename
+            .as_ref()
+            .inspect(|f| hasher.update(f.as_bytes()));
+        hasher.update(self.function.as_bytes());
+        hasher.update(self.lineno.unwrap_or_default().to_be_bytes());
+        hasher.update(self.colno.unwrap_or_default().to_be_bytes());
+        hasher.update(self.platform.as_bytes());
+        hasher.update(self.resolved.to_string().as_bytes());
+        self.module
+            .as_ref()
+            .inspect(|m| hasher.update(m.as_bytes()));
+        self.pre_context
+            .iter()
+            .chain(self.post_context.iter())
+            .for_each(|line| {
+                hasher.update(line.as_bytes());
+            });
+        format!("{:x}", hasher.finalize())
+    }
+
+    pub fn get_context(&self) -> Option<Context> {
+        let context_line = self.context_line.as_ref()?;
+        let lineno = self.lineno?;
+
+        let line = ContextLine::new(lineno, context_line);
+
+        let before = self
+            .pre_context
+            .iter()
+            .take(10)
+            .enumerate()
+            .map(|(i, line)| ContextLine::new(lineno - i as u32 - 1, line.clone()))
+            .collect();
+        let after = self
+            .post_context
+            .iter()
+            .take(10)
+            .enumerate()
+            .map(|(i, line)| ContextLine::new(lineno + i as u32 + 1, line.clone()))
+            .collect();
+        Some(Context {
+            before,
+            line,
+            after,
+        })
+    }
+}
+
+impl From<&CustomFrame> for Frame {
+    fn from(value: &CustomFrame) -> Self {
+        Frame {
+            raw_id: String::new(),
+            mangled_name: value.function.clone(),
+            line: value.lineno,
+            column: value.colno,
+            source: value.filename.clone(),
+            in_app: value.in_app,
+            resolved_name: Some(value.function.clone()),
+            lang: value.platform.clone(),
+            resolved: value.resolved,
+            resolve_failure: None,
+            junk_drawer: None,
+            context: value.get_context(),
+            release: None,
+        }
+    }
+}

--- a/rust/cymbal/src/langs/mod.rs
+++ b/rust/cymbal/src/langs/mod.rs
@@ -1,3 +1,4 @@
+pub mod custom;
 pub mod js;
 pub mod node;
 pub mod python;


### PR DESCRIPTION
No harm really. Thought about just putting the output `Frame` in the enum and passing it straight through, but I want to maintain the ability to change that in the future if we decide to.