### PR TITLE
feat(capture): Set up capture and capture-relay for local dev

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -48,15 +48,27 @@ procs:
 
     cymbal:
         shell: |-
-            bin/check_postgres_up cyclotron && \
+            bin/check_postgres_up && \
             bin/check_kafka_clickhouse_up && \
             bin/start-rust-service cymbal
 
     property-defs-rs:
         shell: |-
-            bin/check_postgres_up cyclotron && \
+            bin/check_postgres_up && \
             bin/check_kafka_clickhouse_up && \
             bin/start-rust-service property-defs-rs
+
+    capture:
+        shell: |-
+            bin/check_postgres_up && \
+            bin/check_kafka_clickhouse_up && \
+            bin/start-rust-service capture
+
+    capture-relay:
+        shell: |-
+            bin/check_postgres_up && \
+            bin/check_kafka_clickhouse_up && \
+            bin/start-rust-service capture-relay
 
     migrate-clickhouse:
         # These migrations are not in the `backend` service, because they typically aren't blocking for backend startup,

--- a/bin/start-rust-service
+++ b/bin/start-rust-service
@@ -68,7 +68,7 @@ case "$RS_SVC" in
     export RUST_LOG=debug,rdkafka=warn
     export RUST_BACKTRACE=1
     export KAFKA_CONSUMER_GROUP=cymbal
-    export KAFKA_CONSUMER_TOPIC=exception_symbolification_events
+    export KAFKA_CONSUMER_TOPIC=exceptions_ingestion
     export OBJECT_STORAGE_BUCKET=posthog
     export OBJECT_STORAGE_ACCESS_KEY_ID=object_storage_root_user
     export OBJECT_STORAGE_SECRET_ACCESS_KEY=object_storage_root_password

--- a/bin/start-rust-service
+++ b/bin/start-rust-service
@@ -22,7 +22,7 @@ RS_SVC="$1"
 case "$RS_SVC" in
   property-defs-rs)
     SQLX_QUERY_LEVEL=${SQLX_QUERY_LEVEL:-warn}
-    export RUST_LOG=debug,sqlx::query=$SQLX_QUERY_LEVEL
+    export RUST_LOG=debug,sqlx::query=$SQLX_QUERY_LEVEL,rdkafka=warn
     export RUST_BACKTRACE=1
     export KAFKA_HOSTS=localhost:9092
     export DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog
@@ -30,6 +30,35 @@ case "$RS_SVC" in
     export SKIP_READS=false
     export FILTER_MODE=opt-out
     export DEBUG=1
+    ;;
+
+  capture)
+    SQLX_QUERY_LEVEL=${SQLX_QUERY_LEVEL:-warn}
+    export RUST_LOG=debug,sqlx::query=$SQLX_QUERY_LEVEL,rdkafka=warn
+    export RUST_BACKTRACE=1
+    export ADDRESS=127.0.0.1:3303 # avoid port conflict in local dev
+    export KAFKA_HOSTS=localhost:9092
+    export REDIS_URL=redis://localhost:6479
+    export DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog
+    export CAPTURE_MODE=events
+    export LOG_LEVEL=debug
+    export DEBUG=1
+    ;;
+
+  capture-relay)
+    SQLX_QUERY_LEVEL=${SQLX_QUERY_LEVEL:-warn}
+    export RUST_LOG=debug,sqlx::query=$SQLX_QUERY_LEVEL,rdkafka=warn
+    export RUST_BACKTRACE=1
+    export ADDRESS=127.0.0.1:3304 # avoid port conflict in local dev
+    export KAFKA_HOSTS=localhost:9092
+    export KAFKA_TOPIC=session_recording_snapshot_item_events
+    export KAFKA_OVERFLOW_TOPIC=session_recording_snapshot_item_overflow
+    export REDIS_URL=redis://localhost:6479
+    export DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog
+    export CAPTURE_MODE=recordings
+    export LOG_LEVEL=debug
+    export DEBUG=1
+    export DEV_RUST_SVC_OVERRIDE=capture # we want to run the same "capture" binary in a separate mode
     ;;
 
   cymbal)
@@ -78,6 +107,13 @@ case "$RS_SVC" in
     exit 1
     ;;
 esac
+
+# in some cases, we need to run the same underlying binary
+# with different configuration - if a given RS_SVC config
+# above sets the override env var, apply it here
+if [[ -n "${DEV_RUST_SVC_OVERRIDE:-}" ]]; then
+  export RS_SVC="$DEV_RUST_SVC_OVERRIDE"
+fi
 
 # ensure Rust services are in scope for "cargo run --bin <SERVICE_NAME>"
 cd rust


### PR DESCRIPTION
## Problem
As part of migrating off `capture.py` we'll need to stand up the replacement Rust services in our local dev env.

## Changes
Part 1 of a series:
* Sets up `capture` and `capture-relay` to run as part of `bin/start` services
* Swaps `cymbal` in `bin/start` to consume new exceptions topic, starts healthy now
* Includes misc. related small cleanups and tweaks to the backing scripts

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Local dev + CI