### PR TITLE
fix: Revert "fix: in cohort filter hanging "

### DIFF
--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -390,8 +390,7 @@ def _recalculate_cohortpeople_for_team_hogql(
             "optimize_on_insert": 0,
             "max_ast_elements": hogql_global_settings.max_ast_elements,
             "max_expanded_ast_elements": hogql_global_settings.max_expanded_ast_elements,
-            "max_bytes_ratio_before_external_group_by": 0.5,
-            "max_bytes_ratio_before_external_sort": 0.5,
+            "max_bytes_before_external_group_by": hogql_global_settings.max_bytes_before_external_group_by,
         },
         workload=Workload.OFFLINE,
     )


### PR DESCRIPTION
Reverts PostHog/posthog#33120 to protect resources on Offline cluster. Context here https://posthog.slack.com/archives/C076R4753Q8/p1749310677162049

This is probably causing queries that were failing before to run successfully but are _very_ expensive. We'll need to provision a lot more resources before we can successfully let these run.