### PR TITLE
feat(csp): add minute to sampling key

### DIFF
--- a/posthog/api/test/test_csp.py
+++ b/posthog/api/test/test_csp.py
@@ -602,12 +602,12 @@ class TestCSPModule(TestCase):
 
         # Verify sampling keys are different due to time component
         assert sampling_key1 != sampling_key2
-        assert "2023-01-01T12:00:00" in sampling_key1
-        assert "2023-01-01T12:01:00" in sampling_key2
+        assert sampling_key1 is not None and "2023-01-01T12:00:00" in sampling_key1
+        assert sampling_key2 is not None and "2023-01-01T12:01:00" in sampling_key2
 
         # Both should contain the URL
-        assert "https://example.com/page" in sampling_key1
-        assert "https://example.com/page" in sampling_key2
+        assert sampling_key1 is not None and "https://example.com/page" in sampling_key1
+        assert sampling_key2 is not None and "https://example.com/page" in sampling_key2
 
     @patch("posthog.api.csp.datetime")
     def test_sampling_consistency_within_same_minute(self, mock_datetime):


### PR DESCRIPTION
## Problem

As discussed [here](https://github.com/PostHog/posthog/pull/32868#discussion_r2114747186), we are dropping entire URL reports, so instead let's add the minute to the sampling key so we will hash over that minute.

## Changes

- Add the datetime minute so for that specific minute we sample it or not instead of always having the same hash result per url.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [x] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

Manually and using the new tests