### PR TITLE
feat(experiments): frequentist UI funnel breakdowns

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/DetailsButton.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/DetailsButton.tsx
@@ -1,0 +1,50 @@
+import { IconGraph } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+import { SharedMetric } from 'scenes/experiments/SharedMetrics/sharedMetricLogic'
+
+import {
+    ExperimentFunnelsQuery,
+    ExperimentMetric,
+    ExperimentTrendsQuery,
+    NodeKind,
+} from '~/queries/schema/schema-general'
+import { Experiment } from '~/types'
+
+export function DetailsButton({
+    metric,
+    isSecondary,
+    experiment,
+    setIsModalOpen,
+}: {
+    metric: ExperimentMetric | ExperimentTrendsQuery | ExperimentFunnelsQuery
+    isSecondary: boolean
+    experiment: Experiment
+    setIsModalOpen: (isOpen: boolean) => void
+}): JSX.Element {
+    if (metric.kind !== NodeKind.ExperimentMetric || metric.metric_type !== 'funnel') {
+        return <></>
+    }
+
+    const primaryMetricsLength =
+        experiment.metrics.length +
+        experiment.saved_metrics.filter((savedMetric: SharedMetric) => savedMetric.metadata?.type === 'primary').length
+    return (
+        <>
+            {(isSecondary || (!isSecondary && primaryMetricsLength > 1)) && (
+                <div
+                    className="absolute bottom-2 left-2 flex justify-center bg-[var(--bg-table)] z-[101]"
+                    // Chart is z-index 100, so we need to be above it
+                >
+                    <LemonButton
+                        type="secondary"
+                        size="xsmall"
+                        icon={<IconGraph />}
+                        onClick={() => setIsModalOpen(true)}
+                    >
+                        Details
+                    </LemonButton>
+                </div>
+            )}
+        </>
+    )
+}

--- a/frontend/src/scenes/experiments/MetricsView/new/DetailsModal.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/DetailsModal.tsx
@@ -1,0 +1,44 @@
+import { LemonButton, LemonModal } from '@posthog/lemon-ui'
+
+import { ExperimentFunnelsQuery, ExperimentMetric, ExperimentTrendsQuery } from '~/queries/schema/schema-general'
+import { ResultsBreakdown, ResultsQuery } from '~/scenes/experiments/components/ResultsBreakdown'
+import type { Experiment } from '~/types'
+
+interface DetailsModalProps {
+    isOpen: boolean
+    onClose: () => void
+    metric: ExperimentMetric | ExperimentTrendsQuery | ExperimentFunnelsQuery
+    result: any
+    experiment: Experiment
+}
+
+export function DetailsModal({ isOpen, onClose, metric, result, experiment }: DetailsModalProps): JSX.Element {
+    // :KLUDGE: workaround until we pass metric into the Frequentist result response
+    result.metric = metric
+
+    return (
+        <LemonModal
+            isOpen={isOpen}
+            onClose={onClose}
+            width={1200}
+            title={`Metric results: ${metric.name || 'Untitled metric'}`}
+            footer={
+                <LemonButton type="secondary" onClick={onClose}>
+                    Close
+                </LemonButton>
+            }
+        >
+            <ResultsBreakdown result={result} experiment={experiment}>
+                {({ query, breakdownResults }) => {
+                    return (
+                        <>
+                            {query && breakdownResults && (
+                                <ResultsQuery query={query} breakdownResults={breakdownResults} />
+                            )}
+                        </>
+                    )
+                }}
+            </ResultsBreakdown>
+        </LemonModal>
+    )
+}

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRow.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRow.tsx
@@ -1,4 +1,5 @@
 import { useActions, useValues } from 'kea'
+import { useState } from 'react'
 import { experimentLogic } from 'scenes/experiments/experimentLogic'
 
 import { ExperimentFunnelsQuery } from '~/queries/schema/schema-general'
@@ -12,6 +13,8 @@ import { ChartLoadingState } from '../shared/ChartLoadingState'
 import { MetricHeader } from '../shared/MetricHeader'
 import { getNiceTickValues } from '../shared/utils'
 import { Chart } from './Chart'
