### PR TITLE
fix(max): remove throttle classes in debug

### DIFF
--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -58,15 +58,15 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelM
 
     def get_throttles(self):
         if (
-            self.action == "create"
-            and not (
-                # Strict limits are skipped for select US region teams (PostHog + an active user we've chatted with)
-                get_instance_region() == "US" and self.team_id in (2, 87921)
-            )
             # Do not apply limits in local development
-            and not settings.DEBUG
+            not settings.DEBUG
+            # Only for streaming
+            and self.action == "create"
+            # Strict limits are skipped for select US region teams (PostHog + an active user we've chatted with)
+            and not (get_instance_region() == "US" and self.team_id in (2, 87921))
         ):
             return [AIBurstRateThrottle(), AISustainedRateThrottle()]
+
         return super().get_throttles()
 
     def get_serializer_class(self):

--- a/ee/api/test/test_conversation.py
+++ b/ee/api/test/test_conversation.py
@@ -2,13 +2,16 @@ import datetime
 import uuid
 from unittest.mock import patch
 
+from django.test import override_settings
 from django.utils import timezone
 from rest_framework import status
 
+from ee.api.conversation import ConversationViewSet
 from ee.hogai.assistant import Assistant
 from ee.models.assistant import Conversation
 from posthog.models.team.team import Team
 from posthog.models.user import User
+from posthog.rate_limit import AIBurstRateThrottle, AISustainedRateThrottle
 from posthog.test.base import APIBaseTest
 
 
@@ -356,3 +359,25 @@ class TestConversation(APIBaseTest):
             # Second result should be the older conversation
             self.assertEqual(results[1]["id"], str(conversation1.id))
             self.assertEqual(results[1]["title"], "Older conversation")
+
+    @override_settings(DEBUG=False)
+    def test_get_throttles_applies_rate_limits_for_create_action(self):
+        """Test that rate limits are applied for create action in non-debug, non-exempt conditions."""
+
+        viewset = ConversationViewSet()
+        viewset.action = "create"
+        viewset.team_id = 12345
+        throttles = viewset.get_throttles()
+        self.assertIsInstance(throttles[0], AIBurstRateThrottle)
+        self.assertIsInstance(throttles[1], AISustainedRateThrottle)
+
+    @override_settings(DEBUG=True)
+    def test_get_throttles_skips_rate_limits_for_debug_mode(self):
+        """Test that rate limits are skipped in debug mode."""
+
+        viewset = ConversationViewSet()
+        viewset.action = "create"
+        viewset.team_id = 12345
+        throttles = viewset.get_throttles()
+        self.assertNotIsInstance(throttles[0], AIBurstRateThrottle)
+        self.assertNotIsInstance(throttles[1], AISustainedRateThrottle)


### PR DESCRIPTION
## Problem

Throttle classes are applied in local development, which forces you to reset the Redis cache when you hit them.

## Changes

- Remove throttling in debug.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Unit tests