### PR TITLE
refactor(spmc): Reduce calls to record batch slice

### DIFF
--- a/posthog/temporal/batch_exports/spmc.py
+++ b/posthog/temporal/batch_exports/spmc.py
@@ -2,6 +2,7 @@ import abc
 import asyncio
 import collections.abc
 import datetime as dt
+import math
 import operator
 import typing
 import uuid
@@ -985,21 +986,25 @@ def slice_record_batch(
         min_records_batch_per_batch: Each slice yielded should contain at least
             this number of records.
     """
-    total_rows = record_batch.num_rows
-    yielded_rows = 0
-    offset = 0
-    length = total_rows
-
     if max_record_batch_size_bytes <= 0 or max_record_batch_size_bytes > record_batch.nbytes:
         yield record_batch
         return
+
+    total_rows = record_batch.num_rows
+    yielded_rows = 0
+    offset = 0
+    estimated = _estimate_rows_to_fit_under_max(record_batch, max_record_batch_size_bytes, min_records_per_batch)
+    length = total_rows - estimated
 
     while yielded_rows < total_rows:
         sliced_record_batch = record_batch.slice(offset=offset, length=length)
         current_rows = sliced_record_batch.num_rows
 
-        if max_record_batch_size_bytes < sliced_record_batch.nbytes and min_records_per_batch < current_rows:
-            length -= 1
+        if sliced_record_batch.nbytes > max_record_batch_size_bytes and current_rows > min_records_per_batch:
+            estimated = _estimate_rows_to_fit_under_max(
+                sliced_record_batch, max_record_batch_size_bytes, min_records_per_batch
+            )
+            length -= estimated
             continue
 
         yield sliced_record_batch
@@ -1007,6 +1012,17 @@ def slice_record_batch(
         yielded_rows += current_rows
         offset = offset + length
         length = total_rows - yielded_rows
+
+
+def _estimate_rows_to_fit_under_max(
+    slice: pa.RecordBatch, max_record_batch_size_bytes: int, min_records_per_batch: int
+) -> int:
+    if slice.nbytes <= max_record_batch_size_bytes or slice.num_rows <= min_records_per_batch:
+        return 0
+
+    avg_bytes_per_row = slice.nbytes / slice.num_rows
+    bytes_diff = slice.nbytes - max_record_batch_size_bytes
+    return max(math.floor(bytes_diff / avg_bytes_per_row), 1)
 
 
 def generate_query_ranges(


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Slicing a record batch is a zero copy operation, so no data is moved around. However, we still pay some cycles for each call: In my testing, execution time grew linearly with the size of a record batch.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

This means we can optimize the `slice_record_batch` function if we reduce the number of calls to `pyarrow.RecordBatch.slice`. The current loop it's quite hot as it is taking 1 record out of the slice at a time. Instead, we can take multiple rows at a time, by estimating how many bytes we are still missing from the target.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
