### PR TITLE
fix: retention mean

### DIFF
--- a/frontend/src/scenes/retention/RetentionTable.tsx
+++ b/frontend/src/scenes/retention/RetentionTable.tsx
@@ -88,7 +88,9 @@ export function RetentionTable({ inSharedMode = false }: { inSharedMode?: boolea
                                     </div>
                                 </td>
 
-                                {!hideSizeColumn && <td>{meanData?.totalCohortSize ?? 0}</td>}
+                                {!hideSizeColumn && (
+                                    <td>{((meanData?.totalCohortSize ?? 0) / cohortRows.length).toFixed(1)}</td>
+                                )}
 
                                 {range(0, totalIntervals).map((interval) => (
                                     <td key={interval}>

--- a/frontend/src/scenes/retention/RetentionTable.tsx
+++ b/frontend/src/scenes/retention/RetentionTable.tsx
@@ -58,7 +58,8 @@ export function RetentionTable({ inSharedMode = false }: { inSharedMode?: boolea
                 </tr>
 
                 {Object.entries(tableRowsSplitByBreakdownValue).map(([breakdownValue, cohortRows], breakdownIndex) => {
-                    const keyForMeanData = breakdownValue === NO_BREAKDOWN_VALUE ? OVERALL_MEAN_KEY : breakdownValue
+                    const noBreakdown = breakdownValue === NO_BREAKDOWN_VALUE
+                    const keyForMeanData = noBreakdown ? OVERALL_MEAN_KEY : breakdownValue
                     const meanData = retentionMeans[keyForMeanData]
 
                     return (
@@ -79,7 +80,7 @@ export function RetentionTable({ inSharedMode = false }: { inSharedMode?: boolea
                                             <IconChevronRight />
                                         )}
                                         <span>
-                                            {breakdownValue === NO_BREAKDOWN_VALUE
+                                            {noBreakdown
                                                 ? 'Mean'
                                                 : breakdownValue === null || breakdownValue === ''
                                                 ? RETENTION_EMPTY_BREAKDOWN_VALUE
@@ -89,7 +90,11 @@ export function RetentionTable({ inSharedMode = false }: { inSharedMode?: boolea
                                 </td>
 
                                 {!hideSizeColumn && (
-                                    <td>{((meanData?.totalCohortSize ?? 0) / cohortRows.length).toFixed(1)}</td>
+                                    <td>
+                                        {noBreakdown
+                                            ? ((meanData?.totalCohortSize ?? 0) / cohortRows.length).toFixed(1)
+                                            : meanData?.totalCohortSize ?? 0}
+                                    </td>
                                 )}
 
                                 {range(0, totalIntervals).map((interval) => (


### PR DESCRIPTION
## Problem

We say "mean" but we display a total size

![image](https://github.com/user-attachments/assets/99dc7f2c-b120-485e-ae84-c2602ad779fc)

Reported here: https://posthoghelp.zendesk.com/agent/tickets/32270 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/35079)

## Changes

Make it display mean:

![image](https://github.com/user-attachments/assets/227428a3-315a-478b-8623-bb3691847e71)

Keep it size with breakdowns

![image](https://github.com/user-attachments/assets/82eb9005-dac2-4fb8-a962-082101de6118)


## How did you test this code?

Local
