### PR TITLE
chore(dwh-google-ads): Call out access to Google Ads must be granted

### DIFF
--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -811,7 +811,7 @@ export const SOURCE_DETAILS: Record<ExternalDataSourceType, SourceConfig> = {
         label: 'Google Ads',
         caption: (
             <>
-                Ensure you have granted PostHog access to your Google Ads account as instructed in the
+                Ensure you have granted PostHog access to your Google Ads account as instructed in the 
                 <Link to="https://posthog.com/docs/cdp/sources/google-ads" target="_blank">
                     documentation
                 </Link>

--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -809,7 +809,15 @@ export const SOURCE_DETAILS: Record<ExternalDataSourceType, SourceConfig> = {
     GoogleAds: {
         name: 'GoogleAds',
         label: 'Google Ads',
-        caption: '',
+        caption: (
+            <>
+                Ensure you have granted PostHog access to your Google Ads account as instructed in the
+                <Link to="https://posthog.com/docs/cdp/sources/google-ads" target="_blank">
+                    documentation
+                </Link>
+                .
+            </>
+        ),
         fields: [
             {
                 name: 'customer_id',

--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -811,7 +811,7 @@ export const SOURCE_DETAILS: Record<ExternalDataSourceType, SourceConfig> = {
         label: 'Google Ads',
         caption: (
             <>
-                Ensure you have granted PostHog access to your Google Ads account as instructed in the 
+                Ensure you have granted PostHog access to your Google Ads account as instructed in the
                 <Link to="https://posthog.com/docs/cdp/sources/google-ads" target="_blank">
                     documentation
                 </Link>


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

When creating a Google Ads source, there is no indication that additional steps to grant access to Google Ads are required.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Add a mention that access needs to be granted, and link to the corresponding documentation.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->