### PR TITLE
chore:  remove tagging from hasTaxonomyFeatures

### DIFF
--- a/frontend/src/scenes/data-management/definition/definitionLogic.ts
+++ b/frontend/src/scenes/data-management/definition/definitionLogic.ts
@@ -102,9 +102,7 @@ export const definitionLogic = kea<definitionLogicType>([
     selectors({
         hasTaxonomyFeatures: [
             (s) => [s.hasAvailableFeature],
-            (hasAvailableFeature) =>
-                hasAvailableFeature(AvailableFeature.INGESTION_TAXONOMY) ||
-                hasAvailableFeature(AvailableFeature.TAGGING),
+            (hasAvailableFeature) => hasAvailableFeature(AvailableFeature.INGESTION_TAXONOMY),
         ],
         isEvent: [() => [router.selectors.location], ({ pathname }) => pathname.includes(urls.eventDefinitions())],
         isProperty: [(s) => [s.isEvent], (isEvent) => !isEvent],


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changes

Tagging and ingestion taxonomy have always been on the same plans together, with the advent of boost, that is no longer the case so this check is more important. 

This is only used in the prop definition components so it's meant for the ingestion taxonomy not the tagging. 

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

Manually 
