### PR TITLE
fix(logs): extract service.name and event.name from json strings

### DIFF
--- a/rust/log-capture/src/log_record.rs
+++ b/rust/log-capture/src/log_record.rs
@@ -95,8 +95,8 @@ impl LogRow {
             None => "".to_string(),
         };
 
-        let event_name = extract(&attributes, "event.name");
-        let service_name = extract(&attributes, "service.name");
+        let event_name = extract_string(&attributes, "event.name");
+        let service_name = extract_string(&attributes, "service.name");
 
         // Trace/span IDs
         let trace_id = extract_trace_id(&record.trace_id);
@@ -129,10 +129,15 @@ impl LogRow {
     }
 }
 
-fn extract(attributes: &[(String, String)], key: &str) -> String {
+// extract a JSON value as a string. If it's a string, strip the surrounding "quotes"
+fn extract_string(attributes: &[(String, String)], key: &str) -> String {
     for (k, val) in attributes.iter() {
         if k == key {
-            return val.to_string();
+            if let Ok(JsonValue::String(value)) = serde_json::from_str::<JsonValue>(val) {
+                return value.to_string();
+            } else {
+                return val.to_string();
+            }
         }
     }
     "".to_string()


### PR DESCRIPTION


> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
we are currently storing service name and event name wrapped in quotes as they are json strings. Unwrap them first if possible
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
