### PR TITLE
fix(flags): Reset variant overrides in filters when multivariate is disabled

### DIFF
--- a/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
@@ -3,7 +3,7 @@ import { MOCK_DEFAULT_PROJECT } from 'lib/api.mock'
 
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
-import { FeatureFlagType, PersonPropertyFilter } from '~/types'
+import { FeatureFlagType, PropertyFilterType, PropertyOperator } from '~/types'
 
 import { featureFlagLogic, NEW_FLAG } from './featureFlagLogic'
 
@@ -83,10 +83,10 @@ describe('featureFlagLogic', () => {
                             properties: [
                                 {
                                     key: '$browser',
-                                    type: 'person',
+                                    type: PropertyFilterType.Person,
                                     value: 'Chrome',
-                                    operator: 'regex',
-                                } as PersonPropertyFilter,
+                                    operator: PropertyOperator.Regex,
+                                },
                             ],
                             rollout_percentage: 100,
                         },

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
@@ -1,0 +1,144 @@
+import { expectLogic, partial } from 'kea-test-utils'
+import { MOCK_DEFAULT_PROJECT } from 'lib/api.mock'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import { FeatureFlagType, PersonPropertyFilter } from '~/types'
+
+import { featureFlagLogic, NEW_FLAG } from './featureFlagLogic'
+
+const MOCK_FEATURE_FLAG = {
+    ...NEW_FLAG,
+    id: 1,
+    key: 'test-flag',
+    name: 'test-name',
+}
+
+const MOCK_FEATURE_FLAG_STATUS = {
+    status: 'active',
+    reason: 'mock reason',
+}
+
+describe('featureFlagLogic', () => {
+    let logic: ReturnType<typeof featureFlagLogic.build>
+
+    beforeEach(async () => {
+        initKeaTests()
+        logic = featureFlagLogic({ id: 1 })
+        logic.mount()
+
+        useMocks({
+            get: {
+                [`/api/projects/${MOCK_DEFAULT_PROJECT.id}/feature_flags/${MOCK_FEATURE_FLAG.id}/`]: () => [
+                    200,
+                    MOCK_FEATURE_FLAG,
+                ],
+                [`/api/projects/${MOCK_DEFAULT_PROJECT.id}/feature_flags/${MOCK_FEATURE_FLAG.id}/status`]: () => [
+                    200,
+                    MOCK_FEATURE_FLAG_STATUS,
+                ],
+            },
+        })
+
+        await expectLogic(logic).toFinishAllListeners()
+    })
+
+    describe('setMultivariateEnabled functionality', () => {
+        it('adds an empty variant when enabling multivariate', async () => {
+            await expectLogic(logic).toMatchValues({
+                featureFlag: partial({
+                    filters: partial({
+                        groups: [
+                            {
+                                properties: [],
+                                variant: null,
+                            },
+                        ],
+                    }),
+                }),
+                variants: [],
+            })
+            await expectLogic(logic, () => {
+                logic.actions.setMultivariateEnabled(true)
+            })
+                .toDispatchActions(['setMultivariateEnabled', 'setMultivariateOptions'])
+                .toMatchValues({
+                    variants: [
+                        {
+                            key: '',
+                            name: '',
+                            rollout_percentage: 100,
+                        },
+                    ],
+                })
+        })
+
+        it('resets the variants and group variant keys when disabling multivariate', async () => {
+            const MOCK_MULTIVARIATE_FEATURE_FLAG: FeatureFlagType = {
+                ...logic.values.featureFlag,
+                filters: {
+                    groups: [
+                        {
+                            variant: 'control1',
+                            properties: [
+                                {
+                                    key: '$browser',
+                                    type: 'person',
+                                    value: 'Chrome',
+                                    operator: 'regex',
+                                } as PersonPropertyFilter,
+                            ],
+                            rollout_percentage: 100,
+                        },
+                    ],
+                    payloads: {
+                        control1: '{"key": "value"}',
+                    },
+                    multivariate: {
+                        variants: [
+                            {
+                                key: 'control1',
+                                name: 'Control 1',
+                                rollout_percentage: 30,
+                            },
+                            {
+                                key: 'control2',
+                                name: 'Control 2',
+                                rollout_percentage: 70,
+                            },
+                        ],
+                    },
+                },
+            }
+
+            await expectLogic(logic, () => {
+                logic.actions.setFeatureFlag(MOCK_MULTIVARIATE_FEATURE_FLAG)
+            })
+                .toDispatchActions(['setFeatureFlag'])
+                .toMatchValues({
+                    featureFlag: MOCK_MULTIVARIATE_FEATURE_FLAG,
+                })
+
+            await expectLogic(logic, () => {
+                logic.actions.setMultivariateEnabled(false)
+            })
+                .toDispatchActions(['setMultivariateEnabled', 'setMultivariateOptions'])
+                .toMatchValues({
+                    featureFlag: partial({
+                        filters: partial({
+                            groups: [
+                                {
+                                    ...MOCK_MULTIVARIATE_FEATURE_FLAG.filters.groups[0],
+                                    variant: null,
+                                },
+                            ],
+                            payloads: {
+                                control1: '{"key": "value"}',
+                            },
+                        }),
+                    }),
+                    variants: [],
+                })
+        })
+    })
+})

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
@@ -132,9 +132,7 @@ describe('featureFlagLogic', () => {
                                     variant: null,
                                 },
                             ],
