### PR TITLE
fix: filter results breakdown correctly for FunnelStep[][].

### DIFF
--- a/frontend/src/scenes/experiments/components/ResultsBreakdown/resultsBreakdownLogic.ts
+++ b/frontend/src/scenes/experiments/components/ResultsBreakdown/resultsBreakdownLogic.ts
@@ -1,7 +1,6 @@
 import { actions, afterMount, connect, kea, path, props, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
-import { FunnelLayout } from 'lib/constants'
-import { FEATURE_FLAGS } from 'lib/constants'
+import { FEATURE_FLAGS, FunnelLayout } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { match, P } from 'ts-pattern'
 
@@ -166,13 +165,16 @@ export const resultsBreakdownLogic = kea<resultsBreakdownLogicType>([
 
                         results = match(results)
                             /**
-                             * filter for FunnelSteps[][]
+                             * filter for FunnelSteps[][]. In this case, we get an array for each breakdown group,
+                             * each with an array of steps. We need to filter for each group and remove any empty arrays.
                              */
                             .with(P.array(P.array({ breakdown_value: P.any })), (nestedSteps) =>
-                                nestedSteps.map((stepGroup) => filterFunnelSteps(stepGroup, variants))
+                                nestedSteps
+                                    .map((stepGroup) => filterFunnelSteps(stepGroup, variants))
+                                    .filter((steps) => steps.length > 0)
                             )
                             /**
-                             * filter for FunnelSteps[]
+                             * filter for FunnelSteps[]. In this case, we just get an array of steps
                              */
                             .with(P.array({ breakdown_value: P.any }), (flatSteps) =>
                                 filterFunnelSteps(flatSteps, variants)


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

In some cases, when the result of the insight is `FunnelStep[][]`, when we filter the steps for breakdowns that align with the feature flags variants, we may have an empty array. If this array is in the first position, the insight visualization breaks.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

This is a straightforward fix; we must filter out empty step arrays after processing the server's response.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/eb9a3ee4-a8e0-4eab-81ed-819773b16faa)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
