### PR TITLE
fix: Return incremental fields only for supported tables

### DIFF
--- a/posthog/temporal/data_imports/pipelines/google_ads/source.py
+++ b/posthog/temporal/data_imports/pipelines/google_ads/source.py
@@ -201,7 +201,7 @@ def get_incremental_fields():
 class BigQueryTable(Table[GoogleAdsColumn]):
     def __init__(self, *args, requires_filter: bool, primary_key: list[str], **kwargs):
         self.requires_filter = requires_filter
-        self.primary_key = primary_key
+        self.primary_key = [pkey.replace(".", "_") for pkey in primary_key]
         super().__init__(*args, **kwargs)
 
 

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -1142,7 +1142,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                     "should_sync": False,
                     "incremental_fields": [
                         {"label": column_name, "type": column_name, "field": column_name, "field_type": column_type}
-                        for column_name, column_type in incremental_fields[name]
+                        for column_name, column_type in incremental_fields.get(name, [])
                     ],
                     "incremental_available": True,
                     "incremental_field": incremental_fields[name][0]


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Couple of small fixes for Google Ads source:
* Format primary keys to use an underscore.
* Only look for incremental fields in schemas that support it.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
