### PR TITLE
fix(migrations): allow adding columns with stable defaults

### DIFF
--- a/posthog/management/commands/test/test_migrations_are_safe.py
+++ b/posthog/management/commands/test/test_migrations_are_safe.py
@@ -66,3 +66,87 @@ COMMIT;
     """
     should_fail = validate_migration_sql(sql_for_unique_index_with_where)
     assert should_fail is False
+
+
+def test_add_column_with_constant_string_default_is_safe() -> None:
+    sql_with_constant_string_default = """
+BEGIN;
+--
+-- Add field default_experiment_stats_method to organization
+--
+ALTER TABLE "posthog_organization" ADD COLUMN "default_experiment_stats_method" varchar(20) DEFAULT 'bayesian' NOT NULL;
+ALTER TABLE "posthog_organization" ALTER COLUMN "default_experiment_stats_method" DROP DEFAULT;
+COMMIT;
+    """
+    should_fail = validate_migration_sql(sql_with_constant_string_default)
+    assert should_fail is False
+
+
+def test_add_column_with_constant_number_default_is_safe() -> None:
+    sql_with_constant_number_default = """
+BEGIN;
+ALTER TABLE "posthog_organization" ADD COLUMN "max_items" integer DEFAULT 100 NOT NULL;
+COMMIT;
+    """
+    should_fail = validate_migration_sql(sql_with_constant_number_default)
+    assert should_fail is False
+
+
+def test_add_column_with_constant_boolean_default_is_safe() -> None:
+    sql_with_constant_boolean_default = """
+BEGIN;
+ALTER TABLE "posthog_organization" ADD COLUMN "is_enabled" boolean DEFAULT TRUE NOT NULL;
+COMMIT;
+    """
+    should_fail = validate_migration_sql(sql_with_constant_boolean_default)
+    assert should_fail is False
+
+
+def test_add_column_with_now_function_default_is_safe() -> None:
+    sql_with_now_default = """
+BEGIN;
+ALTER TABLE "posthog_organization" ADD COLUMN "created_at" timestamp DEFAULT NOW() NOT NULL;
+COMMIT;
+    """
+    should_fail = validate_migration_sql(sql_with_now_default)
+    assert should_fail is False
+
+
+def test_add_column_with_volatile_function_default_is_unsafe() -> None:
+    sql_with_volatile_default = """
+BEGIN;
+ALTER TABLE "posthog_organization" ADD COLUMN "expires_at" timestamp DEFAULT NOW() + INTERVAL '1 day' NOT NULL;
+COMMIT;
+    """
+    should_fail = validate_migration_sql(sql_with_volatile_default)
+    assert should_fail is True
+
+
+def test_add_column_with_no_default_not_null_is_unsafe() -> None:
+    sql_with_no_default = """
+BEGIN;
+ALTER TABLE "posthog_organization" ADD COLUMN "required_field" varchar(20) NOT NULL;
+COMMIT;
+    """
+    should_fail = validate_migration_sql(sql_with_no_default)
+    assert should_fail is True
+
+
+def test_add_column_with_nullable_field_is_safe() -> None:
+    sql_with_nullable_field = """
+BEGIN;
+ALTER TABLE "posthog_organization" ADD COLUMN "optional_field" varchar(20) NULL;
+COMMIT;
+    """
+    should_fail = validate_migration_sql(sql_with_nullable_field)
+    assert should_fail is False
+
+
+def test_add_column_with_random_function_default_is_unsafe() -> None:
+    sql_with_random_default = """
+BEGIN;
+ALTER TABLE "posthog_organization" ADD COLUMN "random_value" float DEFAULT random() NOT NULL;
+COMMIT;
+    """
+    should_fail = validate_migration_sql(sql_with_random_default)
+    assert should_fail is True

--- a/posthog/management/commands/test_migrations_are_safe.py
+++ b/posthog/management/commands/test_migrations_are_safe.py
@@ -60,7 +60,12 @@ def validate_migration_sql(sql) -> bool:
                         or re.match(r"^-?\d+(\.\d+)?$", default_value)  # Number
                         or default_value.upper() in ["TRUE", "FALSE", "NULL"]  # Boolean/NULL
                         or default_value.upper()
-                        in ["NOW()", "CURRENT_TIMESTAMP", "CURRENT_DATE", "CURRENT_TIME"]  # Common constants
+                        in [
+                            "NOW()",
+                            "CURRENT_TIMESTAMP",
+                            "CURRENT_DATE",
+                            "CURRENT_TIME",
+                        ]  # Functions marked as stable in postgres
                     ):
                         # This is safe - adding a column with a constant default doesn't require table rewrite in PostgreSQL 11+
                         continue

--- a/posthog/management/commands/test_migrations_are_safe.py
+++ b/posthog/management/commands/test_migrations_are_safe.py
@@ -44,6 +44,27 @@ def validate_migration_sql(sql) -> bool:
             # Ignore for brand-new tables
             and (table_being_altered not in tables_created_so_far or table_being_altered not in new_tables)
         ):
+            # Check if this is adding a column with a constant default (safe in PostgreSQL 11+)
+            if "ADD COLUMN" in operation_sql and "DEFAULT" in operation_sql:
+                # Extract the default value to check if it's a constant
+                # Match DEFAULT followed by either a quoted string or unquoted value until NOT NULL or end of significant tokens
+                default_match = re.search(
+                    r"DEFAULT\s+((?:'[^']*')|(?:[^'\s]+(?:\s+[^'\s]+)*?))\s+(?:NOT\s+NULL|;|$)", operation_sql, re.I
+                )
+                if default_match:
+                    default_value = default_match.group(1).strip()
+                    # Check if it's a constant (string literal, number, boolean, or simple constant like NOW())
+                    if (
+                        default_value.startswith("'")
+                        and default_value.endswith("'")  # String literal
+                        or re.match(r"^-?\d+(\.\d+)?$", default_value)  # Number
+                        or default_value.upper() in ["TRUE", "FALSE", "NULL"]  # Boolean/NULL
+                        or default_value.upper()
+                        in ["NOW()", "CURRENT_TIMESTAMP", "CURRENT_DATE", "CURRENT_TIME"]  # Common constants
+                    ):
+                        # This is safe - adding a column with a constant default doesn't require table rewrite in PostgreSQL 11+
+                        continue
+
             print(
                 f"\n\n\033[91mFound a non-null field or default added to an existing model. This will lock up the table while migrating. Please add 'null=True, blank=True' to the field.\nSource: `{operation_sql}`"
             )


### PR DESCRIPTION
## Problem

The migration safety checker was incorrectly flagging safe migrations as unsafe. Specifically, it was rejecting migrations that add columns with constant defaults like:

  ```sql
  ALTER TABLE "posthog_organization" ADD COLUMN "default_experiment_stats_method" varchar(20) DEFAULT 'bayesian' NOT NULL;
```

This migration is actually safe because PostgreSQL 11+ optimizes ADD COLUMN operations with constant defaults - they don't require table rewrites and only take a brief metadata lock. There is no difference in locks taken, or time, between this migration and one with `NULL`.

## Changes

  - Updated validate_migration_sql() to detect when ADD COLUMN uses constant defaults
  - Allow migrations that add columns with:
    - String literals ('bayesian')
    - Numbers (42, 3.14)
    - Booleans (TRUE, FALSE, NULL)
    - Stable functions (NOW(), CURRENT_TIMESTAMP)
  - Still reject volatile functions (random()) and columns with no default
  - Added comprehensive test coverage for all scenarios

  The change leverages PostgreSQL 11's optimization where constant defaults are stored in metadata and applied only when rows are accessed, avoiding
  expensive table rewrites while maintaining safety.


## How did you test this code?
- added tests
