### PR TITLE
fix(propdefs): sanitize event names prior to persisting

### DIFF
--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -169,7 +169,7 @@ pub struct Event {
 impl From<&Event> for EventDefinition {
     fn from(event: &Event) -> Self {
         EventDefinition {
-            name: sanitize_event_name(&event.event),
+            name: sanitize_string(&event.event),
             team_id: event.team_id,
             project_id: event.project_id,
             last_seen_at: get_floored_last_seen(),
@@ -288,7 +288,7 @@ impl Event {
             updates.push(Update::EventProperty(EventProperty {
                 team_id: self.team_id,
                 project_id: self.project_id,
-                event: self.event.clone(),
+                event: sanitize_string(&self.event),
                 property: key.clone(),
             }));
 
@@ -412,10 +412,6 @@ fn is_likely_unix_timestamp(n: &serde_json::Number) -> bool {
     false
 }
 
-fn sanitize_event_name(event_name: &str) -> String {
-    event_name.replace('\u{0000}', "\u{FFFD}")
-}
-
 // These hash impls correspond to DB uniqueness constraints, pulled from the TS
 impl Hash for PropertyDefinition {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
@@ -473,7 +469,7 @@ fn will_fit_in_postgres_column(str: &str) -> bool {
 // Postgres doesn't like nulls in strings, so we replace them with uFFFD.
 // This allocates, so only do it right when hitting the DB. We handle nulls
 // in strings just fine.
-pub fn sanitize_string(s: String) -> String {
+pub fn sanitize_string(s: &str) -> String {
     s.replace('\u{0000}', "\u{FFFD}")
 }
 

--- a/rust/property-defs-rs/src/v2_batch_ingestion.rs
+++ b/rust/property-defs-rs/src/v2_batch_ingestion.rs
@@ -245,8 +245,6 @@ pub async fn process_batch_v2(
     let cache_utilization = cache.len() as f64 / config.cache_capacity as f64;
     metrics::gauge!(CACHE_CONSUMED).set(cache_utilization);
 
-    // TODO(eli): implement v1-style delay while cache is warming?
-
     // prep reshaped, isolated data batch bufffers and async join handles
     let mut event_defs = EventDefinitionsBatch::new(config.v2_ingest_batch_size);
     let mut event_props = EventPropertiesBatch::new(config.v2_ingest_batch_size);


### PR DESCRIPTION
## Problem
Seeing some transient bugs in the v2 write path involving invalid null bytes in what should be a UTF-8 string field coming back from Postgres. This is likely due to `EventProperty` event name fields not being sanitized prior to storage, the way `EventDefinition` event names are.

## Changes
* Normalize the handling of event name fields we persist in `property-defs-rs`
* Dedup sanitizer functions in `types.rs`

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Locally and in CI