### PR TITLE
fix(flags): was accidentally including the `autocapture_opt_out` field in the non-config response

### DIFF
--- a/rust/feature-flags/src/api/types.rs
+++ b/rust/feature-flags/src/api/types.rs
@@ -97,8 +97,9 @@ pub struct ConfigResponse {
     pub supported_compression: Vec<String>,
 
     /// If set, disables autocapture
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "autocapture_opt_out")]
-    pub autocapture_opt_out: bool,
+    pub autocapture_opt_out: Option<bool>,
 
     /// Originally capturePerformance was replay only and so boolean true
     /// is equivalent to { network_timing: true }

--- a/rust/feature-flags/src/handler/config_response_builder.rs
+++ b/rust/feature-flags/src/handler/config_response_builder.rs
@@ -611,7 +611,7 @@ mod tests {
         assert_eq!(response.config.flags_persistence_default, Some(false));
         assert_eq!(response.config.autocapture_exceptions, Some(json!(false)));
         assert_eq!(response.config.capture_performance, Some(json!(false)));
-        assert!(!response.config.autocapture_opt_out.unwrap()); // this should be Some(false), not None
+        assert!(!response.config.autocapture_opt_out.unwrap());
         assert!(response.config.capture_dead_clicks.is_none());
     }
 

--- a/rust/feature-flags/src/handler/config_response_builder.rs
+++ b/rust/feature-flags/src/handler/config_response_builder.rs
@@ -125,7 +125,7 @@ fn apply_core_config_fields(response: &mut FlagsResponse, config: &Config, team:
     let capture_network_timing = team.capture_performance_opt_in.unwrap_or(false);
 
     response.config.supported_compression = vec!["gzip".to_string(), "gzip-js".to_string()];
-    response.config.autocapture_opt_out = team.autocapture_opt_out.unwrap_or(false);
+    response.config.autocapture_opt_out = Some(team.autocapture_opt_out.unwrap_or(false));
 
     response.config.analytics = if !*config.debug
         && !config.is_team_excluded(team.id, &config.new_analytics_capture_excluded_team_ids)
@@ -553,7 +553,7 @@ mod tests {
 
         apply_core_config_fields(&mut response, &config, &team);
 
-        assert!(response.config.autocapture_opt_out);
+        assert!(response.config.autocapture_opt_out.unwrap());
     }
 
     #[test]
@@ -566,7 +566,7 @@ mod tests {
 
         apply_core_config_fields(&mut response, &config, &team);
 
-        assert!(!response.config.autocapture_opt_out);
+        assert!(!response.config.autocapture_opt_out.unwrap());
     }
 
     #[test]
@@ -611,7 +611,7 @@ mod tests {
         assert_eq!(response.config.flags_persistence_default, Some(false));
         assert_eq!(response.config.autocapture_exceptions, Some(json!(false)));
         assert_eq!(response.config.capture_performance, Some(json!(false)));
-        assert!(!response.config.autocapture_opt_out);
+        assert!(!response.config.autocapture_opt_out.unwrap()); // this should be Some(false), not None
         assert!(response.config.capture_dead_clicks.is_none());
     }
 

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -1664,7 +1664,7 @@ async fn it_only_includes_config_fields_when_requested() -> Result<()> {
     let json_data = res.json::<Value>().await?;
     println!("json_data: {:?}", json_data);
     assert!(json_data.get("supportedCompression").is_none());
-    assert_eq!(json_data["autocapture_opt_out"], json!(false));
+    assert!(json_data.get("autocapture_opt_out").is_none());
 
     // With config param
     let res = server


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Not really a problem but feels unclean.  I was seeing responses like

<img width="696" alt="image" src="https://github.com/user-attachments/assets/4a37bd5c-29eb-422b-9b9d-5029df60648b" />

where the `autocapture_opt_out` field was being included along with just flag-specific stuff.  Dumb.

## Changes

Only include `autocapture_opt_out` when `?config=true`

## Did you write or update any docs for this change?

- [x] No docs needed for this change

## How did you test this code?
 
- updated existing tests
