### PR TITLE
chore(propdefs): remove inline join-await experiment from v2 write loop

### DIFF
--- a/rust/property-defs-rs/src/v2_batch_ingestion.rs
+++ b/rust/property-defs-rs/src/v2_batch_ingestion.rs
@@ -306,27 +306,6 @@ pub async fn process_batch_v2(
                 }
             }
         }
-
-        // if any of the batches are full, execute them now
-        if handles.is_empty() {
-            continue;
-        }
-        let to_exec = handles;
-        handles = vec![];
-        for handle in to_exec {
-            match handle.await {
-                // metrics are statted in write_*_batch methods so we just log here
-                Ok(result) => match result {
-                    Ok(_) => continue,
-                    Err(db_err) => {
-                        error!("Batch write exhausted retries: {:?}", db_err);
-                    }
-                },
-                Err(join_err) => {
-                    warn!("Batch query JoinError: {:?}", join_err);
-                }
-            }
-        }
     }
 
     // ensure partial batches are flushed to Postgres too


### PR DESCRIPTION
## Problem
Clean up an experiment from before the propdefs v2 write path testing was paused.

## Changes
Join the `tokio` spawned thread handles after the update batch loop is completed in the v2 write path, as we originally did. This code path should be removed before re-enabling it 👍 

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Locally, in CI, and in landed for, in the original deploy tests