### PR TITLE
chore: one less TS enum in the world

### DIFF
--- a/frontend/src/scenes/session-recordings/apm/performanceEventDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/apm/performanceEventDataLogic.ts
@@ -10,12 +10,12 @@ import {
     SessionRecordingDataLogicProps,
 } from 'scenes/session-recordings/player/sessionRecordingDataLogic'
 
-import { FilterableInspectorListItemTypes, PerformanceEvent, RecordingEventType } from '~/types'
+import { PerformanceEvent, RecordingEventType } from '~/types'
 
 import type { performanceEventDataLogicType } from './performanceEventDataLogicType'
 
 export type InspectorListItemPerformance = InspectorListItemBase & {
-    type: FilterableInspectorListItemTypes.NETWORK
+    type: 'network'
     data: PerformanceEvent
 }
 

--- a/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorBottomSettings.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorBottomSettings.tsx
@@ -6,8 +6,6 @@ import { userPreferencesLogic } from 'lib/logic/userPreferencesLogic'
 import { SettingsBar, SettingsMenu, SettingsToggle } from 'scenes/session-recordings/components/PanelSettings'
 import { miniFiltersLogic } from 'scenes/session-recordings/player/inspector/miniFiltersLogic'
 
-import { FilterableInspectorListItemTypes } from '~/types'
-
 import { sessionRecordingPlayerLogic } from '../sessionRecordingPlayerLogic'
 import { playerInspectorLogic } from './playerInspectorLogic'
 
