### PR TITLE
chore(data-modeling): Added temporal logging to the data modeling job

### DIFF
--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -10,7 +10,6 @@ from contextvars import copy_context
 import aiokafka
 import structlog
 import temporalio.activity
-import temporalio.workflow
 from django.conf import settings
 from kafka import KafkaProducer
 from structlog.processors import EventRenamer
@@ -325,6 +324,10 @@ def get_temporal_context() -> dict[str, str | int]:
         # This works because the WorkflowID is made up like f"{external_data_schema_id}-compaction"
         log_source_id = workflow_id.split("-compaction")[0]
         log_source = "deltalake_compaction_job"
+    elif workflow_type == "data-modeling-run":
+        # This works because the WorkflowID is made up like f"{saved_query_id}-{data_interval_end}"
+        log_source_id = workflow_id.rsplit("-", maxsplit=3)[0]
+        log_source = "data_modeling_run"
     else:
         # This works because the WorkflowID is made up like f"{batch_export_id}-{data_interval_end}"
         # Since 'data_interval_end' is an iso formatted datetime string, it has two '-' to separate the

--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -12,7 +12,6 @@ import uuid
 
 import asyncstdlib
 import deltalake
-import structlog
 import temporalio.activity
 import temporalio.common
 import temporalio.exceptions
@@ -30,6 +29,7 @@ from posthog.settings.base_variables import TEST
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.clickhouse import get_client
 from posthog.temporal.common.heartbeat import Heartbeater
+from posthog.temporal.common.logger import FilteringBoundLogger, bind_temporal_worker_logger
 from posthog.temporal.data_imports.pipelines.pipeline.utils import table_from_py_list
 from posthog.temporal.data_imports.util import prepare_s3_files_for_querying
 from posthog.temporal.data_modeling.metrics import get_data_modeling_finished_metric
@@ -42,8 +42,6 @@ from posthog.warehouse.models import (
 )
 from posthog.warehouse.models.data_modeling_job import DataModelingJob
 from posthog.warehouse.util import database_sync_to_async
-
-logger = structlog.get_logger()
 
 # preserve casing since we are already coming from a sql dialect, we don't need to worry about normalizing
 os.environ["SCHEMA__NAMING"] = "direct"
@@ -161,16 +159,24 @@ async def run_dag_activity(inputs: RunDagActivityInputs) -> Results:
     6. If the number of models in the completed, failed, and ancestor failed sets is equal
        to the total number of models passed to this activity, exit the loop. Else, goto 5.
     """
+    logger = await bind_temporal_worker_logger(inputs.team_id)
+
     completed = set()
     ancestor_failed = set()
     failed = set()
     queue: asyncio.Queue[QueueMessage] = asyncio.Queue()
 
-    for node in inputs.dag.values():
+    await logger.adebug(f"DAG size = {len(inputs.dag)}")
+
+    for name, node in inputs.dag.items():
+        await logger.adebug(f"Looping over DAG: {name}. node.label={node.label}")
+
         if not node.parents:
             queue.put_nowait(QueueMessage(status=ModelStatus.READY, label=node.label))
+            await logger.adebug(f"Inserted to queue: {name}. node.label={node.label}")
 
     if queue.empty():
+        await logger.adebug("Queue is empty, raising")
         raise asyncio.QueueEmpty()
 
     running_tasks = set()
@@ -180,12 +186,14 @@ async def run_dag_activity(inputs: RunDagActivityInputs) -> Results:
             message = await queue.get()
             match message:
                 case QueueMessage(status=ModelStatus.READY, label=label):
+                    await logger.adebug(f"Handling queue message READY. label={label}")
                     model = inputs.dag[label]
-                    task = asyncio.create_task(handle_model_ready(model, inputs.team_id, queue, inputs.job_id))
+                    task = asyncio.create_task(handle_model_ready(model, inputs.team_id, queue, inputs.job_id, logger))
                     running_tasks.add(task)
                     task.add_done_callback(running_tasks.discard)
 
                 case QueueMessage(status=ModelStatus.COMPLETED, label=label):
+                    await logger.adebug(f"Handling queue message COMPLETED. label={label}")
                     node = inputs.dag[label]
                     completed.add(node.label)
 
@@ -196,6 +204,8 @@ async def run_dag_activity(inputs: RunDagActivityInputs) -> Results:
                         if completed >= child_node.parents:
                             to_queue.append(child_node)
 
+                    await logger.adebug(f"Putting models in queue: {[node.label for node in to_queue]}")
+
                     task = asyncio.create_task(put_models_in_queue(to_queue, queue))
                     running_tasks.add(task)
                     task.add_done_callback(running_tasks.discard)
@@ -203,6 +213,7 @@ async def run_dag_activity(inputs: RunDagActivityInputs) -> Results:
                     queue.task_done()
 
                 case QueueMessage(status=ModelStatus.FAILED, label=label):
+                    await logger.adebug(f"Handling queue message FAILED. label={label}")
                     node = inputs.dag[label]
                     failed.add(node.label)
 
@@ -228,6 +239,9 @@ async def run_dag_activity(inputs: RunDagActivityInputs) -> Results:
             if len(failed) + len(ancestor_failed) + len(completed) == len(inputs.dag):
                 break
 
+        await logger.adebug(
+            f"run_dag_activity finished. completed={len(completed)}. failed={len(failed)}. ancestor_failed={len(ancestor_failed)}"
+        )
         return Results(completed, failed, ancestor_failed)
 
 
@@ -255,7 +269,9 @@ class CannotCoerceColumnException(Exception):
     pass
 
 
-async def handle_model_ready(model: ModelNode, team_id: int, queue: asyncio.Queue[QueueMessage], job_id: str) -> None:
+async def handle_model_ready(
+    model: ModelNode, team_id: int, queue: asyncio.Queue[QueueMessage], job_id: str, logger: FilteringBoundLogger
+) -> None:
     """Handle a model that is ready to run by materializing.
 
     After materializing is done, we can report back to the execution queue the result. If
