### PR TITLE
SUPPORT SUPERDAY TASK: LOLU

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
@@ -353,6 +353,24 @@ export function SidePanelSupport(): JSX.Element {
                                 </LemonButton>
                             </Section>
 
+                            {/* Report a bug */}
+                            <Section title="Report a bug">
+                                <p>
+                                    Found a bug or issue? Help us improve PostHog by reporting it on GitHub where our
+                                    engineering team can track and fix it.
+                                </p>
+                                <LemonButton
+                                    type="secondary"
+                                    fullWidth
+                                    center
+                                    to="https://github.com/PostHog/posthog/issues/new?template=bug_report.md"
+                                    targetBlank
+                                    className="mt-2"
+                                >
+                                    Report a bug on GitHub
+                                </LemonButton>
+                            </Section>
+
                             {/* Add support hours and table */}
                             <div className="mb-2">
                                 <strong>Support is open Monday - Friday</strong>


### PR DESCRIPTION

## Problem

Users currently need to navigate to GitHub manually to report bugs or issues they encounter while using PostHog. This creates friction in the bug reporting process and may result in fewer bug reports being submitted, which impacts product quality and user experience.

The support menu is the natural place users look for help, but it currently lacks a clear path for bug reporting, potentially leading to bugs being reported through less optimal channels or not reported at all.

## Changes

- Added a new "Report a bug" section to the support menu
- Included explanatory text that clearly communicates the purpose and value of bug reporting
- Added a `LemonButton` that opens GitHub's bug report template directly in a new tab
- Used the existing bug report template URL to ensure proper issue formatting
- Applied consistent styling with existing support menu sections

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

- Verified the support menu renders correctly with the new section
- Tested that the "Report a bug on GitHub" button opens the correct URL (`https://github.com/PostHog/posthog/issues/new?template=bug_report.md`)
- Confirmed the link opens in a new tab as expected (`targetBlank` prop)
- Checked that the section styling is consistent with other sections in the support menu
- Verified the button is accessible and follows existing design pattern

https://github.com/user-attachments/assets/4be22356-9a2a-46e2-ad1e-3e1313bc0199
![github report](https://github.com/user-attachments/assets/9afa5935-5f06-470f-a863-007ccfde16e0)

