### PR TITLE
fix(dashboard): show banner only if filter/variables override present

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -19,7 +19,7 @@ import {
 import { combineUrl } from 'kea-router'
 import type { AlertType } from 'lib/components/Alerts/types'
 import { FEATURE_FLAGS, INSIGHT_VISUAL_ORDER, PRODUCT_VISUAL_ORDER } from 'lib/constants'
-import { toParams } from 'lib/utils'
+import { isEmptyObject, toParams } from 'lib/utils'
 import type { Params } from 'scenes/sceneTypes'
 import type { SurveysTabs } from 'scenes/surveys/surveysLogic'
 import { urls } from 'scenes/urls'
@@ -281,7 +281,9 @@ export const productUrls = {
     ): string => {
         const params = [
             { param: 'dashboard', value: dashboardId },
-            { param: 'variables_override', value: variablesOverride },
+            ...(variablesOverride && !isEmptyObject(variablesOverride)
+                ? [{ param: 'variables_override', value: variablesOverride }]
+                : []),
         ]
             .filter((n) => Boolean(n.value))
             .map((n) => `${n.param}=${encodeURIComponent(JSON.stringify(n.value))}`)

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -2,7 +2,7 @@ import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
 import { BindLogic, useActions, useMountedLogic, useValues } from 'kea'
 import { AccessDenied } from 'lib/components/AccessDenied'
 import { DebugCHQueries } from 'lib/components/CommandPalette/DebugCHQueries'
-import { isObject } from 'lib/utils'
+import { isEmptyObject, isObject } from 'lib/utils'
 import { InsightPageHeader } from 'scenes/insights/InsightPageHeader'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { ReloadInsight } from 'scenes/saved-insights/ReloadInsight'
@@ -57,21 +57,23 @@ export function Insight({ insightId }: InsightSceneProps): JSX.Element {
         return <AccessDenied object="insight" />
     }
 
+    const dashboardOverridesExist =
+        (isObject(filtersOverride) && !isEmptyObject(filtersOverride)) ||
+        (isObject(variablesOverride) && !isEmptyObject(variablesOverride))
+    const overrideType = isObject(filtersOverride) ? 'filters' : 'variables'
+
     return (
         <BindLogic logic={insightLogic} props={insightProps}>
             <div className="Insight">
                 <InsightPageHeader insightLogicProps={insightProps} />
 
-                {(isObject(filtersOverride) || isObject(variablesOverride)) && (
+                {dashboardOverridesExist && (
                     <LemonBanner type="warning" className="mb-4">
                         <div className="flex flex-row items-center justify-between gap-2">
-                            <span>
-                                You are viewing this insight with{' '}
-                                {isObject(variablesOverride) ? 'variables' : 'filters'} from a dashboard
-                            </span>
+                            <span>You are viewing this insight with {overrideType} from a dashboard</span>
 
                             <LemonButton type="secondary" to={urls.insightView(insightId as InsightShortId)}>
-                                Discard dashboard {isObject(variablesOverride) ? 'variables' : 'filters'}
+                                Discard dashboard {overrideType}
                             </LemonButton>
                         </div>
                     </LemonBanner>

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -25,7 +25,7 @@ import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonSwitch } from 'lib/lemon-ui/LemonSwitch'
-import { isObject } from 'lib/utils'
+import { isEmptyObject, isObject } from 'lib/utils'
 import { deleteInsightWithUndo } from 'lib/utils/deleteWithUndo'
 import { useState } from 'react'
 import { NewDashboardModal } from 'scenes/dashboard/NewDashboardModal'
@@ -96,7 +96,10 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
 
     const [addToDashboardModalOpen, setAddToDashboardModalOpenModal] = useState<boolean>(false)
 
-    const dashboardOverridesExist = isObject(filtersOverride) || isObject(variablesOverride)
+    const dashboardOverridesExist =
+        (isObject(filtersOverride) && !isEmptyObject(filtersOverride)) ||
+        (isObject(variablesOverride) && !isEmptyObject(variablesOverride))
+
     const overrideType = isObject(filtersOverride) ? 'filters' : 'variables'
 
     const showCohortButton =


### PR DESCRIPTION
## Problem
When clicking into an insight from the dashboard, we were showing the banner to discard dashboard filters even if there were no filters/variables present.

## Changes
Only pass forward the dashboard filters and variables if non empty and only show the banner in that scenario.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?
👁️ 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
