### PR TITLE
fix(llmo): Fixes for showing Anthropic generations

### DIFF
--- a/products/llm_observability/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
+++ b/products/llm_observability/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
@@ -79,11 +79,7 @@ export function ConversationMessagesDisplay({
                 )
             }
             outputDisplay={outputDisplay}
-            outputHeading={
-                raisedError
-                    ? `Error (${httpStatus})`
-                    : `Output${outputNormalized.length > 1 ? ' (multiple choices)' : ''}`
-            }
+            outputHeading={raisedError ? `Error (${httpStatus})` : 'Output'}
             bordered={bordered}
         />
     )
@@ -111,9 +107,9 @@ export const LLMMessageDisplay = React.memo(
         const [show, setShow] = React.useState(role !== 'system' && role !== 'tool')
 
         // Compute whether the content looks like Markdown.
-        // (Heuristic: looks for code blocks, blockquotes, or headings)
+        // (Heuristic: looks for code blocks, blockquotes, headings, italic, bold, underline, strikethrough)
         const isMarkdownCandidate =
-            content && typeof content === 'string' ? /(\n\s*```|^>\s|#{1,6}\s)/.test(content) : false
+            content && typeof content === 'string' ? /(\n\s*```|^>\s|#{1,6}\s|_|\*|~~)/.test(content) : false
 
         // Render any additional keyword arguments as JSON.
         const additionalKwargsEntries = Array.isArray(additionalKwargs.tools)
@@ -200,7 +196,7 @@ export const LLMMessageDisplay = React.memo(
                 className={clsx(
                     'rounded border text-default',
                     isOutput
-                        ? 'bg-[var(--bg-fill-success-tertiary)]'
+                        ? 'bg-[var(--bg-fill-success-tertiary)] not-last:mb-2'
                         : role === 'user'
                         ? 'bg-[var(--bg-fill-tertiary)]'
                         : role === 'assistant'

--- a/products/llm_observability/frontend/types.ts
+++ b/products/llm_observability/frontend/types.ts
@@ -39,6 +39,12 @@ export interface AnthropicToolCallMessage {
     input: Record<string, any>
 }
 
+export interface AnthropicThinkingMessage {
+    type: 'thinking'
+    thinking: string
+    signature: string
+}
+
 export interface AnthropicToolResultMessage {
     type: 'tool_result'
     tool_use_id: string


### PR DESCRIPTION
## Problem

We weren't showing Anthropic thinking blocks among LLM observability messages.

## Changes

Thinking blocks are now supported (role `assistant (thinking)`).

## How did you test this code?

TODO: Story probably?