### PR TITLE
chore(data-warehouse): Allow sandbox salesforce connections for importing SF data

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -185,6 +185,19 @@ class OauthIntegration:
                 id_path="instance_url",
                 name_path="instance_url",
             )
+        elif kind == "salesforce-sandbox":
+            if not settings.SALESFORCE_CONSUMER_KEY or not settings.SALESFORCE_CONSUMER_SECRET:
+                raise NotImplementedError("Salesforce app not configured")
+
+            return OauthConfig(
+                authorize_url="https://test.salesforce.com/services/oauth2/authorize",
+                token_url="https://test.salesforce.com/services/oauth2/token",
+                client_id=settings.SALESFORCE_CONSUMER_KEY,
+                client_secret=settings.SALESFORCE_CONSUMER_SECRET,
+                scope="full refresh_token",
+                id_path="instance_url",
+                name_path="instance_url",
+            )
         elif kind == "hubspot":
             if not settings.HUBSPOT_APP_CLIENT_ID or not settings.HUBSPOT_APP_CLIENT_SECRET:
                 raise NotImplementedError("Hubspot app not configured")
@@ -311,7 +324,8 @@ class OauthIntegration:
         cls, kind: str, team_id: int, created_by: User, params: dict[str, str]
     ) -> Integration:
         oauth_config = cls.oauth_config_for_kind(kind)