@@ -80,8 +78,8 @@ function ShowOnlyMatching(): JSX.Element {
     const { showOnlyMatching, miniFiltersForType } = useValues(miniFiltersLogic)
     const { setShowOnlyMatching } = useActions(miniFiltersLogic)
 
-    const hasEventsFiltersSelected = miniFiltersForType(FilterableInspectorListItemTypes.EVENTS).some((x) => x.enabled)
-    const hasEventsToDisplay = allItemsByItemType[FilterableInspectorListItemTypes.EVENTS]?.length > 0
+    const hasEventsFiltersSelected = miniFiltersForType('events').some((x) => x.enabled)
+    const hasEventsToDisplay = allItemsByItemType['events']?.length > 0
 
     return (
         <SettingsToggle

--- a/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorControls.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorControls.tsx
@@ -18,13 +18,13 @@ import { useEffect, useState } from 'react'
 import { SettingsBar, SettingsButton, SettingsToggle } from 'scenes/session-recordings/components/PanelSettings'
 import { miniFiltersLogic, SharedListMiniFilter } from 'scenes/session-recordings/player/inspector/miniFiltersLogic'
 import {
+    FilterableInspectorListItemTypes,
     InspectorListItem,
     playerInspectorLogic,
 } from 'scenes/session-recordings/player/inspector/playerInspectorLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { sidePanelSettingsLogic } from '~/layout/navigation-3000/sidepanel/panels/sidePanelSettingsLogic'
-import { FilterableInspectorListItemTypes } from '~/types'
 
 import { sessionRecordingPlayerLogic, SessionRecordingPlayerMode } from '../sessionRecordingPlayerLogic'
 import { InspectorSearchInfo } from './components/InspectorSearchInfo'
@@ -139,12 +139,12 @@ function NetworkFilterSettingsButton(): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
     const { openSettingsPanel } = useActions(sidePanelSettingsLogic)
 
-    const hasNetworkItems = allItemsByItemType[FilterableInspectorListItemTypes.NETWORK]?.length > 0
+    const hasNetworkItems = allItemsByItemType['network']?.length > 0
 
     return (
         <FilterSettingsButton
             data-attr="player-inspector-network-toggle-all"
-            type={FilterableInspectorListItemTypes.NETWORK}
+            type="network"
             icon={<IconDashboard />}
             // we disable the filter toggle-all when there are no items
             disabledReason={!hasNetworkItems ? 'There are no network requests in this recording' : undefined}
@@ -187,12 +187,12 @@ function ConsoleFilterSettingsButton(): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
     const { openSettingsPanel } = useActions(sidePanelSettingsLogic)
 
-    const hasConsoleItems = allItemsByItemType[FilterableInspectorListItemTypes.CONSOLE]?.length > 0
+    const hasConsoleItems = allItemsByItemType['console']?.length > 0
 
     return (
         <FilterSettingsButton
             data-attr="player-inspector-console-toggle-all"
-            type={FilterableInspectorListItemTypes.CONSOLE}
+            type="console"
             icon={<IconTerminal />}
             // we disable the filter toggle-all when there are no items
             disabledReason={!hasConsoleItems ? 'There are no console logs in this recording' : undefined}
@@ -233,12 +233,12 @@ function EventsFilterSettingsButton(): JSX.Element {
     const { logicProps } = useValues(sessionRecordingPlayerLogic)
     const { allItemsByItemType } = useValues(playerInspectorLogic(logicProps))
 
-    const hasEventItems = allItemsByItemType[FilterableInspectorListItemTypes.EVENTS]?.length > 0
+    const hasEventItems = allItemsByItemType['events']?.length > 0
 
     return (
         <FilterSettingsButton
             data-attr="player-inspector-events-toggle-all"
-            type={FilterableInspectorListItemTypes.EVENTS}
+            type="events"
             icon={<IconUnverifiedEvent />}
             // we disable the filter toggle-all when there are no items
             disabledReason={!hasEventItems ? 'There are no events in this recording' : undefined}

--- a/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorList.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorList.tsx
@@ -8,8 +8,6 @@ import AutoSizer from 'react-virtualized/dist/es/AutoSizer'
 import { CellMeasurer, CellMeasurerCache } from 'react-virtualized/dist/es/CellMeasurer'
 import { List, ListRowRenderer } from 'react-virtualized/dist/es/List'
 
-import { FilterableInspectorListItemTypes } from '~/types'
-
 import { sessionRecordingPlayerLogic } from '../sessionRecordingPlayerLogic'
 import { PlayerInspectorListItem } from './components/PlayerInspectorListItem'
 import { playerInspectorLogic } from './playerInspectorLogic'
@@ -127,15 +125,15 @@ export function PlayerInspectorList(): JSX.Element {
                         )}
                     </AutoSizer>
                 </div>
-            ) : inspectorDataState[FilterableInspectorListItemTypes.EVENTS] === 'loading' ||
-              inspectorDataState[FilterableInspectorListItemTypes.CONSOLE] === 'loading' ||
-              inspectorDataState[FilterableInspectorListItemTypes.NETWORK] === 'loading' ? (
+            ) : inspectorDataState['events'] === 'loading' ||
+              inspectorDataState['console'] === 'loading' ||
+              inspectorDataState['network'] === 'loading' ? (
                 <div className="p-2">
                     <LemonSkeleton className="my-1 h-8" repeat={20} fade />
                 </div>
-            ) : inspectorDataState[FilterableInspectorListItemTypes.EVENTS] === 'ready' ||
-              inspectorDataState[FilterableInspectorListItemTypes.CONSOLE] === 'ready' ||
-              inspectorDataState[FilterableInspectorListItemTypes.NETWORK] === 'ready' ? (
+            ) : inspectorDataState['events'] === 'ready' ||
+              inspectorDataState['console'] === 'ready' ||
+              inspectorDataState['network'] === 'ready' ? (
                 // If we are "ready" but with no results this must mean some results are filtered out
                 <div className="p-16 text-center text-secondary">No results matching your filters.</div>
             ) : null}

--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemEvent.stories.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemEvent.stories.tsx
@@ -9,7 +9,7 @@ import {
 import { InspectorListItemEvent } from 'scenes/session-recordings/player/inspector/playerInspectorLogic'
 
 import { mswDecorator } from '~/mocks/browser'
-import { FilterableInspectorListItemTypes, RecordingEventType } from '~/types'
+import { RecordingEventType } from '~/types'
 
 type Story = StoryObj<typeof ItemEvent>
 const meta: Meta<typeof ItemEvent> = {
@@ -47,7 +47,7 @@ function makeItem(
         search: '',
         timeInRecording: 0,
         timestamp: now(),
-        type: FilterableInspectorListItemTypes.EVENTS,
+        type: 'events',
         ...itemOverrides,
     }
 }

--- a/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
@@ -29,7 +29,6 @@ import { useDebouncedCallback } from 'use-debounce'
 import useResizeObserver from 'use-resize-observer'
 
 import { CORE_FILTER_DEFINITIONS_BY_GROUP } from '~/taxonomy/taxonomy'
-import { FilterableInspectorListItemTypes } from '~/types'
 
 import { ItemPerformanceEvent, ItemPerformanceEventDetail } from '../../../apm/playerInspector/ItemPerformanceEvent'
 import { IconWindow } from '../../icons'
@@ -41,15 +40,15 @@ import { ItemEvent, ItemEventDetail } from './ItemEvent'
 const PLAYER_INSPECTOR_LIST_ITEM_MARGIN = 1
 
 const typeToIconAndDescription = {
-    [FilterableInspectorListItemTypes.EVENTS]: {
+    ['events']: {
         Icon: undefined,
         tooltip: 'Recording event',
     },
-    [FilterableInspectorListItemTypes.CONSOLE]: {
+    ['console']: {
         Icon: IconTerminal,
         tooltip: 'Console log',
     },
-    [FilterableInspectorListItemTypes.NETWORK]: {
+    ['network']: {
         Icon: IconDashboard,
         tooltip: 'Network event',
     },
@@ -123,11 +122,11 @@ function RowItemTitle({
 }): JSX.Element {
     return (
         <div className="flex items-center text-text-3000" data-attr="row-item-title">
-            {item.type === FilterableInspectorListItemTypes.NETWORK ? (
+            {item.type === 'network' ? (
                 <ItemPerformanceEvent item={item.data} finalTimestamp={finalTimestamp} />
-            ) : item.type === FilterableInspectorListItemTypes.CONSOLE ? (
+            ) : item.type === 'console' ? (
                 <ItemConsoleLog item={item} />
-            ) : item.type === FilterableInspectorListItemTypes.EVENTS ? (
+            ) : item.type === 'events' ? (
                 <ItemEvent item={item} />
             ) : item.type === 'offline-status' ? (
                 <div className="flex w-full items-start p-2 text-xs font-light font-mono">
@@ -137,7 +136,7 @@ function RowItemTitle({
                 <div className="flex w-full items-start px-2 py-1 font-light font-mono text-xs">
                     Window became {item.status}
                 </div>
-            ) : item.type === FilterableInspectorListItemTypes.DOCTOR ? (
+            ) : item.type === 'doctor' ? (
                 <ItemDoctor item={item} />
             ) : item.type === 'comment' ? (
                 <ItemComment item={item} />
@@ -161,14 +160,14 @@ function RowItemDetail({
 }): JSX.Element | null {
     return (
         <div onClick={onClick}>
-            {item.type === FilterableInspectorListItemTypes.NETWORK ? (
+            {item.type === 'network' ? (
                 <ItemPerformanceEventDetail item={item.data} finalTimestamp={finalTimestamp} />
-            ) : item.type === FilterableInspectorListItemTypes.CONSOLE ? (
+            ) : item.type === 'console' ? (
                 <ItemConsoleLogDetail item={item} />
-            ) : item.type === FilterableInspectorListItemTypes.EVENTS ? (
+            ) : item.type === 'events' ? (
                 <ItemEventDetail item={item} />
             ) : item.type === 'offline-status' ? null : item.type === 'browser-visibility' ? null : item.type ===
-              FilterableInspectorListItemTypes.DOCTOR ? (
+              'doctor' ? (
                 <ItemDoctorDetail item={item} />
             ) : item.type === 'comment' ? (
                 <ItemCommentDetail item={item} />
@@ -233,7 +232,7 @@ export function PlayerInspectorListItem({
     const isHovering = useIsHovering(hoverRef)
 
     let TypeIcon = typeToIconAndDescription[item.type].Icon
-    if (TypeIcon === undefined && item.type === FilterableInspectorListItemTypes.EVENTS) {
+    if (TypeIcon === undefined && item.type === 'events') {
         // KLUDGE this is a hack to lean on this function, yuck
         TypeIcon = eventToIcon(item.data.event)
     }

--- a/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
@@ -40,43 +40,43 @@ import { ItemEvent, ItemEventDetail } from './ItemEvent'
 const PLAYER_INSPECTOR_LIST_ITEM_MARGIN = 1
 
 const typeToIconAndDescription = {
-    ['events']: {
+    events: {
         Icon: undefined,
         tooltip: 'Recording event',
     },
-    ['console']: {
+    console: {
         Icon: IconTerminal,
         tooltip: 'Console log',
     },
-    ['network']: {
+    network: {
         Icon: IconDashboard,
         tooltip: 'Network event',
     },
-    ['offline-status']: {
+    'offline-status': {
         Icon: IconCloud,
         tooltip: 'browser went offline or returned online',
     },
-    ['browser-visibility']: {
+    'browser-visibility': {
         Icon: IconEye,
         tooltip: 'browser tab/window became visible or hidden',
     },
-    ['$session_config']: {
+    $session_config: {
         Icon: IconGear,
         tooltip: 'Session recording config',
     },
-    ['doctor']: {
+    doctor: {
         Icon: undefined,
         tooltip: 'Doctor event',
     },
-    ['comment']: {
+    comment: {
         Icon: IconChat,
         tooltip: 'A user commented on this timestamp in the recording',
     },
-    ['inspector-summary']: {
+    'inspector-summary': {
         Icon: undefined,
         tooltip: undefined,
     },
-    ['inactivity']: {
+    inactivity: {
         Icon: undefined,
         tooltip: undefined,
     },

--- a/frontend/src/scenes/session-recordings/player/inspector/inspectorListFiltering.test.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/inspectorListFiltering.test.ts
@@ -9,7 +9,7 @@ import {
     InspectorListOfflineStatusChange,
 } from 'scenes/session-recordings/player/inspector/playerInspectorLogic'
 
-import { FilterableInspectorListItemTypes, PerformanceEvent } from '~/types'
+import { PerformanceEvent } from '~/types'
 
 describe('filtering inspector list items', () => {
     it('hides context events when no other events', () => {
@@ -86,12 +86,12 @@ describe('filtering inspector list items', () => {
             filterInspectorListItems({
                 allItems: [
                     {
-                        type: FilterableInspectorListItemTypes.EVENTS,
+                        type: 'events',
                         windowId: 'this window',
                         data: { event: '$exception' } as unknown as PerformanceEvent,
                     } as unknown as InspectorListItemEvent,
                     {
-                        type: FilterableInspectorListItemTypes.EVENTS,
+                        type: 'events',
                         windowId: 'a different window',
                         data: { event: '$exception' } as unknown as PerformanceEvent,
                     } as unknown as InspectorListItemEvent,
@@ -110,7 +110,7 @@ describe('filtering inspector list items', () => {
             filterInspectorListItems({
                 allItems: [
                     {
-                        type: FilterableInspectorListItemTypes.EVENTS,
+                        type: 'events',
                         data: { event: 'an event' } as unknown as PerformanceEvent,
                     } as unknown as InspectorListItemEvent,
                 ],
@@ -131,7 +131,7 @@ describe('filtering inspector list items', () => {
             filterInspectorListItems({
                 allItems: [
                     {
-                        type: FilterableInspectorListItemTypes.EVENTS,
+                        type: 'events',
                         data: { event: '$exception' } as unknown as PerformanceEvent,
                     } as unknown as InspectorListItemEvent,
                 ],
@@ -149,16 +149,16 @@ describe('filtering inspector list items', () => {
             filterInspectorListItems({
                 allItems: [
                     {
-                        type: FilterableInspectorListItemTypes.EVENTS,
+                        type: 'events',
                         data: { event: '$exception' } as unknown as PerformanceEvent,
                         highlightColor: 'primary',
                     } as unknown as InspectorListItemEvent,
                     {
-                        type: FilterableInspectorListItemTypes.NETWORK,
+                        type: 'network',
                         data: { event: '$pageview' } as unknown as PerformanceEvent,
                     } as unknown as InspectorListItemPerformance,
                     {
-                        type: FilterableInspectorListItemTypes.DOCTOR,
+                        type: 'doctor',
                         data: { event: '$pageview' } as unknown as PerformanceEvent,
                     } as unknown as InspectorListItemDoctor,
                 ],

--- a/frontend/src/scenes/session-recordings/player/inspector/inspectorListFiltering.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/inspectorListFiltering.ts
@@ -8,8 +8,6 @@ import {
     InspectorListItemEvent,
 } from 'scenes/session-recordings/player/inspector/playerInspectorLogic'
 
-import { FilterableInspectorListItemTypes } from '~/types'
-
 const PostHogMobileEvents = [
     'Deep Link Opened',
     'Application Opened',
@@ -28,7 +26,7 @@ function isPostHogEvent(item: InspectorListItem): boolean {
 }
 
 function isNetworkEvent(item: InspectorListItem): item is InspectorListItemPerformance {
-    return item.type === FilterableInspectorListItemTypes.NETWORK
+    return item.type === 'network'
 }
 
 function isNavigationEvent(item: InspectorListItem): boolean {
@@ -36,7 +34,7 @@ function isNavigationEvent(item: InspectorListItem): boolean {
 }
 
 function isEvent(item: InspectorListItem): item is InspectorListItemEvent {
-    return item.type === FilterableInspectorListItemTypes.EVENTS
+    return item.type === 'events'
 }
 
 function isPageviewOrScreen(item: InspectorListItem): boolean {
@@ -48,7 +46,7 @@ function isAutocapture(item: InspectorListItem): boolean {
 }
 
 function isConsoleEvent(item: InspectorListItem): item is InspectorListItemConsole {
-    return item.type === FilterableInspectorListItemTypes.CONSOLE
+    return item.type === 'console'
 }
 
 function isConsoleError(item: InspectorListItem): boolean {
@@ -150,13 +148,13 @@ export function itemToMiniFilter(
     miniFiltersByKey: { [p: MiniFilterKey]: SharedListMiniFilter }
 ): SharedListMiniFilter | null {
     switch (item.type) {
-        case FilterableInspectorListItemTypes.EVENTS:
+        case 'events':
             return eventsMatch(item, miniFiltersByKey)
-        case FilterableInspectorListItemTypes.CONSOLE:
+        case 'console':
             return consoleMatch(item, miniFiltersByKey)
-        case FilterableInspectorListItemTypes.NETWORK:
+        case 'network':
             return networkMatch(item, miniFiltersByKey)
-        case FilterableInspectorListItemTypes.DOCTOR:
+        case 'doctor':
             if (isDoctorEvent(item)) {
                 return miniFiltersByKey['doctor']
             }

--- a/frontend/src/scenes/session-recordings/player/inspector/miniFiltersLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/miniFiltersLogic.ts
@@ -1,8 +1,7 @@
 import { actions, connect, events, kea, listeners, path, reducers, selectors } from 'kea'
+import { FilterableInspectorListItemTypes } from 'scenes/session-recordings/player/inspector/playerInspectorLogic'
 import { sessionRecordingEventUsageLogic } from 'scenes/session-recordings/sessionRecordingEventUsageLogic'
 import { teamLogic } from 'scenes/teamLogic'
-
-import { FilterableInspectorListItemTypes } from '~/types'
 
 import type { miniFiltersLogicType } from './miniFiltersLogicType'
 
@@ -16,88 +15,88 @@ export type SharedListMiniFilter = {
 
 const MiniFilters: SharedListMiniFilter[] = [
     {
-        type: FilterableInspectorListItemTypes.EVENTS,
+        type: 'events',
         key: 'events-posthog',
         name: 'PostHog',
         tooltip: 'Standard PostHog events except Pageviews, Autocapture, and Exceptions.',
     },
     {
-        type: FilterableInspectorListItemTypes.EVENTS,
+        type: 'events',
         key: 'events-custom',
         name: 'Custom',
         tooltip: 'Custom events tracked by your app',
     },
     {
-        type: FilterableInspectorListItemTypes.EVENTS,
+        type: 'events',
         key: 'events-pageview',
         name: 'Pageview / Screen',
         tooltip: 'Pageview (or Screen for mobile) events',
     },
     {
-        type: FilterableInspectorListItemTypes.EVENTS,
+        type: 'events',
         key: 'events-autocapture',
         name: 'Autocapture',
         tooltip: 'Autocapture events such as clicks and inputs',
     },
     {
-        type: FilterableInspectorListItemTypes.EVENTS,
+        type: 'events',
         key: 'events-exceptions',
         name: 'Exceptions',
         tooltip: 'Exception events from PostHog or its Sentry integration',
     },
     {
-        type: FilterableInspectorListItemTypes.CONSOLE,
+        type: 'console',
         key: 'console-info',
         name: 'Info',
     },
     {
-        type: FilterableInspectorListItemTypes.CONSOLE,
+        type: 'console',
         key: 'console-warn',
         name: 'Warn',
     },
     {
-        type: FilterableInspectorListItemTypes.CONSOLE,
+        type: 'console',
         key: 'console-error',
         name: 'Error',
     },
     {
-        type: FilterableInspectorListItemTypes.NETWORK,
+        type: 'network',
         key: 'performance-fetch',
         name: 'Fetch/XHR',
         tooltip: 'Requests during the session to external resources like APIs via XHR or Fetch',
     },
     {
-        type: FilterableInspectorListItemTypes.NETWORK,
+        type: 'network',
         key: 'performance-document',
         name: 'Doc',
         tooltip: 'Page load information collected on a fresh browser page load, refresh, or page paint.',
     },
     {
-        type: FilterableInspectorListItemTypes.NETWORK,
+        type: 'network',
         key: 'performance-assets-js',
         name: 'JS',
         tooltip: 'Scripts loaded during the session.',
     },
     {
-        type: FilterableInspectorListItemTypes.NETWORK,
+        type: 'network',
         key: 'performance-assets-css',
         name: 'CSS',
         tooltip: 'CSS loaded during the session.',
     },
     {
-        type: FilterableInspectorListItemTypes.NETWORK,
+        type: 'network',
         key: 'performance-assets-img',
         name: 'Img',
         tooltip: 'Images loaded during the session.',
     },
     {
-        type: FilterableInspectorListItemTypes.NETWORK,
+        type: 'network',
         key: 'performance-other',
         name: 'Other',
         tooltip: 'Any other network requests that do not fall into the other categories',
     },
     {
-        type: FilterableInspectorListItemTypes.DOCTOR,
+        type: 'doctor',
         key: 'doctor',
         name: 'Doctor',
         tooltip:
@@ -187,7 +186,7 @@ export const miniFiltersLogic = kea<miniFiltersLogicType>([
 
         hasEventsFiltersSelected: [
             (s) => [s.miniFiltersForType],
-            (miniFiltersForType) => miniFiltersForType(FilterableInspectorListItemTypes.EVENTS).some((x) => x.enabled),
+            (miniFiltersForType) => miniFiltersForType('events').some((x) => x.enabled),
         ],
 
         miniFilters: [

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -67,7 +67,7 @@ export type RecordingComment = {
     timeInRecording: number
 }
 
-const _filterableItemTypes = ['events', 'console', 'network', 'comment', 'doctor'] as const
+const _filterableItemTypes = ['events', 'console', 'network', 'doctor'] as const
 const _itemTypes = [
     ..._filterableItemTypes,
     'performance',

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -75,6 +75,7 @@ const _itemTypes = [
     'browser-visibility',
     'inactivity',
     'inspector-summary',
+    'comment',
 ] as const
 
 export type InspectorListItemType = (typeof _itemTypes)[number]

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1146,13 +1146,6 @@ export enum SessionRecordingSidebarStacking {
     Horizontal = 'horizontal',
 }
 
-export enum FilterableInspectorListItemTypes {
-    EVENTS = 'events',
-    CONSOLE = 'console',
-    NETWORK = 'network',
-    DOCTOR = 'doctor',
-}
-
 export enum SessionPlayerState {
     READY = 'ready',
     BUFFER = 'buffer',


### PR DESCRIPTION
continuing to pull parts out of https://github.com/PostHog/posthog/pull/32955 which is staying too big

we were using half enum and half strings in these types 
TS enums are mostly unnecessary https://www.totaltypescript.com/why-i-dont-like-typescript-enums

so, just use union string type here