### PR TITLE
feat: Filter Rev Analytics by source using generic filter

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -17560,12 +17560,9 @@
                 },
                 "response": {
                     "$ref": "#/definitions/RevenueAnalyticsGrowthRateQueryResponse"
-                },
-                "revenueSources": {
-                    "$ref": "#/definitions/RevenueSources"
                 }
             },
-            "required": ["kind", "properties", "revenueSources"],
+            "required": ["kind", "properties"],
             "type": "object"
         },
         "RevenueAnalyticsBaseQuery<RevenueAnalyticsInsightsQueryResponse>": {
@@ -17586,12 +17583,9 @@
                 },
                 "response": {
                     "$ref": "#/definitions/RevenueAnalyticsInsightsQueryResponse"
-                },
-                "revenueSources": {
-                    "$ref": "#/definitions/RevenueSources"
                 }
             },
-            "required": ["kind", "properties", "revenueSources"],
+            "required": ["kind", "properties"],
             "type": "object"
         },
         "RevenueAnalyticsBaseQuery<RevenueAnalyticsOverviewQueryResponse>": {
@@ -17612,12 +17606,9 @@
                 },
                 "response": {
                     "$ref": "#/definitions/RevenueAnalyticsOverviewQueryResponse"
-                },
-                "revenueSources": {
-                    "$ref": "#/definitions/RevenueSources"
                 }
             },
-            "required": ["kind", "properties", "revenueSources"],
+            "required": ["kind", "properties"],
             "type": "object"
         },
         "RevenueAnalyticsBaseQuery<RevenueAnalyticsTopCustomersQueryResponse>": {
@@ -17638,12 +17629,9 @@
                 },
                 "response": {
                     "$ref": "#/definitions/RevenueAnalyticsTopCustomersQueryResponse"
-                },
-                "revenueSources": {
-                    "$ref": "#/definitions/RevenueSources"
                 }
             },
-            "required": ["kind", "properties", "revenueSources"],
+            "required": ["kind", "properties"],
             "type": "object"
         },
         "RevenueAnalyticsConfig": {
@@ -17726,12 +17714,9 @@
                 },
                 "response": {
                     "$ref": "#/definitions/RevenueAnalyticsGrowthRateQueryResponse"
-                },
-                "revenueSources": {
-                    "$ref": "#/definitions/RevenueSources"
                 }
             },
-            "required": ["kind", "properties", "revenueSources"],
+            "required": ["kind", "properties"],
             "type": "object"
         },
         "RevenueAnalyticsGrowthRateQueryResponse": {
@@ -17796,12 +17781,9 @@
                 },
                 "response": {
                     "$ref": "#/definitions/RevenueAnalyticsInsightsQueryResponse"
-                },
-                "revenueSources": {
-                    "$ref": "#/definitions/RevenueSources"
                 }
             },
-            "required": ["groupBy", "interval", "kind", "properties", "revenueSources"],
+            "required": ["groupBy", "interval", "kind", "properties"],
             "type": "object"
         },
         "RevenueAnalyticsInsightsQueryGroupBy": {
@@ -17881,12 +17863,9 @@
                 },
                 "response": {
                     "$ref": "#/definitions/RevenueAnalyticsOverviewQueryResponse"
-                },
-                "revenueSources": {
-                    "$ref": "#/definitions/RevenueSources"
                 }
             },
-            "required": ["kind", "properties", "revenueSources"],
+            "required": ["kind", "properties"],
             "type": "object"
         },
         "RevenueAnalyticsOverviewQueryResponse": {
@@ -17980,12 +17959,9 @@
                 },
                 "response": {
                     "$ref": "#/definitions/RevenueAnalyticsTopCustomersQueryResponse"
-                },
-                "revenueSources": {
-                    "$ref": "#/definitions/RevenueSources"
                 }
             },
-            "required": ["groupBy", "kind", "properties", "revenueSources"],
+            "required": ["groupBy", "kind", "properties"],
             "type": "object"
         },
         "RevenueAnalyticsTopCustomersQueryResponse": {
@@ -18179,25 +18155,6 @@
                 }
             },
             "required": ["results"],
-            "type": "object"
-        },
-        "RevenueSources": {
-            "additionalProperties": false,
-            "properties": {
-                "dataWarehouseSources": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "events": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": ["dataWarehouseSources", "events"],
             "type": "object"
         },
         "RootAssistantMessage": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1883,15 +1883,6 @@ export type RevenueAnalyticsPropertyFilters = RevenueAnalyticsPropertyFilter[]
 export interface RevenueAnalyticsBaseQuery<R extends Record<string, any>> extends DataNode<R> {
     dateRange?: DateRange
     properties: RevenueAnalyticsPropertyFilters
-    revenueSources: RevenueSources
-}
-
-export interface RevenueSources {
-    // These represent the IDs we're interested in from the data warehouse sources
-    dataWarehouseSources: string[]
-
-    // This is a list of strings that represent the event names we're interested in
-    events: string[]
 }
 
 export type RevenueAnalyticsInsightsQueryGroupBy = 'all' | 'product' | 'cohort'

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -3846,6 +3846,11 @@
             "description": "The product of the revenue event.",
             "label": "Product",
             "type": "String"
+        },
+        "source": {
+            "description": "The source of the revenue event - either an event or a Data Warehouse integration.",
+            "label": "Source",
+            "type": "String"
         }
     },
     "session_properties": {

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -665,6 +665,8 @@ def create_expr_for_revenue_analytics_property(property: RevenueAnalyticsPropert
         return ast.Field(chain=[RevenueAnalyticsInvoiceItemView.get_generic_view_alias(), "amount"])
     elif property.key == "cohort":
         return ast.Field(chain=[RevenueAnalyticsCustomerView.get_generic_view_alias(), "cohort"])
+    elif property.key == "source":
+        return ast.Field(chain=[RevenueAnalyticsInvoiceItemView.get_generic_view_alias(), "source_label"])
     else:
         raise QueryError(f"Revenue analytics property filter key {property.key} not implemented")
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1847,14 +1847,6 @@ class RevenueCurrencyPropertyConfig(BaseModel):
     static: Optional[CurrencyCode] = None
 
 
-class RevenueSources(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    dataWarehouseSources: list[str]
-    events: list[str]
-
-
 class RootAssistantMessage1(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -7375,7 +7367,6 @@ class RevenueAnalyticsBaseQueryRevenueAnalyticsGrowthRateQueryResponse(BaseModel
     )
     properties: list[RevenueAnalyticsPropertyFilter]
     response: Optional[RevenueAnalyticsGrowthRateQueryResponse] = None
-    revenueSources: RevenueSources
 
 
 class RevenueAnalyticsBaseQueryRevenueAnalyticsInsightsQueryResponse(BaseModel):
@@ -7389,7 +7380,6 @@ class RevenueAnalyticsBaseQueryRevenueAnalyticsInsightsQueryResponse(BaseModel):
     )
     properties: list[RevenueAnalyticsPropertyFilter]
     response: Optional[RevenueAnalyticsInsightsQueryResponse] = None
-    revenueSources: RevenueSources
 
 
 class RevenueAnalyticsBaseQueryRevenueAnalyticsOverviewQueryResponse(BaseModel):
@@ -7403,7 +7393,6 @@ class RevenueAnalyticsBaseQueryRevenueAnalyticsOverviewQueryResponse(BaseModel):
     )
     properties: list[RevenueAnalyticsPropertyFilter]
     response: Optional[RevenueAnalyticsOverviewQueryResponse] = None
-    revenueSources: RevenueSources
 
 
 class RevenueAnalyticsBaseQueryRevenueAnalyticsTopCustomersQueryResponse(BaseModel):
@@ -7417,7 +7406,6 @@ class RevenueAnalyticsBaseQueryRevenueAnalyticsTopCustomersQueryResponse(BaseMod
     )
     properties: list[RevenueAnalyticsPropertyFilter]
     response: Optional[RevenueAnalyticsTopCustomersQueryResponse] = None
-    revenueSources: RevenueSources
 
 
 class RevenueAnalyticsConfig(BaseModel):
@@ -7439,7 +7427,6 @@ class RevenueAnalyticsGrowthRateQuery(BaseModel):
     )
     properties: list[RevenueAnalyticsPropertyFilter]
     response: Optional[RevenueAnalyticsGrowthRateQueryResponse] = None
-    revenueSources: RevenueSources
 
 
 class RevenueAnalyticsInsightsQuery(BaseModel):
@@ -7455,7 +7442,6 @@ class RevenueAnalyticsInsightsQuery(BaseModel):
     )
     properties: list[RevenueAnalyticsPropertyFilter]
     response: Optional[RevenueAnalyticsInsightsQueryResponse] = None
-    revenueSources: RevenueSources
 
 
 class RevenueAnalyticsOverviewQuery(BaseModel):
@@ -7469,7 +7455,6 @@ class RevenueAnalyticsOverviewQuery(BaseModel):
     )
     properties: list[RevenueAnalyticsPropertyFilter]
     response: Optional[RevenueAnalyticsOverviewQueryResponse] = None
-    revenueSources: RevenueSources
 
 
 class RevenueAnalyticsTopCustomersQuery(BaseModel):
@@ -7484,7 +7469,6 @@ class RevenueAnalyticsTopCustomersQuery(BaseModel):
     )
     properties: list[RevenueAnalyticsPropertyFilter]
     response: Optional[RevenueAnalyticsTopCustomersQueryResponse] = None
-    revenueSources: RevenueSources
 
 
 class RevenueExampleDataWarehouseTablesQuery(BaseModel):

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -2116,6 +2116,11 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "description": "The cohort of the customer connected to the revenue event.",
             "type": "String",
         },
+        "source": {
+            "label": "Source",
+            "description": "The source of the revenue event - either an event or a Data Warehouse integration.",
+            "type": "String",
+        },
     },
 }
 

--- a/products/revenue_analytics/backend/api.py
+++ b/products/revenue_analytics/backend/api.py
@@ -8,7 +8,11 @@ from posthog.exceptions_capture import capture_exception
 from posthog.hogql import ast
 from posthog.hogql.database.database import create_hogql_database
 from posthog.hogql.query import execute_hogql_query
-from products.revenue_analytics.backend.utils import revenue_selects_from_database
+from products.revenue_analytics.backend.utils import (
+    REVENUE_SELECT_OUTPUT_CUSTOMER_KEY,
+    REVENUE_SELECT_OUTPUT_PRODUCT_KEY,
+    revenue_selects_from_database,
+)
 
 
 class RevenueAnalyticsTaxonomyViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
@@ -25,7 +29,9 @@ class RevenueAnalyticsTaxonomyViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
         if key == "product":  # All products available from revenue analytics
             revenue_selects = revenue_selects_from_database(database)
             product_selects = [
-                select["product"] for select in revenue_selects.values() if select["product"] is not None
+                select[REVENUE_SELECT_OUTPUT_PRODUCT_KEY]
+                for select in revenue_selects.values()
+                if select[REVENUE_SELECT_OUTPUT_PRODUCT_KEY] is not None
             ]
             product_selects_union = ast.SelectSetQuery.create_from_queries(product_selects, set_operator="UNION ALL")
 
@@ -38,7 +44,9 @@ class RevenueAnalyticsTaxonomyViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
         elif key == "cohort":  # All cohorts available from revenue analytics
             revenue_selects = revenue_selects_from_database(database)
             customer_selects = [
-                select["customer"] for select in revenue_selects.values() if select["customer"] is not None
+                select[REVENUE_SELECT_OUTPUT_CUSTOMER_KEY]
+                for select in revenue_selects.values()
+                if select[REVENUE_SELECT_OUTPUT_CUSTOMER_KEY] is not None
             ]
             customer_selects_union = ast.SelectSetQuery.create_from_queries(customer_selects, set_operator="UNION ALL")
 

--- a/products/revenue_analytics/backend/api.py
+++ b/products/revenue_analytics/backend/api.py
@@ -1,3 +1,4 @@
+from typing import cast
 from rest_framework.viewsets import GenericViewSet
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
@@ -28,8 +29,8 @@ class RevenueAnalyticsTaxonomyViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
         values = []
         if key == "product":  # All products available from revenue analytics
             revenue_selects = revenue_selects_from_database(database)
-            product_selects = [
-                select[REVENUE_SELECT_OUTPUT_PRODUCT_KEY]
+            product_selects: list[ast.SelectQuery] = [
+                cast(ast.SelectQuery, select[REVENUE_SELECT_OUTPUT_PRODUCT_KEY])
                 for select in revenue_selects.values()
                 if select[REVENUE_SELECT_OUTPUT_PRODUCT_KEY] is not None
             ]
@@ -43,8 +44,8 @@ class RevenueAnalyticsTaxonomyViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
             )
         elif key == "cohort":  # All cohorts available from revenue analytics
             revenue_selects = revenue_selects_from_database(database)
