### PR TITLE
feat(bi): Add option to hide totals row and exclude percentage rows

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -379,18 +379,22 @@ export const LineGraph = (): JSX.Element => {
                                 }
                             })
 
-                            if (tooltipData.length > 1) {
-                                const rawData = (
-                                    ySeriesData as (AxisSeries<number> | AxisBreakdownSeries<number>)[]
-                                ).reduce((acc: number, cur: AxisSeries<number> | AxisBreakdownSeries<number>) => {
-                                    acc += cur.data[referenceDataPoint.dataIndex]
-                                    return acc
-                                }, 0)
+                            const tooltipTotalData = (
+                                ySeriesData as (AxisSeries<number> | AxisBreakdownSeries<number>)[]
+                            ).filter((n) => n.settings?.formatting?.style !== 'percent')
 
+                            if (tooltipTotalData.length > 1 && chartSettings.showTotalRow !== false) {
+                                const totalRawData = tooltipTotalData.reduce(
+                                    (acc: number, cur: AxisSeries<number> | AxisBreakdownSeries<number>) => {
+                                        acc += cur.data[referenceDataPoint.dataIndex]
+                                        return acc
+                                    },
+                                    0
+                                )
                                 tooltipData.push({
                                     series: '',
-                                    data: rawData.toString(),
-                                    rawData: rawData,
+                                    data: totalRawData.toLocaleString(),
+                                    rawData: totalRawData,
                                     dataIndex: referenceDataPoint.dataIndex,
                                     isTotalRow: true,
                                 })

--- a/frontend/src/queries/nodes/DataVisualization/Components/DisplayTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/DisplayTab.tsx
@@ -28,6 +28,14 @@ export const DisplayTab = (): JSX.Element => {
                         updateChartSettings({ showLegend: value })
                     }}
                 />
+                <LemonSwitch
+                    className="flex-1 mb-3 w-full"
+                    label="Show total row"
+                    checked={chartSettings.showTotalRow ?? true}
+                    onChange={(value) => {
+                        updateChartSettings({ showTotalRow: value })
+                    }}
+                />
             </div>
 
             <div className="mt-1 mb-2 flex flex-col">

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -5771,6 +5771,9 @@
                 "showLegend": {
                     "type": "boolean"
                 },
+                "showTotalRow": {
+                    "type": "boolean"
+                },
                 "stackBars100": {
                     "description": "Whether we fill the bars to 100% in stacked mode",
                     "type": "boolean"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -819,6 +819,7 @@ export interface ChartSettings {
     stackBars100?: boolean
     seriesBreakdownColumn?: string | null
     showLegend?: boolean
+    showTotalRow?: boolean
 }
 
 export interface ConditionalFormattingRule {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -2670,6 +2670,7 @@ class ChartSettings(BaseModel):
     rightYAxisSettings: Optional[YAxisSettings] = None
     seriesBreakdownColumn: Optional[str] = None
     showLegend: Optional[bool] = None
+    showTotalRow: Optional[bool] = None
     stackBars100: Optional[bool] = Field(default=None, description="Whether we fill the bars to 100% in stacked mode")
     xAxis: Optional[ChartAxis] = None
     yAxis: Optional[list[ChartAxis]] = None


### PR DESCRIPTION
## Changes
Changes to the new total row in tooltips for BI visualizations:
- Be able to turn off the total rows via chart settings
- Format the totals row with commas
- Exclude percentage rows from the total 

https://posthog.slack.com/archives/C019RAX2XBN/p1749509495472749?thread_ts=1749143811.107189&cid=C019RAX2XBN
