### PR TITLE
fix(api): Do not return deleted web experiments for `/api/projects/:project_id/web_experiments/`

### DIFF
--- a/posthog/api/web_experiment.py
+++ b/posthog/api/web_experiment.py
@@ -156,6 +156,10 @@ class WebExperimentViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         .all()
     )
 
+    def safely_get_queryset(self, queryset):
+        queryset = queryset.exclude(deleted=True)
+        return queryset
+
 
 @csrf_exempt
 @action(methods=["GET"], detail=True)

--- a/posthog/api/web_experiment.py
+++ b/posthog/api/web_experiment.py
@@ -149,15 +149,11 @@ class WebExperimentViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     scope_object = "experiment"
     serializer_class = WebExperimentsAPISerializer
     authentication_classes = [TemporaryTokenAuthentication]
-    queryset = (
-        WebExperiment.objects.select_related("feature_flag", "created_by")
-        .exclude(deleted=True)
-        .order_by("-created_at")
-        .all()
-    )
+    queryset = WebExperiment.objects.select_related("feature_flag", "created_by").order_by("-created_at").all()
 
     def safely_get_queryset(self, queryset):
-        queryset = queryset.exclude(deleted=True)
+        if self.action == "list":
+            queryset = queryset.filter(deleted=False)
         return queryset
 
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Closes #33670

## Changes

I believe the router for api is using `WebExperimentViewSet`, and as referenced from the other view sets it seems like most are using `safely_get_queryset` if they want to filter/exclude.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [x] No docs needed for this change

## How did you test this code?

Locally:

1) Create no code experiment
2) Delete it 
3) Fire off get api request should not return me the experiment. 

P.S: Is there any unit test that I need to write for this? 
