### PR TITLE
chore(props-def): Track inflight messages

### DIFF
--- a/rust/property-defs-rs/src/lib.rs
+++ b/rust/property-defs-rs/src/lib.rs
@@ -19,7 +19,7 @@ use update_cache::Cache;
 use tokio::sync::mpsc::{self, error::TrySendError};
 use tracing::{error, warn};
 
-use crate::{measuring_channel::MeasuringChannel, metrics_consts::CHANNEL_MESSAGES_IN_FLIGHT};
+use crate::{measuring_channel::MeasuringChannel, metrics_consts::{CHANNEL_CAPACITY, CHANNEL_MESSAGES_IN_FLIGHT}};
 
 pub mod api;
 pub mod app_context;
@@ -48,6 +48,7 @@ pub async fn update_consumer_loop(
             context.worker_liveness.report_healthy().await;
 
             metrics::gauge!(CHANNEL_MESSAGES_IN_FLIGHT).set(channel.len() as f64);
+            metrics::gauge!(CHANNEL_CAPACITY).set(channel.capacity() as f64);
 
             let remaining_capacity = config.update_batch_size - batch.len();
             // We race these two, so we can escape this loop and do a small batch if we've been waiting too long

--- a/rust/property-defs-rs/src/lib.rs
+++ b/rust/property-defs-rs/src/lib.rs
@@ -19,13 +19,16 @@ use update_cache::Cache;
 use tokio::sync::mpsc::{self, error::TrySendError};
 use tracing::{error, warn};
 
-use crate::{measuring_channel::MeasuringChannel, metrics_consts::{CHANNEL_CAPACITY, CHANNEL_MESSAGES_IN_FLIGHT}};
+use crate::{
+    measuring_channel::MeasuringChannel,
+    metrics_consts::{CHANNEL_CAPACITY, CHANNEL_MESSAGES_IN_FLIGHT},
+};
 
 pub mod api;
 pub mod app_context;
 pub mod config;
-pub mod metrics_consts;
 pub mod measuring_channel;
+pub mod metrics_consts;
 pub mod types;
 pub mod update_cache;
 pub mod v2_batch_ingestion;

--- a/rust/property-defs-rs/src/lib.rs
+++ b/rust/property-defs-rs/src/lib.rs
@@ -50,7 +50,8 @@ pub async fn update_consumer_loop(
         while batch.len() < config.update_batch_size {
             context.worker_liveness.report_healthy().await;
 
-            metrics::gauge!(CHANNEL_MESSAGES_IN_FLIGHT).set(channel.len() as f64);
+            metrics::gauge!(CHANNEL_MESSAGES_IN_FLIGHT)
+                .set(channel.get_inflight_messages_count() as f64);
             metrics::gauge!(CHANNEL_CAPACITY).set(channel.capacity() as f64);
 
             let remaining_capacity = config.update_batch_size - batch.len();

--- a/rust/property-defs-rs/src/lib.rs
+++ b/rust/property-defs-rs/src/lib.rs
@@ -16,12 +16,12 @@ use v2_batch_ingestion::process_batch_v2;
 use ahash::AHashSet;
 use update_cache::Cache;
 
-use tokio::sync::mpsc::{self, error::TrySendError};
+use tokio::sync::mpsc::error::TrySendError;
 use tracing::{error, warn};
 
 use crate::{
-    measuring_channel::MeasuringChannel,
-    metrics_consts::{CHANNEL_CAPACITY, CHANNEL_MESSAGES_IN_FLIGHT},
+    measuring_channel::{MeasuringReceiver, MeasuringSender},
+    metrics_consts::CHANNEL_MESSAGES_IN_FLIGHT,
 };
 
 pub mod api;
@@ -40,7 +40,7 @@ pub async fn update_consumer_loop(
     config: Config,
     cache: Arc<Cache>,
     context: Arc<AppContext>,
-    mut channel: MeasuringChannel<Update>,
+    mut channel: MeasuringReceiver<Update>,
 ) {
     loop {
         let mut batch = Vec::with_capacity(config.update_batch_size);
@@ -52,7 +52,6 @@ pub async fn update_consumer_loop(
 
             metrics::gauge!(CHANNEL_MESSAGES_IN_FLIGHT)
                 .set(channel.get_inflight_messages_count() as f64);
-            metrics::gauge!(CHANNEL_CAPACITY).set(channel.capacity() as f64);
 
             let remaining_capacity = config.update_batch_size - batch.len();
             // We race these two, so we can escape this loop and do a small batch if we've been waiting too long
@@ -201,8 +200,8 @@ async fn process_batch_v1(
 pub async fn update_producer_loop(
     config: Config,
     consumer: SingleTopicConsumer,
-    channel: mpsc::Sender<Update>,
     shared_cache: Arc<Cache>,
+    channel: MeasuringSender<Update>,
 ) {
     let mut batch = AHashSet::with_capacity(config.compaction_batch_size);
     let mut last_send = tokio::time::Instant::now();

--- a/rust/property-defs-rs/src/lib.rs
+++ b/rust/property-defs-rs/src/lib.rs
@@ -19,12 +19,13 @@ use update_cache::Cache;
 use tokio::sync::mpsc::{self, error::TrySendError};
 use tracing::{error, warn};
 
-use crate::metrics_consts::CHANNEL_MESSAGES_IN_FLIGHT;
+use crate::{measuring_channel::MeasuringChannel, metrics_consts::CHANNEL_MESSAGES_IN_FLIGHT};
 
 pub mod api;
 pub mod app_context;
 pub mod config;
 pub mod metrics_consts;
+pub mod measuring_channel;
 pub mod types;
 pub mod update_cache;
 pub mod v2_batch_ingestion;
@@ -36,7 +37,7 @@ pub async fn update_consumer_loop(
     config: Config,
     cache: Arc<Cache>,
     context: Arc<AppContext>,
-    mut channel: mpsc::Receiver<Update>,
+    mut channel: MeasuringChannel<Update>,
 ) {
     loop {
         let mut batch = Vec::with_capacity(config.update_batch_size);

--- a/rust/property-defs-rs/src/main.rs
+++ b/rust/property-defs-rs/src/main.rs
@@ -11,14 +11,12 @@ use property_defs_rs::{
     update_cache::Cache,
     measuring_channel::MeasuringChannel,
     update_consumer_loop,
-    update_producer_loop
+    update_producer_loop,
 };
 
 use serve_metrics::{serve, setup_metrics_routes};
 use sqlx::postgres::PgPoolOptions;
-use tokio::{
-    task::JoinHandle,
-};
+use tokio::task::JoinHandle;
 use tracing::{info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
 

--- a/rust/property-defs-rs/src/main.rs
+++ b/rust/property-defs-rs/src/main.rs
@@ -8,11 +8,10 @@ use property_defs_rs::{
     api::v1::{query::Manager, routing::apply_routes},
     app_context::AppContext,
     config::Config,
-    update_cache::Cache,
-    update_consumer_loop,
-    update_producer_loop,
     measuring_channel::measuring_channel,
     metrics_consts::CHANNEL_CAPACITY,
+    update_cache::Cache,
+    update_consumer_loop, update_producer_loop,
 };
 
 use serve_metrics::{serve, setup_metrics_routes};

--- a/rust/property-defs-rs/src/main.rs
+++ b/rust/property-defs-rs/src/main.rs
@@ -84,7 +84,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     start_server(&config, context.clone());
 
-    let channel = MeasuringChannel::new(config.update_batch_size * config.channel_slots_per_worker);
+    let (tx, rx) = measuring_channel(config.update_batch_size * config.channel_slots_per_worker);
 
     let cache = Cache::new(config.cache_capacity);
 
@@ -96,7 +96,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let handle = tokio::spawn(update_producer_loop(
             config.clone(),
             consumer.clone(),
-            channel.tx().clone(),
+            tx.clone(),
             cache.clone(),
         ));
 
@@ -107,7 +107,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config.clone(),
         cache,
         context,
-        channel,
+        rx,
     )));
 
     // if any handle returns, abort the other ones, and then return an error

--- a/rust/property-defs-rs/src/measuring_channel.rs
+++ b/rust/property-defs-rs/src/measuring_channel.rs
@@ -1,0 +1,47 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use tokio::sync::mpsc::{channel, error::{RecvError, SendError}, Receiver, Sender};
+
+pub struct MeasuringChannel<T> {
+    sender: Sender<T>,
+    receiver: Receiver<T>,
+    in_flight_message: AtomicUsize,
+}
+
+impl<T> MeasuringChannel<T> {
+    pub fn new(capacity: usize) -> Self {
+        let (tx, rx) = channel(capacity);
+        Self {
+            sender: tx,
+            receiver: rx,
+            in_flight_message: AtomicUsize::new(0),
+        }
+    }
+
+    pub async fn send(&self, item: T) -> Result<(), SendError<T>> {
+        self.in_flight_message.fetch_add(1, Ordering::Relaxed);
+        self.sender.send(item).await
+    }
+
+    pub async fn recv(&mut self) -> Option<T> {
+        self.in_flight_message.fetch_sub(1, Ordering::Relaxed);
+        self.receiver.recv().await
+    }
+
+    pub async fn recv_many(&mut self, buffer: &mut Vec<T>, limit: usize) -> usize {
+        self.in_flight_message.fetch_sub(limit, Ordering::Relaxed);
+        self.receiver.recv_many(buffer, limit).await
+    }
+
+    pub fn len(&self) -> usize {
+        self.in_flight_message.load(Ordering::Relaxed)
+    }
+
+    pub fn tx(&self) -> &Sender<T> {
+        &self.sender
+    }
+
+    pub fn rx(&self) -> &Receiver<T> {
+        &self.receiver
+    }
+}

--- a/rust/property-defs-rs/src/measuring_channel.rs
+++ b/rust/property-defs-rs/src/measuring_channel.rs
@@ -44,4 +44,8 @@ impl<T> MeasuringChannel<T> {
     pub fn rx(&self) -> &Receiver<T> {
         &self.receiver
     }
+
+    pub fn capacity(&self) -> usize {
+        self.sender.capacity()
+    }
 }

--- a/rust/property-defs-rs/src/measuring_channel.rs
+++ b/rust/property-defs-rs/src/measuring_channel.rs
@@ -24,6 +24,7 @@ impl<T> MeasuringChannel<T> {
             self.in_flight_message.fetch_add(1, Ordering::Relaxed);
         }
         result
+    }
 
     pub async fn recv(&mut self) -> Option<T> {
         let result = self.receiver.recv().await;

--- a/rust/property-defs-rs/src/measuring_channel.rs
+++ b/rust/property-defs-rs/src/measuring_channel.rs
@@ -1,6 +1,10 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use tokio::sync::mpsc::{channel, error::{RecvError, SendError}, Receiver, Sender};
+use tokio::sync::mpsc::{
+    channel,
+    error::{RecvError, SendError},
+    Receiver, Sender,
+};
 
 pub struct MeasuringChannel<T> {
     sender: Sender<T>,
@@ -36,7 +40,8 @@ impl<T> MeasuringChannel<T> {
 
     pub async fn recv_many(&mut self, buffer: &mut Vec<T>, limit: usize) -> usize {
         let received_count = self.receiver.recv_many(buffer, limit).await;
-        self.in_flight_message.fetch_sub(received_count, Ordering::Relaxed);
+        self.in_flight_message
+            .fetch_sub(received_count, Ordering::Relaxed);
         received_count
     }
 

--- a/rust/property-defs-rs/src/measuring_channel.rs
+++ b/rust/property-defs-rs/src/measuring_channel.rs
@@ -9,12 +9,13 @@ use tokio::sync::mpsc::{
     Receiver, Sender,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug§)]
 pub struct MeasuringSender<T> {
     sender: Sender<T>,
     in_flight: Arc<AtomicUsize>,
 }
 
+#[derive(Debug)]
 pub struct MeasuringReceiver<T> {
     receiver: Receiver<T>,
     in_flight: Arc<AtomicUsize>,
@@ -80,10 +81,6 @@ impl<T> MeasuringReceiver<T> {
             self.in_flight.fetch_sub(res, Ordering::Relaxed);
         }
         res
-    }
-
-    pub fn inflight(&self) -> usize {
-        self.in_flight.load(Ordering::Relaxed)
     }
 
     pub fn inner(&self) -> &Receiver<T> {

--- a/rust/property-defs-rs/src/measuring_channel.rs
+++ b/rust/property-defs-rs/src/measuring_channel.rs
@@ -9,7 +9,7 @@ use tokio::sync::mpsc::{
     Receiver, Sender,
 };
 
-#[derive(Clone, Debug§)]
+#[derive(Clone, Debug)]
 pub struct MeasuringSender<T> {
     sender: Sender<T>,
     in_flight: Arc<AtomicUsize>,

--- a/rust/property-defs-rs/src/measuring_channel.rs
+++ b/rust/property-defs-rs/src/measuring_channel.rs
@@ -1,10 +1,6 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use tokio::sync::mpsc::{
-    channel,
-    error::{RecvError, SendError},
-    Receiver, Sender,
-};
+use tokio::sync::mpsc::{channel, error::SendError, Receiver, Sender};
 
 pub struct MeasuringChannel<T> {
     sender: Sender<T>,
@@ -45,7 +41,7 @@ impl<T> MeasuringChannel<T> {
         received_count
     }
 
-    pub fn len(&self) -> usize {
+    pub fn get_inflight_messages_count(&self) -> usize {
         self.in_flight_message.load(Ordering::Relaxed)
     }
 

--- a/rust/property-defs-rs/src/metrics_consts.rs
+++ b/rust/property-defs-rs/src/metrics_consts.rs
@@ -28,6 +28,7 @@ pub const CHUNK_SIZE: &str = "prop_defs_chunk_size";
 pub const DUPLICATES_IN_BATCH: &str = "prop_defs_duplicates_in_batch";
 pub const SINGLE_UPDATE_ISSUE_TIME: &str = "prop_defs_single_update_issue_time_ms";
 pub const CHANNEL_MESSAGES_IN_FLIGHT: &str = "prop_defs_channel_messages_in_flight";
+pub const CHANNEL_CAPACITY: &str = "prop_defs_channel_capacity";
 
 //
 // property-defs-rs "v2" (mirror deploy) metric keys below


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Doing `receiver.len()` produces really strange results in production, this PR tries to add a more reliable way to track inflight messages as well as the channel capacity

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
