### PR TITLE
fix: Forward the invite_modal query param on scene redirects

### DIFF
--- a/frontend/src/lib/utils/sceneLogicUtils.test.ts
+++ b/frontend/src/lib/utils/sceneLogicUtils.test.ts
@@ -1,0 +1,165 @@
+import { withForwardedSearchParams } from './sceneLogicUtils'
+
+describe('sceneLogicUtils', () => {
+    describe('withForwardedSearchParams', () => {
+        it('returns original URL when no params to forward', () => {
+            const redirectUrl = '/dashboard'
+            const currentSearchParams = { invite_modal: 'true', other: 'value' }
+            const forwardedQueryParams: string[] = []
+
+            const result = withForwardedSearchParams(redirectUrl, currentSearchParams, forwardedQueryParams)
+
+            expect(result).toBe('/dashboard')
+        })
+
+        it('returns original URL when forwarded params do not exist in current search params', () => {
+            const redirectUrl = '/dashboard'
+            const currentSearchParams = { other: 'value' }
+            const forwardedQueryParams = ['invite_modal', 'next']
+
+            const result = withForwardedSearchParams(redirectUrl, currentSearchParams, forwardedQueryParams)
+
+            expect(result).toBe('/dashboard')
+        })
+
+        it('returns original URL when forwarded param already exists in redirect URL', () => {
+            const redirectUrl = '/dashboard?invite_modal=existing'
+            const currentSearchParams = { invite_modal: 'true' }
+            const forwardedQueryParams = ['invite_modal']
+
+            const result = withForwardedSearchParams(redirectUrl, currentSearchParams, forwardedQueryParams)
+
+            expect(result).toBe('/dashboard?invite_modal=existing')
+        })
+
+        it('forwards single param when it exists in current search params and not in redirect URL', () => {
+            const redirectUrl = '/dashboard'
+            const currentSearchParams = { invite_modal: 'true' }
+            const forwardedQueryParams = ['invite_modal']
+
+            const result = withForwardedSearchParams(redirectUrl, currentSearchParams, forwardedQueryParams)
+
+            expect(result).toBe('/dashboard?invite_modal=true')
+        })
+
+        it('forwards multiple params when they exist in current search params', () => {
+            const redirectUrl = '/dashboard'
+            const currentSearchParams = { invite_modal: 'true', next: '/insights', other: 'ignored' }
+            const forwardedQueryParams = ['invite_modal', 'next']
+
+            const result = withForwardedSearchParams(redirectUrl, currentSearchParams, forwardedQueryParams)
+
+            expect(result).toBe('/dashboard?invite_modal=true&next=%2Finsights')
+        })
+
+        it('forwards only params that exist, ignoring missing ones', () => {
+            const redirectUrl = '/dashboard'
+            const currentSearchParams = { invite_modal: 'true' }
+            const forwardedQueryParams = ['invite_modal', 'missing_param']
+
+            const result = withForwardedSearchParams(redirectUrl, currentSearchParams, forwardedQueryParams)
+
+            expect(result).toBe('/dashboard?invite_modal=true')
+        })
+
+        it('preserves existing query params in redirect URL while adding forwarded ones', () => {
+            const redirectUrl = '/dashboard?existing=value'
+            const currentSearchParams = { invite_modal: 'true' }
+            const forwardedQueryParams = ['invite_modal']
+
+            const result = withForwardedSearchParams(redirectUrl, currentSearchParams, forwardedQueryParams)
+
+            expect(result).toBe('/dashboard?existing=value&invite_modal=true')
+        })
+
+        it('preserves hash in redirect URL', () => {
+            const redirectUrl = '/dashboard#section'
+            const currentSearchParams = { invite_modal: 'true' }
+            const forwardedQueryParams = ['invite_modal']
+
+            const result = withForwardedSearchParams(redirectUrl, currentSearchParams, forwardedQueryParams)
+
+            expect(result).toBe('/dashboard?invite_modal=true#section')
+        })
+
+        it('preserves complex hash in redirect URL', () => {
+            const redirectUrl = '/dashboard?existing=value#section?nested=param'
+            const currentSearchParams = { invite_modal: 'true' }
+            const forwardedQueryParams = ['invite_modal']
+
+            const result = withForwardedSearchParams(redirectUrl, currentSearchParams, forwardedQueryParams)
+
+            expect(result).toBe('/dashboard?existing=value&invite_modal=true#section?nested=param')
+        })
+
+        it('handles URL encoding correctly', () => {
+            const redirectUrl = '/dashboard'
+            const currentSearchParams = { next: '/insights?filter=test&other=value' }
+            const forwardedQueryParams = ['next']
+
+            const result = withForwardedSearchParams(redirectUrl, currentSearchParams, forwardedQueryParams)
+
+            expect(result).toBe('/dashboard?next=%2Finsights%3Ffilter%3Dtest%26other%3Dvalue')
+        })
+
+        it('handles absolute URLs correctly', () => {
+            const redirectUrl = 'https://example.com/dashboard'
+            const currentSearchParams = { invite_modal: 'true' }
+            const forwardedQueryParams = ['invite_modal']
+
+            const result = withForwardedSearchParams(redirectUrl, currentSearchParams, forwardedQueryParams)
+
+            expect(result).toBe('/dashboard?invite_modal=true')
+        })
+
+        it('handles empty string values', () => {
+            const redirectUrl = '/dashboard'
+            const currentSearchParams = { invite_modal: '' }
+            const forwardedQueryParams = ['invite_modal']
+
+            const result = withForwardedSearchParams(redirectUrl, currentSearchParams, forwardedQueryParams)
+
+            expect(result).toBe('/dashboard?invite_modal=')
+        })
+
+        it('handles special characters in param values', () => {
+            const redirectUrl = '/dashboard'
+            const currentSearchParams = { invite_modal: 'true&false' }
+            const forwardedQueryParams = ['invite_modal']
+
+            const result = withForwardedSearchParams(redirectUrl, currentSearchParams, forwardedQueryParams)
+
+            expect(result).toBe('/dashboard?invite_modal=true%26false')
+        })
+
+        it('does not forward param with falsy values except empty string', () => {
+            const redirectUrl = '/dashboard'
+            const currentSearchParams = {
+                invite_modal: null,
+                next: undefined,
+                other: false,
+                empty: '',
+            }
+            const forwardedQueryParams = ['invite_modal', 'next', 'other', 'empty']
+
+            const result = withForwardedSearchParams(redirectUrl, currentSearchParams, forwardedQueryParams)
+
+            expect(result).toBe('/dashboard?empty=')
+        })
+
+        it('handles complex real-world scenario', () => {
+            const redirectUrl = '/insights/new?dashboard=123'
+            const currentSearchParams = {
+                invite_modal: 'true',
+                next: '/original-destination',
+                utm_source: 'email',
+                other: 'ignored',
+            }
+            const forwardedQueryParams = ['invite_modal', 'next']
+
+            const result = withForwardedSearchParams(redirectUrl, currentSearchParams, forwardedQueryParams)
+
+            expect(result).toBe('/insights/new?dashboard=123&invite_modal=true&next=%2Foriginal-destination')
+        })
+    })
+})

