### PR TITLE
feat(propdefs): integrate cache wrapper into service

### DIFF
--- a/rust/property-defs-rs/src/lib.rs
+++ b/rust/property-defs-rs/src/lib.rs
@@ -6,15 +6,15 @@ use config::Config;
 use metrics_consts::{
     BATCH_ACQUIRE_TIME, CACHE_CONSUMED, CHUNK_SIZE, COMPACTED_UPDATES, DUPLICATES_IN_BATCH,
     EMPTY_EVENTS, EVENTS_RECEIVED, EVENT_PARSE_ERROR, FORCED_SMALL_BATCH, ISSUE_FAILED,
-    RECV_DEQUEUED, SKIPPED_DUE_TO_TEAM_FILTER, UPDATES_CACHE, UPDATES_DROPPED,
-    UPDATES_FILTERED_BY_CACHE, UPDATES_PER_EVENT, UPDATES_SEEN, UPDATE_ISSUE_TIME,
-    UPDATE_PRODUCER_OFFSET, V2_ISOLATED_DB_SELECTED, WORKER_BLOCKED,
+    RECV_DEQUEUED, SKIPPED_DUE_TO_TEAM_FILTER, UPDATES_DROPPED, UPDATES_FILTERED_BY_CACHE,
+    UPDATES_PER_EVENT, UPDATES_SEEN, UPDATE_ISSUE_TIME, UPDATE_PRODUCER_OFFSET,
+    V2_ISOLATED_DB_SELECTED, WORKER_BLOCKED,
 };
 use types::{Event, Update};
 use v2_batch_ingestion::process_batch_v2;
 
 use ahash::AHashSet;
-use quick_cache::sync::Cache;
+use update_cache::Cache;
 
 use tokio::sync::mpsc::{self, error::TrySendError};
 use tracing::{error, warn};
