### PR TITLE
feat(person): Person store reuse fetch

### DIFF
--- a/plugin-server/src/worker/ingestion/groups/batch-writing-group-store.ts
+++ b/plugin-server/src/worker/ingestion/groups/batch-writing-group-store.ts
@@ -18,6 +18,7 @@ import {
     groupCacheOperationsCounter,
     groupCacheSizeHistogram,
     groupDatabaseOperationsPerBatchHistogram,
+    groupFetchPromisesCacheOperationsCounter,
     groupOptimisticUpdateConflictsPerBatchCounter,
 } from './metrics'
 
@@ -437,6 +438,7 @@ export class BatchWritingGroupStoreForBatch implements GroupStoreForBatch {
 
         let fetchPromise = this.fetchPromises.get(cacheKey)
         if (!fetchPromise) {
+            groupFetchPromisesCacheOperationsCounter.inc({ operation: 'miss' })
             fetchPromise = (async () => {
                 try {
                     this.incrementDatabaseOperation('fetchGroup')
@@ -460,6 +462,8 @@ export class BatchWritingGroupStoreForBatch implements GroupStoreForBatch {
                 }
             })()
             this.fetchPromises.set(cacheKey, fetchPromise)
+        } else {
+            groupFetchPromisesCacheOperationsCounter.inc({ operation: 'hit' })
         }
         return fetchPromise
     }

--- a/plugin-server/src/worker/ingestion/groups/metrics.ts
+++ b/plugin-server/src/worker/ingestion/groups/metrics.ts
@@ -23,3 +23,9 @@ export const groupCacheSizeHistogram = new Histogram({
     help: 'Size of the group cache',
     buckets: [0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, Infinity],
 })
+
+export const groupFetchPromisesCacheOperationsCounter = new Counter({
+    name: 'group_fetch_promises_cache_operations_total',
+    help: 'Number of operations on the fetchPromises cache',
+    labelNames: ['operation'],
+})

--- a/plugin-server/src/worker/ingestion/persons/metrics.ts
+++ b/plugin-server/src/worker/ingestion/persons/metrics.ts
@@ -29,6 +29,18 @@ export const personCacheOperationsCounter = new Counter({
     labelNames: ['cache', 'operation'],
 })
 
+export const personFetchForCheckingCacheOperationsCounter = new Counter({
+    name: 'person_fetch_for_checking_cache_operations_total',
+    help: 'Number of operations on the fetchForChecking cache',
+    labelNames: ['operation'],
+})
+
+export const personFetchForUpdateCacheOperationsCounter = new Counter({
+    name: 'person_fetch_for_update_cache_operations_total',
+    help: 'Number of operations on the fetchForUpdate cache',
+    labelNames: ['operation'],
+})
+
 export const personOperationLatencyByVersionSummary = new Summary({
     name: 'person_operation_latency_by_version',
     help: 'Latency distribution of person by version',


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

If we query the same person multiple times in a row, we might be unecessarily launching the a similar promise in parallel until the result comes back, this is not necessary to do, so we can reuse an existing query promise if it exists.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
