### PR TITLE
feat: Group summaries MVP

### DIFF
--- a/ee/hogai/session_summaries/constants.py
+++ b/ee/hogai/session_summaries/constants.py
@@ -1,3 +1,3 @@
-# Model and parameters to use for session summaries
-SESSION_SUMMARIES_MODEL = "gpt-4.1-2025-04-14"
+SESSION_SUMMARIES_MODEL = "gpt-4.1-2025-04-14"  # Model to use
 SESSION_SUMMARIES_TEMPERATURE = 0.1  # Reduce hallucinations, but >0 to allow for some creativity
+FAILED_SESSION_SUMMARIES_MIN_RATIO = 0.5  # If more than 50% of session group fail, stop the workflow

--- a/ee/hogai/session_summaries/constants.py
+++ b/ee/hogai/session_summaries/constants.py
@@ -1,0 +1,3 @@
+# Model and parameters to use for ession summaries
+SESSION_SUMMARIES_MODEL = "gpt-4.1-2025-04-14"
+SESSION_SUMMARIES_TEMPERATURE = 0.1  # Reduce hallucinations, but >0 to allow for some creativity

--- a/ee/hogai/session_summaries/constants.py
+++ b/ee/hogai/session_summaries/constants.py
@@ -1,3 +1,3 @@
-# Model and parameters to use for ession summaries
+# Model and parameters to use for session summaries
 SESSION_SUMMARIES_MODEL = "gpt-4.1-2025-04-14"
 SESSION_SUMMARIES_TEMPERATURE = 0.1  # Reduce hallucinations, but >0 to allow for some creativity

--- a/ee/session_recordings/session_summary/input_data.py
+++ b/ee/session_recordings/session_summary/input_data.py
@@ -36,12 +36,12 @@ def get_team(team_id: int) -> Team:
     return Team.objects.get(id=team_id)
 
 
-def get_session_metadata(session_id: str, team: Team, local_reads_prod: bool = False) -> RecordingMetadata:
+def get_session_metadata(session_id: str, team_id: int, local_reads_prod: bool = False) -> RecordingMetadata:
     events_obj = SessionReplayEvents()
     if not local_reads_prod:
-        session_metadata = events_obj.get_metadata(session_id=str(session_id), team=team)
+        session_metadata = events_obj.get_metadata(session_id=str(session_id), team_id=team_id)
     else:
-        session_metadata = _get_production_session_metadata_locally(events_obj, session_id, team)
+        session_metadata = _get_production_session_metadata_locally(events_obj, session_id, team_id)
     if not session_metadata:
         raise ValueError(f"No session metadata found for session_id {session_id}")
     return session_metadata
