### PR TITLE
fix: trends breakdown logic on clickhouse 25.3

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -1,6 +1,113 @@
 # serializer version: 1
 # name: TestCohortQuery.test_basic_query
   '''
+  (
+     (SELECT source.id AS id
+      FROM
+        (SELECT actor_id AS actor_id,
+                count() AS event_count,
+                groupUniqArray(distinct_id) AS event_distinct_ids,
+                actor_id AS id
+         FROM
+           (SELECT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,
+                   toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                   e.uuid AS uuid,
+                   e.distinct_id AS distinct_id
+            FROM events AS e
+            LEFT OUTER JOIN
+              (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                      person_distinct_id_overrides.distinct_id AS distinct_id
+               FROM person_distinct_id_overrides
+               WHERE equals(person_distinct_id_overrides.team_id, 99999)
+               GROUP BY person_distinct_id_overrides.distinct_id
+               HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+            WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+         GROUP BY actor_id) AS source
+      ORDER BY source.id ASC
+      LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                         join_algorithm='auto')
+   UNION DISTINCT
+     (SELECT source.id AS id
+      FROM
+        (SELECT actor_id AS actor_id,
+                count() AS event_count,
+                groupUniqArray(distinct_id) AS event_distinct_ids,
+                actor_id AS id
+         FROM
+           (SELECT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,
+                   toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                   e.uuid AS uuid,
+                   e.distinct_id AS distinct_id
+            FROM events AS e
+            LEFT OUTER JOIN
+              (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                      person_distinct_id_overrides.distinct_id AS distinct_id
+               FROM person_distinct_id_overrides
+               WHERE equals(person_distinct_id_overrides.team_id, 99999)
+               GROUP BY person_distinct_id_overrides.distinct_id
+               HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+            WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+         GROUP BY actor_id) AS source
+      ORDER BY source.id ASC
+      LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                         join_algorithm='auto')) INTERSECT (
+                                                              (SELECT source.id AS id
+                                                               FROM
+                                                                 (SELECT actor_id AS actor_id,
+                                                                         count() AS event_count,
+                                                                         groupUniqArray(distinct_id) AS event_distinct_ids,
+                                                                         actor_id AS id
+                                                                  FROM
+                                                                    (SELECT min(toTimeZone(e.timestamp, 'UTC')) AS min_timestamp,
+                                                                            minIf(toTimeZone(e.timestamp, 'UTC'), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))) AS min_timestamp_with_condition,
+                                                                            if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,
+                                                                            argMin(e.uuid, toTimeZone(e.timestamp, 'UTC')) AS uuid,
+                                                                            argMin(e.distinct_id, toTimeZone(e.timestamp, 'UTC')) AS distinct_id
+                                                                     FROM events AS e
+                                                                     LEFT OUTER JOIN
+                                                                       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                                                                               person_distinct_id_overrides.distinct_id AS distinct_id
+                                                                        FROM person_distinct_id_overrides
+                                                                        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                                                                        GROUP BY person_distinct_id_overrides.distinct_id
+                                                                        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+                                                                     WHERE and(equals(e.team_id, 99999), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), and(equals(e.event, '$autocapture'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://posthog.com/feedback/123'), 0)))
+                                                                     GROUP BY if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)
+                                                                     HAVING and(ifNull(equals(min_timestamp, min_timestamp_with_condition), isNull(min_timestamp)
+                                                                                       and isNull(min_timestamp_with_condition)), ifNull(notEquals(min_timestamp, fromUnixTimestamp(0)), isNotNull(min_timestamp)
+                                                                                                                                         or isNotNull(fromUnixTimestamp(0)))))
+                                                                  GROUP BY actor_id) AS source
+                                                               ORDER BY source.id ASC
+                                                               LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                                                                                  join_algorithm='auto') INTERSECT
+                                                              (SELECT persons.id AS id
+                                                               FROM
+                                                                 (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', ''), person.version) AS properties___email,
+                                                                         person.id AS id
+                                                                  FROM person
+                                                                  WHERE and(equals(person.team_id, 99999), in(id,
+                                                                                                                (SELECT where_optimization.id AS id
+                                                                                                                 FROM person AS where_optimization
+                                                                                                                 WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, 'email'), ''), 'null'), '^"|"$', ''), 'test@posthog.com'), 0)))))
+                                                                  GROUP BY person.id
+                                                                  HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
+                                                               WHERE ifNull(equals(persons.properties___email, 'test@posthog.com'), 0)
+                                                               ORDER BY persons.id ASC
+                                                               LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                                                                                  join_algorithm='auto')) SETTINGS readonly=2,
+                                                                                                                   max_execution_time=60,
+                                                                                                                   allow_experimental_object_type=1,
+                                                                                                                   format_csv_allow_double_quotes=0,
+                                                                                                                   max_ast_elements=4000000,
+                                                                                                                   max_expanded_ast_elements=4000000,
+                                                                                                                   max_bytes_before_external_group_by=0,
+                                                                                                                   transform_null_in=1,
+                                                                                                                   optimize_min_equality_disjunction_chain_length=4294967295,
+                                                                                                                   allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestCohortQuery.test_basic_query.1
+  '''
   
   SELECT person.person_id AS id
   FROM
