### PR TITLE
fix(batch-exports): Report Prometheus metrics in new consumer

### DIFF
--- a/posthog/temporal/batch_exports/spmc.py
+++ b/posthog/temporal/batch_exports/spmc.py
@@ -1246,12 +1246,12 @@ class ConsumerFromStage:
 
                 # Transform batch to chunks
                 # We also split the file if we reach the max file size
+                num_rows = record_batch.num_rows
                 for chunk in transformer.transform_batch(record_batch):
                     await self.consume_chunk(data=chunk)
 
                     chunk_size = len(chunk)
                     current_file_size += chunk_size
-                    self.rows_exported_counter.add(record_batch.num_rows)
                     self.bytes_exported_counter.add(chunk_size)
 
                     if max_file_size_bytes and current_file_size > max_file_size_bytes:
@@ -1264,6 +1264,7 @@ class ConsumerFromStage:
                         await self.finalize_file()
 
                         current_file_size = 0
+                self.rows_exported_counter.add(num_rows)
 
             # Finalize transformer and consume any remaining data (eg file metadata)
             for chunk in transformer.finalize():


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We publish metrics for rows exported and bytes exported but these were missed in the new consumer implementation.

## Changes

Update Prometheus counters.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Relying on existing tests
