### PR TITLE
fix(capture-rs): default local dev to new exception tracking topic

### DIFF
--- a/bin/start-rust-service
+++ b/bin/start-rust-service
@@ -69,7 +69,7 @@ case "$RS_SVC" in
     export RUST_LOG=debug,rdkafka=warn
     export RUST_BACKTRACE=1
     export KAFKA_CONSUMER_GROUP=cymbal
-    export KAFKA_CONSUMER_TOPIC=exception_symbolification_events
+    export KAFKA_CONSUMER_TOPIC=exceptions_ingestion
     export OBJECT_STORAGE_BUCKET=posthog
     export OBJECT_STORAGE_ACCESS_KEY_ID=object_storage_root_user
     export OBJECT_STORAGE_SECRET_ACCESS_KEY=object_storage_root_password

--- a/bin/start-rust-service
+++ b/bin/start-rust-service
@@ -40,7 +40,6 @@ case "$RS_SVC" in
     export KAFKA_HOSTS=localhost:9092
     export REDIS_URL=redis://localhost:6379
     export DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog
-    export KAFKA_EXCEPTIONS_TOPIC="exceptions_ingestion"
     export CAPTURE_MODE=events
     export LOG_LEVEL=debug
     export DEBUG=1
@@ -50,7 +49,7 @@ case "$RS_SVC" in
     SQLX_QUERY_LEVEL=${SQLX_QUERY_LEVEL:-warn}
     export RUST_LOG=debug,sqlx::query=$SQLX_QUERY_LEVEL,rdkafka=warn
     export RUST_BACKTRACE=1
-    export ADDRESS=0.0.0.0:3304 # avoid port conflict in local dev
+    export ADDRESS=0.0.0.0:3306 # avoid port conflict in local dev
     export KAFKA_HOSTS=localhost:9092
     export KAFKA_TOPIC=session_recording_snapshot_item_events
     export KAFKA_OVERFLOW_TOPIC=session_recording_snapshot_item_overflow

--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -117,7 +117,7 @@ pub struct KafkaConfig {
     pub kafka_client_ingestion_warning_topic: String,
     #[envconfig(default = "events_plugin_ingestion")]
     pub kafka_exceptions_topic: String,
-    #[envconfig(default = "events_plugin_ingestion")]
+    #[envconfig(default = "exceptions_ingestion")]
     pub kafka_heatmaps_topic: String,
     #[envconfig(default = "session_recording_snapshot_item_overflow")]
     pub kafka_replay_overflow_topic: String,


### PR DESCRIPTION
## Problem
I accidentally reverted a change Olly made this AM to the local dev topic `cymbal` consumes!

## Changes
Both these changes mimic production behavior and get back into parity.

* Repoint `cymbal` to new exceptions topic in local dev
* Normalize `capture` exceptions produce topic to point to new topic; should avoid `plugin-server` having to reroute these downstream

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Locally and in CI