### PR TITLE
fix: the order of data points displayed in the chart tooltip

### DIFF
--- a/ee/clickhouse/views/test/test_clickhouse_trends.py
+++ b/ee/clickhouse/views/test/test_clickhouse_trends.py
@@ -125,6 +125,7 @@ def test_includes_only_intervals_within_range(client: Client):
                     "labels": ["5-Sep – 11-Sep", "12-Sep – 18-Sep", "19-Sep – 25-Sep"],
                     "days": ["2021-09-05", "2021-09-12", "2021-09-19"],
                     "filter": ANY,
+                    "order": 0,
                 }
             ],
         }
@@ -195,6 +196,7 @@ def test_can_specify_number_of_smoothing_intervals(client: Client):
                     "labels": ["1-Sep-2021", "2-Sep-2021", "3-Sep-2021"],
                     "days": ["2021-09-01", "2021-09-02", "2021-09-03"],
                     "filter": ANY,
+                    "order": 0,
                 }
             ],
         }
@@ -236,6 +238,7 @@ def test_can_specify_number_of_smoothing_intervals(client: Client):
                     "labels": ["1-Sep-2021", "2-Sep-2021", "3-Sep-2021"],
                     "days": ["2021-09-01", "2021-09-02", "2021-09-03"],
                     "filter": ANY,
+                    "order": 0,
                 }
             ],
         }
@@ -289,6 +292,7 @@ def test_can_specify_number_of_smoothing_intervals(client: Client):
                     "labels": ["1-Sep-2021", "2-Sep-2021", "3-Sep-2021"],
                     "days": ["2021-09-01", "2021-09-02", "2021-09-03"],
                     "filter": ANY,
+                    "order": 0,
                 }
             ],
         }
@@ -361,6 +365,7 @@ def test_smoothing_intervals_copes_with_null_values(client: Client):
                     "labels": ["1-Sep-2021", "2-Sep-2021", "3-Sep-2021"],
                     "days": ["2021-09-01", "2021-09-02", "2021-09-03"],
                     "filter": ANY,
+                    "order": 0,
                 }
             ],
         }
@@ -402,6 +407,7 @@ def test_smoothing_intervals_copes_with_null_values(client: Client):
                     "labels": ["1-Sep-2021", "2-Sep-2021", "3-Sep-2021"],
                     "days": ["2021-09-01", "2021-09-02", "2021-09-03"],
                     "filter": ANY,
+                    "order": 0,
                 }
             ],
         }

