### PR TITLE
feat(propdefs): implement batch APIs on update cache + manage synchronization directly

### DIFF
--- a/rust/property-defs-rs/src/config.rs
+++ b/rust/property-defs-rs/src/config.rs
@@ -41,6 +41,11 @@ pub struct Config {
     #[envconfig(default = "1000000")]
     pub cache_capacity: usize,
 
+    // chunk size for batch inserting or removing Update entries from the cache.
+    // the write lock is held during each chunk operation on the cache
+    #[envconfig(default = "100")]
+    pub cache_lock_chunk_size: usize,
+
     // Each worker maintains a small local batch of updates, which it
     // flushes to the main thread (updating/filtering by the
     // cross-thread cache while it does). This is that batch size.

--- a/rust/property-defs-rs/src/main.rs
+++ b/rust/property-defs-rs/src/main.rs
@@ -84,8 +84,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let (tx, rx) = mpsc::channel(config.update_batch_size * config.channel_slots_per_worker);
 
-    let cache = Cache::new(config.cache_capacity);
-
+    let cache = Cache::new(config.cache_capacity, config.cache_lock_chunk_size);
     let cache = Arc::new(cache);
 
     let mut handles = Vec::new();

--- a/rust/property-defs-rs/src/update_cache.rs
+++ b/rust/property-defs-rs/src/update_cache.rs
@@ -1,39 +1,51 @@
+use std::sync::RwLock;
+
 use crate::{metrics_consts::UPDATES_CACHE, types::Update};
-use quick_cache::sync;
+
+use quick_cache::unsync;
 
 pub struct Cache {
-    eventdefs: sync::Cache<Update, ()>,
-    eventprops: sync::Cache<Update, ()>,
-    propdefs: sync::Cache<Update, ()>,
+    lock_chunk_size: usize,
+    eventdefs: RwLock<unsync::Cache<Update, ()>>,
+    eventprops: RwLock<unsync::Cache<Update, ()>>,
+    propdefs: RwLock<unsync::Cache<Update, ()>>,
 }
 
-// TODO: next iter, try using unsync::Cache(s) here and manage sync access to each
-// manually. This enables implementing new batch insert/remove APIs on this wrapper,
-// since we rarely want to work with just one cache entry at a time in propdefs. I
-// suspect small-batch updates would further reduce internal cache lock contention
-// that can slow down our batch write threads, esp. when a write fails and we evict
 impl Cache {
-    pub fn new(capacity: usize) -> Self {
+    pub fn new(capacity: usize, lock_chunk_size: usize) -> Self {
         Self {
-            eventdefs: sync::Cache::new(capacity),
-            eventprops: sync::Cache::new(capacity),
-            propdefs: sync::Cache::new(capacity),
+            lock_chunk_size,
+            eventdefs: RwLock::new(unsync::Cache::new(capacity)),
+            eventprops: RwLock::new(unsync::Cache::new(capacity)),
+            propdefs: RwLock::new(unsync::Cache::new(capacity)),
         }
     }
 
     pub fn len(&self) -> usize {
-        self.eventdefs.len() + self.eventprops.len() + self.propdefs.len()
+        self.eventdefs_len() + self.eventprops_len() + self.propdefs_len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.propdefs.is_empty() && self.eventdefs.is_empty() && self.eventprops.is_empty()
+        self.propdefs_is_empty() && self.eventdefs_is_empty() && self.eventprops_is_empty()
     }
 
     pub fn contains_key(&self, key: &Update) -> bool {
         let result = match key {
-            Update::Event(_) => self.eventdefs.contains_key(key),
-            Update::EventProperty(_) => self.eventprops.contains_key(key),
-            Update::Property(_) => self.propdefs.contains_key(key),
+            Update::Event(_) => {
+                let cache = self.eventdefs.read().expect("eventdefs_contains_key: lock");
+                cache.contains_key(key)
+            }
+            Update::EventProperty(_) => {
+                let cache = self
+                    .eventprops
+                    .read()
+                    .expect("eventprops_contains_key: lock");
+                cache.contains_key(key)
+            }
+            Update::Property(_) => {
+                let cache = self.propdefs.read().expect("propdefs_contains_key: lock");
+                cache.contains_key(key)
+            }
         };
 
         match result {
@@ -44,20 +56,52 @@ impl Cache {
         result
     }
 
+    pub fn insert_batch(&self, batch: &[Update]) {
+        for chunk in batch[..].chunks(self.lock_chunk_size) {
+            self.do_insert_batch(chunk)
+        }
+    }
+
+    pub fn remove_batch(&self, batch: &[Update]) {
+        for chunk in batch[..].chunks(self.lock_chunk_size) {
+            self.do_remove_batch(chunk)
+        }
+    }
+
     pub fn insert(&self, key: Update) {
         match key {
-            Update::Event(_) => self.eventdefs.insert(key, ()),
-            Update::EventProperty(_) => self.eventprops.insert(key, ()),
-            Update::Property(_) => self.propdefs.insert(key, ()),
+            Update::Event(_) => {
+                let mut cache = self.eventdefs.write().expect("eventdefs_insert: lock");
+                cache.insert(key, ())
+            }
+            Update::EventProperty(_) => {
+                let mut cache = self.eventprops.write().expect("eventprops_insert: lock");
+                cache.insert(key, ())
+            }
+            Update::Property(_) => {
+                let mut cache = self.propdefs.write().expect("propdefs_insert: lock");
+                cache.insert(key, ())
+            }
         }
+
+        metrics::counter!(UPDATES_CACHE, &[("action", "inserted")]).increment(1);
     }
 
     // we don't return the retrieved KV since propdefs doesn't require it
     pub fn remove(&self, key: &Update) {
         let result = match key {
-            Update::Event(_) => self.eventdefs.remove(key),
-            Update::EventProperty(_) => self.eventprops.remove(key),
-            Update::Property(_) => self.propdefs.remove(key),
+            Update::Event(_) => {
+                let mut cache = self.eventdefs.write().expect("eventdefs_remove: lock");
+                cache.remove(key)
+            }
+            Update::EventProperty(_) => {
+                let mut cache = self.eventprops.write().expect("eventprops_remove: lock");
+                cache.remove(key)
+            }
+            Update::Property(_) => {
+                let mut cache = self.propdefs.write().expect("propdefs_remove: lock");
+                cache.remove(key)
+            }
         };
 
         if result.is_some() {
@@ -65,5 +109,137 @@ impl Cache {
         } else {
             metrics::counter!(UPDATES_CACHE, &[("action", "not_cached")]).increment(1);
         }
+    }
+
+    //
+    // Private helper methods
+    //
+
+    // Assumption: the chunk passed in was size-checked by the caller
+    // and includes **only one type** of Update enum variant!
+    fn do_insert_batch(&self, chunk: &[Update]) {
+        if chunk.is_empty() {
+            return;
+        }
+
+        let mut hits: u64 = 0;
+        let mut misses: u64 = 0;
+
+        match chunk[0] {
+            Update::Event(_) => {
+                let mut cache = self.eventdefs.write().expect("eventdefs_write: lock");
+                for evt_def in chunk {
+                    if cache.contains_key(evt_def) {
+                        hits += 1
+                    } else {
+                        cache.insert(evt_def.clone(), ());
+                        misses += 1
+                    }
+                }
+            }
+            Update::EventProperty(_) => {
+                let mut cache = self.eventprops.write().expect("eventprops_write: lock");
+                for evt_prop in chunk {
+                    if cache.contains_key(evt_prop) {
+                        hits += 1
+                    } else {
+                        cache.insert(evt_prop.clone(), ());
+                        misses += 1
+                    }
+                }
+            }
+            Update::Property(_) => {
+                let mut cache = self.propdefs.write().expect("propdefs_write: lock");
+                for prop_def in chunk {
+                    if cache.contains_key(prop_def) {
+                        hits += 1
+                    } else {
+                        cache.insert(prop_def.clone(), ());
+                        misses += 1
+                    }
+                }
+            }
+        }
+
+        metrics::counter!(UPDATES_CACHE, &[("action", "cache_hit")]).increment(hits);
+        metrics::counter!(UPDATES_CACHE, &[("action", "cache_miss")]).increment(misses);
+        metrics::counter!(UPDATES_CACHE, &[("action", "inserted")]).increment(misses);
+    }
+
+    // Assumption: the chunk passed in was size-checked by the caller
+    // and includes **only one type** of Update enum variant!
+    fn do_remove_batch(&self, chunk: &[Update]) {
+        if chunk.is_empty() {
+            return;
+        }
+
+        let mut removed: u64 = 0;
+        let mut not_found: u64 = 0;
+
+        match chunk[0] {
+            Update::Event(_) => {
+                let mut cache = self.eventdefs.write().expect("eventdefs_write: lock");
+                for evt_def in chunk {
+                    if cache.remove(evt_def).is_some() {
+                        removed += 1
+                    } else {
+                        not_found += 1
+                    }
+                }
+            }
+            Update::EventProperty(_) => {
+                let mut cache = self.eventprops.write().expect("eventprops_write: lock");
+                for evt_prop in chunk {
+                    if cache.remove(evt_prop).is_some() {
+                        removed += 1
+                    } else {
+                        not_found += 1
+                    }
+                }
+            }
+            Update::Property(_) => {
+                let mut cache = self.propdefs.write().expect("propdefs_write: lock");
+                for prop_def in chunk {
+                    if cache.remove(prop_def).is_some() {
+                        removed += 1
+                    } else {
+                        not_found += 1
+                    }
+                }
+            }
+        }
+
+        metrics::counter!(UPDATES_CACHE, &[("action", "removed")]).increment(removed);
+        metrics::counter!(UPDATES_CACHE, &[("action", "not_cached")]).increment(not_found);
+    }
+
+    fn eventdefs_len(&self) -> usize {
+        let cache = self.eventdefs.read().expect("eventdefs_len: lock");
+        cache.len()
+    }
+
+    fn eventdefs_is_empty(&self) -> bool {
+        let cache = self.eventdefs.read().expect("eventdefs_is_empty: lock");
+        cache.is_empty()
+    }
+
+    fn eventprops_len(&self) -> usize {
+        let cache = self.eventprops.read().expect("eventprops_len: lock");
+        cache.len()
+    }
+
+    fn eventprops_is_empty(&self) -> bool {
+        let cache = self.eventprops.read().expect("eventprops_is_empty: lock");
+        cache.is_empty()
+    }
+
+    fn propdefs_len(&self) -> usize {
+        let cache = self.propdefs.read().expect("propdefs_len: lock");
+        cache.len()
+    }
+
+    fn propdefs_is_empty(&self) -> bool {
+        let cache = self.propdefs.read().expect("propdefs_is_empty: lock");
+        cache.is_empty()
     }
 }

--- a/rust/property-defs-rs/tests/update_cache.rs
+++ b/rust/property-defs-rs/tests/update_cache.rs
@@ -92,7 +92,7 @@ fn test_cache_removals() {
 
 #[test]
 fn test_batch_cache_insertions() {
-    let cache = Cache::new(10, 10);
+    let cache = Cache::new(300, 10);
 
     let mut evt_defs = vec![];
     let mut evt_props = vec![];
@@ -108,7 +108,7 @@ fn test_batch_cache_insertions() {
 
         evt_props.push(Update::EventProperty(EventProperty {
             event: format!("event def {}", counter),
-            property: format!("event prop {}", counter),
+            property: format!("prop def {}", counter),
             team_id: 1,
             project_id: 1,
         }));
@@ -127,16 +127,21 @@ fn test_batch_cache_insertions() {
         }));
     }
 
+    assert!(cache.is_empty());
     cache.insert_batch(&evt_defs);
-    cache.insert_batch(&evt_props);
-    cache.insert_batch(&prop_defs);
+    assert!(!cache.is_empty());
+    assert!(cache.len() == 100);
 
+    cache.insert_batch(&evt_props);
+    assert!(cache.len() == 200);
+
+    cache.insert_batch(&prop_defs);
     assert!(cache.len() == 300);
 }
 
 #[test]
 fn test_batch_cache_removals() {
-    let cache = Cache::new(10, 10);
+    let cache = Cache::new(300, 10);
 
     let mut evt_defs = vec![];
     let mut evt_props = vec![];

--- a/rust/property-defs-rs/tests/update_cache.rs
+++ b/rust/property-defs-rs/tests/update_cache.rs
@@ -89,3 +89,100 @@ fn test_cache_removals() {
     assert!(!cache.contains_key(&evt_prop));
     assert!(!cache.contains_key(&prop_def));
 }
+
+#[test]
+fn test_batch_cache_insertions() {
+    let cache = Cache::new(10, 10);
+
+    let mut evt_defs = vec![];
+    let mut evt_props = vec![];
+    let mut prop_defs = vec![];
+
+    for _ in 1..=100 {
+        evt_defs.push(Update::Event(EventDefinition {
+            name: String::from("foobar"),
+            team_id: 1,
+            project_id: 1,
+            last_seen_at: Utc::now(),
+        }));
+
+        evt_props.push(Update::EventProperty(EventProperty {
+            event: String::from("foo"),
+            property: String::from("bar"),
+            team_id: 1,
+            project_id: 1,
+        }));
+
+        prop_defs.push(Update::Property(PropertyDefinition {
+            team_id: 1,
+            project_id: 1,
+            name: String::from("baz_count"),
+            is_numerical: true,
+            property_type: Some(PropertyValueType::Numeric),
+            event_type: PropertyParentType::Event,
+            group_type_index: None,
+            property_type_format: None,
+            query_usage_30_day: None,
+            volume_30_day: None,
+        }));
+    }
+
+    cache.insert_batch(&evt_defs);
+    cache.insert_batch(&evt_props);
+    cache.insert_batch(&prop_defs);
+
+    assert!(cache.len() == 300);
+}
+
+#[test]
+fn test_batch_cache_removals() {
+    let cache = Cache::new(10, 10);
+
+    let mut evt_defs = vec![];
+    let mut evt_props = vec![];
+    let mut prop_defs = vec![];
+
+    for _ in 1..=100 {
+        evt_defs.push(Update::Event(EventDefinition {
+            name: String::from("foobar"),
+            team_id: 1,
+            project_id: 1,
+            last_seen_at: Utc::now(),
+        }));
+
+        evt_props.push(Update::EventProperty(EventProperty {
+            event: String::from("foo"),
+            property: String::from("bar"),
+            team_id: 1,
+            project_id: 1,
+        }));
+
+        prop_defs.push(Update::Property(PropertyDefinition {
+            team_id: 1,
+            project_id: 1,
+            name: String::from("baz_count"),
+            is_numerical: true,
+            property_type: Some(PropertyValueType::Numeric),
+            event_type: PropertyParentType::Event,
+            group_type_index: None,
+            property_type_format: None,
+            query_usage_30_day: None,
+            volume_30_day: None,
+        }));
+    }
+
+    cache.insert_batch(&evt_defs);
+    cache.insert_batch(&evt_props);
+    cache.insert_batch(&prop_defs);
+
+    assert!(cache.len() == 300);
+
+    cache.remove_batch(&evt_defs);
+    assert!(cache.len() == 200);
+
+    cache.remove_batch(&evt_props);
+    assert!(cache.len() == 100);
+
+    cache.remove_batch(&prop_defs);
+    assert!(cache.is_empty());
+}

--- a/rust/property-defs-rs/tests/update_cache.rs
+++ b/rust/property-defs-rs/tests/update_cache.rs
@@ -9,7 +9,7 @@ use property_defs_rs::{
 
 #[test]
 fn test_cache_insertions() {
-    let cache = Cache::new(10);
+    let cache = Cache::new(10, 10);
 
     let evt_def = Update::Event(EventDefinition {
         name: String::from("foobar"),
@@ -48,7 +48,7 @@ fn test_cache_insertions() {
 
 #[test]
 fn test_cache_removals() {
-    let cache = Cache::new(10);
+    let cache = Cache::new(10, 10);
 
     let evt_def = Update::Event(EventDefinition {
         name: String::from("foobar"),

--- a/rust/property-defs-rs/tests/update_cache.rs
+++ b/rust/property-defs-rs/tests/update_cache.rs
@@ -98,17 +98,17 @@ fn test_batch_cache_insertions() {
     let mut evt_props = vec![];
     let mut prop_defs = vec![];
 
-    for _ in 1..=100 {
+    for counter in 1..=100 {
         evt_defs.push(Update::Event(EventDefinition {
-            name: String::from("foobar"),
+            name: format!("event def {}", counter),
             team_id: 1,
             project_id: 1,
             last_seen_at: Utc::now(),
         }));
 
         evt_props.push(Update::EventProperty(EventProperty {
-            event: String::from("foo"),
-            property: String::from("bar"),
+            event: format!("event def {}", counter),
+            property: format!("event prop {}", counter),
             team_id: 1,
             project_id: 1,
         }));
@@ -116,7 +116,7 @@ fn test_batch_cache_insertions() {
         prop_defs.push(Update::Property(PropertyDefinition {
             team_id: 1,
             project_id: 1,
-            name: String::from("baz_count"),
+            name: format!("prop def {}", counter),
             is_numerical: true,
             property_type: Some(PropertyValueType::Numeric),
             event_type: PropertyParentType::Event,
@@ -142,17 +142,17 @@ fn test_batch_cache_removals() {
     let mut evt_props = vec![];
     let mut prop_defs = vec![];
 
-    for _ in 1..=100 {
+    for counter in 1..=100 {
         evt_defs.push(Update::Event(EventDefinition {
-            name: String::from("foobar"),
+            name: format!("event def {}", counter),
             team_id: 1,
             project_id: 1,
             last_seen_at: Utc::now(),
         }));
 
         evt_props.push(Update::EventProperty(EventProperty {
-            event: String::from("foo"),
-            property: String::from("bar"),
+            event: format!("event def {}", counter),
+            property: format!("event prop {}", counter),
             team_id: 1,
             project_id: 1,
         }));
@@ -160,7 +160,7 @@ fn test_batch_cache_removals() {
         prop_defs.push(Update::Property(PropertyDefinition {
             team_id: 1,
             project_id: 1,
-            name: String::from("baz_count"),
+            name: format!("prop def {}", counter),
             is_numerical: true,
             property_type: Some(PropertyValueType::Numeric),
             event_type: PropertyParentType::Event,

--- a/rust/property-defs-rs/tests/v2_batch_ingestion.rs
+++ b/rust/property-defs-rs/tests/v2_batch_ingestion.rs
@@ -16,7 +16,10 @@ use property_defs_rs::{
 #[sqlx::test(migrations = "./tests/test_migrations")]
 async fn test_simple_batch_write(db: PgPool) {
     let config = Config::init_with_defaults().unwrap();
-    let cache: Arc<Cache> = Arc::new(Cache::new(config.cache_capacity));
+    let cache: Arc<Cache> = Arc::new(Cache::new(
+        config.cache_capacity,
+        config.cache_lock_chunk_size,
+    ));
     let updates = gen_test_event_updates("$pageview", 100, None);
     // should decompose into 1 event def, 100 event props, 100 prop defs (of event type)
     assert_eq!(updates.len(), 201);
@@ -57,7 +60,10 @@ async fn test_group_batch_write(db: PgPool) {
     .await;
 
     let config = Config::init_with_defaults().unwrap();
-    let cache: Arc<Cache> = Arc::new(Cache::new(config.cache_capacity));
+    let cache: Arc<Cache> = Arc::new(Cache::new(
+        config.cache_capacity,
+        config.cache_lock_chunk_size,
+    ));
     let mut updates =
         gen_test_event_updates("$groupidentify", 100, Some(PropertyParentType::Group));
     // should decompose into 1 group event def, 100 prop defs (of group type), 100 event props
@@ -105,7 +111,10 @@ async fn test_group_batch_write(db: PgPool) {
 #[sqlx::test(migrations = "./tests/test_migrations")]
 async fn test_person_batch_write(db: PgPool) {
     let config = Config::init_with_defaults().unwrap();
-    let cache: Arc<Cache> = Arc::new(Cache::new(config.cache_capacity));
+    let cache: Arc<Cache> = Arc::new(Cache::new(
+        config.cache_capacity,
+        config.cache_lock_chunk_size,
+    ));
     let updates =
         gen_test_event_updates("event_with_person", 100, Some(PropertyParentType::Person));
     // should decompose into 1 event def, 100 event props, 100 prop defs (50 $set, 50 $set_once props)


### PR DESCRIPTION
## Problem
We'd like to explore ways to insert and remove batches of `Update` entries from the pod-local cache without causing lock contention across producer and (many) consumer worker threads.

If this was unblocked, we could refactor the `property-defs-rs` cache strategy to insert `Update`s only when successfully persisted to Postgres, which will improve cache accuracy and allow similar events to be reprocessed when batch writes fail.

## Changes
Since we always have a full batch to insert or delete from the cache, we can experiment with inserting N `Update`s at a time for each lock taken rather than per-`Update`. If N is tuned properly, this could help speed up bulk insertion/removal and reduce lock contention.

This PR implements the experiment, but will land as a no-op; the new batch APIs are not wired up in the event codepath in this PR.

## Did you write or update any docs for this change?

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Locally and in CI