### PR TITLE
feat: Process JSONL in ProcessPoolExecutor

### DIFF
--- a/posthog/temporal/batch_exports/spmc.py
+++ b/posthog/temporal/batch_exports/spmc.py
@@ -51,7 +51,10 @@ from posthog.temporal.batch_exports.temporary_file import (
     WriterFormat,
     get_batch_export_writer,
 )
-from posthog.temporal.batch_exports.transformer import get_stream_transformer
+from posthog.temporal.batch_exports.transformer import (
+    get_stream_transformer,
+    produce_transformed_chunks_to_queue,
+)
 from posthog.temporal.batch_exports.utils import (
     cast_record_batch_json_columns,
     cast_record_batch_schema_json_columns,
@@ -1223,15 +1226,19 @@ class ConsumerFromStage:
             schema=schema,
             include_inserted_at=include_inserted_at,
         )
-
         record_batches_count = 0
         records_count = 0
         bytes_count = 0
-        current_file_size = 0
-        try:
+
+        async def generate_record_batch():
+            nonlocal record_batches_count
+            nonlocal records_count
+            nonlocal bytes_count
+
             async for record_batch in self.generate_record_batches_from_queue(queue, producer_task):
-                record_batches_count += 1
                 record_batch = cast_record_batch_json_columns(record_batch, json_columns=json_columns)
+
+                record_batches_count += 1
                 records_count += record_batch.num_rows
                 bytes_count += record_batch.nbytes
 
@@ -1244,20 +1251,23 @@ class ConsumerFromStage:
                     bytes_count / 1024**2,
                 )
 
-                # Transform batch to chunks
-                # We also split the file if we reach the max file size
-                for chunk in transformer.transform_batch(record_batch):
-                    await self.consume_chunk(data=chunk)
-                    current_file_size += len(chunk)
-                    if max_file_size_bytes and current_file_size > max_file_size_bytes:
-                        for chunk in transformer.finalize():
-                            await self.consume_chunk(chunk)
-                        await self.finalize_file()
-                        current_file_size = 0
+                yield record_batch
 
-            # Finalize transformer and consume any remaining data
-            for chunk in transformer.finalize():
-                await self.consume_chunk(chunk)
+        current_file_size = 0
+
+        chunk_count = 0
+        try:
+            async for chunk in produce_transformed_chunks_to_queue(
+                transformer,
+                generate_record_batch(),
+            ):
+                chunk_count += 1
+                await self.consume_chunk(data=chunk)
+                current_file_size += len(chunk)
+
+                if max_file_size_bytes and current_file_size > max_file_size_bytes:
+                    await self.finalize_file()
+                    current_file_size = 0
 
             # Finalize upload
             await self.finalize()

--- a/posthog/temporal/batch_exports/transformer.py
+++ b/posthog/temporal/batch_exports/transformer.py
@@ -219,7 +219,7 @@ class JSONLStreamTransformer(StreamTransformer):
             return
 
         max_workers = 5
-        task_queue = asyncio.Queue(max_workers)
+        task_queue: asyncio.Queue[asyncio.Future[list[bytes]]] = asyncio.Queue(max_workers)
         loop = asyncio.get_running_loop()
 
         async def producer(executor):


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

JSONL processing is CPU bound and slow. Let's distribute it in a process pool.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Transformers now expose a `iter_transformed_record_batches` to yield chunks of transformed record batches.

The JSONL transformer overrides this implementation to open up a `ProcessPoolExecutor` and run the transformations as separate processes. This works as the JSONL transformer is stateless: We simply keep outputting lines of JSONL.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

Running usual test pipeline. Also updating it locally to increase number of events. With a sample of 1M events of 3KB size, this speeds up execution relative to master branch by about 30%-40%.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
