### PR TITLE
fix: Add some missing taxonomy definitions

### DIFF
--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -324,6 +324,11 @@
             "examples": ["free goodies"],
             "label": "Initial UTM term"
         },
+        "$config_defaults": {
+            "description": "The version of the PostHog config defaults that were used when capturing the event.",
+            "label": "Config defaults",
+            "type": "String"
+        },
         "$configured_session_timeout_ms": {
             "description": "Configured session timeout in milliseconds.",
             "examples": ["1800000"],
@@ -1433,6 +1438,11 @@
             "description": "The timezone as reported by the device",
             "label": "Timezone"
         },
+        "$timezone_offset": {
+            "description": "The timezone offset, as reported by the device. Minutes difference from UTC.",
+            "label": "Timezone offset",
+            "type": "Numeric"
+        },
         "$touch_x": {
             "description": "The location of a Touch event on the X axis",
             "label": "Touch X"
@@ -2128,6 +2138,11 @@
             "description": "UTM term. (First-touch, session-scoped)",
             "examples": ["free goodies"],
             "label": "Initial UTM term"
+        },
+        "$config_defaults": {
+            "description": "The version of the PostHog config defaults that were used when capturing the event.",
+            "label": "Config defaults",
+            "type": "String"
         },
         "$configured_session_timeout_ms": {
             "description": "Configured session timeout in milliseconds.",
@@ -3529,6 +3544,11 @@
         "$timezone": {
             "description": "The timezone as reported by the device",
             "label": "Timezone"
+        },
+        "$timezone_offset": {
+            "description": "The timezone offset, as reported by the device. Minutes difference from UTC.",
+            "label": "Timezone offset",
+            "type": "Numeric"
         },
         "$touch_x": {
             "description": "The location of a Touch event on the X axis",

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -318,6 +318,11 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         },
     },
     "event_properties": {
+        "$config_defaults": {
+            "label": "Config defaults",
+            "description": "The version of the PostHog config defaults that were used when capturing the event.",
+            "type": "String",
+        },
         "$python_runtime": {
             "label": "Python runtime",
             "description": "The Python runtime that was used to capture the event.",
@@ -974,6 +979,11 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         "$timezone": {
             "label": "Timezone",
             "description": "The timezone as reported by the device",
+        },
+        "$timezone_offset": {
+            "label": "Timezone offset",
+            "description": "The timezone offset, as reported by the device. Minutes difference from UTC.",
+            "type": "Numeric",
         },
         "$touch_x": {
             "label": "Touch X",


### PR DESCRIPTION


## Problem

We're missing some property definitions

## Changes

Add them :)

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Checked them out locally