### PR TITLE
chore(batch-exports): Further reduce load on BigQuery by sampling

### DIFF
--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -296,7 +296,7 @@ class BigQueryClient(bigquery.Client):
 
         if "timestamp" in [field.name for field in table.schema]:
             query = f"""
-            SELECT 1 FROM  `{table.full_table_id.replace(":", ".", 1)}` WHERE timestamp IS NOT NULL
+            SELECT 1 FROM  `{table.full_table_id.replace(":", ".", 1)}` TABLESAMPLE SYSTEM (0.0001 PERCENT) WHERE timestamp IS NOT NULL
             """
 
             if table.time_partitioning is not None and table.time_partitioning.field == "timestamp":
@@ -307,7 +307,7 @@ class BigQueryClient(bigquery.Client):
 
         else:
             query = f"""
-            SELECT 1 FROM  `{table.full_table_id.replace(":", ".", 1)}` LIMIT 1
+            SELECT 1 FROM  `{table.full_table_id.replace(":", ".", 1)}` TABLESAMPLE SYSTEM (0.0001 PERCENT) LIMIT 1
             """
 
         try:


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

When checking table permissions, we don't need to use too many resources, yet querying large tables can be quite expensive. We have already added limits to the query, but this PR further increases them by taking a sample.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Take a very small sample of BigQuery table. Just enough to check if we can actually query the table.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->