### PR TITLE
chore(cohorts): use database aggregation for stale metrics

### DIFF
--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -63,28 +63,16 @@ def get_cohort_calculation_candidates_queryset() -> QuerySet:
 
 def update_stale_cohort_metrics() -> None:
     now = timezone.now()
-    stale_cohorts = (
-        Cohort.objects.filter(
-            Q(last_calculation__isnull=False),
-            deleted=False,
-            is_calculating=False,
-            errors_calculating__lte=20,
-        )
-        .exclude(is_static=True)
-        .values_list("last_calculation", flat=True)
-    )
+    base_queryset = Cohort.objects.filter(
+        Q(last_calculation__isnull=False),
+        deleted=False,
+        is_calculating=False,
+        errors_calculating__lte=20,
+    ).exclude(is_static=True)
 
-    stale_24h = stale_36h = stale_48h = 0
-    for last_calc in stale_cohorts:
-        if last_calc <= now - relativedelta(hours=48):
-            stale_48h += 1
-            stale_36h += 1
-            stale_24h += 1
-        elif last_calc <= now - relativedelta(hours=36):
-            stale_36h += 1
-            stale_24h += 1
-        elif last_calc <= now - relativedelta(hours=24):
-            stale_24h += 1
+    stale_24h = base_queryset.filter(last_calculation__lte=now - relativedelta(hours=24)).count()
+    stale_36h = base_queryset.filter(last_calculation__lte=now - relativedelta(hours=36)).count()
+    stale_48h = base_queryset.filter(last_calculation__lte=now - relativedelta(hours=48)).count()
 
     COHORTS_STALE_COUNT_GAUGE.labels(hours="24").set(stale_24h)
     COHORTS_STALE_COUNT_GAUGE.labels(hours="36").set(stale_36h)

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -70,13 +70,9 @@ def update_stale_cohort_metrics() -> None:
         errors_calculating__lte=20,
     ).exclude(is_static=True)
 
-    stale_24h = base_queryset.filter(last_calculation__lte=now - relativedelta(hours=24)).count()
-    stale_36h = base_queryset.filter(last_calculation__lte=now - relativedelta(hours=36)).count()
-    stale_48h = base_queryset.filter(last_calculation__lte=now - relativedelta(hours=48)).count()
-
-    COHORTS_STALE_COUNT_GAUGE.labels(hours="24").set(stale_24h)
-    COHORTS_STALE_COUNT_GAUGE.labels(hours="36").set(stale_36h)
-    COHORTS_STALE_COUNT_GAUGE.labels(hours="48").set(stale_48h)
+    for hours in [24, 36, 48]:
+        stale_count = base_queryset.filter(last_calculation__lte=now - relativedelta(hours=hours)).count()
+        COHORTS_STALE_COUNT_GAUGE.labels(hours=str(hours)).set(stale_count)
 
     stuck_count = (
         Cohort.objects.filter(


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Use database aggregation instead of loading all stale cohorts from db and then iterating.  

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
