### PR TITLE
chore: Do not show others

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -291,6 +291,7 @@ export const FEATURE_FLAGS = {
     ANNOTATIONS_RECORDING_SCOPE: 'annotations-recording-scope', // owner: @pauldambra #team-replay,
     EXPERIMENTS_NEW_RUNNER_RESULTS_BREAKDOWN: 'experiments-new-runner-results-breakdown', // owner: @rodrigoi #team-experiments
     REPLAY_ZEN_MODE: 'replay-zen-mode', // owner: @veryayskiy #team-replay
+    REPLAY_EXCLUDE_FROM_HIDE_RECORDINGS_MENU: 'replay-exclude-from-hide-recordings-menu', // owner: @veryayskiy #team-replay
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFilters.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFilters.tsx
@@ -8,6 +8,8 @@ import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import UniversalFilters from 'lib/components/UniversalFilters/UniversalFilters'
 import { universalFiltersLogic } from 'lib/components/UniversalFilters/universalFiltersLogic'
 import { isUniversalGroupFilterLike } from 'lib/components/UniversalFilters/utils'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { useEffect, useState } from 'react'
 import { TestAccountFilter } from 'scenes/insights/filters/TestAccountFilter'
 import { MaxTool } from 'scenes/max/MaxTool'
@@ -33,30 +35,37 @@ import { SavedFilters } from './SavedFilters'
 export function HideRecordingsMenu(): JSX.Element {
     const { hideViewedRecordings, hideRecordingsMenuLabelFor } = useValues(playerSettingsLogic)
     const { setHideViewedRecordings } = useActions(playerSettingsLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+
+    const items = [
+        {
+            label: hideRecordingsMenuLabelFor(false),
+            onClick: () => setHideViewedRecordings(false),
+            active: !hideViewedRecordings,
+            'data-attr': 'hide-viewed-recordings-show-all',
+        },
+        {
+            label: hideRecordingsMenuLabelFor('current-user'),
+            onClick: () => setHideViewedRecordings('current-user'),
+            active: hideViewedRecordings === 'current-user',
+            'data-attr': 'hide-viewed-recordings-hide-current-user',
+        },
+    ]
+
+    // If the person wished to be excluded from the hide recordings menu, we don't show the option to hide recordings that other people have watched
+    if (!featureFlags[FEATURE_FLAGS.REPLAY_EXCLUDE_FROM_HIDE_RECORDINGS_MENU]) {
+        items.push({
+            label: hideRecordingsMenuLabelFor('any-user'),
+            onClick: () => setHideViewedRecordings('any-user'),
+            active: hideViewedRecordings === 'any-user',
+            'data-attr': 'hide-viewed-recordings-hide-any-user',
+        })
+    }
 
     return (
         <SettingsMenu
             highlightWhenActive={false}
-            items={[
-                {
-                    label: hideRecordingsMenuLabelFor(false),
-                    onClick: () => setHideViewedRecordings(false),
-                    active: !hideViewedRecordings,
-                    'data-attr': 'hide-viewed-recordings-show-all',
-                },
-                {
-                    label: hideRecordingsMenuLabelFor('current-user'),
-                    onClick: () => setHideViewedRecordings('current-user'),
-                    active: hideViewedRecordings === 'current-user',
-                    'data-attr': 'hide-viewed-recordings-hide-current-user',
-                },
-                {
-                    label: hideRecordingsMenuLabelFor('any-user'),
-                    onClick: () => setHideViewedRecordings('any-user'),
-                    active: hideViewedRecordings === 'any-user',
-                    'data-attr': 'hide-viewed-recordings-hide-any-user',
-                },
-            ]}
+            items={items}
             icon={hideViewedRecordings ? <IconHide /> : <IconEye />}
             rounded={true}
             label={hideRecordingsMenuLabelFor(hideViewedRecordings)}

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingPreview.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingPreview.tsx
@@ -5,8 +5,10 @@ import clsx from 'clsx'
 import { useValues } from 'kea'
 import { PropertyIcon } from 'lib/components/PropertyIcon/PropertyIcon'
 import { TZLabel } from 'lib/components/TZLabel'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { colonDelimitedDuration } from 'lib/utils'
 import { DraggableToNotebook } from 'scenes/notebooks/AddToNotebook/DraggableToNotebook'
 import { asDisplay } from 'scenes/persons/person-utils'
@@ -148,7 +150,14 @@ function RecordingOngoingIndicator(): JSX.Element {
 }
 
 export function UnwatchedIndicator({ otherViewersCount }: { otherViewersCount: number }): JSX.Element {
-    const tooltip = otherViewersCount ? (
+    const { featureFlags } = useValues(featureFlagLogic)
+
+    const isExcludedFromHideRecordingsMenu = featureFlags[FEATURE_FLAGS.REPLAY_EXCLUDE_FROM_HIDE_RECORDINGS_MENU]
+
+    // If person wished to be excluded from the hide recordings menu, we don't show the tooltip
+    const tooltip = isExcludedFromHideRecordingsMenu ? (
+        <span>You have not watched this recording yet.</span>
+    ) : otherViewersCount ? (
         <span>
             You have not watched this recording yet. {otherViewersCount} other{' '}
             {otherViewersCount === 1 ? 'person has' : 'people have'}.
@@ -162,10 +171,18 @@ export function UnwatchedIndicator({ otherViewersCount }: { otherViewersCount: n
             <div
                 className={clsx(
                     'UnwatchedIndicator w-2 h-2 rounded-full',
-                    otherViewersCount ? 'UnwatchedIndicator--secondary' : 'UnwatchedIndicator--primary'
+                    isExcludedFromHideRecordingsMenu
+                        ? 'UnwatchedIndicator--primary'
+                        : otherViewersCount
+                        ? 'UnwatchedIndicator--secondary'
+                        : 'UnwatchedIndicator--primary'
                 )}
                 aria-label={
-                    otherViewersCount ? 'unwatched-recording-by-you-label' : 'unwatched-recording-by-everyone-label'
+                    isExcludedFromHideRecordingsMenu
+                        ? 'unwatched-recording-by-you-label'
+                        : otherViewersCount
+                        ? 'unwatched-recording-by-you-label'
+                        : 'unwatched-recording-by-everyone-label'
                 }
             />
         </Tooltip>


### PR DESCRIPTION
Some customers do not want others to see what recording they watched.

So let's add a FF to exclude organizations to see that feature.

### Before
<img width="238" alt="Screenshot 2025-06-17 at 20 44 17" src="https://github.com/user-attachments/assets/7243367c-0174-48c5-94e9-47b3bf37bb64" />
<img width="352" alt="Screenshot 2025-06-17 at 20 44 43" src="https://github.com/user-attachments/assets/1cea82c7-9fa6-49b6-8824-3ea1ee84faf1" />


### After if FF is on
<img width="360" alt="Screenshot 2025-06-17 at 20 36 47" src="https://github.com/user-attachments/assets/10a40aab-e2c8-401e-8569-b58f20e47f4f" />
<img width="292" alt="Screenshot 2025-06-17 at 20 36 43" src="https://github.com/user-attachments/assets/65579893-e2e6-4fed-a684-02953157cc26" />

