### PR TITLE
chore: Add beta tag to google ads

### DIFF
--- a/frontend/src/scenes/data-warehouse/new/NewSourceWizard.tsx
+++ b/frontend/src/scenes/data-warehouse/new/NewSourceWizard.tsx
@@ -170,7 +170,12 @@ function FirstStep({ disableConnectedSources }: Pick<NewSourcesWizardProps, 'dis
                             <div className="flex flex-col">
                                 <span className="gap-1 text-sm font-semibold">
                                     {sourceConfig.label ?? sourceConfig.name}
-                                    {sourceConfig.betaSource && <LemonTag type="warning">BETA</LemonTag>}
+                                    {sourceConfig.betaSource && (
+                                        <span>
+                                            {' '}
+                                            <LemonTag type="warning">BETA</LemonTag>
+                                        </span>
+                                    )}
                                 </span>
                                 {sourceConfig.unreleasedSource && (
                                     <span>Get notified when {sourceConfig.label} is available to connect</span>

--- a/frontend/src/scenes/data-warehouse/new/NewSourceWizard.tsx
+++ b/frontend/src/scenes/data-warehouse/new/NewSourceWizard.tsx
@@ -170,6 +170,7 @@ function FirstStep({ disableConnectedSources }: Pick<NewSourcesWizardProps, 'dis
                             <div className="flex flex-col">
                                 <span className="gap-1 text-sm font-semibold">
                                     {sourceConfig.label ?? sourceConfig.name}
+                                    {sourceConfig.betaSource && <LemonTag type="warning">BETA</LemonTag>}
                                 </span>
                                 {sourceConfig.unreleasedSource && (
                                     <span>Get notified when {sourceConfig.label} is available to connect</span>

--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -1,4 +1,4 @@
-import { LemonTag, lemonToast, Link } from '@posthog/lemon-ui'
+import { lemonToast, Link } from '@posthog/lemon-ui'
 import { actions, connect, kea, listeners, path, props, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
 import { router, urlToAction } from 'kea-router'
@@ -808,11 +808,8 @@ export const SOURCE_DETAILS: Record<ExternalDataSourceType, SourceConfig> = {
     },
     GoogleAds: {
         name: 'GoogleAds',
-        label: (
-            <>
-                Google Ads <LemonTag type="warning">BETA</LemonTag>
-            </>
-        ),
+        label: 'Google Ads',
+        betaSource: true,
         caption: (
             <>
                 Ensure you have granted PostHog access to your Google Ads account as instructed in the

--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -1,4 +1,4 @@
-import { lemonToast, Link } from '@posthog/lemon-ui'
+import { LemonTag, lemonToast, Link } from '@posthog/lemon-ui'
 import { actions, connect, kea, listeners, path, props, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
 import { router, urlToAction } from 'kea-router'
@@ -808,7 +808,11 @@ export const SOURCE_DETAILS: Record<ExternalDataSourceType, SourceConfig> = {
     },
     GoogleAds: {
         name: 'GoogleAds',
-        label: 'Google Ads',
+        label: (
+            <>
+                Google Ads <LemonTag type="warning">BETA</LemonTag>
+            </>
+        ),
         caption: (
             <>
                 Ensure you have granted PostHog access to your Google Ads account as instructed in the

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5060,6 +5060,7 @@ export interface SourceConfig {
     oauthPayload?: string[]
     existingSource?: boolean
     unreleasedSource?: boolean
+    betaSource?: boolean
 }
 
 export interface ProductPricingTierSubrows {


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We want to release Google Ads as a source, but there may be a few more tweaks coming.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Label source as BETA.
Looks like this:

![image](https://github.com/user-attachments/assets/5e7ed05e-edb9-4e62-ba65-6cd6815c8d6a)
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
