### PR TITLE
fix: filters background on the new session replay UI

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/Playlist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/Playlist.tsx
@@ -243,7 +243,9 @@ export function Playlist({
                 )}
                 {featureFlags[FEATURE_FLAGS.REPLAY_FILTERS_IN_PLAYLIST] === 'new' &&
                     isFiltersExpanded &&
-                    filterContent && <div className="bg-white border rounded-md p-2 w-full">{filterContent}</div>}
+                    filterContent && (
+                        <div className="bg-surface-primary border rounded-md p-2 w-full">{filterContent}</div>
+                    )}
             </div>
         </>
     )


### PR DESCRIPTION
## Problem

fixes the background in the new filters UI for session replay for dark mode 

## Changes

| Before | After |
|--------|--------|
| ![CleanShot 2025-06-10 at 17 41 06@2x](https://github.com/user-attachments/assets/82254e22-bc44-49af-b22e-0d6dba8c5586) | <img width="905" alt="image" src="https://github.com/user-attachments/assets/7be909d6-cc7f-4e1d-8231-710df3b2a4e3" /> | 

## Did you write or update any docs for this change?

- [x] No docs needed for this change

## How did you test this code?

tested locally