### PR TITLE
fix(cdp): fix log query

### DIFF
--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -602,7 +602,7 @@ function formatHogQlValue(value: any): string {
     const { teamLogic } = require('scenes/teamLogic')
 
     if (Array.isArray(value)) {
-        return `[${value.map(formatHogQlValue).join(', ')}]`
+        return `(${value.map(formatHogQlValue).join(', ')})`
     } else if (dayjs.isDayjs(value)) {
         return value.tz(teamLogic.values.timezone).format("'YYYY-MM-DD HH:mm:ss'")
     } else if (isHogQlIdentifier(value)) {

--- a/frontend/src/scenes/hog-functions/logs/logsViewerLogic.tsx
+++ b/frontend/src/scenes/hog-functions/logs/logsViewerLogic.tsx
@@ -70,7 +70,7 @@ const loadGroupedLogs = async (request: GroupedLogEntryRequest): Promise<Grouped
             AND timestamp < {filters.dateRange.to}
             AND lower(level) IN ${request.levels.map((level) => `${level.toLowerCase()}`)}
             AND message ILIKE ${`%${request.search}%`}
-            ORDER BY timestamp ${request.order}
+            ORDER BY timestamp DESC
             LIMIT ${LOG_VIEWER_LIMIT}
         )
         GROUP BY instance_id

--- a/frontend/src/scenes/hog-functions/logs/logsViewerLogic.tsx
+++ b/frontend/src/scenes/hog-functions/logs/logsViewerLogic.tsx
@@ -57,19 +57,19 @@ const loadGroupedLogs = async (request: GroupedLogEntryRequest): Promise<Grouped
                 groupArray((timestamp, level, message))
             ) AS messages
         FROM log_entries
-        WHERE log_source = '${request.sourceType}'
-        AND log_source_id = '${request.sourceId}'
+        WHERE log_source = ${request.sourceType}
+        AND log_source_id = ${request.sourceId}
         AND timestamp > {filters.dateRange.from}
         AND timestamp < {filters.dateRange.to}
         AND instance_id in (
             SELECT DISTINCT instance_id
             FROM log_entries
             WHERE log_source = 'hog_function'
-            AND log_source_id = '${request.sourceId}'
+            AND log_source_id = ${request.sourceId}
             AND timestamp > {filters.dateRange.from}
             AND timestamp < {filters.dateRange.to}
-            AND lower(level) IN (${request.levels.map((level) => `'${level.toLowerCase()}'`).join(',')})
-            AND message ILIKE '%${request.search}%'
+            AND lower(level) IN ${request.levels.map((level) => `${level.toLowerCase()}`)}
+            AND message ILIKE ${`%${request.search}%`}
             ORDER BY timestamp ${request.order}
             LIMIT ${LOG_VIEWER_LIMIT}
         )


### PR DESCRIPTION
## Problem

Viewing logs for a hog function is broken.
![2025-06-12 at 16 21 22@2x](https://github.com/user-attachments/assets/c60d8cc6-f995-4776-9863-fdc183834b93)

Query differences using diffchecker: https://www.diffchecker.com/tEgn4CTn/

[This PR](https://github.com/PostHog/posthog/pull/32611) seems to be the cause of the issue

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
