### PR TITLE
fix: Only mark adhoc deletions as completed if the dictionary exists

### DIFF
--- a/dags/deletes.py
+++ b/dags/deletes.py
@@ -748,7 +748,7 @@ def cleanup_delete_assets(
     def mark_adhoc_event_deletes_done(client: Client) -> None:
         # XXX: temporary fix to allow job to resume if the dictionary was deleted but subsequent steps failed; marking
         # completion and dropping the dictionary should be split into separate ops to ensure both can complete safely
-        if create_adhoc_event_deletes_dict.exists():
+        if create_adhoc_event_deletes_dict.exists(client):
             client.execute(f"""
                 INSERT INTO {create_adhoc_event_deletes_dict.source.qualified_name} (team_id, uuid, created_at, deleted_at, is_deleted)
                 SELECT team_id, uuid, created_at, now64(), 1

--- a/dags/deletes.py
+++ b/dags/deletes.py
@@ -745,13 +745,17 @@ def cleanup_delete_assets(
     cluster.map_all_hosts(create_pending_deletions_table.drop).result()
 
     # Mark adhoc event deletes as verified
-    cluster.any_host(
-        lambda client: client.execute(f"""
-            INSERT INTO {create_adhoc_event_deletes_dict.source.qualified_name} (team_id, uuid, created_at, deleted_at, is_deleted)
-            SELECT team_id, uuid, created_at, now64(), 1
-            FROM {create_adhoc_event_deletes_dict.qualified_name}
-    """)
-    ).result()
+    def mark_adhoc_event_deletes_done(client: Client) -> None:
+        # XXX: temporary fix to allow job to resume if the dictionary was deleted but subsequent steps failed; marking
+        # completion and dropping the dictionary should be split into separate ops to ensure both can complete safely
+        if create_adhoc_event_deletes_dict.exists():
+            client.execute(f"""
+                INSERT INTO {create_adhoc_event_deletes_dict.source.qualified_name} (team_id, uuid, created_at, deleted_at, is_deleted)
+                SELECT team_id, uuid, created_at, now64(), 1
+                FROM {create_adhoc_event_deletes_dict.qualified_name}
+            """)
+
+    cluster.any_host(mark_adhoc_event_deletes_done).result()
     cluster.map_all_hosts(create_adhoc_event_deletes_dict.drop).result()
     cluster.any_host(create_adhoc_event_deletes_dict.source.optimize).result()
     return True


### PR DESCRIPTION
## Problem

The scheduled job failed on the last part of the cleanup op: https://dagster.prod-eu.posthog.dev/runs/a04c0142-a0f2-4584-80fd-a414c5a02f2e

Subsequent runs are failing because dependencies no longer exist: https://dagster.prod-eu.posthog.dev/runs/a04c0142-a0f2-4584-80fd-a414c5a02f2e

## Changes

Adds a temporary fix to allow job to resume if the dictionary was deleted but subsequent steps failed. I'll follow up with a change to make this step more retry-safe.

## Did you write or update any docs for this change?

No docs needed for this change

## How did you test this code?

Kinda sorta covered (they still run)