### PR TITLE
feat: Concurrent reads from S3 files in staging area

### DIFF
--- a/posthog/temporal/batch_exports/pre_export_stage.py
+++ b/posthog/temporal/batch_exports/pre_export_stage.py
@@ -615,11 +615,9 @@ class ProducerFromInternalS3Stage:
 
             # Read in batches
             try:
-                async for batch in self._stream_record_batches_from_s3(s3_client, keys):
-                    for record_batch_slice in slice_record_batch(
-                        batch, max_record_batch_size_bytes, min_records_per_batch
-                    ):
-                        await queue.put(record_batch_slice)
+                await self._stream_record_batches_from_s3(
+                    s3_client, keys, queue, max_record_batch_size_bytes, min_records_per_batch
+                )
             except Exception as e:
                 await self.logger.aexception("Unexpected error occurred while producing record batches", exc_info=e)
                 raise
@@ -628,12 +626,20 @@ class ProducerFromInternalS3Stage:
         self,
         s3_client: "S3Client",
         keys: list[str],
+        queue: RecordBatchQueue,
+        max_record_batch_size_bytes: int = 0,
+        min_records_per_batch: int = 100,
     ):
-        for key in keys:
+        async def stream_from_s3_file(key):
             s3_ob = await s3_client.get_object(Bucket=settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET, Key=key)
             assert "Body" in s3_ob, "Body not found in S3 object"
             stream: StreamingBody = s3_ob["Body"]
             # read in 128KB chunks of data from S3
             reader = asyncpa.AsyncRecordBatchReader(stream.iter_chunks(chunk_size=128 * 1024))
             async for batch in reader:
-                yield batch
+                for record_batch_slice in slice_record_batch(batch, max_record_batch_size_bytes, min_records_per_batch):
+                    await queue.put(record_batch_slice)
+
+        async with asyncio.TaskGroup() as tg:
+            for key in keys:
+                tg.create_task(stream_from_s3_file(key))


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We are reading from S3 sequentially.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Do not do that.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
