### PR TITLE
fix: send posthog events using the correct client

### DIFF
--- a/posthog/tasks/early_access_feature.py
+++ b/posthog/tasks/early_access_feature.py
@@ -4,7 +4,7 @@ from posthog.cloud_utils import is_cloud
 from posthog.hogql import ast
 from posthog.hogql.query import execute_hogql_query
 from posthog.models import EarlyAccessFeature
-from ..ph_client import get_regional_ph_client
+from posthog.ph_client import get_regional_ph_client
 
 
 logger = structlog.get_logger(__name__)

--- a/posthog/tasks/early_access_feature.py
+++ b/posthog/tasks/early_access_feature.py
@@ -4,7 +4,7 @@ from posthog.cloud_utils import is_cloud
 from posthog.hogql import ast
 from posthog.hogql.query import execute_hogql_query
 from posthog.models import EarlyAccessFeature
-from posthog.ph_client import get_regional_ph_client
+from posthog.ph_client import get_client
 
 
 logger = structlog.get_logger(__name__)
@@ -71,7 +71,7 @@ def send_events_for_early_access_feature_stage_change(feature_id: str, from_stag
 
     print(f"[CELERY][EARLY ACCESS FEATURE] Found {len(enrolled_persons)} persons enrolled in feature {feature_id}")  # noqa: T201
 
-    posthog_client = get_regional_ph_client()
+    posthog_client = get_client()
 
     if not posthog_client:
         print(f"[CELERY][EARLY ACCESS FEATURE] No PostHog client found")  # noqa: T201

--- a/posthog/tasks/test/test_early_access_feature.py
+++ b/posthog/tasks/test/test_early_access_feature.py
@@ -43,6 +43,7 @@ class TestSendEventsForEarlyAccessFeatureStageChange(APIBaseTest):
                 "user_email": "test@example.com",
             },
         )
+
         mock_client.shutdown.assert_called_once()
 
     @patch("posthog.tasks.early_access_feature.get_regional_ph_client")

--- a/posthog/tasks/test/test_early_access_feature.py
+++ b/posthog/tasks/test/test_early_access_feature.py
@@ -8,7 +8,7 @@ from posthog.test.base import APIBaseTest
 
 
 class TestSendEventsForEarlyAccessFeatureStageChange(APIBaseTest):
-    @patch("posthog.tasks.early_access_feature.get_regional_ph_client")
+    @patch("posthog.tasks.early_access_feature.get_client")
     def test_sends_event_for_enrolled_users(self, mock_get_client: MagicMock) -> None:
         mock_client = MagicMock()
         mock_get_client.return_value = mock_client
@@ -46,7 +46,7 @@ class TestSendEventsForEarlyAccessFeatureStageChange(APIBaseTest):
 
         mock_client.shutdown.assert_called_once()
 
-    @patch("posthog.tasks.early_access_feature.get_regional_ph_client")
+    @patch("posthog.tasks.early_access_feature.get_client")
     def test_no_event_for_enrolled_users_on_different_team(self, mock_get_client: MagicMock) -> None:
         mock_client = MagicMock()
         mock_get_client.return_value = mock_client

--- a/posthog/tasks/test/test_early_access_feature.py
+++ b/posthog/tasks/test/test_early_access_feature.py
@@ -8,8 +8,11 @@ from posthog.test.base import APIBaseTest
 
 
 class TestSendEventsForEarlyAccessFeatureStageChange(APIBaseTest):
-    @patch("posthoganalytics.capture")
-    def test_sends_event_for_enrolled_users(self, mock_capture: MagicMock) -> None:
+    @patch("posthog.tasks.early_access_feature.get_regional_ph_client")
+    def test_sends_event_for_enrolled_users(self, mock_get_client: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
         team = Team.objects.create(organization=self.organization)
         feature_flag = FeatureFlag.objects.create(team=team, key="my-flag", filters={})
         feature = EarlyAccessFeature.objects.create(
@@ -28,10 +31,10 @@ class TestSendEventsForEarlyAccessFeatureStageChange(APIBaseTest):
 
         send_events_for_early_access_feature_stage_change(feature.id, "concept", "beta")
 
-        mock_capture.assert_called_once_with(
+        mock_client.capture.assert_called_once_with(
             "abc123",
             "user moved feature preview stage",
-            {
+            properties={
                 "from": "concept",
                 "to": "beta",
                 "feature_flag_key": feature_flag.key,
@@ -40,9 +43,13 @@ class TestSendEventsForEarlyAccessFeatureStageChange(APIBaseTest):
                 "user_email": "test@example.com",
             },
         )
+        mock_client.shutdown.assert_called_once()
 
-    @patch("posthoganalytics.capture")
-    def test_no_event_for_enrolled_users_on_different_team(self, mock_capture: MagicMock) -> None:
+    @patch("posthog.tasks.early_access_feature.get_regional_ph_client")
+    def test_no_event_for_enrolled_users_on_different_team(self, mock_get_client: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
         team1 = Team.objects.create(organization=self.organization)
         team2 = Team.objects.create(organization=self.organization)
         feature_flag = FeatureFlag.objects.create(team=team1, key="my-flag", filters={})
@@ -63,4 +70,4 @@ class TestSendEventsForEarlyAccessFeatureStageChange(APIBaseTest):
 
         send_events_for_early_access_feature_stage_change(feature.id, "concept", "beta")
 
-        mock_capture.assert_not_called()
+        mock_client.capture.assert_not_called()


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We were importing `posthoganalytics` but we need to construct the client in the celery task.

## Changes

Construct the client.

## How did you test this code?

Unit tests
