### PR TITLE
fix: remove outlier handling from the trend metric transformation utils.

### DIFF
--- a/frontend/src/scenes/experiments/metricQueryUtils.test.ts
+++ b/frontend/src/scenes/experiments/metricQueryUtils.test.ts
@@ -229,51 +229,6 @@ describe('getQuery', () => {
         })
     })
 
-    it('returns the correct query for a mean metric with outlier handling', () => {
-        const metric: ExperimentMetric = {
-            kind: NodeKind.ExperimentMetric,
-            metric_type: ExperimentMetricType.MEAN,
-            source: {
-                kind: NodeKind.EventsNode,
-                event: '$pageview',
-                name: '$pageview',
-                math: ExperimentMetricMathType.Sum,
-                math_property: 'property_value',
-            },
-            lower_bound_percentile: 10,
-            upper_bound_percentile: 90,
-        }
-
-        const query = getQuery({
-            filterTestAccounts: true,
-        })(metric)
-
-        expect(query).toEqual({
-            kind: NodeKind.TrendsQuery,
-            interval: 'day',
-            dateRange: {
-                date_from: dayjs().subtract(EXPERIMENT_DEFAULT_DURATION, 'day').format('YYYY-MM-DDTHH:mm'),
-                date_to: dayjs().endOf('d').format('YYYY-MM-DDTHH:mm'),
-                explicitDate: true,
-            },
-            trendsFilter: {
-                display: ChartDisplayType.ActionsLineGraph,
-            },
-            filterTestAccounts: true,
-            lower_bound_percentile: 10,
-            upper_bound_percentile: 90,
-            series: [
-                {
-                    kind: NodeKind.EventsNode,
-                    event: '$pageview',
-                    name: '$pageview',
-                    math: PropertyMathType.Sum,
-                    math_property: 'property_value',
-                },
-            ],
-        })
-    })
-
     it('returns undefined for unsupported metric types', () => {
         const metric = {
             kind: NodeKind.ExperimentMetric,

--- a/frontend/src/scenes/experiments/metricQueryUtils.ts
+++ b/frontend/src/scenes/experiments/metricQueryUtils.ts
@@ -12,9 +12,7 @@ import type {
     ExperimentEventExposureConfig,
     ExperimentFunnelMetric,
     ExperimentFunnelMetricStep,
-    ExperimentMeanMetric,
     ExperimentMetric,
-    ExperimentMetricOutlierHandling,
     FunnelsFilter,
     FunnelsQuery,
     InsightVizNode,
@@ -83,16 +81,6 @@ const getMathProperties = (
         .with({ math: ExperimentMetricMathType.UniqueSessions }, ({ math }) => ({ math }))
         .otherwise(() => ({ math: ExperimentMetricMathType.TotalCount, math_property: undefined }))
 
-/**
- * returns the outlier handling for a mean metric
- */
-const getOutlierHandling = (metric: ExperimentMeanMetric): ExperimentMetricOutlierHandling => {
-    return {
-        ...(metric.lower_bound_percentile && { lower_bound_percentile: metric.lower_bound_percentile }),
-        ...(metric.upper_bound_percentile && { upper_bound_percentile: metric.upper_bound_percentile }),
-    }
-}
-
 type MetricToQueryOptions = {
     breakdownFilter: BreakdownFilter
     filterTestAccounts: boolean
@@ -144,7 +132,6 @@ export const getQuery =
                     dateRange,
                     interval: trendsInterval,
                     trendsFilter,
-                    ...getOutlierHandling(meanMetric),
                     series: [
                         {
                             kind: source.kind,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Insight trends queries do not support outlier handling like the experiment query does. This could break trends query when using these transformation functions.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Removed outlier handling from `metricsQueryUtils`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

```bash
pnpm --filter=@posthog/frontend jest src/scenes/experiments/metricQueryUtils.test.ts
```

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
