### PR TITLE
fix(experiments): filter soft-deleted no-code experiments

### DIFF
--- a/posthog/api/web_experiment.py
+++ b/posthog/api/web_experiment.py
@@ -149,7 +149,12 @@ class WebExperimentViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     scope_object = "experiment"
     serializer_class = WebExperimentsAPISerializer
     authentication_classes = [TemporaryTokenAuthentication]
-    queryset = WebExperiment.objects.select_related("feature_flag", "created_by").order_by("-created_at").all()
+    queryset = (
+        WebExperiment.objects.select_related("feature_flag", "created_by")
+        .exclude(deleted=True)
+        .order_by("-created_at")
+        .all()
+    )
 
 
 @csrf_exempt
@@ -187,6 +192,7 @@ def web_experiments(request: Request):
         result = WebExperimentsAPISerializer(
             WebExperiment.objects.filter(team_id=team.id)
             .exclude(archived=True)
+            .exclude(deleted=True)
             .exclude(end_date__isnull=False)
             .select_related("feature_flag", "created_by")
             .order_by("-created_at"),


### PR DESCRIPTION
Closes https://github.com/PostHog/posthog/issues/33670 

## Problem
Since we started soft-deleting experiments, the Toolbar shows all experiments, including the deleted ones.
This is because in the Toolbar, no-code experiments are fetched from the separate `/web_experiments` endpoint.

## Changes
Exclude no-code experiments where `deleted=True`

## How did you test this code?

|Before|After|
|----|----|
|<img width="556" alt="image" src="https://github.com/user-attachments/assets/8a2f3a17-08c3-4802-94d3-9b926db9d2bb" />|<img width="557" alt="image" src="https://github.com/user-attachments/assets/375ad636-f64f-444f-a459-cbbeac369e68" />|