### PR TITLE
fix: Do not release event loop until IO

### DIFF
--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -1164,9 +1164,8 @@ class ConcurrentS3Consumer(ConsumerFromStage):
             response: UploadPartOutputTypeDef | None = None
             attempt = 0
 
-            upload_start = time.time()
-
             while response is None:
+                upload_start = time.time()
                 try:
                     response = await client.upload_part(
                         Bucket=self.s3_inputs.bucket_name,

--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -1158,15 +1158,17 @@ class ConcurrentS3Consumer(ConsumerFromStage):
             )
             current_key = self._get_current_key()
             client = self._s3_client
+            assert client is not None, "No S3 client, is multi-part initialized?"
 
             # Retry logic for upload_part
             response: UploadPartOutputTypeDef | None = None
             attempt = 0
 
+            upload_start = time.time()
+
             while response is None:
-                upload_start = time.time()
                 try:
-                    response = await client.upload_part(  # type: ignore
+                    response = await client.upload_part(
                         Bucket=self.s3_inputs.bucket_name,
                         Key=current_key,
                         PartNumber=part_number,

--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -1088,6 +1088,9 @@ class ConcurrentS3Consumer(ConsumerFromStage):
         # Upload parts when buffer is full
         while len(self.current_buffer) >= self.part_size:
             await self._upload_next_part()
+        else:
+            # Ensure that we give pending tasks a chance to run.
+            await asyncio.sleep(0)
 
     async def _upload_next_part(self, final: bool = False):
         """Extract a part from buffer and upload it"""
@@ -1147,14 +1150,14 @@ class ConcurrentS3Consumer(ConsumerFromStage):
             raise NoUploadInProgressError()
 
         try:
-            await self.logger.ainfo(
+            self.logger.info(
                 "Uploading file number %s part %s with upload id %s",
                 self.current_file_index,
                 part_number,
                 self.upload_id,
             )
             current_key = self._get_current_key()
-            client = await self._get_s3_client()
+            client = self._s3_client
 
             # Retry logic for upload_part
             response: UploadPartOutputTypeDef | None = None
@@ -1163,7 +1166,7 @@ class ConcurrentS3Consumer(ConsumerFromStage):
             while response is None:
                 upload_start = time.time()
                 try:
-                    response = await client.upload_part(
+                    response = await client.upload_part(  # type: ignore
                         Bucket=self.s3_inputs.bucket_name,
                         Key=current_key,
                         PartNumber=part_number,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Event loop jumps from task to task on `await`. We are yielding back control to the event loop in our upload task before starting a expensive IO call. This means the expensive IO call has to wait for expensive CPU bound code instead of running in parallel.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

* Do not `await` before `upload_part`.
* Add `await asyncio.sleep(0)` in case the while loop didn't schedule any new parts to let existing tasks run.

This increases throughput on local tests from 0-1 MB/s to 10-30 MB/s on a 1 million row sample with 3KB events.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
