### PR TITLE
feat: change line width and font size

### DIFF
--- a/frontend/src/lib/components/TakeScreenshot/ScreenShotEditor.tsx
+++ b/frontend/src/lib/components/TakeScreenshot/ScreenShotEditor.tsx
@@ -68,7 +68,17 @@ export function ScreenShotEditor({ screenshotKey }: { screenshotKey: string }): 
         setMode('draw')
         setHtml(null)
         setImageFile(null)
-    }, [setIsOpen])
+    }, [
+        setIsOpen,
+        setOriginalImage,
+        setCurrentText,
+        setTextInputPosition,
+        setSelectedTextIndex,
+        setDragStartOffset,
+        setMode,
+        setHtml,
+        setImageFile,
+    ])
 
     const redrawCanvas = useCallback(() => {
         const canvas = canvasRef.current
@@ -123,7 +133,7 @@ export function ScreenShotEditor({ screenshotKey }: { screenshotKey: string }): 
                 ctx.strokeRect(textItem.x - 2, textItem.y - textHeight, textWidth + 4, textHeight + 4)
             }
         })
-    }, [originalImage, drawings, texts, isDrawing, currentPath, color, mode, selectedTextIndex])
+    }, [originalImage, drawings, texts, isDrawing, currentPath, color, mode, selectedTextIndex, lineWidth, fontSize])
 
     useEffect(() => {
         if (isOpen && imageFile && !originalImage) {
@@ -172,7 +182,7 @@ export function ScreenShotEditor({ screenshotKey }: { screenshotKey: string }): 
             setSelectedTextIndex(null)
             setHtml(null)
         }
-    }, [isOpen, imageFile, originalImage, handleClose, html])
+    }, [isOpen, imageFile, originalImage, handleClose, html, setOriginalImage, setSelectedTextIndex, setHtml])
 
     useEffect(() => {
         if (isOpen && originalImage) {
@@ -393,16 +403,15 @@ export function ScreenShotEditor({ screenshotKey }: { screenshotKey: string }): 
                                 colors={getSeriesColorPalette().slice(0, 20)}
                             />
                             <LemonSelect
-                                disabledReason={mode !== 'draw' ? 'Please use the draw mode' : undefined}
                                 value={lineWidth}
                                 onChange={setLineWidth}
                                 options={Array.from({ length: 10 }, (_, i) => {
                                     const value = 1 + i * 2
                                     return {
                                         label: (
-                                            // eslint-disable-next-line react/forbid-dom-props
                                             <div
                                                 className="w-12 bg-gray-700 rounded-full"
+                                                // eslint-disable-next-line react/forbid-dom-props
                                                 style={{ height: `${value}px` }}
                                             />
                                         ),
@@ -421,10 +430,9 @@ export function ScreenShotEditor({ screenshotKey }: { screenshotKey: string }): 
                                 tooltip="Draw"
                             />
                             <LemonSelect
-                                disabledReason={mode !== 'draw' ? undefined : 'Please use the text mode'}
                                 value={fontSize}
                                 onChange={setFontSize}
-                                options={Array.from({ length: 21 }, (_, i) => {
+                                options={Array.from({ length: 20 }, (_, i) => {
                                     const value = 10 + i * 2
                                     return { label: value.toString(), value }
                                 })}

--- a/frontend/src/lib/components/TakeScreenshot/takeScreenshotLogic.ts
+++ b/frontend/src/lib/components/TakeScreenshot/takeScreenshotLogic.ts
@@ -5,10 +5,6 @@ import posthog from 'posthog-js'
 
 import type { takeScreenshotLogicType } from './takeScreenshotLogicType'
 
-export const LINE_WIDTH = 3
-export const TEXT_FONT = '16px Arial'
-export const APPROX_TEXT_HEIGHT = 16
-
 // Define interfaces for better type safety
 export interface Point {
     x: number
@@ -63,6 +59,8 @@ export const takeScreenshotLogic = kea<takeScreenshotLogicType>([
         }),
         setIsLoading: (isLoading: boolean) => ({ isLoading }),
         setBlob: (blob: Blob) => ({ blob }),
+        setLineWidth: (lineWidth: number) => ({ lineWidth }),
+        setFontSize: (fontSize: number) => ({ fontSize }),
     }),
     reducers({
         isOpen: [
@@ -159,6 +157,18 @@ export const takeScreenshotLogic = kea<takeScreenshotLogicType>([
             { x: 0, y: 0, visible: false } as { x: number; y: number; visible: boolean },
             {
                 setTextInputPosition: (_, { textInputPosition }) => textInputPosition,
+            },
+        ],
+        lineWidth: [
+            3,
+            {
+                setLineWidth: (_, { lineWidth }) => lineWidth,
+            },
+        ],
+        fontSize: [
+            16,
+            {
+                setFontSize: (_, { fontSize }) => fontSize,
             },
         ],
     }),


### PR DESCRIPTION
Let's improve a bit our screenshot editor

1. Let's add an ability to change line width
2. Let's add an ability to change font height

<img width="588" alt="Screenshot 2025-06-08 at 12 59 40" src="https://github.com/user-attachments/assets/487357a8-4cf6-4398-987b-0f2301689811" />
<img width="1224" alt="Screenshot 2025-06-08 at 12 59 33" src="https://github.com/user-attachments/assets/bdb1720f-9c8e-418c-995f-854100ef3f6e" />
<img width="1234" alt="Screenshot 2025-06-08 at 12 59 26" src="https://github.com/user-attachments/assets/452b4ebc-87b9-44d5-9d89-2a60d82acea7" />