@@ -63,59 +170,82 @@
 # name: TestCohortQuery.test_cohort_filter_with_another_cohort_with_event_sequence.1
   '''
   /* cohort_calculation: */
-  SELECT if(funnel_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, funnel_query.person_id) AS id
-  FROM
-    (SELECT person_id,
-            max(if(event = '$new_view'
-                   AND event_0_latest_0 < event_0_latest_1
-                   AND event_0_latest_1 <= event_0_latest_0 + INTERVAL 8 day, 2, 1)) = 2 AS steps_0
+    (SELECT cohort_people.person_id AS id
      FROM
-       (SELECT person_id,
-               event,
-               properties,
-               distinct_id, timestamp, event_0_latest_0,
-                                       min(event_0_latest_1) over (PARTITION by person_id
-                                                                   ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) event_0_latest_1
+       (SELECT DISTINCT cohortpeople.person_id AS person_id,
+                        cohortpeople.cohort_id AS cohort_id,
+                        cohortpeople.team_id AS team_id
+        FROM cohortpeople
+        WHERE and(equals(cohortpeople.team_id, 99999), in(tuple(cohortpeople.cohort_id, cohortpeople.version), [(99999, 0)]))) AS cohort_people
+     WHERE and(ifNull(equals(cohort_people.cohort_id, 99999), 0), ifNull(equals(cohort_people.team_id, 99999), 0))
+     LIMIT 100) INTERSECT
+    (SELECT source.id AS id
+     FROM
+       (SELECT aggregation_target AS actor_id,
+               actor_id AS id
         FROM
-          (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
-                  event,
-                  properties,
-                  distinct_id, timestamp, if(event = '$new_view'
-                                             AND timestamp > now() - INTERVAL 8 day, 1, 0) AS event_0_step_0,
-                                          if(event_0_step_0 = 1, timestamp, null) AS event_0_latest_0,
-                                          if(event = '$new_view'
-                                             AND timestamp > now() - INTERVAL 8 day, 1, 0) AS event_0_step_1,
-                                          if(event_0_step_1 = 1, timestamp, null) AS event_0_latest_1
-           FROM events AS e
-           LEFT OUTER JOIN
-             (SELECT distinct_id,
-                     argMax(person_id, version) as person_id
-              FROM person_distinct_id2
-              WHERE team_id = 99999
-              GROUP BY distinct_id
-              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-           WHERE team_id = 99999
-             AND event IN ['$new_view', '$new_view']
-             AND timestamp <= now()
-             AND timestamp >= now() - INTERVAL 8 day ))
-     GROUP BY person_id) funnel_query
-  FULL OUTER JOIN
-    (SELECT *,
-            id AS person_id
-     FROM
-       (SELECT id
-        FROM person
-        WHERE team_id = 99999
-        GROUP BY id
-        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = funnel_query.person_id
-  WHERE 1 = 1
-    AND (((id IN
-             (SELECT person_id
-              FROM cohortpeople
-              WHERE cohort_id = 99999
-                AND team_id = 99999 ))
-          AND (steps_0))) SETTINGS optimize_aggregation_in_order = 1,
-                                   join_algorithm = 'auto'
+          (SELECT aggregation_target AS aggregation_target,
+                  steps AS steps,
+                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
+                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+           FROM
+             (SELECT aggregation_target AS aggregation_target,
+                     steps AS steps,
+                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
+                                     step_1_conversion_time AS step_1_conversion_time
+              FROM
+                (SELECT aggregation_target AS aggregation_target,
+                        timestamp AS timestamp,
+                        step_0 AS step_0,
+                        latest_0 AS latest_0,
+                        step_1 AS step_1,
+                        latest_1 AS latest_1,
+                        if(and(ifNull(less(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalSecond(691200))), 0)), 2, 1) AS steps,
+                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalSecond(691200))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
+                 FROM
+                   (SELECT aggregation_target AS aggregation_target,
+                           timestamp AS timestamp,
+                           step_0 AS step_0,
+                           latest_0 AS latest_0,
+                           step_1 AS step_1,
+                           min(latest_1) OVER (PARTITION BY aggregation_target
+                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS latest_1
+                    FROM
+                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                              if(equals(e.event, '$new_view'), 1, 0) AS step_0,
+                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
+                              if(equals(e.event, '$new_view'), 1, 0) AS step_1,
+                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
+                       FROM events AS e
+                       LEFT OUTER JOIN
+                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                                 person_distinct_id_overrides.distinct_id AS distinct_id
+                          FROM person_distinct_id_overrides
+                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                          GROUP BY person_distinct_id_overrides.distinct_id
+                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$new_view'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
+                 WHERE ifNull(equals(step_0, 1), 0)))
+           GROUP BY aggregation_target,
+                    steps
+           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
+                         and isNull(max(max_steps))))
+        WHERE in(steps,
+                 [2])
+        ORDER BY aggregation_target ASC) AS source
+     ORDER BY source.id ASC
+     LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                        join_algorithm='auto') SETTINGS readonly=2,
+                                                        max_execution_time=60,
+                                                        allow_experimental_object_type=1,
+                                                        format_csv_allow_double_quotes=0,
+                                                        max_ast_elements=4000000,
+                                                        max_expanded_ast_elements=4000000,
+                                                        max_bytes_before_external_group_by=0,
+                                                        transform_null_in=1,
+                                                        optimize_min_equality_disjunction_chain_length=4294967295,
+                                                        allow_experimental_join_condition=1
   '''
 # ---
 # name: TestCohortQuery.test_cohort_filter_with_another_cohort_with_event_sequence.2
