### PR TITLE
feat(cdp): In app warning regarding ad destination support

### DIFF
--- a/frontend/src/scenes/hog-functions/configuration/HogFunctionConfiguration.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/HogFunctionConfiguration.tsx
@@ -256,7 +256,16 @@ export function HogFunctionConfiguration({
                             may result in some events failing to be delivered.
                         </LemonBanner>
                     </div>
-                ) : ['template-google-ads'].includes(templateId ?? '') ? (
+                ) : [
+                      'template-google-ads',
+                      'template-meta-ads',
+                      'template-tiktok-ads',
+                      'template-snapchat-ads',
+                      'template-linkedin-ads',
+                      'template-reddit-pixel',
+                      'template-tiktok-pixel',
+                      'template-snapchat-pixel',
+                  ].includes(templateId ?? '') ? (
                     <div>
                         <LemonBanner type="warning">
                             This is an experimental destination that we do not provide official support for.

--- a/frontend/src/scenes/hog-functions/configuration/HogFunctionConfiguration.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/HogFunctionConfiguration.tsx
@@ -256,6 +256,12 @@ export function HogFunctionConfiguration({
                             may result in some events failing to be delivered.
                         </LemonBanner>
                     </div>
+                ) : ['template-google-ads'].includes(templateId ?? '') ? (
+                    <div>
+                        <LemonBanner type="warning">
+                            This is an experimental destination that we do not provide official support for.
+                        </LemonBanner>
+                    </div>
                 ) : null}
 
                 <Form

--- a/frontend/src/scenes/hog-functions/configuration/HogFunctionConfiguration.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/HogFunctionConfiguration.tsx
@@ -249,13 +249,6 @@ export function HogFunctionConfiguration({
                             <b>Error saving filters:</b> {hogFunction.filters.bytecode_error}
                         </LemonBanner>
                     </div>
-                ) : ['template-reddit-conversions-api', 'template-snapchat-ads'].includes(templateId ?? '') ? (
-                    <div>
-                        <LemonBanner type="warning">
-                            The receiving destination imposes a rate limit of 10 events per second. Exceeding this limit
-                            may result in some events failing to be delivered.
-                        </LemonBanner>
-                    </div>
                 ) : [
                       'template-google-ads',
                       'template-meta-ads',
@@ -265,10 +258,21 @@ export function HogFunctionConfiguration({
                       'template-reddit-pixel',
                       'template-tiktok-pixel',
                       'template-snapchat-pixel',
-                  ].includes(templateId ?? '') ? (
+                      'template-reddit-conversions-api',
+                  ].includes(templateId ?? '') || template?.status === 'alpha' ? (
                     <div>
                         <LemonBanner type="warning">
-                            This is an experimental destination that we do not provide official support for.
+                            <p>
+                                This destination is currently in an experimental state. For many cases this will work
+                                just fine but for others there may be unexpected issues and we do not offer official
+                                customer support for it in these cases.
+                            </p>
+                            {['template-reddit-conversions-api', 'template-snapchat-ads'].includes(templateId ?? '') ? (
+                                <span className="mt-2">
+                                    The receiving destination imposes a rate limit of 10 events per second. Exceeding
+                                    this limit may result in some events failing to be delivered.
+                                </span>
+                            ) : null}
                         </LemonBanner>
                     </div>
                 ) : null}

--- a/plugin-server/src/cdp/templates/_destinations/reddit_ads/reddit.template.ts
+++ b/plugin-server/src/cdp/templates/_destinations/reddit_ads/reddit.template.ts
@@ -34,7 +34,7 @@ const build_inputs = (): HogFunctionInputSchemaType[] => {
 
 export const template: HogFunctionTemplate = {
     free: false,
-    status: 'beta',
+    status: 'alpha',
     type: 'destination',
     id: 'template-reddit-conversions-api',
     name: 'Reddit Conversions API',

--- a/plugin-server/src/cdp/templates/_destinations/snapchat_ads/snapchat.template.ts
+++ b/plugin-server/src/cdp/templates/_destinations/snapchat_ads/snapchat.template.ts
@@ -89,7 +89,7 @@ const build_inputs = (multiProductEvent = false): HogFunctionInputSchemaType[] =
 
 export const template: HogFunctionTemplate = {
     free: false,
-    status: 'beta',
+    status: 'alpha',
     type: 'destination',
     id: 'template-snapchat-ads',
     name: 'Snapchat Ads Conversions',

--- a/plugin-server/src/cdp/templates/_destinations/tiktok_ads/tiktok.template.ts
+++ b/plugin-server/src/cdp/templates/_destinations/tiktok_ads/tiktok.template.ts
@@ -67,7 +67,7 @@ const build_inputs = (multiProductEvent = false): HogFunctionInputSchemaType[] =
 
 export const template: HogFunctionTemplate = {
     free: false,
-    status: 'beta',
+    status: 'alpha',
     type: 'destination',
     id: 'template-tiktok-ads',
     name: 'TikTok Ads Conversions',

--- a/posthog/api/test/test_hog_function_templates.py
+++ b/posthog/api/test/test_hog_function_templates.py
@@ -79,13 +79,13 @@ class TestHogFunctionTemplates(ClickhouseTestMixin, APIBaseTest, QueryMatchingTe
         assert response.status_code == status.HTTP_200_OK, response.json()
         assert len(response.json()["results"]) > 5
 
-    def test_alpha_templates_are_hidden(self):
+    def test_hidden_templates_are_hidden(self):
         self.client.logout()
         response = self.client.get("/api/public_hog_function_templates/")
 
         assert response.status_code == status.HTTP_200_OK, response.json()
         for template_item in response.json()["results"]:
-            assert template_item["status"] != "alpha", f"Alpha template {template_item['id']} should not be returned"
+            assert template_item["status"] != "hidden", f"Hidden template {template_item['id']} should not be returned"
 
     def test_templates_are_sorted_by_usage(self):
         HogFunction.objects.create(

--- a/posthog/cdp/templates/meta_ads/template_meta_ads.py
+++ b/posthog/cdp/templates/meta_ads/template_meta_ads.py
@@ -1,7 +1,7 @@
 from posthog.cdp.templates.hog_function_template import HogFunctionTemplate
 
 template: HogFunctionTemplate = HogFunctionTemplate(
-    status="beta",
+    status="alpha",
     free=False,
     type="destination",
     id="template-meta-ads",

--- a/posthog/cdp/templates/reddit/template_reddit_pixel.py
+++ b/posthog/cdp/templates/reddit/template_reddit_pixel.py
@@ -19,7 +19,7 @@ common_inputs = [
 
 template_reddit_pixel: HogFunctionTemplate = HogFunctionTemplate(
     free=False,
-    status="beta",
+    status="alpha",
     type="site_destination",
     id="template-reddit-pixel",
     name="Reddit Pixel",

--- a/posthog/cdp/templates/snapchat_ads/template_pixel.py
+++ b/posthog/cdp/templates/snapchat_ads/template_pixel.py
@@ -38,7 +38,7 @@ def build_inputs(multiProductEvent=False):
 
 
 template_snapchat_pixel: HogFunctionTemplate = HogFunctionTemplate(
-    status="beta",
+    status="alpha",
     free=False,
     type="site_destination",
     id="template-snapchat-pixel",

--- a/posthog/cdp/templates/tiktok_ads/template_tiktok_pixel.py
+++ b/posthog/cdp/templates/tiktok_ads/template_tiktok_pixel.py
@@ -52,7 +52,7 @@ def build_inputs(multiProductEvent=False):
 
 
 template_tiktok_pixel: HogFunctionTemplate = HogFunctionTemplate(
-    status="beta",
+    status="alpha",
     free=False,
     type="site_destination",
     id="template-tiktok-pixel",


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

![2025-06-16 at 15 12 52](https://github.com/user-attachments/assets/ca987427-f63f-451b-a98b-c7c4d76eb981)

![2025-06-17 at 11 08 01](https://github.com/user-attachments/assets/121cffaa-57e9-4031-8d0f-38dbaadfef8a)

## Changes

- add a warning about not providing official support for the ad destinations
- reduce ad destination status to `alpha` 

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
