### PR TITLE
feat: Add git commit sha to query log

### DIFF
--- a/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
+++ b/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
@@ -547,22 +547,12 @@ function ProfilingStats({ item }: { item: Query }): JSX.Element | null {
 
 function QueryContext({ item }: { item: Query }): JSX.Element | null {
     const logComment = item.logComment
-    const { modifiers, git_commit, container_hostname } = logComment || {}
 
-    const context: Record<string, unknown> = {}
-    if (git_commit) {
-        context.git_commit = git_commit
-    }
-    if (container_hostname) {
-        context.container_hostname = container_hostname
-    }
-    if (modifiers && Object.keys(modifiers).length > 0) {
-        context.modifiers = modifiers
-    }
-
-    if (!git_commit && !container_hostname && !(modifiers && Object.keys(modifiers).length > 0)) {
+    if (!logComment) {
         return null
     }
+
+    const { modifiers, git_commit, container_hostname } = logComment
 
     return (
         <div>
@@ -578,14 +568,16 @@ function QueryContext({ item }: { item: Query }): JSX.Element | null {
                     </tr>
                 </tbody>
             </table>
-            <CodeSnippet
-                language={Language.JSON}
-                maxLinesWithoutExpansion={0}
-                key={item.query_id}
-                className="text-sm mb-2 w-80"
-            >
-                {JSON.stringify(modifiers, null, 2)}
-            </CodeSnippet>
+            {modifiers && Object.keys(modifiers).length > 0 ? (
+                <CodeSnippet
+                    language={Language.JSON}
+                    maxLinesWithoutExpansion={0}
+                    key={item.query_id}
+                    className="text-sm mb-2 w-80"
+                >
+                    {JSON.stringify(modifiers, null, 2)}
+                </CodeSnippet>
+            ) : null}
         </div>
     )
 }

--- a/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
+++ b/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
@@ -443,146 +443,12 @@ export function DebugCHQueries({ insightId }: DebugCHQueriesProps): JSX.Element 
                         },
                     },
                     {
-                        title: 'Profiling stats',
-                        render: function ProfilingStats(_, item) {
-                            const [areAllStatsShown, setAreAllStatsShown] = useState(false)
-                            const event = item['profile_events']
-                            if (!event) {
-                                return
-                            }
+                        title: 'Metadata',
+                        render: (_, item) => {
                             return (
-                                <div>
-                                    {!areAllStatsShown ? (
-                                        <table className="w-80">
-                                            <tbody>
-                                                <tr>
-                                                    <td>Bytes selected (all nodes, uncompressed)</td>
-                                                    <td>
-                                                        {event['SelectedBytes'] != null ? (
-                                                            humanizeBytes(event['SelectedBytes'])
-                                                        ) : (
-                                                            <i>unknown</i>
-                                                        )}
-                                                    </td>
-                                                </tr>
-                                                <tr>
-                                                    <td>Bytes read from disk (excl. page cache)</td>
-                                                    <td>
-                                                        {event['OSReadBytes'] != null ? (
-                                                            humanizeBytes(event['OSReadBytes'])
-                                                        ) : (
-                                                            <i>unknown</i>
-                                                        )}
-                                                    </td>
-                                                </tr>
-                                                <tr>
-                                                    <td>Bytes read from disk (incl. page cache)</td>
-                                                    <td>
-                                                        {event['OSReadChars'] != null ? (
-                                                            humanizeBytes(event['OSReadChars'])
-                                                        ) : (
-                                                            <i>unknown</i>
-                                                        )}
-                                                    </td>
-                                                </tr>
-                                                <tr>
-                                                    <td>Page cache hit rate</td>
-                                                    <td>
-                                                        {event['OSReadBytes'] != null &&
-                                                        event['OSReadChars'] != null ? (
-                                                            `${Math.round(
-                                                                ((event['OSReadChars'] - event['OSReadBytes']) /
-                                                                    event['OSReadChars']) *
-                                                                    100
-                                                            )}%`
-                                                        ) : (
-                                                            <i>unknown</i>
-                                                        )}
-                                                    </td>
-                                                </tr>
-                                                <tr>
-                                                    <td>Bytes received over network</td>
-                                                    <td>
-                                                        {event['NetworkReceiveBytes'] != null ? (
-                                                            humanizeBytes(event['NetworkReceiveBytes'])
-                                                        ) : (
-                                                            <i>unknown</i>
-                                                        )}
-                                                    </td>
-                                                </tr>
-                                            </tbody>
-                                        </table>
-                                    ) : (
-                                        <CodeSnippet
-                                            language={Language.JSON}
-                                            maxLinesWithoutExpansion={0}
-                                            key={item.query_id}
-                                            className="text-sm mb-2"
-                                        >
-                                            {JSON.stringify(event, null, 2)}
-                                        </CodeSnippet>
-                                    )}
-                                    <LemonButton
-                                        type="secondary"
-                                        size="xsmall"
-                                        onClick={() => setAreAllStatsShown(!areAllStatsShown)}
-                                        className="my-1"
-                                        fullWidth
-                                        center
-                                    >
-                                        {areAllStatsShown ? 'Show key stats only' : 'Show full raw stats'}
-                                    </LemonButton>
-                                </div>
-                            )
-                        },
-                    },
-                    {
-                        title: 'Context',
-                        render: function QueryContext(_, item) {
-                            const logComment = item.logComment
-                            const { modifiers, git_commit, container_hostname } = logComment || {}
-
-                            const context: Record<string, unknown> = {}
-                            if (git_commit) {
-                                context.git_commit = git_commit
-                            }
-                            if (container_hostname) {
-                                context.container_hostname = container_hostname
-                            }
-                            if (modifiers && Object.keys(modifiers).length > 0) {
-                                context.modifiers = modifiers
-                            }
-
-                            if (
-                                !git_commit &&
-                                !container_hostname &&
-                                !(modifiers && Object.keys(modifiers).length > 0)
-                            ) {
-                                return null
-                            }
-
-                            return (
-                                <div>
-                                    <table className="w-60">
-                                        <tbody>
-                                            <tr>
-                                                <td>Git commit SHA</td>
-                                                <td>{git_commit}</td>
-                                            </tr>
-                                            <tr>
-                                                <td>Container hostname</td>
-                                                <td>{container_hostname}</td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                    <CodeSnippet
-                                        language={Language.JSON}
-                                        maxLinesWithoutExpansion={0}
-                                        key={item.query_id}
-                                        className="text-sm mb-2 w-60"
-                                    >
-                                        {JSON.stringify(modifiers, null, 2)}
-                                    </CodeSnippet>
+                                <div className="space-y-4">
+                                    <ProfilingStats item={item} />
+                                    <QueryContext item={item} />
                                 </div>
                             )
                         },
@@ -595,5 +461,131 @@ export function DebugCHQueries({ insightId }: DebugCHQueriesProps): JSX.Element 
                 rowClassName="align-top"
             />
         </>
+    )
+}
+
+function ProfilingStats({ item }: { item: Query }): JSX.Element | null {
+    const [areAllStatsShown, setAreAllStatsShown] = useState(false)
+    const event = item['profile_events']
+    if (!event) {
+        return
+    }
+    return (
+        <div>
+            {!areAllStatsShown ? (
+                <table className="w-80">
+                    <tbody>
+                        <tr>
+                            <td>Bytes selected (all nodes, uncompressed)</td>
+                            <td>
+                                {event['SelectedBytes'] != null ? (
+                                    humanizeBytes(event['SelectedBytes'])
+                                ) : (
+                                    <i>unknown</i>
+                                )}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Bytes read from disk (excl. page cache)</td>
+                            <td>
+                                {event['OSReadBytes'] != null ? humanizeBytes(event['OSReadBytes']) : <i>unknown</i>}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Bytes read from disk (incl. page cache)</td>
+                            <td>
+                                {event['OSReadChars'] != null ? humanizeBytes(event['OSReadChars']) : <i>unknown</i>}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Page cache hit rate</td>
+                            <td>
+                                {event['OSReadBytes'] != null && event['OSReadChars'] != null ? (
+                                    `${Math.round(
+                                        ((event['OSReadChars'] - event['OSReadBytes']) / event['OSReadChars']) * 100
+                                    )}%`
+                                ) : (
+                                    <i>unknown</i>
+                                )}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Bytes received over network</td>
+                            <td>
+                                {event['NetworkReceiveBytes'] != null ? (
+                                    humanizeBytes(event['NetworkReceiveBytes'])
+                                ) : (
+                                    <i>unknown</i>
+                                )}
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            ) : (
+                <CodeSnippet
+                    language={Language.JSON}
+                    maxLinesWithoutExpansion={0}
+                    key={item.query_id}
+                    className="text-sm mb-2"
+                >
+                    {JSON.stringify(event, null, 2)}
+                </CodeSnippet>
+            )}
+            <LemonButton
+                type="secondary"
+                size="xsmall"
+                onClick={() => setAreAllStatsShown(!areAllStatsShown)}
+                className="my-1"
+                fullWidth
+                center
+            >
+                {areAllStatsShown ? 'Show key stats only' : 'Show full raw stats'}
+            </LemonButton>
+        </div>
+    )
+}
+
+function QueryContext({ item }: { item: Query }): JSX.Element | null {
+    const logComment = item.logComment
+    const { modifiers, git_commit, container_hostname } = logComment || {}
+
+    const context: Record<string, unknown> = {}
+    if (git_commit) {
+        context.git_commit = git_commit
+    }
+    if (container_hostname) {
+        context.container_hostname = container_hostname
+    }
+    if (modifiers && Object.keys(modifiers).length > 0) {
+        context.modifiers = modifiers
+    }
+
+    if (!git_commit && !container_hostname && !(modifiers && Object.keys(modifiers).length > 0)) {
+        return null
+    }
+
+    return (
+        <div>
+            <table className="w-80">
+                <tbody>
+                    <tr>
+                        <td>Git commit SHA</td>
+                        <td>{git_commit}</td>
+                    </tr>
+                    <tr>
+                        <td>Container hostname</td>
+                        <td>{container_hostname}</td>
+                    </tr>
+                </tbody>
+            </table>
+            <CodeSnippet
+                language={Language.JSON}
+                maxLinesWithoutExpansion={0}
+                key={item.query_id}
+                className="text-sm mb-2 w-80"
+            >
+                {JSON.stringify(modifiers, null, 2)}
+            </CodeSnippet>
+        </div>
     )
 }

--- a/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
+++ b/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
@@ -454,60 +454,63 @@ export function DebugCHQueries({ insightId }: DebugCHQueriesProps): JSX.Element 
                                 <div>
                                     {!areAllStatsShown ? (
                                         <table className="w-80">
-                                            <tr>
-                                                <td>Bytes selected (all nodes, uncompressed)</td>
-                                                <td>
-                                                    {event['SelectedBytes'] != null ? (
-                                                        humanizeBytes(event['SelectedBytes'])
-                                                    ) : (
-                                                        <i>unknown</i>
-                                                    )}
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <td>Bytes read from disk (excl. page cache)</td>
-                                                <td>
-                                                    {event['OSReadBytes'] != null ? (
-                                                        humanizeBytes(event['OSReadBytes'])
-                                                    ) : (
-                                                        <i>unknown</i>
-                                                    )}
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <td>Bytes read from disk (incl. page cache)</td>
-                                                <td>
-                                                    {event['OSReadChars'] != null ? (
-                                                        humanizeBytes(event['OSReadChars'])
-                                                    ) : (
-                                                        <i>unknown</i>
-                                                    )}
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <td>Page cache hit rate</td>
-                                                <td>
-                                                    {event['OSReadBytes'] != null && event['OSReadChars'] != null ? (
-                                                        `${Math.round(
-                                                            ((event['OSReadChars'] - event['OSReadBytes']) /
-                                                                event['OSReadChars']) *
-                                                                100
-                                                        )}%`
-                                                    ) : (
-                                                        <i>unknown</i>
-                                                    )}
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <td>Bytes received over network</td>
-                                                <td>
-                                                    {event['NetworkReceiveBytes'] != null ? (
-                                                        humanizeBytes(event['NetworkReceiveBytes'])
-                                                    ) : (
-                                                        <i>unknown</i>
-                                                    )}
-                                                </td>
-                                            </tr>
+                                            <tbody>
+                                                <tr>
+                                                    <td>Bytes selected (all nodes, uncompressed)</td>
+                                                    <td>
+                                                        {event['SelectedBytes'] != null ? (
+                                                            humanizeBytes(event['SelectedBytes'])
+                                                        ) : (
+                                                            <i>unknown</i>
+                                                        )}
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td>Bytes read from disk (excl. page cache)</td>
+                                                    <td>
+                                                        {event['OSReadBytes'] != null ? (
+                                                            humanizeBytes(event['OSReadBytes'])
+                                                        ) : (
+                                                            <i>unknown</i>
+                                                        )}
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td>Bytes read from disk (incl. page cache)</td>
+                                                    <td>
+                                                        {event['OSReadChars'] != null ? (
+                                                            humanizeBytes(event['OSReadChars'])
+                                                        ) : (
+                                                            <i>unknown</i>
+                                                        )}
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td>Page cache hit rate</td>
+                                                    <td>
+                                                        {event['OSReadBytes'] != null &&
+                                                        event['OSReadChars'] != null ? (
+                                                            `${Math.round(
+                                                                ((event['OSReadChars'] - event['OSReadBytes']) /
+                                                                    event['OSReadChars']) *
+                                                                    100
+                                                            )}%`
+                                                        ) : (
+                                                            <i>unknown</i>
+                                                        )}
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td>Bytes received over network</td>
+                                                    <td>
+                                                        {event['NetworkReceiveBytes'] != null ? (
+                                                            humanizeBytes(event['NetworkReceiveBytes'])
+                                                        ) : (
+                                                            <i>unknown</i>
+                                                        )}
+                                                    </td>
+                                                </tr>
+                                            </tbody>
                                         </table>
                                     ) : (
                                         <CodeSnippet
@@ -529,6 +532,57 @@ export function DebugCHQueries({ insightId }: DebugCHQueriesProps): JSX.Element 
                                     >
                                         {areAllStatsShown ? 'Show key stats only' : 'Show full raw stats'}
                                     </LemonButton>
+                                </div>
+                            )
+                        },
+                    },
+                    {
+                        title: 'Context',
+                        render: function QueryContext(_, item) {
+                            const logComment = item.logComment
+                            const { modifiers, git_commit, container_hostname } = logComment || {}
+
+                            const context: Record<string, unknown> = {}
+                            if (git_commit) {
+                                context.git_commit = git_commit
+                            }
+                            if (container_hostname) {
+                                context.container_hostname = container_hostname
+                            }
+                            if (modifiers && Object.keys(modifiers).length > 0) {
+                                context.modifiers = modifiers
+                            }
+
+                            if (
+                                !git_commit &&
+                                !container_hostname &&
+                                !(modifiers && Object.keys(modifiers).length > 0)
+                            ) {
+                                return null
+                            }
+
+                            return (
+                                <div>
+                                    <table className="w-60">
+                                        <tbody>
+                                            <tr>
+                                                <td>Git commit SHA</td>
+                                                <td>{git_commit}</td>
+                                            </tr>
+                                            <tr>
+                                                <td>Container hostname</td>
+                                                <td>{container_hostname}</td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                    <CodeSnippet
+                                        language={Language.JSON}
+                                        maxLinesWithoutExpansion={0}
+                                        key={item.query_id}
+                                        className="text-sm mb-2 w-60"
+                                    >
+                                        {JSON.stringify(modifiers, null, 2)}
+                                    </CodeSnippet>
                                 </div>
                             )
                         },

--- a/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
+++ b/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
@@ -468,7 +468,7 @@ function ProfilingStats({ item }: { item: Query }): JSX.Element | null {
     const [areAllStatsShown, setAreAllStatsShown] = useState(false)
     const event = item['profile_events']
     if (!event) {
-        return
+        return null
     }
     return (
         <div>

--- a/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
+++ b/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
@@ -611,7 +611,8 @@ function Timing({ item }: { item: Query }): JSX.Element | null {
 
         let slowestSpan = { name: '', duration: 0 }
         const entries = Object.entries(timings)
-        // find the entries where the key is not a prefix of another key. This is quadratic, but the number of entries is small, do something smart if this becomes a problem
+        // Find the entries where the key is not a prefix of another key (with / as the separator).
+        // This is quadratic, but the number of entries is small, do something smart if this becomes a problem
         const leafEntries = entries.filter(
             ([key]) => !entries.some(([otherKey]) => otherKey.startsWith(key + '/') && otherKey !== key)
         )

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -14,7 +14,13 @@ thread_local_storage = threading.local()
 def get_constant_tags():
     # import locally to avoid circular imports
     from posthog.git import get_git_commit_short
-    from posthog.settings import CONTAINER_HOSTNAME
+    from posthog.settings import CONTAINER_HOSTNAME, TEST
+
+    if TEST:
+        return {
+            "git_commit": "test",
+            "container_hostname": "test",
+        }
 
     return {
         "git_commit": get_git_commit_short(),

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -5,14 +5,25 @@ from typing import Any, Optional
 from collections.abc import Generator
 from contextlib import contextmanager
 
+from posthog.git import get_git_commit_short
+from posthog.settings import CONTAINER_HOSTNAME
+
 thread_local_storage = threading.local()
+
+
+def get_constant_tags():
+    return {
+        "git_commit": get_git_commit_short(),
+        "container_hostname": CONTAINER_HOSTNAME,
+    }
 
 
 def get_query_tags():
     try:
-        return thread_local_storage.query_tags
+        tags = thread_local_storage.query_tags
     except AttributeError:
-        return {}
+        tags = {}
+    return {**tags, **get_constant_tags()}
 
 
 def get_query_tag_value(key: str) -> Optional[Any]:

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -5,13 +5,17 @@ from typing import Any, Optional
 from collections.abc import Generator
 from contextlib import contextmanager
 
-from posthog.git import get_git_commit_short
-from posthog.settings import CONTAINER_HOSTNAME
+from cachetools import cached
 
 thread_local_storage = threading.local()
 
 
+@cached(cache={})
 def get_constant_tags():
+    # import locally to avoid circular imports
+    from posthog.git import get_git_commit_short
+    from posthog.settings import CONTAINER_HOSTNAME
+
     return {
         "git_commit": get_git_commit_short(),
         "container_hostname": CONTAINER_HOSTNAME,

--- a/posthog/clickhouse/test/test_query_tagging.py
+++ b/posthog/clickhouse/test/test_query_tagging.py
@@ -1,28 +1,39 @@
 from posthog.clickhouse.query_tagging import tag_queries, get_query_tags, tags_context, clear_tag, reset_query_tags
 
 
+expected_builtin_tags = {
+    "git_commit": "test",
+    "container_hostname": "test",
+}
+
+
 def test_clear_tag():
     clear_tag("some")
     reset_query_tags()
-    assert get_query_tags() == {}
+    assert get_query_tags() == {**expected_builtin_tags}
     tag_queries(another=True)
-    assert get_query_tags() == {"another": True}
+    assert get_query_tags() == {"another": True, **expected_builtin_tags}
     clear_tag("some")
-    assert get_query_tags() == {"another": True}
+    assert get_query_tags() == {"another": True, **expected_builtin_tags}
     clear_tag("another")
-    assert get_query_tags() == {}
+    assert get_query_tags() == {**expected_builtin_tags}
 
 
 def test_tags_context():
     reset_query_tags()
     # Set initial tags
     tag_queries(initial="value")
-    assert get_query_tags() == {"initial": "value"}
+    assert get_query_tags() == {"initial": "value", **expected_builtin_tags}
 
     # Modify tags within context
     with tags_context(in_context="true"):
         tag_queries(test="test_value")
-        assert get_query_tags() == {"initial": "value", "test": "test_value", "in_context": "true"}
+        assert get_query_tags() == {
+            "initial": "value",
+            "test": "test_value",
+            "in_context": "true",
+            **expected_builtin_tags,
+        }
 
         # Modify more
         tag_queries(another="another_value", initial="not a value")
@@ -31,7 +42,8 @@ def test_tags_context():
             "test": "test_value",
             "another": "another_value",
             "in_context": "true",
+            **expected_builtin_tags,
         }
 
     # Verify tags are restored
-    assert get_query_tags() == {"initial": "value"}
+    assert get_query_tags() == {"initial": "value", **expected_builtin_tags}

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -322,7 +322,6 @@ class CHQueries:
             route_id=route.route,
             client_query_id=self._get_param(request, "client_query_id"),
             session_id=self._get_param(request, "session_id"),
-            container_hostname=settings.CONTAINER_HOSTNAME,
             http_referer=request.META.get("HTTP_REFERER"),
             http_user_agent=request.META.get("HTTP_USER_AGENT"),
         )


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

I found myself wanting to know the git commit sha that a query was generated by, so add this to the log_comment, and show it in the UI

## Changes
Add a get_constant_tags() function for values that are appended to all query log comments.

As a drive-by, I moved the container_hostname into this function from the middleware.

When showing this in the UI, I also added some timing data

<img width="1577" alt="Screenshot 2025-06-18 at 09 01 52" src="https://github.com/user-attachments/assets/236eb1dc-fa16-4be7-90d9-f995192a8cce" />


## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

n/a