@@ -189,6 +319,53 @@
 # name: TestCohortQuery.test_cohort_filter_with_extra.1
   '''
   /* cohort_calculation: */
+    (SELECT cohort_people.person_id AS id
+     FROM
+       (SELECT DISTINCT cohortpeople.person_id AS person_id,
+                        cohortpeople.cohort_id AS cohort_id,
+                        cohortpeople.team_id AS team_id
+        FROM cohortpeople
+        WHERE and(equals(cohortpeople.team_id, 99999), in(tuple(cohortpeople.cohort_id, cohortpeople.version), [(99999, 0)]))) AS cohort_people
+     WHERE and(ifNull(equals(cohort_people.cohort_id, 99999), 0), ifNull(equals(cohort_people.team_id, 99999), 0))
+     LIMIT 100) INTERSECT
+    (SELECT source.id AS id
+     FROM
+       (SELECT actor_id AS actor_id,
+               count() AS event_count,
+               groupUniqArray(distinct_id) AS event_distinct_ids,
+               actor_id AS id
+        FROM
+          (SELECT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,
+                  toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.uuid AS uuid,
+                  e.distinct_id AS distinct_id
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+        GROUP BY actor_id) AS source
+     ORDER BY source.id ASC
+     LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                        join_algorithm='auto') SETTINGS readonly=2,
+                                                        max_execution_time=60,
+                                                        allow_experimental_object_type=1,
+                                                        format_csv_allow_double_quotes=0,
+                                                        max_ast_elements=4000000,
+                                                        max_expanded_ast_elements=4000000,
+                                                        max_bytes_before_external_group_by=0,
+                                                        transform_null_in=1,
+                                                        optimize_min_equality_disjunction_chain_length=4294967295,
+                                                        allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestCohortQuery.test_cohort_filter_with_extra.2
+  '''
+  /* cohort_calculation: */
   SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
   FROM
     (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
@@ -228,7 +405,7 @@
                                                                                   join_algorithm = 'auto'
   '''
 # ---
-# name: TestCohortQuery.test_cohort_filter_with_extra.2
+# name: TestCohortQuery.test_cohort_filter_with_extra.3
   '''
   /* cohort_calculation: */
   SELECT count(DISTINCT person_id)
@@ -236,55 +413,60 @@
   WHERE team_id = 99999
     AND cohort_id = 99999
     AND version = 0
-  '''
-# ---
-# name: TestCohortQuery.test_cohort_filter_with_extra.3
-  '''
-  /* cohort_calculation: */
-  SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
-  FROM
-    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
-            countIf(timestamp > now() - INTERVAL 1 week
-                    AND timestamp < now()
-                    AND event = '$pageview'
-                    AND 1=1) > 0 AS performed_event_condition_None_level_level_0_level_1_level_0_0
-     FROM events e
-     LEFT OUTER JOIN
-       (SELECT distinct_id,
-               argMax(person_id, version) as person_id
-        FROM person_distinct_id2
-        WHERE team_id = 99999
-        GROUP BY distinct_id
-        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-     WHERE team_id = 99999
-       AND event IN ['$pageview']
-       AND timestamp <= now()
-       AND timestamp >= now() - INTERVAL 1 week
-     GROUP BY person_id) behavior_query
-  FULL OUTER JOIN
-    (SELECT *,
-            id AS person_id
-     FROM
-       (SELECT id,
-               argMax(properties, version) as person_props
-        FROM person
-        WHERE team_id = 99999
-        GROUP BY id
-        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = behavior_query.person_id
-  WHERE 1 = 1
-    AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', ''))))
-          OR ((performed_event_condition_None_level_level_0_level_1_level_0_0)))) SETTINGS optimize_aggregation_in_order = 1,
-                                                                                           join_algorithm = 'auto'
   '''
 # ---
 # name: TestCohortQuery.test_cohort_filter_with_extra.4
   '''
-  /* cohort_calculation: */
-  SELECT count(DISTINCT person_id)
-  FROM cohortpeople
-  WHERE team_id = 99999
-    AND cohort_id = 99999
-    AND version = 0
+  /* cohort_calculation: */ (
+                               (SELECT persons.id AS id
+                                FROM
+                                  (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', ''), person.version) AS properties___name,
+                                          person.id AS id
+                                   FROM person
+                                   WHERE and(equals(person.team_id, 99999), in(id,
+                                                                                 (SELECT where_optimization.id AS id
+                                                                                  FROM person AS where_optimization
+                                                                                  WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, 'name'), ''), 'null'), '^"|"$', ''), 'test'), 0)))))
+                                   GROUP BY person.id
+                                   HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
+                                WHERE ifNull(equals(persons.properties___name, 'test'), 0)
+                                ORDER BY persons.id ASC
+                                LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                                                   join_algorithm='auto'))
+  UNION DISTINCT (
+                    (SELECT source.id AS id
+                     FROM
+                       (SELECT actor_id AS actor_id,
+                               count() AS event_count,
+                               groupUniqArray(distinct_id) AS event_distinct_ids,
+                               actor_id AS id
+                        FROM
+                          (SELECT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,
+                                  toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                                  e.uuid AS uuid,
+                                  e.distinct_id AS distinct_id
+                           FROM events AS e
+                           LEFT OUTER JOIN
+                             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                                     person_distinct_id_overrides.distinct_id AS distinct_id
+                              FROM person_distinct_id_overrides
+                              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                              GROUP BY person_distinct_id_overrides.distinct_id
+                              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+                        GROUP BY actor_id) AS source
+                     ORDER BY source.id ASC
+                     LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                                        join_algorithm='auto')) SETTINGS readonly=2,
+                                                                         max_execution_time=60,
+                                                                         allow_experimental_object_type=1,
+                                                                         format_csv_allow_double_quotes=0,
+                                                                         max_ast_elements=4000000,
+                                                                         max_expanded_ast_elements=4000000,
+                                                                         max_bytes_before_external_group_by=0,
+                                                                         transform_null_in=1,
+                                                                         optimize_min_equality_disjunction_chain_length=4294967295,
+                                                                         allow_experimental_join_condition=1
   '''
 # ---
 # name: TestCohortQuery.test_cohort_filter_with_extra.5
@@ -329,6 +511,44 @@
 # name: TestCohortQuery.test_performed_event_poe_override
   '''
   
+    (SELECT source.id AS id
+     FROM
+       (SELECT actor_id AS actor_id,
+               count() AS event_count,
+               groupUniqArray(distinct_id) AS event_distinct_ids,
+               actor_id AS id
+        FROM
+          (SELECT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,
+                  toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.uuid AS uuid,
+                  e.distinct_id AS distinct_id
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+        GROUP BY actor_id) AS source
+     ORDER BY source.id ASC
+     LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                        join_algorithm='auto') SETTINGS readonly=2,
+                                                        max_execution_time=60,
+                                                        allow_experimental_object_type=1,
+                                                        format_csv_allow_double_quotes=0,
+                                                        max_ast_elements=4000000,
+                                                        max_expanded_ast_elements=4000000,
+                                                        max_bytes_before_external_group_by=0,
+                                                        transform_null_in=1,
+                                                        optimize_min_equality_disjunction_chain_length=4294967295,
+                                                        allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestCohortQuery.test_performed_event_poe_override.1
+  '''
+  
   SELECT behavior_query.person_id AS id
   FROM
     (SELECT if(not(empty(overrides.distinct_id)), overrides.person_id, e.person_id) AS person_id,
@@ -355,6 +575,78 @@
   '''
 # ---
 # name: TestCohortQuery.test_performed_event_sequence
+  '''
+  
+    (SELECT source.id AS id
+     FROM
+       (SELECT aggregation_target AS actor_id,
+               actor_id AS id
+        FROM
+          (SELECT aggregation_target AS aggregation_target,
+                  steps AS steps,
+                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
+                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+           FROM
+             (SELECT aggregation_target AS aggregation_target,
+                     steps AS steps,
+                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
+                                     step_1_conversion_time AS step_1_conversion_time
+              FROM
+                (SELECT aggregation_target AS aggregation_target,
+                        timestamp AS timestamp,
+                        step_0 AS step_0,
+                        latest_0 AS latest_0,
+                        step_1 AS step_1,
+                        latest_1 AS latest_1,
+                        if(and(ifNull(less(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalSecond(259200))), 0)), 2, 1) AS steps,
+                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalSecond(259200))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
+                 FROM
+                   (SELECT aggregation_target AS aggregation_target,
+                           timestamp AS timestamp,
+                           step_0 AS step_0,
+                           latest_0 AS latest_0,
+                           step_1 AS step_1,
+                           min(latest_1) OVER (PARTITION BY aggregation_target
+                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS latest_1
+                    FROM
+                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
+                              if(equals(e.event, '$pageview'), 1, 0) AS step_1,
+                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
+                       FROM events AS e
+                       LEFT OUTER JOIN
+                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                                 person_distinct_id_overrides.distinct_id AS distinct_id
+                          FROM person_distinct_id_overrides
+                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                          GROUP BY person_distinct_id_overrides.distinct_id
+                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$pageview'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
+                 WHERE ifNull(equals(step_0, 1), 0)))
+           GROUP BY aggregation_target,
+                    steps
+           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
+                         and isNull(max(max_steps))))
+        WHERE in(steps,
+                 [2])
+        ORDER BY aggregation_target ASC) AS source
+     ORDER BY source.id ASC
+     LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                        join_algorithm='auto') SETTINGS readonly=2,
+                                                        max_execution_time=60,
+                                                        allow_experimental_object_type=1,
+                                                        format_csv_allow_double_quotes=0,
+                                                        max_ast_elements=4000000,
+                                                        max_expanded_ast_elements=4000000,
+                                                        max_bytes_before_external_group_by=0,
+                                                        transform_null_in=1,
+                                                        optimize_min_equality_disjunction_chain_length=4294967295,
+                                                        allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestCohortQuery.test_performed_event_sequence.1
   '''
   
   SELECT funnel_query.person_id AS id
@@ -399,6 +691,96 @@
   '''
 # ---
 # name: TestCohortQuery.test_performed_event_sequence_and_clause_with_additional_event
+  '''
+  
+    (SELECT source.id AS id
+     FROM
+       (SELECT aggregation_target AS actor_id,
+               actor_id AS id
+        FROM
+          (SELECT aggregation_target AS aggregation_target,
+                  steps AS steps,
+                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
+                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+           FROM
+             (SELECT aggregation_target AS aggregation_target,
+                     steps AS steps,
+                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
+                                     step_1_conversion_time AS step_1_conversion_time
+              FROM
+                (SELECT aggregation_target AS aggregation_target,
+                        timestamp AS timestamp,
+                        step_0 AS step_0,
+                        latest_0 AS latest_0,
+                        step_1 AS step_1,
+                        latest_1 AS latest_1,
+                        if(and(ifNull(less(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalSecond(259200))), 0)), 2, 1) AS steps,
+                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalSecond(259200))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
+                 FROM
+                   (SELECT aggregation_target AS aggregation_target,
+                           timestamp AS timestamp,
+                           step_0 AS step_0,
+                           latest_0 AS latest_0,
+                           step_1 AS step_1,
+                           min(latest_1) OVER (PARTITION BY aggregation_target
+                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS latest_1
+                    FROM
+                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
+                              if(equals(e.event, '$pageview'), 1, 0) AS step_1,
+                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
+                       FROM events AS e
+                       LEFT OUTER JOIN
+                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                                 person_distinct_id_overrides.distinct_id AS distinct_id
+                          FROM person_distinct_id_overrides
+                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                          GROUP BY person_distinct_id_overrides.distinct_id
+                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$pageview'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
+                 WHERE ifNull(equals(step_0, 1), 0)))
+           GROUP BY aggregation_target,
+                    steps
+           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
+                         and isNull(max(max_steps))))
+        WHERE in(steps,
+                 [2])
+        ORDER BY aggregation_target ASC) AS source
+     ORDER BY source.id ASC
+     LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                        join_algorithm='auto')
+  UNION DISTINCT
+    (SELECT person_id AS id
+     FROM
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id,
+               count() AS `count()`
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), equals(events.event, '$new_view'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))
+        GROUP BY if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)
+        HAVING ifNull(greaterOrEquals(count(), 1), 0)
+        ORDER BY count() DESC)
+     LIMIT 100) SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=4000000,
+                         max_expanded_ast_elements=4000000,
+                         max_bytes_before_external_group_by=0,
+                         transform_null_in=1,
+                         optimize_min_equality_disjunction_chain_length=4294967295,
+                         allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestCohortQuery.test_performed_event_sequence_and_clause_with_additional_event.1
   '''
   
   SELECT funnel_query.person_id AS id
@@ -448,6 +830,110 @@
   '''
 # ---
 # name: TestCohortQuery.test_performed_event_sequence_with_person_properties