-            customer_selects = [
-                select[REVENUE_SELECT_OUTPUT_CUSTOMER_KEY]
+            customer_selects: list[ast.SelectQuery] = [
+                cast(ast.SelectQuery, select[REVENUE_SELECT_OUTPUT_CUSTOMER_KEY])
                 for select in revenue_selects.values()
                 if select[REVENUE_SELECT_OUTPUT_CUSTOMER_KEY] is not None
             ]

--- a/products/revenue_analytics/backend/api.py
+++ b/products/revenue_analytics/backend/api.py
@@ -21,6 +21,7 @@ class RevenueAnalyticsTaxonomyViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
         database = create_hogql_database(team=self.team)
 
         query = None
+        values = []
         if key == "product":  # All products available from revenue analytics
             revenue_selects = revenue_selects_from_database(database)
             product_selects = [
@@ -47,8 +48,10 @@ class RevenueAnalyticsTaxonomyViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
                 select_from=ast.JoinExpr(table=customer_selects_union),
                 order_by=[ast.OrderExpr(expr=ast.Field(chain=["cohort"]), order="ASC")],
             )
+        elif key == "source":  # All sources available from revenue analytics
+            revenue_selects = revenue_selects_from_database(database)
+            values = list(revenue_selects.keys())
 
-        values = []
         if query is not None:
             try:
                 result = execute_hogql_query(query, team=self.team)

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_query_runner.py
@@ -12,7 +12,13 @@ from posthog.schema import (
     RevenueAnalyticsOverviewQuery,
     RevenueAnalyticsTopCustomersQuery,
 )
-from products.revenue_analytics.backend.utils import revenue_selects_from_database
+from products.revenue_analytics.backend.utils import (
+    REVENUE_SELECT_OUTPUT_CHARGE_KEY,
+    REVENUE_SELECT_OUTPUT_CUSTOMER_KEY,
+    REVENUE_SELECT_OUTPUT_INVOICE_ITEM_KEY,
+    REVENUE_SELECT_OUTPUT_PRODUCT_KEY,
+    revenue_selects_from_database,
+)
 from products.revenue_analytics.backend.views.revenue_analytics_invoice_item_view import RevenueAnalyticsInvoiceItemView
 from products.revenue_analytics.backend.views.revenue_analytics_product_view import RevenueAnalyticsProductView
 from products.revenue_analytics.backend.views.revenue_analytics_customer_view import RevenueAnalyticsCustomerView
@@ -115,18 +121,24 @@ class RevenueAnalyticsQueryRunner(QueryRunnerWithHogQLContext):
     ]:
         # Remove the view name because it's not useful for the select query
         parsed_charge_selects = [
-            selects["charge"] for _, selects in self.revenue_selects.items() if selects["charge"] is not None
+            selects[REVENUE_SELECT_OUTPUT_CHARGE_KEY]
+            for _, selects in self.revenue_selects.items()
+            if selects[REVENUE_SELECT_OUTPUT_CHARGE_KEY] is not None
         ]
         parsed_customer_selects = [
-            selects["customer"] for _, selects in self.revenue_selects.items() if selects["customer"] is not None
+            selects[REVENUE_SELECT_OUTPUT_CUSTOMER_KEY]
+            for _, selects in self.revenue_selects.items()
+            if selects[REVENUE_SELECT_OUTPUT_CUSTOMER_KEY] is not None
         ]
         parsed_invoice_item_selects = [
-            selects["invoice_item"]
+            selects[REVENUE_SELECT_OUTPUT_INVOICE_ITEM_KEY]
             for _, selects in self.revenue_selects.items()
-            if selects["invoice_item"] is not None
+            if selects[REVENUE_SELECT_OUTPUT_INVOICE_ITEM_KEY] is not None
         ]
         parsed_product_selects = [
-            selects["product"] for _, selects in self.revenue_selects.items() if selects["product"] is not None
+            selects[REVENUE_SELECT_OUTPUT_PRODUCT_KEY]
+            for _, selects in self.revenue_selects.items()
+            if selects[REVENUE_SELECT_OUTPUT_PRODUCT_KEY] is not None
         ]
 
         return (

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_query_runner.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from datetime import datetime
-from typing import Optional, Union
+from typing import Optional, Union, cast
 from posthog.hogql.property import property_to_expr
 from posthog.hogql_queries.query_runner import QueryRunnerWithHogQLContext
 from posthog.hogql import ast
@@ -120,23 +120,23 @@ class RevenueAnalyticsQueryRunner(QueryRunnerWithHogQLContext):
         ast.SelectSetQuery | None, ast.SelectSetQuery | None, ast.SelectSetQuery | None, ast.SelectSetQuery | None
     ]:
         # Remove the view name because it's not useful for the select query
