### PR TITLE
fix: regex on re-authenticate

### DIFF
--- a/frontend/src/lib/components/TimeSensitiveAuthentication/TimeSensitiveAuthentication.tsx
+++ b/frontend/src/lib/components/TimeSensitiveAuthentication/TimeSensitiveAuthentication.tsx
@@ -27,7 +27,7 @@ export function TimeSensitiveAuthenticationModal(): JSX.Element {
 
     return (
         <LemonModal
-            zIndex="1169"
+            zIndex="1169" // The re-authentication modal should be above the all popovers, including the AI consent popover
             title="Re-authenticate for security"
             isOpen={showAuthenticationModal}
             onClose={() => setDismissedReauthentication(true)}

--- a/frontend/src/lib/components/TimeSensitiveAuthentication/TimeSensitiveAuthentication.tsx
+++ b/frontend/src/lib/components/TimeSensitiveAuthentication/TimeSensitiveAuthentication.tsx
@@ -27,6 +27,7 @@ export function TimeSensitiveAuthenticationModal(): JSX.Element {
 
     return (
         <LemonModal
+            zIndex="1169"
             title="Re-authenticate for security"
             isOpen={showAuthenticationModal}
             onClose={() => setDismissedReauthentication(true)}


### PR DESCRIPTION
## ISSUE

Re-authenticate popup was under AI constent / AI regex helper


## SOLUTION

Let's set it the MAXIMUM z-index as, in reality, it should be above everything.


#### Before
<img width="742" alt="Screenshot 2025-06-08 at 13 28 11" src="https://github.com/user-attachments/assets/e58b7052-6637-487c-8c62-d1aa76bc5d3c" />


#### After
<img width="777" alt="Screenshot 2025-06-08 at 13 27 34" src="https://github.com/user-attachments/assets/6b572188-e513-46f4-9950-a8409e9173f7" />