+  '''
+  
+    (SELECT source.id AS id
+     FROM
+       (SELECT aggregation_target AS actor_id,
+               actor_id AS id
+        FROM
+          (SELECT aggregation_target AS aggregation_target,
+                  steps AS steps,
+                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
+                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+           FROM
+             (SELECT aggregation_target AS aggregation_target,
+                     steps AS steps,
+                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
+                                     step_1_conversion_time AS step_1_conversion_time
+              FROM
+                (SELECT aggregation_target AS aggregation_target,
+                        timestamp AS timestamp,
+                        step_0 AS step_0,
+                        latest_0 AS latest_0,
+                        step_1 AS step_1,
+                        latest_1 AS latest_1,
+                        if(and(ifNull(less(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalSecond(259200))), 0)), 2, 1) AS steps,
+                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalSecond(259200))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
+                 FROM
+                   (SELECT aggregation_target AS aggregation_target,
+                           timestamp AS timestamp,
+                           step_0 AS step_0,
+                           latest_0 AS latest_0,
+                           step_1 AS step_1,
+                           min(latest_1) OVER (PARTITION BY aggregation_target
+                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS latest_1
+                    FROM
+                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
+                              if(equals(e.event, '$pageview'), 1, 0) AS step_1,
+                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
+                       FROM events AS e
+                       LEFT OUTER JOIN
+                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                                 person_distinct_id_overrides.distinct_id AS distinct_id
+                          FROM person_distinct_id_overrides
+                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                          GROUP BY person_distinct_id_overrides.distinct_id
+                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$pageview'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
+                 WHERE ifNull(equals(step_0, 1), 0)))
+           GROUP BY aggregation_target,
+                    steps
+           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
+                         and isNull(max(max_steps))))
+        WHERE in(steps,
+                 [2])
+        ORDER BY aggregation_target ASC) AS source
+     ORDER BY source.id ASC
+     LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                        join_algorithm='auto') INTERSECT
+    (SELECT person_id AS id
+     FROM
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id,
+               count() AS `count()`
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), equals(events.event, '$pageview'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))
+        GROUP BY if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)
+        HAVING ifNull(greaterOrEquals(count(), 1), 0)
+        ORDER BY count() DESC)
+     LIMIT 100) INTERSECT
+    (SELECT persons.id AS id
+     FROM
+       (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', ''), person.version) AS properties___email,
+               person.id AS id
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(id,
+                                                      (SELECT where_optimization.id AS id
+                                                       FROM person AS where_optimization
+                                                       WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, 'email'), ''), 'null'), '^"|"$', ''), 'test@posthog.com'), 0)))))
+        GROUP BY person.id
+        HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
+     WHERE ifNull(equals(persons.properties___email, 'test@posthog.com'), 0)
+     ORDER BY persons.id ASC
+     LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                        join_algorithm='auto') SETTINGS readonly=2,
+                                                        max_execution_time=60,
+                                                        allow_experimental_object_type=1,
+                                                        format_csv_allow_double_quotes=0,
+                                                        max_ast_elements=4000000,
+                                                        max_expanded_ast_elements=4000000,
+                                                        max_bytes_before_external_group_by=0,
+                                                        transform_null_in=1,
+                                                        optimize_min_equality_disjunction_chain_length=4294967295,
+                                                        allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestCohortQuery.test_performed_event_sequence_with_person_properties.1
   '''
   
   SELECT person.person_id AS id