--- a/frontend/src/lib/components/Sparkline.tsx
+++ b/frontend/src/lib/components/Sparkline.tsx
@@ -169,6 +169,7 @@ export function Sparkline({
                                             id: i,
                                             dataIndex: 0,
                                             datasetIndex: 0,
+                                            order: i,
                                             label: dp.dataset.label,
                                             color: dp.dataset.borderColor as string,
                                             count: (dp.dataset.data?.[dp.dataIndex] as number) || 0,

--- a/frontend/src/scenes/hog-functions/metrics/HogFunctionMetrics.tsx
+++ b/frontend/src/scenes/hog-functions/metrics/HogFunctionMetrics.tsx
@@ -218,6 +218,7 @@ function AppMetricsGraph(): JSX.Element {
                                             id: i,
                                             dataIndex: 0,
                                             datasetIndex: 0,
+                                            order: i,
                                             label: dp.dataset.label,
                                             color: dp.dataset.borderColor as string,
                                             count: (dp.dataset.data?.[dp.dataIndex] as number) || 0,

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.stories.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.stories.tsx
@@ -89,6 +89,7 @@ Columns.args = {
             id: 0,
             dataIndex: 3,
             datasetIndex: 2,
+            order: 1,
             dotted: false,
             breakdown_value: 'Safari',
             action: {
@@ -131,6 +132,7 @@ Columns.args = {
             id: 1,
             dataIndex: 3,
             datasetIndex: 0,
+            order: 0,
             dotted: false,
             breakdown_value: 'Chrome',
             action: {
@@ -173,6 +175,7 @@ Columns.args = {
             id: 2,
             dataIndex: 3,
             datasetIndex: 1,
+            order: 0,
             dotted: false,
             breakdown_value: 'Safari',
             action: {

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -168,11 +168,12 @@ export function InsightTooltip({
                     },
                 })
             })
-            dataColumns.sort(
-                (a, b) =>
-                    (truncatedCols[parseInt(a.key as string)]?.action?.order || 0) -
-                    (truncatedCols[parseInt(b.key as string)]?.action?.order || 0)
-            )
+            dataColumns.sort((a, b) => {
+                const itemA = truncatedCols?.find((s) => s.order === parseInt(a.key as string))
+                const itemB = truncatedCols?.find((s) => s.order === parseInt(b.key as string))
+
+                return (itemA?.order || 0) - (itemB?.order || 0)
+            })
             columns.push(...dataColumns)
         }
 

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -131,7 +131,8 @@ export function InsightTooltip({
                 colCutoff
             )
             const dataColumns: LemonTableColumn<InvertedSeriesDatum, keyof InvertedSeriesDatum | undefined>[] = []
-            truncatedCols.forEach((seriesColumn, colIdx) => {
+            truncatedCols.forEach((seriesColumn) => {
+                const colIdx = seriesColumn.order
                 dataColumns.push({
                     key: colIdx.toString(),
                     className: 'datum-counts-column',
@@ -154,7 +155,9 @@ export function InsightTooltip({
                                 colIdx
                             )),
                     render: function renderSeriesColumnData(_, datum) {
-                        const seriesColumnData: SeriesDatum | undefined = datum.seriesData?.[colIdx]
+                        const seriesColumnData: SeriesDatum | undefined = datum.seriesData.find(
+                            (s) => s.order === colIdx
+                        )
                         return renderDatumToTableCell(
                             seriesColumnData?.action?.math_property,
                             seriesColumnData?.count,

--- a/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
@@ -120,12 +120,10 @@ function getPillValues(
     return pillValues
 }
 
-function getDatumTitle(
-    s: SeriesDatum,
-    breakdownFilter: BreakdownFilter | null | undefined,
-    cohorts: any,
-    formatPropertyValueForDisplay: any
-): React.ReactNode {
+function getDatumTitle(s: SeriesDatum, breakdownFilter: BreakdownFilter | null | undefined): React.ReactNode {
+    // NOTE: Assuming these logics are mounted elsewhere, and we're not interested in tracking changes.
+    const cohorts = cohortsModel.findMounted()?.values?.allCohorts
+    const formatPropertyValueForDisplay = propertyDefinitionsModel.findMounted()?.values?.formatPropertyValueForDisplay
     const pillValues = getPillValues(s, breakdownFilter, cohorts, formatPropertyValueForDisplay)
     if (pillValues.length > 0) {
         return (
@@ -148,9 +146,6 @@ export function invertDataSource(
     seriesData: SeriesDatum[],
     breakdownFilter: BreakdownFilter | null | undefined
 ): InvertedSeriesDatum[] {
-    // NOTE: Assuming these logics are mounted elsewhere, and we're not interested in tracking changes.
-    const cohorts = cohortsModel.findMounted()?.values?.allCohorts
-    const formatPropertyValueForDisplay = propertyDefinitionsModel.findMounted()?.values?.formatPropertyValueForDisplay
     const flattenedData: Record<string, InvertedSeriesDatum> = {}
 
     seriesData.forEach((s) => {
@@ -163,7 +158,7 @@ export function invertDataSource(
                 id: datumKey,
                 datasetIndex: s.datasetIndex,
                 color: s.color,
-                datumTitle: getDatumTitle(s, breakdownFilter, cohorts, formatPropertyValueForDisplay),
+                datumTitle: getDatumTitle(s, breakdownFilter),
                 seriesData: [s],
             }
         }

--- a/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
@@ -17,6 +17,7 @@ export interface SeriesDatum {
     compare_label?: CompareLabelType
     action?: ActionFilter
     label?: string
+    order: number
     dotted?: boolean
     color?: string
     count: number
@@ -101,57 +102,69 @@ export function getFormattedDate(input?: string | number, interval: IntervalType
     return String(input)
 }
 
+function getPillValues(
+    s: SeriesDatum,
+    breakdownFilter: BreakdownFilter | null | undefined,
+    cohorts: any,
+    formatPropertyValueForDisplay: any
+): string[] {
+    const pillValues = []
+    if (s.breakdown_value !== undefined) {
+        pillValues.push(
+            formatBreakdownLabel(s.breakdown_value, breakdownFilter, cohorts?.results, formatPropertyValueForDisplay)
+        )
+    }
+    if (s.compare_label) {
+        pillValues.push(capitalizeFirstLetter(String(s.compare_label)))
+    }
+    return pillValues
+}
+
+function getDatumTitle(
+    s: SeriesDatum,
+    breakdownFilter: BreakdownFilter | null | undefined,
+    cohorts: any,
+    formatPropertyValueForDisplay: any
+): React.ReactNode {
+    const pillValues = getPillValues(s, breakdownFilter, cohorts, formatPropertyValueForDisplay)
+    if (pillValues.length > 0) {
+        return (
+            <>
+                {pillValues.map((pill, index) => (
+                    <React.Fragment key={pill}>
+                        <span>{midEllipsis(pill, 60)}</span>
+                        {index < pillValues.length - 1 && ' · '}
+                    </React.Fragment>
+                ))}
+            </>
+        )
+    }
+    return 'Baseline'
+}
+
 export function invertDataSource(
     seriesData: SeriesDatum[],
     breakdownFilter: BreakdownFilter | null | undefined
 ): InvertedSeriesDatum[] {
-    // NOTE: Assuming these logics are mounted elsewhere, and we're not interested in tracking changes.
     const cohorts = cohortsModel.findMounted()?.values?.allCohorts
     const formatPropertyValueForDisplay = propertyDefinitionsModel.findMounted()?.values?.formatPropertyValueForDisplay
     const flattenedData: Record<string, InvertedSeriesDatum> = {}
+
     seriesData.forEach((s) => {
-        let datumTitle
-        const pillValues = []
-        if (s.breakdown_value !== undefined) {
-            pillValues.push(
-                formatBreakdownLabel(
-                    s.breakdown_value,
-                    breakdownFilter,
-                    cohorts?.results,
-                    formatPropertyValueForDisplay
-                )
-            )
-        }
-        if (s.compare_label) {
-            pillValues.push(capitalizeFirstLetter(String(s.compare_label)))
-        }
-        if (pillValues.length > 0) {
-            datumTitle = (
-                <>
-                    {pillValues.map((pill, index) => (
-                        <React.Fragment key={pill}>
-                            <span>{midEllipsis(pill, 60)}</span>
-                            {index < pillValues.length - 1 && ' · '}
-                        </React.Fragment>
-                    ))}
-                </>
-            )
-        } else {
-            // Technically should never reach this point because series data should have at least breakdown or compare values
-            datumTitle = 'Baseline'
-        }
         const datumKey = `${s.breakdown_value}-${s.compare_label}`
         if (datumKey in flattenedData) {
             flattenedData[datumKey].seriesData.push(s)
+            flattenedData[datumKey].seriesData = flattenedData[datumKey].seriesData.sort((a, b) => a.order - b.order)
         } else {
             flattenedData[datumKey] = {
                 id: datumKey,
                 datasetIndex: s.datasetIndex,
                 color: s.color,
-                datumTitle,
+                datumTitle: getDatumTitle(s, breakdownFilter, cohorts, formatPropertyValueForDisplay),
                 seriesData: [s],
             }
         }
     })
+
     return Object.values(flattenedData)
 }

--- a/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
@@ -143,9 +143,6 @@ export function invertDataSource(
         const datumKey = `${s.breakdown_value}-${s.compare_label}`
         if (datumKey in flattenedData) {
             flattenedData[datumKey].seriesData.push(s)
-            flattenedData[datumKey].seriesData = flattenedData[datumKey].seriesData.sort(
-                (a, b) => (b.action?.order ?? b.dataIndex) - (a.action?.order ?? a.dataIndex)
-            )
         } else {
             flattenedData[datumKey] = {
                 id: datumKey,

--- a/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
@@ -139,6 +139,8 @@ function getDatumTitle(
             </>
         )
     }
+
+    // Technically should never reach this point because series data should have at least breakdown or compare values
     return 'Baseline'
 }
 
@@ -146,6 +148,7 @@ export function invertDataSource(
     seriesData: SeriesDatum[],
     breakdownFilter: BreakdownFilter | null | undefined
 ): InvertedSeriesDatum[] {
+    // NOTE: Assuming these logics are mounted elsewhere, and we're not interested in tracking changes.
     const cohorts = cohortsModel.findMounted()?.values?.allCohorts
     const formatPropertyValueForDisplay = propertyDefinitionsModel.findMounted()?.values?.formatPropertyValueForDisplay
     const flattenedData: Record<string, InvertedSeriesDatum> = {}

--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -58,6 +58,7 @@ function useBoldNumberTooltip({
                         dataIndex: 1,
                         datasetIndex: 1,
                         id: 1,
+                        order: 1,
                         label: seriesResult?.label,
                         count: seriesResult?.aggregated_value,
                     },

--- a/frontend/src/scenes/insights/views/LineGraph/tooltip-data.ts
+++ b/frontend/src/scenes/insights/views/LineGraph/tooltip-data.ts
@@ -26,6 +26,7 @@ export function createTooltipData(
                 compare_label: pointDataset?.compare_label ?? pointDataset?.compareLabels?.[dp.dataIndex] ?? undefined,
                 action: pointDataset?.action ?? pointDataset?.actions?.[dp.dataIndex] ?? undefined,
                 label: pointDataset?.label ?? pointDataset.labels?.[dp.dataIndex] ?? undefined,
+                order: pointDataset?.order ?? 0,
                 color: Array.isArray(pointDataset.borderColor)
                     ? pointDataset.borderColor?.[dp.dataIndex]
                     : pointDataset.borderColor,

--- a/frontend/src/scenes/insights/views/WorldMap/WorldMap.tsx
+++ b/frontend/src/scenes/insights/views/WorldMap/WorldMap.tsx
@@ -50,6 +50,7 @@ function useWorldMapTooltip(showPersonsModal: boolean): React.RefObject<SVGSVGEl
                                     dataIndex: 1,
                                     datasetIndex: 1,
                                     id: 1,
+                                    order: 1,
                                     breakdown_value: currentTooltip[0],
                                     count: currentTooltip[1]?.aggregated_value || 0,
                                 },

--- a/posthog/hogql_queries/insights/trends/test/test_formula.py
+++ b/posthog/hogql_queries/insights/trends/test/test_formula.py
@@ -547,6 +547,7 @@ class TestFormula(ClickhouseTestMixin, APIBaseTest):
                     "breakdown_value": "Paris",
                     "action": None,
                     "filter": mock.ANY,
+                    "order": 0,
                 },
                 {
                     "data": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
@@ -575,6 +576,7 @@ class TestFormula(ClickhouseTestMixin, APIBaseTest):
                     "breakdown_value": "London",
                     "action": None,
                     "filter": mock.ANY,
+                    "order": 0,
                 },
             ],
         )

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -416,22 +416,36 @@ class TrendsQueryRunner(QueryRunner):
                     previous_results = returned_results[len(returned_results) // 2 :]
 
                     final_result = []
-                    for formula_node in formula_nodes:
+                    for formula_idx, formula_node in enumerate(formula_nodes):
                         current_formula_results = self.apply_formula(formula_node, current_results)
                         previous_formula_results = self.apply_formula(formula_node, previous_results)
                         # Create a new list for each formula's results
                         formula_results = []
                         formula_results.extend(current_formula_results)
                         formula_results.extend(previous_formula_results)
+
+                        # Set the order based on the formula index
+                        for result in formula_results:
+                            result["order"] = formula_idx
+
                         final_result.extend(formula_results)
                 else:
-                    for formula_node in formula_nodes:
+                    for formula_idx, formula_node in enumerate(formula_nodes):
                         formula_results = self.apply_formula(formula_node, returned_results)
+
+                        # Set the order based on the formula index
+                        for result in formula_results:
+                            result["order"] = formula_idx
+
                         # Create a new list for each formula's results
                         final_result.extend(formula_results)
         else:
             for result in returned_results:
                 if isinstance(result, list):
+                    for item in result:
+                        # Set the order for each item based on the action order
+                        item["order"] = item.get("action", {}).get("order", 0)
+
                     final_result.extend(result)
                 elif isinstance(result, dict):  # type: ignore [unreachable]
                     raise ValueError("This should not happen")


### PR DESCRIPTION


> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
Closes https://github.com/PostHog/posthog/issues/33209

This fixes the issue where the order of items displayed in the tooltip were not consistent when there was an undefined value in the mix. The item would show on the wrong column because we were grouping and sorting the data points based on their index in the returned result.

By adding a new `order` property to each item in the seriesData we can specify where it belongs to and properly map it to the correct column in the tooltip.

This changes the sort added in https://github.com/PostHog/posthog/pull/18657 to work based on the `order` property instead of relying on the data index.

I also refactored the code a bit to make it more readable and also change any related code that would benefit from this new `order` property.


For more information about the issue check https://github.com/PostHog/posthog/issues/33209

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Select two or more series where for one there is no data for some period. There must be no inconsistency when you hover over the chart to view the tooltip; i.e. each data point should be set in the correct column.

<img width="1026" alt="image" src="https://github.com/user-attachments/assets/9a8d63f9-e329-4bf2-bd6e-98eace9edd6a" />

In the example above, the issue is resolved because the dashes (-) are correctly set under the autocapture column. Previously the dashes would show under the wrong column.


<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
