### PR TITLE
chore(flags): Report the ID that starts a dependency cycle

### DIFF
--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -61,8 +61,8 @@ pub enum FlagError {
     DependencyNotFound(DependencyType, i64),
     #[error("Failed to parse cohort filters")]
     CohortFiltersParsingError,
-    #[error("Dependency cycle of type {0}: {1}")]
-    DependencyCycle(DependencyType, String),
+    #[error("Dependency cycle detected. {0} ids in the cycle: {:?}", .1)]
+    DependencyCycle(DependencyType, Vec<i64>),
     #[error("Person not found")]
     PersonNotFound,
     #[error("Person properties not found")]
@@ -179,9 +179,9 @@ impl IntoResponse for FlagError {
                 tracing::error!("Failed to parse cohort filters: {:?}", self);
                 (StatusCode::INTERNAL_SERVER_ERROR, "Failed to parse cohort filters. Please try again later or contact support if the problem persists.".to_string())
             }
-            FlagError::DependencyCycle(dependency_type, msg) => {
-                tracing::error!("{} dependency cycle: {}", dependency_type, msg);
-                (StatusCode::INTERNAL_SERVER_ERROR, msg)
+            FlagError::DependencyCycle(dependency_type, cycle_ids) => {
+                tracing::error!("{} dependency cycle: {:?}", dependency_type, cycle_ids);
+                (StatusCode::INTERNAL_SERVER_ERROR, format!("{} (Cycle: {:?})", dependency_type, cycle_ids))
             }
             FlagError::PersonNotFound => {
                 (StatusCode::BAD_REQUEST, "Person not found. Please check your distinct_id and try again.".to_string())

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -61,8 +61,8 @@ pub enum FlagError {
     DependencyNotFound(DependencyType, i64),
     #[error("Failed to parse cohort filters")]
     CohortFiltersParsingError,
-    #[error("Dependency cycle detected. {0} ids in the cycle: {:?}", .1)]
-    DependencyCycle(DependencyType, Vec<i64>),
+    #[error("Dependency cycle detected: {0} id {1} starts the cycle")]
+    DependencyCycle(DependencyType, i64),
     #[error("Person not found")]
     PersonNotFound,
     #[error("Person properties not found")]
@@ -179,9 +179,9 @@ impl IntoResponse for FlagError {
                 tracing::error!("Failed to parse cohort filters: {:?}", self);
                 (StatusCode::INTERNAL_SERVER_ERROR, "Failed to parse cohort filters. Please try again later or contact support if the problem persists.".to_string())
             }
-            FlagError::DependencyCycle(dependency_type, cycle_ids) => {
-                tracing::error!("{} dependency cycle: {:?}", dependency_type, cycle_ids);
-                (StatusCode::INTERNAL_SERVER_ERROR, format!("Dependency cycle detected. {} ids in the cycle: {:?}", dependency_type, cycle_ids))
+            FlagError::DependencyCycle(dependency_type, cycle_start_id) => {
+                tracing::error!("{} dependency cycle: {:?}", dependency_type, cycle_start_id);
+                (StatusCode::INTERNAL_SERVER_ERROR, format!("Dependency cycle detected: {dependency_type} id {cycle_start_id} starts the cycle"))
             }
             FlagError::PersonNotFound => {
                 (StatusCode::BAD_REQUEST, "Person not found. Please check your distinct_id and try again.".to_string())

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -181,7 +181,7 @@ impl IntoResponse for FlagError {
             }
             FlagError::DependencyCycle(dependency_type, cycle_ids) => {
                 tracing::error!("{} dependency cycle: {:?}", dependency_type, cycle_ids);
-                (StatusCode::INTERNAL_SERVER_ERROR, format!("{} (Cycle: {:?})", dependency_type, cycle_ids))
+                (StatusCode::INTERNAL_SERVER_ERROR, format!("Dependency cycle detected. {} ids in the cycle: {:?}", dependency_type, cycle_ids))
             }
             FlagError::PersonNotFound => {
                 (StatusCode::BAD_REQUEST, "Person not found. Please check your distinct_id and try again.".to_string())

--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -11,9 +11,7 @@ use super::cohort_models::CohortValues;
 use crate::cohorts::cohort_models::{Cohort, CohortId, CohortProperty, InnerCohortProperty};
 use crate::properties::property_matching::match_property;
 use crate::properties::property_models::OperatorType;
-use crate::utils::graph_utils::{
-    build_dependency_graph, get_cycle_nodes, DependencyProvider, DependencyType,
-};
+use crate::utils::graph_utils::{build_dependency_graph, DependencyProvider, DependencyType};
 use crate::{api::errors::FlagError, properties::property_models::PropertyFilter};
 use common_database::Client as DatabaseClient;
 
@@ -297,13 +295,9 @@ pub fn evaluate_dynamic_cohorts(
     // Keep the topological sort to handle dependencies correctly
     let sorted_cohort_ids_as_graph_nodes =
         toposort(&cohort_dependency_graph, None).map_err(|e| {
-            let cycle_nodes = get_cycle_nodes(&cohort_dependency_graph, e.node_id());
-            let cycle_ids: Vec<i64> = cycle_nodes
-                .iter()
-                .map(|&node| cohort_dependency_graph[node].into())
-                .collect();
-
-            FlagError::DependencyCycle(DependencyType::Cohort, cycle_ids)
+            let cycle_start_id = e.node_id();
+            let cohort_id = cohort_dependency_graph[cycle_start_id] as i64;
+            FlagError::DependencyCycle(DependencyType::Cohort, cohort_id)
         })?;
 
     let mut evaluation_results = HashMap::new();
@@ -680,7 +674,7 @@ mod tests {
         let cohort_1 = create_test_cohort_instance(1, Some(2)); // 1 depends on 2
         let cohort_2 = create_test_cohort_instance(2, Some(3)); // 2 depends on 3
         let cohort_3 = create_test_cohort_instance(3, Some(4)); // 3 depends on 4
-        let cohort_4 = create_test_cohort_instance(4, Some(2)); // 4 depends on 2
+        let cohort_4 = create_test_cohort_instance(4, Some(2)); // 4 depends on 2 (starts the cycle)
 
         let cohorts = vec![cohort_1.clone(), cohort_2, cohort_3, cohort_4];
 
@@ -690,30 +684,27 @@ mod tests {
         // Verify we got a cycle error
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert!(matches!(err, FlagError::DependencyCycle(_, _)));
-        if let FlagError::DependencyCycle(dep_type, cycle_ids) = err {
-            assert_eq!(dep_type, DependencyType::Cohort);
-            // The cycle should be [2, 3, 4, 2] (2 -> 3 -> 4 -> 2)
-            assert_eq!(cycle_ids, &[2, 3, 4, 2]);
-        }
+        assert!(matches!(
+            err,
+            FlagError::DependencyCycle(DependencyType::Cohort, 4)
+        ));
     }
 
     #[test]
     fn test_build_cohort_dependency_graph_cycle_detection_handles_self_referential_node() {
-        let cohort_1 = create_test_cohort_instance(1, Some(1)); // 1 depends on itself
+        let self_referential_cohort = create_test_cohort_instance(1, Some(1)); // 1 depends on itself
 
-        let cohorts = vec![cohort_1.clone()];
+        let cohorts = vec![self_referential_cohort.clone()];
 
         // Try to build the graph starting from cohort 1
-        let result = build_cohort_dependency_graph(cohort_1.id, &cohorts);
+        let result = build_cohort_dependency_graph(self_referential_cohort.id, &cohorts);
 
         // Verify we got a cycle error
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert!(matches!(err, FlagError::DependencyCycle(_, _)));
-        if let FlagError::DependencyCycle(dep_type, cycle_ids) = err {
-            assert_eq!(dep_type, DependencyType::Cohort);
-            assert_eq!(cycle_ids, &[1, 1]);
-        }
+        assert!(matches!(
+            err,
+            FlagError::DependencyCycle(DependencyType::Cohort, 1)
+        ));
     }
 }

--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -11,7 +11,9 @@ use super::cohort_models::CohortValues;
 use crate::cohorts::cohort_models::{Cohort, CohortId, CohortProperty, InnerCohortProperty};
 use crate::properties::property_matching::match_property;
 use crate::properties::property_models::OperatorType;
-use crate::utils::graph_utils::{build_dependency_graph, DependencyProvider, DependencyType};
+use crate::utils::graph_utils::{
+    build_dependency_graph, get_cycle_nodes, DependencyProvider, DependencyType,
+};
 use crate::{api::errors::FlagError, properties::property_models::PropertyFilter};
 use common_database::Client as DatabaseClient;
 
@@ -295,10 +297,13 @@ pub fn evaluate_dynamic_cohorts(
     // Keep the topological sort to handle dependencies correctly
     let sorted_cohort_ids_as_graph_nodes =
         toposort(&cohort_dependency_graph, None).map_err(|e| {
-            FlagError::DependencyCycle(
-                DependencyType::Cohort,
-                format!("Cyclic dependency detected: {:?}", e),
-            )
+            let cycle_nodes = get_cycle_nodes(&cohort_dependency_graph, e.node_id());
+            let cycle_ids: Vec<i64> = cycle_nodes
+                .iter()
+                .map(|&node| cohort_dependency_graph[node].into())
+                .collect();
+
+            FlagError::DependencyCycle(DependencyType::Cohort, cycle_ids)
         })?;
 
     let mut evaluation_results = HashMap::new();
@@ -636,5 +641,84 @@ mod tests {
             result.unwrap_err(),
             FlagError::CohortFiltersParsingError
         ));
+    }
+
+    fn create_test_cohort_instance(id: CohortId, depends_on: Option<CohortId>) -> Cohort {
+        Cohort {
+            id,
+            name: Some(format!("Cohort {}", id)),
+            description: None,
+            team_id: 1,
+            deleted: false,
+            filters: depends_on.map(|dep_id| {
+                json!({
+                    "properties": {
+                        "type": "OR",
+                        "values": [{
+                            "type": "OR",
+                            "values": [{
+                                "key": "id",
+                                "type": "cohort",
+                                "value": dep_id,
+                                "negation": false
+                            }]
+                        }]
+                    }
+                })
+            }),
+            query: None,
+            version: None,
+            pending_version: None,
+            count: None,
+            is_calculating: false,
+            is_static: false,
+            errors_calculating: 0,
+            groups: json!({}),
+            created_by_id: None,
+        }
+    }
+
+    #[test]
+    fn test_build_cohort_dependency_graph_cycle_detection() {
+        // Create four cohorts that form a cycle: 2 -> 3 -> 4 -> 2
+        // Cohort 1 is not part of the cycle but depends on 2
+        let cohort_1 = create_test_cohort_instance(1, Some(2)); // 1 depends on 2
+        let cohort_2 = create_test_cohort_instance(2, Some(3)); // 2 depends on 3
+        let cohort_3 = create_test_cohort_instance(3, Some(4)); // 3 depends on 4
+        let cohort_4 = create_test_cohort_instance(4, Some(2)); // 4 depends on 2
+
+        let cohorts = vec![cohort_1.clone(), cohort_2, cohort_3, cohort_4];
+
+        // Try to build the graph starting from cohort 1
+        let result = build_cohort_dependency_graph(cohort_1.id, &cohorts);
+
+        // Verify we got a cycle error
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, FlagError::DependencyCycle(_, _)));
+        if let FlagError::DependencyCycle(dep_type, cycle_ids) = err {
+            assert_eq!(dep_type, DependencyType::Cohort);
+            // The cycle should be [2, 3, 4, 2] (2 -> 3 -> 4 -> 2)
+            assert_eq!(cycle_ids, &[2, 3, 4, 2]);
+        }
+    }
+
+    #[test]
+    fn test_build_cohort_dependency_graph_cycle_detection_handles_self_referential_node() {
+        let cohort_1 = create_test_cohort_instance(1, Some(1)); // 1 depends on itself
+
+        let cohorts = vec![cohort_1.clone()];
+
+        // Try to build the graph starting from cohort 1
+        let result = build_cohort_dependency_graph(cohort_1.id, &cohorts);
+
+        // Verify we got a cycle error
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, FlagError::DependencyCycle(_, _)));
+        if let FlagError::DependencyCycle(dep_type, cycle_ids) = err {
+            assert_eq!(dep_type, DependencyType::Cohort);
+            assert_eq!(cycle_ids, &[1, 1]);
+        }
     }
 }

--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -311,14 +311,9 @@ pub fn evaluate_dynamic_cohorts(
     // Iterate through the sorted nodes in reverse order
     for node in sorted_cohort_ids_as_graph_nodes.into_iter().rev() {
         let cohort_id = cohort_dependency_graph[node];
-        let cohort =
-            cohorts
-                .iter()
-                .find(|c| c.id == cohort_id)
-                .ok_or(FlagError::DependencyNotFound(
-                    DependencyType::Cohort,
-                    cohort_id.into(),
-                ))?;
+        let cohort = cohorts.iter().find(|c| c.id == cohort_id).ok_or_else(|| {
+            FlagError::DependencyNotFound(DependencyType::Cohort, cohort_id.into())
+        })?;
 
         let dependencies = cohort.extract_dependencies()?;
 

--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -133,10 +133,9 @@ where
         Ok(_) => Ok(graph),
         Err(e) => {
             // Use the node that started the cycle (from the toposort error)
-            let cycle_nodes = get_cycle_nodes(&graph, e.node_id());
-            let cycle_ids: Vec<i64> = cycle_nodes.iter().map(|&node| graph[node].into()).collect();
-
-            Err(FlagError::DependencyCycle(T::dependency_type(), cycle_ids).into())
+            let cycle_start_id = e.node_id();
+            let cohort_id = graph[cycle_start_id].into();
+            Err(FlagError::DependencyCycle(T::dependency_type(), cohort_id).into())
         }
     }
 }

--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
-use petgraph::{algo::toposort, graph::DiGraph, visit::EdgeRef};
+use petgraph::{algo::toposort, graph::DiGraph};
 
 use crate::api::errors::FlagError;
 
@@ -138,32 +138,4 @@ where
             Err(FlagError::DependencyCycle(T::dependency_type(), cohort_id).into())
         }
     }
