### PR TITLE
fix(captures-rs): filter out performance events

### DIFF
--- a/rust/capture/src/api.rs
+++ b/rust/capture/src/api.rs
@@ -76,6 +76,9 @@ pub enum CaptureError {
 
     #[error("rate limited")]
     RateLimited,
+
+    #[error("payload empty after filtering invalid event types")]
+    EmptyPayloadFiltered,
 }
 
 impl From<serde_json::Error> for CaptureError {
@@ -107,6 +110,7 @@ impl CaptureError {
             CaptureError::NonRetryableSinkError => "non_retry_sink",
             CaptureError::BillingLimit => "billing_limit",
             CaptureError::RateLimited => "rate_limited",
+            CaptureError::EmptyPayloadFiltered => "empty_filtered_payload",
         }
     }
 }
@@ -126,6 +130,7 @@ impl IntoResponse for CaptureError {
             | CaptureError::MissingSessionId
             | CaptureError::MissingWindowId
             | CaptureError::InvalidSessionId
+            | CaptureError::EmptyPayloadFiltered
             | CaptureError::MissingSnapshotData => (StatusCode::BAD_REQUEST, self.to_string()),
 
             CaptureError::EventTooBig(_) => (StatusCode::PAYLOAD_TOO_LARGE, self.to_string()),

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -198,25 +198,9 @@ async fn handle_legacy(
     // consumes the parent request, so it's no longer in scope to extract metadata from
     let events = match request.events(path.as_str()) {
         Ok(events) => events,
-        Err(e) => {
-            match &e {
-                CaptureError::RequestHydrationError(rhe) => {
-                    // occurs when an unnamed event (no "event" attrib) is submitted to an
-                    // endpoint other than /engage, or the whole payload is malformed
-                    error!("event hydration from request failed: {}", rhe);
-                    return Err(e);
-                }
-                // if the hydrated event batch is empty we surface it here
-                _ => return Err(e),
-            }
-        }
+        Err(e) => return Err(e),
     };
     Span::current().record("batch_size", events.len());
-
-    if events.is_empty() {
-        warn!("rejected empty batch");
-        return Err(CaptureError::EmptyBatch);
-    }
 
     let token = match extract_and_verify_token(&events, maybe_batch_token) {
         Ok(token) => token,
@@ -355,25 +339,9 @@ async fn handle_common(
     // consumes the parent request, so it's no longer in scope to extract metadata from
     let events = match request.events(path.as_str()) {
         Ok(events) => events,
-        Err(e) => {
-            match &e {
-                CaptureError::RequestHydrationError(rhe) => {
-                    // occurs when an unnamed event (no "event" attrib) is submitted to an
-                    // endpoint other than /engage, or the whole payload is malformed
-                    error!("event hydration from request failed: {}", rhe);
-                    return Err(e);
-                }
-                // if the hydrated event batch is empty we surface it here
-                _ => return Err(e),
-            }
-        }
+        Err(e) => return Err(e),
     };
     Span::current().record("batch_size", events.len());
-
-    if events.is_empty() {
-        warn!("rejected empty batch");
-        return Err(CaptureError::EmptyBatch);
-    }
 
     let token = match extract_and_verify_token(&events, maybe_batch_token) {
         Ok(token) => token,

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -205,7 +205,7 @@ async fn handle_legacy(
                     // endpoint other than /engage, or the whole payload is malformed
                     error!("event hydration from request failed: {}", rhe);
                     return Err(e);
-                },
+                }
                 // if the hydrated event batch is empty we surface it here
                 _ => return Err(e),
             }
@@ -362,7 +362,7 @@ async fn handle_common(
                     // endpoint other than /engage, or the whole payload is malformed
                     error!("event hydration from request failed: {}", rhe);
                     return Err(e);
-                },
+                }
                 // if the hydrated event batch is empty we surface it here
                 _ => return Err(e),
             }

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -299,9 +299,9 @@ impl RawRequest {
                         properties: engage_event.properties,
                     }])
                 } else {
-                    Err(CaptureError::RequestHydrationError(String::from(
-                        "non-engage request missing event name attribute",
-                    )))
+                    let err_msg = String::from("non-engage request missing event name attribute");
+                    error!("event hydration from request failed: {}", &err_msg);
+                    Err(CaptureError::RequestHydrationError(err_msg))
                 }
             }
         };
