### PR TITLE
fix(err): add tooltip for script errors

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
@@ -9,7 +9,7 @@ import {
     TaxonomicFilterProps,
 } from 'lib/components/TaxonomicFilter/types'
 import { LemonInput, LemonInputPropsText } from 'lib/lemon-ui/LemonInput/LemonInput'
-import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { Tooltip, TooltipProps } from 'lib/lemon-ui/Tooltip'
 import { forwardRef, useEffect, useMemo, useRef, useState } from 'react'
 
 import { InfiniteSelectResults } from './InfiniteSelectResults'
@@ -133,8 +133,9 @@ export const TaxonomicFilterSearchInput = forwardRef<
     {
         searchInputRef: React.Ref<HTMLInputElement> | null
         onClose: TaxonomicFilterProps['onClose']
-    } & Pick<LemonInputPropsText, 'onClick' | 'size' | 'prefix' | 'fullWidth' | 'onChange'>
->(function UniversalSearchInput({ searchInputRef, onClose, onChange, ...props }, ref): JSX.Element {
+    } & Pick<LemonInputPropsText, 'onClick' | 'size' | 'prefix' | 'fullWidth' | 'onChange'> &
+        Pick<TooltipProps, 'docLink'>
+>(function UniversalSearchInput({ searchInputRef, onClose, onChange, docLink, ...props }, ref): JSX.Element {
     const { searchQuery, searchPlaceholder } = useValues(taxonomicFilterLogic)
     const {
         setSearchQuery: setTaxonomicSearchQuery,
@@ -162,16 +163,10 @@ export const TaxonomicFilterSearchInput = forwardRef<
             suffix={
                 <Tooltip
                     title={
-                        <>
-                            You can easily navigate between tabs with your keyboard.{' '}
-                            <div>
-                                Use <b>tab</b> to move to the next tab.
-                            </div>
-                            <div>
-                                Use <b>shift + tab</b> to move to the previous tab.
-                            </div>
-                        </>
+                        'Fuzzy text search, or filter by specific properties and values.' +
+                        (docLink ? ' Check the documentation for more information.' : '')
                     }
+                    docLink={docLink}
                 >
                     <IconKeyboard style={{ fontSize: '1.2rem' }} className="text-secondary" />
                 </Tooltip>

--- a/products/error_tracking/frontend/components/ErrorFilters/FilterGroup.tsx
+++ b/products/error_tracking/frontend/components/ErrorFilters/FilterGroup.tsx
@@ -93,6 +93,7 @@ const UniversalSearch = (): JSX.Element => {
                     onChange={setSearchQuery}
                     size="small"
                     fullWidth
+                    docLink="https://posthog.com/docs/error-tracking/filter-and-search-issues"
                 />
             </LemonDropdown>
         </BindLogic>

--- a/products/error_tracking/frontend/components/ExceptionCard/Stacktrace/StacktraceGenericDisplay.tsx
+++ b/products/error_tracking/frontend/components/ExceptionCard/Stacktrace/StacktraceGenericDisplay.tsx
@@ -60,7 +60,7 @@ export function StacktraceGenericExceptionHeader({
     loading,
     truncate,
 }: StacktraceBaseExceptionHeaderProps): JSX.Element {
-    const isScriptError = value === 'Non-OK response' && runtime === 'web' && type === 'Error'
+    const isScriptError = value === 'Script error' && runtime === 'web' && type === 'Error'
 
     return (
         <div className="pb-1">

--- a/products/error_tracking/frontend/components/ExceptionCard/Stacktrace/StacktraceGenericDisplay.tsx
+++ b/products/error_tracking/frontend/components/ExceptionCard/Stacktrace/StacktraceGenericDisplay.tsx
@@ -3,6 +3,7 @@ import { useValues } from 'kea'
 import { errorPropertiesLogic } from 'lib/components/Errors/errorPropertiesLogic'
 import { FingerprintRecordPartDisplay } from 'lib/components/Errors/FingerprintRecordPartDisplay'
 import { ChainedStackTraces, ExceptionHeaderProps } from 'lib/components/Errors/StackTraces'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { cn } from 'lib/utils/css-classes'
 import { useCallback } from 'react'
 
@@ -59,6 +60,8 @@ export function StacktraceGenericExceptionHeader({
     loading,
     truncate,
 }: StacktraceBaseExceptionHeaderProps): JSX.Element {
+    const isScriptError = value === 'Non-OK response' && runtime === 'web' && type === 'Error'
+
     return (
         <div className="pb-1">
             <div className="flex gap-2 items-center h-6">
@@ -77,7 +80,20 @@ export function StacktraceGenericExceptionHeader({
                     'line-clamp-1': truncate,
                 })}
             >
-                {loading ? <LemonSkeleton className="w-[50%] h-2" /> : value || 'Unknown message'}
+                {loading ? (
+                    <LemonSkeleton className="w-[50%] h-2" />
+                ) : isScriptError ? (
+                    <Tooltip
+                        title="This error occurs when JavaScript errors are caught by the browser but details are hidden due to cross-origin restrictions."
+                        docLink="https://posthog.com/docs/error-tracking/common-questions#what-is-a-script-error-with-no-stack-traces"
+                        placement="right-end"
+                        delayMs={50}
+                    >
+                        <span>{value}</span>
+                    </Tooltip>
+                ) : (
+                    value || 'Unknown message'
+                )}
             </div>
         </div>
     )


### PR DESCRIPTION
Tiny QoL improvement based on watching a sessions replay. Adds this on hover, if it's a script error.

<img width="398" alt="image" src="https://github.com/user-attachments/assets/54b2911a-b929-43d5-8b1f-b6cfb6d2514a" />


If we think of more specific error cases we should add tooltips for like this, we can break it out into a dedicated component.