### PR TITLE
feat(project-tree): only project folders for shortcuts

### DIFF
--- a/frontend/src/layout/panel-layout/PinnedFolder/PinnedFolder.tsx
+++ b/frontend/src/layout/panel-layout/PinnedFolder/PinnedFolder.tsx
@@ -76,7 +76,7 @@ export function PinnedFolder(): JSX.Element {
                         ) : (
                             <IconBlank />
                         )}
-                        Custom...
+                        Custom project folder...
                     </ButtonPrimitive>
                 </DropdownMenuItem>
             </DropdownMenuContent>
@@ -126,6 +126,7 @@ export function PinnedFolder(): JSX.Element {
                             value={selectedFolder}
                             onChange={setSelectedFolder}
                             includeProtocol
+                            root="project://"
                             className="h-[60vh] min-h-[200px]"
                         />
                     </div>


### PR DESCRIPTION
## Problem

This "Custom..." menu is confusing and it has too many weird things nobody will ever pick

![2025-06-10 10 48 39](https://github.com/user-attachments/assets/880c09b5-9e04-4c4b-81f6-153cc3386ce1)


## Changes

Change to "Custom project folder..."

![2025-06-10 10 46 40](https://github.com/user-attachments/assets/be324597-5c25-4e5a-a2cf-2e76be5b0ec5)

