### PR TITLE
fix(data-warehouse): Only update earliest timestamp if its smaller than the existing

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -48,6 +48,7 @@ from posthog.warehouse.models import (
     ExternalDataSchema,
     ExternalDataSource,
 )
+from posthog.warehouse.models.external_data_schema import process_incremental_value
 
 
 class PipelineNonDLT:
@@ -103,6 +104,9 @@ class PipelineNonDLT:
         self._internal_schema = HogQLSchema()
         self._shutdown_monitor = shutdown_monitor
         self._last_incremental_field_value: Any = None
+        self._earliest_incremental_field_value: Any = process_incremental_value(
+            schema.incremental_field_earliest_value, schema.incremental_field_type
+        )
 
     def run(self):
         pa_memory_pool = pa.default_memory_pool()
@@ -275,12 +279,20 @@ class PipelineNonDLT:
         if last_value is not None:
             if (self._last_incremental_field_value is None) or (last_value > self._last_incremental_field_value):
                 self._last_incremental_field_value = last_value
+
             if self._resource.sort_mode == "asc":
                 self._logger.debug(f"Updating incremental_field_last_value with {self._last_incremental_field_value}")
                 self._schema.update_incremental_field_value(self._last_incremental_field_value)
+
             if self._resource.sort_mode == "desc":
                 earliest_value = _get_incremental_field_value(self._schema, pa_table, aggregate="min")
-                if earliest_value < self._schema.incremental_field_earliest_value:
+
+                if (
+                    self._earliest_incremental_field_value is None
+                    or earliest_value < self._earliest_incremental_field_value
+                ):
+                    self._earliest_incremental_field_value = earliest_value
+
                     self._logger.debug(f"Updating incremental_field_earliest_value with {earliest_value}")
                     self._schema.update_incremental_field_value(earliest_value, type="earliest")
 

--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -280,8 +280,9 @@ class PipelineNonDLT:
                 self._schema.update_incremental_field_value(self._last_incremental_field_value)
             if self._resource.sort_mode == "desc":
                 earliest_value = _get_incremental_field_value(self._schema, pa_table, aggregate="min")
-                self._logger.debug(f"Updating incremental_field_earliest_value with {earliest_value}")
-                self._schema.update_incremental_field_value(earliest_value, type="earliest")
+                if earliest_value < self._schema.incremental_field_earliest_value:
+                    self._logger.debug(f"Updating incremental_field_earliest_value with {earliest_value}")
+                    self._schema.update_incremental_field_value(earliest_value, type="earliest")
 
         _update_job_row_count(self._job.id, pa_table.num_rows, self._logger)
         decrement_rows(self._job.team_id, self._schema.id, pa_table.num_rows)

--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -3,7 +3,6 @@ import uuid
 from datetime import datetime
 from typing import Any, Optional
 
-from dateutil import parser
 from django.conf import settings
 from django.db import close_old_connections
 from django.db.models import Prefetch
@@ -24,9 +23,8 @@ from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceRespo
 from posthog.temporal.data_imports.pipelines.pipeline_sync import PipelineInputs
 from posthog.temporal.data_imports.row_tracking import setup_row_tracking
 from posthog.warehouse.models import ExternalDataJob, ExternalDataSource
-from posthog.warehouse.models.external_data_schema import ExternalDataSchema
+from posthog.warehouse.models.external_data_schema import ExternalDataSchema, process_incremental_value
 from posthog.warehouse.models.ssh_tunnel import SSHTunnel
-from posthog.warehouse.types import IncrementalFieldType
 
 
 @dataclasses.dataclass
@@ -46,20 +44,6 @@ class ImportDataActivityInputs:
             "run_id": self.run_id,
             "reset_pipeline": self.reset_pipeline,
         }
-
-
-def process_incremental_value(value: Any | None, field_type: IncrementalFieldType | None) -> Any | None:
-    if value is None or value == "None" or field_type is None:
-        return None
-
-    if field_type == IncrementalFieldType.Integer or field_type == IncrementalFieldType.Numeric:
-        return value
-
-    if field_type == IncrementalFieldType.DateTime or field_type == IncrementalFieldType.Timestamp:
-        return parser.parse(value)
-
-    if field_type == IncrementalFieldType.Date:
-        return parser.parse(value).date()
 
 
 def _trim_source_job_inputs(source: ExternalDataSource) -> None:

--- a/posthog/warehouse/models/external_data_schema.py
+++ b/posthog/warehouse/models/external_data_schema.py
@@ -1,4 +1,5 @@
 import uuid
+from dateutil import parser
 from datetime import datetime, timedelta
 from typing import Any, Literal
 
@@ -262,6 +263,20 @@ class ExternalDataSchema(CreatedMetaFields, UpdatedMetaFields, UUIDModel, Delete
             self.last_synced_at = None
             self.status = None
             self.save()
+
+
+def process_incremental_value(value: Any | None, field_type: IncrementalFieldType | None) -> Any | None:
+    if value is None or value == "None" or field_type is None:
+        return None
+
+    if field_type == IncrementalFieldType.Integer or field_type == IncrementalFieldType.Numeric:
+        return value
+
+    if field_type == IncrementalFieldType.DateTime or field_type == IncrementalFieldType.Timestamp:
+        return parser.parse(value)
+
+    if field_type == IncrementalFieldType.Date:
+        return parser.parse(value).date()
 
 
 @database_sync_to_async


### PR DESCRIPTION
## Changes
- Only update the `earliest` value if its smaller than what is already in the db