### PR TITLE
fix(batch-exports): Include partition in WHERE clause for BigQuery

### DIFF
--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -293,10 +293,16 @@ class BigQueryClient(bigquery.Client):
     ):
         """Attempt to SELECT from table to check for query permissions."""
         job_config = bigquery.QueryJobConfig()
+
         if "timestamp" in [field.name for field in table.schema]:
             query = f"""
             SELECT 1 FROM  `{table.full_table_id.replace(":", ".", 1)}` WHERE timestamp IS NOT NULL
             """
+
+            if table.time_partitioning is not None and table.time_partitioning.field == "timestamp":
+                today = dt.date.today()
+                query += f" AND timestamp = '{today.isoformat()}'"
+
         else:
             query = f"""
             SELECT 1 FROM  `{table.full_table_id.replace(":", ".", 1)}`

--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -303,9 +303,11 @@ class BigQueryClient(bigquery.Client):
                 today = dt.date.today()
                 query += f" AND timestamp = '{today.isoformat()}'"
 
+            query += " LIMIT 1"
+
         else:
             query = f"""
-            SELECT 1 FROM  `{table.full_table_id.replace(":", ".", 1)}`
+            SELECT 1 FROM  `{table.full_table_id.replace(":", ".", 1)}` LIMIT 1
             """
 
         try:

--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -301,7 +301,7 @@ class BigQueryClient(bigquery.Client):
 
             if table.time_partitioning is not None and table.time_partitioning.field == "timestamp":
                 today = dt.date.today()
-                query += f" AND timestamp = '{today.isoformat()}'"
+                query += f" AND DATE(timestamp) = '{today.isoformat()}'"
 
             query += " LIMIT 1"
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

BigQuery does a full table scan when we `SELECT 1` (for some reason).

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Let's avoid that by including a partition in the `WHERE` clause. We don't actually care about the query results, just testing if we can run it.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->