### PR TITLE
ci(max): Only run evals with `evals-ready` label

### DIFF
--- a/.github/workflows/ci-ai.yml
+++ b/.github/workflows/ci-ai.yml
@@ -1,13 +1,10 @@
 name: AI
 
 on:
+    pull_request:
     push:
         branches:
             - master
-        paths:
-            - 'ee/hogai/**'
-            - '.github/workflows/ci-ai.yml'
-    pull_request:
         paths:
             - 'ee/hogai/**'
             - '.github/workflows/ci-ai.yml'
@@ -21,7 +18,11 @@ jobs:
         timeout-minutes: 30
         name: Run AI evals
         runs-on: ubuntu-latest
-        if: github.repository == 'PostHog/posthog' && (github.event_name == 'push' || (github.event.pull_request.draft == false)) # Braintrust credentials not available on forks
+        # Skipping on forks as Braintrust credentials are not available there
+        if: |
+            github.repository == 'PostHog/posthog' && (
+                github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'evals-ready')
+            )
 
         steps:
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
## Problem

It's _a little_ expensive to run AI evals on every commit, even if only on Max AI PRs. ([Slack thread.](https://posthog.slack.com/archives/C06NZEZ7V3Q/p1749806337928589))

## Changes

As in the Slack thread, making it so that evals run on PRs only if the `evals-ready` label is present. Upside: you can now also request evals on draft PRs. 

## How did you test this code?

Using here.