### PR TITLE
chore(batch-exports): Add untranslateable character to unretryable

### DIFF
--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -884,6 +884,8 @@ class PostgresBatchExportWorkflow(PostHogWorkflow):
                 "CheckViolation",
                 # We do not create foreign keys, so this is a user managed check we have failed.
                 "ForeignKeyViolation",
+                # Data (usually event properties) contains garbage that we cannot clean.
+                "UntranslatableCharacter",
             ],
             finish_inputs=finish_inputs,
         )


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

This error pops up in PostgreSQL occasionally if the events contain particularly garbage data. I think it's rare and isolated to some peculiar workflows, so it's fine to fail on this. Failing will also help us identify the data that's causing trouble, and hopefully find a way to clean it.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
