### PR TITLE
chore(propdefs): remove cache warming delay and related config vars in property-defs-rs

### DIFF
--- a/rust/property-defs-rs/src/config.rs
+++ b/rust/property-defs-rs/src/config.rs
@@ -41,25 +41,6 @@ pub struct Config {
     #[envconfig(default = "1000000")]
     pub cache_capacity: usize,
 
-    // We impose a slow-start, where each batch update operation is delayed by
-    // this many milliseconds, multiplied by the % of the cache currently unused. The idea
-    // is that we want to drip-feed updates to the DB during warmup, since
-    // cache fill rate is highest when it's most empty, and cache fill rate
-    // is exactly equivalent to the rate at which we can issue updates to the DB.
-    // The maths here is:
-    //     max(writes/s) = max_concurrent_transactions * update_batch_size / transaction_seconds
-    // By artificially inflating transaction_time, we put a cap on writes/s. This cap is
-    // then loosened as the cache fills, until we're operating in "normal" mode and
-    // only presenting "true" DB backpressure (in the form of write time) to the main loop.
-    #[envconfig(default = "1000")]
-    pub cache_warming_delay_ms: u32,
-
-    // This is the slow-start cutoff. Once the cache is this full, we
-    // don't delay the batch updates any more. 50% is fine for testing,
-    // in production you want to be using closer to 80-90%
-    #[envconfig(default = "0.5")]
-    pub cache_warming_cutoff: f64,
-
     // Each worker maintains a small local batch of updates, which it
     // flushes to the main thread (updating/filtering by the
     // cross-thread cache while it does). This is that batch size.

--- a/rust/property-defs-rs/src/v2_batch_ingestion.rs
+++ b/rust/property-defs-rs/src/v2_batch_ingestion.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 use crate::{
     config::Config,
     metrics_consts::{
-        CACHE_CONSUMED, ISSUE_FAILED, V2_EVENT_DEFS_BATCH_ATTEMPT, V2_EVENT_DEFS_BATCH_CACHE_TIME,
+        ISSUE_FAILED, V2_EVENT_DEFS_BATCH_ATTEMPT, V2_EVENT_DEFS_BATCH_CACHE_TIME,
         V2_EVENT_DEFS_BATCH_ROWS_AFFECTED, V2_EVENT_DEFS_BATCH_SIZE,
         V2_EVENT_DEFS_BATCH_WRITE_TIME, V2_EVENT_DEFS_CACHE_REMOVED, V2_EVENT_PROPS_BATCH_ATTEMPT,
         V2_EVENT_PROPS_BATCH_CACHE_TIME, V2_EVENT_PROPS_BATCH_ROWS_AFFECTED,
@@ -242,9 +242,6 @@ pub async fn process_batch_v2(
     pool: &PgPool,
     batch: Vec<Update>,
 ) {
-    let cache_utilization = cache.len() as f64 / config.cache_capacity as f64;
-    metrics::gauge!(CACHE_CONSUMED).set(cache_utilization);
-
     // prep reshaped, isolated data batch bufffers and async join handles
     let mut event_defs = EventDefinitionsBatch::new(config.v2_ingest_batch_size);
     let mut event_props = EventPropertiesBatch::new(config.v2_ingest_batch_size);


### PR DESCRIPTION
## Problem
The cache warming delay is ramped down to near no-op in production, and could be cleaned up in the code. Duplicative cache-consumed gauge updates can be consolidated

## Changes
* Only update the cache-consumed gauge once per update batch processed
* Remove cache warming delay logic + related env vars

### TODOs
After this PR lands, I'll need to:
* Remove corresponding refs to config vars from deployments
* Add cache consumption graph to propdefs dashboards; remove cache-warming graph

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Locally and in CI