### PR TITLE
fix(project-tree): insight colors and an icon fix

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
@@ -3,6 +3,7 @@ import {
     IconApp,
     IconApps,
     IconBook,
+    IconCalendar,
     IconChevronRight,
     IconCursor,
     IconDatabase,
@@ -96,31 +97,35 @@ const iconTypes: Record<FileSystemIconType, { icon: JSX.Element; iconColor?: Fil
     },
     insightFunnel: {
         icon: <IconFunnels />,
-        iconColor: ['var(--product-product-analytics-light)'],
+        iconColor: ['var(--insight-funnel-light)'],
     },
     insightTrends: {
         icon: <IconTrends />,
-        iconColor: ['var(--product-product-analytics-light)'],
+        iconColor: ['var(--insight-trends-light)'],
     },
     insightRetention: {
         icon: <IconRetention />,
-        iconColor: ['var(--product-product-analytics-light)'],
+        iconColor: ['var(--insight-retention-light)'],
     },
     insightUserPaths: {
         icon: <IconUserPaths />,
-        iconColor: ['var(--product-product-analytics-light)'],
+        iconColor: ['var(--insight-user-paths-light)', 'var(--insight-user-paths-dark)'],
     },
     insightLifecycle: {
         icon: <IconLifecycle />,
-        iconColor: ['var(--product-product-analytics-light)'],
+        iconColor: ['var(--insight-lifecycle-light)'],
     },
     insightStickiness: {
         icon: <IconStickiness />,
-        iconColor: ['var(--product-product-analytics-light)'],
+        iconColor: ['var(--insight-stickiness-light)'],
     },
     insightHogQL: {
         icon: <IconHogQL />,
-        iconColor: ['var(--product-product-analytics-light)'],
+        iconColor: ['var(--insight-sql-light)'],
+    },
+    insightCalendarHeatmap: {
+        icon: <IconCalendar className="mt-[2px]" />,
+        iconColor: ['var(--insight-calendar-heatmap-light)', 'var(--insight-calendar-heatmap-dark)'],
     },
     cohort: {
         icon: <IconCohort />,

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -10133,7 +10133,8 @@
                 "insightUserPaths",
                 "insightLifecycle",
                 "insightStickiness",
-                "insightHogQL"
+                "insightHogQL",
+                "insightCalendarHeatmap"
             ],
             "type": "string"
         },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2096,7 +2096,7 @@ export type FileSystemIconType =
     | 'insightLifecycle'
     | 'insightStickiness'
     | 'insightHogQL'
-
+    | 'insightCalendarHeatmap'
 export interface FileSystemImport extends Omit<FileSystemEntry, 'id'> {
     id?: string
     iconType?: FileSystemIconType

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -347,6 +347,18 @@
     --product-early-access-features-light: rgb(39 171 151);
     --product-early-access-features-dark: rgb(53 213 189);
 
+    // Insight colors
+    --insight-funnel-light: rgb(47 128 250);
+    --insight-trends-light: rgb(247 165 1);
+    --insight-user-paths-light: rgb(30 179 152);
+    --insight-user-paths-dark: rgb(41 219 187);
+    --insight-retention-light: rgb(243 84 84);
+    --insight-stickiness-light: rgb(247 165 1);
+    --insight-lifecycle-light: rgb(48 171 198);
+    --insight-calendar-heatmap-light: rgb(12 39 146);
+    --insight-calendar-heatmap-dark: rgb(61 91 215);
+    --insight-sql-light: rgb(245 78 0);
+
     // Generic brand color assignments
     // Change these to change the brand colors
     // //////////////////////////////////////////////////////////

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1157,6 +1157,7 @@ class FileSystemIconType(StrEnum):
     INSIGHT_LIFECYCLE = "insightLifecycle"
     INSIGHT_STICKINESS = "insightStickiness"
     INSIGHT_HOG_QL = "insightHogQL"
+    INSIGHT_CALENDAR_HEATMAP = "insightCalendarHeatmap"
 
 
 class FileSystemImport(BaseModel):

--- a/products/product_analytics/manifest.tsx
+++ b/products/product_analytics/manifest.tsx
@@ -126,7 +126,7 @@ export const manifest: ProductManifest = {
             path: `Insight/Calendar heatmap`,
             type: 'insight',
             href: urls.insightNew({ type: InsightType.CALENDAR_HEATMAP }),
-            iconType: 'insightHogQL',
+            iconType: 'insightCalendarHeatmap',
             visualOrder: INSIGHT_VISUAL_ORDER.calendarHeatmap,
         },
     ],


### PR DESCRIPTION

## Problem
Calendar heatmap had wrong icon
Insight types had their own icon colors!

<img width="561" alt="image" src="https://github.com/user-attachments/assets/b1c3b5f8-a767-47d9-9643-d315eddf4e68" />

## Changes
Fix icon
Add colors to specific insights

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Locally