### PR TITLE
chore(flags): Add method to build up evaluation levels from a flags DAG

### DIFF
--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -166,6 +166,76 @@ where
         Ok(results)
     }
 
+    /// Computes evaluation stages where each stage contains nodes that can be safely evaluated in parallel.
+    ///
+    /// This is a "leaves-first" topological batching algorithm, ideal for feature flag evaluation.
+    ///
+    /// Each stage consists of all nodes whose dependencies have already been evaluated.
+    /// Items in earlier stages must be evaluated before items in later stages.
+    ///
+    /// Graph edge semantics reminder:
+    /// - Edges point from dependent → dependency:
+    ///     A → B means "A depends on B" (A requires B to be evaluated first)
+    /// - Therefore:
+    ///     - Outgoing edges = dependencies
+    ///     - Incoming edges = dependents (nodes that require this node)
+    ///
+    /// The algorithm works by repeatedly finding all nodes that have no remaining dependencies (out-degree == 0),
+    /// evaluating them as one stage, and then decrementing the remaining dependencies of their dependents.
+    pub fn evaluation_stages(&self) -> Result<Vec<Vec<&T>>, T::Error> {
+        use petgraph::Direction::{Incoming, Outgoing};
+
+        // how many dependencies each node has remaining
+        let mut out_degree = HashMap::new();
+        // maps NodeIndex → &T for easy lookup later
+        let mut node_map = HashMap::new();
+
+        // Initialize the out-degree and node_map
+        for node_idx in self.graph.node_indices() {
+            let node = &self.graph[node_idx];
+            node_map.insert(node_idx, node);
+            let deg = self.graph.edges_directed(node_idx, Outgoing).count();
+            out_degree.insert(node_idx, deg);
+        }
+
+        let mut stages = Vec::new();
+
+        // We'll add nodes to stages as we find them.
+        // We'll remove nodes from the out_degree map as we process them.
+        // We'll stop when the out_degree map is empty.
+        while !out_degree.is_empty() {
+            let mut current_stage = Vec::new();
+
+            // Find all nodes whose dependencies have been fully satisfied (out-degree == 0)
+            for (&node_idx, &deg) in out_degree.iter() {
+                if deg == 0 {
+                    current_stage.push(node_idx);
+                }
+            }
+
+            if current_stage.is_empty() {
+                // This indicates a cycle — should not occur if graph is properly validated during build (which we do!)
+                return Err(FlagError::DependencyCycle(T::dependency_type(), 0).into());
+            }
+
+            // Collect references to items in this stage
+            let stage_items: Vec<&T> = current_stage.iter().map(|idx| node_map[idx]).collect();
+            stages.push(stage_items);
+
+            // After processing current stage, decrement out-degree (dependency count) of parents (dependents)
+            for node_idx in &current_stage {
+                for parent in self.graph.neighbors_directed(*node_idx, Incoming) {
+                    if let Some(deg) = out_degree.get_mut(&parent) {
+                        *deg -= 1;
+                    }
+                }
+                out_degree.remove(node_idx);
+            }
+        }
+
+        Ok(stages)
+    }
+
     /// Helper to get a node's ID as an i64
     fn get_node_id(&self, index: petgraph::graph::NodeIndex) -> i64 {
         self.graph[index].get_id().into()

--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -125,6 +125,10 @@ where
             for dep_id in node.extract_dependencies()? {
                 if let Some(target_idx) = id_map.get(&dep_id) {
                     graph.add_edge(source_idx, *target_idx, ());
+                } else {
+                    return Err(
+                        FlagError::DependencyNotFound(T::dependency_type(), dep_id.into()).into(),
+                    );
                 }
             }
         }

--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -219,7 +219,7 @@ where
 
             if current_stage.is_empty() {
                 // This indicates a cycle — should not occur if graph is properly validated during build (which we do!)
-                return Err(FlagError::DependencyCycle(T::dependency_type(), 0).into());
+                return Err(FlagError::DependencyCycle(T::dependency_type(), -1).into());
             }
 
             // Collect references to items in this stage

