### PR TITLE
revert: "fix(taxonomy): guard default column configuration behind pay gate"

### DIFF
--- a/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
+++ b/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
@@ -11,7 +11,6 @@ import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
 import { TaxonomicFilter } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
-import { upgradeModalLogic } from 'lib/components/UpgradeModal/upgradeModalLogic'
 import { TeamMembershipLevel } from 'lib/constants'
 import { IconTuning, SortableDragIcon } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -30,7 +29,7 @@ import {
     taxonomicGroupFilterToHogQL,
     trimQuotes,
 } from '~/queries/utils'
-import { AvailableFeature, GroupTypeIndex, PropertyFilterType } from '~/types'
+import { GroupTypeIndex, PropertyFilterType } from '~/types'
 
 import { defaultDataTableColumns, extractExpressionComment, removeExpressionComment } from '../utils'
 import { columnConfiguratorLogic, ColumnConfiguratorLogicProps } from './columnConfiguratorLogic'
@@ -114,7 +113,6 @@ function ColumnConfiguratorModal({ query }: ColumnConfiguratorProps): JSX.Elemen
     const { hideModal, moveColumn, setColumns, selectColumn, unselectColumn, save, toggleSaveAsDefault } =
         useActions(columnConfiguratorLogic)
     const { context } = useValues(columnConfiguratorLogic)
-    const { guardAvailableFeature } = useValues(upgradeModalLogic)
 
     const onEditColumn = (column: string, index: number): void => {
         const newColumn = window.prompt('Edit column', column)
@@ -229,9 +227,7 @@ function ColumnConfiguratorModal({ query }: ColumnConfiguratorProps): JSX.Elemen
                             data-attr="events-table-save-columns-as-default-toggle"
                             bordered
                             checked={saveAsDefault}
-                            onChange={() => {
-                                guardAvailableFeature(AvailableFeature.INGESTION_TAXONOMY, () => toggleSaveAsDefault())
-                            }}
+                            onChange={toggleSaveAsDefault}
                             disabledReason={restrictionReason}
                         />
                     )}


### PR DESCRIPTION
Reverts PostHog/posthog#33155

See https://posthog.slack.com/archives/C08ERRQT41E/p1750179684829269