### PR TITLE
feat(propdefs): Implement cache expiration for all propdefs record types

### DIFF
--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -115,9 +115,10 @@ pub struct PropertyDefinition {
     pub property_type: Option<PropertyValueType>,
     pub event_type: PropertyParentType,
     pub group_type_index: Option<GroupType>,
+    pub last_seen_at: DateTime<Utc>, // Not a DB attribute; for local cache expiry only
     pub property_type_format: Option<String>, // Deprecated
-    pub volume_30_day: Option<i64>,           // Deprecated
-    pub query_usage_30_day: Option<i64>,      // Deprecated
+    pub volume_30_day: Option<i64>,  // Deprecated
+    pub query_usage_30_day: Option<i64>, // Deprecated
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -125,16 +126,19 @@ pub struct EventDefinition {
     pub name: String,
     pub team_id: i32,
     pub project_id: i64,
-    pub last_seen_at: DateTime<Utc>, // Always floored to our update rate for last_seen, so this Eq derive is safe for deduping
+    // Not a DB attribute; for local cache expiry only
+    // Always floored to our update rate for last_seen, so this Eq derive is safe for deduping
+    pub last_seen_at: DateTime<Utc>,
 }
 
 // Derived hash since these are keyed on all fields in the DB
-#[derive(Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct EventProperty {
     pub team_id: i32,
     pub project_id: i64,
     pub event: String,
     pub property: String,
+    pub last_seen_at: DateTime<Utc>, // Not a DB attribute; for local cache expiry only
 }
 
 // Represents a generic update, but comparable, allowing us to dedupe and cache updates
@@ -290,6 +294,7 @@ impl Event {
                 project_id: self.project_id,
                 event: sanitize_string(&self.event),
                 property: key.clone(),
+                last_seen_at: get_floored_last_seen(),
             }));
 
             let property_type = detect_property_type(key, value);
@@ -303,6 +308,7 @@ impl Event {
                 property_type,
                 event_type: parent_type,
                 group_type_index: group_type.clone(),
+                last_seen_at: get_floored_last_seen(),
                 property_type_format: None,
                 volume_30_day: None,
                 query_usage_30_day: None,
@@ -416,17 +422,30 @@ fn is_likely_unix_timestamp(n: &serde_json::Number) -> bool {
 impl Hash for PropertyDefinition {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.team_id.hash(state);
+        // project_id is not consistently populated in posthog_propertydefinition
         self.name.hash(state);
         self.event_type.hash(state);
         self.group_type_index.hash(state);
+        self.last_seen_at.hash(state) // ensure the cache entry expires in 1 hour
     }
 }
 
 impl Hash for EventDefinition {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // project_id is not consistently populated in posthog_eventdefinition
         self.team_id.hash(state);
         self.name.hash(state);
-        self.last_seen_at.hash(state)
+        self.last_seen_at.hash(state) // ensure the cache entry expires in 1 hour
+    }
+}
+
+impl Hash for EventProperty {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.team_id.hash(state);
+        // project_id is not consistently populated in posthog_eventproperty
+        self.event.hash(state);
+        self.property.hash(state);
+        self.last_seen_at.hash(state); // ensure the cache expires these fairly quickly
     }
 }
 

--- a/rust/property-defs-rs/tests/update_cache.rs
+++ b/rust/property-defs-rs/tests/update_cache.rs
@@ -24,6 +24,7 @@ fn test_cache_insertions() {
         property: String::from("bar"),
         team_id: 1,
         project_id: 1,
+        last_seen_at: Utc::now(), // these are normally floored but unimportant for these tests
     });
     cache.insert(evt_prop.clone());
 
@@ -35,6 +36,7 @@ fn test_cache_insertions() {
         property_type: Some(PropertyValueType::Numeric),
         event_type: PropertyParentType::Event,
         group_type_index: None,
+        last_seen_at: Utc::now(), // these are normally floored but unimportant for these tests
         property_type_format: None,
         query_usage_30_day: None,
         volume_30_day: None,
@@ -63,6 +65,7 @@ fn test_cache_removals() {
         property: String::from("bar"),
         team_id: 1,
         project_id: 1,
+        last_seen_at: Utc::now(), // these are normally floored but unimportant for these tests
     });
     cache.insert(evt_prop.clone());
 
@@ -74,6 +77,7 @@ fn test_cache_removals() {
         property_type: Some(PropertyValueType::Numeric),
         event_type: PropertyParentType::Event,
         group_type_index: None,
+        last_seen_at: Utc::now(), // these are normally floored but unimportant for these tests
         property_type_format: None,
         query_usage_30_day: None,
         volume_30_day: None,


### PR DESCRIPTION
## Problem
Only event definitions have a built-in cache expiration window in `property-defs-rs`.  This means if a write batch is lost but the pod remains up and running, property definitions and event properties already in the cache won't be expired until they churn out eventually, or the service is redeployed.

This is more urgent to address, now that the service has received stability improvements and will not be deployed so reguarly.

## Changes
This is a reattempt of the functionality [introduced and reverted in this PR](https://github.com/PostHog/posthog/pull/29676). With the substantially decreased memory footprint landed with the split (wrapped) `Update`s cache, we should be able to safely reintroduce this behavior now 👍 

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Locally, in CI, and in prior test deploy
