### PR TITLE
fix: fixing order of cleaning so it works for self managed src

### DIFF
--- a/frontend/src/scenes/data-warehouse/settings/DataWarehouseSourceScene.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/DataWarehouseSourceScene.tsx
@@ -104,7 +104,7 @@ export function DataWarehouseSourceScene(): JSX.Element {
         return <NotFound object="Data warehouse source" />
     }
 
-    const cleanId = id.replace('managed-', '').replace('self-managed-', '')
+    const cleanId = id.replace('self-managed-', '').replace('managed-', '')
 
     const tabs: LemonTab<DataWarehouseSourceSceneTab>[] = id.startsWith('managed-')
         ? [


### PR DESCRIPTION
## Problem

The is a bug in the path for self managed sources.

## Changes

Reoder cleaning logic so it first clean the `self-managed-` string then `managed-` otherwise it won't work.

## Did you write or update any docs for this change?
NA

## How did you test this code?

Manually:
Before:
![image](https://github.com/user-attachments/assets/259a436c-c7dc-4b02-a65e-77c30d20e531)
![image](https://github.com/user-attachments/assets/f4f0044c-02f5-483f-a178-5777915e5a60)

Now: (working)
<img width="1381" alt="image" src="https://github.com/user-attachments/assets/c1a50fff-2e34-473c-b3b1-986be89aa49f" />


