### PR TITLE
fix(plugin-server): reduce assertion assignor_state errors

### DIFF
--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -13,6 +13,8 @@ import {
 import { hostname } from 'os'
 import { Gauge, Histogram } from 'prom-client'
 
+import { isTestEnv } from '~/utils/env-utils'
+
 import { defaultConfig } from '../config/config'
 import { logger } from '../utils/logger'
 import { captureException } from '../utils/posthog'
@@ -149,9 +151,9 @@ export class KafkaConsumer {
             // Finally any specifically given consumer config overrides
             ...rdKafkaConfig,
             // Below is config that we explicitly DO NOT want to be overrideable by env vars - i.e. things that would require code changes to change
+            'partition.assignment.strategy': isTestEnv() ? 'roundrobin' : 'cooperative-sticky', // Roundrobin is used for testing to avoid flakiness caused by running librdkafka v2.2.0
             'enable.auto.offset.store': false, // NOTE: This is always false - we handle it using a custom function
             'enable.auto.commit': this.config.autoCommit,
-            'partition.assignment.strategy': 'cooperative-sticky',
             'enable.partition.eof': true,
             rebalance_cb: true,
             offset_commit_cb: true,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We see a lot of errors due to 
```
node: rdkafka_sticky_assignor.c:2157: rd_kafka_sticky_assignor_state_destroy: 
Assertion `assignor_state' failed.
```
This seems to be only in librdkafka v2.2.0, but that's the version we are using and updating can be complicated

## Changes

This PR implements using a different assigner strategy for tests (since it should not matter) in order to reduce the amount of CI/CD errors for the assignor_state, once we upgrade librdkafka, we can revert this

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