@@ -514,6 +1000,44 @@
 # name: TestCohortQuery.test_performed_event_with_event_filters_and_explicit_date
   '''
   
+    (SELECT source.id AS id
+     FROM
+       (SELECT actor_id AS actor_id,
+               count() AS event_count,
+               groupUniqArray(distinct_id) AS event_distinct_ids,
+               actor_id AS id
+        FROM
+          (SELECT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,
+                  toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.uuid AS uuid,
+                  e.distinct_id AS distinct_id
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$filter_prop'), ''), 'null'), '^"|"$', ''), 'something'), 0), greaterOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+        GROUP BY actor_id) AS source
+     ORDER BY source.id ASC
+     LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                        join_algorithm='auto') SETTINGS readonly=2,
+                                                        max_execution_time=60,
+                                                        allow_experimental_object_type=1,
+                                                        format_csv_allow_double_quotes=0,
+                                                        max_ast_elements=4000000,
+                                                        max_expanded_ast_elements=4000000,
+                                                        max_bytes_before_external_group_by=0,
+                                                        transform_null_in=1,
+                                                        optimize_min_equality_disjunction_chain_length=4294967295,
+                                                        allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestCohortQuery.test_performed_event_with_event_filters_and_explicit_date.1
+  '''
+  
   SELECT behavior_query.person_id AS id
   FROM
     (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
@@ -540,6 +1064,60 @@
   '''
 # ---
 # name: TestCohortQuery.test_person
+  '''
+  
+    (SELECT source.id AS id
+     FROM
+       (SELECT actor_id AS actor_id,
+               count() AS event_count,
+               groupUniqArray(distinct_id) AS event_distinct_ids,
+               actor_id AS id
+        FROM
+          (SELECT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,
+                  toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.uuid AS uuid,
+                  e.distinct_id AS distinct_id
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+        GROUP BY actor_id) AS source
+     ORDER BY source.id ASC
+     LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                        join_algorithm='auto')
+  UNION DISTINCT
+    (SELECT persons.id AS id
+     FROM
+       (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$sample_field'), ''), 'null'), '^"|"$', ''), person.version) AS `properties___$sample_field`,
+               person.id AS id
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(id,
+                                                      (SELECT where_optimization.id AS id
+                                                       FROM person AS where_optimization
+                                                       WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, '$sample_field'), ''), 'null'), '^"|"$', ''), 'test@posthog.com'), 0)))))
+        GROUP BY person.id
+        HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
+     WHERE ifNull(equals(persons.`properties___$sample_field`, 'test@posthog.com'), 0)
+     ORDER BY persons.id ASC
+     LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                        join_algorithm='auto') SETTINGS readonly=2,
+                                                        max_execution_time=60,
+                                                        allow_experimental_object_type=1,
+                                                        format_csv_allow_double_quotes=0,
+                                                        max_ast_elements=4000000,
+                                                        max_expanded_ast_elements=4000000,
+                                                        max_bytes_before_external_group_by=0,
+                                                        transform_null_in=1,
+                                                        optimize_min_equality_disjunction_chain_length=4294967295,
+                                                        allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestCohortQuery.test_person.1
   '''
   
   SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
@@ -581,6 +1159,60 @@
 # name: TestCohortQuery.test_person_materialized
   '''
   
+    (SELECT source.id AS id
+     FROM
+       (SELECT actor_id AS actor_id,
+               count() AS event_count,
+               groupUniqArray(distinct_id) AS event_distinct_ids,
+               actor_id AS id
+        FROM
+          (SELECT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,
+                  toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.uuid AS uuid,
+                  e.distinct_id AS distinct_id
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+        GROUP BY actor_id) AS source
+     ORDER BY source.id ASC
+     LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                        join_algorithm='auto')
+  UNION DISTINCT
+    (SELECT persons.id AS id
+     FROM
+       (SELECT argMax(nullIf(nullIf(person.`pmat_$sample_field`, ''), 'null'), person.version) AS `properties___$sample_field`,
+               person.id AS id
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(id,
+                                                      (SELECT where_optimization.id AS id
+                                                       FROM person AS where_optimization
+                                                       WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(nullIf(nullIf(where_optimization.`pmat_$sample_field`, ''), 'null'), 'test@posthog.com'), 0)))))
+        GROUP BY person.id
+        HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
+     WHERE ifNull(equals(persons.`properties___$sample_field`, 'test@posthog.com'), 0)
+     ORDER BY persons.id ASC
+     LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                        join_algorithm='auto') SETTINGS readonly=2,
+                                                        max_execution_time=60,
+                                                        allow_experimental_object_type=1,
+                                                        format_csv_allow_double_quotes=0,
+                                                        max_ast_elements=4000000,
+                                                        max_expanded_ast_elements=4000000,
+                                                        max_bytes_before_external_group_by=0,
+                                                        transform_null_in=1,
+                                                        optimize_min_equality_disjunction_chain_length=4294967295,
+                                                        allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestCohortQuery.test_person_materialized.1
+  '''
+  
   SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
   FROM
     (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
@@ -618,6 +1250,129 @@
   '''
 # ---
 # name: TestCohortQuery.test_person_properties_with_pushdowns
