### PR TITLE
fix: Fix virtual properties with PoE

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -405,6 +405,7 @@ def create_hogql_database(
     with timings.measure("modifiers"):
         modifiers = create_default_modifiers_for_team(team, modifiers)
         database = Database(timezone=team.timezone, week_start_day=team.week_start_day)
+        poe = cast(VirtualTable, database.events.fields["poe"])
 
         if modifiers.personsOnEventsMode == PersonsOnEventsMode.DISABLED:
             # no change
@@ -418,7 +419,7 @@ def create_hogql_database(
         elif modifiers.personsOnEventsMode == PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS:
             _use_person_id_from_person_overrides(database)
             _use_person_properties_from_events(database)
-            cast(VirtualTable, database.events.fields["poe"]).fields["id"] = database.events.fields["person_id"]
+            poe.fields["id"] = database.events.fields["person_id"]
 
         elif modifiers.personsOnEventsMode == PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED:
             _use_person_id_from_person_overrides(database)
@@ -464,9 +465,19 @@ def create_hogql_database(
         database.persons.fields["$virt_initial_referring_domain_type"] = create_initial_domain_type(
             "$virt_initial_referring_domain_type", timings=timings
         )
+        poe.fields["$virt_initial_referring_domain_type"] = create_initial_domain_type(
+            "$virt_initial_referring_domain_type",
+            timings=timings,
+            properties_path=["poe", "properties"],
+        )
     with timings.measure("initial_channel_type"):
         database.persons.fields["$virt_initial_channel_type"] = create_initial_channel_type(
             "$virt_initial_channel_type", modifiers.customChannelTypeRules, timings=timings
+        )
+        poe.fields["$virt_initial_channel_type"] = create_initial_channel_type(
+            "$virt_initial_channel_type",
+            timings=timings,
+            properties_path=["poe", "properties"],
         )
 
     with timings.measure("group_type_mapping"):

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -129,7 +129,9 @@
                   "fields": [
                       "id",
                       "created_at",
-                      "properties"
+                      "properties",
+                      "$virt_initial_referring_domain_type",
+                      "$virt_initial_channel_type"
                   ],
                   "hogql_value": "poe",
                   "id": null,
@@ -1410,7 +1412,9 @@
                   "fields": [
                       "id",
                       "created_at",
-                      "properties"
+                      "properties",
+                      "$virt_initial_referring_domain_type",
+                      "$virt_initial_channel_type"
                   ],
                   "hogql_value": "poe",
                   "id": null,

--- a/posthog/hogql/test/__snapshots__/test_resolver.ambr
+++ b/posthog/hogql/test/__snapshots__/test_resolver.ambr
@@ -10668,6 +10668,12 @@
               table_type: <recursion ...>
               virtual_table: {
                 fields: {
+                  $virt_initial_channel_type: {
+                    hidden: False
+                  },
+                  $virt_initial_referring_domain_type: {
+                    hidden: False
+                  },
                   created_at: {
                     hidden: False
                   },


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Virtual properties didn't work with PoE enabled. This doesn't affect local dev but is used a lot in prod.

## Changes

Fix this issue, get PoE properties working

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Added a test
