### PR TITLE
chore: Update localdev docker to match prod

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -98,8 +98,10 @@ services:
         # Note: please keep the default version in sync across
         #       `posthog` and the `charts-clickhouse` repos
         #
-        image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:24.8.7.41}
+        image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:24.8.14.39}
         restart: on-failure
+        environment:
+            CLICKHOUSE_SKIP_USER_SETUP: 1
 
     zookeeper:
         image: zookeeper:3.7.0


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We have a mistmatch between the version in prod and the version used in localdev

## Changes
Update the image in localdev.

I had to add an extra env var to keep the user without a password

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Running existing tests
