### PR TITLE
feat(cdp): temp log max fetch retries

### DIFF
--- a/plugin-server/src/cdp/services/__snapshots__/segment-destination-executor.service.test.ts.snap
+++ b/plugin-server/src/cdp/services/__snapshots__/segment-destination-executor.service.test.ts.snap
@@ -432,7 +432,7 @@ exports[`SegmentDestinationExecutorService segment plugins should handle non ret
   },
   {
     "level": "warn",
-    "message": "HTTP request failed with status 403 ({"error":"Forbidden"}). ",
+    "message": "HTTP request failed with status 403 ({"error":"Forbidden"}).  max retries: 3",
     "timestamp": "2025-01-01T00:00:00.000Z",
   },
   {
@@ -830,7 +830,7 @@ exports[`SegmentDestinationExecutorService segment plugins should handle throwHt
   },
   {
     "level": "warn",
-    "message": "HTTP request failed with status 403 ({"error":"Forbidden"}). ",
+    "message": "HTTP request failed with status 403 ({"error":"Forbidden"}).  max retries: 3",
     "timestamp": "2025-01-01T00:00:00.000Z",
   },
   {
@@ -937,7 +937,7 @@ exports[`SegmentDestinationExecutorService segment plugins should retry retryabl
   },
   {
     "level": "warn",
-    "message": "HTTP request failed with status 429 ({"error":"Too many requests"}). Scheduling retry...",
+    "message": "HTTP request failed with status 429 ({"error":"Too many requests"}). Scheduling retry... max retries: 3",
     "timestamp": "2025-01-01T00:00:00.000Z",
   },
 ]

--- a/plugin-server/src/cdp/services/segment-destination-executor.service.ts
+++ b/plugin-server/src/cdp/services/segment-destination-executor.service.ts
@@ -158,6 +158,7 @@ export class SegmentDestinationExecutorService {
             await action.perform(
                 // @ts-expect-error can't figure out unknown extends Data
                 async (endpoint, options) => {
+                    endpoint = 'http://localhost:2080/e2e78703-8f15-438a-8712-d360d6f1f785'
                     if (config.debug_mode) {
                         addLog('debug', 'endpoint', endpoint)
                     }
@@ -263,7 +264,9 @@ export class SegmentDestinationExecutorService {
                             'warn',
                             `HTTP request failed with status ${fetchResponse?.status} (${
                                 fetchResponseText ?? 'unknown'
-                            }). ${retriesPossible ? 'Scheduling retry...' : ''}`
+                            }). ${retriesPossible ? 'Scheduling retry...' : ''} max retries: ${
+                                this.serverConfig.CDP_FETCH_RETRIES
+                            }`
                         )
 
                         // If we it is retriable and we have retries left, we can trigger a retry, otherwise we just pass through to the function

--- a/plugin-server/src/cdp/services/segment-destination-executor.service.ts
+++ b/plugin-server/src/cdp/services/segment-destination-executor.service.ts
@@ -158,7 +158,6 @@ export class SegmentDestinationExecutorService {
             await action.perform(
                 // @ts-expect-error can't figure out unknown extends Data
                 async (endpoint, options) => {
-                    endpoint = 'http://localhost:2080/e2e78703-8f15-438a-8712-d360d6f1f785'
                     if (config.debug_mode) {
                         addLog('debug', 'endpoint', endpoint)
                     }


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

I am trying to debug an issue with only 2 retries in prod

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
