### PR TITLE
chore(data-warehouse): Raise error if postgres is hitting temp file limits

### DIFF
--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -72,7 +72,8 @@ Non_Retryable_Schema_Errors: dict[ExternalDataSource.Type, list[str]] = {
         "FATAL: no such database",
         "does not exist",
         "timestamp too small",
-        "QueryTimeout",
+        "QueryTimeoutException",
+        "TemporaryFileSizeExceedsLimitException",
     ],
     ExternalDataSource.Type.ZENDESK: ["404 Client Error: Not Found for url", "403 Client Error: Forbidden for url"],
     ExternalDataSource.Type.MYSQL: [

--- a/posthog/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/utils.py
@@ -48,7 +48,11 @@ class DuplicatePrimaryKeysException(Exception):
     pass
 
 
-class QueryTimeout(Exception):
+class QueryTimeoutException(Exception):
+    pass
+
+
+class TemporaryFileSizeExceedsLimitException(Exception):
     pass
 
 


### PR DESCRIPTION
## Changes
- turn off a schema if the postgres server is having to spill out to disk when ordering results and is hitting server errors - this requires an index to be added to the incremental field 