### PR TITLE
fix: fix SERVER_GATEWAY_INTERFACE being set after otel init

### DIFF
--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -43,7 +43,7 @@ class PostHogConfig(AppConfig):
             logger.info(
                 "posthog_config_ready",
                 settings_debug=settings.DEBUG,
-                server_gateway_interface=os.environ.get("SERVER_GATEWAY_INTERFACE"),
+                server_gateway_interface=settings.SERVER_GATEWAY_INTERFACE,
             )
             if settings.SERVER_GATEWAY_INTERFACE == "WSGI":
                 async_to_sync(initialize_self_capture_api_token)()

--- a/posthog/asgi.py
+++ b/posthog/asgi.py
@@ -11,18 +11,16 @@ import structlog
 # PostHog OpenTelemetry Initialization
 from posthog.otel_instrumentation import initialize_otel
 
-initialize_otel()  # Initialize OpenTelemetry first
-
-
-# Get a structlog logger for asgi.py's own messages
-logger = structlog.get_logger(__name__)
-
-
 os.environ["DJANGO_SETTINGS_MODULE"] = "posthog.settings"
 # Try to ensure SERVER_GATEWAY_INTERFACE is fresh for the child process
 if "SERVER_GATEWAY_INTERFACE" in os.environ:
     del os.environ["SERVER_GATEWAY_INTERFACE"]  # Delete if inherited
 os.environ["SERVER_GATEWAY_INTERFACE"] = "ASGI"  # Set definitively
+
+initialize_otel()  # Initialize OpenTelemetry first
+
+# Get a structlog logger for asgi.py's own messages
+logger = structlog.get_logger(__name__)
 
 
 # Django doesn't support lifetime requests and raises an exception

--- a/posthog/wsgi.py
+++ b/posthog/wsgi.py
@@ -14,9 +14,8 @@ from posthog.otel_instrumentation import initialize_otel
 
 from django.core.wsgi import get_wsgi_application
 
-initialize_otel()
-
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
 os.environ.setdefault("SERVER_GATEWAY_INTERFACE", "WSGI")
 
+initialize_otel()
 application = get_wsgi_application()


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