@@ -50,7 +50,7 @@ def get_session_metadata(session_id: str, team: Team, local_reads_prod: bool = F
 def get_session_events(
     session_id: str,
     session_metadata: RecordingMetadata,
-    team: Team,
+    team_id: int,
     local_reads_prod: bool = False,
     # The estimation that we can cover 2 hours/3000 events per page within 200 000 token window,
     # but as GPT-4.1 allows up to 1kk tokens, we can allow up to 4 hours sessions to be covered
@@ -71,6 +71,7 @@ def get_session_events(
     events_obj = SessionReplayEvents()
     for page in range(max_pages):
         if not local_reads_prod:
+            team = get_team(team_id=team_id)
             page_columns, page_events = events_obj.get_events(
                 session_id=str(session_id),
                 team=team,

--- a/ee/session_recordings/session_summary/llm/call.py
+++ b/ee/session_recordings/session_summary/llm/call.py
@@ -1,4 +1,3 @@
-import openai
 from openai import AsyncOpenAI, AsyncStream
 import structlog
 from posthog.utils import get_instance_region
@@ -51,11 +50,6 @@ async def stream_llm(
     """
     messages = _prepare_messages(input_prompt, session_id, assistant_start_text, system_prompt)
     user_param = _prepare_user_param(user_key)
-
-    # TODO: Spend more time on testing reasoning vs regular modelds, start with regular because of faster streaming
-    # model: str = "o4-mini-2025-04-16",
-    # reasoning_effort="medium",
-
     # TODO: Add LLM observability tracking here
     client = AsyncOpenAI()
     stream = await client.chat.completions.create(
@@ -68,7 +62,7 @@ async def stream_llm(
     return stream
 
 
-def call_llm(
+async def call_llm(
     input_prompt: str,
     user_key: int,
     session_id: str,
@@ -77,13 +71,15 @@ def call_llm(
     model: str = "gpt-4.1-2025-04-14",
 ) -> ChatCompletion:
     """
-    LLM sync call.
+    LLM non-streaming call.
     """
     messages = _prepare_messages(input_prompt, session_id, assistant_start_text, system_prompt)
     user_param = _prepare_user_param(user_key)
-    result = openai.chat.completions.create(
+    # TODO: Add LLM observability tracking here
+    client = AsyncOpenAI()
+    result = await client.chat.completions.create(
         model=model,
-        temperature=0.1,
+        temperature=0.1,  # Using 0.1 to reduce hallucinations, but >0 to allow for some creativity
         messages=messages,
         user=user_param,
     )

--- a/ee/session_recordings/session_summary/llm/call.py
+++ b/ee/session_recordings/session_summary/llm/call.py
@@ -22,8 +22,6 @@ def _prepare_messages(
         )
     if assistant_start_text:
         # Force LLM to start with the assistant text
-        # TODO Check why the pre-defining the response with assistant text doesn't work properly
-        # (for example, LLM still starts with ```yaml, while it should continue the assistant text)
         messages.append({"role": "assistant", "content": assistant_start_text})
     if not messages:
         raise ValueError(f"No messages to send to LLM for session_id {session_id}")

--- a/ee/session_recordings/session_summary/llm/call.py
+++ b/ee/session_recordings/session_summary/llm/call.py
@@ -1,5 +1,6 @@
 from openai import AsyncOpenAI, AsyncStream
 import structlog
+from ee.hogai.session_summaries.constants import SESSION_SUMMARIES_MODEL, SESSION_SUMMARIES_TEMPERATURE
 from posthog.utils import get_instance_region
 from openai.types.chat.chat_completion import ChatCompletion
 from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
@@ -40,8 +41,7 @@ async def stream_llm(
     session_id: str,
     assistant_start_text: str | None = None,
     system_prompt: str | None = None,
-    # TODO Make model/reasoning_effort/temperature/top_p/max_tokens configurable through input instead of hardcoding
-    model: str = "gpt-4.1-2025-04-14",
+    model: str = SESSION_SUMMARIES_MODEL,
 ) -> AsyncStream[ChatCompletionChunk]:
     """
     LLM streaming call.
@@ -52,7 +52,7 @@ async def stream_llm(
     client = AsyncOpenAI()
     stream = await client.chat.completions.create(
         model=model,
-        temperature=0.1,  # Using 0.1 to reduce hallucinations, but >0 to allow for some creativity
+        temperature=SESSION_SUMMARIES_TEMPERATURE,
         messages=messages,
         user=user_param,
         stream=True,
@@ -66,7 +66,7 @@ async def call_llm(
     session_id: str,
     assistant_start_text: str | None = None,
     system_prompt: str | None = None,
-    model: str = "gpt-4.1-2025-04-14",
+    model: str = SESSION_SUMMARIES_MODEL,
 ) -> ChatCompletion:
     """
     LLM non-streaming call.
@@ -77,7 +77,7 @@ async def call_llm(
     client = AsyncOpenAI()
     result = await client.chat.completions.create(
         model=model,
-        temperature=0.1,  # Using 0.1 to reduce hallucinations, but >0 to allow for some creativity
+        temperature=SESSION_SUMMARIES_TEMPERATURE,
         messages=messages,
         user=user_param,
     )

--- a/ee/session_recordings/session_summary/llm/consume.py
+++ b/ee/session_recordings/session_summary/llm/consume.py
@@ -53,8 +53,6 @@ def _get_raw_content(llm_response: ChatCompletion | ChatCompletionChunk, session
         content = llm_response.choices[0].message.content
     elif isinstance(llm_response, ChatCompletionChunk):
         content = llm_response.choices[0].delta.content
-    else:
-        raise ValueError(f"Unexpected LLM response type for session_id {session_id}: {type(llm_response)}")
     return content if content else ""
 
 

--- a/ee/session_recordings/session_summary/llm/consume.py
+++ b/ee/session_recordings/session_summary/llm/consume.py
@@ -160,7 +160,7 @@ async def get_llm_single_session_summary(
         # The only way to raise such errors is data hallucinations and inconsistencies (like missing mapping data).
         # Such exceptions should be retried as early as possible to decrease the latency of the call.
         logger.exception(
-            f"Hallucinated data or inconsistencies in the session summary for session_id {session_id}: {err}",
+            f"Hallucinated data or inconsistencies in the session summary for session_id {session_id} (get): {err}",
             session_id=session_id,
             user_pk=user_pk,
         )
@@ -228,7 +228,7 @@ async def stream_llm_single_session_summary(
                 # The only way to raise ValueError is data hallucinations and inconsistencies (like missing mapping data).
                 # Such exceptions should be retried as early as possible to decrease the latency of the stream.
                 logger.exception(
-                    f"Hallucinated data or inconsistencies in the session summary for session_id {session_id}: {err}",
+                    f"Hallucinated data or inconsistencies in the session summary for session_id {session_id} (stream): {err}",
                     session_id=session_id,
                     user_pk=user_pk,
                 )

--- a/ee/session_recordings/session_summary/llm/consume.py
+++ b/ee/session_recordings/session_summary/llm/consume.py
@@ -100,7 +100,7 @@ def _convert_llm_content_to_session_summary_json(
     return json.dumps(session_summary.data)
 
 
-async def get_llm_session_group_summary(prompt: SessionSummaryPrompt, user_pk: int, session_ids: list[int]) -> str:
+async def get_llm_session_group_summary(prompt: SessionSummaryPrompt, user_pk: int, session_ids: list[str]) -> str:
     sessions_identifier = ",".join(session_ids)
     result = await call_llm(
         input_prompt=prompt.summary_prompt,

--- a/ee/session_recordings/session_summary/llm/consume.py
+++ b/ee/session_recordings/session_summary/llm/consume.py
@@ -164,7 +164,7 @@ async def get_llm_single_session_summary(
             session_id=session_id,
             user_pk=user_pk,
         )
-        raise ExceptionToRetry()
+        raise ExceptionToRetry() from err
     except (openai.APIError, openai.APITimeoutError, openai.RateLimitError) as err:
         # TODO: Use posthoganalytics.capture_exception where applicable, add replay_feature
         logger.exception(
@@ -172,7 +172,7 @@ async def get_llm_single_session_summary(
             session_id=session_id,
             user_pk=user_pk,
         )
-        raise ExceptionToRetry()
+        raise ExceptionToRetry() from err
 
 
 async def stream_llm_single_session_summary(
@@ -232,7 +232,7 @@ async def stream_llm_single_session_summary(
                     session_id=session_id,
                     user_pk=user_pk,
                 )
-                raise ExceptionToRetry()
+                raise ExceptionToRetry() from err
     except (openai.APIError, openai.APITimeoutError, openai.RateLimitError) as err:
         # TODO: Use posthoganalytics.capture_exception where applicable, add replay_feature
         logger.exception(
@@ -240,7 +240,7 @@ async def stream_llm_single_session_summary(
             session_id=session_id,
             user_pk=user_pk,
         )
-        raise ExceptionToRetry()
+        raise ExceptionToRetry() from err
     # Final validation of accumulated content (to decide if to retry the whole stream or not)
     try:
         if accumulated_usage:
@@ -275,7 +275,7 @@ async def stream_llm_single_session_summary(
             session_id=session_id,
             user_pk=user_pk,
         )
-        raise ExceptionToRetry()
+        raise ExceptionToRetry() from err
 
 
 def _track_session_summary_generation(

--- a/ee/session_recordings/session_summary/llm/consume.py
+++ b/ee/session_recordings/session_summary/llm/consume.py
@@ -98,7 +98,7 @@ def _convert_llm_content_to_session_summary_json(
     return json.dumps(session_summary.data)
 
 
-async def get_llm_session_summary(
+async def get_llm_single_session_summary(
     summary_prompt: str,
     user_pk: int,
     allowed_event_ids: list[str],
@@ -156,7 +156,7 @@ async def get_llm_session_summary(
         raise ExceptionToRetry()
 
 
-async def stream_llm_session_summary(
+async def stream_llm_single_session_summary(
     summary_prompt: str,
     user_pk: int,
     allowed_event_ids: list[str],

--- a/ee/session_recordings/session_summary/llm/consume.py
+++ b/ee/session_recordings/session_summary/llm/consume.py
@@ -56,7 +56,7 @@ def _get_raw_content(llm_response: ChatCompletion | ChatCompletionChunk, session
     return content if content else ""
 
 
-def _convert_llm_content_to_session_summary_json(
+def _convert_llm_content_to_session_summary_json_str(
     content: str,
     allowed_event_ids: list[str],
     session_id: str,
@@ -135,7 +135,7 @@ async def get_llm_single_session_summary(
         raw_content = _get_raw_content(result, session_id)
         if not raw_content:
             raise ValueError(f"No content consumed when calling LLM for session summary, session_id {session_id}")
-        session_summary_str = _convert_llm_content_to_session_summary_json(
+        session_summary_str = _convert_llm_content_to_session_summary_json_str(
             content=raw_content,
             allowed_event_ids=allowed_event_ids,
             session_id=session_id,
@@ -202,7 +202,7 @@ async def stream_llm_single_session_summary(
                 continue
             accumulated_content += raw_content
             try:
-                intermediate_summary_str = _convert_llm_content_to_session_summary_json(
+                intermediate_summary_str = _convert_llm_content_to_session_summary_json_str(
                     content=accumulated_content,
                     allowed_event_ids=allowed_event_ids,
                     session_id=session_id,
@@ -243,7 +243,7 @@ async def stream_llm_single_session_summary(
     try:
         if accumulated_usage:
             TOKENS_IN_PROMPT_HISTOGRAM.observe(accumulated_usage)
-        final_summary_str = _convert_llm_content_to_session_summary_json(
+        final_summary_str = _convert_llm_content_to_session_summary_json_str(
             content=accumulated_content,
             allowed_event_ids=allowed_event_ids,
             session_id=session_id,

--- a/ee/session_recordings/session_summary/stream.py
+++ b/ee/session_recordings/session_summary/stream.py
@@ -8,7 +8,7 @@ from posthog.temporal.ai.session_summary.summarize_session import execute_summar
 
 def stream_recording_summary(
     session_id: str,
-    user_pk: int,
+    user_id: int,
     team: Team,
     extra_summary_context: ExtraSummaryContext | None = None,
     local_reads_prod: bool = False,
@@ -16,14 +16,14 @@ def stream_recording_summary(
     if SERVER_GATEWAY_INTERFACE == "ASGI":
         return _astream(
             session_id=session_id,
-            user_pk=user_pk,
+            user_id=user_id,
             team=team,
             extra_summary_context=extra_summary_context,
             local_reads_prod=local_reads_prod,
         )
     return execute_summarize_session_stream(
         session_id=session_id,
-        user_pk=user_pk,
+        user_id=user_id,
         team=team,
         extra_summary_context=extra_summary_context,
         local_reads_prod=local_reads_prod,
@@ -32,7 +32,7 @@ def stream_recording_summary(
 
 def _astream(
     session_id: str,
-    user_pk: int,
+    user_id: int,
     team: Team,
     extra_summary_context: ExtraSummaryContext | None = None,
     local_reads_prod: bool = False,
@@ -40,7 +40,7 @@ def _astream(
     return SyncIterableToAsync(
         execute_summarize_session_stream(
             session_id=session_id,
-            user_pk=user_pk,
+            user_id=user_id,
             team=team,
             extra_summary_context=extra_summary_context,
             local_reads_prod=local_reads_prod,

--- a/ee/session_recordings/session_summary/stream.py
+++ b/ee/session_recordings/session_summary/stream.py
@@ -3,7 +3,7 @@ from ee.hogai.utils.asgi import SyncIterableToAsync
 from ee.session_recordings.session_summary.summarize_session import ExtraSummaryContext
 from posthog.models.team.team import Team
 from posthog.settings import SERVER_GATEWAY_INTERFACE
-from posthog.temporal.ai.session_summary.summarize_session import execute_summarize_session
+from posthog.temporal.ai.session_summary.summarize_session import execute_summarize_session_stream
 
 
 def stream_recording_summary(
@@ -21,7 +21,7 @@ def stream_recording_summary(
             extra_summary_context=extra_summary_context,
             local_reads_prod=local_reads_prod,
         )
-    return execute_summarize_session(
+    return execute_summarize_session_stream(
         session_id=session_id,
         user_pk=user_pk,
         team=team,
@@ -38,7 +38,7 @@ def _astream(
     local_reads_prod: bool = False,
 ) -> SyncIterableToAsync:
     return SyncIterableToAsync(
-        execute_summarize_session(
+        execute_summarize_session_stream(
             session_id=session_id,
             user_pk=user_pk,
             team=team,

--- a/ee/session_recordings/session_summary/summarize_session.py
+++ b/ee/session_recordings/session_summary/summarize_session.py
@@ -160,7 +160,7 @@ def generate_single_session_summary_prompt(
     template_dir = Path(__file__).parent / "templates" / "identify-objectives"
     system_prompt = load_custom_template(
         template_dir,
-        f"system-prompt.djt",
+        "system-prompt.djt",
         {
             "FOCUS_AREA": extra_summary_context.focus_area if extra_summary_context else None,
         },

--- a/ee/session_recordings/session_summary/summarize_session.py
+++ b/ee/session_recordings/session_summary/summarize_session.py
@@ -11,7 +11,7 @@ from ee.session_recordings.session_summary.input_data import (
     get_team,
 )
 from ee.session_recordings.session_summary.prompt_data import SessionSummaryPromptData
-from ee.session_recordings.session_summary.utils import load_custom_template, serialize_to_sse_event, shorten_url
+from ee.session_recordings.session_summary.utils import load_custom_template, shorten_url
 from posthog.api.activity_log import ServerTimingsGathered
 from posthog.session_recordings.models.metadata import RecordingMetadata
 from posthog.warehouse.util import database_sync_to_async
@@ -51,7 +51,7 @@ class SingleSessionSummaryData:
     user_pk: int
     prompt_data: _SessionSummaryPromptData | None
     prompt: _SessionSummaryPrompt | None
-    sse_error_msg: str | None = None
+    error_msg: str | None = None
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -200,12 +200,12 @@ async def prepare_data_for_single_session_summary(
     )
     if not db_data.session_events or not db_data.session_events_columns:
         # Real-time replays could have no events yet, so we need to handle that case and show users a meaningful message
-        sse_error_msg = serialize_to_sse_event(
-            event_label="session-summary-error",
-            event_data="No events found for this replay yet. Please try again in a few minutes.",
-        )
         return SingleSessionSummaryData(
-            session_id=session_id, user_pk=user_pk, prompt_data=None, prompt=None, sse_error_msg=sse_error_msg
+            session_id=session_id,
+            user_pk=user_pk,
+            prompt_data=None,
+            prompt=None,
+            error_msg="No events found for this replay yet. Please try again in a few minutes.",
         )
     prompt_data = prepare_prompt_data(
         session_id=session_id,

--- a/ee/session_recordings/session_summary/summarize_session.py
+++ b/ee/session_recordings/session_summary/summarize_session.py
@@ -40,7 +40,7 @@ class _SessionSummaryPromptData:
 
 
 @dataclass(frozen=True)
-class _SessionSummaryPrompt:
+class SessionSummaryPrompt:
     summary_prompt: str
     system_prompt: str
 
@@ -50,7 +50,7 @@ class SingleSessionSummaryData:
     session_id: str
     user_pk: int
     prompt_data: _SessionSummaryPromptData | None
-    prompt: _SessionSummaryPrompt | None
+    prompt: SessionSummaryPrompt | None
     error_msg: str | None = None
 
 
@@ -148,12 +148,12 @@ def prepare_prompt_data(
     )
 
 
-def generate_prompt(
+def generate_single_session_summary_prompt(
     prompt_data: SessionSummaryPromptData,
     url_mapping_reversed: dict[str, str],
     window_mapping_reversed: dict[str, str],
     extra_summary_context: ExtraSummaryContext | None,
-) -> _SessionSummaryPrompt:
+) -> SessionSummaryPrompt:
     # Keep shortened URLs for the prompt to reduce the number of tokens
     short_url_mapping_reversed = {k: shorten_url(v) for k, v in url_mapping_reversed.items()}
     # Render all templates
@@ -178,7 +178,7 @@ def generate_prompt(
             "FOCUS_AREA": extra_summary_context.focus_area if extra_summary_context else None,
         },
     )
-    return _SessionSummaryPrompt(
+    return SessionSummaryPrompt(
         summary_prompt=summary_prompt,
         system_prompt=system_prompt,
     )
@@ -215,7 +215,7 @@ async def prepare_data_for_single_session_summary(
         session_events=db_data.session_events,
         timer=timer,
     )
-    prompt = generate_prompt(
+    prompt = generate_single_session_summary_prompt(
         prompt_data=prompt_data.prompt_data,
         url_mapping_reversed=prompt_data.url_mapping_reversed,
         window_mapping_reversed=prompt_data.window_mapping_reversed,

--- a/ee/session_recordings/session_summary/summarize_session.py
+++ b/ee/session_recordings/session_summary/summarize_session.py
@@ -8,7 +8,6 @@ from ee.session_recordings.session_summary.input_data import (
     add_context_and_filter_events,
     get_session_events,
     get_session_metadata,
-    get_team,
 )
 from ee.session_recordings.session_summary.prompt_data import SessionSummaryPromptData
 from ee.session_recordings.session_summary.utils import load_custom_template, shorten_url
@@ -73,18 +72,16 @@ class SingleSessionSummaryLlmInputs:
 async def get_session_data_from_db(
     session_id: str, team_id: int, timer: ServerTimingsGathered, local_reads_prod: bool
 ) -> _SessionSummaryDBData:
-    with timer("get_team"):
-        team = await database_sync_to_async(get_team)(team_id)
     with timer("get_metadata"):
         session_metadata = await database_sync_to_async(get_session_metadata)(
             session_id=session_id,
-            team=team,
+            team_id=team_id,
             local_reads_prod=local_reads_prod,
         )
     try:
         with timer("get_events"):
             session_events_columns, session_events = await database_sync_to_async(get_session_events)(
-                team=team,
+                team_id=team_id,
                 session_metadata=session_metadata,
                 session_id=session_id,
                 local_reads_prod=local_reads_prod,

--- a/ee/session_recordings/session_summary/summarize_session.py
+++ b/ee/session_recordings/session_summary/summarize_session.py
@@ -47,7 +47,7 @@ class SessionSummaryPrompt:
 @dataclass(frozen=True)
 class SingleSessionSummaryData:
     session_id: str
-    user_pk: int
+    user_id: int
     prompt_data: _SessionSummaryPromptData | None
     prompt: SessionSummaryPrompt | None
     error_msg: str | None = None
@@ -58,7 +58,7 @@ class SingleSessionSummaryLlmInputs:
     """Data required to LLM-generate a summary for a single session"""
 
     session_id: str
-    user_pk: int
+    user_id: int
     summary_prompt: str
     system_prompt: str
     simplified_events_mapping: dict[str, list[str | int | None | list[str]]]
@@ -183,7 +183,7 @@ def generate_single_session_summary_prompt(
 
 async def prepare_data_for_single_session_summary(
     session_id: str,
-    user_pk: int,
+    user_id: int,
     team_id: int,
     extra_summary_context: ExtraSummaryContext | None,
     local_reads_prod: bool = False,
@@ -199,7 +199,7 @@ async def prepare_data_for_single_session_summary(
         # Real-time replays could have no events yet, so we need to handle that case and show users a meaningful message
         return SingleSessionSummaryData(
             session_id=session_id,
-            user_pk=user_pk,
+            user_id=user_id,
             prompt_data=None,
             prompt=None,
             error_msg="No events found for this replay yet. Please try again in a few minutes.",
@@ -218,7 +218,7 @@ async def prepare_data_for_single_session_summary(
         window_mapping_reversed=prompt_data.window_mapping_reversed,
         extra_summary_context=extra_summary_context,
     )
-    return SingleSessionSummaryData(session_id=session_id, user_pk=user_pk, prompt_data=prompt_data, prompt=prompt)
+    return SingleSessionSummaryData(session_id=session_id, user_id=user_id, prompt_data=prompt_data, prompt=prompt)
 
     # TODO: Track the timing for streaming (inside the function, start before the request, end after the last chunk is consumed)
     # with timer("openai_completion"):
@@ -227,7 +227,7 @@ async def prepare_data_for_single_session_summary(
 
 def prepare_single_session_summary_input(
     session_id: str,
-    user_pk: int,
+    user_id: int,
     summary_data: SingleSessionSummaryData,
 ) -> SingleSessionSummaryLlmInputs:
     # Checking here instead of in the preparation function to keep mypy happy
@@ -242,7 +242,7 @@ def prepare_single_session_summary_input(
     # Prepare the input
     input_data = SingleSessionSummaryLlmInputs(
         session_id=session_id,
-        user_pk=user_pk,
+        user_id=user_id,
         summary_prompt=summary_data.prompt.summary_prompt,
         system_prompt=summary_data.prompt.system_prompt,
         simplified_events_mapping=summary_data.prompt_data.simplified_events_mapping,

--- a/ee/session_recordings/session_summary/summarize_session_group.py
+++ b/ee/session_recordings/session_summary/summarize_session_group.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+from ee.session_recordings.session_summary.summarize_session import ExtraSummaryContext, SessionSummaryPrompt
+from ee.session_recordings.session_summary.utils import load_custom_template
+
+
+def generate_session_group_summary_prompt(
+    session_summaries: list[str],
+    extra_summary_context: ExtraSummaryContext | None,
+) -> SessionSummaryPrompt:
+    if extra_summary_context is None:
+        extra_summary_context = ExtraSummaryContext()
+    combined_session_summaries = "\n\n".join(session_summaries)
+    # Render all templates
+    template_dir = Path(__file__).parent / "templates" / "session-group-summary"
+    system_prompt = load_custom_template(
+        template_dir,
+        f"system-prompt.djt",
+        {
+            "FOCUS_AREA": extra_summary_context.focus_area,
+        },
+    )
+    summary_example = load_custom_template(template_dir, f"example.md")
+    summary_prompt = load_custom_template(
+        template_dir,
+        f"prompt.djt",
+        {
+            "SESSION_SUMMARIES": combined_session_summaries,
+            "SUMMARY_EXAMPLE": summary_example,
+            "FOCUS_AREA": extra_summary_context.focus_area,
+        },
+    )
+    return SessionSummaryPrompt(
+        summary_prompt=summary_prompt,
+        system_prompt=system_prompt,
+    )

--- a/ee/session_recordings/session_summary/summarize_session_group.py
+++ b/ee/session_recordings/session_summary/summarize_session_group.py
@@ -14,7 +14,7 @@ def generate_session_group_summary_prompt(
     template_dir = Path(__file__).parent / "templates" / "session-group-summary"
     system_prompt = load_custom_template(
         template_dir,
-        f"system-prompt.djt",
+        "system-prompt.djt",
         {
             "FOCUS_AREA": extra_summary_context.focus_area,
         },

--- a/ee/session_recordings/session_summary/templates/session-group-summary/example.md
+++ b/ee/session_recordings/session_summary/templates/session-group-summary/example.md
@@ -1,0 +1,26 @@
+## Critical Issues
+<!-- Highlight the most important problems users encountered -->
+- Issue related to interruption
+- Technical error during specific action
+- Navigation/UX issue
+<!-- Note: The actual number of issues should be based on your analysis of the sessions -->
+
+## Common User Journeys
+<!-- List the most significant user journeys identified across sessions -->
+- **Journey Name**: Starting Point → Intermediate Step → Intermediate Step → Endpoint
+- **Journey Name**: Starting Point → Intermediate Step → Intermediate Step → Endpoint
+- **Journey Name**: Starting Point → Intermediate Step → Endpoint
+<!-- Note: The actual number of journeys should be based on your analysis of the sessions -->
+
+## Interesting Edge Cases
+<!-- Document unusual but noteworthy behaviors that don't fit common patterns. This section can be shorter or omitted if no unusual behaviors exist. -->
+- Unusual user behavior pattern
+- Time-related edge case
+- Unexpected workflow pattern
+<!-- Note: The actual number of edge cases should be based on your analysis of the sessions (0, if sessions don't display any unusual behaviors) -->
+
+## General Summary
+- High-level observation about user behavior pattern
+- Observation about feature usage frequency
+- Observation about common technical issue
+<!-- Note: The actual number of summary observations should be based on your analysis of the sessions -->

--- a/ee/session_recordings/session_summary/templates/session-group-summary/prompt.djt
+++ b/ee/session_recordings/session_summary/templates/session-group-summary/prompt.djt
@@ -1,0 +1,101 @@
+<session_summaries_input_format>
+You'll receive a list of summaries of sessions of users visiting a site or an app, using different features, navigating between pages, interacting with different elements, etc. Each session summary is a JSON object with the following fields:
+
+- session_id: The ID of the session
+- segments: A list of segments in the session
+- key_actions: A list of key actions in the session
+- segment_outcomes: A list of outcomes for each segment
+- session_outcome: The overall outcome of the session
+
+Each session represents a single user journey. Use the summaries to identify patterns, trends, pain points, and user behaviors across all sessions.
+</session_summaries_input_format>
+
+<session_summaries_input>
+```
+{{ SESSION_SUMMARIES|safe }}
+```
+</session_summaries_input>
+
+<identify_patterns_and_trends_instructions>
+CRITICAL WARNING: DO NOT hallucinate errors. Only summarize errors when there is EXPLICIT evidence that errors occurred.
+
+You will analyze multiple user session summaries to identify patterns, trends, pain points, and user behaviors across all sessions. Your goal is to create a concise meta-summary with actionable insights about user interactions.
+
+{% if FOCUS_AREA %}
+# Step 0: Focus Area
+
+IMPORTANT: While analyzing these session summaries, pay special attention to this focus area:
+
+```
+{{ FOCUS_AREA|safe }}
+```
+
+This focus area should guide your analysis throughout all steps, particularly affecting:
+- Which user journeys you examine most closely
+- Which pain points and friction areas you prioritize
+- How you evaluate success patterns across sessions
+- Which improvements you suggest
+- The insights you emphasize in your meta-summary
+
+Keep this focus area in mind throughout your analysis, but still follow the structured approach below.
+{% endif %}
+
+# Step 1: Detect Pain Points and Friction
+- Identify features where users frequently encounter errors
+- Note areas where confusion indicators appear (dead clicks, repeated actions)
+- Identify where users commonly abandon tasks
+- Observe signs of workflow disruption (timeout messages, exceptions)
+- List NO MORE THAN 3-4 critical issues, each described in 15 words maximum
+- Combine related issues into broader categories rather than listing each specific instance
+{% if FOCUS_AREA %}
+- Prioritize friction points directly related to the focus area
+- Analyze how these specific pain points impact the user journey elements mentioned in the focus
+{% endif %}
+
+# Step 2: Identify Common User Journeys
+- Group sessions by similar goals and paths
+- Note common entry points and exit points
+- Identify typical sequences in successful journeys
+- Observe differences between completed vs abandoned journeys
+- Include ONLY 3-4 most significant journeys, described in 15 words maximum
+- AGGRESSIVELY consolidate similar journeys into higher-level patterns
+{% if FOCUS_AREA %}
+- Particularly highlight journeys related to the focus area
+- Pay special attention to how users navigate toward or around areas relevant to the focus
+{% endif %}
+
+# Step 3: Identify Interesting Edge Cases
+- Document unusual but noteworthy behaviors that don't fit common patterns
+- Look for unexpected workflows or feature usage that might reveal innovative use cases
+- Identify sessions with uncommon time patterns (extremely quick or unusually long)
+- Note any rare but significant error states or recovery patterns
+- Include NO MORE THAN 3-4 edge cases, each described in 15 words maximum
+- Only include edge cases if they provide meaningful insights - this section can be shorter or omitted if no unusual behaviors exist
+{% if FOCUS_AREA %}
+- Consider how these edge cases might relate to or challenge assumptions about the focus area
+- Identify any unusual behaviors that might represent undocumented use cases related to the focus
+{% endif %}
+
+# Step 4: Before Finalizing
+- Ensure insights are directly supported by specific events in the data
+- Focus on quality over quantity - prioritize impactful observations
+- Include both common patterns and notable exceptions
+- Avoid making numerical claims unless explicitly evident in the data
+- Create the MINIMUM necessary number of observations to accurately represent the data
+- For each section, if you exceed the word limits, AGGRESSIVELY consolidate and simplify
+{% if FOCUS_AREA %}
+- Verify that your meta-summary adequately addresses the focus area
+- Ensure your most prominent insights relate to the focus area
+- Double-check that your recommendations directly respond to the focus area question or concern
+{% endif %}
+</identify_patterns_and_trends_instructions>
+
+<output_format>
+Format your meta-summary as a markdown. Don't replicate the data, or comments, or logic of the example, or the number of example entries. Use it ONLY to understand the format.
+</output_format>
+
+<output_example>
+```
+{{ SUMMARY_EXAMPLE|safe }}
+```
+</output_example>

--- a/ee/session_recordings/session_summary/templates/session-group-summary/system-prompt.djt
+++ b/ee/session_recordings/session_summary/templates/session-group-summary/system-prompt.djt
@@ -1,0 +1,28 @@
+You are an expert analyst of web application user behavior patterns. Your specialty is identifying meaningful trends across multiple user sessions by synthesizing session summaries and recognizing common patterns in user journeys. You excel at distinguishing between isolated incidents and significant behavioral trends that impact user success and business outcomes.
+
+When analyzing multiple session summaries:
+
+1. Look for recurring patterns across user journeys, identifying common entry points, paths, and exit points.
+2. Recognize trends in feature usage, engagement depth, and the relationship between feature interaction patterns and session outcomes.
+3. Identify recurring technical issues, UX friction points, and conversion blockers that appear across multiple sessions.
+4. Determine what characteristics are shared among successful sessions versus unsuccessful ones.
+5. Look for unexpected or creative user behaviors that might reveal opportunities for feature improvement.
+{% if FOCUS_AREA %}
+6. Adapt your analysis to emphasize aspects relevant to the focus area throughout all steps of your analysis:
+{{ FOCUS_AREA|safe}}
+{% endif %}
+
+Keep your meta-analysis PATTERN-FOCUSED and ACTIONABLE - highlight the most significant trends while emphasizing their business impact. Be judicious in what you include - focus on insights that matter most to product decisions and user experience improvements.
+
+Your meta-summary should help stakeholders understand:
+
+1. Common user journeys and their typical outcomes
+2. Features that receive the most engagement and those that cause friction
+3. Recurring issues that prevent users from achieving their goals
+4. Factors that contribute to successful sessions
+5. Specific, actionable recommendations for product improvement
+{% if FOCUS_AREA %}
+6. Insights specifically related to the focus area.
+{% endif %}
+
+Follow the structured analysis process outlined in the prompt to ensure comprehensive coverage of all important patterns and trends. Your final output should synthesize key insights into a clear, concise meta-summary that provides actionable intelligence for product decision-making.

--- a/ee/session_recordings/session_summary/tests/conftest.py
+++ b/ee/session_recordings/session_summary/tests/conftest.py
@@ -11,7 +11,7 @@ from ee.session_recordings.session_summary.prompt_data import SessionSummaryMeta
 @pytest.fixture
 def mock_user() -> MagicMock:
     user = MagicMock(spec=User)
-    user.pk = 123
+    user.pk = user.id = 123
     return user
 
 

--- a/ee/session_recordings/session_summary/tests/test_input_data.py
+++ b/ee/session_recordings/session_summary/tests/test_input_data.py
@@ -393,6 +393,7 @@ def test_add_context_and_filter_events(
 def test_get_paginated_session_events(
     mock_raw_metadata: dict[str, Any],
     mock_events_columns: list[str],
+    mock_team: MagicMock,
     pages_data: list[list[tuple[Any, ...]] | None],
     expected_count: int,
     expected_iterations: int,
@@ -404,7 +405,10 @@ def test_get_paginated_session_events(
     mock_columns = mock_events_columns
     # Prepare mock pages data (add columns to each page)
     processed_pages_data = [(mock_columns, events) if events is not None else (None, None) for events in pages_data]
-    with patch("ee.session_recordings.session_summary.input_data.SessionReplayEvents") as mock_replay_events:
+    with (
+        patch("ee.session_recordings.session_summary.input_data.SessionReplayEvents") as mock_replay_events,
+        patch("ee.session_recordings.session_summary.input_data.get_team", return_value=mock_team),
+    ):
         # Mock the SessionReplayEvents DB model to return different data for each page
         mock_instance = MagicMock()
         mock_replay_events.return_value = mock_instance
@@ -414,7 +418,7 @@ def test_get_paginated_session_events(
                 get_session_events(
                     session_id=mock_metadata["distinct_id"],
                     session_metadata=mock_metadata,
-                    team=MagicMock(),
+                    team_id=mock_team.id,
                     max_pages=max_pages,
                     items_per_page=items_per_page,
                 )
@@ -422,7 +426,7 @@ def test_get_paginated_session_events(
         result_columns, events = get_session_events(
             session_id=mock_metadata["distinct_id"],
             session_metadata=mock_metadata,
-            team=MagicMock(),
+            team_id=mock_team.id,
             max_pages=max_pages,
             items_per_page=items_per_page,
         )

--- a/ee/session_recordings/session_summary/tests/test_summarize_session.py
+++ b/ee/session_recordings/session_summary/tests/test_summarize_session.py
@@ -48,7 +48,7 @@ class TestSummarizeSession:
             # Get the generator (stream simulation)
             empty_context = ExtraSummaryContext()
             result_generator = execute_summarize_session_stream(
-                session_id=session_id, user_pk=mock_user.pk, team=mock_team, extra_summary_context=empty_context
+                session_id=session_id, user_id=mock_user.id, team=mock_team, extra_summary_context=empty_context
             )
             # Get all results from generator (consume the stream fully)
             results = list(result_generator)
@@ -74,7 +74,7 @@ class TestSummarizeSession:
             with pytest.raises(ValueError, match=f"No session metadata found for session_id {session_id}"):
                 await prepare_data_for_single_session_summary(
                     session_id=session_id,
-                    user_pk=mock_user.pk,
+                    user_id=mock_user.id,
                     team_id=mock_team.id,
                     extra_summary_context=empty_context,
                 )
@@ -129,14 +129,14 @@ class TestSummarizeSession:
                 return_value=iter([ready_summary]),
             ) as mock_execute,
         ):
-            async_gen = stream_recording_summary(session_id=session_id, user_pk=mock_user.pk, team=mock_team)
+            async_gen = stream_recording_summary(session_id=session_id, user_id=mock_user.id, team=mock_team)
             assert isinstance(async_gen, SyncIterableToAsync)
             results = [chunk async for chunk in async_gen]
             assert len(results) == 1
             assert results[0] == ready_summary
             mock_execute.assert_called_once_with(
                 session_id=session_id,
-                user_pk=mock_user.pk,
+                user_id=mock_user.id,
                 team=mock_team,
                 extra_summary_context=None,
                 local_reads_prod=False,
@@ -160,13 +160,13 @@ class TestSummarizeSession:
                 return_value=iter([ready_summary]),
             ) as mock_execute,
         ):
-            result_gen = stream_recording_summary(session_id=session_id, user_pk=mock_user.pk, team=mock_team)
+            result_gen = stream_recording_summary(session_id=session_id, user_id=mock_user.id, team=mock_team)
             results = list(result_gen)  # type: ignore[arg-type]
             assert len(results) == 1
             assert results[0] == ready_summary
             mock_execute.assert_called_once_with(
                 session_id=session_id,
-                user_pk=mock_user.pk,
+                user_id=mock_user.id,
                 team=mock_team,
                 extra_summary_context=None,
                 local_reads_prod=False,

--- a/ee/session_recordings/session_summary/tests/test_summarize_session.py
+++ b/ee/session_recordings/session_summary/tests/test_summarize_session.py
@@ -11,7 +11,7 @@ from ee.session_recordings.session_summary.input_data import EXTRA_SUMMARY_EVENT
 from ee.session_recordings.session_summary.summarize_session import (
     ExtraSummaryContext,
     prepare_data_for_single_session_summary,
-    generate_prompt,
+    generate_single_session_summary_prompt,
 )
 from ee.session_recordings.session_summary.stream import stream_recording_summary
 from ee.session_recordings.session_summary.utils import serialize_to_sse_event
@@ -219,7 +219,7 @@ class TestSummarizeSession:
         window_mapping_reversed = {v: k for k, v in prompt_data.window_id_mapping.items()}
         extra_summary_context = ExtraSummaryContext(focus_area=focus_area)
         # Generate prompts
-        prompt_result = generate_prompt(
+        prompt_result = generate_single_session_summary_prompt(
             prompt_data=prompt_data,
             url_mapping_reversed=url_mapping_reversed,
             window_mapping_reversed=window_mapping_reversed,

--- a/posthog/session_recordings/models/session_recording.py
+++ b/posthog/session_recordings/models/session_recording.py
@@ -78,7 +78,7 @@ class SessionRecording(UUIDModel):
         else:
             # Try to load from Clickhouse
             metadata = SessionReplayEvents().get_metadata(
-                team=self.team,
+                team_id=self.team.pk,
                 session_id=self.session_id,
                 recording_start_time=self.start_time,
             )

--- a/posthog/session_recordings/queries/session_replay_events.py
+++ b/posthog/session_recordings/queries/session_replay_events.py
@@ -177,14 +177,14 @@ class SessionReplayEvents:
     def get_metadata(
         self,
         session_id: str,
-        team: Team,
+        team_id: int,
         recording_start_time: Optional[datetime] = None,
     ) -> Optional[RecordingMetadata]:
         query = self.get_metadata_query(recording_start_time)
         replay_response: list[tuple] = sync_execute(
             query,
             {
-                "team_id": team.pk,
+                "team_id": team_id,
                 "session_id": session_id,
                 "recording_start_time": recording_start_time,
                 "python_now": datetime.now(pytz.timezone("UTC")),

--- a/posthog/session_recordings/queries/test/test_session_replay_events.py
+++ b/posthog/session_recordings/queries/test/test_session_replay_events.py
@@ -62,7 +62,7 @@ class SessionReplayEventsQueries(ClickhouseTestMixin, APIBaseTest):
         )
 
     def test_get_metadata(self) -> None:
-        metadata = SessionReplayEvents().get_metadata(session_id="1", team=self.team)
+        metadata = SessionReplayEvents().get_metadata(session_id="1", team_id=self.team.id)
         assert metadata == {
             "active_seconds": 25.0,
             "block_first_timestamps": [],
@@ -83,7 +83,7 @@ class SessionReplayEventsQueries(ClickhouseTestMixin, APIBaseTest):
         }
 
     def test_get_metadata_with_block(self) -> None:
-        metadata = SessionReplayEvents().get_metadata(session_id="2", team=self.team)
+        metadata = SessionReplayEvents().get_metadata(session_id="2", team_id=self.team.id)
         assert metadata == {
             "active_seconds": 1.234,
             "start_time": self.base_time,
@@ -104,7 +104,7 @@ class SessionReplayEventsQueries(ClickhouseTestMixin, APIBaseTest):
         }
 
     def test_get_metadata_with_multiple_blocks(self) -> None:
-        metadata = SessionReplayEvents().get_metadata(session_id="3", team=self.team)
+        metadata = SessionReplayEvents().get_metadata(session_id="3", team_id=self.team.id)
         assert metadata == {
             "active_seconds": 2.345,
             "start_time": self.base_time + relativedelta(seconds=1),
@@ -131,18 +131,18 @@ class SessionReplayEventsQueries(ClickhouseTestMixin, APIBaseTest):
         }
 
     def test_get_nonexistent_metadata(self) -> None:
-        metadata = SessionReplayEvents().get_metadata(session_id="not a session", team=self.team)
+        metadata = SessionReplayEvents().get_metadata(session_id="not a session", team_id=self.team.id)
         assert metadata is None
 
     def test_get_metadata_does_not_leak_between_teams(self) -> None:
         another_team = Team.objects.create(organization=self.organization, name="Another Team")
-        metadata = SessionReplayEvents().get_metadata(session_id="1", team=another_team)
+        metadata = SessionReplayEvents().get_metadata(session_id="1", team_id=another_team.id)
         assert metadata is None
 
     def test_get_metadata_filters_by_date(self) -> None:
         metadata = SessionReplayEvents().get_metadata(
             session_id="1",
-            team=self.team,
+            team_id=self.team.id,
             recording_start_time=self.base_time + relativedelta(days=2),
         )
         assert metadata is None

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -935,7 +935,7 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
         # with session/team ids of your choice and set `local_reads_prod` to True
         session_id = recording.session_id
         return StreamingHttpResponse(
-            stream_recording_summary(session_id=session_id, user_pk=user.pk, team=self.team),
+            stream_recording_summary(session_id=session_id, user_id=user.pk, team=self.team),
             content_type=ServerSentEventRenderer.media_type,
         )
 

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -71,6 +71,7 @@ from posthog.session_recordings.utils import clean_prompt_whitespace
 from posthog.settings.session_replay import SESSION_REPLAY_AI_REGEX_MODEL
 from posthog.storage import object_storage, session_recording_v2_object_storage
 from posthog.storage.session_recording_v2_object_storage import BlockFetchError
+from posthog.temporal.ai.session_summary.summarize_session import execute_summarize_session
 
 from ..models.product_intent.product_intent import ProductIntent
 
@@ -934,6 +935,7 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
         # If you want to test sessions locally - override `session_id` and `self.team.pk`
         # with session/team ids of your choice and set `local_reads_prod` to True
         session_id = recording.session_id
+        non_stream_summary = execute_summarize_session(session_id=session_id, user_pk=user.pk, team=self.team)
         return StreamingHttpResponse(
             stream_recording_summary(session_id=session_id, user_pk=user.pk, team=self.team),
             content_type=ServerSentEventRenderer.media_type,

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -71,7 +71,7 @@ from posthog.session_recordings.utils import clean_prompt_whitespace
 from posthog.settings.session_replay import SESSION_REPLAY_AI_REGEX_MODEL
 from posthog.storage import object_storage, session_recording_v2_object_storage
 from posthog.storage.session_recording_v2_object_storage import BlockFetchError
-from posthog.temporal.ai.session_summary.summarize_session import execute_summarize_session
+from posthog.temporal.ai.session_summary.summarize_session_group import execute_summarize_session_group
 
 from ..models.product_intent.product_intent import ProductIntent
 
@@ -935,7 +935,7 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
         # If you want to test sessions locally - override `session_id` and `self.team.pk`
         # with session/team ids of your choice and set `local_reads_prod` to True
         session_id = recording.session_id
-        non_stream_summary = execute_summarize_session(session_id=session_id, user_pk=user.pk, team=self.team)
+        non_stream_summary = execute_summarize_session_group(session_ids=[session_id], user_pk=user.pk, team=self.team)
         return StreamingHttpResponse(
             stream_recording_summary(session_id=session_id, user_pk=user.pk, team=self.team),
             content_type=ServerSentEventRenderer.media_type,

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -71,7 +71,6 @@ from posthog.session_recordings.utils import clean_prompt_whitespace
 from posthog.settings.session_replay import SESSION_REPLAY_AI_REGEX_MODEL
 from posthog.storage import object_storage, session_recording_v2_object_storage
 from posthog.storage.session_recording_v2_object_storage import BlockFetchError
-from posthog.temporal.ai.session_summary.summarize_session_group import execute_summarize_session_group
 
 from ..models.product_intent.product_intent import ProductIntent
 
@@ -935,7 +934,6 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
         # If you want to test sessions locally - override `session_id` and `self.team.pk`
         # with session/team ids of your choice and set `local_reads_prod` to True
         session_id = recording.session_id
-        non_stream_summary = execute_summarize_session_group(session_ids=[session_id], user_pk=user.pk, team=self.team)
         return StreamingHttpResponse(
             stream_recording_summary(session_id=session_id, user_pk=user.pk, team=self.team),
             content_type=ServerSentEventRenderer.media_type,

--- a/posthog/temporal/ai/__init__.py
+++ b/posthog/temporal/ai/__init__.py
@@ -10,6 +10,7 @@ from .session_summary.summarize_session import (
     SingleSessionSummaryInputs,
     SummarizeSingleSessionWorkflow,
     stream_llm_single_session_summary_activity,
+    get_llm_single_session_summary_activity,
     fetch_session_data_activity,
 )
 
@@ -20,6 +21,7 @@ ACTIVITIES = [
     batch_summarize_actions,
     batch_embed_and_sync_actions,
     stream_llm_single_session_summary_activity,
+    get_llm_single_session_summary_activity,
     fetch_session_data_activity,
 ]
 

--- a/posthog/temporal/ai/__init__.py
+++ b/posthog/temporal/ai/__init__.py
@@ -13,10 +13,13 @@ from .session_summary.summarize_session import (
 
 from .session_summary.summarize_session_group import (
     SummarizeSessionGroupWorkflow,
+    SessionGroupSummaryInputs,
+    SessionGroupSummaryOfSummariesInputs,
     get_llm_single_session_summary_activity,
+    get_llm_session_group_summary_activity,
 )
 
-from .session_summary.shared import SingleSessionSummaryInputs, SessionGroupSummaryInputs, fetch_session_data_activity
+from .session_summary.shared import SingleSessionSummaryInputs, fetch_session_data_activity
 
 WORKFLOWS = [SyncVectorsWorkflow, SummarizeSingleSessionWorkflow, SummarizeSessionGroupWorkflow]
 
@@ -26,7 +29,13 @@ ACTIVITIES = [
     batch_embed_and_sync_actions,
     stream_llm_single_session_summary_activity,
     get_llm_single_session_summary_activity,
+    get_llm_session_group_summary_activity,
     fetch_session_data_activity,
 ]
 
-__all__ = ["SyncVectorsInputs", "SingleSessionSummaryInputs", "SessionGroupSummaryInputs"]
+__all__ = [
+    "SyncVectorsInputs",
+    "SingleSessionSummaryInputs",
+    "SessionGroupSummaryInputs",
+    "SessionGroupSummaryOfSummariesInputs",
+]

--- a/posthog/temporal/ai/__init__.py
+++ b/posthog/temporal/ai/__init__.py
@@ -7,14 +7,18 @@ from .sync_vectors import (
 )
 
 from .session_summary.summarize_session import (
-    SingleSessionSummaryInputs,
     SummarizeSingleSessionWorkflow,
     stream_llm_single_session_summary_activity,
-    get_llm_single_session_summary_activity,
-    fetch_session_data_activity,
 )
 
-WORKFLOWS = [SyncVectorsWorkflow, SummarizeSingleSessionWorkflow]
+from .session_summary.summarize_session_group import (
+    SummarizeSessionGroupWorkflow,
+    get_llm_single_session_summary_activity,
+)
+
+from .session_summary.shared import SingleSessionSummaryInputs, SessionGroupSummaryInputs, fetch_session_data_activity
+
+WORKFLOWS = [SyncVectorsWorkflow, SummarizeSingleSessionWorkflow, SummarizeSessionGroupWorkflow]
 
 ACTIVITIES = [
     get_approximate_actions_count,
@@ -25,4 +29,4 @@ ACTIVITIES = [
     fetch_session_data_activity,
 ]
 
-__all__ = ["SyncVectorsInputs", "SingleSessionSummaryInputs"]
+__all__ = ["SyncVectorsInputs", "SingleSessionSummaryInputs", "SessionGroupSummaryInputs"]

--- a/posthog/temporal/ai/session_summary/shared.py
+++ b/posthog/temporal/ai/session_summary/shared.py
@@ -14,6 +14,7 @@ class SingleSessionSummaryInputs:
     team_id: int
     redis_input_key: str
     redis_output_key: str
+    stream: bool = False
     extra_summary_context: ExtraSummaryContext | None = None
     local_reads_prod: bool = False
 

--- a/posthog/temporal/ai/session_summary/shared.py
+++ b/posthog/temporal/ai/session_summary/shared.py
@@ -87,5 +87,5 @@ def get_single_session_summary_llm_input_from_redis(
     except Exception as e:
         raise ValueError(
             f"Failed to parse single session summary LLM input data ({raw_redis_data}) for Redis key {redis_input_key}: {e}"
-        )
+        ) from e
     return redis_data

--- a/posthog/temporal/ai/session_summary/shared.py
+++ b/posthog/temporal/ai/session_summary/shared.py
@@ -1,0 +1,43 @@
+import dataclasses
+import gzip
+import json
+from ee.session_recordings.session_summary.summarize_session import ExtraSummaryContext, SingleSessionSummaryLlmInputs
+from redis import Redis
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class SingleSessionSummaryInputs:
+    """Workflow input to get summary for a single session"""
+
+    session_id: str
+    user_pk: int
+    team_id: int
+    redis_input_key: str
+    redis_output_key: str
+    extra_summary_context: ExtraSummaryContext | None = None
+    local_reads_prod: bool = False
+
+
+def compress_llm_input_data(llm_input_data: SingleSessionSummaryLlmInputs) -> bytes:
+    return gzip.compress(json.dumps(dataclasses.asdict(llm_input_data)).encode("utf-8"))
+
+
+def get_single_session_summary_llm_input_from_redis(
+    redis_client: Redis, redis_input_key: str
+) -> SingleSessionSummaryLlmInputs:
+    raw_redis_data = redis_client.get(redis_input_key)
+    if not raw_redis_data:
+        raise ValueError(f"Single session summary LLM input data not found in Redis for key {redis_input_key}")
+    try:
+        # Decompress the data
+        if isinstance(raw_redis_data, bytes):
+            redis_data_str = gzip.decompress(raw_redis_data).decode("utf-8")
+        else:
+            # Fallback for uncompressed data (if stored as string)
+            redis_data_str = raw_redis_data
+        redis_data = SingleSessionSummaryLlmInputs(**json.loads(redis_data_str))
+    except Exception as e:
+        raise ValueError(
+            f"Failed to parse single session summary LLM input data ({raw_redis_data}) for Redis key {redis_input_key}: {e}"
+        )
+    return redis_data

--- a/posthog/temporal/ai/session_summary/shared.py
+++ b/posthog/temporal/ai/session_summary/shared.py
@@ -12,8 +12,8 @@ class SingleSessionSummaryInputs:
     session_id: str
     user_pk: int
     team_id: int
-    redis_input_key: str
-    redis_output_key: str
+    redis_input_key: str | None = None
+    redis_output_key: str | None = None
     stream: bool = False
     extra_summary_context: ExtraSummaryContext | None = None
     local_reads_prod: bool = False

--- a/posthog/temporal/ai/session_summary/shared.py
+++ b/posthog/temporal/ai/session_summary/shared.py
@@ -3,6 +3,16 @@ import gzip
 import json
 from ee.session_recordings.session_summary.summarize_session import ExtraSummaryContext, SingleSessionSummaryLlmInputs
 from redis import Redis
+from ee.session_recordings.session_summary.summarize_session import (
+    prepare_data_for_single_session_summary,
+    prepare_single_session_summary_input,
+)
+import structlog
+from ee.session_recordings.session_summary import ExceptionToRetry
+import temporalio
+from posthog.redis import get_client
+
+logger = structlog.get_logger(__name__)
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
@@ -14,9 +24,43 @@ class SingleSessionSummaryInputs:
     team_id: int
     redis_input_key: str
     redis_output_key: str | None = None
-    stream: bool = False
     extra_summary_context: ExtraSummaryContext | None = None
     local_reads_prod: bool = False
+
+
+@temporalio.activity.defn
+async def fetch_session_data_activity(session_input: SingleSessionSummaryInputs) -> str | None:
+    """Fetch data from DB for a single session and store in Redis (to avoid hitting Temporal memory limits), return Redis key"""
+    summary_data = await prepare_data_for_single_session_summary(
+        session_id=session_input.session_id,
+        user_pk=session_input.user_pk,
+        team_id=session_input.team_id,
+        extra_summary_context=session_input.extra_summary_context,
+        local_reads_prod=session_input.local_reads_prod,
+    )
+    if summary_data.error_msg is not None:
+        # If we weren't able to collect the required data - retry
+        logger.exception(
+            f"Not able to fetch data from the DB for session {session_input.session_id} (by user {session_input.user_pk}): {summary_data.error_msg}",
+            session_id=session_input.session_id,
+            user_pk=session_input.user_pk,
+        )
+        raise ExceptionToRetry()
+    input_data = prepare_single_session_summary_input(
+        session_id=session_input.session_id,
+        user_pk=session_input.user_pk,
+        summary_data=summary_data,
+    )
+    # Connect to Redis and prepare the input
+    redis_client = get_client()
+    compressed_llm_input_data = compress_llm_input_data(input_data)
+    redis_client.setex(
+        session_input.redis_input_key,
+        900,  # 15 minutes TTL to keep alive for retries
+        compressed_llm_input_data,
+    )
+    # Nothing to return if the fetch was successful, as the data is stored in Redis
+    return None
 
 
 def compress_llm_input_data(llm_input_data: SingleSessionSummaryLlmInputs) -> bytes:

--- a/posthog/temporal/ai/session_summary/shared.py
+++ b/posthog/temporal/ai/session_summary/shared.py
@@ -28,18 +28,6 @@ class SingleSessionSummaryInputs:
     local_reads_prod: bool = False
 
 
-@dataclasses.dataclass(frozen=True, kw_only=True)
-class SessionGroupSummaryInputs:
-    """Workflow input to get summary for a group of sessions"""
-
-    session_ids: list[str]
-    user_pk: int
-    team_id: int
-    redis_input_key_base: str
-    extra_summary_context: ExtraSummaryContext | None = None
-    local_reads_prod: bool = False
-
-
 @temporalio.activity.defn
 async def fetch_session_data_activity(inputs: SingleSessionSummaryInputs) -> str | None:
     """Fetch data from DB for a single session and store in Redis (to avoid hitting Temporal memory limits), return Redis key"""

--- a/posthog/temporal/ai/session_summary/shared.py
+++ b/posthog/temporal/ai/session_summary/shared.py
@@ -12,7 +12,7 @@ class SingleSessionSummaryInputs:
     session_id: str
     user_pk: int
     team_id: int
-    redis_input_key: str | None = None
+    redis_input_key: str
     redis_output_key: str | None = None
     stream: bool = False
     extra_summary_context: ExtraSummaryContext | None = None

--- a/posthog/temporal/ai/session_summary/shared.py
+++ b/posthog/temporal/ai/session_summary/shared.py
@@ -23,7 +23,7 @@ class SingleSessionSummaryInputs:
     """Workflow input to get summary for a single session"""
 
     session_id: str
-    user_pk: int
+    user_id: int
     team_id: int
     redis_input_key: str
     redis_output_key: str | None = None
@@ -36,7 +36,7 @@ async def fetch_session_data_activity(inputs: SingleSessionSummaryInputs) -> str
     """Fetch data from DB for a single session and store in Redis (to avoid hitting Temporal memory limits), return Redis key"""
     summary_data = await prepare_data_for_single_session_summary(
         session_id=inputs.session_id,
-        user_pk=inputs.user_pk,
+        user_id=inputs.user_id,
         team_id=inputs.team_id,
         extra_summary_context=inputs.extra_summary_context,
         local_reads_prod=inputs.local_reads_prod,
@@ -44,14 +44,14 @@ async def fetch_session_data_activity(inputs: SingleSessionSummaryInputs) -> str
     if summary_data.error_msg is not None:
         # If we weren't able to collect the required data - retry
         logger.exception(
-            f"Not able to fetch data from the DB for session {inputs.session_id} (by user {inputs.user_pk}): {summary_data.error_msg}",
+            f"Not able to fetch data from the DB for session {inputs.session_id} (by user {inputs.user_id}): {summary_data.error_msg}",
             session_id=inputs.session_id,
-            user_pk=inputs.user_pk,
+            user_id=inputs.user_id,
         )
         raise ExceptionToRetry()
     input_data = prepare_single_session_summary_input(
         session_id=inputs.session_id,
-        user_pk=inputs.user_pk,
+        user_id=inputs.user_id,
         summary_data=summary_data,
     )
     # Connect to Redis and prepare the input

--- a/posthog/temporal/ai/session_summary/shared.py
+++ b/posthog/temporal/ai/session_summary/shared.py
@@ -14,6 +14,9 @@ from posthog.redis import get_client
 
 logger = structlog.get_logger(__name__)
 
+# How long to store the DB data in Redis within Temporal session summaries jobs
+SESSION_SUMMARIES_DB_DATA_REDIS_TTL = 900  # 15 minutes to keep alive for retries
+
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class SingleSessionSummaryInputs:
@@ -56,7 +59,7 @@ async def fetch_session_data_activity(inputs: SingleSessionSummaryInputs) -> str
     compressed_llm_input_data = compress_llm_input_data(input_data)
     redis_client.setex(
         inputs.redis_input_key,
-        900,  # 15 minutes TTL to keep alive for retries
+        SESSION_SUMMARIES_DB_DATA_REDIS_TTL,
         compressed_llm_input_data,
     )
     # Nothing to return if the fetch was successful, as the data is stored in Redis

--- a/posthog/temporal/ai/session_summary/summarize_session.py
+++ b/posthog/temporal/ai/session_summary/summarize_session.py
@@ -107,9 +107,6 @@ class SummarizeSingleSessionWorkflow(PostHogWorkflow):
             heartbeat_timeout=timedelta(seconds=30),
             retry_policy=RetryPolicy(maximum_attempts=3),
         )
-        temporalio.workflow.logger.info(
-            f"Successfully executed summarize-session workflow with id {temporalio.workflow.info().workflow_id}"
-        )
         return summary
 
 

--- a/posthog/temporal/ai/session_summary/summarize_session.py
+++ b/posthog/temporal/ai/session_summary/summarize_session.py
@@ -51,7 +51,7 @@ async def stream_llm_single_session_summary_activity(inputs: SingleSessionSummar
     # Stream summary from the LLM stream
     session_summary_generator = stream_llm_single_session_summary(
         session_id=llm_input.session_id,
-        user_pk=llm_input.user_pk,
+        user_id=llm_input.user_id,
         # Prompt
         summary_prompt=llm_input.summary_prompt,
         system_prompt=llm_input.system_prompt,
@@ -149,7 +149,7 @@ async def _check_handle_data(handle: WorkflowHandle) -> tuple[WorkflowExecutionS
 
 def execute_summarize_session_stream(
     session_id: str,
-    user_pk: int,
+    user_id: int,
     team: Team,
     extra_summary_context: ExtraSummaryContext | None = None,
     local_reads_prod: bool = False,
@@ -161,11 +161,11 @@ def execute_summarize_session_stream(
     shared_id = uuid.uuid4()
     # Prepare the input data
     redis_client = get_client()
-    redis_input_key = f"session-summary:single:stream-input:{session_id}:{user_pk}-{team.id}:{shared_id}"
-    redis_output_key = f"session-summary:single:stream-output:{session_id}:{user_pk}-{team.id}:{shared_id}"
+    redis_input_key = f"session-summary:single:stream-input:{session_id}:{user_id}-{team.id}:{shared_id}"
+    redis_output_key = f"session-summary:single:stream-output:{session_id}:{user_id}-{team.id}:{shared_id}"
     session_input = SingleSessionSummaryInputs(
         session_id=session_id,
-        user_pk=user_pk,
+        user_id=user_id,
         team_id=team.id,
         extra_summary_context=extra_summary_context,
         local_reads_prod=local_reads_prod,
@@ -173,7 +173,7 @@ def execute_summarize_session_stream(
         redis_output_key=redis_output_key,
     )
     # Connect to Temporal and start streaming the workflow
-    workflow_id = f"session-summary:single:stream:{session_id}:{user_pk}:{shared_id}"
+    workflow_id = f"session-summary:single:stream:{session_id}:{user_id}:{shared_id}"
     handle = asyncio.run(_start_workflow(inputs=session_input, workflow_id=workflow_id))
     last_summary_state = ""
     while True:

--- a/posthog/temporal/ai/session_summary/summarize_session.py
+++ b/posthog/temporal/ai/session_summary/summarize_session.py
@@ -9,7 +9,7 @@ import structlog
 import temporalio
 from temporalio.common import RetryPolicy, WorkflowIDReusePolicy
 from django.conf import settings
-from ee.session_recordings.session_summary.llm.consume import stream_llm_session_summary
+from ee.session_recordings.session_summary.llm.consume import stream_llm_single_session_summary
 from ee.session_recordings.session_summary.summarize_session import ExtraSummaryContext
 from ee.session_recordings.session_summary.utils import serialize_to_sse_event
 from posthog import constants
@@ -45,7 +45,7 @@ async def stream_llm_single_session_summary_activity(inputs: SingleSessionSummar
     temporalio.activity.heartbeat()
     last_heartbeat_timestamp = time.time()
     # Stream summary from the LLM stream
-    session_summary_generator = stream_llm_session_summary(
+    session_summary_generator = stream_llm_single_session_summary(
         session_id=llm_input.session_id,
         user_pk=llm_input.user_pk,
         # Prompt

--- a/posthog/temporal/ai/session_summary/summarize_session.py
+++ b/posthog/temporal/ai/session_summary/summarize_session.py
@@ -177,6 +177,7 @@ def execute_summarize_session_stream(
     last_summary_state = ""
     while True:
         try:
+            # TODO: Rework to rely on Redis overly or reuse the loop to avoid creating new loops for each iteration
             status, final_result = asyncio.run(_check_handle_data(handle))
             # If no status yet, wait a bit
             if status is None:

--- a/posthog/temporal/ai/session_summary/summarize_session.py
+++ b/posthog/temporal/ai/session_summary/summarize_session.py
@@ -167,7 +167,6 @@ def execute_summarize_session_stream(
         user_pk=user_pk,
         team_id=team.id,
         extra_summary_context=extra_summary_context,
-        stream=True,
         local_reads_prod=local_reads_prod,
         redis_input_key=redis_input_key,
         redis_output_key=redis_output_key,

--- a/posthog/temporal/ai/session_summary/summarize_session_group.py
+++ b/posthog/temporal/ai/session_summary/summarize_session_group.py
@@ -102,6 +102,7 @@ class SummarizeSessionGroupWorkflow(PostHogWorkflow):
     async def _fetch_session_data(inputs: SingleSessionSummaryInputs) -> None | Exception:
         """
         Fetch and handle the session data for a single session to avoid one activity failing the whole group.
+        The data is stored in Redis to avoid hitting Temporal memory limits, so activity returns nothing if successful.
         """
         try:
             # TODO: Instead of getting session data from DB one by one, we can optimize it by getting multiple sessions in one call

--- a/posthog/temporal/ai/session_summary/summarize_session_group.py
+++ b/posthog/temporal/ai/session_summary/summarize_session_group.py
@@ -1,0 +1,141 @@
+import asyncio
+from datetime import timedelta
+import json
+import uuid
+import structlog
+import temporalio
+from temporalio.common import RetryPolicy, WorkflowIDReusePolicy
+from django.conf import settings
+from ee.session_recordings.session_summary.llm.consume import get_llm_session_summary
+from ee.session_recordings.session_summary.summarize_session import ExtraSummaryContext
+from posthog import constants
+from posthog.redis import get_client
+from posthog.models.team.team import Team
+from posthog.temporal.ai.session_summary.shared import (
+    SessionGroupSummaryInputs,
+    SingleSessionSummaryInputs,
+    get_single_session_summary_llm_input_from_redis,
+    fetch_session_data_activity,
+)
+from posthog.temporal.common.base import PostHogWorkflow
+from posthog.temporal.common.client import async_connect
+
+logger = structlog.get_logger(__name__)
+
+
+@temporalio.activity.defn
+async def get_llm_single_session_summary_activity(inputs: SingleSessionSummaryInputs) -> str:
+    """Summarize a single session in one call"""
+    redis_client = get_client()
+    llm_input = get_single_session_summary_llm_input_from_redis(
+        redis_client=redis_client,
+        redis_input_key=inputs.redis_input_key,
+    )
+    # Get summary from LLM
+    session_summary_str = await get_llm_session_summary(
+        session_id=llm_input.session_id,
+        user_pk=llm_input.user_pk,
+        # Prompt
+        summary_prompt=llm_input.summary_prompt,
+        system_prompt=llm_input.system_prompt,
+        # Mappings to enrich events
+        allowed_event_ids=list(llm_input.simplified_events_mapping.keys()),
+        simplified_events_mapping=llm_input.simplified_events_mapping,
+        simplified_events_columns=llm_input.simplified_events_columns,
+        url_mapping_reversed=llm_input.url_mapping_reversed,
+        window_mapping_reversed=llm_input.window_mapping_reversed,
+        # Session metadata
+        session_start_time_str=llm_input.session_start_time_str,
+        session_duration=llm_input.session_duration,
+    )
+    # Not storing the summary in Redis yet, as for 30 sessions we should fit within Temporal memory limits
+    # TODO: Store in Redis to avoid hitting memory limits with larger amount of sessions
+    return session_summary_str
+
+
+@temporalio.workflow.defn(name="summarize-session-group")
+class SummarizeSessionGroupWorkflow(PostHogWorkflow):
+    @staticmethod
+    def parse_inputs(inputs: list[str]) -> SessionGroupSummaryInputs:
+        """Parse inputs from the management command CLI."""
+        loaded = json.loads(inputs[0])
+        return SessionGroupSummaryInputs(**loaded)
+
+    @temporalio.workflow.run
+    async def run(self, inputs: SessionGroupSummaryInputs) -> dict[str, str]:
+        # Fetch data for each session and store in Redis
+        session_inputs = []
+        for session_id in inputs.session_ids:
+            redis_input_key = f"{inputs.redis_input_key_base}:{session_id}"
+            single_session_input = SingleSessionSummaryInputs(
+                session_id=session_id,
+                user_pk=inputs.user_pk,
+                team_id=inputs.team_id,
+                redis_input_key=redis_input_key,
+                extra_summary_context=inputs.extra_summary_context,
+                local_reads_prod=inputs.local_reads_prod,
+            )
+            await temporalio.workflow.execute_activity(
+                fetch_session_data_activity,
+                single_session_input,
+                start_to_close_timeout=timedelta(minutes=3),
+                retry_policy=RetryPolicy(maximum_attempts=1),
+            )
+            session_inputs.append(single_session_input)
+        # Summarize all sessions
+        summaries = {}
+        for session_input in session_inputs:
+            summary = await temporalio.workflow.execute_activity(
+                get_llm_single_session_summary_activity,
+                session_input,
+                start_to_close_timeout=timedelta(minutes=5),
+                retry_policy=RetryPolicy(maximum_attempts=3),
+            )
+            summaries[session_input.session_id] = summary
+        temporalio.workflow.logger.info(
+            f"Successfully executed summarize-session-group workflow with id {temporalio.workflow.info().workflow_id}"
+        )
+        # TODO: Return summary of summaries instead
+        return summaries
+
+
+async def _execute_workflow(inputs: SessionGroupSummaryInputs, workflow_id: str) -> str:
+    client = await async_connect()
+    retry_policy = RetryPolicy(maximum_attempts=int(settings.TEMPORAL_WORKFLOW_MAX_ATTEMPTS))
+    result = await client.execute_workflow(
+        "summarize-session-group",
+        inputs,
+        id=workflow_id,
+        id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+        task_queue=constants.GENERAL_PURPOSE_TASK_QUEUE,
+        retry_policy=retry_policy,
+    )
+    return result
+
+
+def execute_summarize_session_group(
+    session_ids: list[str],
+    user_pk: int,
+    team: Team,
+    extra_summary_context: ExtraSummaryContext | None = None,
+    local_reads_prod: bool = False,
+) -> str:
+    """
+    Start the workflow and return the final summary for the group of sessions.
+    """
+    # Use shared identifier to be able to construct all the ids to check/debug
+    shared_id = uuid.uuid4()
+    # Prepare the input data
+    redis_input_key_base = f"session-summary:group:get-input:{user_pk}-{team.id}:{shared_id}"
+    session_group_input = SessionGroupSummaryInputs(
+        session_ids=session_ids,
+        user_pk=user_pk,
+        team_id=team.id,
+        redis_input_key_base=redis_input_key_base,
+        extra_summary_context=extra_summary_context,
+        local_reads_prod=local_reads_prod,
+    )
+    # Connect to Temporal and execute the workflow
+    workflow_id = f"session-summary:group:{user_pk}-{team.id}:{shared_id}"
+    result = asyncio.run(_execute_workflow(inputs=session_group_input, workflow_id=workflow_id))
+    return result

--- a/posthog/temporal/ai/session_summary/summarize_session_group.py
+++ b/posthog/temporal/ai/session_summary/summarize_session_group.py
@@ -183,6 +183,8 @@ class SummarizeSessionGroupWorkflow(PostHogWorkflow):
         async with asyncio.TaskGroup() as tg:
             tasks = {}
             for session_input in inputs:
+                # TODO: When stories summaries in Redis (>50) - rework to use tuples also
+                # to have the same taskgroun function for both fetch/summarize tasks
                 tasks[session_input.session_id] = tg.create_task(self._run_summary(session_input))
         for session_id, task in tasks.items():
             res = task.result()

--- a/posthog/temporal/ai/session_summary/summarize_session_group.py
+++ b/posthog/temporal/ai/session_summary/summarize_session_group.py
@@ -6,7 +6,7 @@ import structlog
 import temporalio
 from temporalio.common import RetryPolicy, WorkflowIDReusePolicy
 from django.conf import settings
-from ee.session_recordings.session_summary.llm.consume import get_llm_session_summary
+from ee.session_recordings.session_summary.llm.consume import get_llm_single_session_summary
 from ee.session_recordings.session_summary.summarize_session import ExtraSummaryContext
 from posthog import constants
 from posthog.redis import get_client
@@ -33,7 +33,7 @@ async def get_llm_single_session_summary_activity(inputs: SingleSessionSummaryIn
         redis_input_key=inputs.redis_input_key,
     )
     # Get summary from LLM
-    session_summary_str = await get_llm_session_summary(
+    session_summary_str = await get_llm_single_session_summary(
         session_id=llm_input.session_id,
         user_pk=llm_input.user_pk,
         # Prompt

--- a/posthog/temporal/ai/session_summary/summarize_session_group.py
+++ b/posthog/temporal/ai/session_summary/summarize_session_group.py
@@ -107,8 +107,8 @@ class SummarizeSessionGroupWorkflow(PostHogWorkflow):
             await temporalio.workflow.execute_activity(
                 fetch_session_data_activity,
                 inputs,
-                start_to_close_timeout=timedelta(minutes=3),
-                retry_policy=RetryPolicy(maximum_attempts=1),
+                start_to_close_timeout=timedelta(minutes=10),
+                retry_policy=RetryPolicy(maximum_attempts=3),
             )
             return None
         except Exception as err:  # Activity retries exhausted
@@ -163,7 +163,7 @@ class SummarizeSessionGroupWorkflow(PostHogWorkflow):
             return await temporalio.workflow.execute_activity(
                 get_llm_single_session_summary_activity,
                 inputs,
-                start_to_close_timeout=timedelta(minutes=5),
+                start_to_close_timeout=timedelta(minutes=10),
                 retry_policy=RetryPolicy(maximum_attempts=3),
             )
         except Exception as err:  # Activity retries exhausted
@@ -215,7 +215,7 @@ class SummarizeSessionGroupWorkflow(PostHogWorkflow):
                 user_pk=inputs.user_pk,
                 extra_summary_context=inputs.extra_summary_context,
             ),
-            start_to_close_timeout=timedelta(minutes=5),
+            start_to_close_timeout=timedelta(minutes=10),
             retry_policy=RetryPolicy(maximum_attempts=3),
         )
         return summary_of_summaries

--- a/posthog/temporal/tests/ai/conftest.py
+++ b/posthog/temporal/tests/ai/conftest.py
@@ -22,7 +22,7 @@ def mock_single_session_summary_inputs(
     ) -> SingleSessionSummaryInputs:
         return SingleSessionSummaryInputs(
             session_id=session_id,
-            user_pk=mock_user.pk,
+            user_id=mock_user.id,
             team_id=mock_team.id,
             redis_input_key=redis_input_key,
             redis_output_key=redis_output_key,
@@ -44,7 +44,7 @@ def mock_single_session_summary_llm_inputs(
     def _create_inputs(session_id: str) -> SingleSessionSummaryLlmInputs:
         return SingleSessionSummaryLlmInputs(
             session_id=session_id,
-            user_pk=mock_user.pk,
+            user_id=mock_user.id,
             summary_prompt="Generate a summary for this session",
             system_prompt="You are a helpful assistant that summarizes user sessions",
             simplified_events_mapping=mock_events_mapping,
@@ -70,7 +70,7 @@ def mock_session_group_summary_inputs(
     ) -> SessionGroupSummaryInputs:
         return SessionGroupSummaryInputs(
             session_ids=session_ids,
-            user_pk=mock_user.pk,
+            user_id=mock_user.id,
             team_id=mock_team.id,
             redis_input_key_base=redis_input_key_base,
         )

--- a/posthog/temporal/tests/ai/conftest.py
+++ b/posthog/temporal/tests/ai/conftest.py
@@ -7,6 +7,7 @@ import pytest
 from typing import Any
 from posthog.redis import get_client
 from posthog.temporal.ai.session_summary.summarize_session_group import SessionGroupSummaryInputs
+from posthog.temporal.ai.session_summary.shared import SESSION_SUMMARIES_DB_DATA_REDIS_TTL
 
 
 @pytest.fixture
@@ -86,7 +87,7 @@ class RedisTestContext:
         """Set up Redis input data and track keys for cleanup."""
         self.redis_client.setex(
             input_key,
-            900,  # 15 minutes TTL
+            SESSION_SUMMARIES_DB_DATA_REDIS_TTL,
             input_data,
         )
         keys = [input_key] if not output_key else [input_key, output_key]

--- a/posthog/temporal/tests/ai/conftest.py
+++ b/posthog/temporal/tests/ai/conftest.py
@@ -1,1 +1,87 @@
+from collections.abc import Callable, Generator
+from ee.session_recordings.session_summary.summarize_session import SingleSessionSummaryLlmInputs
 from ee.session_recordings.session_summary.tests.conftest import *
+from posthog.temporal.ai.session_summary.shared import SingleSessionSummaryInputs
+from unittest.mock import MagicMock
+import pytest
+from typing import Any
+from posthog.redis import get_client
+
+
+@pytest.fixture
+def mock_single_session_summary_inputs(
+    mock_user: MagicMock,
+    mock_team: MagicMock,
+) -> Callable:
+    """Factory to produce inputs for single-session-summary related workflows/activities"""
+
+    def _create_inputs(
+        session_id: str, redis_input_key: str = "test_input_key", redis_output_key: str = "test_output_key"
+    ) -> SingleSessionSummaryInputs:
+        return SingleSessionSummaryInputs(
+            session_id=session_id,
+            user_pk=mock_user.pk,
+            team_id=mock_team.id,
+            redis_input_key=redis_input_key,
+            redis_output_key=redis_output_key,
+        )
+
+    return _create_inputs
+
+
+@pytest.fixture
+def mock_single_session_summary_llm_inputs(
+    mock_user: MagicMock,
+    mock_events_mapping: dict[str, list[Any]],
+    mock_events_columns: list[str],
+    mock_url_mapping_reversed: dict[str, str],
+    mock_window_mapping_reversed: dict[str, str],
+) -> Callable:
+    """Factory to produce inputs for single-session summarization LLM calls, usually stored in Redis"""
+
+    def _create_inputs(session_id: str) -> SingleSessionSummaryLlmInputs:
+        return SingleSessionSummaryLlmInputs(
+            session_id=session_id,
+            user_pk=mock_user.pk,
+            summary_prompt="Generate a summary for this session",
+            system_prompt="You are a helpful assistant that summarizes user sessions",
+            simplified_events_mapping=mock_events_mapping,
+            simplified_events_columns=mock_events_columns,
+            url_mapping_reversed=mock_url_mapping_reversed,
+            window_mapping_reversed=mock_window_mapping_reversed,
+            session_start_time_str="2025-03-31T18:40:32.302000Z",
+            session_duration=5323,
+        )
+
+    return _create_inputs
+
+
+class RedisTestContext:
+    def __init__(self):
+        self.redis_client = get_client()
+        self.keys_to_cleanup = []
+
+    def setup_input_data(self, input_data: bytes, input_key: str, output_key: str | None = None):
+        """Set up Redis input data and track keys for cleanup."""
+        self.redis_client.setex(
+            input_key,
+            900,  # 15 minutes TTL
+            input_data,
+        )
+        keys = [input_key] if not output_key else [input_key, output_key]
+        self.keys_to_cleanup.extend(keys)
+
+    def cleanup(self):
+        """Clean up all tracked Redis keys."""
+        for key in self.keys_to_cleanup:
+            self.redis_client.delete(key)
+
+
+@pytest.fixture
+def redis_test_setup() -> Generator[RedisTestContext, None, None]:
+    """Context manager for Redis test setup and cleanup."""
+    context = RedisTestContext()
+    try:
+        yield context
+    finally:
+        context.cleanup()

--- a/posthog/temporal/tests/ai/conftest.py
+++ b/posthog/temporal/tests/ai/conftest.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 from typing import Any
 from posthog.redis import get_client
+from posthog.temporal.ai.session_summary.summarize_session_group import SessionGroupSummaryInputs
 
 
 @pytest.fixture
@@ -51,6 +52,26 @@ def mock_single_session_summary_llm_inputs(
             window_mapping_reversed=mock_window_mapping_reversed,
             session_start_time_str="2025-03-31T18:40:32.302000Z",
             session_duration=5323,
+        )
+
+    return _create_inputs
+
+
+@pytest.fixture
+def mock_session_group_summary_inputs(
+    mock_user: MagicMock,
+    mock_team: MagicMock,
+) -> Callable:
+    """Factory to produce inputs for session-group-summary related workflows/activities"""
+
+    def _create_inputs(
+        session_ids: list[str], redis_input_key_base: str = "test_input_base"
+    ) -> SessionGroupSummaryInputs:
+        return SessionGroupSummaryInputs(
+            session_ids=session_ids,
+            user_pk=mock_user.pk,
+            team_id=mock_team.id,
+            redis_input_key_base=redis_input_key_base,
         )
 
     return _create_inputs

--- a/posthog/temporal/tests/ai/test_summarize_session.py
+++ b/posthog/temporal/tests/ai/test_summarize_session.py
@@ -118,7 +118,7 @@ class TestFetchSessionDataActivity:
                 redis_test_setup.redis_client, input_data.redis_input_key
             )
             assert decompressed_data.session_id == session_id
-            assert decompressed_data.user_pk == input_data.user_pk
+            assert decompressed_data.user_id == input_data.user_id
 
     @pytest.mark.asyncio
     async def test_fetch_session_data_activity_no_events_raises_error(
@@ -273,7 +273,7 @@ class TestSummarizeSingleSessionWorkflow:
         session_id = "test_session_id"
         sample_session_summary_data = SingleSessionSummaryData(
             session_id=session_id,
-            user_pk=mock_user.pk,
+            user_id=mock_user.id,
             prompt_data=True,  # type: ignore
             prompt=True,  # type: ignore
             error_msg=None,
@@ -338,7 +338,7 @@ class TestSummarizeSingleSessionWorkflow:
             result = list(
                 execute_summarize_session_stream(
                     session_id=session_id,
-                    user_pk=mock_user.pk,
+                    user_id=mock_user.id,
                     team=mock_team,
                     extra_summary_context=None,
                     local_reads_prod=False,

--- a/posthog/temporal/tests/ai/test_summarize_session.py
+++ b/posthog/temporal/tests/ai/test_summarize_session.py
@@ -501,7 +501,7 @@ class TestSummarizeSessionWorkflow:
             redis_get_call_count += 1
             if redis_get_call_count in (1, 2):
                 # First two calls fail with a retryable exception
-                raise ApplicationError("Simulated stream_llm_session_summary failure", non_retryable=False)
+                raise ApplicationError("Simulated stream_llm_single_session_summary failure", non_retryable=False)
             else:
                 # Subsequent calls succeed - return actual data
                 return original_get(key)
@@ -559,7 +559,7 @@ class TestSummarizeSessionWorkflow:
             # Retries limit is 3, so failing 3 times should lead to workflow failure
             if redis_get_call_count in (1, 2, 3):
                 # First two calls fail with a retryable exception
-                raise ApplicationError("Simulated stream_llm_session_summary failure", non_retryable=False)
+                raise ApplicationError("Simulated stream_llm_single_session_summary failure", non_retryable=False)
             else:
                 # Subsequent calls succeed - return actual data
                 return original_get(key)

--- a/posthog/temporal/tests/ai/test_summarize_session.py
+++ b/posthog/temporal/tests/ai/test_summarize_session.py
@@ -195,7 +195,7 @@ class TestStreamLlmSummaryActivity:
             assert spy_setex.call_count == 1 + 8
 
 
-class TestSummarizeSessionWorkflow:
+class TestSummarizeSingleSessionWorkflow:
     @asynccontextmanager
     async def workflow_test_environment(
         self,

--- a/posthog/temporal/tests/ai/test_summarize_session.py
+++ b/posthog/temporal/tests/ai/test_summarize_session.py
@@ -94,7 +94,7 @@ class TestFetchSessionDataActivity:
         spy_setex = mocker.spy(redis_test_setup.redis_client, "setex")
         with (
             # Mock DB calls
-            patch("ee.session_recordings.session_summary.summarize_session.get_team", return_value=mock_team),
+            patch("ee.session_recordings.session_summary.input_data.get_team", return_value=mock_team),
             patch(
                 "ee.session_recordings.session_summary.summarize_session.get_session_metadata",
                 return_value=mock_raw_metadata,
@@ -133,7 +133,7 @@ class TestFetchSessionDataActivity:
         input_data = mock_single_session_summary_inputs(session_id)
         with (
             # Mock DB calls - return columns but no events (empty list)
-            patch("ee.session_recordings.session_summary.summarize_session.get_team", return_value=mock_team),
+            patch("ee.session_recordings.session_summary.input_data.get_team", return_value=mock_team),
             patch(
                 "ee.session_recordings.session_summary.summarize_session.get_session_metadata",
                 return_value=mock_raw_metadata,
@@ -220,7 +220,7 @@ class TestSummarizeSingleSessionWorkflow:
                         "ee.session_recordings.session_summary.llm.consume.stream_llm", return_value=mock_stream_llm()
                     ),
                     # Mock DB calls
-                    patch("ee.session_recordings.session_summary.summarize_session.get_team", return_value=mock_team),
+                    patch("ee.session_recordings.session_summary.input_data.get_team", return_value=mock_team),
                     patch(
                         "ee.session_recordings.session_summary.summarize_session.get_session_metadata",
                         return_value=mock_raw_metadata,

--- a/posthog/temporal/tests/ai/test_summarize_session_group.py
+++ b/posthog/temporal/tests/ai/test_summarize_session_group.py
@@ -1,12 +1,15 @@
 import json
 from collections.abc import Callable
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+import importlib
 
 import pytest
 from pytest_mock import MockerFixture
 from posthog.temporal.ai.session_summary.shared import compress_llm_input_data, SingleSessionSummaryInputs
 from posthog.temporal.ai.session_summary.summarize_session_group import (
+    SessionGroupSummaryOfSummariesInputs,
+    get_llm_session_group_summary_activity,
     get_llm_single_session_summary_activity,
 )
 from posthog.temporal.tests.ai.conftest import RedisTestContext
@@ -15,20 +18,25 @@ from datetime import datetime
 
 
 @pytest.fixture
-def mock_call_llm(mock_valid_llm_yaml_response: str) -> ChatCompletion:
-    return ChatCompletion(
-        id="test_id",
-        model="gpt-4.1-2025-04-14",
-        object="chat.completion",
-        created=int(datetime.now().timestamp()),
-        choices=[
-            Choice(
-                finish_reason="stop",
-                index=0,
-                message=ChatCompletionMessage(content=mock_valid_llm_yaml_response, role="assistant"),
-            )
-        ],
-    )
+def mock_call_llm(mock_valid_llm_yaml_response: str) -> Callable:
+    def _mock_call_llm(custom_content: str | None = None) -> ChatCompletion:
+        return ChatCompletion(
+            id="test_id",
+            model="gpt-4.1-2025-04-14",
+            object="chat.completion",
+            created=int(datetime.now().timestamp()),
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    message=ChatCompletionMessage(
+                        content=custom_content or mock_valid_llm_yaml_response, role="assistant"
+                    ),
+                )
+            ],
+        )
+
+    return _mock_call_llm
 
 
 @pytest.mark.asyncio
@@ -37,9 +45,10 @@ async def test_get_llm_single_session_summary_activity_standalone(
     mock_enriched_llm_json_response: dict[str, Any],
     mock_single_session_summary_llm_inputs: Callable[[str], Any],
     mock_single_session_summary_inputs: Callable[[str, str], SingleSessionSummaryInputs],
-    mock_call_llm: ChatCompletion,
+    mock_call_llm: Callable,
     redis_test_setup: RedisTestContext,
 ):
+    # Prepare input data
     session_id = "test_single_session_id"
     llm_input = mock_single_session_summary_llm_inputs(session_id)
     compressed_llm_input_data = compress_llm_input_data(llm_input)
@@ -53,14 +62,44 @@ async def test_get_llm_single_session_summary_activity_standalone(
         input_data.redis_input_key,
         input_data.redis_output_key,
     )
-    # Run the activity and verify results
+    # Execute the activity and verify results
     expected_summary = json.dumps(mock_enriched_llm_json_response)
     with patch(
         "ee.session_recordings.session_summary.llm.consume.call_llm",
-        new=AsyncMock(return_value=mock_call_llm),
+        new=AsyncMock(return_value=mock_call_llm()),
     ):
         result = await get_llm_single_session_summary_activity(input_data)
         assert result == expected_summary
         # Verify Redis operations count
         assert spy_get.call_count == 1  # Get input data
         assert spy_setex.call_count == 1  # Inital setip + 0 from the activity
+
+
+@pytest.mark.asyncio
+async def test_get_llm_session_group_summary_activity_standalone(
+    mock_user: MagicMock,
+    mock_enriched_llm_json_response: dict[str, Any],
+    mock_call_llm: Callable,
+    mocker: MockerFixture,
+):
+    # Prepare input data
+    session_ids = ["test_single_session_id_1", "test_single_session_id_2"]
+    enriched_summary_str = json.dumps(mock_enriched_llm_json_response)
+    session_summaries = [enriched_summary_str, enriched_summary_str]
+    activity_input = SessionGroupSummaryOfSummariesInputs(
+        session_ids=session_ids,
+        session_summaries=session_summaries,
+        user_pk=mock_user.pk,
+    )
+    expected_summary_of_summaries = "everything is good"
+    # Spy on the prompt generator to ensure it was called with the correct arguments
+    summary_module = importlib.import_module("posthog.temporal.ai.session_summary.summarize_session_group")
+    spy_generate_prompt = mocker.spy(summary_module, "generate_session_group_summary_prompt")
+    # Execute the activity and verify results
+    with patch(
+        "ee.session_recordings.session_summary.llm.consume.call_llm",
+        new=AsyncMock(return_value=mock_call_llm(custom_content=expected_summary_of_summaries)),
+    ):
+        result = await get_llm_session_group_summary_activity(activity_input)
+        assert result == expected_summary_of_summaries
+        spy_generate_prompt.assert_called_once_with(session_summaries, None)

--- a/posthog/temporal/tests/ai/test_summarize_session_group.py
+++ b/posthog/temporal/tests/ai/test_summarize_session_group.py
@@ -1,0 +1,66 @@
+import json
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pytest_mock import MockerFixture
+from posthog.temporal.ai.session_summary.shared import compress_llm_input_data, SingleSessionSummaryInputs
+from posthog.temporal.ai.session_summary.summarize_session_group import (
+    get_llm_single_session_summary_activity,
+)
+from posthog.temporal.tests.ai.conftest import RedisTestContext
+from openai.types.chat.chat_completion import ChatCompletion, Choice, ChatCompletionMessage
+from datetime import datetime
+
+
+@pytest.fixture
+def mock_call_llm(mock_valid_llm_yaml_response: str) -> ChatCompletion:
+    return ChatCompletion(
+        id="test_id",
+        model="gpt-4.1-2025-04-14",
+        object="chat.completion",
+        created=int(datetime.now().timestamp()),
+        choices=[
+            Choice(
+                finish_reason="stop",
+                index=0,
+                message=ChatCompletionMessage(content=mock_valid_llm_yaml_response, role="assistant"),
+            )
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_llm_single_session_summary_activity_standalone(
+    mocker: MockerFixture,
+    mock_enriched_llm_json_response: dict[str, Any],
+    mock_single_session_summary_llm_inputs: Callable[[str], Any],
+    mock_single_session_summary_inputs: Callable[[str, str], SingleSessionSummaryInputs],
+    mock_call_llm: ChatCompletion,
+    redis_test_setup: RedisTestContext,
+):
+    session_id = "test_single_session_id"
+    llm_input = mock_single_session_summary_llm_inputs(session_id)
+    compressed_llm_input_data = compress_llm_input_data(llm_input)
+    input_data = mock_single_session_summary_inputs(session_id)
+    # Set up spies to track Redis operations
+    spy_get = mocker.spy(redis_test_setup.redis_client, "get")
+    spy_setex = mocker.spy(redis_test_setup.redis_client, "setex")
+    # Store initial input data
+    redis_test_setup.setup_input_data(
+        compressed_llm_input_data,
+        input_data.redis_input_key,
+        input_data.redis_output_key,
+    )
+    # Run the activity and verify results
+    expected_summary = json.dumps(mock_enriched_llm_json_response)
+    with patch(
+        "ee.session_recordings.session_summary.llm.consume.call_llm",
+        new=AsyncMock(return_value=mock_call_llm),
+    ):
+        result = await get_llm_single_session_summary_activity(input_data)
+        assert result == expected_summary
+        # Verify Redis operations count
+        assert spy_get.call_count == 1  # Get input data
+        assert spy_setex.call_count == 1  # Inital setip + 0 from the activity

--- a/posthog/temporal/tests/ai/test_summarize_session_group.py
+++ b/posthog/temporal/tests/ai/test_summarize_session_group.py
@@ -11,10 +11,10 @@ from pytest_mock import MockerFixture
 from ee.session_recordings.session_summary.prompt_data import SessionSummaryPromptData
 from posthog.temporal.ai.session_summary.shared import (
     compress_llm_input_data,
-    SingleSessionSummaryInputs,
     fetch_session_data_activity,
 )
 from posthog.temporal.ai.session_summary.summarize_session_group import (
+    SessionGroupSummaryInputs,
     SessionGroupSummaryOfSummariesInputs,
     SummarizeSessionGroupWorkflow,
     execute_summarize_session_group,
@@ -58,8 +58,8 @@ def mock_call_llm(mock_valid_llm_yaml_response: str) -> Callable:
 async def test_get_llm_single_session_summary_activity_standalone(
     mocker: MockerFixture,
     mock_enriched_llm_json_response: dict[str, Any],
-    mock_single_session_summary_llm_inputs: Callable[[str], Any],
-    mock_single_session_summary_inputs: Callable[[str, str], SingleSessionSummaryInputs],
+    mock_single_session_summary_llm_inputs: Callable,
+    mock_single_session_summary_inputs: Callable,
     mock_call_llm: Callable,
     redis_test_setup: RedisTestContext,
 ):
@@ -206,7 +206,7 @@ class TestSummarizeSessionGroupWorkflow:
         self,
         mock_session_group_summary_inputs: Callable,
         identifier_suffix: str,
-    ) -> tuple[str, str, SingleSessionSummaryInputs, str, str]:
+    ) -> tuple[list[str], str, SessionGroupSummaryInputs, str]:
         # Prepare test data
         session_ids = [
             f"test_workflow_session_id_{identifier_suffix}_1",

--- a/posthog/temporal/tests/ai/test_summarize_session_group.py
+++ b/posthog/temporal/tests/ai/test_summarize_session_group.py
@@ -104,7 +104,7 @@ async def test_get_llm_session_group_summary_activity_standalone(
     activity_input = SessionGroupSummaryOfSummariesInputs(
         session_ids=session_ids,
         session_summaries=session_summaries,
-        user_pk=mock_user.pk,
+        user_id=mock_user.id,
     )
     expected_summary_of_summaries = "everything is good"
     # Spy on the prompt generator to ensure it was called with the correct arguments
@@ -231,7 +231,7 @@ class TestSummarizeSessionGroupWorkflow:
             new=AsyncMock(return_value=expected_summary),
         ):
             # Wait for workflow to complete and get result
-            result = execute_summarize_session_group(session_ids=session_ids, user_pk=mock_user.pk, team=mock_team)
+            result = execute_summarize_session_group(session_ids=session_ids, user_id=mock_user.id, team=mock_team)
             assert result == expected_summary
 
     @pytest.mark.asyncio

--- a/posthog/temporal/tests/ai/test_summarize_session_group.py
+++ b/posthog/temporal/tests/ai/test_summarize_session_group.py
@@ -1,4 +1,4 @@
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, contextmanager
 import json
 from collections.abc import Callable
 from typing import Any
@@ -17,6 +17,7 @@ from posthog.temporal.ai.session_summary.shared import (
 from posthog.temporal.ai.session_summary.summarize_session_group import (
     SessionGroupSummaryOfSummariesInputs,
     SummarizeSessionGroupWorkflow,
+    execute_summarize_session_group,
     get_llm_session_group_summary_activity,
     get_llm_single_session_summary_activity,
 )
@@ -27,6 +28,8 @@ from openai.types.chat.chat_completion import ChatCompletion, Choice, ChatComple
 from datetime import datetime
 from temporalio.testing import WorkflowEnvironment
 from posthog.temporal.ai import WORKFLOWS
+
+pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
@@ -118,6 +121,50 @@ async def test_get_llm_session_group_summary_activity_standalone(
 
 
 class TestSummarizeSessionGroupWorkflow:
+    @contextmanager
+    def execute_test_environment(
+        self,
+        session_ids: list[str],
+        mock_call_llm: Callable,
+        mock_team: MagicMock,
+        mock_raw_metadata: dict[str, Any],
+        mock_raw_events_columns: list[str],
+        mock_raw_events: list[tuple[Any, ...]],
+        mock_valid_event_ids: list[str],
+        custom_content: str | None = None,
+    ):
+        """Test environment for sync Django functions to run the workflow from"""
+        # Mock LLM responses:
+        # Session calls - mock_valid_llm_yaml_response to simulate single-session-summary (YAML)
+        # Summary call (last) - summary of summaries (str)
+        call_llm_side_effects = [mock_call_llm() for _ in range(len(session_ids))] + [
+            mock_call_llm(custom_content=custom_content)
+        ]
+        with (
+            # Mock LLM call
+            patch(
+                "ee.session_recordings.session_summary.llm.consume.call_llm",
+                new=AsyncMock(side_effect=call_llm_side_effects),
+            ),
+            # Mock DB calls
+            patch("ee.session_recordings.session_summary.summarize_session.get_team", return_value=mock_team),
+            patch(
+                "ee.session_recordings.session_summary.summarize_session.get_session_metadata",
+                return_value=mock_raw_metadata,
+            ),
+            patch(
+                "ee.session_recordings.session_summary.summarize_session.get_session_events",
+                return_value=(mock_raw_events_columns, mock_raw_events),
+            ),
+            # Mock deterministic hex generation
+            patch.object(
+                SessionSummaryPromptData,
+                "_get_deterministic_hex",
+                side_effect=iter(mock_valid_event_ids * len(session_ids)),
+            ),
+        ):
+            yield
+
     @asynccontextmanager
     async def workflow_test_environment(
         self,
@@ -130,47 +177,29 @@ class TestSummarizeSessionGroupWorkflow:
         mock_valid_event_ids: list[str],
         custom_content: str | None = None,
     ) -> AsyncGenerator[tuple[WorkflowEnvironment, Worker], None]:
-        # Mock LLM responses:
-        # Session calls - mock_valid_llm_yaml_response to simulate single-session-summary (YAML)
-        # Summary call (last) - summary of summaries (str)
-        call_llm_side_effects = [mock_call_llm() for _ in range(len(session_ids))] + [
-            mock_call_llm(custom_content=custom_content)
-        ]
-        async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
-            async with Worker(
-                activity_environment.client,
-                task_queue=constants.GENERAL_PURPOSE_TASK_QUEUE,
-                workflows=WORKFLOWS,
-                activities=[
-                    get_llm_single_session_summary_activity,
-                    get_llm_session_group_summary_activity,
-                    fetch_session_data_activity,
-                ],
-                workflow_runner=UnsandboxedWorkflowRunner(),
-            ) as worker:
-                with (
-                    # Mock LLM call
-                    patch(
-                        "ee.session_recordings.session_summary.llm.consume.call_llm",
-                        new=AsyncMock(side_effect=call_llm_side_effects),
-                    ),
-                    # Mock DB calls
-                    patch("ee.session_recordings.session_summary.summarize_session.get_team", return_value=mock_team),
-                    patch(
-                        "ee.session_recordings.session_summary.summarize_session.get_session_metadata",
-                        return_value=mock_raw_metadata,
-                    ),
-                    patch(
-                        "ee.session_recordings.session_summary.summarize_session.get_session_events",
-                        return_value=(mock_raw_events_columns, mock_raw_events),
-                    ),
-                    # Mock deterministic hex generation
-                    patch.object(
-                        SessionSummaryPromptData,
-                        "_get_deterministic_hex",
-                        side_effect=iter(mock_valid_event_ids * len(session_ids)),
-                    ),
-                ):
+        """Test environment for Temporal workflow"""
+        with self.execute_test_environment(
+            session_ids,
+            mock_call_llm,
+            mock_team,
+            mock_raw_metadata,
+            mock_raw_events_columns,
+            mock_raw_events,
+            mock_valid_event_ids,
+            custom_content=custom_content,
+        ):
+            async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
+                async with Worker(
+                    activity_environment.client,
+                    task_queue=constants.GENERAL_PURPOSE_TASK_QUEUE,
+                    workflows=WORKFLOWS,
+                    activities=[
+                        get_llm_single_session_summary_activity,
+                        get_llm_session_group_summary_activity,
+                        fetch_session_data_activity,
+                    ],
+                    workflow_runner=UnsandboxedWorkflowRunner(),
+                ) as worker:
                     yield activity_environment, worker
 
     def setup_workflow_test(
@@ -189,6 +218,22 @@ class TestSummarizeSessionGroupWorkflow:
         expected_summary = "everything is good"
         return session_ids, workflow_id, workflow_input, expected_summary
 
+    def test_execute_summarize_session_group(
+        self,
+        mock_user: MagicMock,
+        mock_team: MagicMock,
+        mock_session_group_summary_inputs: Callable,
+    ):
+        """Test the execute_summarize_session_group starts a Temporal workflow and returns the expected result"""
+        session_ids, _, _, expected_summary = self.setup_workflow_test(mock_session_group_summary_inputs, "execute")
+        with patch(
+            "posthog.temporal.ai.session_summary.summarize_session_group._execute_workflow",
+            new=AsyncMock(return_value=expected_summary),
+        ):
+            # Wait for workflow to complete and get result
+            result = execute_summarize_session_group(session_ids=session_ids, user_pk=mock_user.pk, team=mock_team)
+            assert result == expected_summary
+
     @pytest.mark.asyncio
     async def test_summarize_session_group_workflow(
         self,
@@ -204,7 +249,7 @@ class TestSummarizeSessionGroupWorkflow:
     ):
         """Test that the workflow completes successfully and returns the expected result"""
         session_ids, workflow_id, workflow_input, expected_summary = self.setup_workflow_test(
-            mock_session_group_summary_inputs, "mixed"
+            mock_session_group_summary_inputs, "success"
         )
         # Set up spies to track Redis operations
         spy_get = mocker.spy(redis_test_setup.redis_client, "get")

--- a/posthog/temporal/tests/ai/test_summarize_session_group.py
+++ b/posthog/temporal/tests/ai/test_summarize_session_group.py
@@ -1,20 +1,34 @@
+from contextlib import asynccontextmanager
 import json
 from collections.abc import Callable
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 import importlib
-
+import uuid
+from temporalio.worker import Worker, UnsandboxedWorkflowRunner
 import pytest
 from pytest_mock import MockerFixture
-from posthog.temporal.ai.session_summary.shared import compress_llm_input_data, SingleSessionSummaryInputs
+from ee.session_recordings.session_summary.prompt_data import SessionSummaryPromptData
+from posthog.temporal.ai.session_summary.shared import (
+    compress_llm_input_data,
+    SingleSessionSummaryInputs,
+    fetch_session_data_activity,
+)
 from posthog.temporal.ai.session_summary.summarize_session_group import (
     SessionGroupSummaryOfSummariesInputs,
+    SummarizeSessionGroupWorkflow,
     get_llm_session_group_summary_activity,
     get_llm_single_session_summary_activity,
 )
+from posthog import constants
+from collections.abc import AsyncGenerator
 from posthog.temporal.tests.ai.conftest import RedisTestContext
 from openai.types.chat.chat_completion import ChatCompletion, Choice, ChatCompletionMessage
 from datetime import datetime
+from temporalio.testing import WorkflowEnvironment
+from posthog.temporal.ai import WORKFLOWS
+
+pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
@@ -103,3 +117,118 @@ async def test_get_llm_session_group_summary_activity_standalone(
         result = await get_llm_session_group_summary_activity(activity_input)
         assert result == expected_summary_of_summaries
         spy_generate_prompt.assert_called_once_with(session_summaries, None)
+
+
+class TestSummarizeSessionGroupWorkflow:
+    @asynccontextmanager
+    async def workflow_test_environment(
+        self,
+        session_ids: list[str],
+        mock_call_llm: Callable,
+        mock_team: MagicMock,
+        mock_raw_metadata: dict[str, Any],
+        mock_raw_events_columns: list[str],
+        mock_raw_events: list[tuple[Any, ...]],
+        mock_valid_event_ids: list[str],
+        custom_content: str | None = None,
+    ) -> AsyncGenerator[tuple[WorkflowEnvironment, Worker], None]:
+        # Mock LLM responses:
+        # Session calls - mock_valid_llm_yaml_response to simulate single-session-summary (YAML)
+        # Summary call (last) - summary of summaries (str)
+        call_llm_side_effects = [mock_call_llm() for _ in range(len(session_ids))] + [
+            mock_call_llm(custom_content=custom_content)
+        ]
+        async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
+            async with Worker(
+                activity_environment.client,
+                task_queue=constants.GENERAL_PURPOSE_TASK_QUEUE,
+                workflows=WORKFLOWS,
+                activities=[
+                    get_llm_single_session_summary_activity,
+                    get_llm_session_group_summary_activity,
+                    fetch_session_data_activity,
+                ],
+                workflow_runner=UnsandboxedWorkflowRunner(),
+            ) as worker:
+                with (
+                    # Mock LLM call
+                    patch(
+                        "ee.session_recordings.session_summary.llm.consume.call_llm",
+                        new=AsyncMock(side_effect=call_llm_side_effects),
+                    ),
+                    # Mock DB calls
+                    patch("ee.session_recordings.session_summary.summarize_session.get_team", return_value=mock_team),
+                    patch(
+                        "ee.session_recordings.session_summary.summarize_session.get_session_metadata",
+                        return_value=mock_raw_metadata,
+                    ),
+                    patch(
+                        "ee.session_recordings.session_summary.summarize_session.get_session_events",
+                        return_value=(mock_raw_events_columns, mock_raw_events),
+                    ),
+                    # Mock deterministic hex generation
+                    patch.object(
+                        SessionSummaryPromptData,
+                        "_get_deterministic_hex",
+                        side_effect=iter(mock_valid_event_ids * len(session_ids)),
+                    ),
+                ):
+                    yield activity_environment, worker
+
+    def setup_workflow_test(
+        self,
+        mock_session_group_summary_inputs: Callable,
+        identifier_suffix: str,
+    ) -> tuple[str, str, SingleSessionSummaryInputs, str, str]:
+        # Prepare test data
+        session_ids = [
+            f"test_workflow_session_id_{identifier_suffix}_1",
+            f"test_workflow_session_id_{identifier_suffix}_2",
+        ]
+        redis_input_key_base = f"test_group_fetch_{identifier_suffix}_base"
+        workflow_input = mock_session_group_summary_inputs(session_ids, redis_input_key_base)
+        workflow_id = f"test_workflow_{identifier_suffix}_{uuid.uuid4()}"
+        expected_summary = "everything is good"
+        return session_ids, workflow_id, workflow_input, expected_summary
+
+    @pytest.mark.asyncio
+    async def test_summarize_session_group_workflow(
+        self,
+        mocker: MockerFixture,
+        mock_team: MagicMock,
+        mock_call_llm: Callable,
+        mock_raw_metadata: dict[str, Any],
+        mock_raw_events_columns: list[str],
+        mock_raw_events: list[tuple[Any, ...]],
+        mock_valid_event_ids: list[str],
+        mock_session_group_summary_inputs: Callable,
+        redis_test_setup: RedisTestContext,
+    ):
+        """Test that the workflow completes successfully and returns the expected result"""
+        session_ids, workflow_id, workflow_input, expected_summary = self.setup_workflow_test(
+            mock_session_group_summary_inputs, "mixed"
+        )
+        # Set up spies to track Redis operations
+        spy_get = mocker.spy(redis_test_setup.redis_client, "get")
+        spy_setex = mocker.spy(redis_test_setup.redis_client, "setex")
+        async with self.workflow_test_environment(
+            session_ids,
+            mock_call_llm,
+            mock_team,
+            mock_raw_metadata,
+            mock_raw_events_columns,
+            mock_raw_events,
+            mock_valid_event_ids,
+            custom_content=expected_summary,
+        ) as (activity_environment, worker):
+            # Wait for workflow to complete and get result
+            result = await activity_environment.client.execute_workflow(
+                SummarizeSessionGroupWorkflow.run,
+                workflow_input,
+                id=workflow_id,
+                task_queue=worker.task_queue,
+            )
+            assert result == expected_summary
+            # Verify Redis operations count
+            assert spy_setex.call_count == len(session_ids)  # Store DB query data for each session
+            assert spy_get.call_count == len(session_ids)  # Get DB query data for each session

--- a/posthog/temporal/tests/ai/test_summarize_session_group.py
+++ b/posthog/temporal/tests/ai/test_summarize_session_group.py
@@ -87,7 +87,7 @@ async def test_get_llm_single_session_summary_activity_standalone(
         assert result == expected_summary
         # Verify Redis operations count
         assert spy_get.call_count == 1  # Get input data
-        assert spy_setex.call_count == 1  # Inital setip + 0 from the activity
+        assert spy_setex.call_count == 1  # Inital setup + 0 from the activity
 
 
 @pytest.mark.asyncio

--- a/posthog/temporal/tests/ai/test_summarize_session_group.py
+++ b/posthog/temporal/tests/ai/test_summarize_session_group.py
@@ -147,7 +147,7 @@ class TestSummarizeSessionGroupWorkflow:
                 new=AsyncMock(side_effect=call_llm_side_effects),
             ),
             # Mock DB calls
-            patch("ee.session_recordings.session_summary.summarize_session.get_team", return_value=mock_team),
+            patch("ee.session_recordings.session_summary.input_data.get_team", return_value=mock_team),
             patch(
                 "ee.session_recordings.session_summary.summarize_session.get_session_metadata",
                 return_value=mock_raw_metadata,


### PR DESCRIPTION
## Changes:

**What's done:**

- Summarize up to 50 sessions concurrently
- Text summarization, easily embedded/consumable by the agent
- Faster non-stream call for per-session summaries (to avoid spending time/resources on enriching/validating chunks)
- Retry/safe handling logic, to not fail the workflow even if some sessions fail

**What's next:**

- Get multiple sessions per DB call to process more sessions at once
- Create a separate Temporal queue & workers & deployment policy for Max AI to not be blocked by other workflows (as we are in the general queue right now) and process more sessions at once
- Store sub-summaries in Redis (in addition to DB-extracted data we already store there) to process more sessions at once (to not hit Temporal limits)

**What's after next:**

- Rework summary prompt/template into JSON to include enriched events, to be usable from UI as-is. Start iterating on quality and prepare evals.


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
