### PR TITLE
fix(logs): correctly render json values in log attributes

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -12719,7 +12719,7 @@
             "additionalProperties": false,
             "properties": {
                 "attributes": {
-                    "type": "string"
+                    "type": "object"
                 },
                 "body": {
                     "type": "string"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2033,7 +2033,7 @@ export interface LogMessage {
     trace_id: string
     span_id: string
     body: string
-    attributes: string
+    attributes: Record<string, any>
     /**  @format date-time */
     timestamp: string
     /**  @format date-time */

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -3056,7 +3056,7 @@ class LogMessage(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    attributes: str
+    attributes: dict[str, Any]
     body: str
     event_name: str
     instrumentation_scope: str

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -154,6 +154,12 @@ export const logsLogic = kea<logsLogicType>([
                         signal,
                     })
                     actions.setLogsAbortController(null)
+                    response.results.forEach((row) => {
+                        Object.keys(row.attributes).forEach((key) => {
+                            const value = row.attributes[key]
+                            row.attributes[key] = typeof value === 'string' ? value : JSON.stringify(value)
+                        })
+                    })
                     return response.results
                 },
             },


### PR DESCRIPTION
## Problem

attributes now come back as objects from the API, but we need to render them correctly as strings or we end up with [object Object] in the front-end. Do the conversion when we receive from the API so we don't have to duplicate this code anywhere

## Changes

before:
<img width="388" alt="image" src="https://github.com/user-attachments/assets/bf434f8d-adc3-4fda-8fb2-44b96cb09d50" />

after:
<img width="661" alt="image" src="https://github.com/user-attachments/assets/5e0a4f0f-f089-4bf2-94d1-0a925eddfa03" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