+  '''
+  (
+     (SELECT source.id AS id
+      FROM
+        (SELECT actor_id AS actor_id,
+                count() AS event_count,
+                groupUniqArray(distinct_id) AS event_distinct_ids,
+                actor_id AS id
+         FROM
+           (SELECT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,
+                   toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                   e.uuid AS uuid,
+                   e.distinct_id AS distinct_id
+            FROM events AS e
+            LEFT OUTER JOIN
+              (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                      person_distinct_id_overrides.distinct_id AS distinct_id
+               FROM person_distinct_id_overrides
+               WHERE equals(person_distinct_id_overrides.team_id, 99999)
+               GROUP BY person_distinct_id_overrides.distinct_id
+               HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+            WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+         GROUP BY actor_id) AS source
+      ORDER BY source.id ASC
+      LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                         join_algorithm='auto')
+   UNION DISTINCT
+     (SELECT source.id AS id
+      FROM
+        (SELECT actor_id AS actor_id,
+                count() AS event_count,
+                groupUniqArray(distinct_id) AS event_distinct_ids,
+                actor_id AS id
+         FROM
+           (SELECT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,
+                   toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                   e.uuid AS uuid,
+                   e.distinct_id AS distinct_id
+            FROM events AS e
+            LEFT OUTER JOIN
+              (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                      person_distinct_id_overrides.distinct_id AS distinct_id
+               FROM person_distinct_id_overrides
+               WHERE equals(person_distinct_id_overrides.team_id, 99999)
+               GROUP BY person_distinct_id_overrides.distinct_id
+               HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+            WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+         GROUP BY actor_id) AS source
+      ORDER BY source.id ASC
+      LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                         join_algorithm='auto')
+   UNION DISTINCT
+     (SELECT persons.id AS id
+      FROM
+        (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', ''), person.version) AS properties___name,
+                person.id AS id
+         FROM person
+         WHERE and(equals(person.team_id, 99999), in(id,
+                                                       (SELECT where_optimization.id AS id
+                                                        FROM person AS where_optimization
+                                                        WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, 'name'), ''), 'null'), '^"|"$', ''), 'special'), 0)))))
+         GROUP BY person.id
+         HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
+      WHERE ifNull(equals(persons.properties___name, 'special'), 0)
+      ORDER BY persons.id ASC
+      LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                         join_algorithm='auto')) INTERSECT (
+                                                              (SELECT source.id AS id
+                                                               FROM
+                                                                 (SELECT actor_id AS actor_id,
+                                                                         count() AS event_count,
+                                                                         groupUniqArray(distinct_id) AS event_distinct_ids,
+                                                                         actor_id AS id
+                                                                  FROM
+                                                                    (SELECT min(toTimeZone(e.timestamp, 'UTC')) AS min_timestamp,
+                                                                            minIf(toTimeZone(e.timestamp, 'UTC'), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))) AS min_timestamp_with_condition,
+                                                                            if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,
+                                                                            argMin(e.uuid, toTimeZone(e.timestamp, 'UTC')) AS uuid,
+                                                                            argMin(e.distinct_id, toTimeZone(e.timestamp, 'UTC')) AS distinct_id
+                                                                     FROM events AS e
+                                                                     LEFT OUTER JOIN
+                                                                       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                                                                               person_distinct_id_overrides.distinct_id AS distinct_id
+                                                                        FROM person_distinct_id_overrides
+                                                                        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                                                                        GROUP BY person_distinct_id_overrides.distinct_id
+                                                                        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+                                                                     WHERE and(equals(e.team_id, 99999), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), and(equals(e.event, '$autocapture'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://posthog.com/feedback/123'), 0)))
+                                                                     GROUP BY if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)
+                                                                     HAVING and(ifNull(equals(min_timestamp, min_timestamp_with_condition), isNull(min_timestamp)
+                                                                                       and isNull(min_timestamp_with_condition)), ifNull(notEquals(min_timestamp, fromUnixTimestamp(0)), isNotNull(min_timestamp)
+                                                                                                                                         or isNotNull(fromUnixTimestamp(0)))))
+                                                                  GROUP BY actor_id) AS source
+                                                               ORDER BY source.id ASC
+                                                               LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                                                                                  join_algorithm='auto') INTERSECT
+                                                              (SELECT persons.id AS id
+                                                               FROM
+                                                                 (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', ''), person.version) AS properties___email,
+                                                                         person.id AS id
+                                                                  FROM person
+                                                                  WHERE and(equals(person.team_id, 99999), in(id,
+                                                                                                                (SELECT where_optimization.id AS id
+                                                                                                                 FROM person AS where_optimization
+                                                                                                                 WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, 'email'), ''), 'null'), '^"|"$', ''), 'test@posthog.com'), 0)))))
+                                                                  GROUP BY person.id
+                                                                  HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
+                                                               WHERE ifNull(equals(persons.properties___email, 'test@posthog.com'), 0)
+                                                               ORDER BY persons.id ASC
+                                                               LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                                                                                  join_algorithm='auto')) SETTINGS readonly=2,
+                                                                                                                   max_execution_time=60,
+                                                                                                                   allow_experimental_object_type=1,
+                                                                                                                   format_csv_allow_double_quotes=0,
+                                                                                                                   max_ast_elements=4000000,
+                                                                                                                   max_expanded_ast_elements=4000000,
+                                                                                                                   max_bytes_before_external_group_by=0,
+                                                                                                                   transform_null_in=1,
+                                                                                                                   optimize_min_equality_disjunction_chain_length=4294967295,
+                                                                                                                   allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestCohortQuery.test_person_properties_with_pushdowns.1
   '''
   
   SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
@@ -672,6 +1427,82 @@
 # ---
 # name: TestCohortQuery.test_person_props_only
   '''
+  (
+     (SELECT persons.id AS id
+      FROM
+        (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', ''), person.version) AS properties___email,
+                person.id AS id
+         FROM person
+         WHERE and(equals(person.team_id, 99999), in(id,
+                                                       (SELECT where_optimization.id AS id
+                                                        FROM person AS where_optimization
+                                                        WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, 'email'), ''), 'null'), '^"|"$', ''), 'test1@posthog.com'), 0)))))
+         GROUP BY person.id
+         HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
+      WHERE ifNull(equals(persons.properties___email, 'test1@posthog.com'), 0)
+      ORDER BY persons.id ASC
+      LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                         join_algorithm='auto')
+   UNION DISTINCT
+     (SELECT persons.id AS id
+      FROM
+        (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', ''), person.version) AS properties___email,
+                person.id AS id
+         FROM person
+         WHERE and(equals(person.team_id, 99999), in(id,
+                                                       (SELECT where_optimization.id AS id
+                                                        FROM person AS where_optimization
+                                                        WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, 'email'), ''), 'null'), '^"|"$', ''), 'test2@posthog.com'), 0)))))
+         GROUP BY person.id
+         HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
+      WHERE ifNull(equals(persons.properties___email, 'test2@posthog.com'), 0)
+      ORDER BY persons.id ASC
+      LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                         join_algorithm='auto'))
+  UNION DISTINCT (
+                    (SELECT persons.id AS id
+                     FROM
+                       (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', ''), person.version) AS properties___name,
+                               person.id AS id
+                        FROM person
+                        WHERE and(equals(person.team_id, 99999), in(id,
+                                                                      (SELECT where_optimization.id AS id
+                                                                       FROM person AS where_optimization
+                                                                       WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, 'name'), ''), 'null'), '^"|"$', ''), 'test3'), 0)))))
+                        GROUP BY person.id
+                        HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
+                     WHERE ifNull(equals(persons.properties___name, 'test3'), 0)
+                     ORDER BY persons.id ASC
+                     LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                                        join_algorithm='auto') INTERSECT
+                    (SELECT persons.id AS id
+                     FROM
+                       (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', ''), person.version) AS properties___email,
+                               person.id AS id
+                        FROM person
+                        WHERE and(equals(person.team_id, 99999), in(id,
+                                                                      (SELECT where_optimization.id AS id
+                                                                       FROM person AS where_optimization
+                                                                       WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, 'email'), ''), 'null'), '^"|"$', ''), 'test3@posthog.com'), 0)))))
+                        GROUP BY person.id
+                        HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
+                     WHERE ifNull(equals(persons.properties___email, 'test3@posthog.com'), 0)
+                     ORDER BY persons.id ASC
+                     LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                                        join_algorithm='auto')) SETTINGS readonly=2,
+                                                                         max_execution_time=60,
+                                                                         allow_experimental_object_type=1,
+                                                                         format_csv_allow_double_quotes=0,
+                                                                         max_ast_elements=4000000,
+                                                                         max_expanded_ast_elements=4000000,
+                                                                         max_bytes_before_external_group_by=0,
+                                                                         transform_null_in=1,
+                                                                         optimize_min_equality_disjunction_chain_length=4294967295,
+                                                                         allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestCohortQuery.test_person_props_only.1
+  '''
   
   SELECT id
   FROM person
