### PR TITLE
feat(propdefs): rollback partial batch writes to avoid constraint errors on retry

### DIFF
--- a/rust/property-defs-rs/src/v2_batch_ingestion.rs
+++ b/rust/property-defs-rs/src/v2_batch_ingestion.rs
@@ -559,7 +559,7 @@ async fn write_event_definitions_batch(
         match result {
             Err(e) => {
                 let rollback_msg = format!(
-                    "failed to rollback posthog_eventydefinition insert w/error: {:?}",
+                    "failed to rollback posthog_eventdefinition insert w/error: {:?}",
                     &e
                 );
                 tx.rollback().await.expect(&rollback_msg);


### PR DESCRIPTION
## Problem
Since cutting over to v2 write path on `property-defs-rs` service, we see sporadic table constraint violation errors coming back from Postgres. These are fairly rare, and typically do not cause trouble for the service, but last night we saw a burst of them that caused an alert. The error is:

```
Ensure that no rows proposed for insertion within the same command have duplicate constrained values.
```

This is most likely a result of relying on PG `autocommit` and single-statement batch writes in the v2 write path. In the (fairly rare) occasion that a write fails, we resubmit it but without transaction boundaries, a partial success was possible, introducing the potential for the retry to contain duplicate values for columns with constraints.

## Changes
Wrap _each individual batch write attempt_ in a DB transaction.

*Note*: this could be hazardous in other ways: an increase in explicit, large-batch DB locking, especially on redeploy as pod caches warm, caused trouble for this service in the past on the v1 write path.

🎗️ tldr: _this change is risky_, and will need observation and possibly a revert if it doesn't behave well at production scale

*Alternatives*:
1. Introduce global (Redis-backed) cache to avoid cache warming cycles in the status quo deploy flow, as planned prior to pausing work on the service last quarter
2. Avoid retries on batch fails; aim at better cache expiration and expect future event submissions to "self-heal" missed updates during partial write fails. These _are_ pretty rare on their own
3. Use (somewhat unreliable) PG-internal MVCC metrics or read-before-write to attempt to prune retries of written rows in a partial-fail + retry scenario

☝️ we can explore these options if adding transaction wrapping doesn't help

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Locally, CI, and soon test deploy + observation