--- a/frontend/src/lib/utils/sceneLogicUtils.test.ts
+++ b/frontend/src/lib/utils/sceneLogicUtils.test.ts
@@ -32,16 +32,6 @@ describe('sceneLogicUtils', () => {
             expect(result).toBe('/dashboard?invite_modal=existing')
         })
 
-        it('forwards single param when it exists in current search params and not in redirect URL', () => {
-            const redirectUrl = '/dashboard'
-            const currentSearchParams = { invite_modal: 'true' }
-            const forwardedQueryParams = ['invite_modal']
-
-            const result = withForwardedSearchParams(redirectUrl, currentSearchParams, forwardedQueryParams)
-
-            expect(result).toBe('/dashboard?invite_modal=true')
-        })
-
         it('forwards multiple params when they exist in current search params', () => {
             const redirectUrl = '/dashboard'
             const currentSearchParams = { invite_modal: 'true', next: '/insights', other: 'ignored' }
@@ -50,16 +40,6 @@ describe('sceneLogicUtils', () => {
             const result = withForwardedSearchParams(redirectUrl, currentSearchParams, forwardedQueryParams)
 
             expect(result).toBe('/dashboard?invite_modal=true&next=%2Finsights')
-        })
-
-        it('forwards only params that exist, ignoring missing ones', () => {
-            const redirectUrl = '/dashboard'
-            const currentSearchParams = { invite_modal: 'true' }
-            const forwardedQueryParams = ['invite_modal', 'missing_param']
-
-            const result = withForwardedSearchParams(redirectUrl, currentSearchParams, forwardedQueryParams)
-
-            expect(result).toBe('/dashboard?invite_modal=true')
         })
 
         it('preserves existing query params in redirect URL while adding forwarded ones', () => {
@@ -73,16 +53,6 @@ describe('sceneLogicUtils', () => {
         })
 
         it('preserves hash in redirect URL', () => {
-            const redirectUrl = '/dashboard#section'
-            const currentSearchParams = { invite_modal: 'true' }
-            const forwardedQueryParams = ['invite_modal']
-
-            const result = withForwardedSearchParams(redirectUrl, currentSearchParams, forwardedQueryParams)
-
-            expect(result).toBe('/dashboard?invite_modal=true#section')
-        })
-
-        it('preserves complex hash in redirect URL', () => {
             const redirectUrl = '/dashboard?existing=value#section?nested=param'
             const currentSearchParams = { invite_modal: 'true' }
             const forwardedQueryParams = ['invite_modal']
@@ -102,16 +72,6 @@ describe('sceneLogicUtils', () => {
             expect(result).toBe('/dashboard?next=%2Finsights%3Ffilter%3Dtest%26other%3Dvalue')
         })
 
-        it('handles absolute URLs correctly', () => {
-            const redirectUrl = 'https://example.com/dashboard'
-            const currentSearchParams = { invite_modal: 'true' }
-            const forwardedQueryParams = ['invite_modal']
-
-            const result = withForwardedSearchParams(redirectUrl, currentSearchParams, forwardedQueryParams)
-
-            expect(result).toBe('/dashboard?invite_modal=true')
-        })
-
         it('handles empty string values', () => {
             const redirectUrl = '/dashboard'
             const currentSearchParams = { invite_modal: '' }
@@ -122,17 +82,7 @@ describe('sceneLogicUtils', () => {
             expect(result).toBe('/dashboard?invite_modal=')
         })
 
-        it('handles special characters in param values', () => {
-            const redirectUrl = '/dashboard'
-            const currentSearchParams = { invite_modal: 'true&false' }
-            const forwardedQueryParams = ['invite_modal']
-
-            const result = withForwardedSearchParams(redirectUrl, currentSearchParams, forwardedQueryParams)
-
-            expect(result).toBe('/dashboard?invite_modal=true%26false')
-        })
-
-        it('does not forward param with falsy values except empty string', () => {
+        it('forwards param with falsy values', () => {
             const redirectUrl = '/dashboard'
             const currentSearchParams = {
                 invite_modal: null,
@@ -144,22 +94,32 @@ describe('sceneLogicUtils', () => {
 
             const result = withForwardedSearchParams(redirectUrl, currentSearchParams, forwardedQueryParams)
 
-            expect(result).toBe('/dashboard?empty=')
+            expect(result).toBe('/dashboard?invite_modal=null&other=false&empty=')
         })
 
-        it('handles complex real-world scenario', () => {
-            const redirectUrl = '/insights/new?dashboard=123'
+        it('never overwrites existing params in redirect URL', () => {
+            const redirectUrl = '/dashboard?invite_modal=existing&other=preserved'
             const currentSearchParams = {
-                invite_modal: 'true',
-                next: '/original-destination',
-                utm_source: 'email',
-                other: 'ignored',
+                invite_modal: 'new-value',
+                next: '/destination',
+                other: 'different',
             }
-            const forwardedQueryParams = ['invite_modal', 'next']
+            const forwardedQueryParams = ['invite_modal', 'next', 'other']
 
             const result = withForwardedSearchParams(redirectUrl, currentSearchParams, forwardedQueryParams)
 
-            expect(result).toBe('/insights/new?dashboard=123&invite_modal=true&next=%2Foriginal-destination')
+            // Only 'next' should be added since 'invite_modal' and 'other' already exist
+            expect(result).toBe('/dashboard?invite_modal=existing&other=preserved&next=%2Fdestination')
+        })
+
+        it('preserves existing params even with empty values in redirect URL', () => {
+            const redirectUrl = '/dashboard?invite_modal='
+            const currentSearchParams = { invite_modal: 'true' }
+            const forwardedQueryParams = ['invite_modal']
+
+            const result = withForwardedSearchParams(redirectUrl, currentSearchParams, forwardedQueryParams)
+
+            expect(result).toBe('/dashboard?invite_modal=')
         })
     })
 })

--- a/frontend/src/lib/utils/sceneLogicUtils.ts
+++ b/frontend/src/lib/utils/sceneLogicUtils.ts
@@ -21,7 +21,7 @@ export function withForwardedSearchParams(
 
     // For each whitelisted param that exists in current URL
     forwardedQueryParams.forEach((param) => {
-        if (currentSearchParams[param] && !redirectSearchParams.has(param)) {
+        if (currentSearchParams[param] !== undefined && !redirectSearchParams.has(param)) {
             redirectSearchParams.set(param, currentSearchParams[param])
             paramsWereForwarded = true
         }

--- a/frontend/src/lib/utils/sceneLogicUtils.ts
+++ b/frontend/src/lib/utils/sceneLogicUtils.ts
@@ -1,0 +1,39 @@
+import { Params } from 'scenes/sceneTypes'
+
+/**
+ * Forwards whitelisted query parameters from the current URL to the redirect URL.
+ * Only forwards params that exist in the current URL and don't already exist in the redirect URL.
+ * This is specifically used for scene redirects to maintain important query parameters across redirects.
+ */
+export function withForwardedSearchParams(
+    redirectUrl: string,
+    currentSearchParams: Params,
+    forwardedQueryParams: string[]
+): string {
+    // If no params to forward, return the original URL
+    if (!forwardedQueryParams?.length) {
+        return redirectUrl
+    }
+
+    const redirectUrlObj = new URL(redirectUrl, window.location.origin)
+    const redirectSearchParams = new URLSearchParams(redirectUrlObj.search)
+    let paramsWereForwarded = false
+
+    // For each whitelisted param that exists in current URL
+    forwardedQueryParams.forEach((param) => {
+        if (currentSearchParams[param] && !redirectSearchParams.has(param)) {
+            redirectSearchParams.set(param, currentSearchParams[param])
+            paramsWereForwarded = true
+        }
+    })
+
+    // Only modify the URL if we actually forwarded any params
+    if (!paramsWereForwarded) {
+        return redirectUrl
+    }
+
+    // Reconstruct the URL with the forwarded params
+    redirectUrlObj.search = redirectSearchParams.toString()
+    // Return just the pathname and search to avoid origin being included
+    return redirectUrlObj.pathname + redirectUrlObj.search + redirectUrlObj.hash
+}

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -5,8 +5,16 @@ import { BarStatus } from 'lib/components/CommandBar/types'
 import { TeamMembershipLevel } from 'lib/constants'
 import { getRelativeNextPath } from 'lib/utils'
 import { addProjectIdIfMissing, removeProjectIdIfPresent } from 'lib/utils/router-utils'
+import { withForwardedSearchParams } from 'lib/utils/sceneLogicUtils'
 import posthog from 'posthog-js'
-import { emptySceneParams, preloadedScenes, redirects, routes, sceneConfigurations } from 'scenes/scenes'
+import {
+    emptySceneParams,
+    forwardedRedirectQueryParams,
+    preloadedScenes,
+    redirects,
+    routes,
+    sceneConfigurations,
+} from 'scenes/scenes'
 import {
     LoadedScene,
     Params,
@@ -482,8 +490,11 @@ export const sceneLogic = kea<sceneLogicType>([
         for (const path of Object.keys(redirects)) {
             mapping[path] = (params, searchParams, hashParams) => {
                 const redirect = redirects[path]
-                router.actions.replace(
+                const redirectUrl =
                     typeof redirect === 'function' ? redirect(params, searchParams, hashParams) : redirect
+
+                router.actions.replace(
+                    withForwardedSearchParams(redirectUrl, searchParams, forwardedRedirectQueryParams)
                 )
             }
         }

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -501,6 +501,8 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
 }
 
 // NOTE: These redirects will fully replace the URL. If you want to keep support for query and hash params then you should use a function (not string) redirect
+// NOTE: If you need a query param to be automatically forwarded to the redirect URL, add it to the forwardedRedirectQueryParams array
+export const forwardedRedirectQueryParams: string[] = ['invite_modal']
 export const redirects: Record<
     string,
     string | ((params: Params, searchParams: Params, hashParams: Params) => string)


### PR DESCRIPTION
## Problem

Closes #32640 

## Changes

- Add a mechanism to automatically forward certain whitelisted query params to the scene redirect URLs. 
- Add invite_modal as the only query param to be forwarded for now.

## How did you test this code?

- Manually, unit tests