@@ -274,22 +290,22 @@ async def handle_model_ready(model: ModelNode, team_id: int, queue: asyncio.Queu
             saved_query = await get_saved_query(team, model.label)
             job = await database_sync_to_async(DataModelingJob.objects.get)(id=job_id)
 
-            await materialize_model(model.label, team, saved_query, job)
+            await materialize_model(model.label, team, saved_query, job, logger)
     except CHQueryErrorMemoryLimitExceeded as err:
         await logger.aexception("Memory limit exceeded for model %s", model.label, job_id=job_id)
-        await handle_error(job, model, queue, err, "Memory limit exceeded for model %s: %s")
+        await handle_error(job, model, queue, err, "Memory limit exceeded for model %s: %s", logger)
     except CannotCoerceColumnException as err:
         await logger.aexception("Type coercion error for model %s", model.label, job_id=job_id)
-        await handle_error(job, model, queue, err, "Type coercion error for model %s: %s")
+        await handle_error(job, model, queue, err, "Type coercion error for model %s: %s", logger)
     except DataModelingCancelledException as err:
         await logger.aexception("Data modeling run was cancelled for model %s", model.label, job_id=job_id)
-        await handle_cancelled(job, model, queue, err, "Data modeling run was cancelled for model %s: %s")
+        await handle_cancelled(job, model, queue, err, "Data modeling run was cancelled for model %s: %s", logger)
     except Exception as err:
         await logger.aexception(
             "Failed to materialize model %s due to unexpected error: %s", model.label, str(err), job_id=job_id
         )
         capture_exception(err)
-        await handle_error(job, model, queue, err, "Failed to materialize model %s due to error: %s")
+        await handle_error(job, model, queue, err, "Failed to materialize model %s due to error: %s", logger)
     else:
         await logger.ainfo("Materialized model %s", model.label)
         await queue.put(QueueMessage(status=ModelStatus.COMPLETED, label=model.label))
@@ -298,10 +314,16 @@ async def handle_model_ready(model: ModelNode, team_id: int, queue: asyncio.Queu
 
 
 async def handle_error(
-    job: DataModelingJob, model: ModelNode, queue: asyncio.Queue[QueueMessage], error: Exception, error_message: str
+    job: DataModelingJob,
+    model: ModelNode,
+    queue: asyncio.Queue[QueueMessage],
+    error: Exception,
+    error_message: str,
+    logger: FilteringBoundLogger,
 ):
     if job:
         await logger.ainfo("Marking job %s as failed", job.id)
+        await logger.aerror(f"handle_error: error={error}. error_message={error_message}")
         job.status = DataModelingJob.Status.FAILED
         job.error = str(error)
         await database_sync_to_async(job.save)()
@@ -309,9 +331,15 @@ async def handle_error(
 
 
 async def handle_cancelled(
-    job: DataModelingJob, model: ModelNode, queue: asyncio.Queue[QueueMessage], error: Exception, error_message: str
+    job: DataModelingJob,
+    model: ModelNode,
+    queue: asyncio.Queue[QueueMessage],
+    error: Exception,
+    error_message: str,
+    logger: FilteringBoundLogger,
 ):
     if job:
+        await logger.aerror(f"handle_cancelled: error={error}. error_message={error_message}")
         job.status = DataModelingJob.Status.CANCELLED
         job.error = str(error)
         await database_sync_to_async(job.save)()
@@ -351,7 +379,11 @@ async def get_saved_query(team: Team, model_label: str) -> DataWarehouseSavedQue
 
 
 async def materialize_model(
-    model_label: str, team: Team, saved_query: DataWarehouseSavedQuery, job: DataModelingJob
+    model_label: str,
+    team: Team,
+    saved_query: DataWarehouseSavedQuery,
+    job: DataModelingJob,
+    logger: FilteringBoundLogger,
 ) -> tuple[str, DeltaTable, uuid.UUID]:
     """Materialize a given model by running its query and piping the results into a delta table.
 
@@ -363,6 +395,7 @@ async def materialize_model(
         saved_query: The saved query to materialize.
         job: The DataModelingJob record for this run that tracks the lifecycle and rows of the run.
     """
+    await logger.adebug(f"Starting materialize_model for {model_label}. saved_query.name={saved_query.name}")
 
     query_columns = saved_query.columns
     if not query_columns:
@@ -376,6 +409,8 @@ async def materialize_model(
         table_uri = f"{settings.BUCKET_URL}/team_{team.pk}_model_{model_label}/modeling/{saved_query.normalized_name}"
         storage_options = _get_credentials()
 
+        await logger.adebug(f"Delta table URI = {table_uri}")
+
         # Delete existing table first so that there are no schema conflicts
         s3 = get_s3_client()
         try:
@@ -385,7 +420,7 @@ async def materialize_model(
         except FileNotFoundError:
             await logger.adebug(f"Table at {table_uri} not found - skipping deletion")
 
-        async for index, batch in asyncstdlib.enumerate(hogql_table(hogql_query, team)):
+        async for index, batch in asyncstdlib.enumerate(hogql_table(hogql_query, team, logger)):
             mode: typing.Literal["error", "append", "overwrite", "ignore"] = "append"
             schema_mode: typing.Literal["merge", "overwrite"] | None = "merge"
             if index == 0:
@@ -402,13 +437,14 @@ async def materialize_model(
 
             row_count = row_count + batch.num_rows
 
+        await logger.adebug(f"Finished writing to delta table. row_count={row_count}")
         delta_table = deltalake.DeltaTable(table_uri=table_uri, storage_options=storage_options)
     except Exception as e:
         error_message = str(e)
         if "Query exceeds memory limits" in error_message:
             saved_query.latest_error = error_message
             await database_sync_to_async(saved_query.save)()
-            await mark_job_as_failed(job, error_message)
+            await mark_job_as_failed(job, error_message, logger)
             raise CHQueryErrorMemoryLimitExceeded(
                 f"Query for model {model_label} exceeds memory limits. Try reducing its scope by changing the time range."
             ) from e
@@ -416,7 +452,7 @@ async def materialize_model(
         elif "Cannot coerce type" in error_message:
             saved_query.latest_error = error_message
             await database_sync_to_async(saved_query.save)()
-            await mark_job_as_failed(job, error_message)
+            await mark_job_as_failed(job, error_message, logger)
 
             raise CannotCoerceColumnException(f"Type coercion error in model {model_label}: {error_message}") from e
         else:
@@ -424,21 +460,24 @@ async def materialize_model(
             error_message = "Your query failed to materialize. If this query ran for a long time, try optimizing it."
             await logger.aerror("Failed to materialize model with unexpected error: %s", str(e))
             await database_sync_to_async(saved_query.save)()
-            await mark_job_as_failed(job, error_message)
+            await mark_job_as_failed(job, error_message, logger)
             raise Exception(f"Failed to materialize model {model_label}: {error_message}") from e
 
     data_modeling_job = await database_sync_to_async(DataModelingJob.objects.get)(id=job.id)
     if data_modeling_job.status == DataModelingJob.Status.CANCELLED:
         raise DataModelingCancelledException("Data modeling run was cancelled")
 
+    await logger.adebug("Compacting delta table")
     delta_table.optimize.compact()
+    await logger.adebug("Vacuuming delta table")
     delta_table.vacuum(retention_hours=24, enforce_retention_duration=False, dry_run=False)
 
     file_uris = delta_table.file_uris()
 
+    await logger.adebug("Copying query files in S3")
     prepare_s3_files_for_querying(saved_query.folder_path, saved_query.normalized_name, file_uris, True)
 
-    await update_table_row_count(saved_query, row_count)
+    await update_table_row_count(saved_query, row_count, logger)
 
     # Update the job record with the row count and completed status
     job.rows_materialized = row_count
@@ -446,20 +485,26 @@ async def materialize_model(
     job.last_run_at = dt.datetime.now(dt.UTC)
     await database_sync_to_async(job.save)()
 
+    await logger.adebug("Setting DataModelingJob.Status = COMPLETED")
+
     return (saved_query.normalized_name, delta_table, job.id)
 
 
-async def mark_job_as_failed(job: DataModelingJob, error_message: str) -> None:
+async def mark_job_as_failed(job: DataModelingJob, error_message: str, logger: FilteringBoundLogger) -> None:
     """
     Mark DataModelingJob as failed
     """
+
+    await logger.aerror(f"mark_job_as_failed: {error_message}")
     await logger.ainfo("Marking job %s as failed", job.id)
     job.status = DataModelingJob.Status.FAILED
     job.error = error_message
     await database_sync_to_async(job.save)()
 
 
-async def update_table_row_count(saved_query: DataWarehouseSavedQuery, row_count: int) -> None:
+async def update_table_row_count(
+    saved_query: DataWarehouseSavedQuery, row_count: int, logger: FilteringBoundLogger
+) -> None:
     try:
         table = None
         if saved_query.table_id:
@@ -479,7 +524,7 @@ async def update_table_row_count(saved_query: DataWarehouseSavedQuery, row_count
         await logger.aexception("Failed to update row count for table %s: %s", saved_query.name, str(e))
 
 
-async def hogql_table(query: str, team: Team):
+async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger):
     """A HogQL table given by a HogQL query."""
 
     query_node = parse_select(query)
@@ -502,6 +547,8 @@ async def hogql_table(query: str, team: Team):
         dialect="clickhouse",
         stack=[],
     )
+
+    await logger.adebug(f"Running clickhouse query: {printed}")
 
     async with get_client() as client:
         async for batch, pa_schema in client.astream_query_in_batches(printed, query_parameters=context.values):
@@ -568,6 +615,10 @@ class InvalidSelector(Exception):
 @temporalio.activity.defn
 async def build_dag_activity(inputs: BuildDagActivityInputs) -> DAG:
     """Construct a DAG from provided selector inputs."""
+
+    logger = await bind_temporal_worker_logger(inputs.team_id)
+    await logger.adebug(f"starting build_dag_activity. selectors = {[select.label for select in inputs.select]}")
+
     async with Heartbeater():
         selector_paths: SelectorPaths = {}
 
@@ -582,6 +633,7 @@ async def build_dag_activity(inputs: BuildDagActivityInputs) -> DAG:
                     descendants="ALL",
                 )
             ] = matching_paths
+            await logger.adebug(f"No selectors passed. Selecting all model paths")
 
         for selector_input in inputs.select:
             query = f"*.{selector_input.label}.*"
@@ -696,6 +748,10 @@ class CreateJobModelInputs:
 
 @temporalio.activity.defn
 async def create_job_model_activity(inputs: CreateJobModelInputs) -> str:
+    logger = await bind_temporal_worker_logger(inputs.team_id)
+
+    await logger.adebug(f"Creating DataModelingJob for {[selector.label for selector in inputs.select]}")
+
     team = await database_sync_to_async(Team.objects.get)(id=inputs.team_id)
     workflow_id = temporalio.activity.info().workflow_id
     workflow_run_id = temporalio.activity.info().workflow_run_id
@@ -713,6 +769,7 @@ async def create_job_model_activity(inputs: CreateJobModelInputs) -> str:
 @temporalio.activity.defn
 async def start_run_activity(inputs: StartRunActivityInputs) -> None:
     """Activity that starts a run by updating statuses of associated models."""
+    logger = await bind_temporal_worker_logger(inputs.team_id)
 
     try:
         async with asyncio.TaskGroup() as tg:
@@ -720,6 +777,7 @@ async def start_run_activity(inputs: StartRunActivityInputs) -> None:
                 if model.selected is False:
                     continue
 
+                await logger.adebug(f"Updating saved query status for {label} to RUNNING")
                 tg.create_task(
                     update_saved_query_status(label, DataWarehouseSavedQuery.Status.RUNNING, None, inputs.team_id)
                 )
@@ -746,16 +804,20 @@ class FinishRunActivityInputs:
 @temporalio.activity.defn
 async def finish_run_activity(inputs: FinishRunActivityInputs) -> None:
     """Activity that finishes a run by updating statuses of associated models."""
+    logger = await bind_temporal_worker_logger(inputs.team_id)
+
     run_at = dt.datetime.fromisoformat(inputs.run_at)
 
     try:
         async with asyncio.TaskGroup() as tg:
             for label in inputs.completed:
+                await logger.adebug(f"Updating saved query status for {label} to COMPLETED")
                 tg.create_task(
                     update_saved_query_status(label, DataWarehouseSavedQuery.Status.COMPLETED, run_at, inputs.team_id)
                 )
 
             for label in inputs.failed:
+                await logger.adebug(f"Updating saved query status for {label} to FAILED")
                 tg.create_task(
                     update_saved_query_status(label, DataWarehouseSavedQuery.Status.FAILED, None, inputs.team_id)
                 )
@@ -816,11 +878,14 @@ class CancelJobsActivityInputs:
 class FailJobsActivityInputs:
     job_id: str
     error: str
+    team_id: int
 
 
 @temporalio.activity.defn
 async def cancel_jobs_activity(inputs: CancelJobsActivityInputs) -> None:
     """Activity to cancel data modeling jobs."""
+    logger = await bind_temporal_worker_logger(inputs.team_id)
+
     await database_sync_to_async(
         DataModelingJob.objects.filter(workflow_id=inputs.workflow_id, workflow_run_id=inputs.workflow_run_id).update
     )(status=DataModelingJob.Status.CANCELLED)
@@ -832,9 +897,10 @@ async def cancel_jobs_activity(inputs: CancelJobsActivityInputs) -> None:
 @temporalio.activity.defn
 async def fail_jobs_activity(inputs: FailJobsActivityInputs) -> None:
     """Activity to fail data modeling jobs."""
+    logger = await bind_temporal_worker_logger(inputs.team_id)
     job = await database_sync_to_async(DataModelingJob.objects.get)(id=inputs.job_id)
 
-    await mark_job_as_failed(job, inputs.error)
+    await mark_job_as_failed(job, inputs.error, logger)
 
 
 @dataclasses.dataclass
@@ -947,7 +1013,7 @@ class RunWorkflow(PostHogWorkflow):
 
             await temporalio.workflow.execute_activity(
                 fail_jobs_activity,
-                FailJobsActivityInputs(job_id=job_id, error=str(e)),
+                FailJobsActivityInputs(job_id=job_id, error=str(e), team_id=inputs.team_id),
                 start_to_close_timeout=dt.timedelta(minutes=5),
                 retry_policy=temporalio.common.RetryPolicy(
                     maximum_attempts=3,
@@ -957,7 +1023,7 @@ class RunWorkflow(PostHogWorkflow):
         except Exception as e:
             await temporalio.workflow.execute_activity(
                 fail_jobs_activity,
-                FailJobsActivityInputs(job_id=job_id, error=str(e)),
+                FailJobsActivityInputs(job_id=job_id, error=str(e), team_id=inputs.team_id),
                 start_to_close_timeout=dt.timedelta(minutes=5),
                 retry_policy=temporalio.common.RetryPolicy(
                     maximum_attempts=3,

--- a/posthog/temporal/tests/data_modeling/test_run_workflow.py
+++ b/posthog/temporal/tests/data_modeling/test_run_workflow.py
@@ -353,6 +353,7 @@ async def test_materialize_model(ateam, bucket_name, minio_client, pageview_even
             ateam,
             saved_query,
             job,
+            unittest.mock.AsyncMock(),
         )
 
     s3_objects = await minio_client.list_objects_v2(
@@ -417,6 +418,7 @@ async def test_materialize_model_with_pascal_cased_name(ateam, bucket_name, mini
             ateam,
             saved_query,
             job,
+            unittest.mock.AsyncMock(),
         )
 
     s3_objects = await minio_client.list_objects_v2(
@@ -916,6 +918,7 @@ async def test_dlt_direct_naming(ateam, bucket_name, minio_client, pageview_even
             ateam,
             saved_query,
             job,
+            unittest.mock.AsyncMock(),
         )
 
     # Check that the column names maintain their original casing


### PR DESCRIPTION
## Problem
- Its hard to know whats going on in a modeling job, logs are not attached to running jobs

## Changes
- Use the temporal logger instead of a standard structlog, meaning the logs will go into clickhouse and we can easily filter on the job id 
- Added a bunch more logs everywhere to get a clearer idea of whats going on 

## How did you test this code?
Ran a few jobs locally
