### PR TITLE
fix(messaging): use different flags for dogfooding messaging vs. early access

### DIFF
--- a/frontend/src/layout/navigation-3000/navigationLogic.tsx
+++ b/frontend/src/layout/navigation-3000/navigationLogic.tsx
@@ -610,7 +610,7 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
                                   tooltipDocLink: 'https://posthog.com/docs/links',
                               }
                             : null,
-                        featureFlags[FEATURE_FLAGS.MESSAGING]
+                        featureFlags[FEATURE_FLAGS.MESSAGING_AUTOMATION]
                             ? {
                                   identifier: Scene.MessagingBroadcasts,
                                   label: 'Messaging',

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -19,7 +19,7 @@ import {
 import { combineUrl } from 'kea-router'
 import type { AlertType } from 'lib/components/Alerts/types'
 import { FEATURE_FLAGS, INSIGHT_VISUAL_ORDER, PRODUCT_VISUAL_ORDER } from 'lib/constants'
-import { isEmptyObject, toParams } from 'lib/utils'
+import { toParams } from 'lib/utils'
 import type { Params } from 'scenes/sceneTypes'
 import type { SurveysTabs } from 'scenes/surveys/surveysLogic'
 import { urls } from 'scenes/urls'
@@ -299,9 +299,7 @@ export const productUrls = {
     ): string => {
         const params = [
             { param: 'dashboard', value: dashboardId },
-            ...(variablesOverride && !isEmptyObject(variablesOverride)
-                ? [{ param: 'variables_override', value: variablesOverride }]
-                : []),
+            { param: 'variables_override', value: variablesOverride },
         ]
             .filter((n) => Boolean(n.value))
             .map((n) => `${n.param}=${encodeURIComponent(JSON.stringify(n.value))}`)
@@ -520,7 +518,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         visualOrder: PRODUCT_VISUAL_ORDER.messaging,
         category: 'Tools',
         tags: ['alpha'],
-        flag: FEATURE_FLAGS.MESSAGING,
+        flag: FEATURE_FLAGS.MESSAGING_AUTOMATION,
     },
     { path: 'Product analytics', category: 'Analytics', type: 'insight', href: urls.insights() },
     {

--- a/products/messaging/manifest.tsx
+++ b/products/messaging/manifest.tsx
@@ -92,7 +92,11 @@ export const manifest: ProductManifest = {
             visualOrder: PRODUCT_VISUAL_ORDER.messaging,
             category: 'Tools',
             tags: ['alpha'],
-            flag: FEATURE_FLAGS.MESSAGING,
+            /**
+             * We'll keep early-access flag (FEATURE_FLAGS.MESSAGING) enabled but use this
+             * automation flag for sidebar visibility to enable internal dogfooding
+             */
+            flag: FEATURE_FLAGS.MESSAGING_AUTOMATION,
         },
     ],
 }


### PR DESCRIPTION

## Problem

Context: https://posthog.slack.com/archives/C08H8MAM0KG/p1749652423305019

This happens if the flag backing the early access feature is disabled. I disabled it to hide our feature from the nav. Now we'll enable the flag so that the feature preview sign-up works correctly, and use this flag for showing it in the navbar: https://us.posthog.com/project/2/feature_flags/124038 so that we an dogfood.

## How did you test this code?
<img width="510" alt="Screenshot 2025-06-11 at 10 17 07 AM" src="https://github.com/user-attachments/assets/6e4c1fb9-e11a-492b-8e3b-5d280febf894" />
<img width="587" alt="Screenshot 2025-06-11 at 10 17 22 AM" src="https://github.com/user-attachments/assets/b75dda39-9bbe-47f9-9028-bf48c15813c2" />

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
