### PR TITLE
chore: open screenshot editor for exports to all

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/exports/SidePanelExports.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/exports/SidePanelExports.tsx
@@ -7,7 +7,7 @@ import { takeScreenshotLogic } from 'lib/components/TakeScreenshot/takeScreensho
 import { dayjs } from 'lib/dayjs'
 import { IconRefresh, IconWithCount } from 'lib/lemon-ui/icons'
 
-import { ExportedAssetType } from '~/types'
+import { ExportedAssetType, ExporterFormat } from '~/types'
 
 import { SidePanelPaneHeader } from '../../components/SidePanelPaneHeader'
 import { sidePanelExportsLogic } from './sidePanelExportsLogic'
@@ -78,16 +78,18 @@ const ExportsContent = (): JSX.Element => {
                                 </div>
                             </div>
                             <div className="flex gap-2 mr-2">
-                                <LemonButton
-                                    tooltip="Edit"
-                                    size="small"
-                                    disabledReason={disabledReason}
-                                    type={isNotDownloaded ? 'primary' : 'secondary'}
-                                    icon={<IconPencil />}
-                                    onClick={() => {
-                                        void handleEdit(asset)
-                                    }}
-                                />
+                                {asset.export_format === ExporterFormat.PNG && (
+                                    <LemonButton
+                                        tooltip="Edit"
+                                        size="small"
+                                        disabledReason={disabledReason}
+                                        type={isNotDownloaded ? 'primary' : 'secondary'}
+                                        icon={<IconPencil />}
+                                        onClick={() => {
+                                            void handleEdit(asset)
+                                        }}
+                                    />
+                                )}
                                 <LemonButton
                                     tooltip="Download"
                                     size="small"

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/exports/SidePanelExports.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/exports/SidePanelExports.tsx
@@ -4,10 +4,8 @@ import { useActions, useValues } from 'kea'
 import { downloadExportedAsset, exportedAssetBlob } from 'lib/components/ExportButton/exporter'
 import { ScreenShotEditor } from 'lib/components/TakeScreenshot/ScreenShotEditor'
 import { takeScreenshotLogic } from 'lib/components/TakeScreenshot/takeScreenshotLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { IconRefresh, IconWithCount } from 'lib/lemon-ui/icons'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { ExportedAssetType } from '~/types'
 
@@ -26,7 +24,6 @@ export const SidePanelExportsIcon = (): JSX.Element => {
 const ExportsContent = (): JSX.Element => {
     const { exports, freshUndownloadedExports } = useValues(sidePanelExportsLogic)
     const { loadExports, removeFresh } = useActions(sidePanelExportsLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
     const { setBlob } = useActions(takeScreenshotLogic({ screenshotKey: 'exports' }))
 
     const handleEdit = async (asset: ExportedAssetType): Promise<void> => {
@@ -38,90 +35,6 @@ const ExportsContent = (): JSX.Element => {
         setBlob(r)
     }
 
-    if (featureFlags[FEATURE_FLAGS.SCREENSHOT_EDITOR]) {
-        return (
-            <div className="flex flex-col flex-1 overflow-hidden">
-                <div className="flex-1 overflow-y-auto p-2">
-                    <div className="flex justify-end">
-                        <LemonButton onClick={loadExports} type="tertiary" size="small" icon={<IconRefresh />}>
-                            Refresh
-                        </LemonButton>
-                    </div>
-
-                    <ScreenShotEditor screenshotKey="exports" />
-
-                    {exports.map((asset) => {
-                        const isNotDownloaded = freshUndownloadedExports.some((fresh) => fresh.id === asset.id)
-                        const stillCalculating = !asset.has_content && !asset.exception
-                        let disabledReason: string | undefined = undefined
-                        if (asset.exception) {
-                            disabledReason = asset.exception
-                        } else if (!asset.has_content) {
-                            disabledReason = 'Export not ready yet'
-                        }
-
-                        return (
-                            <div
-                                className="flex justify-between mt-2 gap-2 border rounded bg-fill-primary items-center"
-                                key={asset.id}
-                            >
-                                <div className="flex items-center justify-between flex-auto p-2">
-                                    <div>
-                                        <span className="text-link font-medium block">{asset.filename}</span>
-                                        {asset.created_at && (
-                                            <span className="text-xs mt-1">{dayjs(asset.created_at).fromNow()}</span>
-                                        )}
-                                        {asset.expires_after && (
-                                            <span className="text-xs text-secondary mt-1">
-                                                {' '}
-                                                · expires {dayjs(asset.expires_after).fromNow()}
-                                            </span>
-                                        )}
-                                        {isNotDownloaded && (
-                                            <span className="text-xs text-secondary mt-1"> · not downloaded yet</span>
-                                        )}
-                                    </div>
-                                </div>
-                                <div className="flex gap-2 mr-2">
-                                    <LemonButton
-                                        tooltip="Edit"
-                                        size="small"
-                                        disabledReason={disabledReason}
-                                        type={isNotDownloaded ? 'primary' : 'secondary'}
-                                        icon={<IconPencil />}
-                                        onClick={() => {
-                                            void handleEdit(asset)
-                                        }}
-                                    />
-                                    <LemonButton
-                                        tooltip="Download"
-                                        size="small"
-                                        type={isNotDownloaded ? 'primary' : 'secondary'}
-                                        key={asset.id}
-                                        disabledReason={disabledReason}
-                                        onClick={() => {
-                                            removeFresh(asset)
-                                            void downloadExportedAsset(asset)
-                                        }}
-                                        sideIcon={
-                                            stillCalculating ? (
-                                                <Spinner />
-                                            ) : asset.has_content ? (
-                                                <IconDownload className="text-link" />
-                                            ) : (
-                                                <IconWarning className="text-link" />
-                                            )
-                                        }
-                                    />
-                                </div>
-                            </div>
-                        )
-                    })}
-                </div>
-            </div>
-        )
-    }
-
     return (
         <div className="flex flex-col flex-1 overflow-hidden">
             <div className="flex-1 overflow-y-auto p-2">
@@ -131,6 +44,7 @@ const ExportsContent = (): JSX.Element => {
                     </LemonButton>
                 </div>
 
+                <ScreenShotEditor screenshotKey="exports" />
                 {exports.map((asset) => {
                     const isNotDownloaded = freshUndownloadedExports.some((fresh) => fresh.id === asset.id)
                     const stillCalculating = !asset.has_content && !asset.exception
@@ -142,37 +56,59 @@ const ExportsContent = (): JSX.Element => {
                     }
 
                     return (
-                        <div className="mt-2" key={asset.id}>
-                            <LemonButton
-                                type={isNotDownloaded ? 'primary' : 'secondary'}
-                                fullWidth
-                                disabledReason={disabledReason}
-                                onClick={() => {
-                                    removeFresh(asset)
-                                    void downloadExportedAsset(asset)
-                                }}
-                                sideIcon={asset.has_content ? <IconDownload className="text-link" /> : undefined}
-                            >
-                                <div className="flex items-center justify-between flex-auto p-2">
-                                    <div>
-                                        <span className="text-link font-medium block">{asset.filename}</span>
-                                        {asset.created_at && (
-                                            <span className="text-xs mt-1">{dayjs(asset.created_at).fromNow()}</span>
-                                        )}
-                                        {asset.expires_after && (
-                                            <span className="text-xs text-secondary mt-1">
-                                                {' '}
-                                                · expires {dayjs(asset.expires_after).fromNow()}
-                                            </span>
-                                        )}
-                                        {isNotDownloaded && (
-                                            <span className="text-xs text-secondary mt-1"> · not downloaded yet</span>
-                                        )}
-                                    </div>
-                                    <div>{stillCalculating && <Spinner />}</div>
-                                    <div>{asset.exception && <IconWarning className="text-link" />}</div>
+                        <div
+                            className="flex justify-between mt-2 gap-2 border rounded bg-fill-primary items-center"
+                            key={asset.id}
+                        >
+                            <div className="flex items-center justify-between flex-auto p-2">
+                                <div>
+                                    <span className="text-link font-medium block">{asset.filename}</span>
+                                    {asset.created_at && (
+                                        <span className="text-xs mt-1">{dayjs(asset.created_at).fromNow()}</span>
+                                    )}
+                                    {asset.expires_after && (
+                                        <span className="text-xs text-secondary mt-1">
+                                            {' '}
+                                            · expires {dayjs(asset.expires_after).fromNow()}
+                                        </span>
+                                    )}
+                                    {isNotDownloaded && (
+                                        <span className="text-xs text-secondary mt-1"> · not downloaded yet</span>
+                                    )}
                                 </div>
-                            </LemonButton>
+                            </div>
+                            <div className="flex gap-2 mr-2">
+                                <LemonButton
+                                    tooltip="Edit"
+                                    size="small"
+                                    disabledReason={disabledReason}
+                                    type={isNotDownloaded ? 'primary' : 'secondary'}
+                                    icon={<IconPencil />}
+                                    onClick={() => {
+                                        void handleEdit(asset)
+                                    }}
+                                />
+                                <LemonButton
+                                    tooltip="Download"
+                                    size="small"
+                                    type={isNotDownloaded ? 'primary' : 'secondary'}
+                                    key={asset.id}
+                                    disabledReason={disabledReason}
+                                    onClick={() => {
+                                        removeFresh(asset)
+                                        void downloadExportedAsset(asset)
+                                    }}
+                                    sideIcon={
+                                        stillCalculating ? (
+                                            <Spinner />
+                                        ) : asset.has_content ? (
+                                            <IconDownload className="text-link" />
+                                        ) : (
+                                            <IconWarning className="text-link" />
+                                        )
+                                    }
+                                />
+                            </div>
                         </div>
                     )
                 })}


### PR DESCRIPTION
Tests show that Screenshot editor works 10/10 with images in Export.

Let's open it to everyone.

But we keep Heatmaps behind the FF as with HTML it sometimes does not work.