### PR TITLE
chore(cohort): add stuck cohort metric

### DIFF
--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -36,7 +36,7 @@ COHORTS_STALE_COUNT_GAUGE = Gauge(
 )
 
 COHORT_STUCK_COUNT_GAUGE = Gauge(
-    "cohort_stuck_count", "Number of cohorts that are stuck calculating for more than 12 hours "
+    "cohort_stuck_count", "Number of cohorts that are stuck calculating for more than 1 hours"
 )
 
 logger = structlog.get_logger(__name__)
@@ -87,7 +87,7 @@ def update_stale_cohort_metrics() -> None:
     stuck_count = (
         Cohort.objects.filter(
             is_calculating=True,
-            last_calculation__lte=now - relativedelta(hours=12),
+            last_calculation__lte=now - relativedelta(hours=1),
             last_calculation__isnull=False,
             deleted=False,
         )

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -36,7 +36,7 @@ COHORTS_STALE_COUNT_GAUGE = Gauge(
 )
 
 COHORT_STUCK_COUNT_GAUGE = Gauge(
-    "cohort_stuck_count", "Number of cohorts that are stuck calculating for more than 1 hours"
+    "cohort_stuck_count", "Number of cohorts that are stuck calculating for more than 1 hour"
 )
 
 logger = structlog.get_logger(__name__)

--- a/posthog/tasks/test/test_calculate_cohort.py
+++ b/posthog/tasks/test/test_calculate_cohort.py
@@ -14,6 +14,7 @@ from posthog.tasks.calculate_cohort import (
     MAX_ERRORS_CALCULATING,
     update_stale_cohort_metrics,
     COHORTS_STALE_COUNT_GAUGE,
+    COHORT_STUCK_COUNT_GAUGE,
 )
 from posthog.test.base import APIBaseTest
 
@@ -199,6 +200,55 @@ def calculate_cohort_test_factory(event_factory: Callable, person_factory: Calla
             self.assertEqual(set_calls[0][0][0], 3)  # 24h: stale_24h, stale_36h, stale_48h
             self.assertEqual(set_calls[1][0][0], 2)  # 36h: stale_36h, stale_48h
             self.assertEqual(set_calls[2][0][0], 1)  # 48h: stale_48h
+
+        @patch.object(COHORT_STUCK_COUNT_GAUGE, "set")
+        def test_stuck_cohort_metrics(self, mock_set: MagicMock) -> None:
+            now = timezone.now()
+
+            # Create stuck cohort - is_calculating=True and last_calculation > 12 hours ago
+            Cohort.objects.create(
+                team_id=self.team.pk,
+                name="stuck_cohort",
+                last_calculation=now - relativedelta(hours=15),  # Older than 12 hours
+                deleted=False,
+                is_calculating=True,  # Stuck calculating
+                errors_calculating=5,
+                is_static=False,
+            )
+
+            # Create another stuck cohort
+            Cohort.objects.create(
+                team_id=self.team.pk,
+                name="stuck_cohort_2",
+                last_calculation=now - relativedelta(hours=20),  # Older than 12 hours
+                deleted=False,
+                is_calculating=True,  # Stuck calculating
+                errors_calculating=2,
+                is_static=False,
+            )
+
+            Cohort.objects.create(
+                team_id=self.team.pk,
+                name="not_calculating",
+                last_calculation=now - relativedelta(hours=15),  # Old but not calculating
+                deleted=False,
+                is_calculating=False,  # Not calculating
+                errors_calculating=0,
+                is_static=False,
+            )
+
+            Cohort.objects.create(
+                team_id=self.team.pk,
+                name="recent_calculation",
+                last_calculation=now - relativedelta(hours=5),  # Recent calculation
+                deleted=False,
+                is_calculating=True,  # Calculating but recent
+                errors_calculating=0,
+                is_static=False,
+            )
+
+            update_stale_cohort_metrics()
+            mock_set.assert_called_with(2)
 
         @patch("posthog.tasks.calculate_cohort.increment_version_and_enqueue_calculate_cohort")
         @patch("posthog.tasks.calculate_cohort.logger")

--- a/posthog/tasks/test/test_calculate_cohort.py
+++ b/posthog/tasks/test/test_calculate_cohort.py
@@ -209,7 +209,7 @@ def calculate_cohort_test_factory(event_factory: Callable, person_factory: Calla
             Cohort.objects.create(
                 team_id=self.team.pk,
                 name="stuck_cohort",
-                last_calculation=now - relativedelta(hours=15),  # Older than 12 hours
+                last_calculation=now - relativedelta(hours=2),
                 deleted=False,
                 is_calculating=True,  # Stuck calculating
                 errors_calculating=5,
@@ -220,7 +220,7 @@ def calculate_cohort_test_factory(event_factory: Callable, person_factory: Calla
             Cohort.objects.create(
                 team_id=self.team.pk,
                 name="stuck_cohort_2",
-                last_calculation=now - relativedelta(hours=20),  # Older than 12 hours
+                last_calculation=now - relativedelta(hours=3),
                 deleted=False,
                 is_calculating=True,  # Stuck calculating
                 errors_calculating=2,
@@ -230,7 +230,7 @@ def calculate_cohort_test_factory(event_factory: Callable, person_factory: Calla
             Cohort.objects.create(
                 team_id=self.team.pk,
                 name="not_calculating",
-                last_calculation=now - relativedelta(hours=15),  # Old but not calculating
+                last_calculation=now - relativedelta(hours=24),  # Old but not calculating
                 deleted=False,
                 is_calculating=False,  # Not calculating
                 errors_calculating=0,
@@ -240,9 +240,9 @@ def calculate_cohort_test_factory(event_factory: Callable, person_factory: Calla
             Cohort.objects.create(
                 team_id=self.team.pk,
                 name="recent_calculation",
-                last_calculation=now - relativedelta(hours=5),  # Recent calculation
+                last_calculation=now - relativedelta(minutes=59),  # Recent calculation
                 deleted=False,
-                is_calculating=True,  # Calculating but recent
+                is_calculating=True,
                 errors_calculating=0,
                 is_static=False,
             )


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Stuck cohorts (a cohort that is showing "in progress" in the UI for several hours/days/weeks) are an issue reported by users. Adding a metric so we can monitor it once I merge more changes to cohort calculations in.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
