### PR TITLE
fix: org domain admain make org searchable so it doesn't load them all

### DIFF
--- a/posthog/admin/admins/organization_domain_admin.py
+++ b/posthog/admin/admins/organization_domain_admin.py
@@ -23,6 +23,7 @@ class OrganizationDomainAdmin(admin.ModelAdmin):
         "verification_challenge",
         "last_verification_retry",
     )
+    autocomplete_fields = ["organization"]
     fieldsets = (
         (None, {"fields": ("id", "organization", "domain")}),
         ("Verification", {"fields": ("verification_challenge", "verified_at", "last_verification_retry")}),


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changes

When we use org directly it tried to load them all so making it auto complete will only load a few and make the page more performant

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

Locally
