### PR TITLE
fix: automatically restart stuck cohorts

### DIFF
--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -117,7 +117,7 @@ def enqueue_cohorts_to_calculate(parallel_count: int) -> None:
     """
     Calculates maximum N cohorts in parallel.
 
-    First processes stuck cohorts (priority), then fills remaining capacity with regular cohorts.
+    First processes stuck cohorts, then fills remaining capacity with regular cohorts.
 
     Args:
         parallel_count: Maximum number of cohorts to calculate in parallel.

--- a/posthog/tasks/test/test_calculate_cohort.py
+++ b/posthog/tasks/test/test_calculate_cohort.py
@@ -12,7 +12,9 @@ from posthog.tasks.calculate_cohort import (
     enqueue_cohorts_to_calculate,
     MAX_AGE_MINUTES,
     MAX_ERRORS_CALCULATING,
+    MAX_STUCK_COHORTS_TO_RESET,
     update_stale_cohort_metrics,
+    reset_stuck_cohorts,
     COHORTS_STALE_COUNT_GAUGE,
     COHORT_STUCK_COUNT_GAUGE,
     increment_version_and_enqueue_calculate_cohort,
@@ -608,5 +610,36 @@ def calculate_cohort_test_factory(event_factory: Callable, person_factory: Calla
 
             mock_chain.assert_called_once_with(mock_task, mock_task, mock_task)
             mock_chain_instance.apply_async.assert_called_once()
+
+        @patch("posthog.tasks.calculate_cohort.logger")
+        def test_reset_stuck_cohorts_respects_max_limit(self, mock_logger: MagicMock) -> None:
+            now = timezone.now()
+
+            # Create more stuck cohorts than the limit
+            stuck_cohorts = []
+            for i in range(MAX_STUCK_COHORTS_TO_RESET + 5):  # Create 5 more than the limit
+                cohort = Cohort.objects.create(
+                    team_id=self.team.pk,
+                    name=f"Stuck Cohort {i}",
+                    is_calculating=True,
+                    last_calculation=now - relativedelta(hours=2, minutes=i),  # Different times for ordering
+                    deleted=False,
+                    is_static=False,
+                )
+                stuck_cohorts.append(cohort)
+
+            # Call the function
+            reset_stuck_cohorts()
+
+            # Count how many were actually reset
+            reset_count = sum(1 for cohort in stuck_cohorts if not Cohort.objects.get(id=cohort.id).is_calculating)
+
+            # Should only reset up to the limit
+            self.assertEqual(reset_count, MAX_STUCK_COHORTS_TO_RESET)
+            # Verify logging shows the correct count
+            mock_logger.warning.assert_called_once()
+            log_kwargs = mock_logger.warning.call_args[1]
+            self.assertEqual(log_kwargs["reset_count"], MAX_STUCK_COHORTS_TO_RESET)
+            self.assertEqual(len(log_kwargs["cohort_ids"]), MAX_STUCK_COHORTS_TO_RESET)
 
     return TestCalculateCohort


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Cohorts often get stuck in a calculating state where `is_calculating` is never set back to false even though the underlying query has completed or failed. This means the cohort is never picked up again by our periodic task for recalculation. The likely cause of the calculation getting stuck in this state is due to OOMs cause by exports. Investigation notes: https://posthog.slack.com/archives/C07Q2U4BH4L/p1749841936710429

The last time I tried to reset stuck cohorts, it resulted in significant load to ClickHouse. See thread here: https://posthog.slack.com/archives/C076R4753Q8/p1749310677162049

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

This time, I want to limit reseting cohorts to only 10 at a time. 

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [x] No docs needed for this change
- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
