### PR TITLE
feat: Tag queries with service name

### DIFF
--- a/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
+++ b/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
@@ -557,7 +557,7 @@ function QueryContext({ item }: { item: Query }): JSX.Element | null {
         return null
     }
 
-    const { modifiers, git_commit, service_name, container_hostname } = logComment
+    const { container_hostname, git_commit, modifiers, service_name } = logComment
 
     return (
         <div>

--- a/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
+++ b/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
@@ -557,16 +557,28 @@ function QueryContext({ item }: { item: Query }): JSX.Element | null {
         return null
     }
 
-    const { modifiers, git_commit, container_hostname } = logComment
+    const { modifiers, git_commit, service_name, container_hostname } = logComment
 
     return (
         <div>
             <table className="w-80">
                 <tbody>
-                    <tr>
-                        <td>Git commit SHA</td>
-                        <td>{git_commit}</td>
-                    </tr>
+                    {git_commit && typeof git_commit === 'string' ? (
+                        <tr>
+                            <td>Git commit SHA</td>
+                            <td>
+                                <LinkPosthogCommit commit={git_commit} />
+                            </td>
+                        </tr>
+                    ) : null}
+                    {service_name && typeof service_name === 'string' ? (
+                        <tr>
+                            <td>Service name</td>
+                            <td>
+                                <LinkPosthogService service={service_name} />
+                            </td>
+                        </tr>
+                    ) : null}
                     <tr>
                         <td>Container hostname</td>
                         <td>{container_hostname}</td>
@@ -683,5 +695,28 @@ function Timing({ item }: { item: Query }): JSX.Element | null {
                 {showFullTiming ? 'Show slowest span only' : 'Show full timing'}
             </LemonButton>
         </div>
+    )
+}
+
+function LinkPosthogCommit({ commit }: { commit: string }): JSX.Element {
+    return (
+        <Link to={`https://www.github.com/PostHog/posthog/commit/${commit}`} target="_blank">
+            {commit}
+        </Link>
+    )
+}
+
+function LinkPosthogService({ service }: { service: string }): JSX.Element {
+    if (service.includes('local-dev')) {
+        return <span>{service}</span>
+    }
+
+    return (
+        <Link
+            to={`https://argocd-internal.internal.posthog.dev/applications?search=${encodeURIComponent(service)}`}
+            target="_blank"
+        >
+            {service}
+        </Link>
     )
 }

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -14,17 +14,19 @@ thread_local_storage = threading.local()
 def get_constant_tags():
     # import locally to avoid circular imports
     from posthog.git import get_git_commit_short
-    from posthog.settings import CONTAINER_HOSTNAME, TEST
+    from posthog.settings import CONTAINER_HOSTNAME, TEST, OTEL_SERVICE_NAME
 
     if TEST:
         return {
             "git_commit": "test",
             "container_hostname": "test",
+            "service_name": "test",
         }
 
     return {
         "git_commit": get_git_commit_short(),
         "container_hostname": CONTAINER_HOSTNAME,
+        "service_name": OTEL_SERVICE_NAME,
     }
 
 

--- a/posthog/clickhouse/test/test_query_tagging.py
+++ b/posthog/clickhouse/test/test_query_tagging.py
@@ -1,7 +1,7 @@
 from posthog.clickhouse.query_tagging import tag_queries, get_query_tags, tags_context, clear_tag, reset_query_tags
 
 
-expected_builtin_tags = {
+expected_constant_tags = {
     "git_commit": "test",
     "container_hostname": "test",
     "service_name": "test",
@@ -11,20 +11,20 @@ expected_builtin_tags = {
 def test_clear_tag():
     clear_tag("some")
     reset_query_tags()
-    assert get_query_tags() == {**expected_builtin_tags}
+    assert get_query_tags() == {**expected_constant_tags}
     tag_queries(another=True)
-    assert get_query_tags() == {"another": True, **expected_builtin_tags}
+    assert get_query_tags() == {"another": True, **expected_constant_tags}
     clear_tag("some")
-    assert get_query_tags() == {"another": True, **expected_builtin_tags}
+    assert get_query_tags() == {"another": True, **expected_constant_tags}
     clear_tag("another")
-    assert get_query_tags() == {**expected_builtin_tags}
+    assert get_query_tags() == {**expected_constant_tags}
 
 
 def test_tags_context():
     reset_query_tags()
     # Set initial tags
     tag_queries(initial="value")
-    assert get_query_tags() == {"initial": "value", **expected_builtin_tags}
+    assert get_query_tags() == {"initial": "value", **expected_constant_tags}
 
     # Modify tags within context
     with tags_context(in_context="true"):
@@ -33,7 +33,7 @@ def test_tags_context():
             "initial": "value",
             "test": "test_value",
             "in_context": "true",
-            **expected_builtin_tags,
+            **expected_constant_tags,
         }
 
         # Modify more
@@ -43,8 +43,8 @@ def test_tags_context():
             "test": "test_value",
             "another": "another_value",
             "in_context": "true",
-            **expected_builtin_tags,
+            **expected_constant_tags,
         }
 
     # Verify tags are restored
-    assert get_query_tags() == {"initial": "value", **expected_builtin_tags}
+    assert get_query_tags() == {"initial": "value", **expected_constant_tags}

--- a/posthog/clickhouse/test/test_query_tagging.py
+++ b/posthog/clickhouse/test/test_query_tagging.py
@@ -4,6 +4,7 @@ from posthog.clickhouse.query_tagging import tag_queries, get_query_tags, tags_c
 expected_builtin_tags = {
     "git_commit": "test",
     "container_hostname": "test",
+    "service_name": "test",
 }
 
 

--- a/posthog/settings/__init__.py
+++ b/posthog/settings/__init__.py
@@ -107,6 +107,8 @@ AUTO_LOGIN: bool = get_from_env("AUTO_LOGIN", False, type_cast=str_to_bool)
 
 CONTAINER_HOSTNAME: str = os.getenv("HOSTNAME", "unknown")
 
+OTEL_SERVICE_NAME: str | None = os.getenv("OTEL_SERVICE_NAME", None)
+
 PROM_PUSHGATEWAY_ADDRESS: str | None = os.getenv("PROM_PUSHGATEWAY_ADDRESS", None)
 
 HOGQL_INCREASED_MAX_EXECUTION_TIME: int = get_from_env("HOGQL_INCREASED_MAX_EXECUTION_TIME", 600, type_cast=int)


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

I wanted to know which service a query I was debugging was running on

## Changes
Add OTEL_SERVICE_NAME to the query log comment

As a bonus, I made the git commit sha link to github, and the service name link to Argo, so you can check on deployments

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

n/a