### PR TITLE
feat(flags): support disabling flags in `/flags` endpoint (useful for the posthog-js client)

### DIFF
--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -47,6 +47,10 @@ pub struct FlagRequest {
     )]
     pub distinct_id: Option<String>,
     pub geoip_disable: Option<bool>,
+    // Web and mobile clients can configure this parameter to disable flags for a request.
+    // It's mostly used for folks who want to save money on flag evaluations while still using
+    // `/flags` to load the rest of their PostHog configuration.
+    pub disable_flags: Option<bool>,
     #[serde(default)]
     pub person_properties: Option<HashMap<String, Value>>,
     #[serde(default)]
@@ -113,13 +117,18 @@ impl FlagRequest {
 
     /// Extracts the properties from the request.
     /// If the request contains person_properties, they are returned.
-    // TODO do I even need this one?
     pub fn extract_properties(&self) -> HashMap<String, Value> {
         let mut properties = HashMap::new();
         if let Some(person_properties) = &self.person_properties {
             properties.extend(person_properties.clone());
         }
         properties
+    }
+
+    /// Checks if feature flags should be disabled for this request.
+    /// Returns true if disable_flags is explicitly set to true.
+    pub fn is_flags_disabled(&self) -> bool {
+        matches!(self.disable_flags, Some(true))
     }
 }
 