@@ -34,7 +34,7 @@ const UPDATE_RETRY_DELAY_MS: u64 = 50;
 
 pub async fn update_consumer_loop(
     config: Config,
-    cache: Arc<Cache<Update, ()>>,
+    cache: Arc<Cache>,
     context: Arc<AppContext>,
     mut channel: mpsc::Receiver<Update>,
 ) {
@@ -131,7 +131,7 @@ pub async fn update_consumer_loop(
 
 async fn process_batch_v1(
     config: &Config,
-    cache: Arc<Cache<Update, ()>>,
+    cache: Arc<Cache>,
     context: Arc<AppContext>,
     mut batch: Vec<Update>,
 ) {
@@ -173,14 +173,7 @@ async fn process_batch_v1(
                     );
                     // We clear any updates that were in this batch from the cache, so that
                     // if we see them again we'll try again to issue them.
-                    chunk.iter().for_each(|u| {
-                        if m_cache.remove(u).is_some() {
-                            metrics::counter!(UPDATES_CACHE, &[("action", "removed")]).increment(1);
-                        } else {
-                            metrics::counter!(UPDATES_CACHE, &[("action", "not_cached")])
-                                .increment(1);
-                        }
-                    });
+                    chunk.iter().for_each(|u| m_cache.remove(u));
                     return;
                 }
 
@@ -205,7 +198,7 @@ pub async fn update_producer_loop(
     config: Config,
     consumer: SingleTopicConsumer,
     channel: mpsc::Sender<Update>,
-    shared_cache: Arc<Cache<Update, ()>>,
+    shared_cache: Arc<Cache>,
 ) {
     let mut batch = AHashSet::with_capacity(config.compaction_batch_size);
     let mut last_send = tokio::time::Instant::now();
@@ -276,8 +269,7 @@ pub async fn update_producer_loop(
         {
             last_send = tokio::time::Instant::now();
             for update in batch.drain() {
-                if shared_cache.get(&update).is_some() {
-                    metrics::counter!(UPDATES_CACHE, &[("action", "hit")]).increment(1);
+                if shared_cache.contains_key(&update) {
                     // the above can replace this metric when we have new hit/miss stats both flowing
                     metrics::counter!(UPDATES_FILTERED_BY_CACHE).increment(1);
                     continue;
@@ -288,8 +280,7 @@ pub async fn update_producer_loop(
                 // they are safely persisted to Postgres, and painfully extract them
                 // when batch writes fail. This may be a fine trade for now, since
                 // v2 batch writes fail much less often than v1
-                metrics::counter!(UPDATES_CACHE, &[("action", "miss")]).increment(1);
-                shared_cache.insert(update.clone(), ());
+                shared_cache.insert(update.clone());
 
                 match channel.try_send(update) {
                     Ok(_) => {}

--- a/rust/property-defs-rs/src/main.rs
+++ b/rust/property-defs-rs/src/main.rs
@@ -6,10 +6,9 @@ use common_kafka::kafka_consumer::SingleTopicConsumer;
 use futures::future::ready;
 use property_defs_rs::{
     api::v1::query::Manager, api::v1::routing::apply_routes, app_context::AppContext,
-    config::Config, update_consumer_loop, update_producer_loop,
+    config::Config, update_cache::Cache, update_consumer_loop, update_producer_loop,
 };
 
-use quick_cache::sync::Cache;
 use serve_metrics::{serve, setup_metrics_routes};
 use sqlx::postgres::PgPoolOptions;
 use tokio::{

--- a/rust/property-defs-rs/src/metrics_consts.rs
+++ b/rust/property-defs-rs/src/metrics_consts.rs
@@ -51,7 +51,7 @@ pub const V2_EVENT_PROPS_BATCH_CACHE_TIME: &str = "propdefs_v2_eventprops_batch_
 pub const V2_EVENT_PROPS_CACHE_REMOVED: &str = "propdefs_v2_eventprops_cache_removed";
 pub const V2_EVENT_PROPS_CACHE_HIT: &str = "propdefs_v2_eventprops_cache_hit";
 pub const V2_EVENT_PROPS_CACHE_MISS: &str = "propdefs_v2_eventprops_cache_miss";
-pub const V2_EVENT_PROPS_BATCH_SIZE: &str = "propdefs_v2_event_props_batch_size";
+pub const V2_EVENT_PROPS_BATCH_SIZE: &str = "propdefs_v2_eventprops_batch_size";
 
 pub const V2_PROP_DEFS_BATCH_WRITE_TIME: &str = "propdefs_v2_propdefs_batch_ms";
 pub const V2_PROP_DEFS_BATCH_ATTEMPT: &str = "propdefs_v2_propdefs_batch_attempt";

--- a/rust/property-defs-rs/src/update_cache.rs
+++ b/rust/property-defs-rs/src/update_cache.rs
@@ -1,4 +1,4 @@
-use crate::types::Update;
+use crate::{metrics_consts::UPDATES_CACHE, types::Update};
 use quick_cache::sync;
 
 pub struct Cache {
@@ -7,6 +7,11 @@ pub struct Cache {
     propdefs: sync::Cache<Update, ()>,
 }
 
+// TODO: next iter, try using unsync::Cache(s) here and manage sync access to each
+// manually. This enables implementing new batch insert/remove APIs on this wrapper,
+// since we rarely want to work with just one cache entry at a time in propdefs. I
+// suspect small-batch updates would further reduce internal cache lock contention
+// that can slow down our batch write threads, esp. when a write fails and we evict
 impl Cache {
     pub fn new(capacity: usize) -> Self {
         Self {
@@ -15,12 +20,28 @@ impl Cache {
             propdefs: sync::Cache::new(capacity),
         }
     }
+
+    pub fn len(&self) -> usize {
+        self.eventdefs.len() + self.eventprops.len() + self.propdefs.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.propdefs.is_empty() && self.eventdefs.is_empty() && self.eventprops.is_empty()
+    }
+
     pub fn contains_key(&self, key: &Update) -> bool {
-        match key {
+        let result = match key {
             Update::Event(_) => self.eventdefs.contains_key(key),
             Update::EventProperty(_) => self.eventprops.contains_key(key),
             Update::Property(_) => self.propdefs.contains_key(key),
-        }
+        };
+
+        match result {
+            true => metrics::counter!(UPDATES_CACHE, &[("action", "hit")]).increment(1),
+            _ => metrics::counter!(UPDATES_CACHE, &[("action", "miss")]).increment(1),
+        };
+
+        result
     }
 
     pub fn insert(&self, key: Update) {
@@ -33,10 +54,16 @@ impl Cache {
 
     // we don't return the retrieved KV since propdefs doesn't require it
     pub fn remove(&self, key: &Update) {
-        match key {
+        let result = match key {
             Update::Event(_) => self.eventdefs.remove(key),
             Update::EventProperty(_) => self.eventprops.remove(key),
             Update::Property(_) => self.propdefs.remove(key),
         };
+
+        if result.is_some() {
+            metrics::counter!(UPDATES_CACHE, &[("action", "removed")]).increment(1);
+        } else {
+            metrics::counter!(UPDATES_CACHE, &[("action", "not_cached")]).increment(1);
+        }
     }
 }

--- a/rust/property-defs-rs/src/v2_batch_ingestion.rs
+++ b/rust/property-defs-rs/src/v2_batch_ingestion.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 use crate::{
     config::Config,
     metrics_consts::{
-        CACHE_CONSUMED, V2_EVENT_DEFS_BATCH_ATTEMPT, V2_EVENT_DEFS_BATCH_CACHE_TIME,
+        CACHE_CONSUMED, ISSUE_FAILED, V2_EVENT_DEFS_BATCH_ATTEMPT, V2_EVENT_DEFS_BATCH_CACHE_TIME,
         V2_EVENT_DEFS_BATCH_ROWS_AFFECTED, V2_EVENT_DEFS_BATCH_SIZE,
         V2_EVENT_DEFS_BATCH_WRITE_TIME, V2_EVENT_DEFS_CACHE_REMOVED, V2_EVENT_PROPS_BATCH_ATTEMPT,
         V2_EVENT_PROPS_BATCH_CACHE_TIME, V2_EVENT_PROPS_BATCH_ROWS_AFFECTED,
@@ -329,6 +329,7 @@ pub async fn process_batch_v2(
             Ok(result) => match result {
                 Ok(_) => continue,
                 Err(db_err) => {
+                    metrics::counter!(ISSUE_FAILED, &[("reason", "failed")]).increment(1);
                     error!("Batch write exhausted retries: {:?}", db_err);
                 }
             },


### PR DESCRIPTION
## Problem
Ingestion team would like to apply some lightweight, short-term remediations to the `property-defs-rs` service (in KTLO while we await an alternative solution)

## Changes
Wire up the new split-cache-by-target-table wrapper. This isn't likely to be a huge win alone, but should help with the v2 write path keeping up with evictions when a batch write fails, and will be easy to iterate on (i.e. add batch insert/removal APIs that could be more impactful) once landed.

## Did you write or update any docs for this change?


- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Locally and in CI. Deploy test once landed