### PR TITLE
fix(propdefs): revert "avoid posthog_propertydefinition constraint errors on v2 batch write retries"

### DIFF
--- a/rust/property-defs-rs/src/v2_batch_ingestion.rs
+++ b/rust/property-defs-rs/src/v2_batch_ingestion.rs
@@ -434,8 +434,7 @@ async fn write_property_definitions_batch(
                     COALESCE(project_id, team_id::bigint), name, type,
                     COALESCE(group_type_index, -1))
                 DO UPDATE SET property_type=EXCLUDED.property_type
-                WHERE (posthog_propertydefinition.property_type IS NULL
-                    OR posthog_propertydefinition.property_type != EXCLUDED.property_type)"#,
+                WHERE posthog_propertydefinition.property_type IS NULL"#,
             )
             .bind(&batch.ids)
             .bind(&batch.names)


### PR DESCRIPTION
Reverts PostHog/posthog#33768 - the increase in the query's latency and expense doesn't justify the potential decrease in batch errors, and in fact was causing some new retry fails as formulated.