### PR TITLE
chore(flags): Rename `build_from_nodes` and change it to return errors and partial graph

### DIFF
--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -1,8 +1,17 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
-use petgraph::{algo::toposort, graph::DiGraph};
+use petgraph::{
+    algo::toposort,
+    graph::{DiGraph, NodeIndex},
+};
 
 use crate::api::errors::FlagError;
+
+#[derive(Debug, Clone)]
+pub enum GraphError<Id> {
+    MissingDependency(Id),
+    CycleDetected(Id),
+}
 
 /// Trait for types that can provide their dependencies
 pub trait DependencyProvider {
@@ -39,7 +48,7 @@ where
     T: DependencyProvider + Clone,
     T::Error: From<FlagError>,
 {
-    /// Creates a new DependencyGraph from a list of items, starting from an initial item.
+    /// Creates a new DependencyGraph from a list of items, starting from an initial root item.
     /// The graph will include all dependencies of the initial item and their dependencies.
     ///
     /// Graph semantics:
@@ -103,15 +112,39 @@ where
             }
         }
 
-        Self::build_from_nodes(&nodes_to_include)
+        let (graph, errors) = Self::from_nodes(&nodes_to_include)?;
+
+        // If there are any errors (missing dependencies or cycles), fail
+        if !errors.is_empty() {
+            // Return the first error as the failure reason
+            match errors[0] {
+                GraphError::MissingDependency(id) => {
+                    return Err(
+                        FlagError::DependencyNotFound(T::dependency_type(), id.into()).into(),
+                    );
+                }
+                GraphError::CycleDetected(id) => {
+                    return Err(FlagError::DependencyCycle(T::dependency_type(), id.into()).into());
+                }
+            }
+        }
+
+        Ok(graph)
     }
 
