### PR TITLE
chore: remove stray backtick from modal

### DIFF
--- a/frontend/src/lib/components/SaveTo/SaveTo.tsx
+++ b/frontend/src/lib/components/SaveTo/SaveTo.tsx
@@ -27,7 +27,7 @@ export function SaveToModal(): JSX.Element {
             title="Select a folder to save to"
             description={
                 <>
-                    Saving to: <LemonSnack>{destinationFolder}</LemonSnack>`
+                    Saving to: <LemonSnack>{destinationFolder}</LemonSnack>
                 </>
             }
             // This is a bit of a hack. Without it, the flow "insight" -> "add to dashboard button" ->


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

There is a stray backtick in the `SaveToModal`. See image:

<img width="810" alt="Screenshot 2025-06-08 at 9 05 12 AM" src="https://github.com/user-attachments/assets/1cdb0ea8-83e7-4c9d-a252-bb0b632a7ebd" />

## Changes

Removes the stray backtick from the modal 🙂 

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?