### PR TITLE
fix: gracefully handle errors in Max

### DIFF
--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -20,7 +20,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.exceptions import Conflict
 from posthog.models.user import User
 from posthog.rate_limit import AIBurstRateThrottle, AISustainedRateThrottle
-from posthog.schema import AssistantEventType, FailureMessage, HumanMessage
+from posthog.schema import FailureMessage, HumanMessage
 from posthog.utils import get_instance_region
 from uuid import uuid4
 
@@ -125,8 +125,7 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelM
                     content="Oops! It looks like I'm having trouble answering this. Could you please try again?",
                     id=str(uuid4()),
                 )
-                yield f"event: {AssistantEventType.MESSAGE}\n"
-                yield f"data: {failure_message.model_dump_json(exclude_none=True)}\n\n"
+                yield assistant._serialize_message(failure_message)
 
         assistant._stream = safe_stream_wrapper  # type: ignore[method-assign]
         return StreamingHttpResponse(assistant.stream(), content_type="text/event-stream")

--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -1,6 +1,7 @@
 from typing import cast
 
 import pydantic
+import structlog
 from django.conf import settings
 from django.http import StreamingHttpResponse
 from rest_framework import serializers, status
@@ -19,8 +20,12 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.exceptions import Conflict
 from posthog.models.user import User
 from posthog.rate_limit import AIBurstRateThrottle, AISustainedRateThrottle
-from posthog.schema import HumanMessage
+from posthog.schema import AssistantEventType, FailureMessage, HumanMessage
 from posthog.utils import get_instance_region
+from uuid import uuid4
+
+
+logger = structlog.get_logger(__name__)
 
 
 class MessageSerializer(serializers.Serializer):
@@ -103,6 +108,27 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelM
             trace_id=serializer.validated_data["trace_id"],
             mode=AssistantMode.ASSISTANT,
         )
+
+        # Store original method and wrap it with error handling
+        original_stream_method = assistant._stream
+
+        def safe_stream_wrapper():
+            """Wrapper generator that ensures errors are handled gracefully."""
+            try:
+                yield from original_stream_method()
+            except Exception as e:
+                # Log the error but don't re-raise
+                logger.exception("Error in assistant stream", error=e)
+
+                # Send proper SSE-formatted error message
+                failure_message = FailureMessage(
+                    content="Oops! It looks like I'm having trouble answering this. Could you please try again?",
+                    id=str(uuid4()),
+                )
+                yield f"event: {AssistantEventType.MESSAGE}\n"
+                yield f"data: {failure_message.model_dump_json(exclude_none=True)}\n\n"
+
+        assistant._stream = safe_stream_wrapper  # type: ignore[method-assign]
         return StreamingHttpResponse(assistant.stream(), content_type="text/event-stream")
 
     @action(detail=True, methods=["PATCH"])

--- a/ee/api/test/test_conversation.py
+++ b/ee/api/test/test_conversation.py
@@ -162,19 +162,32 @@ class TestConversation(APIBaseTest):
         )
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-    def test_streaming_error_handling(self):
-        def raise_error():
-            yield "some content"
-            raise Exception("Streaming error")
+    def test_streaming_error_after_content_yields_proper_message(self):
+        """Test that errors occurring after streaming content yield proper SSE-formatted error messages."""
 
-        with patch.object(Assistant, "_stream", side_effect=raise_error):
+        def stream_then_error():
+            yield 'event: message\ndata: {"type": "human", "content": "Hello"}\n\n'
+            yield 'event: message\ndata: {"type": "assistant", "content": "Hi there"}\n\n'
+            raise RuntimeError("Backend processing error")
+
+        with patch.object(Assistant, "_stream", side_effect=stream_then_error):
             response = self.client.post(
                 f"/api/environments/{self.team.id}/conversations/",
                 {"content": "test query", "trace_id": str(uuid.uuid4())},
             )
-            with self.assertRaises(Exception) as context:
-                b"".join(response.streaming_content)
-            self.assertTrue("Streaming error" in str(context.exception))
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            # Get all streaming content
+            content = self._get_streaming_content(response).decode("utf-8")
+
+            # Should contain original messages
+            self.assertIn('{"type": "human", "content": "Hello"}', content)
+            self.assertIn('{"type": "assistant", "content": "Hi there"}', content)
+
+            # Should contain error message at the end
+            self.assertIn("event: message", content)
+            self.assertIn('"type":"ai/failure"', content)
+            self.assertIn("It looks like I'm having trouble answering this", content)
 
     def test_cancel_conversation(self):
         conversation = Conversation.objects.create(

--- a/ee/api/test/test_conversation.py
+++ b/ee/api/test/test_conversation.py
@@ -189,6 +189,21 @@ class TestConversation(APIBaseTest):
             self.assertIn('"type":"ai/failure"', content)
             self.assertIn("It looks like I'm having trouble answering this", content)
 
+            # Verify the error message is the last thing the client sees
+            # Split content into lines and find the last message event
+            lines = content.strip().split("\n")
+            last_message_event = None
+            for i in range(len(lines) - 1, -1, -1):
+                if lines[i].startswith("event: message"):
+                    # Find the corresponding data line
+                    if i + 1 < len(lines) and lines[i + 1].startswith("data: "):
+                        last_message_event = lines[i + 1]
+                        break
+
+            self.assertIsNotNone(last_message_event, "Should have a last message event")
+            self.assertIn('"type":"ai/failure"', last_message_event)
+            self.assertIn("It looks like I'm having trouble answering this", last_message_event)
+
     def test_cancel_conversation(self):
         conversation = Conversation.objects.create(
             user=self.user, team=self.team, title="Test conversation", type=Conversation.Type.ASSISTANT


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
Whenever there's a backend problem in Max, the HTTP stream closes, telling the user there's a "network error".
We instead want to gracefully tell the frontend we've had some internal issues in answering their question.

## Changes
- Wrap the stream in an error handler that sends SSE-formatted failure events to the frontend

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Edited old test + visual testing