### PR TITLE
feat(logs): simplify log interval steps

### DIFF
--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -210,17 +210,18 @@ class LogsQueryRunner(QueryRunner):
 
         _step = dt.timedelta(seconds=int(60 * round(_step.total_seconds() / 60)))
         interval_type = IntervalType.MINUTE
-        interval_count = _step.total_seconds() // 60
 
-        if _step > dt.timedelta(minutes=30):
-            _step = dt.timedelta(seconds=int(3600 * round(_step.total_seconds() / 3600)))
-            interval_type = IntervalType.HOUR
-            interval_count = _step.total_seconds() // 3600
+        def find_closest(target, arr):
+            if not arr:
+                raise ValueError("Input array cannot be empty")
+            closest_number = min(arr, key=lambda x: (abs(x - target), x))
 
-        if _step > dt.timedelta(days=1):
-            _step = dt.timedelta(seconds=int(86400 * round(_step.total_seconds() / 86400)))
-            interval_type = IntervalType.DAY
-            interval_count = _step.total_seconds() // 86400
+            return closest_number
+
+        # set the number of intervals to a "round" number of minutes
+        # it's hard to reason about the rate of logs on e.g. 13 minute intervals
+        # the min interval is 1 minute and max interval is 1 day
+        interval_count = find_closest(_step.total_seconds() // 60, [1, 2, 5, 10, 15, 30, 60, 120, 240, 360, 720, 1440])
 
         return QueryDateRange(
             date_range=self.query.dateRange,


### PR DESCRIPTION

## Problem

had an overly complicated and janky algorithm for picking the sparkline interval

simplify it to just convert to a hard-coded "round" number of minutes, from 1 minute to 1 day.

this means we don't end up with awkward 13 minute intervals or anything like that, while also having enough steps that we don't get overly dense or sparse sparklines

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
