### PR TITLE
fix(groups): Fix error where we rewrite groups unnecessarily

### DIFF
--- a/plugin-server/src/worker/ingestion/groups/batch-writing-group-store.test.ts
+++ b/plugin-server/src/worker/ingestion/groups/batch-writing-group-store.test.ts
@@ -259,5 +259,28 @@ describe('BatchWritingGroupStore', () => {
                 {}
             )
         })
+
+        it('should not write to db if no properties are changed', async () => {
+            const groupStoreForBatch = groupStore.forBatch()
+
+            // Mock the db.fetchGroup to return a group with the same properties
+            jest.spyOn(db, 'fetchGroup').mockResolvedValue(group)
+
+            await groupStoreForBatch.upsertGroup(
+                teamId,
+                projectId,
+                1,
+                'test',
+                group.group_properties,
+                DateTime.now(),
+                false
+            )
+
+            await groupStoreForBatch.flush()
+
+            expect(db.updateGroupOptimistically).toHaveBeenCalledTimes(0)
+            expect(db.updateGroup).toHaveBeenCalledTimes(0)
+            expect(db.insertGroup).toHaveBeenCalledTimes(0)
+        })
     })
 })

--- a/plugin-server/src/worker/ingestion/groups/batch-writing-group-store.ts
+++ b/plugin-server/src/worker/ingestion/groups/batch-writing-group-store.ts
@@ -454,7 +454,7 @@ export class BatchWritingGroupStoreForBatch implements GroupStoreForBatch {
                             const groupUpdate = fromGroup(existingGroup)
                             this.addGroupToCache(teamId, groupKey, {
                                 ...groupUpdate,
-                                needsWrite: true,
+                                needsWrite: false,
                             })
                             return groupUpdate
                         } else {

--- a/plugin-server/src/worker/ingestion/groups/batch-writing-group-store.ts
+++ b/plugin-server/src/worker/ingestion/groups/batch-writing-group-store.ts
@@ -178,7 +178,15 @@ export class BatchWritingGroupStoreForBatch implements GroupStoreForBatch {
         const group = await this.getGroup(teamId, groupTypeIndex, groupKey, false, null)
 
         if (!group) {
-            await this.upsertGroupDirectly(teamId, groupTypeIndex, groupKey, properties, timestamp, false, 'cr')
+            await this.upsertGroupDirectly(
+                teamId,
+                groupTypeIndex,
+                groupKey,
+                properties,
+                timestamp,
+                false,
+                'batch-create'
+            )
             return
         }
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We are adding every group we fetch from the database to the cache with the value `needsWrite:true`, this is a mistake
For some reason we are adding suffix `cr` to a metric label, we should be having something more readabale

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
