### PR TITLE
fix(project-tree): restore product menu fixes + pinned menus 

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -165,8 +165,9 @@ export function ProjectTree({
 
         const showSelectMenuItems = root === 'project://' && item.record?.path && !item.disableSelect && !onlyTree
 
-        // Show product menu items if the item is a product or shortcut
-        const showProductMenuItems = root === 'products://' || root === 'shortcuts://'
+        // Show product menu items if the item is a product or shortcut (and the item is a product, products have 1 slash in the href)
+        const showProductMenuItems =
+            root === 'products://' || (root === 'shortcuts://' && item.record?.href.split('/').length - 1 === 1)
 
         // Note: renderMenuItems() is called often, so we're using custom components to isolate logic and network requests
         const productMenu =
@@ -496,7 +497,10 @@ export function ProjectTree({
                 )
             }}
             itemSideActionButton={(item) => {
-                if (root === 'products://' || root === 'shortcuts://') {
+                const showProductMenuItems =
+                    root === 'products://' || (root === 'shortcuts://' && item.record?.href.split('/').length - 1 === 1)
+
+                if (showProductMenuItems) {
                     if (item.name === 'Product analytics') {
                         return (
                             <ButtonPrimitive iconOnly isSideActionRight className="z-2">

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -163,22 +163,24 @@ export function ProjectTree({
         const MenuSubTrigger = type === 'context' ? ContextMenuSubTrigger : DropdownMenuSubTrigger
         const MenuSubContent = type === 'context' ? ContextMenuSubContent : DropdownMenuSubContent
 
-        const showSelectMenuItems =
-            item.record?.protocol === 'project://' && item.record?.path && !item.disableSelect && !onlyTree
+        const showSelectMenuItems = root === 'project://' && item.record?.path && !item.disableSelect && !onlyTree
+
+        // Show product menu items if the item is a product or shortcut and the item isn't user made (ref is for user-made items)
+        const showProductMenuItems = (root === 'products://' || root === 'shortcuts://') && item.record?.ref === null
 
         // Note: renderMenuItems() is called often, so we're using custom components to isolate logic and network requests
         const productMenu =
-            item.record?.protocol === 'products://' && item.name === 'Product analytics' ? (
+            showProductMenuItems && item.name === 'Product analytics' ? (
                 <>
                     <ProductAnalyticsMenuItems MenuItem={MenuItem} MenuSeparator={MenuSeparator} />
                     <MenuSeparator />
                 </>
-            ) : item.record?.protocol === 'products://' && item.name === 'Session replay' ? (
+            ) : showProductMenuItems && item.name === 'Session replay' ? (
                 <>
                     <SessionReplayMenuItems MenuItem={MenuItem} MenuSeparator={MenuSeparator} />
                     <MenuSeparator />
                 </>
-            ) : item.record?.protocol === 'products://' && item.name === 'Dashboards' ? (
+            ) : showProductMenuItems && item.name === 'Dashboards' ? (
                 <>
                     <DashboardsMenuItems MenuItem={MenuItem} MenuSeparator={MenuSeparator} />
                     <MenuSeparator />
@@ -494,7 +496,7 @@ export function ProjectTree({
                 )
             }}
             itemSideActionButton={(item) => {
-                if (item.record?.protocol === 'products://') {
+                if ((root === 'products://' || root === 'shortcuts://') && item.record?.ref === null) {
                     if (item.name === 'Product analytics') {
                         return (
                             <ButtonPrimitive iconOnly isSideActionRight className="z-2">

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -493,12 +493,20 @@ export function ProjectTree({
                     </DropdownMenuGroup>
                 )
             }}
-            itemSideActionIcon={(item) => {
+            itemSideActionButton={(item) => {
                 if (item.record?.protocol === 'products://') {
                     if (item.name === 'Product analytics') {
-                        return <IconPlusSmall className="text-tertiary" />
+                        return (
+                            <ButtonPrimitive iconOnly isSideActionRight className="z-2">
+                                <IconPlusSmall className="text-tertiary" />
+                            </ButtonPrimitive>
+                        )
                     } else if (item.name === 'Dashboards' || item.name === 'Session replay') {
-                        return <IconChevronRight className="size-3 text-tertiary rotate-90" />
+                        return (
+                            <ButtonPrimitive iconOnly isSideActionRight className="z-2">
+                                <IconChevronRight className="size-3 text-tertiary rotate-90" />
+                            </ButtonPrimitive>
+                        )
                     }
                 }
             }}

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -165,8 +165,8 @@ export function ProjectTree({
 
         const showSelectMenuItems = root === 'project://' && item.record?.path && !item.disableSelect && !onlyTree
 
-        // Show product menu items if the item is a product or shortcut and the item isn't user made (ref is for user-made items)
-        const showProductMenuItems = (root === 'products://' || root === 'shortcuts://') && item.record?.ref === null
+        // Show product menu items if the item is a product or shortcut
+        const showProductMenuItems = root === 'products://' || root === 'shortcuts://'
 
         // Note: renderMenuItems() is called often, so we're using custom components to isolate logic and network requests
         const productMenu =
@@ -496,7 +496,7 @@ export function ProjectTree({
                 )
             }}
             itemSideActionButton={(item) => {
-                if ((root === 'products://' || root === 'shortcuts://') && item.record?.ref === null) {
+                if (root === 'products://' || root === 'shortcuts://') {
                     if (item.name === 'Product analytics') {
                         return (
                             <ButtonPrimitive iconOnly isSideActionRight className="z-2">

--- a/frontend/src/layout/panel-layout/ProjectTree/menus/DashboardsMenuItems.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/menus/DashboardsMenuItems.tsx
@@ -3,7 +3,7 @@ import { useValues } from 'kea'
 import { router } from 'kea-router'
 import { Link } from 'lib/lemon-ui/Link'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
-import { DropdownMenuItem } from 'lib/ui/DropdownMenu/DropdownMenu'
+import { DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator } from 'lib/ui/DropdownMenu/DropdownMenu'
 import { urls } from 'scenes/urls'
 
 import { dashboardsModel } from '~/models/dashboardsModel'
@@ -17,6 +17,8 @@ export function DashboardsMenuItems({ MenuItem = DropdownMenuItem }: CustomMenuP
 
     return (
         <>
+            <DropdownMenuLabel>Pinned dashboards</DropdownMenuLabel>
+            <DropdownMenuSeparator />
             {pinnedDashboards.length > 0 ? (
                 pinnedDashboards.map((dashboard) => (
                     <MenuItem asChild key={dashboard.id}>

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -125,8 +125,6 @@ type LemonTreeBaseProps = Omit<HTMLAttributes<HTMLDivElement>, 'onDragEnd'> & {
     isItemDroppable?: (item: TreeDataItem) => boolean
     /** The side action to render for the item. */
     itemSideAction?: (item: TreeDataItem) => React.ReactNode | undefined
-    /** The icon for the side action, defaults to ellipsis */
-    itemSideActionIcon?: (item: TreeDataItem) => React.ReactNode
     /** The button to render for the item's side action. */
     itemSideActionButton?: (item: TreeDataItem) => React.ReactNode
     /** The context menu to render for the item. */
@@ -246,7 +244,6 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
             isItemDroppable,
             depth = 0,
             itemSideAction,
-            itemSideActionIcon,
             itemSideActionButton,
             isItemEditing,
             onItemNameChange,
@@ -617,7 +614,6 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                                             renderItemTooltip={renderItemTooltip}
                                             renderItemIcon={renderItemIcon}
                                             itemSideAction={itemSideAction}
-                                            itemSideActionIcon={itemSideActionIcon}
                                             depth={depth + 1}
                                             isItemActive={isItemActive}
                                             isItemDraggable={isItemDraggable}
@@ -681,7 +677,6 @@ const LemonTree = forwardRef<LemonTreeRef, LemonTreeProps>(
             isItemDraggable,
             isItemDroppable,
             itemSideAction,
-            itemSideActionIcon,
             isItemEditing,
             onItemNameChange,
             enableDragAndDrop = false,
@@ -1392,7 +1387,6 @@ const LemonTree = forwardRef<LemonTreeRef, LemonTreeProps>(
                             defaultNodeIcon={defaultNodeIcon}
                             showFolderActiveState={showFolderActiveState}
                             itemSideAction={itemSideAction}
-                            itemSideActionIcon={itemSideActionIcon}
                             isItemEditing={isItemEditing}
                             onItemNameChange={onItemNameChange}
                             className={cn('p-1', {


### PR DESCRIPTION

## Problem
We lost product specific side action icons
Pinned products didn't have product-specific menus

## Changes
Fix product menu side action icons
Pinned products get product specific menus

<img width="748" alt="image" src="https://github.com/user-attachments/assets/0232ce44-af91-4f31-a43c-dbeac45b0f61" />

> TODO/BUG: if a user creates an item named "Product analytics" or "Session replay" or "Dashboards", it will get the menus! 

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Manually