### PR TITLE
fix(err): match condition in assignment rule

### DIFF
--- a/rust/cymbal/src/assignment_rules.rs
+++ b/rust/cymbal/src/assignment_rules.rs
@@ -180,12 +180,14 @@ impl AssignmentRule {
         while i < context.max_steps {
             let step_result = vm.step()?;
             match step_result {
-                StepOutcome::Finished(Value::Bool(b)) if b => {
-                    return Ok(NewAssignment::try_new(
-                        self.user_id,
-                        self.user_group_id,
-                        self.role_id,
-                    ))
+                StepOutcome::Finished(Value::Bool(b)) => {
+                    if b {
+                        return Ok(NewAssignment::try_new(
+                            self.user_id,
+                            self.user_group_id,
+                            self.role_id,
+                        ));
+                    }
                 }
                 StepOutcome::Finished(res) => {
                     return Err(VmError::Other(format!(


### PR DESCRIPTION
Grouping rules aren't impacted by this, only assignment rules. 🤦 