### PR TITLE
fix(lint): exclude kea type files from prettier

### DIFF
--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,3 +1,4 @@
 .cache/
 src/taxonomy/core-filter-definitions-by-group.json
 dist/
+*Type.ts

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,4 +1,4 @@
 .cache/
 src/taxonomy/core-filter-definitions-by-group.json
 dist/
-*Type.ts
+*LogicType.ts


### PR DESCRIPTION
## Problem

```
❯ pnpm --filter=@posthog/frontend prettier:check

> @posthog/frontend@0.0.0 prettier:check /Users/thomas/Posthog/posthog/frontend
> prettier --check "../{cypress,products,frontend/src}/**/*.{js,mjs,ts,tsx,json,yaml,yml,css,scss}"

Checking formatting...
[warn] src/layout/navigation-3000/sidepanel/panels/access_control/accessControlLogicType.ts
[warn] src/layout/navigation-3000/sidepanel/panels/access_control/resourcesAccessControlLogicType.ts
[warn] src/layout/navigation-3000/sidepanel/panels/access_control/roleAccessControlLogicType.ts
[warn] src/layout/navigation-3000/sidepanel/panels/activation/activationLogicType.ts
[warn] src/layout/navigation-3000/sidepanel/panels/activity/sidePanelActivityLogicType.ts
[warn] src/layout/navigation/Breadcrumbs/breadcrumbsLogicType.ts
[warn] src/layout/panel-layout/ProjectTree/projectTreeLogicType.ts
...
```

## Changes

Exclude kea type files from prettier.

## How did you test this code?

n/a