### PR TITLE
chore(sql-editor): Update the editor copy for limited rows

### DIFF
--- a/frontend/src/queries/nodes/DataNode/LoadNext.tsx
+++ b/frontend/src/queries/nodes/DataNode/LoadNext.tsx
@@ -87,8 +87,8 @@ export function LoadPreviewText({ localResponse }: { localResponse?: Record<stri
     return (
         <>
             <span>
-                Showing {showFirstPrefix ? 'the first ' : ' '}
-                {isSingleEntry ? 'one' : resultCount} {isSingleEntry ? 'entry' : 'entries'}
+                {showFirstPrefix ? 'Limited to the first ' : 'Showing '}
+                {isSingleEntry ? 'one row' : `${resultCount} rows`}
             </span>
             {lastRefreshTimeUtc && (
                 <>


### PR DESCRIPTION
## Problem
- The copy at the bottom of the editor is confusing - suggests we have pagination and not that the query is limited

<img width="296" alt="image" src="https://github.com/user-attachments/assets/02d575f5-4bec-41fc-a1b8-1e2aa3e96383" />

## Changes
- Updated the copy to use rows instead of entries, made it clearer that there's no pagination but instead the query is limited
  - (the editor is the only component that uses this, so we can freely change it)