### PR TITLE
fix(groups): Group Flush should handle MessageSizeTooLargeError

### DIFF
--- a/plugin-server/src/worker/ingestion/groups/batch-writing-group-store.test.ts
+++ b/plugin-server/src/worker/ingestion/groups/batch-writing-group-store.test.ts
@@ -296,11 +296,6 @@ describe('BatchWritingGroupStore', () => {
         it('should capture warning and stop retrying if message size too large', async () => {
             // we need to mock the kafka producer queueMessages method
             db.upsertGroupClickhouse = jest.fn().mockRejectedValue(new MessageSizeTooLarge('test', new Error('test')))
-            // mock captureIngestionWarning
-            jest.mock('../utils', () => ({
-                ...jest.requireActual('../utils'),
-                captureIngestionWarning: jest.fn().mockResolvedValue(undefined),
-            }))
 
             const groupStoreForBatch = groupStore.forBatch()
 

--- a/plugin-server/src/worker/ingestion/groups/batch-writing-group-store.test.ts
+++ b/plugin-server/src/worker/ingestion/groups/batch-writing-group-store.test.ts
@@ -1,9 +1,19 @@
 import { DateTime } from 'luxon'
 
+import { MessageSizeTooLarge } from '~/src/utils/db/error'
+
 import { Group, ProjectId, TeamId } from '../../../types'
 import { DB } from '../../../utils/db/db'
 import { BatchWritingGroupStore } from './batch-writing-group-store'
 import { groupCacheOperationsCounter } from './metrics'
+
+// Mock the utils module
+jest.mock('../utils', () => ({
+    captureIngestionWarning: jest.fn().mockResolvedValue(undefined),
+}))
+
+// Import the mocked function
+import { captureIngestionWarning } from '../utils'
 
 // Mock the DB class
 
@@ -281,6 +291,27 @@ describe('BatchWritingGroupStore', () => {
             expect(db.updateGroupOptimistically).toHaveBeenCalledTimes(0)
             expect(db.updateGroup).toHaveBeenCalledTimes(0)
             expect(db.insertGroup).toHaveBeenCalledTimes(0)
+        })
+
+        it('should capture warning and stop retrying if message size too large', async () => {
+            // we need to mock the kafka producer queueMessages method
+            db.upsertGroupClickhouse = jest.fn().mockRejectedValue(new MessageSizeTooLarge('test', new Error('test')))
+            // mock captureIngestionWarning
+            jest.mock('../utils', () => ({
+                ...jest.requireActual('../utils'),
+                captureIngestionWarning: jest.fn().mockResolvedValue(undefined),
+            }))
+
+            const groupStoreForBatch = groupStore.forBatch()
+
+            await groupStoreForBatch.upsertGroup(teamId, projectId, 1, 'test', { a: 'test' }, DateTime.now(), false)
+
+            await groupStoreForBatch.flush()
+
+            expect(db.updateGroupOptimistically).toHaveBeenCalledTimes(1)
+            expect(db.updateGroup).toHaveBeenCalledTimes(0)
+            expect(db.insertGroup).toHaveBeenCalledTimes(0)
+            expect(captureIngestionWarning).toHaveBeenCalledTimes(1)
         })
     })
 })


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We had an issue in production, as the flush logic did not handle KafkaMessageTooLarge errors, which are non-transient and should produce an ingestion warning message. This PR fixes this

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
