### PR TITLE
fix: lemon tabs data attrs

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTabs/LemonTabs.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTabs/LemonTabs.tsx
@@ -15,6 +15,8 @@ export interface AbstractLemonTab<T extends string | number> {
     /** URL of the tab if it can be linked to (which is usually a good practice). */
     link?: string
     tooltipDocLink?: string
+    /** data-attr to be placed on the tab button, useful for autocapture */
+    'data-attr'?: string
 }
 
 /** A tab with content. In this case the LemonTabs component automatically renders content of the active tab. */
@@ -30,6 +32,7 @@ export interface LemonTabsProps<T extends string | number> {
     /** List of tabs. Falsy entries are ignored - they're there to make conditional tabs convenient. */
     tabs: (LemonTab<T> | null | false)[]
     size?: 'small' | 'medium'
+    /** data-attr to be placed on the tab container, useful for autocapture */
     'data-attr'?: string
     barClassName?: string
     className?: string
@@ -102,6 +105,7 @@ export function LemonTabs<T extends string | number>({
                                         : undefined
                                 }
                                 ref={tab.key === activeKey ? selectionRef : undefined}
+                                data-attr={tab['data-attr']}
                             >
                                 {tab.link ? (
                                     <Link className="LemonTabs__tab-content" to={tab.link}>

--- a/frontend/src/scenes/session-recordings/SessionRecordings.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordings.tsx
@@ -16,7 +16,7 @@ import { VersionCheckerBanner } from 'lib/components/VersionChecker/VersionCheck
 import { FEATURE_FLAGS } from 'lib/constants'
 import { useAsyncHandler } from 'lib/hooks/useAsyncHandler'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
-import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
+import { LemonTab, LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { NotebookSelectButton } from 'scenes/notebooks/NotebookSelectButton/NotebookSelectButton'
@@ -226,20 +226,24 @@ const ReplayPageTabs: ReplayTab[] = [
         label: 'Recordings',
         tooltipDocLink: 'https://posthog.com/docs/session-replay/tutorials',
         key: ReplayTabs.Home,
+        'data-attr': 'session-recordings-home-tab',
     },
     {
         label: 'Playlists → Collections',
         tooltipDocLink: 'https://posthog.com/docs/session-replay/how-to-watch-recordings',
         key: ReplayTabs.Playlists,
         tooltip: 'View & create collections',
+        'data-attr': 'session-recordings-collections-tab',
     },
     {
         label: 'Figure out what to watch',
         key: ReplayTabs.Templates,
+        'data-attr': 'session-recordings-templates-tab',
     },
     {
         label: 'Settings',
         key: ReplayTabs.Settings,
+        'data-attr': 'session-recordings-settings-tab',
     },
 ]
 
@@ -250,7 +254,7 @@ function PageTabs(): JSX.Element {
         <LemonTabs
             activeKey={tab}
             onChange={(t) => router.actions.push(urls.replay(t as ReplayTabs))}
-            tabs={ReplayPageTabs.map((replayTab) => {
+            tabs={ReplayPageTabs.map((replayTab): LemonTab<string> => {
                 return {
                     label: (
                         <>
@@ -263,6 +267,7 @@ function PageTabs(): JSX.Element {
                     key: replayTab.key,
                     tooltip: replayTab.tooltip,
                     tooltipDocLink: replayTab.tooltipDocLink,
+                    'data-attr': replayTab['data-attr'],
                 }
             })}
         />

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -5,6 +5,7 @@ import {
     LemonButtonProps,
     LemonInput,
     LemonModal,
+    LemonTab,
     LemonTabs,
     Popover,
 } from '@posthog/lemon-ui'
@@ -296,7 +297,7 @@ export const RecordingsUniversalFiltersEmbed = ({
         )
     }
 
-    const tabs = [
+    const tabs: LemonTab<string>[] = [
         {
             key: 'filters',
             label: <div className="px-2">Filters</div>,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -792,6 +792,7 @@ export type ReplayTab = {
     key: ReplayTabs
     tooltip?: string
     tooltipDocLink?: string
+    'data-attr'?: string
 }
 
 export enum ExperimentsTabs {


### PR DESCRIPTION
we hadn't typed our tabs, so I added data-attrs but they were ignored

and anyway lemon tabs didn't support a data-attr on the tab itself...

and so...

<img width="869" alt="Screenshot 2025-06-11 at 11 33 36" src="https://github.com/user-attachments/assets/067e548e-0d13-4d78-8054-992d13005397" />
