### PR TITLE
fix(batch-exports): Do not merge partial data in BigQuery orderless

### DIFF
--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -646,8 +646,10 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
         Heartbeater() as heartbeater,
         set_status_to_running_task(run_id=inputs.run_id, logger=logger),
     ):
+        is_orderless = str(inputs.team_id) in settings.BATCH_EXPORT_ORDERLESS_TEAM_IDS
+
         _, details = await should_resume_from_activity_heartbeat(activity, BigQueryHeartbeatDetails)
-        if details is None or str(inputs.team_id) in settings.BATCH_EXPORT_ORDERLESS_TEAM_IDS:
+        if details is None or is_orderless:
             details = BigQueryHeartbeatDetails()
 
         done_ranges: list[DateRange] = details.done_ranges
@@ -779,6 +781,7 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
                         bigquery_table=bigquery_stage_table if can_perform_merge else bigquery_table,
                         table_schema=stage_schema if can_perform_merge else schema,
                     )
+
                     try:
                         await run_consumer(
                             consumer=consumer,
@@ -791,9 +794,24 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
                             multiple_files=True,
                         )
 
-                    # ensure we always write data to final table, even if we fail halfway through, as if we resume from
-                    # a heartbeat, we can continue without losing data
-                    finally:
+                    except Exception:
+                        # Ensure we always write data to final table,  even if
+                        # we fail halfway through, as if we resume from a
+                        # heartbeat, we can continue without losing data
+                        # However, orderless batch exports should not merge
+                        # partial data as they will resume from the beginning.
+                        if can_perform_merge and not is_orderless:
+                            await bq_client.amerge_tables(
+                                final_table=bigquery_table,
+                                stage_table=bigquery_stage_table,
+                                mutable=mutable,
+                                merge_key=merge_key,
+                                update_key=update_key,
+                                stage_fields_cast_to_json=json_columns,
+                            )
+                        raise
+
+                    else:
                         if can_perform_merge:
                             await bq_client.amerge_tables(
                                 final_table=bigquery_table,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

When running an orderless batch export we will resume from the beginning after the batch export fails. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Thus we should not merge any partial data on failure to avoid duplicating data if we eventually succeed.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
