### PR TITLE
chore(flags): Add new feature flag property filter

### DIFF
--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -1,11 +1,14 @@
 use crate::api::errors::FlagError;
-use crate::api::types::{ConfigResponse, FlagDetails, FlagsResponse, FromFeatureAndMatch};
+use crate::api::types::{
+    ConfigResponse, FlagDetails, FlagValue, FlagsResponse, FromFeatureAndMatch,
+};
 use crate::cohorts::cohort_cache_manager::CohortCacheManager;
 use crate::cohorts::cohort_models::{Cohort, CohortId};
 use crate::cohorts::cohort_operations::{apply_cohort_membership_logic, evaluate_dynamic_cohorts};
 use crate::flags::flag_group_type_mapping::{GroupTypeIndex, GroupTypeMappingCache};
 use crate::flags::flag_match_reason::FeatureFlagMatchReason;
-use crate::flags::flag_models::{FeatureFlag, FeatureFlagList, FlagPropertyGroup};
+use crate::flags::flag_matching_utils::all_flag_values_match;
+use crate::flags::flag_models::{FeatureFlag, FeatureFlagId, FeatureFlagList, FlagPropertyGroup};
 use crate::metrics::consts::{
     DB_PERSON_AND_GROUP_PROPERTIES_READS_COUNTER, FLAG_DB_PROPERTIES_FETCH_TIME,
     FLAG_EVALUATE_ALL_CONDITIONS_TIME, FLAG_EVALUATION_ERROR_COUNTER, FLAG_EVALUATION_TIME,
@@ -29,7 +32,7 @@ use tracing::error;
 use uuid::Uuid;
 
 #[cfg(test)] // Only used in the tests
-use crate::api::types::{FlagValue, LegacyFlagsResponse};
+use crate::api::types::LegacyFlagsResponse;
 
 use super::flag_matching_utils::{
     all_properties_match, calculate_hash, fetch_and_locally_cache_all_relevant_properties,
@@ -56,6 +59,16 @@ pub struct FeatureFlagMatch {
     pub payload: Option<Value>,
 }
 
+impl FeatureFlagMatch {
+    pub fn get_flag_value(&self) -> FlagValue {
+        match (self.matches, &self.variant) {
+            (true, Some(variant)) => FlagValue::String(variant.clone()),
+            (true, None) => FlagValue::Boolean(true),
+            (false, _) => FlagValue::Boolean(false),
+        }
+    }
+}
+
 /// This struct maintains evaluation state by caching database-sourced data during feature flag evaluation.
 /// It stores person IDs, properties, group properties, and cohort matches that are fetched from the database,
 /// allowing them to be reused across multiple flag evaluations within the same request without additional DB lookups.
@@ -73,6 +86,8 @@ pub struct FlagEvaluationState {
     cohorts: Option<Vec<Cohort>>,
     /// Cache of static cohort membership results to avoid repeated DB lookups
     static_cohort_matches: Option<HashMap<CohortId, bool>>,
+    /// Cache of flag evaluation results to avoid repeated DB lookups
+    flag_evaluation_results: HashMap<FeatureFlagId, FlagValue>,
 }
 
 impl FlagEvaluationState {
@@ -114,6 +129,10 @@ impl FlagEvaluationState {
 
     pub fn set_static_cohort_matches(&mut self, matches: HashMap<CohortId, bool>) {
         self.static_cohort_matches = Some(matches);
+    }
+
+    pub fn add_flag_evaluation_result(&mut self, flag_id: FeatureFlagId, flag_value: FlagValue) {
+        self.flag_evaluation_results.insert(flag_id, flag_value);
     }
 }
 
@@ -483,6 +502,8 @@ impl FeatureFlagMatcher {
                 hash_key_overrides.clone(),
             ) {
                 Ok(Some(flag_match)) => {
+                    self.flag_evaluation_state
+                        .add_flag_evaluation_result(flag.id, flag_match.get_flag_value());
                     flag_details_map
                         .insert(flag.key.clone(), FlagDetails::create(flag, &flag_match));
                 }
@@ -521,6 +542,7 @@ impl FeatureFlagMatcher {
                 .prepare_flag_evaluation_state(&flags_needing_db_properties)
                 .await
             {
+                // Handle database errors and return early
                 errors_while_computing_flags = true;
                 let reason = parse_exception_for_prometheus_label(&e);
                 for flag in flags_needing_db_properties {
@@ -541,62 +563,64 @@ impl FeatureFlagMatcher {
                     config: ConfigResponse::default(),
                 };
             }
+        }
 
-            // Step 3: Evaluate remaining flags with cached properties
-            let flag_get_match_timer = common_metrics::timing_guard(FLAG_GET_MATCH_TIME, &[]);
+        // Step 3: Evaluate remaining flags with cached properties
+        let flag_get_match_timer = common_metrics::timing_guard(FLAG_GET_MATCH_TIME, &[]);
 
-            // Create a HashMap for quick flag lookups
-            let flags_map: HashMap<_, _> = flags_needing_db_properties
-                .iter()
-                .map(|flag| (flag.key.clone(), flag))
+        // Create a HashMap for quick flag lookups
+        let flags_map: HashMap<_, _> = flags_needing_db_properties
+            .iter()
+            .map(|flag| (flag.key.clone(), flag))
+            .collect();
+
+        let results: Vec<(String, Result<FeatureFlagMatch, FlagError>)> =
+            flags_needing_db_properties
+                .par_iter()
+                .map(|flag| {
+                    (
+                        flag.key.clone(),
+                        self.get_match(flag, None, hash_key_overrides.clone()),
+                    )
+                })
                 .collect();
 
-            let results: Vec<(String, Result<FeatureFlagMatch, FlagError>)> =
-                flags_needing_db_properties
-                    .par_iter()
-                    .map(|flag| {
-                        (
-                            flag.key.clone(),
-                            self.get_match(flag, None, hash_key_overrides.clone()),
-                        )
-                    })
-                    .collect();
+        for (flag_key, result) in results {
+            let flag = flags_map.get(&flag_key).unwrap();
 
-            for (flag_key, result) in results {
-                let flag = flags_map.get(&flag_key).unwrap();
-
-                match result {
-                    Ok(flag_match) => {
-                        flag_details_map.insert(flag_key, FlagDetails::create(flag, &flag_match));
-                    }
-                    Err(e) => {
-                        errors_while_computing_flags = true;
-                        // TODO add posthog error tracking
-                        error!(
-                            "Error evaluating feature flag '{}' for distinct_id '{}': {:?}",
-                            flag_key, self.distinct_id, e
-                        );
-                        let reason = parse_exception_for_prometheus_label(&e);
-                        inc(
-                            FLAG_EVALUATION_ERROR_COUNTER,
-                            &[("reason".to_string(), reason.to_string())],
-                            1,
-                        );
-                        flag_details_map.insert(flag_key, FlagDetails::create_error(flag, reason));
-                    }
+            match result {
+                Ok(flag_match) => {
+                    self.flag_evaluation_state
+                        .add_flag_evaluation_result(flag.id, flag_match.get_flag_value());
+                    flag_details_map.insert(flag_key, FlagDetails::create(flag, &flag_match));
+                }
+                Err(e) => {
+                    errors_while_computing_flags = true;
+                    // TODO add posthog error tracking
+                    error!(
+                        "Error evaluating feature flag '{}' for distinct_id '{}': {:?}",
+                        flag_key, self.distinct_id, e
+                    );
+                    let reason = parse_exception_for_prometheus_label(&e);
+                    inc(
+                        FLAG_EVALUATION_ERROR_COUNTER,
+                        &[("reason".to_string(), reason.to_string())],
+                        1,
+                    );
+                    flag_details_map.insert(flag_key, FlagDetails::create_error(flag, reason));
                 }
             }
-            flag_get_match_timer
-                .label(
-                    "outcome",
-                    if errors_while_computing_flags {
-                        "error"
-                    } else {
-                        "success"
-                    },
-                )
-                .fin();
         }
+        flag_get_match_timer
+            .label(
+                "outcome",
+                if errors_while_computing_flags {
+                    "error"
+                } else {
+                    "success"
+                },
+            )
+            .fin();
 
         FlagsResponse {
             errors_while_computing_flags,
@@ -897,9 +921,25 @@ impl FeatureFlagMatcher {
                 return self.check_rollout(feature_flag, rollout_percentage, hash_key_overrides);
             }
 
+            // Separate flag value filters from other filters
+            let (flag_value_filters, other_filters): (Vec<PropertyFilter>, Vec<PropertyFilter>) =
+                flag_property_filters
+                    .iter()
+                    .cloned()
+                    .partition(|prop| prop.is_feature_flag());
+
+            if !flag_value_filters.is_empty()
+                && !all_flag_values_match(
+                    &flag_value_filters,
+                    &self.flag_evaluation_state.flag_evaluation_results,
+                )
+            {
+                return Ok((false, FeatureFlagMatchReason::NoConditionMatch));
+            }
+
             // Separate cohort and non-cohort filters
             let (cohort_filters, non_cohort_filters): (Vec<PropertyFilter>, Vec<PropertyFilter>) =
-                flag_property_filters
+                other_filters
                     .iter()
                     .cloned()
                     .partition(|prop| prop.is_cohort());
@@ -1744,6 +1784,66 @@ mod tests {
             None,
             None,
         );
+        let (is_match, reason) = matcher
+            .is_condition_match(&flag, &condition, None, None)
+            .unwrap();
+        assert!(is_match);
+        assert_eq!(reason, FeatureFlagMatchReason::ConditionMatch);
+    }
+
+    #[tokio::test]
+    async fn test_is_condition_match_flag_value_operator() {
+        let reader = setup_pg_reader_client(None).await;
+        let writer = setup_pg_writer_client(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
+        let flag = create_test_flag(
+            Some(2),
+            None,
+            None,
+            None,
+            Some(FlagFilters {
+                groups: vec![FlagPropertyGroup {
+                    properties: Some(vec![]),
+                    rollout_percentage: Some(100.0),
+                    variant: None,
+                }],
+                multivariate: None,
+                aggregation_group_type_index: None,
+                payloads: None,
+                super_groups: None,
+                holdout_groups: None,
+            }),
+            None,
+            None,
+            None,
+        );
+
+        let condition = FlagPropertyGroup {
+            variant: None,
+            properties: Some(vec![PropertyFilter {
+                key: "1".to_string(),
+                value: Some(json!(true)),
+                operator: Some(OperatorType::FlagValue),
+                prop_type: PropertyType::Flag,
+                group_type_index: None,
+                negation: None,
+            }]),
+            rollout_percentage: Some(100.0),
+        };
+
+        let mut matcher = FeatureFlagMatcher::new(
+            "test_user".to_string(),
+            1,
+            1,
+            reader,
+            writer,
+            cohort_cache,
+            None,
+            None,
+        );
+        matcher
+            .flag_evaluation_state
+            .add_flag_evaluation_result(1, FlagValue::Boolean(true));
         let (is_match, reason) = matcher
             .is_condition_match(&flag, &condition, None, None)
             .unwrap();

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -7,7 +7,7 @@ use crate::cohorts::cohort_models::{Cohort, CohortId};
 use crate::cohorts::cohort_operations::{apply_cohort_membership_logic, evaluate_dynamic_cohorts};
 use crate::flags::flag_group_type_mapping::{GroupTypeIndex, GroupTypeMappingCache};
 use crate::flags::flag_match_reason::FeatureFlagMatchReason;
-use crate::flags::flag_matching_utils::all_flag_values_match;
+use crate::flags::flag_matching_utils::all_flag_condition_properties_match;
 use crate::flags::flag_models::{FeatureFlag, FeatureFlagId, FeatureFlagList, FlagPropertyGroup};
 use crate::metrics::consts::{
     DB_PERSON_AND_GROUP_PROPERTIES_READS_COUNTER, FLAG_DB_PROPERTIES_FETCH_TIME,
@@ -929,7 +929,7 @@ impl FeatureFlagMatcher {
                     .partition(|prop| prop.is_feature_flag());
 
             if !flag_value_filters.is_empty()
-                && !all_flag_values_match(
+                && !all_flag_condition_properties_match(
                     &flag_value_filters,
                     &self.flag_evaluation_state.flag_evaluation_results,
                 )

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -1823,7 +1823,7 @@ mod tests {
             properties: Some(vec![PropertyFilter {
                 key: "1".to_string(),
                 value: Some(json!(true)),
-                operator: Some(OperatorType::FlagValue),
+                operator: Some(OperatorType::Exact),
                 prop_type: PropertyType::Flag,
                 group_type_index: None,
                 negation: None,

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -233,7 +233,7 @@ pub fn all_properties_match(
         .all(|property| match_property(property, matching_property_values, false).unwrap_or(false))
 }
 
-pub fn all_flag_values_match(
+pub fn all_flag_condition_properties_match(
     flag_condition_properties: &[PropertyFilter],
     flag_evaluation_results: &HashMap<FeatureFlagId, FlagValue>,
 ) -> bool {

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -263,7 +263,9 @@ pub fn match_flag_filter_value(
     match filter.value {
         Some(Value::Bool(true)) => flag_value != &FlagValue::Boolean(false),
         Some(Value::Bool(false)) => flag_value == &FlagValue::Boolean(false),
-        Some(Value::String(ref s)) => flag_value == &FlagValue::String(s.clone()),
+        Some(Value::String(ref s)) => {
+            matches!(flag_value, FlagValue::String(flag_str) if flag_str == s)
+        }
         _ => false,
     }
 }

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -246,26 +246,18 @@ pub fn match_flag_filter_value(
     filter: &PropertyFilter,
     flag_evaluation_results: &HashMap<FeatureFlagId, FlagValue>,
 ) -> bool {
-    let flag_id = filter.get_feature_flag_id();
-    if flag_id.is_none() {
+    let Some(flag_id) = filter.get_feature_flag_id() else {
         return false;
-    }
-    // Grab the existing flag value for this flag id if any
-    let flag_value = flag_evaluation_results.get(&flag_id.unwrap());
-    if flag_value.is_none() {
-        // This means this condition depends on a flag that doesn't exist yet, so it's not a match
+    };
+    
+    let Some(flag_value) = flag_evaluation_results.get(&flag_id) else {
         return false;
-    }
-    // If the filter flag value is boolean and is `true`, then we need to see if the `flag_value` is not `false`.
-    // If the filter flag value is boolean and is `false`, then we need to see if the `flag_value` is `false`.
-    // If the filter flag value is a string, we need to see if the `flag_value` is the same as the filter flag value.
-    let flag_value = flag_value.unwrap();
+    };
+
     match filter.value {
         Some(Value::Bool(true)) => flag_value != &FlagValue::Boolean(false),
         Some(Value::Bool(false)) => flag_value == &FlagValue::Boolean(false),
-        Some(Value::String(ref s)) => {
-            matches!(flag_value, FlagValue::String(flag_str) if flag_str == s)
-        }
+        Some(Value::String(ref s)) => matches!(flag_value, FlagValue::String(flag_str) if flag_str == s),
         _ => false,
     }
 }

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -249,7 +249,7 @@ pub fn match_flag_filter_value(
     let Some(flag_id) = filter.get_feature_flag_id() else {
         return false;
     };
-    
+
     let Some(flag_value) = flag_evaluation_results.get(&flag_id) else {
         return false;
     };
@@ -257,7 +257,9 @@ pub fn match_flag_filter_value(
     match filter.value {
         Some(Value::Bool(true)) => flag_value != &FlagValue::Boolean(false),
         Some(Value::Bool(false)) => flag_value == &FlagValue::Boolean(false),
-        Some(Value::String(ref s)) => matches!(flag_value, FlagValue::String(flag_str) if flag_str == s),
+        Some(Value::String(ref s)) => {
+            matches!(flag_value, FlagValue::String(flag_str) if flag_str == s)
+        }
         _ => false,
     }
 }

--- a/rust/feature-flags/src/flags/flag_models.rs
+++ b/rust/feature-flags/src/flags/flag_models.rs
@@ -44,12 +44,14 @@ pub struct FlagFilters {
     pub holdout_groups: Option<Vec<FlagPropertyGroup>>,
 }
 
+pub type FeatureFlagId = i32;
+
 // TODO: see if you can combine these two structs, like we do with cohort models
 // this will require not deserializing on read and instead doing it lazily, on-demand
 // (which, tbh, is probably a better idea)
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FeatureFlag {
-    pub id: i32,
+    pub id: FeatureFlagId,
     pub team_id: i32,
     pub name: Option<String>,
     pub key: String,

--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -4,7 +4,6 @@ use crate::flags::flag_models::*;
 use crate::properties::property_models::{PropertyFilter, PropertyType};
 use common_database::Client as DatabaseClient;
 use common_redis::Client as RedisClient;
-use std::collections::HashSet;
 use std::sync::Arc;
 use tracing::instrument;
 
@@ -63,27 +62,6 @@ impl FeatureFlag {
                 .as_object()
                 .and_then(|obj| obj.get(match_val).cloned())
         })
-    }
-
-    /// Extracts dependent FeatureFlagIds from the feature flag's filters
-    ///
-    /// # Returns
-    /// * `HashSet<FeatureFlagId>` - A set of dependent feature flag IDs
-    /// * `FlagError` - If there is an error parsing the filters
-    pub fn extract_dependencies(&self) -> Result<HashSet<FeatureFlagId>, FlagError> {
-        let mut dependencies = HashSet::new();
-        for group in &self.filters.groups {
-            if let Some(properties) = &group.properties {
-                for filter in properties {
-                    if filter.is_feature_flag() {
-                        if let Some(feature_flag_id) = filter.get_feature_flag_id() {
-                            dependencies.insert(feature_flag_id);
-                        }
-                    }
-                }
-            }
-        }
-        Ok(dependencies)
     }
 }
 

--- a/rust/feature-flags/src/properties/property_matching.rs
+++ b/rust/feature-flags/src/properties/property_matching.rs
@@ -235,6 +235,9 @@ pub fn match_property(
         OperatorType::In | OperatorType::NotIn => Err(FlagMatchingError::ValidationError(
             "In/NotIn operators should be handled by cohort matching".to_string(),
         )),
+        OperatorType::FlagValue => Err(FlagMatchingError::ValidationError(
+            "FlagValue operators are handled by flag matching code".to_string(),
+        )),
     }
 }
 

--- a/rust/feature-flags/src/properties/property_matching.rs
+++ b/rust/feature-flags/src/properties/property_matching.rs
@@ -235,9 +235,6 @@ pub fn match_property(
         OperatorType::In | OperatorType::NotIn => Err(FlagMatchingError::ValidationError(
             "In/NotIn operators should be handled by cohort matching".to_string(),
         )),
-        OperatorType::FlagValue => Err(FlagMatchingError::ValidationError(
-            "FlagValue operators are handled by flag matching code".to_string(),
-        )),
     }
 }
 

--- a/rust/feature-flags/src/properties/property_models.rs
+++ b/rust/feature-flags/src/properties/property_models.rs
@@ -20,6 +20,7 @@ pub enum OperatorType {
     IsDateBefore,
     In,
     NotIn,
+    FlagValue,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -31,6 +32,9 @@ pub enum PropertyType {
     Cohort,
     #[serde(rename = "group")]
     Group,
+    // A flag property is compared to another flag evaluation result
+    #[serde(rename = "flag")]
+    Flag,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/rust/feature-flags/src/properties/property_models.rs
+++ b/rust/feature-flags/src/properties/property_models.rs
@@ -20,7 +20,6 @@ pub enum OperatorType {
     IsDateBefore,
     In,
     NotIn,
-    FlagValue,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
This adds a new Property Filter type `flag` and a new `OperatorType` of `FlagValue`. At the moment, this is not exposed in the UI.

## Problem

Related to #29016

## Changes

As we evaluate feature flags, we store the flag value (aka the boolean result or variant) in the `FlagEvaluationState`. When a feature flag condition evaluates, it looks at the flag evaluation state to determine if it matches.

The rules are as such:

* Filter value is `true`, then it matches if the flag it depends on evaluates to `true` or any variant.
* Filter value is a variant string, then it matches if the flag it depends on evaluates to that exact variant.
* Filter value is `false`, then it matches if the flag it depends on is `false`.

If the dependent flag is not in the flag evaluation state, we return `false` for now.

This PR does not include building up a dependency graph and doing the topological sort so that we evaluate flags in the correct order to prevent evaluating a flag that depends on another flag before that other flag.

Because there's no UI to create such flags, this code is effectively a no-op. I just wanted to get a PR in to get 👀 on the approach and to keep the size of the PR reasonable.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Unit tests.