### PR TITLE
fix(web-analytics): Reset web analytics filters if we couldn't parse them

### DIFF
--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -2866,6 +2866,9 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
 
             if (parsedFilters && !objectsEqual(parsedFilters, values.webAnalyticsFilters)) {
                 actions.setWebAnalyticsFilters(parsedFilters)
+            } else if (!parsedFilters && filters) {
+                // if filters were set, but we failed to parse them, we reset the filters
+                actions.setWebAnalyticsFilters([])
             }
             if (
                 conversionGoalActionId &&

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -2862,13 +2862,9 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 return
             }
 
-            const parsedFilters = isWebAnalyticsPropertyFilters(filters) ? filters : undefined
-
+            const parsedFilters = filters ? (isWebAnalyticsPropertyFilters(filters) ? filters : []) : undefined
             if (parsedFilters && !objectsEqual(parsedFilters, values.webAnalyticsFilters)) {
                 actions.setWebAnalyticsFilters(parsedFilters)
-            } else if (!parsedFilters && filters) {
-                // if filters were set, but we failed to parse them, we reset the filters
-                actions.setWebAnalyticsFilters([])
             }
             if (
                 conversionGoalActionId &&


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Seen here https://posthoghelp.zendesk.com/agent/tickets/32178 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/34014)

The url contains `filters=%5Bobject%20Object%5D%20`

## Changes

I couldn't see how we would get into this state, but let's at least make sure that if we see this in the wild, the user can get out of it

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Tried the URL in the ticket on my localhost env