@@ -705,28 +1536,82 @@
 # name: TestCohortQuery.test_precalculated_cohort_filter_with_extra_filters.1
   '''
   /* cohort_calculation: */
-  SELECT person.person_id AS id
-  FROM
-    (SELECT *,
-            id AS person_id
+    (SELECT cohort_people.person_id AS id
      FROM
-       (SELECT id,
-               argMax(properties, version) as person_props
+       (SELECT DISTINCT cohortpeople.person_id AS person_id,
+                        cohortpeople.cohort_id AS cohort_id,
+                        cohortpeople.team_id AS team_id
+        FROM cohortpeople
+        WHERE and(equals(cohortpeople.team_id, 99999), in(tuple(cohortpeople.cohort_id, cohortpeople.version), [(99999, 0)]))) AS cohort_people
+     WHERE and(ifNull(equals(cohort_people.cohort_id, 99999), 0), ifNull(equals(cohort_people.team_id, 99999), 0))
+     LIMIT 100)
+  UNION DISTINCT
+    (SELECT persons.id AS id
+     FROM
+       (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', ''), person.version) AS properties___name,
+               person.id AS id
         FROM person
-        WHERE team_id = 99999
-        GROUP BY id
-        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)) person
-  WHERE 1 = 1
-    AND (((id IN
-             (SELECT person_id
-              FROM cohortpeople
-              WHERE cohort_id = 99999
-                AND team_id = 99999 ))
-          OR (has(['test2'], replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', ''))))) SETTINGS optimize_aggregation_in_order = 1,
-                                                                                                              join_algorithm = 'auto'
+        WHERE and(equals(person.team_id, 99999), in(id,
+                                                      (SELECT where_optimization.id AS id
+                                                       FROM person AS where_optimization
+                                                       WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, 'name'), ''), 'null'), '^"|"$', ''), 'test2'), 0)))))
+        GROUP BY person.id
+        HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
+     WHERE ifNull(equals(persons.properties___name, 'test2'), 0)
+     ORDER BY persons.id ASC
+     LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                        join_algorithm='auto') SETTINGS readonly=2,
+                                                        max_execution_time=60,
+                                                        allow_experimental_object_type=1,
+                                                        format_csv_allow_double_quotes=0,
+                                                        max_ast_elements=4000000,
+                                                        max_expanded_ast_elements=4000000,
+                                                        max_bytes_before_external_group_by=0,
+                                                        transform_null_in=1,
+                                                        optimize_min_equality_disjunction_chain_length=4294967295,
+                                                        allow_experimental_join_condition=1
   '''
 # ---
 # name: TestCohortQuery.test_precalculated_cohort_filter_with_extra_filters.2
+  '''
+  /* cohort_calculation: */
+    (SELECT cohort_people.person_id AS id
+     FROM
+       (SELECT DISTINCT cohortpeople.person_id AS person_id,
+                        cohortpeople.cohort_id AS cohort_id,
+                        cohortpeople.team_id AS team_id
+        FROM cohortpeople
+        WHERE and(equals(cohortpeople.team_id, 99999), in(tuple(cohortpeople.cohort_id, cohortpeople.version), [(99999, 0)]))) AS cohort_people
+     WHERE and(ifNull(equals(cohort_people.cohort_id, 99999), 0), ifNull(equals(cohort_people.team_id, 99999), 0))
+     LIMIT 100)
+  UNION DISTINCT
+    (SELECT persons.id AS id
+     FROM
+       (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', ''), person.version) AS properties___name,
+               person.id AS id
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(id,
+                                                      (SELECT where_optimization.id AS id
+                                                       FROM person AS where_optimization
+                                                       WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, 'name'), ''), 'null'), '^"|"$', ''), 'test2'), 0)))))
+        GROUP BY person.id
+        HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
+     WHERE ifNull(equals(persons.properties___name, 'test2'), 0)
+     ORDER BY persons.id ASC
+     LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                        join_algorithm='auto') SETTINGS readonly=2,
+                                                        max_execution_time=60,
+                                                        allow_experimental_object_type=1,
+                                                        format_csv_allow_double_quotes=0,
+                                                        max_ast_elements=4000000,
+                                                        max_expanded_ast_elements=4000000,
+                                                        max_bytes_before_external_group_by=0,
+                                                        transform_null_in=1,
+                                                        optimize_min_equality_disjunction_chain_length=4294967295,
+                                                        allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestCohortQuery.test_precalculated_cohort_filter_with_extra_filters.3
   '''
   /* cohort_calculation: */
   SELECT person.person_id AS id
