### PR TITLE
fix: don't copy dashboard filters on duplicate

### DIFF
--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -34,6 +34,7 @@ import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { InsightSaveButton } from 'scenes/insights/InsightSaveButton'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
+import { insightsApi } from 'scenes/insights/utils/api'
 import { NotebookSelectButton } from 'scenes/notebooks/NotebookSelectButton/NotebookSelectButton'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { projectLogic } from 'scenes/projectLogic'
@@ -251,9 +252,24 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                     {hasDashboardItemId && (
                                         <>
                                             <LemonButton
-                                                onClick={() =>
-                                                    duplicateInsight(insight as QueryBasedInsightModel, true)
-                                                }
+                                                onClick={() => {
+                                                    void (async () => {
+                                                        // We do not want to duplicate the dashboard filters that might be included in this insight
+                                                        // Ideally we would store those separately and be able to remove them on duplicate or edit, but current we merge them
+                                                        // irreversibly in apply_dashboard_filters and return that to the front-end
+                                                        if (insight.short_id) {
+                                                            const cleanInsight = await insightsApi.getByShortId(
+                                                                insight.short_id
+                                                            )
+                                                            if (cleanInsight) {
+                                                                duplicateInsight(cleanInsight, true)
+                                                                return
+                                                            }
+                                                        }
+                                                        // Fallback to original behavior if load failed
+                                                        duplicateInsight(insight as QueryBasedInsightModel, true)
+                                                    })()
+                                                }}
                                                 fullWidth
                                                 data-attr="duplicate-insight-from-insight-view"
                                             >


### PR DESCRIPTION
Similar to https://github.com/PostHog/posthog/pull/33477 for edit mode

Duplicate should not include the filters
