### PR TITLE
chore(web-analytics): move query engine toggle to page header

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsHeaderButtons.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsHeaderButtons.tsx
@@ -1,0 +1,98 @@
+import { IconBolt } from '@posthog/icons'
+import { useActions, useValues } from 'kea'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { LemonSwitch } from 'lib/lemon-ui/LemonSwitch'
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { Popover } from 'lib/lemon-ui/Popover'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { useState } from 'react'
+import { teamLogic } from 'scenes/teamLogic'
+import { WebAnalyticsMenu } from 'scenes/web-analytics/WebAnalyticsMenu'
+
+export function WebAnalyticsHeaderButtons(): JSX.Element {
+    const { featureFlags } = useValues(featureFlagLogic)
+    const { currentTeam } = useValues(teamLogic)
+    const { updateCurrentTeam } = useActions(teamLogic)
+    const [showPopover, setShowPopover] = useState(false)
+
+    const hasFeatureFlag = featureFlags[FEATURE_FLAGS.SETTINGS_WEB_ANALYTICS_PRE_AGGREGATED_TABLES]
+    const isUsingNewEngine = currentTeam?.modifiers?.useWebAnalyticsPreAggregatedTables
+
+    const handleToggleEngine = (checked: boolean): void => {
+        updateCurrentTeam({
+            modifiers: {
+                ...currentTeam?.modifiers,
+                useWebAnalyticsPreAggregatedTables: checked,
+            },
+        })
+    }
+
+    return (
+        <div className="flex items-center gap-2">
+            {hasFeatureFlag && (
+                <Popover
+                    visible={showPopover}
+                    onClickOutside={() => setShowPopover(false)}
+                    overlay={
+                        <div className="p-4 max-w-160">
+                            <div className="flex items-center gap-2 mb-2">
+                                <h3 className="font-semibold flex items-center gap-2">
+                                    About the New Query Engine
+                                    <LemonTag type="warning" className="uppercase">
+                                        Beta
+                                    </LemonTag>
+                                </h3>
+                            </div>
+                            <p className="mb-3">
+                                Our new Web Analytics Query Engine powers faster queries using pre-aggregated data,
+                                giving you quicker access to insights and it's much better at handling large datasets.
+                            </p>
+
+                            <div className="mb-3">
+                                <strong>A few things to note:</strong>
+                                <ul className="list-disc ml-4 mt-1 space-y-1">
+                                    <li>
+                                        Some filters may not yet be supported, but we're working on expanding coverage.
+                                    </li>
+                                    <li>
+                                        We use smart approximation techniques to keep performance high, and we aim for
+                                        less than 1% difference compared to exact results.
+                                    </li>
+                                    <li>
+                                        You can toggle the engine on or off directly from this interface if you want to
+                                        compare results or prefer the previous method.
+                                    </li>
+                                </ul>
+                            </div>
+
+                            <div className="mb-3">
+                                <strong>Coming Soon:</strong>
+                                <ul className="list-disc ml-4 mt-1 space-y-1">
+                                    <li>Use the new engine for chart visualizations</li>
+                                    <li>Support for channel types in breakdowns</li>
+                                    <li>Enable conversion goals</li>
+                                    <li>Further improvements in accuracy</li>
+                                    <li>More filters!</li>
+                                </ul>
+                            </div>
+                        </div>
+                    }
+                >
+                    <div
+                        className="flex items-center gap-2 cursor-pointer"
+                        onClick={() => handleToggleEngine(!isUsingNewEngine)}
+                        onMouseEnter={() => setShowPopover(true)}
+                        onMouseLeave={() => setShowPopover(false)}
+                    >
+                        <IconBolt className={isUsingNewEngine ? 'text-warning' : 'text-muted'} />
+                        <span className="text-sm font-medium">
+                            {isUsingNewEngine ? 'New Query Engine' : 'Regular Query Engine'}
+                        </span>
+                        <LemonSwitch checked={!!isUsingNewEngine} onChange={handleToggleEngine} size="small" />
+                    </div>
+                </Popover>
+            )}
+            <WebAnalyticsMenu />
+        </div>
+    )
+}

--- a/frontend/src/scenes/web-analytics/WebAnalyticsMenu.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsMenu.tsx
@@ -1,25 +1,15 @@
 import { IconEllipsis, IconSearch } from '@posthog/icons'
 import { useActions, useValues } from 'kea'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonMenu } from 'lib/lemon-ui/LemonMenu'
 import { LemonSwitch } from 'lib/lemon-ui/LemonSwitch'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import { webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
 
 export const WebAnalyticsMenu = (): JSX.Element => {
     const { shouldFilterTestAccounts } = useValues(webAnalyticsLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
-    const { currentTeam } = useValues(teamLogic)
 
     const { setShouldFilterTestAccounts } = useActions(webAnalyticsLogic)
-    const { updateCurrentTeam } = useActions(teamLogic)
-
-    const handlePreAggChange = (mode: boolean): void => {
-        updateCurrentTeam({ modifiers: { ...currentTeam?.modifiers, useWebAnalyticsPreAggregatedTables: mode } })
-    }
 
     return (
         <LemonMenu
@@ -41,18 +31,6 @@ export const WebAnalyticsMenu = (): JSX.Element => {
                         />
                     ),
                 },
-                featureFlags[FEATURE_FLAGS.SETTINGS_WEB_ANALYTICS_PRE_AGGREGATED_TABLES]
-                    ? {
-                          label: () => (
-                              <LemonSwitch
-                                  checked={currentTeam?.modifiers?.useWebAnalyticsPreAggregatedTables ?? false}
-                                  onChange={handlePreAggChange}
-                                  fullWidth={true}
-                                  label="Allow pre-aggregated tables"
-                              />
-                          ),
-                      }
-                    : null,
             ].filter(Boolean)}
             closeOnClickInside={false}
         >

--- a/frontend/src/scenes/web-analytics/WebAnalyticsScene.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsScene.tsx
@@ -1,13 +1,13 @@
 import { PageHeader } from 'lib/components/PageHeader'
 import { SceneExport } from 'scenes/sceneTypes'
 import { WebAnalyticsDashboard } from 'scenes/web-analytics/WebAnalyticsDashboard'
+import { WebAnalyticsHeaderButtons } from 'scenes/web-analytics/WebAnalyticsHeaderButtons'
 import { webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
-import { WebAnalyticsMenu } from 'scenes/web-analytics/WebAnalyticsMenu'
 
 export function WebAnalyticsScene(): JSX.Element {
     return (
         <>
-            <PageHeader buttons={<WebAnalyticsMenu />} />
+            <PageHeader buttons={<WebAnalyticsHeaderButtons />} />
 
             <WebAnalyticsDashboard />
         </>


### PR DESCRIPTION
## Problem

We're rolling this out to a few customers who requested the beta, so it would be better if it were more visible for them to enable or disable.

<img width="1080" alt="image" src="https://github.com/user-attachments/assets/67f4941a-4995-4164-b191-51280117ecc1" />


## Changes

- Moved out of the ellipsis menu to its own PageHeader component.

## Did you write or update any docs for this change?

- [x] No docs needed for this change

## How did you test this code?

Manually.