@@ -762,6 +1647,24 @@
 # name: TestCohortQuery.test_static_cohort_filter.1
   '''
   
+    (SELECT person_static_cohort.person_id AS id
+     FROM person_static_cohort
+     WHERE and(equals(person_static_cohort.team_id, 99999), equals(person_static_cohort.cohort_id, 99999), equals(person_static_cohort.team_id, 99999))
+     LIMIT 100) SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=4000000,
+                         max_expanded_ast_elements=4000000,
+                         max_bytes_before_external_group_by=0,
+                         transform_null_in=1,
+                         optimize_min_equality_disjunction_chain_length=4294967295,
+                         allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestCohortQuery.test_static_cohort_filter.2
+  '''
+  
   SELECT person.person_id AS id
   FROM
     (SELECT *,
@@ -791,6 +1694,48 @@
   '''
 # ---
 # name: TestCohortQuery.test_static_cohort_filter_with_extra.1
+  '''
+  
+    (SELECT person_static_cohort.person_id AS id
+     FROM person_static_cohort
+     WHERE and(equals(person_static_cohort.team_id, 99999), equals(person_static_cohort.cohort_id, 99999), equals(person_static_cohort.team_id, 99999))
+     LIMIT 100) INTERSECT
+    (SELECT source.id AS id
+     FROM
+       (SELECT actor_id AS actor_id,
+               count() AS event_count,
+               groupUniqArray(distinct_id) AS event_distinct_ids,
+               actor_id AS id
+        FROM
+          (SELECT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,
+                  toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.uuid AS uuid,
+                  e.distinct_id AS distinct_id
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+        GROUP BY actor_id) AS source
+     ORDER BY source.id ASC
+     LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                        join_algorithm='auto') SETTINGS readonly=2,
+                                                        max_execution_time=60,
+                                                        allow_experimental_object_type=1,
+                                                        format_csv_allow_double_quotes=0,
+                                                        max_ast_elements=4000000,
+                                                        max_expanded_ast_elements=4000000,
+                                                        max_bytes_before_external_group_by=0,
+                                                        transform_null_in=1,
+                                                        optimize_min_equality_disjunction_chain_length=4294967295,
+                                                        allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestCohortQuery.test_static_cohort_filter_with_extra.2
   '''
   
   SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
@@ -832,7 +1777,50 @@
                                                                                   join_algorithm = 'auto'
   '''
 # ---
-# name: TestCohortQuery.test_static_cohort_filter_with_extra.2
+# name: TestCohortQuery.test_static_cohort_filter_with_extra.3
+  '''
+  (
+     (SELECT person_static_cohort.person_id AS id
+      FROM person_static_cohort
+      WHERE and(equals(person_static_cohort.team_id, 99999), equals(person_static_cohort.cohort_id, 99999), equals(person_static_cohort.team_id, 99999))
+      LIMIT 100))
+  UNION DISTINCT (
+                    (SELECT source.id AS id
+                     FROM
+                       (SELECT actor_id AS actor_id,
+                               count() AS event_count,
+                               groupUniqArray(distinct_id) AS event_distinct_ids,
+                               actor_id AS id
+                        FROM
+                          (SELECT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,
+                                  toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                                  e.uuid AS uuid,
+                                  e.distinct_id AS distinct_id
+                           FROM events AS e
+                           LEFT OUTER JOIN
+                             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                                     person_distinct_id_overrides.distinct_id AS distinct_id
+                              FROM person_distinct_id_overrides
+                              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                              GROUP BY person_distinct_id_overrides.distinct_id
+                              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+                        GROUP BY actor_id) AS source
+                     ORDER BY source.id ASC
+                     LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                                        join_algorithm='auto')) SETTINGS readonly=2,
+                                                                         max_execution_time=60,
+                                                                         allow_experimental_object_type=1,
+                                                                         format_csv_allow_double_quotes=0,
+                                                                         max_ast_elements=4000000,
+                                                                         max_expanded_ast_elements=4000000,
+                                                                         max_bytes_before_external_group_by=0,
+                                                                         transform_null_in=1,
+                                                                         optimize_min_equality_disjunction_chain_length=4294967295,
+                                                                         allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestCohortQuery.test_static_cohort_filter_with_extra.4
   '''
   
   SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
@@ -896,43 +1884,49 @@
 # name: TestCohortQuery.test_unwrapping_static_cohort_filter_hidden_in_layers_of_cohorts.2
   '''
   /* cohort_calculation: */
-  SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
-  FROM
-    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
-            countIf(timestamp > now() - INTERVAL 1 week
-                    AND timestamp < now()
-                    AND event = '$pageview'
-                    AND 1=1) > 0 AS performed_event_condition_None_level_level_0_level_1_0
-     FROM events e
-     LEFT OUTER JOIN
-       (SELECT distinct_id,
-               argMax(person_id, version) as person_id
-        FROM person_distinct_id2
-        WHERE team_id = 99999
-        GROUP BY distinct_id
-        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-     WHERE team_id = 99999
-       AND event IN ['$pageview']
-       AND timestamp <= now()
-       AND timestamp >= now() - INTERVAL 1 week
-     GROUP BY person_id) behavior_query
-  FULL OUTER JOIN
-    (SELECT *,
-            id AS person_id
+    (SELECT cohort_people.person_id AS id
      FROM
-       (SELECT id
-        FROM person
-        WHERE team_id = 99999
-        GROUP BY id
-        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = behavior_query.person_id
-  WHERE 1 = 1
-    AND (((id IN
-             (SELECT person_id
-              FROM cohortpeople
-              WHERE cohort_id = 99999
-                AND team_id = 99999 ))
-          OR (performed_event_condition_None_level_level_0_level_1_0))) SETTINGS optimize_aggregation_in_order = 1,
-                                                                                 join_algorithm = 'auto'
+       (SELECT DISTINCT cohortpeople.person_id AS person_id,
+                        cohortpeople.cohort_id AS cohort_id,
+                        cohortpeople.team_id AS team_id
+        FROM cohortpeople
+        WHERE and(equals(cohortpeople.team_id, 99999), in(tuple(cohortpeople.cohort_id, cohortpeople.version), [(99999, 0)]))) AS cohort_people
+     WHERE and(ifNull(equals(cohort_people.cohort_id, 99999), 0), ifNull(equals(cohort_people.team_id, 99999), 0))
+     LIMIT 100)
+  UNION DISTINCT
+    (SELECT source.id AS id
+     FROM
+       (SELECT actor_id AS actor_id,
+               count() AS event_count,
+               groupUniqArray(distinct_id) AS event_distinct_ids,
+               actor_id AS id
+        FROM
+          (SELECT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,
+                  toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.uuid AS uuid,
+                  e.distinct_id AS distinct_id
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+        GROUP BY actor_id) AS source
+     ORDER BY source.id ASC
+     LIMIT 100 SETTINGS optimize_aggregation_in_order=1,
+                        join_algorithm='auto') SETTINGS readonly=2,
+                                                        max_execution_time=60,
+                                                        allow_experimental_object_type=1,
+                                                        format_csv_allow_double_quotes=0,
+                                                        max_ast_elements=4000000,
+                                                        max_expanded_ast_elements=4000000,
+                                                        max_bytes_before_external_group_by=0,
+                                                        transform_null_in=1,
+                                                        optimize_min_equality_disjunction_chain_length=4294967295,
+                                                        allow_experimental_join_condition=1
   '''
 # ---
 # name: TestCohortQuery.test_unwrapping_static_cohort_filter_hidden_in_layers_of_cohorts.3

--- a/posthog/hogql_queries/insights/trends/trends_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_builder.py
@@ -527,7 +527,8 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
                 if isinstance(breakdown_alias.get("histogram_bin_count"), int)
             ]
 
-            query.select.extend(
+            assert query.select_from is not None and isinstance(query.select_from.table, ast.SelectQuery)
+            query.select_from.table.select.extend(
                 [
                     # Using arrays would be more efficient here, _but_ only if there's low cardinality in breakdown_values
                     # If cardinality is high it'd blow up memory

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -1039,7 +1039,7 @@ class ClickhouseTestMixin(QueryMatchingTest):
         return value
 
     def capture_select_queries(self):
-        return self.capture_queries_startswith(("SELECT", "WITH", "select", "with"))
+        return self.capture_queries(lambda x: re.match(r"[\s(]*(SELECT|WITH)", x, re.I))
 
     def capture_queries_startswith(self, query_prefixes: Union[str, tuple[str, ...]]):
         return self.capture_queries(lambda x: x.startswith(query_prefixes))

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -1039,7 +1039,7 @@ class ClickhouseTestMixin(QueryMatchingTest):
         return value
 
     def capture_select_queries(self):
-        return self.capture_queries(lambda x: re.match(r"[\s(]*(SELECT|WITH)", x, re.I))
+        return self.capture_queries(lambda x: re.match(r"[\s(]*(SELECT|WITH)", x, re.I) is not None)
 
     def capture_queries_startswith(self, query_prefixes: Union[str, tuple[str, ...]]):
         return self.capture_queries(lambda x: x.startswith(query_prefixes))


### PR DESCRIPTION
move some logic into a subselect to avoid an aggregate issue that an improvement to clickhouse called out

tested locally with 25.3