@@ -309,11 +309,21 @@ impl RawRequest {
         // do some basic hydrated event payload filtering here
         match result {
             Ok(mut events) => {
-                // silently filter event types we don't want to ingest without erroring
+                if events.is_empty() {
+                    warn!("rejected empty batch");
+                    return Err(CaptureError::EmptyBatch);
+                }
+
+                // filter event types we don't want to ingest; return a sentinel
+                // error response if this results in an empty payload
                 events.retain(|event| event.event != "$performance_event");
+                if events.is_empty() {
+                    return Err(CaptureError::EmptyPayloadFiltered);
+                }
                 Ok(events)
             }
 
+            // pass along payload hydration and other error types
             _ => result,
         }
     }

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -306,12 +306,14 @@ impl RawRequest {
             }
         };
 
-        // filter out event types we dont' want to ingest
+        // do some basic hydrated event payload filtering here
         match result {
             Ok(mut events) => {
+                // silently filter event types we dont' want to ingest without erroring
                 events.retain(|event| event.event != "$performance_event");
                 Ok(events)
             }
+
             _ => result,
         }
     }

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -309,7 +309,7 @@ impl RawRequest {
         // do some basic hydrated event payload filtering here
         match result {
             Ok(mut events) => {
-                // silently filter event types we dont' want to ingest without erroring
+                // silently filter event types we don't want to ingest without erroring
                 events.retain(|event| event.event != "$performance_event");
                 Ok(events)
             }

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -281,7 +281,7 @@ impl RawRequest {
     }
 
     pub fn events(self, path: &str) -> Result<Vec<RawEvent>, CaptureError> {
-        match self {
+        let result = match self {
             RawRequest::Array(events) => Ok(events),
             RawRequest::One(event) => Ok(vec![*event]),
             RawRequest::Batch(req) => Ok(req.batch),
@@ -304,6 +304,15 @@ impl RawRequest {
                     )))
                 }
             }
+        };
+
+        // filter out event types we dont' want to ingest
+        match result {
+            Ok(mut events) => {
+                events.retain(|event| event.event != "$performance_event");
+                Ok(events)
+            }
+            _ => result,
         }
     }
 

--- a/rust/capture/tests/events.rs
+++ b/rust/capture/tests/events.rs
@@ -43,6 +43,65 @@ async fn it_captures_one_event() -> Result<()> {
 }
 
 #[tokio::test]
+async fn it_drops_performance_events() -> Result<()> {
+    setup_tracing();
+    let token = random_string("token", 16);
+    let distinct_id = random_string("id", 16);
+
+    let main_topic = EphemeralTopic::new().await;
+    let histo_topic = EphemeralTopic::new().await;
+    let server = ServerHandle::for_topics(&main_topic, &histo_topic).await;
+
+    let retained_one = json!({
+        "token": token,
+        "event": "some_event",
+        "distinct_id": distinct_id
+    });
+    // we should be filtering these out prior to publishing to ingest topic
+    let should_drop = json!({
+        "token": token,
+        "event": "$performance_event",
+        "distinct_id": distinct_id
+    });
+    let retained_two = json!({
+        "token": token,
+        "event": "some_other_event",
+        "distinct_id": distinct_id
+    });
+
+    let res = server.capture_events(retained_one.to_string()).await;
+    assert_eq!(StatusCode::OK, res.status());
+    let res = server.capture_events(should_drop.to_string()).await;
+    assert_eq!(StatusCode::OK, res.status());
+    let res = server.capture_events(retained_two.to_string()).await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    let got = main_topic.next_event()?;
+    assert_json_include!(
+        actual: got,
+        expected: json!({
+            "token": token,
+            "event": "some_event",
+            "distinct_id": distinct_id
+        })
+    );
+
+    // the next event in the topic should be retained_two
+    // since we filter out should_drop
+    let got = main_topic.next_event()?;
+    assert_json_include!(
+        actual: got,
+        expected: json!({
+            "token": token,
+            "event": "some_other_event",
+            "distinct_id": distinct_id
+        })
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn it_drops_events_if_dropper_enabled() -> Result<()> {
     setup_tracing();
     let token = random_string("token", 16);


### PR DESCRIPTION
## Problem
`capture-rs` should filter out `$performance_event`s prior to passing along to the ingest pipeline.

## Changes
* Filter performance events from hydrated event payloads
* New test case

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Locally and in CI