### PR TITLE
feat: Timeout and wait for query in batch exports

### DIFF
--- a/posthog/temporal/batch_exports/pre_export_stage.py
+++ b/posthog/temporal/batch_exports/pre_export_stage.py
@@ -534,8 +534,10 @@ async def _write_batch_export_record_batches_to_s3(
                     query, query_parameters=query_parameters, query_id=str(query_id), timeout=300
                 )
             except ClickHouseClientTimeoutError:
-                status = ClickHouseQueryStatus.RUNNING
+                status = await client.acheck_query(str(query_id), raise_on_error=True)
+
                 while status == ClickHouseQueryStatus.RUNNING:
+                    await asyncio.sleep(10)
                     status = await client.acheck_query(str(query_id), raise_on_error=True)
 
             except Exception as e:

--- a/posthog/temporal/batch_exports/pre_export_stage.py
+++ b/posthog/temporal/batch_exports/pre_export_stage.py
@@ -534,6 +534,10 @@ async def _write_batch_export_record_batches_to_s3(
                     query, query_parameters=query_parameters, query_id=str(query_id), timeout=300
                 )
             except ClickHouseClientTimeoutError:
+                await logger.awarning(
+                    f"Timed-out waiting for insert into S3 with ID: {str(query_id)}. Will attempt to check query status before continuing"
+                )
+
                 status = await client.acheck_query(str(query_id), raise_on_error=True)
 
                 while status == ClickHouseQueryStatus.RUNNING:

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -489,6 +489,9 @@ class ClickHouseClient:
             events = set()
             error = None
             for line in lines:
+                if not line:
+                    continue
+
                 event, error_value = line.decode("utf-8").split(",", 1)
                 events.add(event)
 

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -2,6 +2,7 @@ import asyncio
 import collections.abc
 import contextlib
 import datetime as dt
+import enum
 import json
 import ssl
 import typing
@@ -85,6 +86,12 @@ def encode_clickhouse_data(data: typing.Any, quote_char="'") -> bytes:
             return f"{quote_char}{str_data}{quote_char}".encode()
 
 
+class ClickHouseQueryStatus(enum.StrEnum):
+    FINISHED = "Finished"
+    RUNNING = "Running"
+    ERROR = "Error"
+
+
 class ChunkBytesAsyncStreamIterator:
     """Async iterator of HTTP chunk bytes.
 
@@ -128,6 +135,25 @@ class ClickHouseAllReplicasAreStaleError(ClickHouseError):
 
     def __init__(self, query, error_message):
         super().__init__(query, error_message)
+
+
+class ClickHouseClientTimeoutError(ClickHouseError):
+    """Exception raised when `ClickHouseClient` timed-out waiting for a response.
+
+    This does not indicate the query failed as the timeout is local.
+    """
+
+    def __init__(self, query, query_id: str):
+        self.query_id = query_id
+        super().__init__(query, f"Timed-out waiting for response running query '{query_id}'")
+
+
+class ClickHouseQueryNotFound(ClickHouseError):
+    """Exception raised when a query with a given ID is not found."""
+
+    def __init__(self, query, query_id: str):
+        self.query_id = query_id
+        super().__init__(query, f"Query with ID '{query_id}' was not found in query log")
 
 
 class ClickHouseClient:
@@ -305,7 +331,7 @@ class ClickHouseClient:
 
     @contextlib.asynccontextmanager
     async def apost_query(
-        self, query, *data, query_parameters, query_id
+        self, query, *data, query_parameters, query_id, timeout: float | None = None
     ) -> collections.abc.AsyncIterator[aiohttp.ClientResponse]:
         """POST a query to the ClickHouse HTTP interface.
 
@@ -346,9 +372,19 @@ class ClickHouseClient:
         else:
             request_data = query.encode("utf-8")
 
-        async with self.session.post(url=self.url, params=params, headers=self.headers, data=request_data) as response:
-            await self.acheck_response(response, query)
-            yield response
+        if timeout:
+            client_timeout = aiohttp.ClientTimeout(total=timeout)
+        else:
+            client_timeout = None
+
+        try:
+            async with self.session.post(
+                url=self.url, params=params, headers=self.headers, data=request_data, timeout=client_timeout
+            ) as response:
+                await self.acheck_response(response, query)
+                yield response
+        except TimeoutError:
+            raise ClickHouseClientTimeoutError(query, query_id)
 
     @contextlib.contextmanager
     def post_query(self, query, *data, query_parameters, query_id) -> collections.abc.Iterator:
