### PR TITLE
feat(experiments): frequentist UI variant tooltips

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/legacy/ChartEmptyState.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/legacy/ChartEmptyState.tsx
@@ -1,7 +1,8 @@
 import { IconActivity, IconClock } from '@posthog/icons'
 import { LemonTag } from '@posthog/lemon-ui'
 
-import { EXPERIMENT_MIN_EXPOSURES_FOR_RESULTS } from '../../constants'
+import { EXPERIMENT_MIN_EXPOSURES_FOR_RESULTS } from '~/scenes/experiments/constants'
+
 import { ErrorChecklist } from './ErrorChecklist'
 
 interface ChartEmptyStateProps {

--- a/frontend/src/scenes/experiments/MetricsView/legacy/ChartModal.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/legacy/ChartModal.tsx
@@ -6,11 +6,10 @@ import {
     ExperimentTrendsQuery,
     NodeKind,
 } from '~/queries/schema/schema-general'
+import { ExploreButton, ResultsQuery } from '~/scenes/experiments/ExperimentView/components'
+import { SignificanceText, WinningVariantText } from '~/scenes/experiments/ExperimentView/Overview'
+import { SummaryTable } from '~/scenes/experiments/ExperimentView/SummaryTable'
 import { ExperimentIdType } from '~/types'
-
-import { ExploreButton, ResultsQuery } from '../../ExperimentView/components'
-import { SignificanceText, WinningVariantText } from '../../ExperimentView/Overview'
-import { SummaryTable } from '../../ExperimentView/SummaryTable'
 
 interface ChartModalProps {
     isOpen: boolean

--- a/frontend/src/scenes/experiments/MetricsView/new/Chart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/Chart.tsx
@@ -2,7 +2,9 @@ import { ExperimentVariantResultFrequentist } from '~/queries/schema/schema-gene
 
 import { VIEW_BOX_WIDTH } from './constants'
 import { GridLines } from './GridLines'
+import { useTooltipHover } from './useTooltipHover'
 import { VariantBar } from './VariantBar'
+import { VariantTooltip } from './VariantTooltip'
 
 export function Chart({
     chartSvgRef,
@@ -21,6 +23,8 @@ export function Chart({
     tickValues: number[]
     isSecondary: boolean
 }): JSX.Element {
+    const { showTooltip, hideTooltip, showTooltipFromTooltip, isTooltipVisible } = useTooltipHover()
+
     return (
         <div className="relative w-full">
             <div className="flex justify-center">
@@ -34,19 +38,36 @@ export function Chart({
                         {/* Vertical grid lines */}
                         <GridLines tickValues={tickValues} chartRadius={chartRadius} chartHeight={chartHeight} />
                     </g>
-                    {/* Variant bars */}
-                    {variantResults.map((variant: any, index: number) => (
-                        <VariantBar
-                            key={variant.key}
-                            variant={variant}
-                            index={index}
-                            chartRadius={chartRadius}
-                            metricIndex={metricIndex}
-                            isSecondary={isSecondary}
-                        />
-                    ))}
+                    <g className="variant-bars-layer">
+                        {/* Variant bars */}
+                        {variantResults.map((variantResult: any, index: number) => (
+                            <VariantBar
+                                key={`variant-bar-${variantResult.key}`}
+                                variantResult={variantResult}
+                                index={index}
+                                chartRadius={chartRadius}
+                                metricIndex={metricIndex}
+                                isSecondary={isSecondary}
+                                onMouseEnter={() => showTooltip(variantResult.key)}
+                                onMouseLeave={hideTooltip}
+                            />
+                        ))}
+                    </g>
                 </svg>
             </div>
+
+            {variantResults.map((variantResult: any, index: number) => (
+                <VariantTooltip
+                    key={`tooltip-${variantResult.key}`}
+                    variantResult={variantResult}
+                    index={index}
+                    chartRadius={chartRadius}
+                    chartSvgRef={chartSvgRef}
+                    isVisible={isTooltipVisible(variantResult.key)}
+                    onMouseEnter={() => showTooltipFromTooltip(variantResult.key)}
+                    onMouseLeave={hideTooltip}
+                />
+            ))}
         </div>
     )
 }

--- a/frontend/src/scenes/experiments/MetricsView/new/Chart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/Chart.tsx
@@ -40,7 +40,7 @@ export function Chart({
                     </g>
                     <g className="variant-bars-layer">
                         {/* Variant bars */}
-                        {variantResults.map((variantResult: any, index: number) => (
+                        {variantResults.map((variantResult: ExperimentVariantResultFrequentist, index: number) => (
                             <VariantBar
                                 key={`variant-bar-${variantResult.key}`}
                                 variantResult={variantResult}
@@ -56,7 +56,7 @@ export function Chart({
                 </svg>
             </div>
 
-            {variantResults.map((variantResult: any, index: number) => (
+            {variantResults.map((variantResult: ExperimentVariantResultFrequentist, index: number) => (
                 <VariantTooltip
                     key={`tooltip-${variantResult.key}`}
                     variantResult={variantResult}

--- a/frontend/src/scenes/experiments/MetricsView/new/VariantBar.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/VariantBar.tsx
@@ -5,19 +5,23 @@ import { valueToXCoordinate } from '../shared/utils'
 import { BAR_HEIGHT, BAR_SPACING, SVG_EDGE_MARGIN, VIEW_BOX_WIDTH } from './constants'
 
 export function VariantBar({
-    variant,
+    variantResult,
     index,
     chartRadius,
     metricIndex,
     isSecondary,
+    onMouseEnter,
+    onMouseLeave,
 }: {
-    variant: ExperimentVariantResultFrequentist
+    variantResult: ExperimentVariantResultFrequentist
     index: number
     chartRadius: number
     metricIndex: number
     isSecondary: boolean
+    onMouseEnter: () => void
+    onMouseLeave: () => void
 }): JSX.Element {
-    const interval = variant.confidence_interval
+    const interval = variantResult.confidence_interval
 
     const [lower, upper] = interval ? [interval[0], interval[1]] : [0, 0]
 
@@ -35,7 +39,7 @@ export function VariantBar({
     const deltaX = valueToXCoordinate(delta, chartRadius, VIEW_BOX_WIDTH, SVG_EDGE_MARGIN)
 
     return (
-        <g key={variant.key}>
+        <g key={variantResult.key} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} className="cursor-pointer">
             {hasEnoughData ? (
                 <>
                     {/* Variant name */}
@@ -47,11 +51,11 @@ export function VariantBar({
                         dominantBaseline="middle"
                         fill="var(--text-secondary)"
                     >
-                        {variant.key}
+                        {variantResult.key}
                     </text>
 
                     {/* Confidence interval bar */}
-                    {variant.key === 'control' ? (
+                    {variantResult.key === 'control' ? (
                         <rect
                             x={x1}
                             y={y}
@@ -66,7 +70,7 @@ export function VariantBar({
                         <>
                             <defs>
                                 <linearGradient
-                                    id={`gradient-${metricIndex}-${variant.key}-${
+                                    id={`gradient-${metricIndex}-${variantResult.key}-${
                                         isSecondary ? 'secondary' : 'primary'
                                     }`}
                                     x1="0"
@@ -100,7 +104,7 @@ export function VariantBar({
                                 y={y}
                                 width={x2 - x1}
                                 height={BAR_HEIGHT}
-                                fill={`url(#gradient-${metricIndex}-${variant.key}-${
+                                fill={`url(#gradient-${metricIndex}-${variantResult.key}-${
                                     isSecondary ? 'secondary' : 'primary'
                                 })`}
                             />
@@ -113,7 +117,9 @@ export function VariantBar({
                         y1={y}
                         x2={deltaX}
                         y2={y + BAR_HEIGHT}
-                        stroke={variant.key === 'control' ? colors.BAR_MIDDLE_POINT_CONTROL : colors.BAR_MIDDLE_POINT}
+                        stroke={
+                            variantResult.key === 'control' ? colors.BAR_MIDDLE_POINT_CONTROL : colors.BAR_MIDDLE_POINT
+                        }
                         strokeWidth={2}
                         shapeRendering="crispEdges"
                     />
@@ -129,7 +135,7 @@ export function VariantBar({
                         dominantBaseline="middle"
                         fill="var(--text-secondary)"
                     >
-                        {variant.key}
+                        {variantResult.key}
                     </text>
 
                     {/* "Not enough data" message */}

--- a/frontend/src/scenes/experiments/MetricsView/new/VariantTooltip.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/VariantTooltip.tsx
@@ -1,0 +1,113 @@
+import { ExperimentVariantResultFrequentist } from '~/queries/schema/schema-general'
+
+import { formatPValue, valueToXCoordinate } from '../shared/utils'
+import { BAR_HEIGHT, BAR_SPACING, SVG_EDGE_MARGIN, VIEW_BOX_WIDTH } from './constants'
+
+interface VariantTooltipProps {
+    variantResult: ExperimentVariantResultFrequentist
+    index: number
+    chartRadius: number
+    chartSvgRef: React.RefObject<SVGSVGElement>
+    isVisible: boolean
+    onMouseEnter?: () => void
+    onMouseLeave?: () => void
+}
+
+export function VariantTooltip({
+    variantResult,
+    index,
+    chartRadius,
+    chartSvgRef,
+    isVisible,
+    onMouseEnter,
+    onMouseLeave,
+}: VariantTooltipProps): JSX.Element | null {
+    if (!isVisible || !chartSvgRef.current) {
+        return null
+    }
+
+    // Calculate SVG coordinates (same as VariantBar)
+    const interval = variantResult.confidence_interval
+    const [lower, upper] = interval ? [interval[0], interval[1]] : [0, 0]
+
+    const y = BAR_SPACING + (BAR_HEIGHT + BAR_SPACING) * index
+    const x1 = valueToXCoordinate(lower, chartRadius, VIEW_BOX_WIDTH, SVG_EDGE_MARGIN)
+    const x2 = valueToXCoordinate(upper, chartRadius, VIEW_BOX_WIDTH, SVG_EDGE_MARGIN)
+
+    // Calculate middle of the bar
+    const barCenterX = (x1 + x2) / 2
+    const barTopY = y
+
+    // Convert SVG coordinates to screen coordinates
+    const svgRect = chartSvgRef.current.getBoundingClientRect()
+    const svgViewBox = chartSvgRef.current.viewBox.baseVal
+
+    const screenX = svgRect.left + (barCenterX / svgViewBox.width) * svgRect.width
+    const screenY = svgRect.top + (barTopY / svgViewBox.height) * svgRect.height
+
+    const confidenceIntervalPercent = interval ? `[${(lower * 100).toFixed(2)}%, ${(upper * 100).toFixed(2)}%]` : 'N/A'
+
+    return (
+        <div
+            className="fixed -translate-x-1/2 -translate-y-full bg-[var(--bg-surface-primary)] border border-[var(--border-primary)] px-3 py-2 rounded-md text-[13px] shadow-md z-[100] min-w-[300px]"
+            // eslint-disable-next-line react/forbid-dom-props
+            style={{
+                left: screenX,
+                top: screenY - 10,
+                pointerEvents: 'auto',
+            }}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
+        >
+            <div className="flex flex-col gap-1">
+                <div className="font-semibold">{variantResult.key}</div>
+
+                <div className="flex justify-between items-center">
+                    <span className="text-secondary font-semibold">Samples:</span>
+                    <span className="font-semibold">{variantResult.number_of_samples}</span>
+                </div>
+
+                <div className="flex justify-between items-center">
+                    <span className="text-secondary font-semibold">Sum:</span>
+                    <span className="font-semibold">{variantResult.sum}</span>
+                </div>
+
+                <div className="flex justify-between items-center">
+                    <span className="text-secondary font-semibold">P-value:</span>
+                    <span className="font-semibold">{formatPValue(variantResult.p_value)}</span>
+                </div>
+
+                <div className="flex justify-between items-center">
+                    <span className="text-secondary font-semibold">Significant:</span>
+                    <span className={`font-semibold ${variantResult.significant ? 'text-success' : 'text-muted'}`}>
+                        {variantResult.significant ? 'Yes' : 'No'}
+                    </span>
+                </div>
+
+                <div className="flex justify-between items-center">
+                    <span className="text-secondary font-semibold">Delta:</span>
+                    <span className="font-semibold">
+                        {variantResult.key === 'control' ? (
+                            <em className="text-secondary">Baseline</em>
+                        ) : (
+                            (() => {
+                                const deltaPercent = interval ? ((lower + upper) / 2) * 100 : 0
+                                const isPositive = deltaPercent > 0
+                                return (
+                                    <span className={isPositive ? 'text-success' : 'text-danger'}>
+                                        {`${isPositive ? '+' : ''}${deltaPercent.toFixed(2)}%`}
+                                    </span>
+                                )
+                            })()
+                        )}
+                    </span>
+                </div>
+
+                <div className="flex justify-between items-center">
+                    <span className="text-secondary font-semibold">Confidence interval:</span>
+                    <span className="font-semibold">{confidenceIntervalPercent}</span>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/experiments/MetricsView/new/VariantTooltip.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/VariantTooltip.tsx
@@ -3,16 +3,6 @@ import { ExperimentVariantResultFrequentist } from '~/queries/schema/schema-gene
 import { formatPValue, valueToXCoordinate } from '../shared/utils'
 import { BAR_HEIGHT, BAR_SPACING, SVG_EDGE_MARGIN, VIEW_BOX_WIDTH } from './constants'
 
-interface VariantTooltipProps {
-    variantResult: ExperimentVariantResultFrequentist
-    index: number
-    chartRadius: number
-    chartSvgRef: React.RefObject<SVGSVGElement>
-    isVisible: boolean
-    onMouseEnter?: () => void
-    onMouseLeave?: () => void
-}
-
 export function VariantTooltip({
     variantResult,
     index,
@@ -21,7 +11,15 @@ export function VariantTooltip({
     isVisible,
     onMouseEnter,
     onMouseLeave,
-}: VariantTooltipProps): JSX.Element | null {
+}: {
+    variantResult: ExperimentVariantResultFrequentist
+    index: number
+    chartRadius: number
+    chartSvgRef: React.RefObject<SVGSVGElement>
+    isVisible: boolean
+    onMouseEnter?: () => void
+    onMouseLeave?: () => void
+}): JSX.Element | null {
     if (!isVisible || !chartSvgRef.current) {
         return null
     }

--- a/frontend/src/scenes/experiments/MetricsView/new/useTooltipHover.ts
+++ b/frontend/src/scenes/experiments/MetricsView/new/useTooltipHover.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 export function useTooltipHover(): {
     showTooltip: (variantKey: string) => void
@@ -38,6 +38,15 @@ export function useTooltipHover(): {
     const isTooltipVisible = (variantKey: string): boolean => {
         return hoveredVariant === variantKey || hoveredTooltip === variantKey
     }
+
+    // Cleanup timeout on unmount to prevent memory leaks
+    useEffect(() => {
+        return () => {
+            if (hideTimeoutRef.current) {
+                clearTimeout(hideTimeoutRef.current)
+            }
+        }
+    }, [])
 
     return {
         showTooltip,

--- a/frontend/src/scenes/experiments/MetricsView/new/useTooltipHover.ts
+++ b/frontend/src/scenes/experiments/MetricsView/new/useTooltipHover.ts
@@ -1,0 +1,48 @@
+import { useRef, useState } from 'react'
+
+export function useTooltipHover(): {
+    showTooltip: (variantKey: string) => void
+    hideTooltip: () => void
+    showTooltipFromTooltip: (variantKey: string) => void
+    isTooltipVisible: (variantKey: string) => boolean
+} {
+    const [hoveredVariant, setHoveredVariant] = useState<string | null>(null)
+    const [hoveredTooltip, setHoveredTooltip] = useState<string | null>(null)
+    const hideTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+
+    const showTooltip = (variantKey: string): void => {
+        if (hideTimeoutRef.current) {
+            clearTimeout(hideTimeoutRef.current)
+            hideTimeoutRef.current = null
+        }
+        setHoveredVariant(variantKey)
+        setHoveredTooltip(null)
+    }
+
+    const hideTooltip = (): void => {
+        hideTimeoutRef.current = setTimeout(() => {
+            setHoveredVariant(null)
+            setHoveredTooltip(null)
+        }, 150)
+    }
+
+    const showTooltipFromTooltip = (variantKey: string): void => {
+        if (hideTimeoutRef.current) {
+            clearTimeout(hideTimeoutRef.current)
+            hideTimeoutRef.current = null
+        }
+        setHoveredTooltip(variantKey)
+        setHoveredVariant(null)
+    }
+
+    const isTooltipVisible = (variantKey: string): boolean => {
+        return hoveredVariant === variantKey || hoveredTooltip === variantKey
+    }
+
+    return {
+        showTooltip,
+        hideTooltip,
+        showTooltipFromTooltip,
+        isTooltipVisible,
+    }
+}

--- a/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
+++ b/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
@@ -121,3 +121,18 @@ export function getNiceTickValues(maxAbsValue: number, tickRangeFactor: number =
     }
     return ticks
 }
+
+export function formatPValue(pValue: number | null | undefined): string {
+    if (!pValue) {
+        return 'N/A'
+    }
+
+    if (pValue < 0.001) {
+        // Use scientific notation for very small p-values
+        return `< 0.001`
+    } else if (pValue < 0.01) {
+        // Show 4 decimal places for small p-values
+        return pValue.toFixed(4)
+    }
+    return pValue.toFixed(3)
+}

--- a/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
+++ b/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
@@ -129,7 +129,7 @@ export function formatPValue(pValue: number | null | undefined): string {
 
     if (pValue < 0.001) {
         // Use scientific notation for very small p-values
-        return `< 0.001`
+        return '< 0.001'
     } else if (pValue < 0.01) {
         // Show 4 decimal places for small p-values
         return pValue.toFixed(4)


### PR DESCRIPTION
## Changes
Another iteration of the frequentist UI: adding variant-level tooltips to display detailed results.

As opposed to the legacy implementation, I'm rendering a separate tooltip for each variant bar. This is less brittle and easier to reason about than the old implementation, where we were rendering a single tooltip and sending updates to it on hover. The tooltip handles its positioning internally using similar calculations to that of the variant bar.

The tooltip renders the information from variant results. We probably want more fields here, like "mean" or "conversion rate" depending on the metric. This info is not yet present in the variant result, so not rendering it for now, and just rendered what I saw in the result object.

<img width="1190" alt="image" src="https://github.com/user-attachments/assets/7f01e844-56fc-4727-a97e-543c97b44202" />

## How did you test this code?
👀 