### PR TITLE
refactor(insights): instrument legacy api endpoints

### DIFF
--- a/ee/clickhouse/views/insights.py
+++ b/ee/clickhouse/views/insights.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 from ee.clickhouse.queries.funnels.funnel_correlation import FunnelCorrelation
 from ee.clickhouse.queries.stickiness import ClickhouseStickiness
 from posthog.api.documentation import extend_schema
-from posthog.api.insight import InsightViewSet
+from posthog.api.insight import InsightViewSet, capture_legacy_api_call
 from posthog.decorators import cached_by_filters
 from posthog.models import Insight
 from posthog.models.dashboard import Dashboard
@@ -41,6 +41,8 @@ class EnterpriseInsightsViewSet(InsightViewSet):
     @extend_schema(exclude=True)
     @action(methods=["GET", "POST"], url_path="funnel/correlation", detail=False)
     def funnel_correlation(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        capture_legacy_api_call(request, self.team)
+
         result = self.calculate_funnel_correlation(request)
         return Response(result)
 

--- a/ee/clickhouse/views/person.py
+++ b/ee/clickhouse/views/person.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from posthog.api.insight import capture_legacy_api_call
 from rest_framework import request, response
 from posthog.api.utils import action
 
@@ -20,6 +21,8 @@ from posthog.utils import format_query_params_absolute_url
 class EnterprisePersonViewSet(PersonViewSet):
     @action(methods=["GET", "POST"], url_path="funnel/correlation", detail=False)
     def funnel_correlation(self, request: request.Request, **kwargs) -> response.Response:
+        capture_legacy_api_call(request, self.team)
+
         if request.user.is_anonymous or not self.team:
             return response.Response(data=[])
 

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -531,6 +531,7 @@ class CohortViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
                 "request": request,
                 "from_cohort_id": cohort.pk,
                 "team_id": team.pk,
+                "get_team": lambda: team,
             },
         )
 

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -3,6 +3,7 @@ import csv
 from collections import defaultdict
 from django.db import DatabaseError
 from loginas.utils import is_impersonated_session
+from posthog.api.insight import capture_legacy_api_call
 import structlog
 
 from posthog.models.activity_logging.activity_log import log_activity, Detail, dict_changes_between, load_activity
@@ -233,6 +234,7 @@ class CohortSerializer(serializers.ModelSerializer):
             if existing_cohort_id:
                 filter_data = {**filter_data, "from_cohort_id": existing_cohort_id}
             if filter_data:
+                capture_legacy_api_call(request, self.context["get_team"]())
                 insert_cohort_from_insight_filter.delay(cohort.pk, filter_data, self.context["team_id"])
 
     def create(self, validated_data: dict, *args: Any, **kwargs: Any) -> Cohort:

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -9,6 +9,7 @@ from django.shortcuts import get_object_or_404
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiExample, OpenApiParameter
 from loginas.utils import is_impersonated_session
+from posthog.api.insight import capture_legacy_api_call
 from prometheus_client import Counter
 from rest_framework import request, response, serializers, viewsets
 from rest_framework.exceptions import MethodNotAllowed, NotFound, ValidationError
@@ -703,6 +704,8 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
     @action(methods=["GET", "POST"], detail=False)
     def funnel(self, request: request.Request, **kwargs) -> response.Response:
+        capture_legacy_api_call(request, self.team)
+
         if request.user.is_anonymous or not self.team:
             return response.Response(data=[])
 
@@ -732,6 +735,8 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
     @action(methods=["GET"], detail=False)
     def trends(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
+        capture_legacy_api_call(request, self.team)
+
         if request.user.is_anonymous or not self.team:
             return response.Response(data=[])
 


### PR DESCRIPTION
## Problem

I think these endpoints aren't used any more and have PRs up for removing them. Let's instrument, to make sure this is actually the case.

https://github.com/PostHog/posthog/pull/33596
https://github.com/PostHog/posthog/pull/33597

## Changes

Adds instrumentation for legacy api endpoints.

## How did you test this code?

Debugger