-}
-
-/// Given a graph and a node that is part of a cycle, returns the nodes in that cycle.
-/// The cycle starts with the node that is pointed to by the given node and ends with that same node.
-/// This function assumes a cycle exists starting at the given node.
-pub fn get_cycle_nodes<N, E>(
-    graph: &DiGraph<N, E>,
-    start: petgraph::graph::NodeIndex,
-) -> Vec<petgraph::graph::NodeIndex> {
-    // Get the first node in the cycle (the one that start points to)
-    let first = graph
-        .edges(start)
-        .next()
-        .expect("Cycle should have at least one edge")
-        .target();
-
-    // Build the cycle by following edges until we get back to first
-    let mut visited = HashSet::new();
-    let cycle: Vec<_> = std::iter::successors(Some(first), |&current| {
-        if visited.contains(&current) {
-            None
-        } else {
-            visited.insert(current);
-            graph.edges(current).next().map(|edge| edge.target())
-        }
-    })
-    .collect();
-    cycle
 }

--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -134,8 +134,8 @@ where
         Err(e) => {
             // Use the node that started the cycle (from the toposort error)
             let cycle_start_id = e.node_id();
-            let cohort_id = graph[cycle_start_id].into();
-            Err(FlagError::DependencyCycle(T::dependency_type(), cohort_id).into())
+            let dependency_id = graph[cycle_start_id].into();
+            Err(FlagError::DependencyCycle(T::dependency_type(), dependency_id).into())
         }
     }
 }


### PR DESCRIPTION
This PR adds unit tests for our dependency cycle detection for feature flags that have dependencies on cohorts and other feature flags (a coming feature).

It updates our cycle detection so that when we detect a cycle, we report the id that started the cycle in a structured way (aka as a property of the `DependencyCycle` error.

For example, suppose we have:

```
cohort:1 -> cohort:2 -> cohort:3 -> cohort:4 -> cohort:2
```

We detect a cycle that starts at `cohort:4` pointing to `cohort:2` so we report `4`. This is the cohort they'll want to update.
 

> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

No problem, just a refactoring and improved tests.

## Changes

No behavioral changes other than error message reporting

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Unit test