### PR TITLE
fix(max): infinite loaders in tools

### DIFF
--- a/ee/hogai/graph/root/nodes.py
+++ b/ee/hogai/graph/root/nodes.py
@@ -18,8 +18,8 @@ from langchain_core.runnables import RunnableConfig
 from langchain_openai import ChatOpenAI
 from pydantic import BaseModel
 
-from ee.hogai.graph.memory.nodes import should_run_onboarding_before_insights
 import products
+from ee.hogai.graph.memory.nodes import should_run_onboarding_before_insights
 from ee.hogai.tool import CONTEXTUAL_TOOL_NAME_TO_TOOL, create_and_query_insight, search_documentation
 from ee.hogai.utils.types import AssistantState, PartialAssistantState
 from posthog.schema import (
@@ -304,6 +304,7 @@ class RootNodeTools(AssistantNode):
                         ui_payload={tool_call.name: result.artifact},
                         id=str(uuid4()),
                         tool_call_id=tool_call.id,
+                        visible=True,
                     )
                 ],
                 root_tool_call_id=None,  # Tool handled already

--- a/ee/hogai/graph/root/test/test_nodes.py
+++ b/ee/hogai/graph/root/test/test_nodes.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 from langchain_core.messages import (
     AIMessage as LangchainAIMessage,
@@ -581,6 +581,7 @@ class TestRootNodeTools(BaseTest):
         self.assertEqual(result.root_tool_call_id, None)  # Tool was fully handled by the node
         self.assertIsNone(result.root_tool_insight_plan)  # No insight plan for contextual tools
         self.assertIsNone(result.root_tool_insight_type)  # No insight type for contextual tools
+        self.assertTrue(result.messages[-1].visible)  # The tool call must have the visible attribute set
 
     def test_run_multiple_tool_calls_raises(self):
         node = RootNodeTools(self.team)


### PR DESCRIPTION
## Problem

Reasoning messages are not getting automatically removed because the AssistantToolCallMessage from the injected Max tools didn't return `visible=True`.

## Changes

- Set the visible=true.
- Add tests.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Unit tests & manual testing