-    /// Builds a full dependency graph from the provided set of nodes.
-    /// Strictly validates cycles and self-referential edges.
-    /// Supports multiple roots and independent subgraphs and independent nodes.
-    pub fn build_from_nodes(nodes: &[T]) -> Result<Self, T::Error> {
+    /// Builds a full multi-root dependency graph from the provided set of nodes.
+    /// Returns a tuple of the graph and a vector of errors.
+    /// The errors are returned in the order they were encountered.
+    /// The graph is returned even if there are errors.
+    /// - Cycles are detected and removed from the graph.
+    /// - Missing dependencies are detected and removed from the graph.
+    /// - A partial-graph is returned even if there are errors.
+    #[allow(clippy::type_complexity)]
+    pub fn from_nodes(nodes: &[T]) -> Result<(Self, Vec<GraphError<T::Id>>), T::Error> {
         let mut graph = DiGraph::new();
-        let mut id_map = HashMap::new();
+        let mut id_map = HashMap::with_capacity(nodes.len());
+        let mut errors = Vec::new();
+        let mut nodes_with_missing_deps = Vec::new();
 
         // Insert all nodes first
         for node in nodes {
@@ -119,32 +152,74 @@ where
             id_map.insert(node.get_id(), idx);
         }
 
-        // Insert edges (strict: only between known nodes)
+        // Insert edges and track nodes with missing dependencies
         for node in nodes {
             let source_idx = id_map[&node.get_id()];
             for dep_id in node.extract_dependencies()? {
                 if let Some(target_idx) = id_map.get(&dep_id) {
                     graph.add_edge(source_idx, *target_idx, ());
                 } else {
-                    return Err(
-                        FlagError::DependencyNotFound(T::dependency_type(), dep_id.into()).into(),
-                    );
+                    errors.push(GraphError::MissingDependency(dep_id));
+                    nodes_with_missing_deps.push(source_idx);
                 }
             }
         }
 
-        // Validate cycles after full wiring.
-        // Use toposort to detect cycles because it gives us the Id of the node that causes the cycle.
-        if let Err(e) = toposort(&graph, None) {
-            let cycle_start_node = e.node_id();
-            let cycle_id = graph[cycle_start_node].get_id().into();
-            return Err(FlagError::DependencyCycle(T::dependency_type(), cycle_id).into());
+        // Remove all nodes with missing dependencies and their dependents
+        nodes_with_missing_deps.sort_by(|a, b| b.cmp(a));
+        for node_idx in nodes_with_missing_deps {
+            Self::remove_node_and_dependents_from_graph(&mut graph, node_idx);
         }
 
-        Ok(Self { graph })
+        // Remove all cycles from the graph
+        Self::remove_all_cycles(&mut graph, &mut errors);
+
+        Ok((Self { graph }, errors))
     }
 
-    /// Traverses the graph in reverse topological order (dependencies first)
+    /// Removes all cycles from the graph, adding cycle errors to the errors vector.
+    /// This method modifies the graph in-place and continues until no cycles remain.
+    fn remove_all_cycles(graph: &mut DiGraph<T, ()>, errors: &mut Vec<GraphError<T::Id>>) {
+        // Validate cycles after full wiring - keep removing cycles until none remain
+        while let Err(e) = toposort(&*graph, None) {
+            let cycle_start_node = e.node_id();
+            let cycle_id = graph[cycle_start_node].get_id();
+            errors.push(GraphError::CycleDetected(cycle_id));
+            // Remove cycle and its dependents
+            Self::remove_node_and_dependents_from_graph(graph, cycle_start_node);
+        }
+    }
+
+    fn remove_node_and_dependents_from_graph(
+        graph: &mut DiGraph<T, ()>,
+        node_idx: petgraph::graph::NodeIndex,
+    ) {
+        use petgraph::Direction::Incoming;
+        let mut to_remove = Vec::new();
+        let mut stack = vec![node_idx];
+        let mut visited = HashSet::new();
+
+        while let Some(idx) = stack.pop() {
+            if visited.insert(idx) {
+                to_remove.push(idx);
+                // Add all nodes that depend on this node (incoming edges = dependents)
+                for dependent in graph.neighbors_directed(idx, Incoming) {
+                    if !visited.contains(&dependent) {
+                        stack.push(dependent);
+                    }
+                }
+            }
+        }
+
+        // Sort indices in descending order to avoid index shifting issues
+        to_remove.sort_by(|a, b| b.cmp(a));
+
+        for idx in to_remove {
+            graph.remove_node(idx);
+        }
+    }
+
+    /// Traverses the graph in reverse topological order (dependencies first);
     pub fn for_each_dependencies_first<F, R>(
         &self,
         mut callback: F,
@@ -187,48 +262,42 @@ where
     /// The algorithm works by repeatedly finding all nodes that have no remaining dependencies (out-degree == 0),
     /// evaluating them as one stage, and then decrementing the remaining dependencies of their dependents.
     pub fn evaluation_stages(&self) -> Result<Vec<Vec<&T>>, T::Error> {
-        use petgraph::Direction::{Incoming, Outgoing};
+        let mut out_degree = self.build_evaluation_maps()?;
+        Self::compute_stages(&self.graph, &mut out_degree)
+    }
 
-        // how many dependencies each node has remaining
-        let mut out_degree = HashMap::new();
-        // maps NodeIndex → &T for easy lookup later
-        let mut node_map = HashMap::new();
-
-        // Initialize the out-degree and node_map
+    fn build_evaluation_maps(&self) -> Result<HashMap<NodeIndex, usize>, T::Error> {
+        use petgraph::Direction::Outgoing;
+        let node_count = self.graph.node_count();
+        let mut out_degree: HashMap<NodeIndex, usize> = HashMap::with_capacity(node_count);
         for node_idx in self.graph.node_indices() {
-            let node = &self.graph[node_idx];
-            node_map.insert(node_idx, node);
             let deg = self.graph.edges_directed(node_idx, Outgoing).count();
             out_degree.insert(node_idx, deg);
         }
+        Ok(out_degree)
+    }
 
-        let mut stages = Vec::new();
-
-        // We'll add nodes to stages as we find them.
-        // We'll remove nodes from the out_degree map as we process them.
-        // We'll stop when the out_degree map is empty.
+    fn compute_stages<'a>(
+        graph: &'a DiGraph<T, ()>,
+        out_degree: &mut HashMap<NodeIndex, usize>,
+    ) -> Result<Vec<Vec<&'a T>>, T::Error> {
+        use petgraph::Direction::Incoming;
+        let node_count = graph.node_count();
+        let mut stages = Vec::with_capacity(node_count);
         while !out_degree.is_empty() {
             let mut current_stage = Vec::new();
-
-            // Find all nodes whose dependencies have been fully satisfied (out-degree == 0)
             for (&node_idx, &deg) in out_degree.iter() {
                 if deg == 0 {
                     current_stage.push(node_idx);
                 }
             }
-
             if current_stage.is_empty() {
-                // This indicates a cycle — should not occur if graph is properly validated during build (which we do!)
                 return Err(FlagError::DependencyCycle(T::dependency_type(), -1).into());
             }
-
-            // Collect references to items in this stage
-            let stage_items: Vec<&T> = current_stage.iter().map(|idx| node_map[idx]).collect();
+            let stage_items: Vec<&'a T> = current_stage.iter().map(|idx| &graph[*idx]).collect();
             stages.push(stage_items);
-
-            // After processing current stage, decrement out-degree (dependency count) of parents (dependents)
             for node_idx in &current_stage {
-                for parent in self.graph.neighbors_directed(*node_idx, Incoming) {
+                for parent in graph.neighbors_directed(*node_idx, Incoming) {
                     if let Some(deg) = out_degree.get_mut(&parent) {
                         *deg -= 1;
                     }
@@ -236,11 +305,11 @@ where
                 out_degree.remove(node_idx);
             }
         }
-
         Ok(stages)
     }
 
     /// Helper to get a node's ID as an i64
+    #[inline]
     fn get_node_id(&self, index: petgraph::graph::NodeIndex) -> i64 {
         self.graph[index].get_id().into()
     }
@@ -253,5 +322,12 @@ where
     #[cfg(test)]
     pub(crate) fn edge_count(&self) -> usize {
         self.graph.edge_count()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn contains_node(&self, id: T::Id) -> bool {
+        self.graph
+            .node_indices()
+            .any(|idx| self.graph[idx].get_id() == id)
     }
 }

--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -33,7 +33,10 @@ pub enum DependencyType {
 
 impl std::fmt::Display for DependencyType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&format!("{:?}", self).to_lowercase())
+        match self {
+            DependencyType::Flag => f.write_str("flag"),
+            DependencyType::Cohort => f.write_str("cohort"),
+        }
     }
 }
 

--- a/rust/feature-flags/src/utils/test_graph_utils.rs
+++ b/rust/feature-flags/src/utils/test_graph_utils.rs
@@ -40,7 +40,7 @@ mod tests {
         }
     }
 
