### PR TITLE
fix(csp): ensure we return 204 for fully sampled out responses

### DIFF
--- a/posthog/api/csp.py
+++ b/posthog/api/csp.py
@@ -1,7 +1,9 @@
 import json
+import structlog
 from typing import Optional
 
-import structlog
+from django.http import HttpResponse
+from rest_framework import status
 
 from posthog.exceptions import generate_exception_response
 from posthog.sampling import sample_on_property
@@ -171,7 +173,7 @@ def process_csp_report(request):
                     document_url=properties.get("document_url"),
                     sample_rate=sample_rate,
                 )
-                return None, None
+                return None, cors_response(request, HttpResponse(status=status.HTTP_204_NO_CONTENT))
 
             return (
                 build_csp_event(
@@ -200,7 +202,7 @@ def process_csp_report(request):
                     total_violations=len(violations_props),
                     sample_rate=sample_rate,
                 )
-                return None, None
+                return None, cors_response(request, HttpResponse(status=status.HTTP_204_NO_CONTENT))
 
             return [
                 build_csp_event(prop, distinct_id, session_id, version, user_agent) for prop in sampled_violations

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -2727,3 +2727,40 @@ class TestCapture(BaseTest):
 
         assert status.HTTP_204_NO_CONTENT == response.status_code
         mock_logger.exception.assert_called_once()
+
+    def test_csp_sampled_out_report_uri_does_not_return_400(self):
+        csp_report = {
+            "csp-report": {
+                "document-uri": "https://example.com/foo/bar",
+                "violated-directive": "default-src self",
+            }
+        }
+
+        # Use 0% sampling rate to ensure report is sampled out
+        response = self.client.post(
+            f"/report/?token={self.team.api_token}&sample_rate=0.0",
+            data=json.dumps(csp_report),
+            content_type="application/csp-report",
+        )
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    def test_csp_sampled_out_report_to_does_not_return_400(self):
+        report_to_format = [
+            {
+                "type": "csp-violation",
+                "body": {
+                    "documentURL": "https://example.com/foo/bar",
+                    "effectiveDirective": "script-src",
+                },
+            }
+        ]
+
+        # Use 0% sampling rate to ensure report is sampled out
+        response = self.client.post(
+            f"/report/?token={self.team.api_token}&sample_rate=0.0",
+            data=json.dumps(report_to_format),
+            content_type="application/reports+json",
+        )
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT

--- a/posthog/api/test/test_csp.py
+++ b/posthog/api/test/test_csp.py
@@ -501,7 +501,6 @@ class TestCSPModule(TestCase):
         result, error = process_csp_report(request)
 
         assert result is None
-        assert error is not None  # Should return 204 No Content response
         assert error.status_code == 204
         mock_logger.warning.assert_called_with(
             "CSP report sampled out - report-uri format",
@@ -531,7 +530,6 @@ class TestCSPModule(TestCase):
         result, error = process_csp_report(request)
 
         assert result is None
-        assert error is not None  # Should return 204 No Content response
         assert error.status_code == 204
         mock_logger.warning.assert_called_with(
             "CSP report sampled out - report-to format",

--- a/posthog/api/test/test_csp.py
+++ b/posthog/api/test/test_csp.py
@@ -501,7 +501,8 @@ class TestCSPModule(TestCase):
         result, error = process_csp_report(request)
 
         assert result is None
-        assert error is None
+        assert error is not None  # Should return 204 No Content response
+        assert error.status_code == 204
         mock_logger.warning.assert_called_with(
             "CSP report sampled out - report-uri format",
             document_url="https://example.com/foo/bar",
@@ -530,7 +531,8 @@ class TestCSPModule(TestCase):
         result, error = process_csp_report(request)
 
         assert result is None
-        assert error is None
+        assert error is not None  # Should return 204 No Content response
+        assert error.status_code == 204
         mock_logger.warning.assert_called_with(
             "CSP report sampled out - report-to format",
             total_violations=1,


### PR DESCRIPTION
## Problem

When a CSP report is sampled out in `process_csp_report`, it returns `None, None` because we wanted to be extra safe not to change the ingestion pipeline. 

The thing is that we are making it execute for those cases, as we were reusing the same structure, it was treating this as an empty JSON request and trying to do `get_data(request)` as a regular event ingestion.

To fix it, when it is fully sampled out, return a 204. This is still on our CSP-only land, so it should not mess up ingestion.

https://github.com/PostHog/posthog/blob/bc3c18a758299e92b24f0f8905466b3b4190b722/posthog/api/capture.py#L481-L484

## Changes

- Return a 204 for fully sampled out requests to keep up with browser standards

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Manually with the CSP playground sandbox and unit tests.