### PR TITLE
fix(experiments): fix failing import

### DIFF
--- a/posthog/hogql_queries/experiments/utils.py
+++ b/posthog/hogql_queries/experiments/utils.py
@@ -9,12 +9,11 @@ from posthog.schema import (
     ExperimentVariantFunnelsBaseStats,
     ExperimentVariantTrendsBaseStats,
 )
-from products.experiments.stats.frequentist.method import FrequentistConfig, FrequentistMethod
-from products.experiments.stats.frequentist.statistics import (
+from products.experiments.stats.frequentist.method import FrequentistConfig, FrequentistMethod, TestType
+from products.experiments.stats.shared.enums import DifferenceType
+from products.experiments.stats.shared.statistics import (
     SampleMeanStatistic,
     ProportionStatistic,
-    TestType,
-    DifferenceType,
 )
 from posthog.hogql_queries.experiments import CONTROL_VARIANT_KEY
 


### PR DESCRIPTION
## Problem
We have a failing import currently crashing all queries. Not sure why mypy didn't catch this.

```
from products.experiments.stats.frequentist.statistics import (
ModuleNotFoundError: No module named 'products.experiments.stats.frequentist.statistics'
```

## How did you test this code?
Locally tested that queries load correctly.