### PR TITLE
feat(logs): add exclude filter button and filters on breakdowns

### DIFF
--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import json
 from zoneinfo import ZoneInfo
 
 from posthog.clickhouse.client.connection import Workload
@@ -106,7 +107,7 @@ class LogsQueryRunner(QueryRunner):
                     "trace_id": result[1],
                     "span_id": result[2],
                     "body": result[3],
-                    "attributes": result[4],
+                    "attributes": {k: json.loads(v) for k, v in result[4].items()},
                     "timestamp": result[5],
                     "observed_timestamp": result[6],
                     "severity_text": result[7],

--- a/products/logs/frontend/AttributeBreakdowns.tsx
+++ b/products/logs/frontend/AttributeBreakdowns.tsx
@@ -1,9 +1,18 @@
-import { LemonTable } from '@posthog/lemon-ui'
+import { IconMinusSquare, IconPlusSquare } from '@posthog/icons'
+import { LemonButton, LemonTable } from '@posthog/lemon-ui'
 import { useValues } from 'kea'
+
+import { PropertyOperator } from '~/types'
 
 import { attributeBreakdownLogic } from './attributeBreakdownLogic'
 
-export const AttributeBreakdowns = ({ attribute }: { attribute: string }): JSX.Element => {
+export const AttributeBreakdowns = ({
+    attribute,
+    addFilter,
+}: {
+    attribute: string
+    addFilter: (key: string, value: string, operator?: PropertyOperator) => void
+}): JSX.Element => {
     const logic = attributeBreakdownLogic({ attribute })
     const { attributeValues, logCount, breakdowns } = useValues(logic)
 
@@ -24,6 +33,28 @@ export const AttributeBreakdowns = ({ attribute }: { attribute: string }): JSX.E
                 dataSource={dataSource}
                 size="small"
                 columns={[
+                    {
+                        key: 'actions',
+                        width: 0,
+                        render: (_, record) => (
+                            <div className="flex gap-x-0">
+                                <LemonButton
+                                    tooltip="Add as filter"
+                                    size="xsmall"
+                                    onClick={() => addFilter(attribute, record.value)}
+                                >
+                                    <IconPlusSquare />
+                                </LemonButton>
+                                <LemonButton
+                                    tooltip="Exclude as filter"
+                                    size="xsmall"
+                                    onClick={() => addFilter(attribute, record.value, PropertyOperator.IsNot)}
+                                >
+                                    <IconMinusSquare />
+                                </LemonButton>
+                            </div>
+                        ),
+                    },
                     {
                         title: 'Count',
                         key: 'count',

--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -1,6 +1,6 @@
 import './sparkline-loading.scss'
 
-import { IconFilter, IconPlusSquare } from '@posthog/icons'
+import { IconFilter, IconMinusSquare, IconPlusSquare } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, LemonSegmentedButton, LemonTable, LemonTag, LemonTagType } from '@posthog/lemon-ui'
 import colors from 'ansi-colors'
 import { useActions, useValues } from 'kea'
@@ -125,13 +125,13 @@ const ExpandedLog = ({ log }: { log: LogMessage }): JSX.Element => {
     const attributes = log.attributes
     const rows = Object.entries(attributes).map(([key, value]) => ({ key, value }))
 
-    const addFilter = (key: string, value: string): void => {
+    const addFilter = (key: string, value: string, operator = PropertyOperator.Exact): void => {
         const newGroup = { ...filterGroup.values[0] } as UniversalFiltersGroup
 
         newGroup.values.push({
             key,
             value: [value],
-            operator: PropertyOperator.Exact,
+            operator: operator,
             type: PropertyFilterType.Log,
         })
 
@@ -147,13 +147,20 @@ const ExpandedLog = ({ log }: { log: LogMessage }): JSX.Element => {
                     key: 'actions',
                     width: 0,
                     render: (_, record) => (
-                        <div className="flex gap-x-1">
+                        <div className="flex gap-x-0">
                             <LemonButton
                                 tooltip="Add as filter"
                                 size="xsmall"
                                 onClick={() => addFilter(record.key, record.value)}
                             >
                                 <IconPlusSquare />
+                            </LemonButton>
+                            <LemonButton
+                                tooltip="Exclude as filter"
+                                size="xsmall"
+                                onClick={() => addFilter(record.key, record.value, PropertyOperator.IsNot)}
+                            >
+                                <IconMinusSquare />
                             </LemonButton>
                             <LemonButton
                                 tooltip="Show breakdown"
@@ -182,7 +189,7 @@ const ExpandedLog = ({ log }: { log: LogMessage }): JSX.Element => {
                 noIndent: true,
                 showRowExpansionToggle: false,
                 isRowExpanded: (record) => expandedAttributeBreaksdowns.includes(record.key),
-                expandedRowRender: (record) => <AttributeBreakdowns attribute={record.key} />,
+                expandedRowRender: (record) => <AttributeBreakdowns attribute={record.key} addFilter={addFilter} />,
             }}
         />
     )


### PR DESCRIPTION
## Problem

add the "Add as filter" button to the attribute breakdown fields

also add an additional "Exclude as filter" button

I also json parsed the attributes we return as we store json encoded attributes in the database, but showing those values is confusing (and it broke filters as we filter on the evaluated expression)

## Changes
<img width="463" alt="image" src="https://github.com/user-attachments/assets/6d00851a-8a83-487e-9056-c6f66847b40f" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