-    mod graph_creation {
+    mod new_graph_creation {
         use super::*;
 
         #[test]
@@ -99,7 +99,7 @@ mod tests {
         }
     }
 
-    mod error_handling {
+    mod new_error_handling {
         use super::*;
 
         #[test]
@@ -148,7 +148,7 @@ mod tests {
         }
     }
 
-    mod traversal {
+    mod new_traversal {
         use super::*;
 
         #[test]
@@ -304,7 +304,7 @@ mod tests {
         }
     }
 
-    mod edge_cases {
+    mod new_edge_cases {
         use super::*;
 
         #[test]
@@ -338,30 +338,27 @@ mod tests {
         }
     }
 
-    mod build_from_nodes_tests {
+    mod from_nodes_tests {
+        use crate::utils::graph_utils::GraphError;
+
         use super::*;
 
         #[test]
         fn test_build_multiple_independent_nodes() {
-            // Independent nodes: 1, 2, 3
             let items = vec![
                 TestItem::new(1, HashSet::new()),
                 TestItem::new(2, HashSet::new()),
                 TestItem::new(3, HashSet::new()),
             ];
 
-            let graph = DependencyGraph::build_from_nodes(&items).unwrap();
+            let (graph, errors) = DependencyGraph::from_nodes(&items).unwrap();
+            assert!(errors.is_empty(), "Expected no errors, found: {:?}", errors);
             assert_eq!(graph.node_count(), 3);
             assert_eq!(graph.edge_count(), 0);
         }
 
         #[test]
         fn test_build_multiple_subgraphs() {
-            // Build a forest with disconnected subgraphs:
-            // Subgraph 1: 1 -> 2 -> 3
-            // Subgraph 2: 4 -> 5
-            // Subgraph 3: 6
-
             let items = vec![
                 TestItem::new(1, HashSet::from([2])),
                 TestItem::new(2, HashSet::from([3])),
@@ -371,29 +368,140 @@ mod tests {
                 TestItem::new(6, HashSet::new()),
             ];
 
-            let graph = DependencyGraph::build_from_nodes(&items).unwrap();
-
-            // Total nodes: 6
+            let (graph, errors) = DependencyGraph::from_nodes(&items).unwrap();
+            assert!(errors.is_empty(), "Expected no errors, found: {:?}", errors);
             assert_eq!(graph.node_count(), 6);
-            // Total edges: 3 (1->2, 2->3, 4->5)
             assert_eq!(graph.edge_count(), 3);
         }
 
         #[test]
-        fn test_build_from_nodes_with_missing_dependencies() {
-            // Node 1 depends on Node 999, which is not in the list
-            let items = vec![TestItem::new(1, HashSet::from([999]))];
+        fn test_build_multiple_subgraphs_removes_cycles() {
+            let items = vec![
+                TestItem::new(1, HashSet::from([2])),
+                TestItem::new(2, HashSet::from([3])),
+                TestItem::new(3, HashSet::new()),
+                TestItem::new(4, HashSet::from([5])),
+                TestItem::new(5, HashSet::new()),
+                TestItem::new(6, HashSet::new()),
+                // Cycle: (11, 12) -> (10, 13) -> (7 -> 8 -> 9 -> 7)
+                TestItem::new(7, HashSet::from([8])),
+                TestItem::new(8, HashSet::from([9])), // Starts the cycle.
+                TestItem::new(9, HashSet::from([7])),
+                TestItem::new(10, HashSet::from([7])), // Needs to removed because it depends on a cycle.
+                TestItem::new(11, HashSet::from([10])), // Needs to removed because it depends on a node that depends on a cycle.
+                TestItem::new(12, HashSet::from([10])), // Needs to removed because it depends on a node that depends on a cycle.
+                TestItem::new(13, HashSet::from([10])), // Needs to removed because it depends on a cycle.
+                // Cycle: 14 -> 15 -> 16 -> 14
+                TestItem::new(14, HashSet::from([15])),
+                TestItem::new(15, HashSet::from([16])),
+                TestItem::new(16, HashSet::from([14])),
+            ];
 
-            let result = DependencyGraph::build_from_nodes(&items);
-
-            assert!(
-                result.is_err(),
-                "Expected an error due to missing dependencies"
+            let (graph, errors) = DependencyGraph::from_nodes(&items).unwrap();
+            assert_eq!(
+                errors.len(),
+                2,
+                "Expected two cycle errors, found: {:?}",
+                errors
             );
-            assert!(matches!(
-                result.unwrap_err(),
-                FlagError::DependencyNotFound(DependencyType::Flag, 999)
-            ));
+            // Check that both cycles are detected (order may vary)
+            let cycle_ids: Vec<_> = errors
+                .iter()
+                .filter_map(|e| {
+                    if let GraphError::CycleDetected(id) = e {
+                        Some(*id)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            assert!(cycle_ids.contains(&9), "Expected cycle starting at node 9");
+            assert!(
+                cycle_ids.contains(&16),
+                "Expected cycle starting at node 16"
+            );
+            println!("Graph: {:?}", graph);
+            assert_eq!(
+                graph.node_count(),
+                6,
+                "Expected only the valid subgraphs (1->2->3, 4->5, 6)"
+            );
+            assert_eq!(graph.edge_count(), 3, "Expected edges: 1->2, 2->3, 4->5");
+
+            assert!(graph.contains_node(1));
+            assert!(graph.contains_node(2));
+            assert!(graph.contains_node(3));
+            assert!(graph.contains_node(4));
+            assert!(graph.contains_node(5));
+            assert!(graph.contains_node(6));
+
+            assert!(!graph.contains_node(7));
+            assert!(!graph.contains_node(8));
+            assert!(!graph.contains_node(9));
+            assert!(!graph.contains_node(10));
+
+            assert!(!graph.contains_node(14));
+            assert!(!graph.contains_node(15));
+            assert!(!graph.contains_node(16));
+        }
+
+        #[test]
+        fn test_build_from_nodes_with_missing_dependencies() {
+            // 4 -> 3 -> 1 -> (999: missing)
+            // 2 -> 1 -> (999: missing)
+            // 6 -> (1000: missing)
+            let items = vec![
+                TestItem::new(1, HashSet::from([999])),  // Missing dependency.
+                TestItem::new(2, HashSet::from([1])), // Depends on node that depends on a missing dependency.
+                TestItem::new(3, HashSet::from([1])), // Depends on node that depends on a missing dependency.
+                TestItem::new(4, HashSet::from([2])), // Depends on node that depends on a node that depends on a missing dependency.
+                TestItem::new(5, HashSet::new()),     // Should remain.
+                TestItem::new(6, HashSet::from([1000])), // Missing dependency.
+            ];
+
+            let (graph, errors) = DependencyGraph::from_nodes(&items).unwrap();
+            println!(
+                "Remaining node IDs: {:?}",
+                (0..10)
+                    .filter(|id| graph.contains_node(*id))
+                    .collect::<Vec<_>>()
+            );
+            println!("Errors: {:?}", errors);
+            assert_eq!(
+                graph.node_count(),
+                1,
+                "Expected only the valid subgraph (5)"
+            );
+            assert_eq!(
+                errors.len(),
+                2,
+                "Expected two errors due to missing dependencies"
+            );
+            // Check that both missing dependencies are reported (order may vary)
+            let missing_ids: Vec<_> = errors
+                .iter()
+                .filter_map(|e| {
+                    if let GraphError::MissingDependency(id) = e {
+                        Some(*id)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            assert!(
+                missing_ids.contains(&999),
+                "Expected missing dependency 999"
+            );
+            assert!(
+                missing_ids.contains(&1000),
+                "Expected missing dependency 1000"
+            );
+            assert!(graph.contains_node(5));
+            assert!(!graph.contains_node(1));
+            assert!(!graph.contains_node(2));
+            assert!(!graph.contains_node(3));
+            assert!(!graph.contains_node(4));
+            assert!(!graph.contains_node(6));
         }
     }
 
@@ -402,14 +510,14 @@ mod tests {
 
         #[test]
         fn test_linear_chain_stages() {
-            // 1 -> 2 -> 3
             let items = vec![
                 TestItem::new(1, HashSet::from([2])),
                 TestItem::new(2, HashSet::from([3])),
                 TestItem::new(3, HashSet::new()),
             ];
 
-            let graph = DependencyGraph::build_from_nodes(&items).unwrap();
+            let (graph, errors) = DependencyGraph::from_nodes(&items).unwrap();
+            assert!(errors.is_empty(), "Expected no errors, found: {:?}", errors);
             let stages = graph.evaluation_stages().unwrap();
 
             assert_eq!(stages.len(), 3);
@@ -435,7 +543,8 @@ mod tests {
                 TestItem::new(3, HashSet::new()),
             ];
 
-            let graph = DependencyGraph::build_from_nodes(&items).unwrap();
+            let (graph, errors) = DependencyGraph::from_nodes(&items).unwrap();
+            assert!(errors.is_empty(), "Expected no errors, found: {:?}", errors);
             let stages = graph.evaluation_stages().unwrap();
 
             assert_eq!(stages.len(), 1);
@@ -454,7 +563,8 @@ mod tests {
                 TestItem::new(6, HashSet::new()),
             ];
 
-            let graph = DependencyGraph::build_from_nodes(&items).unwrap();
+            let (graph, errors) = DependencyGraph::from_nodes(&items).unwrap();
+            assert!(errors.is_empty(), "Expected no errors, found: {:?}", errors);
             let stages = graph.evaluation_stages().unwrap();
 
             let expected_stages: Vec<HashSet<_>> = vec![
@@ -485,7 +595,8 @@ mod tests {
                 TestItem::new(4, HashSet::new()),
             ];
 
-            let graph = DependencyGraph::build_from_nodes(&items).unwrap();
+            let (graph, errors) = DependencyGraph::from_nodes(&items).unwrap();
+            assert!(errors.is_empty(), "Expected no errors, found: {:?}", errors);
             let stages = graph.evaluation_stages().unwrap();
 
             let expected_stages: Vec<HashSet<_>> = vec![
@@ -509,14 +620,6 @@ mod tests {
 
         #[test]
         fn test_evaluation_stages_complex_shared_dependencies() {
-            // Notice 4 is at different levels, but only evaluated once.
-            // 1 -> 2 -> 3 -> 4
-            // 5 -> 4 -> 6
-            // 6
-            // 7
-            // 8 -> 9
-            // 9
-
             let items = vec![
                 TestItem::new(1, HashSet::from([2])),
                 TestItem::new(2, HashSet::from([3])),
@@ -529,7 +632,8 @@ mod tests {
                 TestItem::new(9, HashSet::new()),
             ];
 
-            let graph = DependencyGraph::build_from_nodes(&items).unwrap();
+            let (graph, errors) = DependencyGraph::from_nodes(&items).unwrap();
+            assert!(errors.is_empty(), "Expected no errors, found: {:?}", errors);
             let stages = graph.evaluation_stages().unwrap();
 
             let expected_stages: Vec<HashSet<_>> = vec![

--- a/rust/feature-flags/src/utils/test_graph_utils.rs
+++ b/rust/feature-flags/src/utils/test_graph_utils.rs
@@ -383,14 +383,19 @@ mod tests {
                 TestItem::new(4, HashSet::from([5])),
                 TestItem::new(5, HashSet::new()),
                 TestItem::new(6, HashSet::new()),
-                // Cycle: (11, 12) -> (10, 13) -> (7 -> 8 -> 9 -> 7)
+                // Cycle: (7 -> 8 -> 9 -> 7)
+                // 10 -> (7 cycle)
+                // 11 -> 10 -> (7 cycle)
+                // 11 -> (7 cycle)
+                // 12 -> 10 -> (7 cycle)
+                // 13 -> (7 cycle)
                 TestItem::new(7, HashSet::from([8])),
                 TestItem::new(8, HashSet::from([9])), // Starts the cycle.
                 TestItem::new(9, HashSet::from([7])),
                 TestItem::new(10, HashSet::from([7])), // Needs to removed because it depends on a cycle.
-                TestItem::new(11, HashSet::from([10])), // Needs to removed because it depends on a node that depends on a cycle.
+                TestItem::new(11, HashSet::from([10, 7])), // Needs to removed because it depends on a node that depends on a cycle.
                 TestItem::new(12, HashSet::from([10])), // Needs to removed because it depends on a node that depends on a cycle.
-                TestItem::new(13, HashSet::from([10])), // Needs to removed because it depends on a cycle.
+                TestItem::new(13, HashSet::from([7])), // Needs to removed because it depends on a cycle.
                 // Cycle: 14 -> 15 -> 16 -> 14
                 TestItem::new(14, HashSet::from([15])),
                 TestItem::new(15, HashSet::from([16])),

--- a/rust/feature-flags/src/utils/test_graph_utils.rs
+++ b/rust/feature-flags/src/utils/test_graph_utils.rs
@@ -420,7 +420,6 @@ mod tests {
                 cycle_ids.contains(&16),
                 "Expected cycle starting at node 16"
             );
-            println!("Graph: {:?}", graph);
             assert_eq!(
                 graph.node_count(),
                 6,
@@ -460,13 +459,6 @@ mod tests {
             ];
 
             let (graph, errors) = DependencyGraph::from_nodes(&items).unwrap();
-            println!(
-                "Remaining node IDs: {:?}",
-                (0..10)
-                    .filter(|id| graph.contains_node(*id))
-                    .collect::<Vec<_>>()
-            );
-            println!("Errors: {:?}", errors);
             assert_eq!(
                 graph.node_count(),
                 1,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

When we're evaluating feature flags that can depend on other flags, if there are any missing dependencies or cycles, we still want to evaluate the rest of the flags that don't have any problems while setting `errors_while_computing_flags` to `true`.

## Changes

Renamed `build_from_nodes` to `from_nodes` (seems more idiomatic) which now removes any cycles and any flags that depend on the cycle (and any ancestor dependents) on up since none of them would be able to be evaluated.

For example:

```
0 -> 1 -> 2 -> 3 -> 4 -> 2
```

Would require us to remove the entire set `[0, 1, 2, 3, 4]` because `[2, 3, 4]` forms a cycle and `1` depends on the cycle and `0` depends on `1` which depends on a cycle.

Same goes for missing dependencies.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Unit tests.