-                            payloads: {
-                                control1: '{"key": "value"}',
-                            },
+                            payloads: {},
                         }),
                     }),
                     variants: [],

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
@@ -42,6 +42,7 @@ describe('featureFlagLogic', () => {
 
         await expectLogic(logic).toFinishAllListeners()
     })
+
     afterEach(() => {
         logic.unmount()
     })

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
@@ -42,6 +42,9 @@ describe('featureFlagLogic', () => {
 
         await expectLogic(logic).toFinishAllListeners()
     })
+    afterEach(() => {
+        logic.unmount()
+    })
 
     describe('setMultivariateEnabled functionality', () => {
         it('adds an empty variant when enabling multivariate', async () => {

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -84,7 +84,7 @@ const getDefaultRollbackCondition = (): FeatureFlagRollbackConditions => ({
     },
 })
 
-const NEW_FLAG: FeatureFlagType = {
+export const NEW_FLAG: FeatureFlagType = {
     id: null,
     created_at: null,
     key: '',
@@ -919,6 +919,7 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
                 if (values.featureFlag.experiment_set) {
                     return await api.experiments.get(values.featureFlag.experiment_set[0])
                 }
+                return null
             },
         },
     })),

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -404,7 +404,11 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
                     if (!state) {
                         return state
                     }
-                    return { ...state, filters: { ...state.filters, multivariate: multivariateOptions } }
+                    const variantsSet = new Set(multivariateOptions?.variants.map((variant) => variant.key))
+                    const groups = state.filters.groups.map((group) =>
+                        !group.variant || variantsSet.has(group.variant) ? group : { ...group, variant: null }
+                    )
+                    return { ...state, filters: { ...state.filters, groups, multivariate: multivariateOptions } }
                 },
                 setRemoteConfigEnabled: (state, { enabled }) => {
                     if (!state) {

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -408,7 +408,17 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
                     const groups = state.filters.groups.map((group) =>
                         !group.variant || variantsSet.has(group.variant) ? group : { ...group, variant: null }
                     )
-                    return { ...state, filters: { ...state.filters, groups, multivariate: multivariateOptions } }
+                    const oldPayloads = state.filters.payloads ?? {}
+                    const payloads = Object.keys(oldPayloads).reduce((newPayloads, variantKey) => {
+                        if (variantsSet.has(variantKey)) {
+                            return { ...newPayloads, [variantKey]: oldPayloads[variantKey] }
+                        }
+                        return newPayloads
+                    }, {})
+                    return {
+                        ...state,
+                        filters: { ...state.filters, groups, payloads, multivariate: multivariateOptions },
+                    }
                 },
                 setRemoteConfigEnabled: (state, { enabled }) => {
                     if (!state) {

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -409,12 +409,12 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
                         !group.variant || variantsSet.has(group.variant) ? group : { ...group, variant: null }
                     )
                     const oldPayloads = state.filters.payloads ?? {}
-                    const payloads = Object.keys(oldPayloads).reduce((newPayloads, variantKey) => {
+                    const payloads: Record<string, JsonType> = {}
+                    for (const variantKey of Object.keys(oldPayloads)) {
                         if (variantsSet.has(variantKey)) {
-                            return { ...newPayloads, [variantKey]: oldPayloads[variantKey] }
+                            payloads[variantKey] = oldPayloads[variantKey]
                         }
-                        return newPayloads
-                    }, {})
+                    }
                     return {
                         ...state,
                         filters: { ...state.filters, groups, payloads, multivariate: multivariateOptions },


### PR DESCRIPTION
This PR is copied from #33255. I had to open this one to get CI to run properly.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Trying to change a previously saved multivariate feature flag with a variant override to a boolean flag will trigger a server validation error that prevents the flag from being saved.

![image](https://github.com/user-attachments/assets/3ecf0b30-0e48-418b-9e3b-201ad3c5b67e)

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Closes #33189

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- Update the `setMultivariateOptions` reducer so it removes any `variant` value from the filters that is no longer set in the `multivariateOptions.variants` array.
- Create a test file for featureFlagLogic. For now, I only added the relevant tests to these changes.
- Make the return type for `loadExperiment` consistent to avoid TypeScript errors (this happened while running the tests).

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

1. Create and save a multivariate flag with a condition set that contains a variant override.
![image](https://github.com/user-attachments/assets/37318e3f-9bb5-4657-96b9-ede764cd6168)

2. Edit the flag, change the Served Value to Release toggle (boolean). Confirm the change of value type.
![image](https://github.com/user-attachments/assets/4558f910-b517-42c1-9b02-b5555e7f58e5)

3. Save your changes. In the `master` branch, the server returns an error, in this branch, the feature flag will be saved successfully.
![image](https://github.com/user-attachments/assets/0ea75a78-50ff-468e-8ec5-722cc0cb714d)

