### PR TITLE
fix(insights): insight kind check for longer timeouts

### DIFF
--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -134,6 +134,7 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
                 data, self.team, data.client_query_id, request.user
             )
             self._tag_client_query_id(client_query_id)
+            query_dict = query.model_dump()
 
             result = process_query_model(
                 self.team,
@@ -146,9 +147,9 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
                     # QUERY_ASYNC provides extended max execution time for insight queries
                     LimitContext.QUERY_ASYNC
                     if (
-                        is_insight_query(query)
-                        or is_insight_actors_query(query)
-                        or is_insight_actors_options_query(query)
+                        is_insight_query(query_dict)
+                        or is_insight_actors_query(query_dict)
+                        or is_insight_actors_options_query(query_dict)
                     )
                     and get_query_tag_value("access_method") != "personal_api_key"
                     else None

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -290,48 +290,56 @@ def get_pk_or_uuid(queryset: QuerySet, key: Union[int, str]) -> QuerySet:
         return queryset.filter(pk=key)
 
 
-def is_insight_query(query):
-    insight_kinds = {
-        "TrendsQuery",
-        "FunnelsQuery",
-        "RetentionQuery",
-        "PathsQuery",
-        "StickinessQuery",
-        "LifecycleQuery",
-    }
-    if getattr(query, "kind", None) in insight_kinds:
+INSIGHT_KINDS = {
+    "TrendsQuery",
+    "FunnelsQuery",
+    "RetentionQuery",
+    "PathsQuery",
+    "StickinessQuery",
+    "LifecycleQuery",
+}
+
+INSIGHT_ACTORS_KINDS = {
+    "InsightActorsQuery",
+    "FunnelsActorsQuery",
+    "FunnelCorrelationActorsQuery",
+    "StickinessActorsQuery",
+}
+
+
+def is_insight_query(query: dict) -> bool:
+    kind = query.get("kind") or getattr(query, "kind", None)
+    source = query.get("source") or getattr(query, "source", None)
+
+    if kind in INSIGHT_KINDS:
         return True
-    if getattr(query, "kind", None) == "HogQLQuery":
+    if kind == "HogQLQuery":
         return True
-    if getattr(query, "kind", None) == "DataTableNode":
-        source = getattr(query, "source", None)
-        if source and getattr(source, "kind", None) in insight_kinds:
+    if kind == "DataTableNode":
+        if source and (source.get("kind") or getattr(source, "kind", None)) in INSIGHT_KINDS:
             return True
-    if getattr(query, "kind", None) == "DataVisualizationNode":
-        source = getattr(query, "source", None)
-        if source and getattr(source, "kind", None) in insight_kinds:
+    if kind == "DataVisualizationNode":
+        if source and (source.get("kind") or getattr(source, "kind", None)) in INSIGHT_KINDS:
+            return True
+
+    return False
+
+
+def is_insight_actors_query(query: dict) -> bool:
+    kind = query.get("kind") or getattr(query, "kind", None)
+    source = query.get("source") or getattr(query, "source", None)
+
+    if kind in INSIGHT_ACTORS_KINDS:
+        return True
+    if kind == "ActorsQuery":
+        if source and (source.get("kind") or getattr(source, "kind", None)) in INSIGHT_ACTORS_KINDS:
             return True
     return False
 
 
-def is_insight_actors_query(query):
-    insight_actors_kinds = {
-        "InsightActorsQuery",
-        "FunnelsActorsQuery",
-        "FunnelCorrelationActorsQuery",
-        "StickinessActorsQuery",
-    }
-    if getattr(query, "kind", None) in insight_actors_kinds:
-        return True
-    if getattr(query, "kind", None) == "ActorsQuery":
-        source = getattr(query, "source", None)
-        if source and getattr(source, "kind", None) in insight_actors_kinds:
-            return True
-    return False
-
-
-def is_insight_actors_options_query(query):
-    if getattr(query, "kind", None) == "InsightActorsQueryOptions":
+def is_insight_actors_options_query(query: dict) -> bool:
+    kind = query.get("kind") or getattr(query, "kind", None)
+    if kind == "InsightActorsQueryOptions":
         return True
     return False
 

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -308,8 +308,8 @@ INSIGHT_ACTORS_KINDS = {
 
 
 def is_insight_query(query: dict) -> bool:
-    kind = query.get("kind") or getattr(query, "kind", None)
-    source = query.get("source") or getattr(query, "source", None)
+    kind = query.get("kind")
+    source = query.get("source")
 
     if kind in INSIGHT_KINDS:
         return True
@@ -326,8 +326,8 @@ def is_insight_query(query: dict) -> bool:
 
 
 def is_insight_actors_query(query: dict) -> bool:
-    kind = query.get("kind") or getattr(query, "kind", None)
-    source = query.get("source") or getattr(query, "source", None)
+    kind = query.get("kind")
+    source = query.get("source")
 
     if kind in INSIGHT_ACTORS_KINDS:
         return True
@@ -338,7 +338,7 @@ def is_insight_actors_query(query: dict) -> bool:
 
 
 def is_insight_actors_options_query(query: dict) -> bool:
-    kind = query.get("kind") or getattr(query, "kind", None)
+    kind = query.get("kind")
     if kind == "InsightActorsQueryOptions":
         return True
     return False

--- a/posthog/caching/calculate_results.py
+++ b/posthog/caching/calculate_results.py
@@ -5,7 +5,6 @@ import structlog
 from pydantic import BaseModel
 
 from posthog.api.services.query import ExecutionMode, process_query_dict
-from posthog.api.utils import is_insight_query
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.hogql_queries.legacy_compatibility.flagged_conversion_manager import conversion_to_query_based
 from posthog.hogql_queries.query_runner import get_query_runner_or_none
@@ -82,10 +81,8 @@ def calculate_for_query_based_insight(
         user=user,
         insight_id=insight.pk,
         dashboard_id=dashboard.pk if dashboard else None,
-        limit_context=(
-            # QUERY_ASYNC provides extended max execution time for insight queries
-            LimitContext.QUERY_ASYNC if is_insight_query(insight.query) else None
-        ),
+        # QUERY_ASYNC provides extended max execution time for insight queries
+        limit_context=LimitContext.QUERY_ASYNC,
     )
 
     if isinstance(process_response, BaseModel):


### PR DESCRIPTION
## Problem
`insight.query` was a dict, so `getattr` wasn't working on it.

## Changes
First try dict access.
Don't think we need the backup `getattr`?
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?
Tested locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