+import { DetailsButton } from './DetailsButton'
+import { DetailsModal } from './DetailsModal'
 
 export function MetricRow({
     metric,
@@ -44,6 +47,8 @@ export function MetricRow({
     const { chartSvgRef, chartSvgHeight } = useSvgResizeObserver([tickValues, chartRadius])
     const panelHeight = Math.max(chartSvgHeight, 60)
 
+    const [isModalOpen, setIsModalOpen] = useState(false)
+
     return (
         <div
             className={`w-full border border-primary bg-light ${metricIndex === metrics.length - 1 ? 'rounded-b' : ''}`}
@@ -73,14 +78,29 @@ export function MetricRow({
                     style={{ height: `${panelHeight}px` }}
                 >
                     {result && hasMinimumExposureForResults ? (
-                        <Chart
-                            chartSvgRef={chartSvgRef}
-                            variantResults={variantResults}
-                            chartRadius={chartRadius}
-                            metricIndex={metricIndex}
-                            tickValues={tickValues}
-                            isSecondary={isSecondary}
-                        />
+                        <div className="relative">
+                            <Chart
+                                chartSvgRef={chartSvgRef}
+                                variantResults={variantResults}
+                                chartRadius={chartRadius}
+                                metricIndex={metricIndex}
+                                tickValues={tickValues}
+                                isSecondary={isSecondary}
+                            />
+                            <DetailsButton
+                                metric={metric}
+                                isSecondary={isSecondary}
+                                experiment={experiment}
+                                setIsModalOpen={setIsModalOpen}
+                            />
+                            <DetailsModal
+                                isOpen={isModalOpen}
+                                onClose={() => setIsModalOpen(false)}
+                                metric={metric}
+                                result={result}
+                                experiment={experiment}
+                            />
+                        </div>
                     ) : resultsLoading ? (
                         <ChartLoadingState height={panelHeight} />
                     ) : (

--- a/frontend/src/scenes/experiments/MetricsView/new/Metrics.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/Metrics.tsx
@@ -2,8 +2,10 @@ import { IconInfo } from '@posthog/icons'
 import { Tooltip } from '@posthog/lemon-ui'
 import { useValues } from 'kea'
 import { IconAreaChart } from 'lib/lemon-ui/icons'
+import { ResultsBreakdown } from 'scenes/experiments/components/ResultsBreakdown/ResultsBreakdown'
+import { ResultsQuery } from 'scenes/experiments/components/ResultsBreakdown/ResultsQuery'
 
-import { NewExperimentQueryResponse } from '~/queries/schema/schema-general'
+import { ExperimentMetric, NewExperimentQueryResponse } from '~/queries/schema/schema-general'
 
 import { experimentLogic } from '../../experimentLogic'
 import { AddPrimaryMetric, AddSecondaryMetric } from '../shared/AddMetric'
@@ -90,28 +92,56 @@ export function Metrics({ isSecondary }: { isSecondary?: boolean }): JSX.Element
                 </div>
             </div>
             {metrics.length > 0 ? (
-                <div className="w-full overflow-x-auto">
-                    <div className="min-w-[1000px]">
-                        <div className="rounded bg-[var(--bg-table)]">
-                            <ConfidenceIntervalAxis chartRadius={chartRadius} />
-                            {metrics.map((metric, metricIndex) => {
-                                return (
-                                    <MetricRow
-                                        key={metricIndex}
-                                        metrics={metrics}
-                                        metricIndex={metricIndex}
-                                        result={results[metricIndex]}
-                                        metric={metric}
-                                        metricType={getInsightType(metric)}
-                                        isSecondary={!!isSecondary}
-                                        chartRadius={chartRadius}
-                                        error={errors[metricIndex]}
-                                    />
-                                )
-                            })}
+                <>
+                    <div className="w-full overflow-x-auto">
+                        <div className="min-w-[1000px]">
+                            <div className="rounded bg-[var(--bg-table)]">
+                                <ConfidenceIntervalAxis chartRadius={chartRadius} />
+                                {metrics.map((metric, metricIndex) => {
+                                    return (
+                                        <>
+                                            <MetricRow
+                                                key={metricIndex}
+                                                metrics={metrics}
+                                                metricIndex={metricIndex}
+                                                result={results[metricIndex]}
+                                                metric={metric}
+                                                metricType={getInsightType(metric)}
+                                                isSecondary={!!isSecondary}
+                                                chartRadius={chartRadius}
+                                                error={errors[metricIndex]}
+                                            />
+                                            {metrics.length === 1 && (
+                                                <div className="mt-2">
+                                                    <ResultsBreakdown
+                                                        result={{
+                                                            ...results[metricIndex],
+                                                            metric: metric as ExperimentMetric,
+                                                        }}
+                                                        experiment={experiment}
+                                                    >
+                                                        {({ query, breakdownResults }) => {
+                                                            return (
+                                                                <>
+                                                                    {query && breakdownResults && (
+                                                                        <ResultsQuery
+                                                                            query={query}
+                                                                            breakdownResults={breakdownResults}
+                                                                        />
+                                                                    )}
+                                                                </>
+                                                            )
+                                                        }}
+                                                    </ResultsBreakdown>
+                                                </div>
+                                            )}
+                                        </>
+                                    )
+                                })}
+                            </div>
                         </div>
                     </div>
-                </div>
+                </>
             ) : (
                 <div className="border rounded bg-surface-primary pt-6 pb-8 text-secondary mt-2">
                     <div className="flex flex-col items-center mx-auto deprecated-space-y-3">

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
@@ -27,6 +27,7 @@ export interface SharedMetric {
     created_at: string | null
     updated_at: string | null
     tags: string[]
+    metadata?: Record<string, any>
 }
 
 export const NEW_SHARED_METRIC: Partial<SharedMetric> = {


### PR DESCRIPTION
## Changes
Added funnel breakdowns to the Frequentist UI.

The "Details" modal is currently only available for funnel results. Still need to figure out what to show in the summary table for Frequentist.

#### Single primary metric
<img width="1259" alt="image" src="https://github.com/user-attachments/assets/ae02fb13-5899-450d-b623-5be44a576663" />

#### Multiple primary metrics (via Details modal)
<img width="966" alt="image" src="https://github.com/user-attachments/assets/57c5afa9-0fcd-4fbf-ae4c-b92d23bd6349" />

## How did you test this code?
👀 