### PR TITLE
fix: fleible player control layout

### DIFF
--- a/frontend/src/scenes/session-recordings/player/controller/PlayerController.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/PlayerController.tsx
@@ -70,16 +70,15 @@ export function PlayerController(): JSX.Element {
     return (
         <div className="bg-surface-primary flex flex-col select-none">
             <Seekbar />
-            <div className="w-full px-2 py-1 relative flex items-center justify-center" ref={ref}>
-                <div className="absolute left-2">
-                    <Timestamp size={size} />
-                </div>
+            <div className="w-full px-2 py-1 relative flex items-center justify-between" ref={ref}>
+                <Timestamp size={size} />
+
                 <div className="flex gap-0.5 items-center justify-center">
                     <SeekSkip direction="backward" />
                     <PlayPauseButton />
                     <SeekSkip direction="forward" />
                 </div>
-                <div className="absolute right-2 flex justify-end items-center">
+                <div className="flex justify-end items-center">
                     {playlistLogic ? <PlayerUpNext playlistLogic={playlistLogic} /> : undefined}
                     <FullScreen />
                 </div>


### PR DESCRIPTION
keeping on lifting things out of https://github.com/PostHog/posthog/pull/32955

the fixed central player controls sometimes overlap the other controls... so let's change how we layout

<img width="855" alt="Screenshot 2025-06-10 at 21 27 02" src="https://github.com/user-attachments/assets/ece4a4df-f241-4aea-8692-fca306dae8f0" />
<img width="428" alt="Screenshot 2025-06-10 at 21 26 57" src="https://github.com/user-attachments/assets/7cddf94b-29cd-426e-bf55-ac9dbaa33ce6" />