@@ -398,12 +434,16 @@ class ClickHouseClient:
             self.check_response(response, query)
             yield response
 
-    async def execute_query(self, query, *data, query_parameters=None, query_id: str | None = None) -> None:
+    async def execute_query(
+        self, query, *data, query_parameters=None, query_id: str | None = None, timeout: float | None = None
+    ) -> None:
         """Execute the given query in ClickHouse.
 
         This method doesn't return any response.
         """
-        async with self.apost_query(query, *data, query_parameters=query_parameters, query_id=query_id):
+        async with self.apost_query(
+            query, *data, query_parameters=query_parameters, query_id=query_id, timeout=timeout
+        ):
             return None
 
     async def read_query(self, query, query_parameters=None, query_id: str | None = None) -> bytes:
@@ -414,6 +454,62 @@ class ClickHouseClient:
         """
         async with self.aget_query(query, query_parameters=query_parameters, query_id=query_id) as response:
             return await response.content.read()
+
+    async def acheck_query(
+        self,
+        query_id: str,
+        raise_on_error: bool = True,
+    ) -> ClickHouseQueryStatus:
+        """Check the status of a query in ClickHouse.
+
+        Arguments:
+            query_id: The ID of the query to check.
+            raise_on_error: Whether to raise an exception if the query has
+                failed.
+        """
+        query = """
+        SELECT type, exception
+        FROM clusterAllReplicas('{{cluster_name:String}}', system.query_log)
+        WHERE query_id = {{query_id:String}}
+        FORMAT CSV
+        """
+
+        async with self.apost_query(
+            query,
+            query_parameters={"query_id": query_id, "cluster_name": settings.CLICKHOUSE_CLUSTER},
+            query_id=f"{query_id}-CHECK",
+        ) as response:
+            resp = await response.content.read()
+
+            if not resp:
+                raise ClickHouseQueryNotFound(query, query_id)
+
+            lines = resp.split(b"\n")
+
+            events = set()
+            error = None
+            for line in lines:
+                event, error = line.decode("utf-8").split(",")
+                events.add(event)
+
+                if error:
+                    error = error
+
+            if "QueryFinish" in events:
+                return ClickHouseQueryStatus.FINISHED
+            elif "ExceptionWhileProcessing" in events or "ExceptionBeforeStart" in events:
+                if raise_on_error:
+                    if error is not None:
+                        error_message = error
+                    else:
+                        error_message = f"Unknown query error in query with ID: {query_id}"
+                    raise ClickHouseError(query, error_message=error_message)
+
+                return ClickHouseQueryStatus.ERROR
+            elif "QueryStart" in events:
+                return ClickHouseQueryStatus.RUNNING
+            else:
+                raise ClickHouseQueryNotFound(query, query_id)
 
     async def stream_query_as_jsonl(
         self,

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -489,7 +489,7 @@ class ClickHouseClient:
             events = set()
             error = None
             for line in lines:
-                event, error_value = line.decode("utf-8").split(",")
+                event, error_value = line.decode("utf-8").split(",", 1)
                 events.add(event)
 
                 if error_value:

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -469,7 +469,7 @@ class ClickHouseClient:
         """
         query = """
         SELECT type, exception
-        FROM clusterAllReplicas('{{cluster_name:String}}', system.query_log)
+        FROM clusterAllReplicas({{cluster_name:String}}, system.query_log)
         WHERE query_id = {{query_id:String}}
         FORMAT CSV
         """

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -474,7 +474,7 @@ class ClickHouseClient:
         FORMAT CSV
         """
 
-        async with self.apost_query(
+        async with self.aget_query(
             query,
             query_parameters={"query_id": query_id, "cluster_name": settings.CLICKHOUSE_CLUSTER},
             query_id=f"{query_id}-CHECK",
@@ -489,11 +489,11 @@ class ClickHouseClient:
             events = set()
             error = None
             for line in lines:
-                event, error = line.decode("utf-8").split(",")
+                event, error_value = line.decode("utf-8").split(",")
                 events.add(event)
 
-                if error:
-                    error = error
+                if error_value:
+                    error = error_value
 
             if "QueryFinish" in events:
                 return ClickHouseQueryStatus.FINISHED


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We have reason to believe that when running orderless batch exports insert queries to the staging area in S3 can finish successfully but not properly communicate a response to the worker client. This causes the worker to wait forever as it is not configured to time out.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

1. Timeout on INSERT queries.
2. Check query log for query status.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
