### PR TITLE
fix(flags): fixing cohort parsing issue

### DIFF
--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -75,9 +75,10 @@ impl Cohort {
     /// * `HashSet<CohortId>` - A set of dependent cohort IDs
     /// * `FlagError` - If there is an error parsing the filters
     pub fn extract_dependencies(&self) -> Result<HashSet<CohortId>, FlagError> {
-        // Static cohorts have no filters, so they have no dependencies
-        // Annoyingly, though, rather than having None, they have an object like this
-        // {"properties": {}}
+        // NB: static cohorts have no filters, so they have no dependencies
+        // BUT, sometimes instead of having `None` or `{}`, they have an object like this
+        // `{"properties": {}}`
+        // So we need to explicitly check for this case and just return an empty set rather than trying to parse the filters at all
         if self.is_static {
             return Ok(HashSet::new());
         }
@@ -602,5 +603,84 @@ mod tests {
             [dependent_cohort.id].iter().cloned().collect();
 
         assert_eq!(dependencies, expected_dependencies);
+    }
+
+    #[tokio::test]
+    async fn test_static_cohort_with_malformed_filters() {
+        // Test that static cohorts with malformed filters don't cause parsing errors
+        let static_cohort_with_bad_filters = Cohort {
+            id: 999,
+            name: Some("Static Cohort with Bad Filters".to_string()),
+            description: None,
+            team_id: 1,
+            deleted: false,
+            // This is the problematic case - static cohorts sometimes have {"properties": {}}
+            // instead of null, which would fail JSON parsing if we tried to parse it
+            filters: Some(json!({"properties": {}})),
+            query: None,
+            version: None,
+            pending_version: None,
+            count: Some(100),
+            is_calculating: false,
+            is_static: true, // This is the key - it's static
+            errors_calculating: 0,
+            groups: json!({}),
+            created_by_id: None,
+        };
+
+        // This should not fail even though the filters are malformed
+        let dependencies = static_cohort_with_bad_filters
+            .extract_dependencies()
+            .unwrap();
+        assert_eq!(dependencies, HashSet::new());
+
+        // Test another malformed case - empty object
+        let static_cohort_empty_filters = Cohort {
+            id: 998,
+            name: Some("Static Cohort Empty".to_string()),
+            description: None,
+            team_id: 1,
+            deleted: false,
+            filters: Some(json!({})), // Empty object
+            query: None,
+            version: None,
+            pending_version: None,
+            count: Some(50),
+            is_calculating: false,
+            is_static: true,
+            errors_calculating: 0,
+            groups: json!({}),
+            created_by_id: None,
+        };
+
+        let dependencies = static_cohort_empty_filters.extract_dependencies().unwrap();
+        assert_eq!(dependencies, HashSet::new());
+
+        // Verify that a dynamic cohort with the same malformed filters WOULD fail
+        let dynamic_cohort_with_bad_filters = Cohort {
+            id: 997,
+            name: Some("Dynamic Cohort with Bad Filters".to_string()),
+            description: None,
+            team_id: 1,
+            deleted: false,
+            filters: Some(json!({"properties": {}})), // Same malformed filters
+            query: None,
+            version: None,
+            pending_version: None,
+            count: None,
+            is_calculating: false,
+            is_static: false, // This is dynamic, so it should fail
+            errors_calculating: 0,
+            groups: json!({}),
+            created_by_id: None,
+        };
+
+        // This should fail because it's dynamic and the filters are malformed
+        let result = dynamic_cohort_with_bad_filters.extract_dependencies();
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            FlagError::CohortFiltersParsingError
+        ));
     }
 }

--- a/rust/feature-flags/src/metrics/utils.rs
+++ b/rust/feature-flags/src/metrics/utils.rs
@@ -57,6 +57,7 @@ pub fn parse_exception_for_prometheus_label(err: &FlagError) -> &'static str {
         FlagError::TimeoutError => "timeout_error",
         FlagError::NoGroupTypeMappings => "no_group_type_mappings",
         FlagError::CohortNotFound(_) => "cohort_not_found",
+        FlagError::CohortFiltersParsingError => "cohort_filters_parsing_error",
         _ => "unknown",
     }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Noticing some error logs around flags that have cohort dependencies where one of the cohorts is static ("Bravehearts v2" is a static cohort).  Something like this

```
{"groups": [{"variant": null, "properties": [{"key": "id", "type": "cohort", "value": 98012, "operator": "in", "cohort_name": "Admin"}], "rollout_percentage": 100}, {"variant": null, "properties": [{"key": "id", "type": "cohort", "value": 115795, "operator": "in", "cohort_name": "Bravehearts v2"}], "rollout_percentage": 100}, {"variant": null, "properties": [], "rollout_percentage": 100}, {"variant": null, "properties": [{"key": "firebase_id", "type": "person", "value": ["MjV4a4wompSKxn0ekREN44DuFB03", "URBBH8sUtNQDuF3VWPN5UwNfdKQ2"], "operator": "exact"}], "rollout_percentage": 100}], "payloads": {}, "multivariate": null}
```

Static cohorts are supposed to have an empty `filters` column, so my code just returns empty HashSet when building the dependencies.  However, turns out this empty `filters` column assumption is not the case, and some static cohorts have `{}` or `{properties:{}}` in the `filters` column as well.

<img width="532" alt="image" src="https://github.com/user-attachments/assets/9d5450a8-3659-4851-a07b-a3487d248985" />

This meant I was failing to parse dependencies from static cohorts that had `{properties:{}}`, and I got some logs like this:

```
2025-06-11T19:35:32.564625Z ERROR ThreadId(24) feature_flags::cohorts::cohort_operations: Failed to parse filters for cohort 102890 (team 92193): missing field `type`
2025-06-11T19:35:32.564633Z ERROR ThreadId(30) feature_flags::cohorts::cohort_operations: Failed to parse filters for cohort 102890 (team 92193): missing field `type`
2025-06-11T19:35:32.564758Z ERROR ThreadId(03) feature_flags::flags::flag_matching: Error evaluating feature flag 'enable_ahk_backfill' for distinct_id 'ntVrCG7QXcSyAJOwF1SGFwyxsk03': CohortFiltersParsingError
2025-06-11T19:35:32.564781Z ERROR ThreadId(03) feature_flags::flags::flag_matching: Error evaluating feature flag 'ai_streaming_enabled' for distinct_id 'ntVrCG7QXcSyAJOwF1SGFwyxsk03': CohortFiltersParsingError
```

## Changes

- removed a function that wasn't doing anything
- fixed my dependency builder to just set the filters to `HashSet::new()` if it's static; don't even _try_ to parse it.

## Did you write or update any docs for this change?

- [x] No docs needed for this change

## How did you test this code?

- new test for this behavior