-        parsed_charge_selects = [
-            selects[REVENUE_SELECT_OUTPUT_CHARGE_KEY]
+        parsed_charge_selects: list[ast.SelectQuery] = [
+            cast(ast.SelectQuery, selects[REVENUE_SELECT_OUTPUT_CHARGE_KEY])
             for _, selects in self.revenue_selects.items()
             if selects[REVENUE_SELECT_OUTPUT_CHARGE_KEY] is not None
         ]
-        parsed_customer_selects = [
-            selects[REVENUE_SELECT_OUTPUT_CUSTOMER_KEY]
+        parsed_customer_selects: list[ast.SelectQuery] = [
+            cast(ast.SelectQuery, selects[REVENUE_SELECT_OUTPUT_CUSTOMER_KEY])
             for _, selects in self.revenue_selects.items()
             if selects[REVENUE_SELECT_OUTPUT_CUSTOMER_KEY] is not None
         ]
-        parsed_invoice_item_selects = [
-            selects[REVENUE_SELECT_OUTPUT_INVOICE_ITEM_KEY]
+        parsed_invoice_item_selects: list[ast.SelectQuery] = [
+            cast(ast.SelectQuery, selects[REVENUE_SELECT_OUTPUT_INVOICE_ITEM_KEY])
             for _, selects in self.revenue_selects.items()
             if selects[REVENUE_SELECT_OUTPUT_INVOICE_ITEM_KEY] is not None
         ]
-        parsed_product_selects = [
-            selects[REVENUE_SELECT_OUTPUT_PRODUCT_KEY]
+        parsed_product_selects: list[ast.SelectQuery] = [
+            cast(ast.SelectQuery, selects[REVENUE_SELECT_OUTPUT_PRODUCT_KEY])
             for _, selects in self.revenue_selects.items()
             if selects[REVENUE_SELECT_OUTPUT_PRODUCT_KEY] is not None
         ]

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_query_runner.py
@@ -105,7 +105,7 @@ class RevenueAnalyticsQueryRunner(QueryRunnerWithHogQLContext):
 
     @cached_property
     def revenue_selects(self) -> defaultdict[str, dict[str, ast.SelectQuery | None]]:
-        return revenue_selects_from_database(self.database, self.query.revenueSources)
+        return revenue_selects_from_database(self.database)
 
     @cached_property
     def revenue_subqueries(

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_top_customers_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_top_customers_query_runner.py
@@ -64,7 +64,7 @@ class RevenueAnalyticsTopCustomersQueryRunner(RevenueAnalyticsQueryRunner):
             select_from.next_join = ast.JoinExpr(
                 table=customer_subquery,
                 alias=RevenueAnalyticsCustomerView.get_generic_view_alias(),
-                join_type="INNER JOIN",
+                join_type="LEFT JOIN",
                 constraint=ast.JoinConstraint(
                     constraint_type="ON",
                     expr=ast.CompareOperation(

--- a/products/revenue_analytics/backend/hogql_queries/revenue_example_events_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_example_events_query_runner.py
@@ -76,7 +76,7 @@ class RevenueExampleEventsQueryRunner(QueryRunnerWithHogQLContext):
                                 constraint_type="ON",
                                 expr=ast.CompareOperation(
                                     op=CompareOperationOp.Eq,
-                                    left=ast.Field(chain=["events", "uuid"]),
+                                    left=ast.Call(name="toString", args=[ast.Field(chain=["events", "uuid"])]),
                                     right=ast.Field(chain=["view", "id"]),
                                 ),
                             ),

--- a/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_growth_rate_query_runner.ambr
+++ b/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_growth_rate_query_runner.ambr
@@ -1,8 +1,62 @@
 # serializer version: 1
 # name: TestRevenueAnalyticsGrowthRateQueryRunner.test_no_crash_when_no_data
   '''
-  SELECT 1
-  WHERE 0
+  SELECT revenue_with_growth.month AS month,
+         revenue_with_growth.revenue AS revenue,
+         revenue_with_growth.previous_month_revenue AS previous_month_revenue,
+         revenue_with_growth.month_over_month_growth_rate AS month_over_month_growth_rate,
+         avg(revenue_with_growth.month_over_month_growth_rate) OVER (
+                                                                     ORDER BY revenue_with_growth.month ASC ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) AS three_month_growth_rate,
+                                                                    avg(revenue_with_growth.month_over_month_growth_rate) OVER (
+                                                                                                                                ORDER BY revenue_with_growth.month ASC ROWS BETWEEN 5 PRECEDING AND CURRENT ROW) AS six_month_growth_rate
+  FROM
+    (SELECT monthly_revenue.month AS month,
+            monthly_revenue.revenue AS revenue,
+            lagInFrame(monthly_revenue.revenue, 1) OVER (
+                                                         ORDER BY monthly_revenue.month ASC) AS previous_month_revenue,
+                                                        divide(minus(monthly_revenue.revenue, previous_month_revenue), previous_month_revenue) AS month_over_month_growth_rate
+     FROM
+       (SELECT toStartOfMonth(revenue_analytics_invoice_item.timestamp) AS month,
+               sum(revenue_analytics_invoice_item.amount) AS revenue
+        FROM
+          (SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+           FROM
+             (SELECT toString(events.uuid) AS id,
+                     'revenue_analytics.purchase' AS source_label,
+                     toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                     NULL AS product_id,
+                     events.distinct_id AS customer_id,
+                     NULL AS invoice_id,
+                     toString(events.`$session_id`) AS session_id,
+                     events.event AS event_name,
+                     upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+                     accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                     1 AS enable_currency_aware_divider,
+                     if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                     divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                     'GBP' AS currency,
+                     if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+              FROM events
+              WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
+              ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
+        WHERE and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2015-01-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), 0))
+        GROUP BY month
+        ORDER BY month ASC) AS monthly_revenue) AS revenue_with_growth
+  ORDER BY revenue_with_growth.month ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -17,8 +71,105 @@
 # ---
 # name: TestRevenueAnalyticsGrowthRateQueryRunner.test_no_crash_when_no_source_is_selected
   '''
-  SELECT 1
-  WHERE 0
+  SELECT revenue_with_growth.month AS month,
+         revenue_with_growth.revenue AS revenue,
+         revenue_with_growth.previous_month_revenue AS previous_month_revenue,
+         revenue_with_growth.month_over_month_growth_rate AS month_over_month_growth_rate,
+         avg(revenue_with_growth.month_over_month_growth_rate) OVER (
+                                                                     ORDER BY revenue_with_growth.month ASC ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) AS three_month_growth_rate,
+                                                                    avg(revenue_with_growth.month_over_month_growth_rate) OVER (
+                                                                                                                                ORDER BY revenue_with_growth.month ASC ROWS BETWEEN 5 PRECEDING AND CURRENT ROW) AS six_month_growth_rate
+  FROM
+    (SELECT monthly_revenue.month AS month,
+            monthly_revenue.revenue AS revenue,
+            lagInFrame(monthly_revenue.revenue, 1) OVER (
+                                                         ORDER BY monthly_revenue.month ASC) AS previous_month_revenue,
+                                                        divide(minus(monthly_revenue.revenue, previous_month_revenue), previous_month_revenue) AS month_over_month_growth_rate
+     FROM
+       (SELECT toStartOfMonth(revenue_analytics_invoice_item.timestamp) AS month,
+               sum(revenue_analytics_invoice_item.amount) AS revenue
+        FROM
+          (SELECT `stripe.posthog_test.invoice_item_revenue_view`.id AS id,
+                  `stripe.posthog_test.invoice_item_revenue_view`.source_label AS source_label,
+                  `stripe.posthog_test.invoice_item_revenue_view`.timestamp AS timestamp,
+                  `stripe.posthog_test.invoice_item_revenue_view`.product_id AS product_id,
+                  `stripe.posthog_test.invoice_item_revenue_view`.customer_id AS customer_id,
+                  `stripe.posthog_test.invoice_item_revenue_view`.invoice_id AS invoice_id,
+                  `stripe.posthog_test.invoice_item_revenue_view`.session_id AS session_id,
+                  `stripe.posthog_test.invoice_item_revenue_view`.event_name AS event_name,
+                  `stripe.posthog_test.invoice_item_revenue_view`.original_currency AS original_currency,
+                  `stripe.posthog_test.invoice_item_revenue_view`.original_amount AS original_amount,
+                  `stripe.posthog_test.invoice_item_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                  `stripe.posthog_test.invoice_item_revenue_view`.currency_aware_divider AS currency_aware_divider,
+                  `stripe.posthog_test.invoice_item_revenue_view`.currency_aware_amount AS currency_aware_amount,
+                  `stripe.posthog_test.invoice_item_revenue_view`.currency AS currency,
+                  `stripe.posthog_test.invoice_item_revenue_view`.amount AS amount
+           FROM
+             (SELECT invoice.invoice_item_id AS id,
+                     'stripe.posthog_test' AS source_label,
+                     invoice.created_at AS timestamp,
+                     invoice.product_id AS product_id,
+                     invoice.customer_id AS customer_id,
+                     id AS invoice_id,
+                     NULL AS session_id,
+                     NULL AS event_name,
+                     upper(invoice.currency) AS original_currency,
+                     accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                     in(original_currency,
+                        ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                       if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                       divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                       'GBP' AS currency,
+                       if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))) AS amount
+              FROM
+                (SELECT posthog_test_stripe_invoice.id AS id,
+                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                        posthog_test_stripe_invoice.customer AS customer_id,
+                        arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                        JSONExtractString(data, 'id') AS invoice_item_id,
+                        JSONExtractString(data, 'amount') AS amount_captured,
+                        JSONExtractString(data, 'currency') AS currency,
+                        JSONExtractString(data, 'price', 'product') AS product_id
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.growth_rate_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                 WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+           UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+           FROM
+             (SELECT toString(events.uuid) AS id,
+                     'revenue_analytics.purchase' AS source_label,
+                     toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                     NULL AS product_id,
+                     events.distinct_id AS customer_id,
+                     NULL AS invoice_id,
+                     toString(events.`$session_id`) AS session_id,
+                     events.event AS event_name,
+                     upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+                     accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                     1 AS enable_currency_aware_divider,
+                     if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                     divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                     'GBP' AS currency,
+                     if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+              FROM events
+              WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
+              ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
+        WHERE and(and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2015-01-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), 0)), ifNull(equals(revenue_analytics_invoice_item.source_label, 'non-existent-source'), 0))
+        GROUP BY month
+        ORDER BY month ASC) AS monthly_revenue) AS revenue_with_growth
+  ORDER BY revenue_with_growth.month ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -93,7 +244,41 @@
                         JSONExtractString(data, 'currency') AS currency,
                         JSONExtractString(data, 'price', 'product') AS product_id
                  FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.growth_rate_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                 WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`) AS revenue_analytics_invoice_item
+                 WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+           UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+           FROM
+             (SELECT toString(events.uuid) AS id,
+                     'revenue_analytics.purchase' AS source_label,
+                     toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                     NULL AS product_id,
+                     events.distinct_id AS customer_id,
+                     NULL AS invoice_id,
+                     toString(events.`$session_id`) AS session_id,
+                     events.event AS event_name,
+                     upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+                     accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                     1 AS enable_currency_aware_divider,
+                     if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                     divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                     'GBP' AS currency,
+                     if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+              FROM events
+              WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
+              ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
         WHERE and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2015-01-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), 0))
         GROUP BY month
         ORDER BY month ASC) AS monthly_revenue) AS revenue_with_growth
@@ -172,7 +357,41 @@
                         JSONExtractString(data, 'currency') AS currency,
                         JSONExtractString(data, 'price', 'product') AS product_id
                  FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.growth_rate_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                 WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`) AS revenue_analytics_invoice_item
+                 WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+           UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+           FROM
+             (SELECT toString(events.uuid) AS id,
+                     'revenue_analytics.purchase' AS source_label,
+                     toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                     NULL AS product_id,
+                     events.distinct_id AS customer_id,
+                     NULL AS invoice_id,
+                     toString(events.`$session_id`) AS session_id,
+                     events.event AS event_name,
+                     upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+                     accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                     1 AS enable_currency_aware_divider,
+                     if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                     divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                     'GBP' AS currency,
+                     if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+              FROM events
+              WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
+              ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
         WHERE and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-02-03 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-04-04 23:59:59', 'UTC'))), 0))
         GROUP BY month
         ORDER BY month ASC) AS monthly_revenue) AS revenue_with_growth
@@ -251,7 +470,41 @@
                         JSONExtractString(data, 'currency') AS currency,
                         JSONExtractString(data, 'price', 'product') AS product_id
                  FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.growth_rate_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                 WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`) AS revenue_analytics_invoice_item
+                 WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+           UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+           FROM
+             (SELECT toString(events.uuid) AS id,
+                     'revenue_analytics.purchase' AS source_label,
+                     toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                     NULL AS product_id,
+                     events.distinct_id AS customer_id,
+                     NULL AS invoice_id,
+                     toString(events.`$session_id`) AS session_id,
+                     events.event AS event_name,
+                     upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+                     accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                     1 AS enable_currency_aware_divider,
+                     if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                     divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                     'GBP' AS currency,
+                     if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+              FROM events
+              WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
+              ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
         WHERE and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-01-02 23:59:59', 'UTC'))), 0))
         GROUP BY month
         ORDER BY month ASC) AS monthly_revenue) AS revenue_with_growth
@@ -288,23 +541,66 @@
        (SELECT toStartOfMonth(revenue_analytics_invoice_item.timestamp) AS month,
                sum(revenue_analytics_invoice_item.amount) AS revenue
         FROM
-          (SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+          (SELECT `stripe.posthog_test.invoice_item_revenue_view`.id AS id,
+                  `stripe.posthog_test.invoice_item_revenue_view`.source_label AS source_label,
+                  `stripe.posthog_test.invoice_item_revenue_view`.timestamp AS timestamp,
+                  `stripe.posthog_test.invoice_item_revenue_view`.product_id AS product_id,
+                  `stripe.posthog_test.invoice_item_revenue_view`.customer_id AS customer_id,
+                  `stripe.posthog_test.invoice_item_revenue_view`.invoice_id AS invoice_id,
+                  `stripe.posthog_test.invoice_item_revenue_view`.session_id AS session_id,
+                  `stripe.posthog_test.invoice_item_revenue_view`.event_name AS event_name,
+                  `stripe.posthog_test.invoice_item_revenue_view`.original_currency AS original_currency,
+                  `stripe.posthog_test.invoice_item_revenue_view`.original_amount AS original_amount,
+                  `stripe.posthog_test.invoice_item_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                  `stripe.posthog_test.invoice_item_revenue_view`.currency_aware_divider AS currency_aware_divider,
+                  `stripe.posthog_test.invoice_item_revenue_view`.currency_aware_amount AS currency_aware_amount,
+                  `stripe.posthog_test.invoice_item_revenue_view`.currency AS currency,
+                  `stripe.posthog_test.invoice_item_revenue_view`.amount AS amount
            FROM
-             (SELECT events.uuid AS id,
+             (SELECT invoice.invoice_item_id AS id,
+                     'stripe.posthog_test' AS source_label,
+                     invoice.created_at AS timestamp,
+                     invoice.product_id AS product_id,
+                     invoice.customer_id AS customer_id,
+                     id AS invoice_id,
+                     NULL AS session_id,
+                     NULL AS event_name,
+                     upper(invoice.currency) AS original_currency,
+                     accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                     in(original_currency,
+                        ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                       if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                       divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                       'GBP' AS currency,
+                       if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))) AS amount
+              FROM
+                (SELECT posthog_test_stripe_invoice.id AS id,
+                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                        posthog_test_stripe_invoice.customer AS customer_id,
+                        arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                        JSONExtractString(data, 'id') AS invoice_item_id,
+                        JSONExtractString(data, 'amount') AS amount_captured,
+                        JSONExtractString(data, 'currency') AS currency,
+                        JSONExtractString(data, 'price', 'product') AS product_id
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.growth_rate_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                 WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+           UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+           FROM
+             (SELECT toString(events.uuid) AS id,
                      'revenue_analytics.purchase' AS source_label,
                      toTimeZone(events.timestamp, 'UTC') AS timestamp,
                      NULL AS product_id,
@@ -321,10 +617,8 @@
                      if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
               FROM events
               WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
-              ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`
-           WHERE in(`revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name,
-                    ['purchase'])) AS revenue_analytics_invoice_item
-        WHERE and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2015-01-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), 0))
+              ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
+        WHERE and(and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2015-01-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), 0)), ifNull(equals(revenue_analytics_invoice_item.source_label, 'revenue_analytics.purchase'), 0))
         GROUP BY month
         ORDER BY month ASC) AS monthly_revenue) AS revenue_with_growth
   ORDER BY revenue_with_growth.month ASC
@@ -360,23 +654,66 @@
        (SELECT toStartOfMonth(revenue_analytics_invoice_item.timestamp) AS month,
                sum(revenue_analytics_invoice_item.amount) AS revenue
         FROM
-          (SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
-                  `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+          (SELECT `stripe.posthog_test.invoice_item_revenue_view`.id AS id,
+                  `stripe.posthog_test.invoice_item_revenue_view`.source_label AS source_label,
+                  `stripe.posthog_test.invoice_item_revenue_view`.timestamp AS timestamp,
+                  `stripe.posthog_test.invoice_item_revenue_view`.product_id AS product_id,
+                  `stripe.posthog_test.invoice_item_revenue_view`.customer_id AS customer_id,
+                  `stripe.posthog_test.invoice_item_revenue_view`.invoice_id AS invoice_id,
+                  `stripe.posthog_test.invoice_item_revenue_view`.session_id AS session_id,
+                  `stripe.posthog_test.invoice_item_revenue_view`.event_name AS event_name,
+                  `stripe.posthog_test.invoice_item_revenue_view`.original_currency AS original_currency,
+                  `stripe.posthog_test.invoice_item_revenue_view`.original_amount AS original_amount,
+                  `stripe.posthog_test.invoice_item_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                  `stripe.posthog_test.invoice_item_revenue_view`.currency_aware_divider AS currency_aware_divider,
+                  `stripe.posthog_test.invoice_item_revenue_view`.currency_aware_amount AS currency_aware_amount,
+                  `stripe.posthog_test.invoice_item_revenue_view`.currency AS currency,
+                  `stripe.posthog_test.invoice_item_revenue_view`.amount AS amount
            FROM
-             (SELECT events.uuid AS id,
+             (SELECT invoice.invoice_item_id AS id,
+                     'stripe.posthog_test' AS source_label,
+                     invoice.created_at AS timestamp,
+                     invoice.product_id AS product_id,
+                     invoice.customer_id AS customer_id,
+                     id AS invoice_id,
+                     NULL AS session_id,
+                     NULL AS event_name,
+                     upper(invoice.currency) AS original_currency,
+                     accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                     in(original_currency,
+                        ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                       if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                       divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                       'GBP' AS currency,
+                       if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))) AS amount
+              FROM
+                (SELECT posthog_test_stripe_invoice.id AS id,
+                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                        posthog_test_stripe_invoice.customer AS customer_id,
+                        arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                        JSONExtractString(data, 'id') AS invoice_item_id,
+                        JSONExtractString(data, 'amount') AS amount_captured,
+                        JSONExtractString(data, 'currency') AS currency,
+                        JSONExtractString(data, 'price', 'product') AS product_id
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.growth_rate_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                 WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+           UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+           FROM
+             (SELECT toString(events.uuid) AS id,
                      'revenue_analytics.purchase' AS source_label,
                      toTimeZone(events.timestamp, 'UTC') AS timestamp,
                      NULL AS product_id,
@@ -394,10 +731,8 @@
                        if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
               FROM events
               WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
-              ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`
-           WHERE in(`revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name,
-                    ['purchase'])) AS revenue_analytics_invoice_item
-        WHERE and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2015-01-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), 0))
+              ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
+        WHERE and(and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2015-01-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), 0)), ifNull(equals(revenue_analytics_invoice_item.source_label, 'revenue_analytics.purchase'), 0))
         GROUP BY month
         ORDER BY month ASC) AS monthly_revenue) AS revenue_with_growth
   ORDER BY revenue_with_growth.month ASC
@@ -475,7 +810,41 @@
                         JSONExtractString(data, 'currency') AS currency,
                         JSONExtractString(data, 'price', 'product') AS product_id
                  FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.growth_rate_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                 WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`) AS revenue_analytics_invoice_item
+                 WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+           UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                            `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+           FROM
+             (SELECT toString(events.uuid) AS id,
+                     'revenue_analytics.purchase' AS source_label,
+                     toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                     NULL AS product_id,
+                     events.distinct_id AS customer_id,
+                     NULL AS invoice_id,
+                     toString(events.`$session_id`) AS session_id,
+                     events.event AS event_name,
+                     upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+                     accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                     1 AS enable_currency_aware_divider,
+                     if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                     divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                     'GBP' AS currency,
+                     if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+              FROM events
+              WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
+              ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
         LEFT JOIN
           (SELECT `stripe.posthog_test.product_revenue_view`.id AS id,
                   `stripe.posthog_test.product_revenue_view`.source_label AS source_label,

--- a/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_insights_query_runner.ambr
+++ b/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_insights_query_runner.ambr
@@ -1,34 +1,169 @@
 # serializer version: 1
 # name: TestRevenueAnalyticsInsightsQueryRunner.test_no_crash_when_no_data
   '''
-  SELECT 1
-  WHERE 0
-  LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     format_csv_allow_double_quotes=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1
+  SELECT sum(amount) AS value,
+         day_start AS day_start,
+         breakdown_by AS breakdown_by
+  FROM
+    (SELECT revenue_analytics_invoice_item.source_label AS breakdown_by,
+            revenue_analytics_invoice_item.amount AS amount,
+            toStartOfMonth(revenue_analytics_invoice_item.timestamp) AS day_start
+     FROM
+       (SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+        FROM
+          (SELECT toString(events.uuid) AS id,
+                  'revenue_analytics.purchase' AS source_label,
+                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                  NULL AS product_id,
+                  events.distinct_id AS customer_id,
+                  NULL AS invoice_id,
+                  toString(events.`$session_id`) AS session_id,
+                  events.event AS event_name,
+                  upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                  1 AS enable_currency_aware_divider,
+                  if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                  divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                  'GBP' AS currency,
+                  if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+           FROM events
+           WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
+           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
+     WHERE and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2024-11-30 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), 0)))
+  GROUP BY day_start,
+           breakdown_by
+  ORDER BY day_start DESC,
+           value DESC,
+           breakdown_by ASC
+  LIMIT 10000 SETTINGS readonly=2,
+                       max_execution_time=60,
+                       allow_experimental_object_type=1,
+                       format_csv_allow_double_quotes=1,
+                       max_ast_elements=4000000,
+                       max_expanded_ast_elements=4000000,
+                       max_bytes_before_external_group_by=0,
+                       transform_null_in=1,
+                       optimize_min_equality_disjunction_chain_length=4294967295,
+                       allow_experimental_join_condition=1
   '''
 # ---
 # name: TestRevenueAnalyticsInsightsQueryRunner.test_no_crash_when_no_source_is_selected
   '''
-  SELECT 1
-  WHERE 0
-  LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     format_csv_allow_double_quotes=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1
+  SELECT sum(amount) AS value,
+         day_start AS day_start,
+         breakdown_by AS breakdown_by
+  FROM
+    (SELECT revenue_analytics_invoice_item.source_label AS breakdown_by,
+            revenue_analytics_invoice_item.amount AS amount,
+            toStartOfMonth(revenue_analytics_invoice_item.timestamp) AS day_start
+     FROM
+       (SELECT `stripe.posthog_test.invoice_item_revenue_view`.id AS id,
+               `stripe.posthog_test.invoice_item_revenue_view`.source_label AS source_label,
+               `stripe.posthog_test.invoice_item_revenue_view`.timestamp AS timestamp,
+               `stripe.posthog_test.invoice_item_revenue_view`.product_id AS product_id,
+               `stripe.posthog_test.invoice_item_revenue_view`.customer_id AS customer_id,
+               `stripe.posthog_test.invoice_item_revenue_view`.invoice_id AS invoice_id,
+               `stripe.posthog_test.invoice_item_revenue_view`.session_id AS session_id,
+               `stripe.posthog_test.invoice_item_revenue_view`.event_name AS event_name,
+               `stripe.posthog_test.invoice_item_revenue_view`.original_currency AS original_currency,
+               `stripe.posthog_test.invoice_item_revenue_view`.original_amount AS original_amount,
+               `stripe.posthog_test.invoice_item_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+               `stripe.posthog_test.invoice_item_revenue_view`.currency_aware_divider AS currency_aware_divider,
+               `stripe.posthog_test.invoice_item_revenue_view`.currency_aware_amount AS currency_aware_amount,
+               `stripe.posthog_test.invoice_item_revenue_view`.currency AS currency,
+               `stripe.posthog_test.invoice_item_revenue_view`.amount AS amount
+        FROM
+          (SELECT invoice.invoice_item_id AS id,
+                  'stripe.posthog_test' AS source_label,
+                  invoice.created_at AS timestamp,
+                  invoice.product_id AS product_id,
+                  invoice.customer_id AS customer_id,
+                  id AS invoice_id,
+                  NULL AS session_id,
+                  NULL AS event_name,
+                  upper(invoice.currency) AS original_currency,
+                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                  in(original_currency,
+                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                    'GBP' AS currency,
+                    if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))) AS amount
+           FROM
+             (SELECT posthog_test_stripe_invoice.id AS id,
+                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                     posthog_test_stripe_invoice.customer AS customer_id,
+                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                     JSONExtractString(data, 'id') AS invoice_item_id,
+                     JSONExtractString(data, 'amount') AS amount_captured,
+                     JSONExtractString(data, 'currency') AS currency,
+                     JSONExtractString(data, 'price', 'product') AS product_id
+              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+        UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+        FROM
+          (SELECT toString(events.uuid) AS id,
+                  'revenue_analytics.purchase' AS source_label,
+                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                  NULL AS product_id,
+                  events.distinct_id AS customer_id,
+                  NULL AS invoice_id,
+                  toString(events.`$session_id`) AS session_id,
+                  events.event AS event_name,
+                  upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                  1 AS enable_currency_aware_divider,
+                  if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                  divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                  'GBP' AS currency,
+                  if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+           FROM events
+           WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
+           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
+     WHERE and(and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2024-11-30 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), 0)), ifNull(equals(revenue_analytics_invoice_item.source_label, 'non-existent-source'), 0)))
+  GROUP BY day_start,
+           breakdown_by
+  ORDER BY day_start DESC,
+           value DESC,
+           breakdown_by ASC
+  LIMIT 10000 SETTINGS readonly=2,
+                       max_execution_time=60,
+                       allow_experimental_object_type=1,
+                       format_csv_allow_double_quotes=1,
+                       max_ast_elements=4000000,
+                       max_expanded_ast_elements=4000000,
+                       max_bytes_before_external_group_by=0,
+                       transform_null_in=1,
+                       optimize_min_equality_disjunction_chain_length=4294967295,
+                       allow_experimental_join_condition=1
   '''
 # ---
 # name: TestRevenueAnalyticsInsightsQueryRunner.test_with_data
@@ -83,7 +218,41 @@
                      JSONExtractString(data, 'currency') AS currency,
                      JSONExtractString(data, 'price', 'product') AS product_id
               FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`) AS revenue_analytics_invoice_item
+              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+        UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+        FROM
+          (SELECT toString(events.uuid) AS id,
+                  'revenue_analytics.purchase' AS source_label,
+                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                  NULL AS product_id,
+                  events.distinct_id AS customer_id,
+                  NULL AS invoice_id,
+                  toString(events.`$session_id`) AS session_id,
+                  events.event AS event_name,
+                  upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                  1 AS enable_currency_aware_divider,
+                  if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                  divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                  'GBP' AS currency,
+                  if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+           FROM events
+           WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
+           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
      WHERE and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2024-11-30 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), 0)))
   GROUP BY day_start,
            breakdown_by
@@ -154,7 +323,41 @@
                      JSONExtractString(data, 'currency') AS currency,
                      JSONExtractString(data, 'price', 'product') AS product_id
               FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`) AS revenue_analytics_invoice_item
+              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+        UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+        FROM
+          (SELECT toString(events.uuid) AS id,
+                  'revenue_analytics.purchase' AS source_label,
+                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                  NULL AS product_id,
+                  events.distinct_id AS customer_id,
+                  NULL AS invoice_id,
+                  toString(events.`$session_id`) AS session_id,
+                  events.event AS event_name,
+                  upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                  1 AS enable_currency_aware_divider,
+                  if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                  divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                  'GBP' AS currency,
+                  if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+           FROM events
+           WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
+           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
      WHERE and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-02-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-05-01 23:59:59', 'UTC'))), 0)))
   GROUP BY day_start,
            breakdown_by
@@ -225,7 +428,41 @@
                      JSONExtractString(data, 'currency') AS currency,
                      JSONExtractString(data, 'price', 'product') AS product_id
               FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`) AS revenue_analytics_invoice_item
+              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+        UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+        FROM
+          (SELECT toString(events.uuid) AS id,
+                  'revenue_analytics.purchase' AS source_label,
+                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                  NULL AS product_id,
+                  events.distinct_id AS customer_id,
+                  NULL AS invoice_id,
+                  toString(events.`$session_id`) AS session_id,
+                  events.event AS event_name,
+                  upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                  1 AS enable_currency_aware_divider,
+                  if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                  divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                  'GBP' AS currency,
+                  if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+           FROM events
+           WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
+           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
      LEFT JOIN
        (SELECT `stripe.posthog_test.customer_revenue_view`.id AS id,
                `stripe.posthog_test.customer_revenue_view`.source_label AS source_label,
@@ -321,7 +558,41 @@
                      JSONExtractString(data, 'currency') AS currency,
                      JSONExtractString(data, 'price', 'product') AS product_id
               FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`) AS revenue_analytics_invoice_item
+              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+        UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+        FROM
+          (SELECT toString(events.uuid) AS id,
+                  'revenue_analytics.purchase' AS source_label,
+                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                  NULL AS product_id,
+                  events.distinct_id AS customer_id,
+                  NULL AS invoice_id,
+                  toString(events.`$session_id`) AS session_id,
+                  events.event AS event_name,
+                  upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                  1 AS enable_currency_aware_divider,
+                  if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                  divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                  'GBP' AS currency,
+                  if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+           FROM events
+           WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
+           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
      LEFT JOIN
        (SELECT `stripe.posthog_test.product_revenue_view`.id AS id,
                `stripe.posthog_test.product_revenue_view`.source_label AS source_label,
@@ -401,7 +672,41 @@
                      JSONExtractString(data, 'currency') AS currency,
                      JSONExtractString(data, 'price', 'product') AS product_id
               FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`) AS revenue_analytics_invoice_item
+              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+        UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+        FROM
+          (SELECT toString(events.uuid) AS id,
+                  'revenue_analytics.purchase' AS source_label,
+                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                  NULL AS product_id,
+                  events.distinct_id AS customer_id,
+                  NULL AS invoice_id,
+                  toString(events.`$session_id`) AS session_id,
+                  events.event AS event_name,
+                  upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                  1 AS enable_currency_aware_divider,
+                  if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                  divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                  'GBP' AS currency,
+                  if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+           FROM events
+           WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
+           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
      WHERE and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2024-12-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2024-12-31 23:59:59', 'UTC'))), 0)))
   GROUP BY day_start,
            breakdown_by
@@ -430,23 +735,66 @@
             revenue_analytics_invoice_item.amount AS amount,
             toStartOfMonth(revenue_analytics_invoice_item.timestamp) AS day_start
      FROM
-       (SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+       (SELECT `stripe.posthog_test.invoice_item_revenue_view`.id AS id,
+               `stripe.posthog_test.invoice_item_revenue_view`.source_label AS source_label,
+               `stripe.posthog_test.invoice_item_revenue_view`.timestamp AS timestamp,
+               `stripe.posthog_test.invoice_item_revenue_view`.product_id AS product_id,
+               `stripe.posthog_test.invoice_item_revenue_view`.customer_id AS customer_id,
+               `stripe.posthog_test.invoice_item_revenue_view`.invoice_id AS invoice_id,
+               `stripe.posthog_test.invoice_item_revenue_view`.session_id AS session_id,
+               `stripe.posthog_test.invoice_item_revenue_view`.event_name AS event_name,
+               `stripe.posthog_test.invoice_item_revenue_view`.original_currency AS original_currency,
+               `stripe.posthog_test.invoice_item_revenue_view`.original_amount AS original_amount,
+               `stripe.posthog_test.invoice_item_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+               `stripe.posthog_test.invoice_item_revenue_view`.currency_aware_divider AS currency_aware_divider,
+               `stripe.posthog_test.invoice_item_revenue_view`.currency_aware_amount AS currency_aware_amount,
+               `stripe.posthog_test.invoice_item_revenue_view`.currency AS currency,
+               `stripe.posthog_test.invoice_item_revenue_view`.amount AS amount
         FROM
-          (SELECT events.uuid AS id,
+          (SELECT invoice.invoice_item_id AS id,
+                  'stripe.posthog_test' AS source_label,
+                  invoice.created_at AS timestamp,
+                  invoice.product_id AS product_id,
+                  invoice.customer_id AS customer_id,
+                  id AS invoice_id,
+                  NULL AS session_id,
+                  NULL AS event_name,
+                  upper(invoice.currency) AS original_currency,
+                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                  in(original_currency,
+                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                    'GBP' AS currency,
+                    if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))) AS amount
+           FROM
+             (SELECT posthog_test_stripe_invoice.id AS id,
+                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                     posthog_test_stripe_invoice.customer AS customer_id,
+                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                     JSONExtractString(data, 'id') AS invoice_item_id,
+                     JSONExtractString(data, 'amount') AS amount_captured,
+                     JSONExtractString(data, 'currency') AS currency,
+                     JSONExtractString(data, 'price', 'product') AS product_id
+              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+        UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+        FROM
+          (SELECT toString(events.uuid) AS id,
                   'revenue_analytics.purchase' AS source_label,
                   toTimeZone(events.timestamp, 'UTC') AS timestamp,
                   NULL AS product_id,
@@ -463,10 +811,8 @@
                   if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
            FROM events
            WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
-           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`
-        WHERE in(`revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name,
-                 ['purchase'])) AS revenue_analytics_invoice_item
-     WHERE and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2024-11-30 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), 0)))
+           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
+     WHERE and(and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2024-11-30 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), 0)), ifNull(equals(revenue_analytics_invoice_item.source_label, 'revenue_analytics.purchase'), 0)))
   GROUP BY day_start,
            breakdown_by
   ORDER BY day_start DESC,
@@ -494,23 +840,66 @@
             revenue_analytics_invoice_item.amount AS amount,
             toStartOfMonth(revenue_analytics_invoice_item.timestamp) AS day_start
      FROM
-       (SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+       (SELECT `stripe.posthog_test.invoice_item_revenue_view`.id AS id,
+               `stripe.posthog_test.invoice_item_revenue_view`.source_label AS source_label,
+               `stripe.posthog_test.invoice_item_revenue_view`.timestamp AS timestamp,
+               `stripe.posthog_test.invoice_item_revenue_view`.product_id AS product_id,
+               `stripe.posthog_test.invoice_item_revenue_view`.customer_id AS customer_id,
+               `stripe.posthog_test.invoice_item_revenue_view`.invoice_id AS invoice_id,
+               `stripe.posthog_test.invoice_item_revenue_view`.session_id AS session_id,
+               `stripe.posthog_test.invoice_item_revenue_view`.event_name AS event_name,
+               `stripe.posthog_test.invoice_item_revenue_view`.original_currency AS original_currency,
+               `stripe.posthog_test.invoice_item_revenue_view`.original_amount AS original_amount,
+               `stripe.posthog_test.invoice_item_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+               `stripe.posthog_test.invoice_item_revenue_view`.currency_aware_divider AS currency_aware_divider,
+               `stripe.posthog_test.invoice_item_revenue_view`.currency_aware_amount AS currency_aware_amount,
+               `stripe.posthog_test.invoice_item_revenue_view`.currency AS currency,
+               `stripe.posthog_test.invoice_item_revenue_view`.amount AS amount
         FROM
-          (SELECT events.uuid AS id,
+          (SELECT invoice.invoice_item_id AS id,
+                  'stripe.posthog_test' AS source_label,
+                  invoice.created_at AS timestamp,
+                  invoice.product_id AS product_id,
+                  invoice.customer_id AS customer_id,
+                  id AS invoice_id,
+                  NULL AS session_id,
+                  NULL AS event_name,
+                  upper(invoice.currency) AS original_currency,
+                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                  in(original_currency,
+                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                    'GBP' AS currency,
+                    if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))) AS amount
+           FROM
+             (SELECT posthog_test_stripe_invoice.id AS id,
+                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                     posthog_test_stripe_invoice.customer AS customer_id,
+                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                     JSONExtractString(data, 'id') AS invoice_item_id,
+                     JSONExtractString(data, 'amount') AS amount_captured,
+                     JSONExtractString(data, 'currency') AS currency,
+                     JSONExtractString(data, 'price', 'product') AS product_id
+              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+        UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+        FROM
+          (SELECT toString(events.uuid) AS id,
                   'revenue_analytics.purchase' AS source_label,
                   toTimeZone(events.timestamp, 'UTC') AS timestamp,
                   NULL AS product_id,
@@ -528,10 +917,8 @@
                     if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
            FROM events
            WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
-           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`
-        WHERE in(`revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name,
-                 ['purchase'])) AS revenue_analytics_invoice_item
-     WHERE and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2024-11-30 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), 0)))
+           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
+     WHERE and(and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2024-11-30 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), 0)), ifNull(equals(revenue_analytics_invoice_item.source_label, 'revenue_analytics.purchase'), 0)))
   GROUP BY day_start,
            breakdown_by
   ORDER BY day_start DESC,
@@ -601,7 +988,41 @@
                      JSONExtractString(data, 'currency') AS currency,
                      JSONExtractString(data, 'price', 'product') AS product_id
               FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`) AS revenue_analytics_invoice_item
+              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+        UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+        FROM
+          (SELECT toString(events.uuid) AS id,
+                  'revenue_analytics.purchase' AS source_label,
+                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                  NULL AS product_id,
+                  events.distinct_id AS customer_id,
+                  NULL AS invoice_id,
+                  toString(events.`$session_id`) AS session_id,
+                  events.event AS event_name,
+                  upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                  1 AS enable_currency_aware_divider,
+                  if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                  divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                  'GBP' AS currency,
+                  if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+           FROM events
+           WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
+           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
      LEFT JOIN
        (SELECT `stripe.posthog_test.product_revenue_view`.id AS id,
                `stripe.posthog_test.product_revenue_view`.source_label AS source_label,
@@ -681,7 +1102,41 @@
                      JSONExtractString(data, 'currency') AS currency,
                      JSONExtractString(data, 'price', 'product') AS product_id
               FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`) AS revenue_analytics_invoice_item
+              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+        UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+        FROM
+          (SELECT toString(events.uuid) AS id,
+                  'revenue_analytics.purchase' AS source_label,
+                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                  NULL AS product_id,
+                  events.distinct_id AS customer_id,
+                  NULL AS invoice_id,
+                  toString(events.`$session_id`) AS session_id,
+                  events.event AS event_name,
+                  upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                  1 AS enable_currency_aware_divider,
+                  if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                  divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                  'GBP' AS currency,
+                  if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+           FROM events
+           WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
+           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
      LEFT JOIN
        (SELECT `stripe.posthog_test.product_revenue_view`.id AS id,
                `stripe.posthog_test.product_revenue_view`.source_label AS source_label,

--- a/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_overview_query_runner.ambr
+++ b/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_overview_query_runner.ambr
@@ -1,9 +1,45 @@
 # serializer version: 1
 # name: TestRevenueAnalyticsOverviewQueryRunner.test_no_crash_when_no_data
   '''
-  SELECT 0 AS revenue,
-         0 AS paying_customer_count,
-         0 AS avg_revenue_per_customer
+  SELECT accurateCastOrNull(sum(revenue_analytics_invoice_item.amount), 'Decimal64(10)') AS revenue,
+         count(DISTINCT revenue_analytics_invoice_item.customer_id) AS paying_customer_count,
+         if(ifNull(equals(paying_customer_count, 0), 0), 0, ifNull(divideDecimal(revenue, accurateCastOrNull(paying_customer_count, 'Decimal64(10)')), 0)) AS avg_revenue_per_customer
+  FROM
+    (SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+            `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+            `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+            `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+            `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+            `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+            `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+            `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+            `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+            `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+            `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+            `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+     FROM
+       (SELECT toString(events.uuid) AS id,
+               'revenue_analytics.purchase' AS source_label,
+               toTimeZone(events.timestamp, 'UTC') AS timestamp,
+               NULL AS product_id,
+               events.distinct_id AS customer_id,
+               NULL AS invoice_id,
+               toString(events.`$session_id`) AS session_id,
+               events.event AS event_name,
+               upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+               accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+               1 AS enable_currency_aware_divider,
+               if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+               divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+               'GBP' AS currency,
+               if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+        FROM events
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
+        ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
+  WHERE and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-04-30 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), 0))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -64,7 +100,41 @@
                   JSONExtractString(data, 'currency') AS currency,
                   JSONExtractString(data, 'price', 'product') AS product_id
            FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.overview_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-           WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`) AS revenue_analytics_invoice_item
+           WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+     UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+     FROM
+       (SELECT toString(events.uuid) AS id,
+               'revenue_analytics.purchase' AS source_label,
+               toTimeZone(events.timestamp, 'UTC') AS timestamp,
+               NULL AS product_id,
+               events.distinct_id AS customer_id,
+               NULL AS invoice_id,
+               toString(events.`$session_id`) AS session_id,
+               events.event AS event_name,
+               upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+               accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+               1 AS enable_currency_aware_divider,
+               if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+               divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+               'GBP' AS currency,
+               if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+        FROM events
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
+        ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
   WHERE and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-04-30 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), 0))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -126,7 +196,41 @@
                   JSONExtractString(data, 'currency') AS currency,
                   JSONExtractString(data, 'price', 'product') AS product_id
            FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.overview_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-           WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`) AS revenue_analytics_invoice_item
+           WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+     UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+     FROM
+       (SELECT toString(events.uuid) AS id,
+               'revenue_analytics.purchase' AS source_label,
+               toTimeZone(events.timestamp, 'UTC') AS timestamp,
+               NULL AS product_id,
+               events.distinct_id AS customer_id,
+               NULL AS invoice_id,
+               toString(events.`$session_id`) AS session_id,
+               events.event AS event_name,
+               upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+               accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+               1 AS enable_currency_aware_divider,
+               if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+               divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+               'GBP' AS currency,
+               if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+        FROM events
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
+        ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
   WHERE and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-01-02 23:59:59', 'UTC'))), 0))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -146,23 +250,66 @@
          count(DISTINCT revenue_analytics_invoice_item.customer_id) AS paying_customer_count,
          if(ifNull(equals(paying_customer_count, 0), 0), 0, ifNull(divideDecimal(revenue, accurateCastOrNull(paying_customer_count, 'Decimal64(10)')), 0)) AS avg_revenue_per_customer
   FROM
-    (SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+    (SELECT `stripe.posthog_test.invoice_item_revenue_view`.id AS id,
+            `stripe.posthog_test.invoice_item_revenue_view`.source_label AS source_label,
+            `stripe.posthog_test.invoice_item_revenue_view`.timestamp AS timestamp,
+            `stripe.posthog_test.invoice_item_revenue_view`.product_id AS product_id,
+            `stripe.posthog_test.invoice_item_revenue_view`.customer_id AS customer_id,
+            `stripe.posthog_test.invoice_item_revenue_view`.invoice_id AS invoice_id,
+            `stripe.posthog_test.invoice_item_revenue_view`.session_id AS session_id,
+            `stripe.posthog_test.invoice_item_revenue_view`.event_name AS event_name,
+            `stripe.posthog_test.invoice_item_revenue_view`.original_currency AS original_currency,
+            `stripe.posthog_test.invoice_item_revenue_view`.original_amount AS original_amount,
+            `stripe.posthog_test.invoice_item_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+            `stripe.posthog_test.invoice_item_revenue_view`.currency_aware_divider AS currency_aware_divider,
+            `stripe.posthog_test.invoice_item_revenue_view`.currency_aware_amount AS currency_aware_amount,
+            `stripe.posthog_test.invoice_item_revenue_view`.currency AS currency,
+            `stripe.posthog_test.invoice_item_revenue_view`.amount AS amount
      FROM
-       (SELECT events.uuid AS id,
+       (SELECT invoice.invoice_item_id AS id,
+               'stripe.posthog_test' AS source_label,
+               invoice.created_at AS timestamp,
+               invoice.product_id AS product_id,
+               invoice.customer_id AS customer_id,
+               id AS invoice_id,
+               NULL AS session_id,
+               NULL AS event_name,
+               upper(invoice.currency) AS original_currency,
+               accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+               in(original_currency,
+                  ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                 if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                 divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                 'GBP' AS currency,
+                 if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))) AS amount
+        FROM
+          (SELECT posthog_test_stripe_invoice.id AS id,
+                  parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                  posthog_test_stripe_invoice.customer AS customer_id,
+                  arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                  JSONExtractString(data, 'id') AS invoice_item_id,
+                  JSONExtractString(data, 'amount') AS amount_captured,
+                  JSONExtractString(data, 'currency') AS currency,
+                  JSONExtractString(data, 'price', 'product') AS product_id
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.overview_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+           WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+     UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+     FROM
+       (SELECT toString(events.uuid) AS id,
                'revenue_analytics.purchase' AS source_label,
                toTimeZone(events.timestamp, 'UTC') AS timestamp,
                NULL AS product_id,
@@ -179,10 +326,8 @@
                if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
-        ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`
-     WHERE in(`revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name,
-              ['purchase'])) AS revenue_analytics_invoice_item
-  WHERE and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2023-11-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2024-01-31 23:59:59', 'UTC'))), 0))
+        ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
+  WHERE and(and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2023-11-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2024-01-31 23:59:59', 'UTC'))), 0)), ifNull(equals(revenue_analytics_invoice_item.source_label, 'revenue_analytics.purchase'), 0))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -201,23 +346,66 @@
          count(DISTINCT revenue_analytics_invoice_item.customer_id) AS paying_customer_count,
          if(ifNull(equals(paying_customer_count, 0), 0), 0, ifNull(divideDecimal(revenue, accurateCastOrNull(paying_customer_count, 'Decimal64(10)')), 0)) AS avg_revenue_per_customer
   FROM
-    (SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
-            `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+    (SELECT `stripe.posthog_test.invoice_item_revenue_view`.id AS id,
+            `stripe.posthog_test.invoice_item_revenue_view`.source_label AS source_label,
+            `stripe.posthog_test.invoice_item_revenue_view`.timestamp AS timestamp,
+            `stripe.posthog_test.invoice_item_revenue_view`.product_id AS product_id,
+            `stripe.posthog_test.invoice_item_revenue_view`.customer_id AS customer_id,
+            `stripe.posthog_test.invoice_item_revenue_view`.invoice_id AS invoice_id,
+            `stripe.posthog_test.invoice_item_revenue_view`.session_id AS session_id,
+            `stripe.posthog_test.invoice_item_revenue_view`.event_name AS event_name,
+            `stripe.posthog_test.invoice_item_revenue_view`.original_currency AS original_currency,
+            `stripe.posthog_test.invoice_item_revenue_view`.original_amount AS original_amount,
+            `stripe.posthog_test.invoice_item_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+            `stripe.posthog_test.invoice_item_revenue_view`.currency_aware_divider AS currency_aware_divider,
+            `stripe.posthog_test.invoice_item_revenue_view`.currency_aware_amount AS currency_aware_amount,
+            `stripe.posthog_test.invoice_item_revenue_view`.currency AS currency,
+            `stripe.posthog_test.invoice_item_revenue_view`.amount AS amount
      FROM
-       (SELECT events.uuid AS id,
+       (SELECT invoice.invoice_item_id AS id,
+               'stripe.posthog_test' AS source_label,
+               invoice.created_at AS timestamp,
+               invoice.product_id AS product_id,
+               invoice.customer_id AS customer_id,
+               id AS invoice_id,
+               NULL AS session_id,
+               NULL AS event_name,
+               upper(invoice.currency) AS original_currency,
+               accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+               in(original_currency,
+                  ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                 if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                 divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                 'GBP' AS currency,
+                 if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))) AS amount
+        FROM
+          (SELECT posthog_test_stripe_invoice.id AS id,
+                  parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                  posthog_test_stripe_invoice.customer AS customer_id,
+                  arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                  JSONExtractString(data, 'id') AS invoice_item_id,
+                  JSONExtractString(data, 'amount') AS amount_captured,
+                  JSONExtractString(data, 'currency') AS currency,
+                  JSONExtractString(data, 'price', 'product') AS product_id
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.overview_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+           WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+     UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+     FROM
+       (SELECT toString(events.uuid) AS id,
                'revenue_analytics.purchase' AS source_label,
                toTimeZone(events.timestamp, 'UTC') AS timestamp,
                NULL AS product_id,
@@ -235,10 +423,8 @@
                  if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
-        ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`
-     WHERE in(`revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name,
-              ['purchase'])) AS revenue_analytics_invoice_item
-  WHERE and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2023-11-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2024-01-31 23:59:59', 'UTC'))), 0))
+        ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
+  WHERE and(and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2023-11-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2024-01-31 23:59:59', 'UTC'))), 0)), ifNull(equals(revenue_analytics_invoice_item.source_label, 'revenue_analytics.purchase'), 0))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -299,7 +485,41 @@
                   JSONExtractString(data, 'currency') AS currency,
                   JSONExtractString(data, 'price', 'product') AS product_id
            FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.overview_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-           WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`) AS revenue_analytics_invoice_item
+           WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+     UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                      `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+     FROM
+       (SELECT toString(events.uuid) AS id,
+               'revenue_analytics.purchase' AS source_label,
+               toTimeZone(events.timestamp, 'UTC') AS timestamp,
+               NULL AS product_id,
+               events.distinct_id AS customer_id,
+               NULL AS invoice_id,
+               toString(events.`$session_id`) AS session_id,
+               events.event AS event_name,
+               upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+               accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+               1 AS enable_currency_aware_divider,
+               if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+               divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+               'GBP' AS currency,
+               if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+        FROM events
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
+        ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
   LEFT JOIN
     (SELECT `stripe.posthog_test.product_revenue_view`.id AS id,
             `stripe.posthog_test.product_revenue_view`.source_label AS source_label,

--- a/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_top_customers_query_runner.ambr
+++ b/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_top_customers_query_runner.ambr
@@ -6,11 +6,49 @@
          inner.amount AS amount,
          inner.month AS month
   FROM
-    (SELECT '' AS customer_id,
-            '' AS month,
-            0 AS amount
-     WHERE 0) AS inner
-  INNER JOIN
+    (SELECT revenue_analytics_invoice_item.customer_id AS customer_id,
+            toStartOfMonth(revenue_analytics_invoice_item.timestamp) AS month,
+            sum(revenue_analytics_invoice_item.amount) AS amount
+     FROM
+       (SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+               `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+        FROM
+          (SELECT toString(events.uuid) AS id,
+                  'revenue_analytics.purchase' AS source_label,
+                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                  NULL AS product_id,
+                  events.distinct_id AS customer_id,
+                  NULL AS invoice_id,
+                  toString(events.`$session_id`) AS session_id,
+                  events.event AS event_name,
+                  upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                  1 AS enable_currency_aware_divider,
+                  if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                  divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                  'GBP' AS currency,
+                  if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+           FROM events
+           WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
+           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
+     WHERE and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2015-01-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-04-21 23:59:59', 'UTC'))), 0))
+     GROUP BY customer_id,
+              month
+     LIMIT 20 BY month) AS inner
+  LEFT JOIN
     (SELECT `stripe.posthog_test.customer_revenue_view`.id AS id,
             `stripe.posthog_test.customer_revenue_view`.source_label AS source_label,
             `stripe.posthog_test.customer_revenue_view`.timestamp AS timestamp,
@@ -43,15 +81,121 @@
 # ---
 # name: TestRevenueAnalyticsTopCustomersQueryRunner.test_no_crash_when_no_source_is_selected
   '''
-  SELECT '' AS name,
+  SELECT revenue_analytics_customer.name AS name,
          inner.customer_id AS customer_id,
          inner.amount AS amount,
          inner.month AS month
   FROM
-    (SELECT '' AS customer_id,
-            '' AS month,
-            0 AS amount
-     WHERE 0) AS inner
+    (SELECT revenue_analytics_invoice_item.customer_id AS customer_id,
+            toStartOfMonth(revenue_analytics_invoice_item.timestamp) AS month,
+            sum(revenue_analytics_invoice_item.amount) AS amount
+     FROM
+       (SELECT `stripe.posthog_test.invoice_item_revenue_view`.id AS id,
+               `stripe.posthog_test.invoice_item_revenue_view`.source_label AS source_label,
+               `stripe.posthog_test.invoice_item_revenue_view`.timestamp AS timestamp,
+               `stripe.posthog_test.invoice_item_revenue_view`.product_id AS product_id,
+               `stripe.posthog_test.invoice_item_revenue_view`.customer_id AS customer_id,
+               `stripe.posthog_test.invoice_item_revenue_view`.invoice_id AS invoice_id,
+               `stripe.posthog_test.invoice_item_revenue_view`.session_id AS session_id,
+               `stripe.posthog_test.invoice_item_revenue_view`.event_name AS event_name,
+               `stripe.posthog_test.invoice_item_revenue_view`.original_currency AS original_currency,
+               `stripe.posthog_test.invoice_item_revenue_view`.original_amount AS original_amount,
+               `stripe.posthog_test.invoice_item_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+               `stripe.posthog_test.invoice_item_revenue_view`.currency_aware_divider AS currency_aware_divider,
+               `stripe.posthog_test.invoice_item_revenue_view`.currency_aware_amount AS currency_aware_amount,
+               `stripe.posthog_test.invoice_item_revenue_view`.currency AS currency,
+               `stripe.posthog_test.invoice_item_revenue_view`.amount AS amount
+        FROM
+          (SELECT invoice.invoice_item_id AS id,
+                  'stripe.posthog_test' AS source_label,
+                  invoice.created_at AS timestamp,
+                  invoice.product_id AS product_id,
+                  invoice.customer_id AS customer_id,
+                  id AS invoice_id,
+                  NULL AS session_id,
+                  NULL AS event_name,
+                  upper(invoice.currency) AS original_currency,
+                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                  in(original_currency,
+                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                    'GBP' AS currency,
+                    if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))) AS amount
+           FROM
+             (SELECT posthog_test_stripe_invoice.id AS id,
+                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                     posthog_test_stripe_invoice.customer AS customer_id,
+                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                     JSONExtractString(data, 'id') AS invoice_item_id,
+                     JSONExtractString(data, 'amount') AS amount_captured,
+                     JSONExtractString(data, 'currency') AS currency,
+                     JSONExtractString(data, 'price', 'product') AS product_id
+              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.top_customers_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+        UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+        FROM
+          (SELECT toString(events.uuid) AS id,
+                  'revenue_analytics.purchase' AS source_label,
+                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                  NULL AS product_id,
+                  events.distinct_id AS customer_id,
+                  NULL AS invoice_id,
+                  toString(events.`$session_id`) AS session_id,
+                  events.event AS event_name,
+                  upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                  1 AS enable_currency_aware_divider,
+                  if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                  divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                  'GBP' AS currency,
+                  if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+           FROM events
+           WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
+           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
+     WHERE and(and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2015-01-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-04-21 23:59:59', 'UTC'))), 0)), ifNull(equals(revenue_analytics_invoice_item.source_label, 'non-existent-source'), 0))
+     GROUP BY customer_id,
+              month
+     LIMIT 20 BY month) AS inner
+  LEFT JOIN
+    (SELECT `stripe.posthog_test.customer_revenue_view`.id AS id,
+            `stripe.posthog_test.customer_revenue_view`.source_label AS source_label,
+            `stripe.posthog_test.customer_revenue_view`.timestamp AS timestamp,
+            `stripe.posthog_test.customer_revenue_view`.name AS name,
+            `stripe.posthog_test.customer_revenue_view`.email AS email,
+            `stripe.posthog_test.customer_revenue_view`.phone AS phone,
+            `stripe.posthog_test.customer_revenue_view`.cohort AS cohort
+     FROM
+       (SELECT outer.id AS id,
+               'stripe.posthog_test' AS source_label,
+               parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
+               outer.name AS name,
+               outer.email AS email,
+               outer.phone AS phone,
+               cohort_inner.cohort_readable AS cohort
+        FROM
+          (SELECT *
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.top_customers_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `created` DateTime')) AS outer
+        LEFT JOIN
+          (SELECT invoice.customer AS customer_id,
+                  toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))) AS cohort,
+                  formatDateTime(cohort, '%Y-%m') AS cohort_readable
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.top_customers_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
+           GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)) AS `stripe.posthog_test.customer_revenue_view`) AS revenue_analytics_customer ON equals(revenue_analytics_customer.id, inner.customer_id)
   ORDER BY amount DESC
   LIMIT 20 BY month
   LIMIT 100 SETTINGS readonly=2,
@@ -119,12 +263,46 @@
                      JSONExtractString(data, 'currency') AS currency,
                      JSONExtractString(data, 'price', 'product') AS product_id
               FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.top_customers_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`) AS revenue_analytics_invoice_item
+              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+        UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+        FROM
+          (SELECT toString(events.uuid) AS id,
+                  'revenue_analytics.purchase' AS source_label,
+                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                  NULL AS product_id,
+                  events.distinct_id AS customer_id,
+                  NULL AS invoice_id,
+                  toString(events.`$session_id`) AS session_id,
+                  events.event AS event_name,
+                  upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                  1 AS enable_currency_aware_divider,
+                  if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                  divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                  'GBP' AS currency,
+                  if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+           FROM events
+           WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
+           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
      WHERE and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2015-01-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-04-21 23:59:59', 'UTC'))), 0))
      GROUP BY customer_id,
               month
      LIMIT 20 BY month) AS inner
-  INNER JOIN
+  LEFT JOIN
     (SELECT `stripe.posthog_test.customer_revenue_view`.id AS id,
             `stripe.posthog_test.customer_revenue_view`.source_label AS source_label,
             `stripe.posthog_test.customer_revenue_view`.timestamp AS timestamp,
@@ -216,12 +394,46 @@
                      JSONExtractString(data, 'currency') AS currency,
                      JSONExtractString(data, 'price', 'product') AS product_id
               FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.top_customers_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`) AS revenue_analytics_invoice_item
+              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+        UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+        FROM
+          (SELECT toString(events.uuid) AS id,
+                  'revenue_analytics.purchase' AS source_label,
+                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                  NULL AS product_id,
+                  events.distinct_id AS customer_id,
+                  NULL AS invoice_id,
+                  toString(events.`$session_id`) AS session_id,
+                  events.event AS event_name,
+                  upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                  1 AS enable_currency_aware_divider,
+                  if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                  divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                  'GBP' AS currency,
+                  if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+           FROM events
+           WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
+           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
      WHERE and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-02-03 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-03-04 23:59:59', 'UTC'))), 0))
      GROUP BY customer_id,
               month
      LIMIT 20 BY month) AS inner
-  INNER JOIN
+  LEFT JOIN
     (SELECT `stripe.posthog_test.customer_revenue_view`.id AS id,
             `stripe.posthog_test.customer_revenue_view`.source_label AS source_label,
             `stripe.posthog_test.customer_revenue_view`.timestamp AS timestamp,
@@ -313,12 +525,46 @@
                      JSONExtractString(data, 'currency') AS currency,
                      JSONExtractString(data, 'price', 'product') AS product_id
               FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.top_customers_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`) AS revenue_analytics_invoice_item
+              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+        UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+        FROM
+          (SELECT toString(events.uuid) AS id,
+                  'revenue_analytics.purchase' AS source_label,
+                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                  NULL AS product_id,
+                  events.distinct_id AS customer_id,
+                  NULL AS invoice_id,
+                  toString(events.`$session_id`) AS session_id,
+                  events.event AS event_name,
+                  upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                  1 AS enable_currency_aware_divider,
+                  if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                  divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                  'GBP' AS currency,
+                  if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+           FROM events
+           WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
+           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
      WHERE and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2015-01-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-04-21 23:59:59', 'UTC'))), 0))
      GROUP BY customer_id,
               month
      LIMIT 20 BY month) AS inner
-  INNER JOIN
+  LEFT JOIN
     (SELECT `stripe.posthog_test.customer_revenue_view`.id AS id,
             `stripe.posthog_test.customer_revenue_view`.source_label AS source_label,
             `stripe.posthog_test.customer_revenue_view`.timestamp AS timestamp,
@@ -361,7 +607,7 @@
 # ---
 # name: TestRevenueAnalyticsTopCustomersQueryRunner.test_with_events_data
   '''
-  SELECT '' AS name,
+  SELECT revenue_analytics_customer.name AS name,
          inner.customer_id AS customer_id,
          inner.amount AS amount,
          inner.month AS month
@@ -370,23 +616,66 @@
             toStartOfMonth(revenue_analytics_invoice_item.timestamp) AS month,
             sum(revenue_analytics_invoice_item.amount) AS amount
      FROM
-       (SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+       (SELECT `stripe.posthog_test.invoice_item_revenue_view`.id AS id,
+               `stripe.posthog_test.invoice_item_revenue_view`.source_label AS source_label,
+               `stripe.posthog_test.invoice_item_revenue_view`.timestamp AS timestamp,
+               `stripe.posthog_test.invoice_item_revenue_view`.product_id AS product_id,
+               `stripe.posthog_test.invoice_item_revenue_view`.customer_id AS customer_id,
+               `stripe.posthog_test.invoice_item_revenue_view`.invoice_id AS invoice_id,
+               `stripe.posthog_test.invoice_item_revenue_view`.session_id AS session_id,
+               `stripe.posthog_test.invoice_item_revenue_view`.event_name AS event_name,
+               `stripe.posthog_test.invoice_item_revenue_view`.original_currency AS original_currency,
+               `stripe.posthog_test.invoice_item_revenue_view`.original_amount AS original_amount,
+               `stripe.posthog_test.invoice_item_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+               `stripe.posthog_test.invoice_item_revenue_view`.currency_aware_divider AS currency_aware_divider,
+               `stripe.posthog_test.invoice_item_revenue_view`.currency_aware_amount AS currency_aware_amount,
+               `stripe.posthog_test.invoice_item_revenue_view`.currency AS currency,
+               `stripe.posthog_test.invoice_item_revenue_view`.amount AS amount
         FROM
-          (SELECT events.uuid AS id,
+          (SELECT invoice.invoice_item_id AS id,
+                  'stripe.posthog_test' AS source_label,
+                  invoice.created_at AS timestamp,
+                  invoice.product_id AS product_id,
+                  invoice.customer_id AS customer_id,
+                  id AS invoice_id,
+                  NULL AS session_id,
+                  NULL AS event_name,
+                  upper(invoice.currency) AS original_currency,
+                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                  in(original_currency,
+                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                    'GBP' AS currency,
+                    if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))) AS amount
+           FROM
+             (SELECT posthog_test_stripe_invoice.id AS id,
+                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                     posthog_test_stripe_invoice.customer AS customer_id,
+                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                     JSONExtractString(data, 'id') AS invoice_item_id,
+                     JSONExtractString(data, 'amount') AS amount_captured,
+                     JSONExtractString(data, 'currency') AS currency,
+                     JSONExtractString(data, 'price', 'product') AS product_id
+              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.top_customers_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+        UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+        FROM
+          (SELECT toString(events.uuid) AS id,
                   'revenue_analytics.purchase' AS source_label,
                   toTimeZone(events.timestamp, 'UTC') AS timestamp,
                   NULL AS product_id,
@@ -403,13 +692,36 @@
                   if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
            FROM events
            WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
-           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`
-        WHERE in(`revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name,
-                 ['purchase'])) AS revenue_analytics_invoice_item
-     WHERE and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2023-11-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2024-01-31 23:59:59', 'UTC'))), 0))
+           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
+     WHERE and(and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2023-11-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2024-01-31 23:59:59', 'UTC'))), 0)), ifNull(equals(revenue_analytics_invoice_item.source_label, 'revenue_analytics.purchase'), 0))
      GROUP BY customer_id,
               month
      LIMIT 20 BY month) AS inner
+  LEFT JOIN
+    (SELECT `stripe.posthog_test.customer_revenue_view`.id AS id,
+            `stripe.posthog_test.customer_revenue_view`.source_label AS source_label,
+            `stripe.posthog_test.customer_revenue_view`.timestamp AS timestamp,
+            `stripe.posthog_test.customer_revenue_view`.name AS name,
+            `stripe.posthog_test.customer_revenue_view`.email AS email,
+            `stripe.posthog_test.customer_revenue_view`.phone AS phone,
+            `stripe.posthog_test.customer_revenue_view`.cohort AS cohort
+     FROM
+       (SELECT outer.id AS id,
+               'stripe.posthog_test' AS source_label,
+               parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
+               outer.name AS name,
+               outer.email AS email,
+               outer.phone AS phone,
+               cohort_inner.cohort_readable AS cohort
+        FROM
+          (SELECT *
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.top_customers_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `created` DateTime')) AS outer
+        LEFT JOIN
+          (SELECT invoice.customer AS customer_id,
+                  toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))) AS cohort,
+                  formatDateTime(cohort, '%Y-%m') AS cohort_readable
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.top_customers_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
+           GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)) AS `stripe.posthog_test.customer_revenue_view`) AS revenue_analytics_customer ON equals(revenue_analytics_customer.id, inner.customer_id)
   ORDER BY amount DESC
   LIMIT 20 BY month
   LIMIT 100 SETTINGS readonly=2,
@@ -426,7 +738,7 @@
 # ---
 # name: TestRevenueAnalyticsTopCustomersQueryRunner.test_with_events_data_and_currency_aware_divider
   '''
-  SELECT '' AS name,
+  SELECT revenue_analytics_customer.name AS name,
          inner.customer_id AS customer_id,
          inner.amount AS amount,
          inner.month AS month
@@ -435,23 +747,66 @@
             toStartOfMonth(revenue_analytics_invoice_item.timestamp) AS month,
             sum(revenue_analytics_invoice_item.amount) AS amount
      FROM
-       (SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
-               `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+       (SELECT `stripe.posthog_test.invoice_item_revenue_view`.id AS id,
+               `stripe.posthog_test.invoice_item_revenue_view`.source_label AS source_label,
+               `stripe.posthog_test.invoice_item_revenue_view`.timestamp AS timestamp,
+               `stripe.posthog_test.invoice_item_revenue_view`.product_id AS product_id,
+               `stripe.posthog_test.invoice_item_revenue_view`.customer_id AS customer_id,
+               `stripe.posthog_test.invoice_item_revenue_view`.invoice_id AS invoice_id,
+               `stripe.posthog_test.invoice_item_revenue_view`.session_id AS session_id,
+               `stripe.posthog_test.invoice_item_revenue_view`.event_name AS event_name,
+               `stripe.posthog_test.invoice_item_revenue_view`.original_currency AS original_currency,
+               `stripe.posthog_test.invoice_item_revenue_view`.original_amount AS original_amount,
+               `stripe.posthog_test.invoice_item_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+               `stripe.posthog_test.invoice_item_revenue_view`.currency_aware_divider AS currency_aware_divider,
+               `stripe.posthog_test.invoice_item_revenue_view`.currency_aware_amount AS currency_aware_amount,
+               `stripe.posthog_test.invoice_item_revenue_view`.currency AS currency,
+               `stripe.posthog_test.invoice_item_revenue_view`.amount AS amount
         FROM
-          (SELECT events.uuid AS id,
+          (SELECT invoice.invoice_item_id AS id,
+                  'stripe.posthog_test' AS source_label,
+                  invoice.created_at AS timestamp,
+                  invoice.product_id AS product_id,
+                  invoice.customer_id AS customer_id,
+                  id AS invoice_id,
+                  NULL AS session_id,
+                  NULL AS event_name,
+                  upper(invoice.currency) AS original_currency,
+                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                  in(original_currency,
+                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                    'GBP' AS currency,
+                    if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))) AS amount
+           FROM
+             (SELECT posthog_test_stripe_invoice.id AS id,
+                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                     posthog_test_stripe_invoice.customer AS customer_id,
+                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                     JSONExtractString(data, 'id') AS invoice_item_id,
+                     JSONExtractString(data, 'amount') AS amount_captured,
+                     JSONExtractString(data, 'currency') AS currency,
+                     JSONExtractString(data, 'price', 'product') AS product_id
+              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.top_customers_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+        UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+        FROM
+          (SELECT toString(events.uuid) AS id,
                   'revenue_analytics.purchase' AS source_label,
                   toTimeZone(events.timestamp, 'UTC') AS timestamp,
                   NULL AS product_id,
@@ -469,13 +824,36 @@
                     if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
            FROM events
            WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
-           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`
-        WHERE in(`revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name,
-                 ['purchase'])) AS revenue_analytics_invoice_item
-     WHERE and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2023-11-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2024-01-31 23:59:59', 'UTC'))), 0))
+           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
+     WHERE and(and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2023-11-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2024-01-31 23:59:59', 'UTC'))), 0)), ifNull(equals(revenue_analytics_invoice_item.source_label, 'revenue_analytics.purchase'), 0))
      GROUP BY customer_id,
               month
      LIMIT 20 BY month) AS inner
+  LEFT JOIN
+    (SELECT `stripe.posthog_test.customer_revenue_view`.id AS id,
+            `stripe.posthog_test.customer_revenue_view`.source_label AS source_label,
+            `stripe.posthog_test.customer_revenue_view`.timestamp AS timestamp,
+            `stripe.posthog_test.customer_revenue_view`.name AS name,
+            `stripe.posthog_test.customer_revenue_view`.email AS email,
+            `stripe.posthog_test.customer_revenue_view`.phone AS phone,
+            `stripe.posthog_test.customer_revenue_view`.cohort AS cohort
+     FROM
+       (SELECT outer.id AS id,
+               'stripe.posthog_test' AS source_label,
+               parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
+               outer.name AS name,
+               outer.email AS email,
+               outer.phone AS phone,
+               cohort_inner.cohort_readable AS cohort
+        FROM
+          (SELECT *
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.top_customers_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `created` DateTime')) AS outer
+        LEFT JOIN
+          (SELECT invoice.customer AS customer_id,
+                  toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))) AS cohort,
+                  formatDateTime(cohort, '%Y-%m') AS cohort_readable
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.top_customers_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
+           GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)) AS `stripe.posthog_test.customer_revenue_view`) AS revenue_analytics_customer ON equals(revenue_analytics_customer.id, inner.customer_id)
   ORDER BY amount DESC
   LIMIT 20 BY month
   LIMIT 100 SETTINGS readonly=2,
@@ -543,7 +921,41 @@
                      JSONExtractString(data, 'currency') AS currency,
                      JSONExtractString(data, 'price', 'product') AS product_id
               FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.top_customers_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `subscription_id` String, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`) AS revenue_analytics_invoice_item
+              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`
+        UNION ALL SELECT `revenue_analytics.purchase.invoice_item_revenue_view_events`.id AS id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.source_label AS source_label,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.timestamp AS timestamp,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.product_id AS product_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.customer_id AS customer_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.invoice_id AS invoice_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.session_id AS session_id,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.event_name AS event_name,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_currency AS original_currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.original_amount AS original_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_divider AS currency_aware_divider,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency_aware_amount AS currency_aware_amount,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.currency AS currency,
+                         `revenue_analytics.purchase.invoice_item_revenue_view_events`.amount AS amount
+        FROM
+          (SELECT toString(events.uuid) AS id,
+                  'revenue_analytics.purchase' AS source_label,
+                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                  NULL AS product_id,
+                  events.distinct_id AS customer_id,
+                  NULL AS invoice_id,
+                  toString(events.`$session_id`) AS session_id,
+                  events.event AS event_name,
+                  upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                  1 AS enable_currency_aware_divider,
+                  if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                  divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                  'GBP' AS currency,
+                  if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+           FROM events
+           WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
+           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.invoice_item_revenue_view_events`) AS revenue_analytics_invoice_item
      WHERE and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2015-01-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-04-21 23:59:59', 'UTC'))), 0))
      GROUP BY customer_id,
               month

--- a/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_example_events_query_runner.ambr
+++ b/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_example_events_query_runner.ambr
@@ -23,7 +23,7 @@
             view.session_id AS session_id,
             view.timestamp AS timestamp
      FROM
-       (SELECT events.uuid AS id,
+       (SELECT toString(events.uuid) AS id,
                'revenue_analytics.purchase_a' AS source_label,
                toTimeZone(events.timestamp, 'UTC') AS timestamp,
                events.distinct_id AS customer_id,
@@ -40,7 +40,7 @@
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_a'), isNotNull(amount)))
         ORDER BY timestamp DESC) AS view
-     INNER JOIN events ON equals(events.uuid, view.id)
+     INNER JOIN events ON equals(toString(events.uuid), view.id)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -72,7 +72,7 @@
                       view.session_id AS session_id,
                       view.timestamp AS timestamp
      FROM
-       (SELECT events.uuid AS id,
+       (SELECT toString(events.uuid) AS id,
                'revenue_analytics.purchase_b' AS source_label,
                toTimeZone(events.timestamp, 'UTC') AS timestamp,
                events.distinct_id AS customer_id,
@@ -89,7 +89,7 @@
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_b'), isNotNull(amount)))
         ORDER BY timestamp DESC) AS view
-     INNER JOIN events ON equals(events.uuid, view.id)
+     INNER JOIN events ON equals(toString(events.uuid), view.id)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -165,7 +165,7 @@
             view.session_id AS session_id,
             view.timestamp AS timestamp
      FROM
-       (SELECT events.uuid AS id,
+       (SELECT toString(events.uuid) AS id,
                'revenue_analytics.purchase_a' AS source_label,
                toTimeZone(events.timestamp, 'UTC') AS timestamp,
                events.distinct_id AS customer_id,
@@ -183,7 +183,7 @@
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_a'), isNotNull(amount)))
         ORDER BY timestamp DESC) AS view
-     INNER JOIN events ON equals(events.uuid, view.id)
+     INNER JOIN events ON equals(toString(events.uuid), view.id)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -215,7 +215,7 @@
                       view.session_id AS session_id,
                       view.timestamp AS timestamp
      FROM
-       (SELECT events.uuid AS id,
+       (SELECT toString(events.uuid) AS id,
                'revenue_analytics.purchase_b' AS source_label,
                toTimeZone(events.timestamp, 'UTC') AS timestamp,
                events.distinct_id AS customer_id,
@@ -233,7 +233,7 @@
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_b'), isNotNull(amount)))
         ORDER BY timestamp DESC) AS view
-     INNER JOIN events ON equals(events.uuid, view.id)
+     INNER JOIN events ON equals(toString(events.uuid), view.id)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -265,7 +265,7 @@
                       view.session_id AS session_id,
                       view.timestamp AS timestamp
      FROM
-       (SELECT events.uuid AS id,
+       (SELECT toString(events.uuid) AS id,
                'revenue_analytics.purchase_c' AS source_label,
                toTimeZone(events.timestamp, 'UTC') AS timestamp,
                events.distinct_id AS customer_id,
@@ -283,7 +283,7 @@
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_c'), isNotNull(amount)))
         ORDER BY timestamp DESC) AS view
-     INNER JOIN events ON equals(events.uuid, view.id)
+     INNER JOIN events ON equals(toString(events.uuid), view.id)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -342,7 +342,7 @@
             view.session_id AS session_id,
             view.timestamp AS timestamp
      FROM
-       (SELECT events.uuid AS id,
+       (SELECT toString(events.uuid) AS id,
                'revenue_analytics.purchase_a' AS source_label,
                toTimeZone(events.timestamp, 'UTC') AS timestamp,
                events.distinct_id AS customer_id,
@@ -360,7 +360,7 @@
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_a'), isNotNull(amount)))
         ORDER BY timestamp DESC) AS view
-     INNER JOIN events ON equals(events.uuid, view.id)
+     INNER JOIN events ON equals(toString(events.uuid), view.id)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -392,7 +392,7 @@
                       view.session_id AS session_id,
                       view.timestamp AS timestamp
      FROM
-       (SELECT events.uuid AS id,
+       (SELECT toString(events.uuid) AS id,
                'revenue_analytics.purchase_b' AS source_label,
                toTimeZone(events.timestamp, 'UTC') AS timestamp,
                events.distinct_id AS customer_id,
@@ -410,7 +410,7 @@
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_b'), isNotNull(amount)))
         ORDER BY timestamp DESC) AS view
-     INNER JOIN events ON equals(events.uuid, view.id)
+     INNER JOIN events ON equals(toString(events.uuid), view.id)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -442,7 +442,7 @@
                       view.session_id AS session_id,
                       view.timestamp AS timestamp
      FROM
-       (SELECT events.uuid AS id,
+       (SELECT toString(events.uuid) AS id,
                'revenue_analytics.purchase_c' AS source_label,
                toTimeZone(events.timestamp, 'UTC') AS timestamp,
                events.distinct_id AS customer_id,
@@ -460,7 +460,7 @@
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_c'), isNotNull(amount)))
         ORDER BY timestamp DESC) AS view
-     INNER JOIN events ON equals(events.uuid, view.id)
+     INNER JOIN events ON equals(toString(events.uuid), view.id)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -519,7 +519,7 @@
             view.session_id AS session_id,
             view.timestamp AS timestamp
      FROM
-       (SELECT events.uuid AS id,
+       (SELECT toString(events.uuid) AS id,
                'revenue_analytics.purchase_a' AS source_label,
                toTimeZone(events.timestamp, 'UTC') AS timestamp,
                events.distinct_id AS customer_id,
@@ -536,7 +536,7 @@
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_a'), isNotNull(amount)))
         ORDER BY timestamp DESC) AS view
-     INNER JOIN events ON equals(events.uuid, view.id)
+     INNER JOIN events ON equals(toString(events.uuid), view.id)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -568,7 +568,7 @@
                       view.session_id AS session_id,
                       view.timestamp AS timestamp
      FROM
-       (SELECT events.uuid AS id,
+       (SELECT toString(events.uuid) AS id,
                'revenue_analytics.purchase_b' AS source_label,
                toTimeZone(events.timestamp, 'UTC') AS timestamp,
                events.distinct_id AS customer_id,
@@ -585,7 +585,7 @@
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_b'), isNotNull(amount)))
         ORDER BY timestamp DESC) AS view
-     INNER JOIN events ON equals(events.uuid, view.id)
+     INNER JOIN events ON equals(toString(events.uuid), view.id)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -617,7 +617,7 @@
                       view.session_id AS session_id,
                       view.timestamp AS timestamp
      FROM
-       (SELECT events.uuid AS id,
+       (SELECT toString(events.uuid) AS id,
                'revenue_analytics.purchase_c' AS source_label,
                toTimeZone(events.timestamp, 'UTC') AS timestamp,
                events.distinct_id AS customer_id,
@@ -634,7 +634,7 @@
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_c'), isNotNull(amount)))
         ORDER BY timestamp DESC) AS view
-     INNER JOIN events ON equals(events.uuid, view.id)
+     INNER JOIN events ON equals(toString(events.uuid), view.id)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -682,7 +682,7 @@
          view.session_id AS session_id,
          view.timestamp AS timestamp
   FROM
-    (SELECT events.uuid AS id,
+    (SELECT toString(events.uuid) AS id,
             'revenue_analytics.purchase' AS source_label,
             toTimeZone(events.timestamp, 'UTC') AS timestamp,
             events.distinct_id AS customer_id,
@@ -699,7 +699,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
      ORDER BY timestamp DESC) AS view
-  INNER JOIN events ON equals(events.uuid, view.id)
+  INNER JOIN events ON equals(toString(events.uuid), view.id)
   LEFT OUTER JOIN
     (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
             person_distinct_id_overrides.distinct_id AS distinct_id
@@ -746,7 +746,7 @@
          view.session_id AS session_id,
          view.timestamp AS timestamp
   FROM
-    (SELECT events.uuid AS id,
+    (SELECT toString(events.uuid) AS id,
             'revenue_analytics.purchase' AS source_label,
             toTimeZone(events.timestamp, 'UTC') AS timestamp,
             events.distinct_id AS customer_id,
@@ -764,7 +764,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
      ORDER BY timestamp DESC) AS view
-  INNER JOIN events ON equals(events.uuid, view.id)
+  INNER JOIN events ON equals(toString(events.uuid), view.id)
   LEFT OUTER JOIN
     (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
             person_distinct_id_overrides.distinct_id AS distinct_id

--- a/products/revenue_analytics/backend/hogql_queries/test/test_revenue_analytics_overview_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/test/test_revenue_analytics_overview_query_runner.py
@@ -10,7 +10,6 @@ from posthog.schema import (
     CurrencyCode,
     DateRange,
     HogQLQueryModifiers,
-    RevenueSources,
     PropertyOperator,
     RevenueAnalyticsPropertyFilter,
     RevenueAnalyticsOverviewQuery,
@@ -136,20 +135,16 @@ class TestRevenueAnalyticsOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
     def _run_revenue_analytics_overview_query(
         self,
         date_range: DateRange | None = None,
-        revenue_sources: RevenueSources | None = None,
         properties: list[RevenueAnalyticsPropertyFilter] | None = None,
     ):
         if date_range is None:
             date_range = DateRange(date_from="-30d")
-        if revenue_sources is None:
-            revenue_sources = RevenueSources(events=[], dataWarehouseSources=[str(self.source.id)])
         if properties is None:
             properties = []
 
         with freeze_time(self.QUERY_TIMESTAMP):
             query = RevenueAnalyticsOverviewQuery(
                 dateRange=date_range,
-                revenueSources=revenue_sources,
                 properties=properties,
                 modifiers=HogQLQueryModifiers(formatCsvAllowDoubleQuotes=True),
             )
@@ -242,7 +237,13 @@ class TestRevenueAnalyticsOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         results = self._run_revenue_analytics_overview_query(
             date_range=DateRange(date_from="2023-11-01", date_to="2024-01-31"),
-            revenue_sources=RevenueSources(events=["purchase"], dataWarehouseSources=[]),
+            properties=[
+                RevenueAnalyticsPropertyFilter(
+                    key="source",
+                    operator=PropertyOperator.EXACT,
+                    value=["revenue_analytics.purchase"],
+                )
+            ],
         ).results
 
         self.assertEqual(
@@ -275,7 +276,13 @@ class TestRevenueAnalyticsOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         results = self._run_revenue_analytics_overview_query(
             date_range=DateRange(date_from="2023-11-01", date_to="2024-01-31"),
-            revenue_sources=RevenueSources(events=["purchase"], dataWarehouseSources=[]),
+            properties=[
+                RevenueAnalyticsPropertyFilter(
+                    key="source",
+                    operator=PropertyOperator.EXACT,
+                    value=["revenue_analytics.purchase"],
+                )
+            ],
         ).results
 
         self.assertEqual(

--- a/products/revenue_analytics/backend/utils.py
+++ b/products/revenue_analytics/backend/utils.py
@@ -9,37 +9,43 @@ from products.revenue_analytics.backend.views import (
     RevenueAnalyticsProductView,
 )
 
-RevenueSelectOutput = defaultdict[str, dict[str, ast.SelectQuery | None]]
+REVENUE_SELECT_OUTPUT_CUSTOMER_KEY = "customer"
+REVENUE_SELECT_OUTPUT_INVOICE_ITEM_KEY = "invoice_item"
+REVENUE_SELECT_OUTPUT_PRODUCT_KEY = "product"
+REVENUE_SELECT_OUTPUT_CHARGE_KEY = "charge"
+
+MAP_FROM_VIEW_TO_KEY = {
+    RevenueAnalyticsChargeView: REVENUE_SELECT_OUTPUT_CHARGE_KEY,
+    RevenueAnalyticsCustomerView: REVENUE_SELECT_OUTPUT_CUSTOMER_KEY,
+    RevenueAnalyticsInvoiceItemView: REVENUE_SELECT_OUTPUT_INVOICE_ITEM_KEY,
+    RevenueAnalyticsProductView: REVENUE_SELECT_OUTPUT_PRODUCT_KEY,
+}
+
+RevenueSelectOutputInnerDict = dict[str, ast.SelectQuery | None]
+RevenueSelectOutput = defaultdict[str, RevenueSelectOutputInnerDict]
+EMPTY_REVENUE_SELECT_OUTPUT_GENERATOR = lambda: RevenueSelectOutputInnerDict(
+    {
+        REVENUE_SELECT_OUTPUT_CHARGE_KEY: None,
+        REVENUE_SELECT_OUTPUT_CUSTOMER_KEY: None,
+        REVENUE_SELECT_OUTPUT_INVOICE_ITEM_KEY: None,
+        REVENUE_SELECT_OUTPUT_PRODUCT_KEY: None,
+    }
+)
 
 
 def revenue_selects_from_database(database: Database) -> RevenueSelectOutput:
-    selects: RevenueSelectOutput = defaultdict(
-        lambda: {"charge": None, "customer": None, "invoice_item": None, "product": None}
-    )
+    selects: RevenueSelectOutput = defaultdict(EMPTY_REVENUE_SELECT_OUTPUT_GENERATOR)
 
     for view_name in database.get_views():
         view = database.get_table(view_name)
 
         if isinstance(view, RevenueAnalyticsBaseView):
-            select: ast.SelectQuery | None = None
-            if view.source_id is not None:
-                select = ast.SelectQuery(
-                    select=[ast.Field(chain=["*"])],
-                    select_from=ast.JoinExpr(table=ast.Field(chain=[view.name])),
-                )
-            else:
-                select = ast.SelectQuery(
-                    select=[ast.Field(chain=["*"])],
-                    select_from=ast.JoinExpr(table=ast.Field(chain=[view.name])),
-                )
+            view_key = MAP_FROM_VIEW_TO_KEY.get(view.__class__)
 
-            if isinstance(view, RevenueAnalyticsChargeView):
-                selects[view.prefix]["charge"] = select
-            elif isinstance(view, RevenueAnalyticsCustomerView):
-                selects[view.prefix]["customer"] = select
-            elif isinstance(view, RevenueAnalyticsInvoiceItemView):
-                selects[view.prefix]["invoice_item"] = select
-            elif isinstance(view, RevenueAnalyticsProductView):
-                selects[view.prefix]["product"] = select
+            if view_key is not None:
+                selects[view.prefix][view_key] = ast.SelectQuery(
+                    select=[ast.Field(chain=["*"])],
+                    select_from=ast.JoinExpr(table=ast.Field(chain=[view.name])),
+                )
 
     return selects

--- a/products/revenue_analytics/backend/utils.py
+++ b/products/revenue_analytics/backend/utils.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 from posthog.hogql import ast
 from posthog.hogql.database.database import Database
-from posthog.schema import RevenueSources
 from products.revenue_analytics.backend.views import (
     RevenueAnalyticsBaseView,
     RevenueAnalyticsChargeView,
@@ -13,10 +12,7 @@ from products.revenue_analytics.backend.views import (
 RevenueSelectOutput = defaultdict[str, dict[str, ast.SelectQuery | None]]
 
 
-def revenue_selects_from_database(
-    database: Database,
-    revenue_sources: RevenueSources | None = None,
-) -> RevenueSelectOutput:
+def revenue_selects_from_database(database: Database) -> RevenueSelectOutput:
     selects: RevenueSelectOutput = defaultdict(
         lambda: {"charge": None, "customer": None, "invoice_item": None, "product": None}
     )
@@ -27,26 +23,15 @@ def revenue_selects_from_database(
         if isinstance(view, RevenueAnalyticsBaseView):
             select: ast.SelectQuery | None = None
             if view.source_id is not None:
-                if revenue_sources is None or view.source_id in revenue_sources.dataWarehouseSources:
-                    select = ast.SelectQuery(
-                        select=[ast.Field(chain=["*"])],
-                        select_from=ast.JoinExpr(table=ast.Field(chain=[view.name])),
-                    )
+                select = ast.SelectQuery(
+                    select=[ast.Field(chain=["*"])],
+                    select_from=ast.JoinExpr(table=ast.Field(chain=[view.name])),
+                )
             else:
-                if revenue_sources is None or len(revenue_sources.events) > 0:
-                    select = ast.SelectQuery(
-                        select=[ast.Field(chain=["*"])],
-                        select_from=ast.JoinExpr(table=ast.Field(chain=[view.name])),
-                    )
-
-                    if revenue_sources is not None:
-                        select.where = ast.Call(
-                            name="in",
-                            args=[
-                                ast.Field(chain=["event_name"]),
-                                ast.Constant(value=revenue_sources.events),
-                            ],
-                        )
+                select = ast.SelectQuery(
+                    select=[ast.Field(chain=["*"])],
+                    select_from=ast.JoinExpr(table=ast.Field(chain=[view.name])),
+                )
 
             if isinstance(view, RevenueAnalyticsChargeView):
                 selects[view.prefix]["charge"] = select

--- a/products/revenue_analytics/backend/views/revenue_analytics_charge_view.py
+++ b/products/revenue_analytics/backend/views/revenue_analytics_charge_view.py
@@ -74,7 +74,7 @@ class RevenueAnalyticsChargeView(RevenueAnalyticsBaseView):
 
             query = ast.SelectQuery(
                 select=[
-                    ast.Alias(alias="id", expr=ast.Field(chain=["uuid"])),
+                    ast.Alias(alias="id", expr=ast.Call(name="toString", args=[ast.Field(chain=["uuid"])])),
                     ast.Alias(alias="source_label", expr=ast.Constant(value=prefix)),
                     ast.Alias(alias="timestamp", expr=ast.Field(chain=["timestamp"])),
                     ast.Alias(alias="customer_id", expr=ast.Field(chain=["distinct_id"])),

--- a/products/revenue_analytics/backend/views/revenue_analytics_invoice_item_view.py
+++ b/products/revenue_analytics/backend/views/revenue_analytics_invoice_item_view.py
@@ -84,7 +84,7 @@ class RevenueAnalyticsInvoiceItemView(RevenueAnalyticsBaseView):
 
             query = ast.SelectQuery(
                 select=[
-                    ast.Alias(alias="id", expr=ast.Field(chain=["uuid"])),
+                    ast.Alias(alias="id", expr=ast.Call(name="toString", args=[ast.Field(chain=["uuid"])])),
                     ast.Alias(alias="source_label", expr=ast.Constant(value=prefix)),
                     ast.Alias(alias="timestamp", expr=ast.Field(chain=["timestamp"])),
                     ast.Alias(alias="product_id", expr=ast.Constant(value=None)),

--- a/products/revenue_analytics/frontend/RevenueAnalyticsFilters.tsx
+++ b/products/revenue_analytics/frontend/RevenueAnalyticsFilters.tsx
@@ -1,5 +1,4 @@
-import { IconFilter, IconPlus } from '@posthog/icons'
-import { LemonButton, LemonDropdown, LemonSwitch, Link, Tooltip } from '@posthog/lemon-ui'
+import { Tooltip } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { CUSTOM_OPTION_KEY } from 'lib/components/DateFilter/types'
@@ -8,17 +7,12 @@ import { isRevenueAnalyticsPropertyFilter } from 'lib/components/PropertyFilters
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { dayjs } from 'lib/dayjs'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
-import { IconWithBadge } from 'lib/lemon-ui/icons'
 import { DATE_FORMAT, formatDateRange } from 'lib/utils'
 import { cn } from 'lib/utils/css-classes'
-import { useEffect, useRef, useState } from 'react'
-import { DataWarehouseSourceIcon } from 'scenes/data-warehouse/settings/DataWarehouseSourceIcon'
-import { urls } from 'scenes/urls'
 
 import { navigationLogic } from '~/layout/navigation/navigationLogic'
 import { ReloadAll } from '~/queries/nodes/DataNode/Reload'
-import { RevenueAnalyticsEventItem } from '~/queries/schema/schema-general'
-import { DateMappingOption, ExternalDataSource } from '~/types'
+import { DateMappingOption } from '~/types'
 
 import { revenueAnalyticsLogic } from './revenueAnalyticsLogic'
 
@@ -56,25 +50,6 @@ const DATE_FILTER_DATE_OPTIONS: DateMappingOption[] = [
         defaultInterval: 'month',
     },
 ]
-
-type ParsedRecord = Record<string, boolean>
-const buildEvents = (allEvents: RevenueAnalyticsEventItem[], state: ParsedRecord): ParsedRecord => {
-    return allEvents.reduce((acc, event) => {
-        if (!(event.eventName in acc)) {
-            acc[event.eventName] = true
-        }
-        return acc
-    }, state)
-}
-
-const buildDataWarehouseSources = (sources: ExternalDataSource[], state: ParsedRecord): ParsedRecord => {
-    return sources.reduce((acc, source) => {
-        if (!(source.id in acc)) {
-            acc[source.id] = true
-        }
-        return acc
-    }, state)
-}
 
 export const RevenueAnalyticsFilters = (): JSX.Element => {
     const { mobileLayout } = useValues(navigationLogic)
@@ -118,143 +93,7 @@ export const RevenueAnalyticsFilters = (): JSX.Element => {
                         />
                     )}
                 </div>
-
-                <RevenueAnalyticsFiltersModal />
             </div>
         </div>
-    )
-}
-
-const RevenueAnalyticsFiltersModal = (): JSX.Element => {
-    const { revenueEnabledEvents, revenueEnabledDataWarehouseSources } = useValues(revenueAnalyticsLogic)
-    const { setRevenueSources } = useActions(revenueAnalyticsLogic)
-
-    const [events, setEvents] = useState(() => buildEvents(revenueEnabledEvents, {}))
-    const [dataWarehouseSources, setDataWarehouseSources] = useState(() =>
-        buildDataWarehouseSources(revenueEnabledDataWarehouseSources ?? [], {})
-    )
-
-    // When the revenue sources change, we need to update the events and data warehouse sources
-    useEffect(() => {
-        setEvents((events) => buildEvents(revenueEnabledEvents, events))
-        setDataWarehouseSources((dataWarehouseSources) =>
-            buildDataWarehouseSources(revenueEnabledDataWarehouseSources ?? [], dataWarehouseSources)
-        )
-    }, [revenueEnabledEvents, revenueEnabledDataWarehouseSources])
-
-    // The modal below insists in keeping references to the old values because of the way `Overlay` works.
-    // So we need to keep our own references to the values and update them on every render.
-    const eventsRef = useRef(events)
-    useEffect(() => {
-        eventsRef.current = events
-    }, [events])
-    const dataWarehouseSourcesRef = useRef(dataWarehouseSources)
-    useEffect(() => {
-        dataWarehouseSourcesRef.current = dataWarehouseSources
-    }, [dataWarehouseSources])
-
-    const updateEvent = (eventName: string, enabled: boolean): void => {
-        setEvents((events) => ({ ...events, [eventName]: enabled }))
-    }
-
-    const updateDataWarehouseSource = (sourceId: string, enabled: boolean): void => {
-        setDataWarehouseSources((dataWarehouseSources) => ({ ...dataWarehouseSources, [sourceId]: enabled }))
-    }
-
-    const areAllEventsEnabled = Object.values(events).every((enabled) => enabled)
-    const areAllEventsDisabled = Object.values(events).length > 0 && Object.values(events).every((enabled) => !enabled)
-    const areAllDataWarehouseSourcesEnabled = Object.values(dataWarehouseSources).every((enabled) => enabled)
-    const areAllDataWarehouseSourcesDisabled =
-        Object.values(dataWarehouseSources).length > 0 &&
-        Object.values(dataWarehouseSources).every((enabled) => !enabled)
-    const areAllEnabled = areAllEventsEnabled && areAllDataWarehouseSourcesEnabled
-    const areAllDisabled = areAllEventsDisabled || areAllDataWarehouseSourcesDisabled
-
-    return (
-        <LemonDropdown
-            closeOnClickInside={false}
-            onVisibilityChange={(visible): void => {
-                if (visible) {
-                    return
-                }
-
-                const selectedEvents = revenueEnabledEvents.filter((event) => eventsRef.current[event.eventName])
-                const selectedDataWarehouseSources =
-                    revenueEnabledDataWarehouseSources?.filter(
-                        (source) => dataWarehouseSourcesRef.current[source.id]
-                    ) ?? []
-                setRevenueSources({ events: selectedEvents, dataWarehouseSources: selectedDataWarehouseSources })
-            }}
-            overlay={
-                <div className="flex flex-col sm:flex-row justify-between sm:min-w-[400px] p-2 gap-5">
-                    <div>
-                        <span className="text-sm font-medium pb-2">
-                            Events
-                            <Link className="ml-1" to={urls.revenueSettings()}>
-                                <IconPlus />
-                            </Link>
-                        </span>
-                        <div className="flex flex-col gap-1">
-                            {revenueEnabledEvents.map((event) => (
-                                <div className="flex flex-row gap-1" key={event.eventName}>
-                                    <LemonSwitch
-                                        checked={events[event.eventName]}
-                                        onChange={(checked) => updateEvent(event.eventName, checked)}
-                                    />
-                                    {event.eventName}
-                                </div>
-                            ))}
-
-                            {revenueEnabledEvents.length === 0 && (
-                                <>
-                                    <span className="text-sm text-muted-alt">No revenue events found</span>
-                                </>
-                            )}
-                        </div>
-                    </div>
-                    <div>
-                        <span className="text-sm font-medium pb-2">
-                            Data warehouse sources
-                            <Link className="ml-1" to={urls.revenueSettings()}>
-                                <IconPlus />
-                            </Link>
-                        </span>
-                        <div className="flex flex-col gap-1">
-                            {revenueEnabledDataWarehouseSources?.map((source) => (
-                                <div className="flex flex-row gap-1" key={source.id}>
-                                    <LemonSwitch
-                                        checked={dataWarehouseSources[source.id]}
-                                        onChange={(checked) => updateDataWarehouseSource(source.id, checked)}
-                                    />
-                                    <span className="ml-1">{source.prefix || source.source_type}</span>
-                                    <DataWarehouseSourceIcon type={source.source_type} size="xsmall" />
-                                </div>
-                            ))}
-
-                            {!revenueEnabledDataWarehouseSources?.length && (
-                                <>
-                                    <span className="text-sm text-muted-alt">
-                                        No enabled revenue data warehouse sources found
-                                    </span>
-                                </>
-                            )}
-                        </div>
-                    </div>
-                </div>
-            }
-        >
-            <LemonButton
-                size="small"
-                tooltip="Choose which revenue sources should be taken into consideration"
-                icon={
-                    <IconWithBadge
-                        content={areAllDisabled ? '!' : !areAllEnabled ? '*' : undefined}
-                        status={areAllDisabled ? 'danger' : 'data'}
-                    >
-                        <IconFilter />
-                    </IconWithBadge>
-                }
-            />
-        </LemonDropdown>
     )
 }


### PR DESCRIPTION
Rather than having a custom filter to choose which events/sources we wanna use for displaying our data, let's instead offload it to the same filters we're already using for the rest of the ui.

This will also solve a lot of bugs we had where we loaded this page before we'd finished loading sources from the backend.

<img width="827" alt="image" src="https://github.com/user-attachments/assets/5c45a226-c427-4b4e-82e2-4b2a4ebc5053" />
