### PR TITLE
fix(logs): fix bytes encoding error in logs query runner

### DIFF
--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -126,8 +126,8 @@ class LogsQueryRunner(QueryRunner):
             """
             SELECT
             uuid,
-            trace_id,
-            span_id,
+            hex(trace_id),
+            hex(span_id),
             body,
             attributes,
             timestamp,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

trace_id and span_id are byte columns, and serializing bytes to json for the query cache fails

wrap them in hex()

fixes: https://us.posthog.com/project/2/error_tracking/019759df-d8ca-7040-b577-221543d71892

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
