### PR TITLE
fix(flags): Add stable sorting of conditions so we can reorder them.

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -156,7 +156,7 @@ export function FeatureFlagReleaseConditions({
 
     const renderReleaseConditionGroup = (group: FeatureFlagGroupType, index: number): JSX.Element => {
         return (
-            <div className="w-full" key={`${index}-${filterGroups.length}`}>
+            <div className="w-full" key={group.sort_key}>
                 {index > 0 && <div className="condition-set-separator">OR</div>}
                 <div className="mb-4 border rounded p-4 bg-surface-primary">
                     <div className="flex items-center justify-between">
@@ -275,7 +275,7 @@ export function FeatureFlagReleaseConditions({
                         <div>
                             <PropertyFilters
                                 orFiltering={true}
-                                pageKey={`feature-flag-${id}-${index}-${filterGroups.length}-${
+                                pageKey={`feature-flag-${id}-${group.sort_key}-${filterGroups.length}-${
                                     filters.aggregation_group_type_index ?? ''
                                 }`}
                                 propertyFilters={group?.properties}
@@ -446,7 +446,7 @@ export function FeatureFlagReleaseConditions({
         const hasMatchingEarlyAccessFeature = earlyAccessFeaturesList?.find((f: any) => f.flagKey === featureFlagKey)
 
         return (
-            <div className="w-full" key={`${index}-${filterGroups.length}`}>
+            <div className="w-full" key={group.sort_key}>
                 {index > 0 && <div className="condition-set-separator">OR</div>}
                 <div className="mb-4 rounded p-4 bg-surface-primary">
                     <div className="flex items-center justify-between">

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsLogic.ts
@@ -19,6 +19,15 @@ import {
 
 import type { featureFlagReleaseConditionsLogicType } from './FeatureFlagReleaseConditionsLogicType'
 
+// Helper function to move a condition set to a new index
+function moveConditionSet<T>(groups: T[], index: number, newIndex: number): T[] {
+    const updatedGroups = [...groups]
+    const item = updatedGroups[index]
+    updatedGroups.splice(index, 1)
+    updatedGroups.splice(newIndex, 0, item)
+    return updatedGroups
+}
+
 // TODO: Type onChange errors properly
 export interface FeatureFlagReleaseConditionsLogicProps {
     filters: FeatureFlagFilters
@@ -123,25 +132,16 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                     return { ...state, groups }
                 },
                 moveConditionSetDown: (state, { index }) => {
-                    if (!state || index === state.groups.length - 1) {
+                    if (!state || index >= state.groups.length - 1) {
                         return state
                     }
-
-                    const groups = [...state.groups]
-                    const condition = groups[index]
-                    groups.splice(index, 1)
-                    groups.splice(index + 1, 0, condition)
-                    return { ...state, groups }
+                    return { ...state, groups: moveConditionSet(state.groups, index, index + 1) }
                 },
                 moveConditionSetUp: (state, { index }) => {
-                    if (!state || index === 0) {
+                    if (!state || index <= 0) {
                         return state
                     }
-                    const groups = [...state.groups]
-                    const condition = groups[index]
-                    groups.splice(index, 1)
-                    groups.splice(index - 1, 0, condition)
-                    return { ...state, groups }
+                    return { ...state, groups: moveConditionSet(state.groups, index, index - 1) }
                 },
             },
         ],

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsLogic.ts
@@ -166,7 +166,12 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                     if (!state) {
                         return state
                     }
-                    const groups = state.groups.concat([state.groups[index]])
+                    const groups = state.groups.concat([
+                        {
+                            ...state.groups[index],
+                            sort_key: generateUUID(),
+                        },
+                    ])
                     return { ...state, groups }
                 },
                 moveConditionSetDown: (state, { index }) => {

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -250,9 +250,23 @@ export const getRecordingFilterForFlagVariant = (
 }
 
 // This helper function removes the created_at, id, and created_by fields from a flag
+// and cleans the groups and super_groups by removing the sort_key field.
 function cleanFlag(flag: Partial<FeatureFlagType>): Partial<FeatureFlagType> {
     const { created_at, id, created_by, last_modified_by, ...cleanedFlag } = flag
-    return cleanedFlag
+    return {
+        ...cleanedFlag,
+        filters: {
+            ...cleanedFlag.filters,
+            groups: cleanFilterGroups(cleanedFlag.filters?.groups || []),
+            super_groups: cleanFilterGroups(cleanedFlag.filters?.super_groups || []),
+        },
+    }
+}
+
+// Strip out sort_key from groups before saving. The sort_key is here for React to be able to
+// render the release conditions in the correct order.
+function cleanFilterGroups(groups: FeatureFlagGroupType[]): FeatureFlagGroupType[] {
+    return groups.map(({ sort_key, ...rest }) => rest)
 }
 
 export const featureFlagLogic = kea<featureFlagLogicType>([

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -266,7 +266,7 @@ function cleanFlag(flag: Partial<FeatureFlagType>): Partial<FeatureFlagType> {
 // Strip out sort_key from groups before saving. The sort_key is here for React to be able to
 // render the release conditions in the correct order.
 function cleanFilterGroups(groups: FeatureFlagGroupType[]): FeatureFlagGroupType[] {
-    return groups.map(({ sort_key, ...rest }) => rest)
+    return groups.map(({ sort_key, ...rest }: FeatureFlagGroupType) => rest)
 }
 
 export const featureFlagLogic = kea<featureFlagLogicType>([

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.test.ts
@@ -396,4 +396,112 @@ describe('the feature flag release conditions logic', () => {
             })
         })
     })
+
+    describe('moving condition sets', () => {
+        it('moves simple condition set up', () => {
+            const filters = generateFeatureFlagFilters([
+                { properties: [], rollout_percentage: 50, variant: null },
+                { properties: [], rollout_percentage: 75, variant: null },
+                { properties: [], rollout_percentage: 100, variant: null },
+            ])
+            logic.actions.setFilters(filters)
+
+            logic.actions.moveConditionSetUp(1)
+
+            expect(logic.values.filters.groups).toEqual([
+                { properties: [], rollout_percentage: 75, variant: null },
+                { properties: [], rollout_percentage: 50, variant: null },
+                { properties: [], rollout_percentage: 100, variant: null },
+            ])
+        })
+
+        it('moves simple condition set down', () => {
+            const filters = generateFeatureFlagFilters([
+                { properties: [], rollout_percentage: 50, variant: null },
+                { properties: [], rollout_percentage: 75, variant: null },
+                { properties: [], rollout_percentage: 100, variant: null },
+            ])
+            logic.actions.setFilters(filters)
+
+            logic.actions.moveConditionSetDown(0)
+
+            expect(logic.values.filters.groups).toEqual([
+                { properties: [], rollout_percentage: 75, variant: null },
+                { properties: [], rollout_percentage: 50, variant: null },
+                { properties: [], rollout_percentage: 100, variant: null },
+            ])
+        })
+
+        it('preserves properties after reordering', () => {
+            const filters = generateFeatureFlagFilters([
+                {
+                    properties: [
+                        {
+                            key: '$current_url',
+                            type: PropertyFilterType.Person,
+                            value: 'qa-33-percent-off-yearly-v1',
+                            operator: PropertyOperator.IContains,
+                        },
+                    ],
+                    rollout_percentage: 50,
+                    variant: null,
+                },
+                {
+                    properties: [
+                        {
+                            key: 'current_organization_membership_level',
+                            type: PropertyFilterType.Person,
+                            value: ['15'],
+                            operator: PropertyOperator.Exact,
+                        },
+                        {
+                            key: 'email',
+                            type: PropertyFilterType.Person,
+                            value: ['customer-two@example.com', 'customer-six@example.com'],
+                            operator: PropertyOperator.Exact,
+                        },
+                    ],
+                    rollout_percentage: 75,
+                    variant: null,
+                },
+            ])
+
+            logic.actions.setFilters(filters)
+
+            logic.actions.moveConditionSetUp(1)
+
+            expect(logic.values.filters.groups).toEqual([
+                {
+                    properties: [
+                        {
+                            key: 'current_organization_membership_level',
+                            type: PropertyFilterType.Person,
+                            value: ['15'],
+                            operator: 'exact',
+                        },
+                        {
+                            key: 'email',
+                            type: PropertyFilterType.Person,
+                            value: ['customer-two@example.com', 'customer-six@example.com'],
+                            operator: PropertyOperator.Exact,
+                        },
+                    ],
+                    rollout_percentage: 75,
+                    variant: null,
+                },
+                {
+                    properties: [
+                        {
+                            key: '$current_url',
+                            type: PropertyFilterType.Person,
+                            value: 'qa-33-percent-off-yearly-v1',
+                            operator: PropertyOperator.IContains,
+                        },
+                    ],
+                    rollout_percentage: 50,
+                    variant: null,
+                },
+            ])
+        })
+    })
 })

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.test.ts
@@ -400,35 +400,35 @@ describe('the feature flag release conditions logic', () => {
     describe('moving condition sets', () => {
         it('moves simple condition set up', () => {
             const filters = generateFeatureFlagFilters([
-                { properties: [], rollout_percentage: 50, variant: null },
-                { properties: [], rollout_percentage: 75, variant: null },
-                { properties: [], rollout_percentage: 100, variant: null },
+                { properties: [], rollout_percentage: 50, variant: null, sort_key: 'A' },
+                { properties: [], rollout_percentage: 75, variant: null, sort_key: 'B' },
+                { properties: [], rollout_percentage: 100, variant: null, sort_key: 'C' },
             ])
             logic.actions.setFilters(filters)
 
             logic.actions.moveConditionSetUp(1)
 
             expect(logic.values.filters.groups).toEqual([
-                { properties: [], rollout_percentage: 75, variant: null },
-                { properties: [], rollout_percentage: 50, variant: null },
-                { properties: [], rollout_percentage: 100, variant: null },
+                { properties: [], rollout_percentage: 75, variant: null, sort_key: 'B' },
+                { properties: [], rollout_percentage: 50, variant: null, sort_key: 'A' },
+                { properties: [], rollout_percentage: 100, variant: null, sort_key: 'C' },
             ])
         })
 
         it('moves simple condition set down', () => {
             const filters = generateFeatureFlagFilters([
-                { properties: [], rollout_percentage: 50, variant: null },
-                { properties: [], rollout_percentage: 75, variant: null },
-                { properties: [], rollout_percentage: 100, variant: null },
+                { properties: [], rollout_percentage: 50, variant: null, sort_key: 'A' },
+                { properties: [], rollout_percentage: 75, variant: null, sort_key: 'B' },
+                { properties: [], rollout_percentage: 100, variant: null, sort_key: 'C' },
             ])
             logic.actions.setFilters(filters)
 
             logic.actions.moveConditionSetDown(0)
 
             expect(logic.values.filters.groups).toEqual([
-                { properties: [], rollout_percentage: 75, variant: null },
-                { properties: [], rollout_percentage: 50, variant: null },
-                { properties: [], rollout_percentage: 100, variant: null },
+                { properties: [], rollout_percentage: 75, variant: null, sort_key: 'B' },
+                { properties: [], rollout_percentage: 50, variant: null, sort_key: 'A' },
+                { properties: [], rollout_percentage: 100, variant: null, sort_key: 'C' },
             ])
         })
 
@@ -445,6 +445,7 @@ describe('the feature flag release conditions logic', () => {
                     ],
                     rollout_percentage: 50,
                     variant: null,
+                    sort_key: 'A',
                 },
                 {
                     properties: [
@@ -463,6 +464,7 @@ describe('the feature flag release conditions logic', () => {
                     ],
                     rollout_percentage: 75,
                     variant: null,
+                    sort_key: 'B',
                 },
             ])
 
@@ -488,6 +490,7 @@ describe('the feature flag release conditions logic', () => {
                     ],
                     rollout_percentage: 75,
                     variant: null,
+                    sort_key: 'B',
                 },
                 {
                     properties: [
@@ -500,6 +503,7 @@ describe('the feature flag release conditions logic', () => {
                     ],
                     rollout_percentage: 50,
                     variant: null,
+                    sort_key: 'A',
                 },
             ])
         })

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.test.ts
@@ -477,7 +477,7 @@ describe('the feature flag release conditions logic', () => {
                             key: 'current_organization_membership_level',
                             type: PropertyFilterType.Person,
                             value: ['15'],
-                            operator: 'exact',
+                            operator: PropertyOperator.Exact,
                         },
                         {
                             key: 'email',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3226,6 +3226,7 @@ export interface FeatureFlagGroupType {
     rollout_percentage?: number | null
     variant?: string | null
     users_affected?: number
+    sort_key: string // Client-side only stable id for sorting.
 }
 
 export interface MultivariateFlagVariant {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3226,7 +3226,7 @@ export interface FeatureFlagGroupType {
     rollout_percentage?: number | null
     variant?: string | null
     users_affected?: number
-    sort_key: string // Client-side only stable id for sorting.
+    sort_key?: string | null // Client-side only stable id for sorting.
 }
 
 export interface MultivariateFlagVariant {


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

When reordering condition sets, we'd get weird rendering issues in the UI, though the underlying state was correct.

The issue is we're using the index as the React component key for the list of conditions and as we all no, that's a no-no because the index isn't stable. It was fine before we added controls to allow re-ordering conditions up and down (added in https://github.com/PostHog/posthog/pull/29282).

But with these new controls, the index of a condition can change causing weird state issues.

Fixes #33757 

## Changes

So instead of using the index as the key, we generate a random key to use as the React component key and store this in the `sort_key` property of `FeatureFlagGroupType`.

When saving the flag, we strip the sort_key out because it's only needed by React.

Also did a bit of refactoring and added unit tests to confirm that the problem is not our code for moving conditions within the filters JSON.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Manual testing.