@@ -241,32 +250,75 @@ mod tests {
 
     #[test]
     fn test_extract_token() {
-        // Test valid token
-        let flag_request = FlagRequest {
-            token: Some("valid_token".to_string()),
-            ..Default::default()
-        };
-        assert_eq!(flag_request.extract_token().unwrap(), "valid_token");
+        let json = json!({
+            "distinct_id": "alakazam",
+            "token": "my_token1",
+        });
+        let bytes = Bytes::from(json.to_string());
 
-        // Test empty token
-        let flag_request = FlagRequest {
-            token: Some("".to_string()),
-            ..Default::default()
-        };
-        assert!(matches!(
-            flag_request.extract_token(),
-            Err(FlagError::NoTokenError)
-        ));
+        let flag_payload = FlagRequest::from_bytes(bytes).expect("failed to parse request");
 
-        // Test missing token
-        let flag_request = FlagRequest {
-            token: None,
-            ..Default::default()
+        match flag_payload.extract_token() {
+            Ok(token) => assert_eq!(token, "my_token1"),
+            _ => panic!("expected token"),
         };
-        assert!(matches!(
-            flag_request.extract_token(),
-            Err(FlagError::NoTokenError)
-        ));
+
+        let json = json!({
+            "distinct_id": "alakazam",
+            "token": "",
+        });
+        let bytes = Bytes::from(json.to_string());
+
+        let flag_payload = FlagRequest::from_bytes(bytes).expect("failed to parse request");
+
+        match flag_payload.extract_token() {
+            Err(FlagError::NoTokenError) => (),
+            _ => panic!("expected empty token error"),
+        };
+
+        let json = json!({
+            "distinct_id": "alakazam",
+        });
+        let bytes = Bytes::from(json.to_string());
+
+        let flag_payload = FlagRequest::from_bytes(bytes).expect("failed to parse request");
+
+        match flag_payload.extract_token() {
+            Err(FlagError::NoTokenError) => (),
+            _ => panic!("expected no token error"),
+        };
+    }
+
+    #[test]
+    fn test_disable_flags() {
+        // Test with disable_flags: true
+        let json = json!({
+            "distinct_id": "test_id",
+            "token": "test_token",
+            "disable_flags": true
+        });
+        let bytes = Bytes::from(json.to_string());
+        let flag_payload = FlagRequest::from_bytes(bytes).expect("failed to parse request");
+        assert!(flag_payload.is_flags_disabled());
+
+        // Test with disable_flags: false
+        let json = json!({
+            "distinct_id": "test_id",
+            "token": "test_token",
+            "disable_flags": false
+        });
+        let bytes = Bytes::from(json.to_string());
+        let flag_payload = FlagRequest::from_bytes(bytes).expect("failed to parse request");
+        assert!(!flag_payload.is_flags_disabled());
+
+        // Test without disable_flags field
+        let json = json!({
+            "distinct_id": "test_id",
+            "token": "test_token"
+        });
+        let bytes = Bytes::from(json.to_string());
+        let flag_payload = FlagRequest::from_bytes(bytes).expect("failed to parse request");
+        assert!(!flag_payload.is_flags_disabled());
     }
 
     #[tokio::test]

--- a/rust/feature-flags/src/handler/billing.rs
+++ b/rust/feature-flags/src/handler/billing.rs
@@ -37,16 +37,18 @@ pub async fn check_limits(
     Ok(None)
 }
 
+/// Records usage metrics for feature flag requests.
+///
+/// Only increments billing counters if there are billable flags present.
+/// Survey targeting flags (prefixed with "survey-targeting-") are not billable.
 pub async fn record_usage(
     context: &RequestContext,
     filtered_flags: &FeatureFlagList,
     team_id: i32,
 ) {
-    if filtered_flags
-        .flags
-        .iter()
-        .any(|f| !f.key.starts_with(SURVEY_TARGETING_FLAG_PREFIX))
-    {
+    let has_billable_flags = contains_billable_flags(filtered_flags);
+
+    if has_billable_flags {
         if let Err(e) = increment_request_count(
             context.state.redis.clone(),
             team_id,
@@ -64,13 +66,29 @@ pub async fn record_usage(
     }
 }
 
-/// Helper function to determine if usage should be recorded
-/// This function is extracted for testing purposes
-pub fn should_record_usage(filtered_flags: &FeatureFlagList) -> bool {
+/// Checks if the flag list contains any billable flags.
+///
+/// Returns true if there are any flags that are NOT survey targeting flags.
+/// Survey targeting flags (those starting with "survey-targeting-") are free
+/// and don't count toward billing.
+fn contains_billable_flags(filtered_flags: &FeatureFlagList) -> bool {
     filtered_flags
         .flags
         .iter()
-        .any(|f| !f.key.starts_with(SURVEY_TARGETING_FLAG_PREFIX))
+        .any(|flag| is_billable_flag(&flag.key))
+}
+
+/// Determines if a flag is billable based on its key.
+///
+/// Returns true for regular feature flags, false for survey targeting flags.
+fn is_billable_flag(flag_key: &str) -> bool {
+    !flag_key.starts_with(SURVEY_TARGETING_FLAG_PREFIX)
+}
+
+/// Helper function to determine if usage should be recorded
+/// This function is extracted for testing purposes
+pub fn should_record_usage(filtered_flags: &FeatureFlagList) -> bool {
+    contains_billable_flags(filtered_flags)
 }
 
 #[cfg(test)]

--- a/rust/feature-flags/src/handler/flags.rs
+++ b/rust/feature-flags/src/handler/flags.rs
@@ -81,7 +81,13 @@ pub async fn evaluate_for_request(
     groups: Option<HashMap<String, Value>>,
     hash_key_override: Option<String>,
     request_id: Uuid,
+    disable_flags: bool,
 ) -> FlagsResponse {
+    // If flags are disabled, return empty FlagsResponse
+    if disable_flags {
+        return FlagsResponse::new(false, HashMap::new(), None, request_id);
+    }
+
     let ctx = FeatureFlagEvaluationContext {
         team_id,
         project_id,

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -29,7 +29,7 @@ pub async fn process_request(context: RequestContext) -> Result<FlagsResponse, F
     let (original_distinct_id, verified_token, request) =
         authentication::parse_and_authenticate(&context, &flag_service).await?;
 
-    // Check billing limits early
+    // Check quota limits early
     if let Some(quota_limited_response) = billing::check_limits(&context, &verified_token).await? {
         return Ok(quota_limited_response);
     }
@@ -42,8 +42,10 @@ pub async fn process_request(context: RequestContext) -> Result<FlagsResponse, F
 
     let filtered_flags =
         flags::fetch_and_filter(&flag_service, team.project_id, &request, &context.meta).await?;
+
     let property_overrides = properties::prepare_overrides(&context, &request)?;
 
+    // Evaluate flags (this will return empty if disable_flags is true)
     let flags_response = flags::evaluate_for_request(
         &context.state,
         team.id,
@@ -55,12 +57,18 @@ pub async fn process_request(context: RequestContext) -> Result<FlagsResponse, F
         property_overrides.groups,
         property_overrides.hash_key,
         context.request_id,
+        request.is_flags_disabled(),
     )
     .await;
 
+    // build the rest of the FlagsResponse, since the caller may have passed in `&config=true` and may need additional fields
+    // beyond just feature flags
     let response = config_response_builder::build_response(flags_response, &context, &team).await?;
 
-    billing::record_usage(&context, &filtered_flags, team.id).await;
+    // Only record billing if flags are not disabled
+    if !request.is_flags_disabled() {
+        billing::record_usage(&context, &filtered_flags, team.id).await;
+    }
 
     Ok(response)
 }

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -3004,3 +3004,475 @@ async fn test_config_error_tracking_disabled() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_disable_flags_returns_empty_response() -> Result<()> {
+    let config = DEFAULT_TEST_CONFIG.clone();
+
+    let distinct_id = "user_distinct_id".to_string();
+
+    let client = setup_redis_client(Some(config.redis_url.clone()));
+    let pg_client = setup_pg_reader_client(None).await;
+    let team = insert_new_team_in_redis(client.clone()).await.unwrap();
+    let token = team.api_token;
+
+    insert_new_team_in_pg(pg_client.clone(), Some(team.id))
+        .await
+        .unwrap();
+
+    insert_person_for_team_in_pg(pg_client.clone(), team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
+
+    // Insert a flag that would normally match
+    let flag_json = json!([{
+        "id": 1,
+        "key": "test-flag",
+        "name": "Test Flag",
+        "active": true,
+        "deleted": false,
+        "team_id": team.id,
+        "filters": {
+            "groups": [
+                {
+                    "properties": [],
+                    "rollout_percentage": 100
+                }
+            ],
+        },
+    }]);
+
+    insert_flags_for_team_in_redis(
+        client,
+        team.id,
+        team.project_id,
+        Some(flag_json.to_string()),
+    )
+    .await?;
+
+    let server = ServerHandle::for_config(config).await;
+
+    // Request with disable_flags: true
+    let payload = json!({
+        "token": token,
+        "distinct_id": distinct_id,
+        "disable_flags": true
+    });
+
+    let res = server
+        .send_flags_request(payload.to_string(), None, None)
+        .await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    let json_data = res.json::<Value>().await?;
+    assert_json_include!(
+        actual: json_data,
+        expected: json!({
+            "errorsWhileComputingFlags": false,
+            "featureFlags": {},
+            "featureFlagPayloads": {}
+        })
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_disable_flags_returns_empty_response_v2() -> Result<()> {
+    let config = DEFAULT_TEST_CONFIG.clone();
+
+    let distinct_id = "user_distinct_id".to_string();
+
+    let client = setup_redis_client(Some(config.redis_url.clone()));
+    let pg_client = setup_pg_reader_client(None).await;
+    let team = insert_new_team_in_redis(client.clone()).await.unwrap();
+    let token = team.api_token;
+
+    insert_new_team_in_pg(pg_client.clone(), Some(team.id))
+        .await
+        .unwrap();
+
+    insert_person_for_team_in_pg(pg_client.clone(), team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
+
+    // Insert a flag that would normally match
+    let flag_json = json!([{
+        "id": 1,
+        "key": "test-flag",
+        "name": "Test Flag",
+        "active": true,
+        "deleted": false,
+        "team_id": team.id,
+        "filters": {
+            "groups": [
+                {
+                    "properties": [],
+                    "rollout_percentage": 100
+                }
+            ],
+        },
+    }]);
+
+    insert_flags_for_team_in_redis(
+        client,
+        team.id,
+        team.project_id,
+        Some(flag_json.to_string()),
+    )
+    .await?;
+
+    let server = ServerHandle::for_config(config).await;
+
+    // Request with disable_flags: true using v2 API
+    let payload = json!({
+        "token": token,
+        "distinct_id": distinct_id,
+        "disable_flags": true
+    });
+
+    let res = server
+        .send_flags_request(payload.to_string(), Some("2"), None)
+        .await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    let json_data = res.json::<Value>().await?;
+    assert_json_include!(
+        actual: json_data,
+        expected: json!({
+            "errorsWhileComputingFlags": false,
+            "flags": {}
+        })
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_disable_flags_false_still_returns_flags() -> Result<()> {
+    let config = DEFAULT_TEST_CONFIG.clone();
+
+    let distinct_id = "user_distinct_id".to_string();
+
+    let client = setup_redis_client(Some(config.redis_url.clone()));
+    let pg_client = setup_pg_reader_client(None).await;
+    let team = insert_new_team_in_redis(client.clone()).await.unwrap();
+    let token = team.api_token;
+
+    insert_new_team_in_pg(pg_client.clone(), Some(team.id))
+        .await
+        .unwrap();
+
+    insert_person_for_team_in_pg(pg_client.clone(), team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
+
+    // Insert a flag that should match
+    let flag_json = json!([{
+        "id": 1,
+        "key": "test-flag",
+        "name": "Test Flag",
+        "active": true,
+        "deleted": false,
+        "team_id": team.id,
+        "filters": {
+            "groups": [
+                {
+                    "properties": [],
+                    "rollout_percentage": 100
+                }
+            ],
+        },
+    }]);
+
+    insert_flags_for_team_in_redis(
+        client,
+        team.id,
+        team.project_id,
+        Some(flag_json.to_string()),
+    )
+    .await?;
+
+    let server = ServerHandle::for_config(config).await;
+
+    // Request with disable_flags: false (should still return flags)
+    let payload = json!({
+        "token": token,
+        "distinct_id": distinct_id,
+        "disable_flags": false
+    });
+
+    let res = server
+        .send_flags_request(payload.to_string(), None, None)
+        .await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    let json_data = res.json::<Value>().await?;
+    assert_json_include!(
+        actual: json_data,
+        expected: json!({
+            "errorsWhileComputingFlags": false,
+            "featureFlags": {
+                "test-flag": true
+            }
+        })
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_disable_flags_with_config_still_returns_config_data() -> Result<()> {
+    let config = DEFAULT_TEST_CONFIG.clone();
+
+    let distinct_id = "user_distinct_id".to_string();
+
+    let client = setup_redis_client(Some(config.redis_url.clone()));
+    let pg_client = setup_pg_reader_client(None).await;
+    let team = insert_new_team_in_redis(client.clone()).await.unwrap();
+    let token = team.api_token;
+
+    insert_new_team_in_pg(pg_client.clone(), Some(team.id))
+        .await
+        .unwrap();
+
+    insert_person_for_team_in_pg(pg_client.clone(), team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
+
+    // Insert a flag that would normally match
+    let flag_json = json!([{
+        "id": 1,
+        "key": "test-flag",
+        "name": "Test Flag",
+        "active": true,
+        "deleted": false,
+        "team_id": team.id,
+        "filters": {
+            "groups": [
+                {
+                    "properties": [],
+                    "rollout_percentage": 100
+                }
+            ],
+        },
+    }]);
+
+    insert_flags_for_team_in_redis(
+        client,
+        team.id,
+        team.project_id,
+        Some(flag_json.to_string()),
+    )
+    .await?;
+
+    let server = ServerHandle::for_config(config).await;
+
+    // Request with disable_flags: true AND config: true
+    let payload = json!({
+        "token": token,
+        "distinct_id": distinct_id,
+        "disable_flags": true
+    });
+
+    let res = server
+        .send_flags_request(payload.to_string(), None, Some("true"))
+        .await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    let json_data = res.json::<Value>().await?;
+
+    // Verify flags are empty (due to disable_flags)
+    assert_json_include!(
+        actual: json_data,
+        expected: json!({
+            "errorsWhileComputingFlags": false,
+            "featureFlags": {},
+            "featureFlagPayloads": {}
+        })
+    );
+
+    // Verify config data is still present (due to config=true)
+    assert_json_include!(
+        actual: json_data,
+        expected: json!({
+            "supportedCompression": ["gzip", "gzip-js"],
+            "autocapture_opt_out": false,
+            "config": {
+                "enable_collect_everything": true
+            },
+            "toolbarParams": {},
+            "isAuthenticated": false,
+            "defaultIdentifiedOnly": true
+        })
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_disable_flags_with_config_v2_still_returns_config_data() -> Result<()> {
+    let config = DEFAULT_TEST_CONFIG.clone();
+
+    let distinct_id = "user_distinct_id".to_string();
+
+    let client = setup_redis_client(Some(config.redis_url.clone()));
+    let pg_client = setup_pg_reader_client(None).await;
+    let team = insert_new_team_in_redis(client.clone()).await.unwrap();
+    let token = team.api_token;
+
+    insert_new_team_in_pg(pg_client.clone(), Some(team.id))
+        .await
+        .unwrap();
+
+    insert_person_for_team_in_pg(pg_client.clone(), team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
+
+    // Insert a flag that would normally match
+    let flag_json = json!([{
+        "id": 1,
+        "key": "test-flag",
+        "name": "Test Flag",
+        "active": true,
+        "deleted": false,
+        "team_id": team.id,
+        "filters": {
+            "groups": [
+                {
+                    "properties": [],
+                    "rollout_percentage": 100
+                }
+            ],
+        },
+    }]);
+
+    insert_flags_for_team_in_redis(
+        client,
+        team.id,
+        team.project_id,
+        Some(flag_json.to_string()),
+    )
+    .await?;
+
+    let server = ServerHandle::for_config(config).await;
+
+    // Request with disable_flags: true AND config: true using v2 API
+    let payload = json!({
+        "token": token,
+        "distinct_id": distinct_id,
+        "disable_flags": true
+    });
+
+    let res = server
+        .send_flags_request(payload.to_string(), Some("2"), Some("true"))
+        .await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    let json_data = res.json::<Value>().await?;
+
+    // Verify flags are empty (due to disable_flags)
+    assert_json_include!(
+        actual: json_data,
+        expected: json!({
+            "errorsWhileComputingFlags": false,
+            "flags": {}
+        })
+    );
+
+    // Verify config data is still present (due to config=true)
+    assert_json_include!(
+        actual: json_data,
+        expected: json!({
+            "supportedCompression": ["gzip", "gzip-js"],
+            "autocapture_opt_out": false,
+            "config": {
+                "enable_collect_everything": true
+            },
+            "toolbarParams": {},
+            "isAuthenticated": false,
+            "defaultIdentifiedOnly": true
+        })
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_disable_flags_without_config_param_has_minimal_response() -> Result<()> {
+    let config = DEFAULT_TEST_CONFIG.clone();
+
+    let distinct_id = "user_distinct_id".to_string();
+
+    let client = setup_redis_client(Some(config.redis_url.clone()));
+    let pg_client = setup_pg_reader_client(None).await;
+    let team = insert_new_team_in_redis(client.clone()).await.unwrap();
+    let token = team.api_token;
+
+    insert_new_team_in_pg(pg_client.clone(), Some(team.id))
+        .await
+        .unwrap();
+
+    insert_person_for_team_in_pg(pg_client.clone(), team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
+
+    // Insert a flag that would normally match
+    let flag_json = json!([{
+        "id": 1,
+        "key": "test-flag",
+        "name": "Test Flag",
+        "active": true,
+        "deleted": false,
+        "team_id": team.id,
+        "filters": {
+            "groups": [
+                {
+                    "properties": [],
+                    "rollout_percentage": 100
+                }
+            ],
+        },
+    }]);
+
+    insert_flags_for_team_in_redis(
+        client,
+        team.id,
+        team.project_id,
+        Some(flag_json.to_string()),
+    )
+    .await?;
+
+    let server = ServerHandle::for_config(config).await;
+
+    // Request with disable_flags: true but NO config parameter
+    let payload = json!({
+        "token": token,
+        "distinct_id": distinct_id,
+        "disable_flags": true
+    });
+
+    let res = server
+        .send_flags_request(payload.to_string(), Some("2"), None)
+        .await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    let json_data = res.json::<Value>().await?;
+
+    // Verify flags are empty (due to disable_flags)
+    assert_json_include!(
+        actual: json_data,
+        expected: json!({
+            "errorsWhileComputingFlags": false,
+            "flags": {}
+        })
+    );
+
+    // Verify minimal config data (since config=true was not requested)
+    // Should NOT have the full config fields like supportedCompression, etc.
+    assert!(json_data.get("supportedCompression").is_none());
+    assert!(json_data.get("config").is_none());
+    assert!(json_data.get("toolbarParams").is_none());
+
+    Ok(())
+}


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Another thing I missed when back-propagating `/decide` support to `/flags` was that I now needed to support `disable_flags` on the `/flags&config=true` endpoint (since RemoteConfig just wouldn't call `/flags` at all in this case).  

Straightforward enough but I need to basically mark the flags chunk as missing and then still return the rest of the config response.

## Changes

- The changes described above
- Cleaned up the billing code to make it more explicit
- fixed up some tests for missing tokens that weren't testing enough info
- new integration tests

## Did you write or update any docs for this change?

- [x] No docs needed for this change
