### PR TITLE
feat(logs): order log attributes by popularity

### DIFF
--- a/products/logs/backend/api.py
+++ b/products/logs/backend/api.py
@@ -73,13 +73,18 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
         results = sync_execute(
             """
 SELECT
-    arraySort(groupArrayDistinct(attribute_key)) as keys
-FROM log_attributes
-WHERE time_bucket >= toStartOfInterval(now() - interval 1 hour, interval 10 minute)
-AND team_id = %(team_id)s
-AND attribute_key LIKE %(search)s
-GROUP BY team_id
-LIMIT 1
+    groupArray(attribute_key) as keys
+FROM (
+    SELECT
+        attribute_key,
+        sum(attribute_count)
+    FROM log_attributes
+    WHERE time_bucket >= toStartOfInterval(now() - interval 1 hour, interval 10 minute)
+    AND team_id = %(team_id)s
+    AND attribute_key LIKE %(search)s
+    GROUP BY team_id, attribute_key
+    ORDER BY sum(attribute_count) desc, attribute_key asc
+)
 """,
             args={"search": f"%{search}%", "team_id": self.team.id},
             workload=Workload.LOGS,
@@ -106,14 +111,19 @@ LIMIT 1
         results = sync_execute(
             """
 SELECT
-    arraySort(groupArrayDistinct(attribute_value)) as values
-FROM log_attributes
-WHERE time_bucket >= toStartOfInterval(now() - interval 1 hour, interval 10 minute)
-AND team_id = %(team_id)s
-AND attribute_key = %(key)s
-AND attribute_value LIKE %(search)s
-GROUP BY team_id
-LIMIT 1
+    groupArray(attribute_value) as keys
+FROM (
+    SELECT
+        attribute_value,
+        sum(attribute_count)
+    FROM log_attributes
+    WHERE time_bucket >= toStartOfInterval(now() - interval 1 hour, interval 10 minute)
+    AND team_id = %(team_id)s
+    AND attribute_key = %(key)s
+    AND attribute_value LIKE %(search)s
+    GROUP BY team_id, attribute_value
+    ORDER BY sum(attribute_count) desc, attribute_value asc
+)
 """,
             args={"key": key, "search": f"%{search}%", "team_id": self.team.id},
             workload=Workload.LOGS,

--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -146,7 +146,6 @@ class LogsQueryRunner(QueryRunner):
         query.where = self.where()
         order_dir = "ASC" if self.query.orderBy == "earliest" else "DESC"
         query.order_by = [
-            parse_order_expr(f"service_name {order_dir}"),
             parse_order_expr(f"toUnixTimestamp(timestamp) {order_dir}"),
         ]
 


### PR DESCRIPTION
## Problem
previously when filtering an attribute key or value it was shown in alphabetical order. Update it so it orders by most used key or value
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