--- a/rust/feature-flags/src/utils/test_graph_utils.rs
+++ b/rust/feature-flags/src/utils/test_graph_utils.rs
@@ -337,4 +337,46 @@ mod tests {
             assert_eq!(graph.edge_count(), 1);
         }
     }
+
+    mod build_from_nodes_tests {
+        use super::*;
+
+        #[test]
+        fn test_build_multiple_independent_nodes() {
+            // Independent nodes: 1, 2, 3
+            let items = vec![
+                TestItem::new(1, HashSet::new()),
+                TestItem::new(2, HashSet::new()),
+                TestItem::new(3, HashSet::new()),
+            ];
+
+            let graph = DependencyGraph::build_from_nodes(&items).unwrap();
+            assert_eq!(graph.node_count(), 3);
+            assert_eq!(graph.edge_count(), 0);
+        }
+
+        #[test]
+        fn test_build_multiple_subgraphs() {
+            // Build a forest with disconnected subgraphs:
+            // Subgraph 1: 1 -> 2 -> 3
+            // Subgraph 2: 4 -> 5
+            // Subgraph 3: 6
+
+            let items = vec![
+                TestItem::new(1, HashSet::from([2])),
+                TestItem::new(2, HashSet::from([3])),
+                TestItem::new(3, HashSet::new()),
+                TestItem::new(4, HashSet::from([5])),
+                TestItem::new(5, HashSet::new()),
+                TestItem::new(6, HashSet::new()),
+            ];
+
+            let graph = DependencyGraph::build_from_nodes(&items).unwrap();
+
+            // Total nodes: 6
+            assert_eq!(graph.node_count(), 6);
+            // Total edges: 3 (1->2, 2->3, 4->5)
+            assert_eq!(graph.edge_count(), 3);
+        }
+    }
 }

--- a/rust/feature-flags/src/utils/test_graph_utils.rs
+++ b/rust/feature-flags/src/utils/test_graph_utils.rs
@@ -378,6 +378,23 @@ mod tests {
             // Total edges: 3 (1->2, 2->3, 4->5)
             assert_eq!(graph.edge_count(), 3);
         }
+
+        #[test]
+        fn test_build_from_nodes_with_missing_dependencies() {
+            // Node 1 depends on Node 999, which is not in the list
+            let items = vec![TestItem::new(1, HashSet::from([999]))];
+
+            let result = DependencyGraph::build_from_nodes(&items);
+
+            assert!(
+                result.is_err(),
+                "Expected an error due to missing dependencies"
+            );
+            assert!(matches!(
+                result.unwrap_err(),
+                FlagError::DependencyNotFound(DependencyType::Flag, 999)
+            ));
+        }
     }
 
     mod evaluation_stages {


### PR DESCRIPTION
## Problem

In preparation for the upcoming feature where feature flags can depend on other feature flags, we need to consider feature flag dependencies. Typically, this would require that we sort flags topologically, reverse them, and then evaluate them sequentially.

However, our current code evaluates flags in parallel, and we'd like to keep doing that. So what we need to do is build up a multi-root DAG (Directed Acyclic Graph) and evaluate flag dependencies in stages. This PR implements the ability to build those stages (it doesn't do the evaluation in stages yet).

Related to #29016 

## Changes

This adds a two new methods: `build_from_nodes` which takes in a collection of nodes and builds up a multi-root graph with all the nodes.

The second new method is `evaluation_stages`. This returns flags in stages where each stage must be evaluated before the next stage can be evaluated. Here's an example: 

Suppose we have these flags (represented by IDs) and their dependencies (represented by arrows):

```
1
2 -> 3 -> 4
3 -> 4
4
5
6
7 -> 8
8
```

In other words:

1, 5, 6 - are independent flags (no dependencies, nobody depends on them)
2 depends on 3
3 depends on 4

When we evaluate these flags, we have to do them in the following stages:

1. `[1, 4, 5, 6, 8]` _(leaf nodes and indpendent flags)_
2. `[3, 7]` _(flags with one dependency)_
3. `[2]` _(flags with two dependencies)_

This allows us to evaluate the flags in each stage in parallel while making sure we always evaluate dependencies before parents.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Unit tests