-
+        # test.salesforce.com
+        # https://test.salesforce.com/services/oauth2/token
         res = requests.post(
             oauth_config.token_url,
             data={
@@ -326,7 +340,26 @@ class OauthIntegration:
         config: dict = res.json()
 
         if res.status_code != 200 or not config.get("access_token"):
-            raise Exception("Oauth error")
+            # Hack to try getting sandbox auth token instead of their salesforce production account
+            if kind == "salesforce":
+                oauth_config = cls.oauth_config_for_kind("salesforce-sandbox")
+                res = requests.post(
+                    oauth_config.token_url,
+                    data={
+                        "client_id": oauth_config.client_id,
+                        "client_secret": oauth_config.client_secret,
+                        "code": params["code"],
+                        "redirect_uri": OauthIntegration.redirect_uri(kind),
+                        "grant_type": "authorization_code",
+                    },
+                )
+
+                config = res.json()
+
+                if res.status_code != 200 or not config.get("access_token"):
+                    raise Exception("Oauth error")
+            else:
+                raise Exception("Oauth error")
 
         if oauth_config.token_info_url:
             # If token info url is given we call it and check the integration id from there

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -324,8 +324,6 @@ class OauthIntegration:
         cls, kind: str, team_id: int, created_by: User, params: dict[str, str]
     ) -> Integration:
         oauth_config = cls.oauth_config_for_kind(kind)
-        # test.salesforce.com
-        # https://test.salesforce.com/services/oauth2/token
         res = requests.post(
             oauth_config.token_url,
             data={

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -355,9 +355,11 @@ class OauthIntegration:
                 config = res.json()
 
                 if res.status_code != 200 or not config.get("access_token"):
-                    raise Exception("Oauth error")
+                    logger.error(f"Oauth error for {kind}", response=res.text)
+                    raise Exception(f"Oauth error for {kind}. Status code = {res.status_code}")
             else:
-                raise Exception("Oauth error")
+                logger.error(f"Oauth error for {kind}", response=res.text)
+                raise Exception(f"Oauth error. Status code = {res.status_code}")
 
         if oauth_config.token_info_url:
             # If token info url is given we call it and check the integration id from there

--- a/posthog/temporal/data_imports/pipelines/salesforce/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/salesforce/__init__.py
@@ -11,7 +11,7 @@ from dlt.sources.helpers.rest_client.paginators import BasePaginator
 from posthog.temporal.common.logger import get_temporal_context
 from posthog.temporal.data_imports.pipelines.rest_source import RESTAPIConfig, rest_api_resources
 from posthog.temporal.data_imports.pipelines.rest_source.typing import EndpointResource
-from posthog.temporal.data_imports.pipelines.salesforce.auth import SalseforceAuth
+from posthog.temporal.data_imports.pipelines.salesforce.auth import SalesforceAuth
 
 LOGGER = structlog.get_logger()
 
@@ -459,7 +459,7 @@ def salesforce_source(
     config: RESTAPIConfig = {
         "client": {
             "base_url": instance_url,
-            "auth": SalseforceAuth(refresh_token, access_token, instance_url),
+            "auth": SalesforceAuth(refresh_token, access_token, instance_url),
             "paginator": SalesforceEndpointPaginator(instance_url=instance_url, is_incremental=is_incremental),
         },
         "resource_defaults": {

--- a/posthog/temporal/data_imports/pipelines/salesforce/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/salesforce/__init__.py
@@ -409,6 +409,9 @@ class SalesforceEndpointPaginator(BasePaginator):
         self._model_name = model_name
 
     def update_request(self, request: Request) -> None:
+        if not self._has_next_page:
+            return
+
         if self.is_incremental:
             # Cludge: Need to get initial value for date filter
             query = request.params.get("q", "")
@@ -456,7 +459,7 @@ def salesforce_source(
     config: RESTAPIConfig = {
         "client": {
             "base_url": instance_url,
-            "auth": SalseforceAuth(refresh_token, access_token),
+            "auth": SalseforceAuth(refresh_token, access_token, instance_url),
             "paginator": SalesforceEndpointPaginator(instance_url=instance_url, is_incremental=is_incremental),
         },
         "resource_defaults": {

--- a/posthog/temporal/data_imports/pipelines/salesforce/auth.py
+++ b/posthog/temporal/data_imports/pipelines/salesforce/auth.py
@@ -4,7 +4,7 @@ from dlt.common.pendulum import pendulum
 from dlt.sources.helpers.rest_client.auth import BearerTokenAuth
 
 
-class SalseforceAuth(BearerTokenAuth):
+class SalesforceAuth(BearerTokenAuth):
     def __init__(self, refresh_token, access_token, instance_url):
         self.parse_native_representation(access_token)
         self.refresh_token = refresh_token

--- a/posthog/temporal/data_imports/pipelines/salesforce/auth.py
+++ b/posthog/temporal/data_imports/pipelines/salesforce/auth.py
@@ -5,10 +5,11 @@ from dlt.sources.helpers.rest_client.auth import BearerTokenAuth
 
 
 class SalseforceAuth(BearerTokenAuth):
-    def __init__(self, refresh_token, access_token):
+    def __init__(self, refresh_token, access_token, instance_url):
         self.parse_native_representation(access_token)
         self.refresh_token = refresh_token
         self.token_expiry: pendulum.DateTime = pendulum.now()
+        self.instance_url = instance_url
 
     def __call__(self, request):
         if self.token is None or self.is_token_expired():
@@ -20,7 +21,7 @@ class SalseforceAuth(BearerTokenAuth):
         return pendulum.now() >= self.token_expiry
 
     def obtain_token(self) -> None:
-        new_token = salesforce_refresh_access_token(self.refresh_token)
+        new_token = salesforce_refresh_access_token(self.refresh_token, self.instance_url)
         self.parse_native_representation(new_token)
         self.token_expiry = pendulum.now().add(hours=1)
 
@@ -59,9 +60,9 @@ class SalesforceAuthRequestError(Exception):
         raise cls(error_message, response=response)
 
 
-def salesforce_refresh_access_token(refresh_token: str) -> str:
+def salesforce_refresh_access_token(refresh_token: str, instance_url: str) -> str:
     res = requests.post(
-        "https://login.salesforce.com/services/oauth2/token",
+        f"{instance_url}/services/oauth2/token",
         data={
             "grant_type": "refresh_token",
             "client_id": settings.SALESFORCE_CONSUMER_KEY,
@@ -75,9 +76,9 @@ def salesforce_refresh_access_token(refresh_token: str) -> str:
     return res.json()["access_token"]
 
 
-def get_salesforce_access_token_from_code(code: str, redirect_uri: str) -> tuple[str, str]:
+def get_salesforce_access_token_from_code(code: str, redirect_uri: str, instance_url: str) -> tuple[str, str]:
     res = requests.post(
-        "https://login.salesforce.com/services/oauth2/token",
+        f"{instance_url}/services/oauth2/token",
         data={
             "grant_type": "authorization_code",
             "client_id": settings.SALESFORCE_CONSUMER_KEY,

--- a/posthog/temporal/data_imports/pipelines/salesforce/test/test_auth.py
+++ b/posthog/temporal/data_imports/pipelines/salesforce/test/test_auth.py
@@ -21,7 +21,7 @@ def test_salesforce_refresh_access_token_raises_on_client_failure():
         ),
         pytest.raises(auth.SalesforceAuthRequestError) as exc,
     ):
-        _ = auth.salesforce_refresh_access_token("something")
+        _ = auth.salesforce_refresh_access_token("something", "https://login.salesforce.com")
 
     assert exc.value.response == response
     assert "Client Error" in str(exc.value)
@@ -43,7 +43,7 @@ def test_salesforce_refresh_access_token_raises_on_server_failure():
         ),
         pytest.raises(auth.SalesforceAuthRequestError) as exc,
     ):
-        _ = auth.salesforce_refresh_access_token("something")
+        _ = auth.salesforce_refresh_access_token("something", "https://login.salesforce.com")
 
     assert exc.value.response == response
     assert "Server Error" in str(exc.value)
@@ -65,7 +65,7 @@ def test_get_salesforce_access_token_from_code_raises_on_client_failure():
         ),
         pytest.raises(auth.SalesforceAuthRequestError) as exc,
     ):
-        _ = auth.get_salesforce_access_token_from_code("something", "something")
+        _ = auth.get_salesforce_access_token_from_code("something", "something", "https://login.salesforce.com")
 
     assert exc.value.response == response
     assert "Client Error" in str(exc.value)
@@ -87,7 +87,7 @@ def test_get_salesforce_access_token_from_code_raises_on_server_failure():
         ),
         pytest.raises(auth.SalesforceAuthRequestError) as exc,
     ):
-        _ = auth.get_salesforce_access_token_from_code("something", "something")
+        _ = auth.get_salesforce_access_token_from_code("something", "something", "https://login.salesforce.com")
 
     assert exc.value.response == response
     assert "Server Error" in str(exc.value)

--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -465,10 +465,12 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
 
             salesforce_access_token = integration.access_token
 
-            if not salesforce_access_token:
-                salesforce_access_token = salesforce_refresh_access_token(salesforce_refresh_token)
-
             salesforce_instance_url = integration.config.get("instance_url")
+
+            if not salesforce_access_token:
+                salesforce_access_token = salesforce_refresh_access_token(
+                    salesforce_refresh_token, salesforce_instance_url
+                )
 
             source = salesforce_source(
                 instance_url=salesforce_instance_url,


### PR DESCRIPTION
## Problem
- Users using a sandbox salesforce account can't connect their account via data warehouse
- https://posthoghelp.zendesk.com/agent/tickets/31879 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/33991)

## Changes
- If we can't get the users access token, try again using the `test.salesforce.com` endpoint instead
- Update all auth requests to use the users instance domain 
  - this comes directly from salesforce and so can't be changed by the user

## How did you test this code?
Connected a sandbox account and synced it 
