### PR TITLE
fix(ingestion-e2e): make e2e-tests less flaky

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
@@ -1,1 +1,0 @@
-export class PersonStoreManager {}

--- a/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
@@ -1,0 +1,1 @@
+export class PersonStoreManager {}

--- a/plugin-server/tests/helpers/sql.ts
+++ b/plugin-server/tests/helpers/sql.ts
@@ -278,7 +278,7 @@ export async function createUserTeamAndOrganization(
         available_product_features: [],
         domain_whitelist: [],
         is_member_join_email_enabled: false,
-        slug: Math.round(Math.random() * 10000),
+        slug: new UUIDT().toString(),
     } as RawOrganization)
     await updateOrganizationAvailableFeatures(db, organizationId, [{ key: 'data_pipelines', name: 'Data Pipelines' }])
     await insertRow(db, 'posthog_organizationmembership', {


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

This PR attempts to make ingestion e2e tests less flaky

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
