### PR TITLE
fix(capture-rs): silently accept empty payloads resulting from filtering invalid event types

### DIFF
--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -421,6 +421,15 @@ pub async fn event_legacy(
             })
         }
 
+        Err(CaptureError::EmptyPayloadFiltered) => {
+            // as per legacy behavior, for now we'll silently accept these submissions
+            // when invalid event type filtering has resulted in an empty event payload
+            Ok(CaptureResponse {
+                status: CaptureResponseCode::Ok,
+                quota_limited: None,
+            })
+        }
+
         Err(err) => {
             report_internal_error_metrics(err.to_metric_tag(), "parsing");
             error!("event_legacy: request payload processing error: {:?}", err);
@@ -492,6 +501,16 @@ pub async fn event(
                 quota_limited: None,
             })
         }
+
+        Err(CaptureError::EmptyPayloadFiltered) => {
+            // as per legacy behavior, for now we'll silently accept these submissions
+            // when invalid event type filtering has resulted in an empty event payload
+            Ok(CaptureResponse {
+                status: CaptureResponseCode::Ok,
+                quota_limited: None,
+            })
+        }
+
         Err(err) => {
             report_internal_error_metrics(err.to_metric_tag(), "parsing");
             Err(err)

--- a/rust/capture/tests/events.rs
+++ b/rust/capture/tests/events.rs
@@ -72,7 +72,7 @@ async fn it_drops_performance_events() -> Result<()> {
 
     let res = server.capture_events(retained_one.to_string()).await;
     assert_eq!(StatusCode::OK, res.status());
-    // this one will return a 4xx since the batch will be empty post-filtering
+    // silently ignored if the filtering of unsupported event types results in an empty payload
     let res = server.capture_events(should_drop.to_string()).await;
     assert_eq!(StatusCode::OK, res.status());
     let res = server.capture_events(retained_two.to_string()).await;

--- a/rust/capture/tests/events.rs
+++ b/rust/capture/tests/events.rs
@@ -74,7 +74,7 @@ async fn it_drops_performance_events() -> Result<()> {
     assert_eq!(StatusCode::OK, res.status());
     // this one will return a 4xx since the batch will be empty post-filtering
     let res = server.capture_events(should_drop.to_string()).await;
-    assert_eq!(StatusCode::BAD_REQUEST, res.status());
+    assert_eq!(StatusCode::OK, res.status());
     let res = server.capture_events(retained_two.to_string()).await;
     assert_eq!(StatusCode::OK, res.status());
 


### PR DESCRIPTION
## Problem
There are still a lot of old SDKs submitting `$performance_event`s that legacy capture dropped silently. Let's mirror that behavior for now vs. returning a sentinel error that encourages SDK upgrade

## Changes
* Update handling of new capture error on filtered payloads
* Adjust unit test accordingly

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Locally and in CI