### PR TITLE
docs(insights): remove deprecated api methods and fields

### DIFF
--- a/ee/clickhouse/views/insights.py
+++ b/ee/clickhouse/views/insights.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 
 from ee.clickhouse.queries.funnels.funnel_correlation import FunnelCorrelation
 from ee.clickhouse.queries.stickiness import ClickhouseStickiness
+from posthog.api.documentation import extend_schema
 from posthog.api.insight import InsightViewSet
 from posthog.decorators import cached_by_filters
 from posthog.models import Insight
@@ -37,6 +38,7 @@ class EnterpriseInsightsViewSet(InsightViewSet):
     # Returns significant events, i.e. those that are correlated with a person
     # making it through a funnel
     # ******************************************
+    @extend_schema(exclude=True)
     @action(methods=["GET", "POST"], url_path="funnel/correlation", detail=False)
     def funnel_correlation(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         result = self.calculate_funnel_correlation(request)

--- a/posthog/api/annotation.py
+++ b/posthog/api/annotation.py
@@ -70,7 +70,7 @@ class AnnotationsLimitOffsetPagination(pagination.LimitOffsetPagination):
 
 class AnnotationsViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelViewSet):
     """
-    Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/user-guides/annotations) for more information on annotations.
+    Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more information on annotations.
     """
 
     scope_object = "annotation"

--- a/posthog/api/documentation.py
+++ b/posthog/api/documentation.py
@@ -5,6 +5,7 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
     extend_schema,  # noqa: F401
     extend_schema_field,
+    extend_schema_serializer,  # noqa: F401
 )  # # noqa: F401 for easy import
 from drf_spectacular.extensions import OpenApiAuthenticationExtension
 from rest_framework import fields, serializers

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -16,7 +16,7 @@ from django.utils.text import slugify
 from django.utils.timezone import now
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiParameter, extend_schema_view
+from drf_spectacular.utils import OpenApiExample, OpenApiParameter, extend_schema_view
 from loginas.utils import is_impersonated_session
 from prometheus_client import Counter
 from rest_framework import request, serializers, status, viewsets
@@ -29,7 +29,7 @@ from rest_framework_csv import renderers as csvrenderers
 
 from posthog import schema
 from posthog.schema import QueryStatus
-from posthog.api.documentation import extend_schema
+from posthog.api.documentation import extend_schema, extend_schema_field
 from posthog.api.forbid_destroy_model import ForbidDestroyModel
 from posthog.api.monitoring import Feature, monitor
 from posthog.api.routing import TeamAndOrgViewSetMixin
@@ -220,6 +220,8 @@ class InsightBasicSerializer(
 
     dashboard_tiles = DashboardTileBasicSerializer(many=True, read_only=True)
     created_by = UserBasicSerializer(read_only=True)
+    filters = serializers.HiddenField(default=dict)
+    saved = serializers.HiddenField(default=dict)
 
     class Meta:
         model = Insight
@@ -273,6 +275,22 @@ class InsightBasicSerializer(
         return [tile.dashboard_id for tile in instance.dashboard_tiles.all()]
 
 
+@extend_schema_field(
+    {
+        "type": "object",
+        "example": {
+            "kind": "InsightVizNode",
+            "source": {
+                "kind": "TrendsQuery",
+                "series": [
+                    {"kind": "EventsNode", "math": "total", "name": "$pageview", "event": "$pageview", "version": 1}
+                ],
+                "version": 1,
+            },
+            "version": 1,
+        },
+    }
+)
 class QueryFieldSerializer(serializers.Serializer):
     def to_representation(self, value):
         return self.parent._query_variables_mapping(value)  # type: ignore
@@ -779,7 +797,12 @@ Whether to refresh the retrieved insights, how aggresively, and if sync or async
 - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
 - `'force_async'` - kick off background calculation, even if fresh results are already cached
 Background calculation can be tracked using the `query_status` response field.""",
-            )
+            ),
+            OpenApiParameter(
+                name="basic",
+                type=OpenApiTypes.BOOL,
+                description="Return basic insight metadata only (no results, faster).",
+            ),
         ]
     ),
 )
@@ -1017,6 +1040,7 @@ When set, the specified dashboard's filters and date range override will be appl
 
         return Response(serialized_data)
 
+    @extend_schema(exclude=True)
     @action(methods=["GET", "POST"], detail=False, required_scopes=["insight:read"])
     def trend(self, request: request.Request, *args: Any, **kwargs: Any):
         capture_legacy_api_call(request, self.team)
@@ -1110,6 +1134,7 @@ When set, the specified dashboard's filters and date range override will be appl
 
         return {"result": result.results, "timezone": team.timezone}
 
+    @extend_schema(exclude=True)
     @action(methods=["GET", "POST"], detail=False, required_scopes=["insight:read"])
     def funnel(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
         capture_legacy_api_call(request, self.team)
@@ -1218,6 +1243,7 @@ When set, the specified dashboard's filters and date range override will be appl
         cancel_query_on_cluster(team_id=self.team.pk, client_query_id=request.data["client_query_id"])
         return Response(status=status.HTTP_201_CREATED)
 
+    @extend_schema(exclude=True)  # internal endpoint, not for public use
     @action(methods=["POST"], detail=False)
     def timing(self, request: request.Request, **kwargs):
         from posthog.kafka_client.client import KafkaProducer

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -16,7 +16,7 @@ from django.utils.text import slugify
 from django.utils.timezone import now
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiExample, OpenApiParameter, extend_schema_view
+from drf_spectacular.utils import OpenApiParameter, extend_schema_view
 from loginas.utils import is_impersonated_session
 from prometheus_client import Counter
 from rest_framework import request, serializers, status, viewsets

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -29,7 +29,7 @@ from rest_framework_csv import renderers as csvrenderers
 
 from posthog import schema
 from posthog.schema import QueryStatus
-from posthog.api.documentation import extend_schema, extend_schema_field
+from posthog.api.documentation import extend_schema, extend_schema_field, extend_schema_serializer
 from posthog.api.forbid_destroy_model import ForbidDestroyModel
 from posthog.api.monitoring import Feature, monitor
 from posthog.api.routing import TeamAndOrgViewSetMixin
@@ -208,6 +208,7 @@ class DashboardTileBasicSerializer(serializers.ModelSerializer):
         fields = ["id", "dashboard_id", "deleted"]
 
 
+@extend_schema_serializer(exclude_fields=["filters", "saved"])
 class InsightBasicSerializer(
     TaggedItemSerializerMixin,
     UserPermissionsSerializerMixin,
@@ -220,8 +221,6 @@ class InsightBasicSerializer(
 
     dashboard_tiles = DashboardTileBasicSerializer(many=True, read_only=True)
     created_by = UserBasicSerializer(read_only=True)
-    filters = serializers.HiddenField(default=dict)
-    saved = serializers.HiddenField(default=dict)
 
     class Meta:
         model = Insight


### PR DESCRIPTION
## Problem

The insights API docs still reference legacy endpoints: https://posthog.com/docs/api/insights

## Changes

🤞 this removes them for real. Also a couple of minor improvements.

## How did you test this code?

```
./manage.py spectacular --color --file schema.yml
docker run -p 80:8080 -e SWAGGER_JSON=/schema.yml -v ${PWD}/schema.yml:/schema.yml swaggerapi/swagger-ui
```