### PR TITLE
feat(logs): optimise severity level filtering by disabling transform_null_in

### DIFF
--- a/products/logs/backend/api.py
+++ b/products/logs/backend/api.py
@@ -79,7 +79,7 @@ WHERE time_bucket >= toStartOfInterval(now() - interval 1 hour, interval 10 minu
 AND team_id = %(team_id)s
 AND attribute_key LIKE %(search)s
 GROUP BY team_id
-LIMIT 1;
+LIMIT 1
 """,
             args={"search": f"%{search}%", "team_id": self.team.id},
             workload=Workload.LOGS,
@@ -113,7 +113,7 @@ AND team_id = %(team_id)s
 AND attribute_key = %(key)s
 AND attribute_value LIKE %(search)s
 GROUP BY team_id
-LIMIT 1;
+LIMIT 1
 """,
             args={"key": key, "search": f"%{search}%", "team_id": self.team.id},
             workload=Workload.LOGS,

--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -187,7 +187,11 @@ class LogsQueryRunner(QueryRunner):
 
     @cached_property
     def settings(self):
-        return HogQLGlobalSettings(allow_experimental_object_type=False, allow_experimental_join_condition=False)
+        return HogQLGlobalSettings(
+            allow_experimental_object_type=False,
+            allow_experimental_join_condition=False,
+            transform_null_in=False,
+        )
 
     @cached_property
     def query_date_range(self) -> QueryDateRange:

--- a/products/logs/backend/schema.sql
+++ b/products/logs/backend/schema.sql
@@ -66,7 +66,7 @@ PARTITION BY toDate(time_bucket)
 ORDER BY (team_id, service_name, time_bucket, attribute_key, attribute_value);
 
 set enable_dynamic_type=1;
-CREATE MATERIALIZED VIEW default.log_to_log_attributes TO default.log_attributes2
+CREATE MATERIALIZED VIEW default.log_to_log_attributes TO default.log_attributes
 (
     `team_id` Int32,
     `time_bucket` DateTime64(0),


### PR DESCRIPTION

> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
transform_null_in causes clickhouse to not always use bloom filter indexes for `field in ('a', 'b', 'c')` type expressions, such as we do for severity level filtering.

we don't need transform_null_in set for logs so disable this to correctly use the index
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
