### PR TITLE
chore: Add a rule to auto-detect flox usage rules

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -17,4 +17,8 @@ DO NOT GIVE ME HIGH LEVEL SHIT, IF I ASK FOR FIX OR EXPLANATION, I WANT ACTUAL C
 - Please respect my formatting preferences when you provide code.
 - Please respect all code comments, they're usually there for a reason. Remove them ONLY if they're completely irrelevant after a code change. if unsure, do not remove the comment.
 - Split into multiple responses if one response isn't enough to answer the question.
-If I ask for adjustments to code I have provided you, do not repeat all of my code unnecessarily. Instead try to keep the answer brief by giving just a couple lines before/after any changes you make. Multiple code blocks are ok.
+- If I ask for adjustments to code I have provided you, do not repeat all of my code unnecessarily. Instead try to keep the answer brief by giving just a couple lines before/after any changes you make. Multiple code blocks are ok.
+- Auto-detect flox environment before running terminal commands
+- If flox is available: ALWAYS use `flox activate -- bash -c "<command>"` pattern
+- Never use `flox activate` in interactive sessions (it hangs)
+


### PR DESCRIPTION
## Problem

- When Cursor tries to run commands in Agent mode, and the dev is using flox (i.e. agent does `flox activate` and then some commands), terminal executions in the chat side panel hang and you need to Skip in order to continue.

## Changes

- This adds some guidance for Cursor to auto-detect if flox is used and if yes, to use the appropriate command syntax to run commands in the flox env context.
