### PR TITLE
fix(propdefs): Avoid posthog_propertydefinition constraint errors on v2 batch write retries

### DIFF
--- a/rust/property-defs-rs/src/v2_batch_ingestion.rs
+++ b/rust/property-defs-rs/src/v2_batch_ingestion.rs
@@ -434,7 +434,8 @@ async fn write_property_definitions_batch(
                     COALESCE(project_id, team_id::bigint), name, type,
                     COALESCE(group_type_index, -1))
                 DO UPDATE SET property_type=EXCLUDED.property_type
-                WHERE posthog_propertydefinition.property_type IS NULL"#,
+                WHERE (posthog_propertydefinition.property_type IS NULL
+                    OR posthog_propertydefintion.property_type != EXCLUDED.property_type)"#,
             )
             .bind(&batch.ids)
             .bind(&batch.names)

--- a/rust/property-defs-rs/src/v2_batch_ingestion.rs
+++ b/rust/property-defs-rs/src/v2_batch_ingestion.rs
@@ -435,7 +435,7 @@ async fn write_property_definitions_batch(
                     COALESCE(group_type_index, -1))
                 DO UPDATE SET property_type=EXCLUDED.property_type
                 WHERE (posthog_propertydefinition.property_type IS NULL
-                    OR posthog_propertydefintion.property_type != EXCLUDED.property_type)"#,
+                    OR posthog_propertydefinition.property_type != EXCLUDED.property_type)"#,
             )
             .bind(&batch.ids)
             .bind(&batch.names)


### PR DESCRIPTION
## Problem
Part two of a series of PRs attempting to address constraint violation DB errors seen in v2 batch write errors, this one targeting the `posthog_propertydefinition` table.

## Changes
Don't attempt to update rows on conflict where `property_type` in the DB already equals the batch's record to-be-inserted. This should allow retries on partially-written failed batches to avoid constraint errors.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Locally and in CI