### PR TITLE
fix(project-tree): bring back pinned dashboards

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -32,6 +32,7 @@ import { RefObject, useEffect, useRef, useState } from 'react'
 import { navigation3000Logic } from '~/layout/navigation-3000/navigationLogic'
 import { NewMenu } from '~/layout/panel-layout/menus/NewMenu'
 import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
+import { DashboardsMenuItems } from '~/layout/panel-layout/ProjectTree/menus/DashboardsMenuItems'
 import { projectTreeDataLogic } from '~/layout/panel-layout/ProjectTree/projectTreeDataLogic'
 import { FileSystemEntry } from '~/queries/schema/schema-general'
 import { UserBasicType } from '~/types'
@@ -175,6 +176,11 @@ export function ProjectTree({
             ) : item.record?.protocol === 'products://' && item.name === 'Session replay' ? (
                 <>
                     <SessionReplayMenuItems MenuItem={MenuItem} MenuSeparator={MenuSeparator} />
+                    <MenuSeparator />
+                </>
+            ) : item.record?.protocol === 'products://' && item.name === 'Dashboards' ? (
+                <>
+                    <DashboardsMenuItems MenuItem={MenuItem} MenuSeparator={MenuSeparator} />
                     <MenuSeparator />
                 </>
             ) : null


### PR DESCRIPTION
## Changes

Restore pinned dashboards in this menu:

<img width="417" alt="image" src="https://github.com/user-attachments/assets/a36a1250-ef46-4302-a581-8cde22e65644" />

