### PR TITLE
fix: UI context breaks on new insight

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -503,7 +503,7 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
         },
         setMaxContext: () => {
             // Set MaxAI context when insight changes
-            if (values.insight && values.insight.query) {
+            if (values.insight && values.insight.id && values.insight.query) {
                 maxContextLogic.findMounted()?.actions.addOrUpdateActiveInsight(values.insight, values.isInViewMode)
             }
         },


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
Max breaks when reloading the page on the insight editing view. This is because new unsaved insights don't have an ID.

## Changes
- Do not add the insight as available to the UI context if the insight doesn't have an ID.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [X] No docs needed for this change

## How did you test this code?
Locally
