### PR TITLE
feat: typed query tagging

### DIFF
--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from contextlib import contextmanager
-from enum import Enum
+from enum import StrEnum
 from functools import cache
 from collections.abc import Mapping
 
@@ -16,7 +16,7 @@ from posthog.settings import data_stores
 from posthog.utils import patchable
 
 
-class Workload(Enum):
+class Workload(StrEnum):
     # Default workload
     DEFAULT = "DEFAULT"
     # Analytics queries, other 'lively' queries
@@ -27,7 +27,7 @@ class Workload(Enum):
     LOGS = "LOGS"
 
 
-class NodeRole(Enum):
+class NodeRole(StrEnum):
     ALL = "ALL"
     COORDINATOR = "COORDINATOR"
     DATA = "DATA"
@@ -36,7 +36,7 @@ class NodeRole(Enum):
 _default_workload = Workload.ONLINE
 
 
-class ClickHouseUser(Enum):
+class ClickHouseUser(StrEnum):
     # Default, not annotated queries goes here.
     DEFAULT = "default"
     # All /api/ requests called programmatically

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import threading
 import traceback
@@ -21,7 +20,7 @@ from posthog.clickhouse.client.connection import (
     ClickHouseUser,
 )
 from posthog.clickhouse.client.escape import substitute_params
-from posthog.clickhouse.query_tagging import tag_queries, get_query_tag_value, get_query_tags
+from posthog.clickhouse.query_tagging import get_query_tag_value, get_query_tags, QueryTags, AccessMethod
 from posthog.cloud_utils import is_cloud
 from posthog.errors import wrap_query_error, ch_error_type
 from posthog.exceptions import ClickhouseAtCapacity
@@ -129,26 +128,25 @@ def sync_execute(
             flush_persons_and_events()
         except ModuleNotFoundError:  # when we run plugin server tests it tries to run above, ignore
             pass
-
-    is_personal_api_key = get_query_tag_value("access_method") == "personal_api_key"
+    tags = get_query_tags()
+    is_personal_api_key = tags.access_method == AccessMethod.PERSONAL_API_KEY
 
     # When someone uses an API key, always put their query to the offline cluster
     # Execute all celery tasks not directly set to be online on the offline cluster
-    if workload == Workload.DEFAULT and (is_personal_api_key or get_query_tag_value("kind") == "celery"):
+    if workload == Workload.DEFAULT and (is_personal_api_key or tags.kind == "celery"):
         workload = Workload.OFFLINE
 
-    tag_id: str = get_query_tag_value("id") or ""
     # Make sure we always have process_query_task on the online cluster
-    if tag_id == "posthog.tasks.tasks.process_query_task":
+    tags_id: str = tags.id or ""
+    if tags_id == "posthog.tasks.tasks.process_query_task":
         workload = Workload.ONLINE
         ch_user = ClickHouseUser.APP
 
-    chargeable = get_query_tag_value("chargeable") or 0
     # Customer is paying for API
     if (
         team_id
         and workload == Workload.OFFLINE
-        and chargeable
+        and tags.chargeable
         and is_cloud()
         and team_id in API_QUERIES_ON_ONLINE_CLUSTER
     ):
@@ -158,7 +156,7 @@ def sync_execute(
         workload = get_default_clickhouse_workload_type()
 
     if team_id is not None:
-        tag_queries(team_id=team_id)
+        tags.team_id = team_id
 
     prepared_sql, prepared_args, tags = _prepare_query(query=query, args=args, workload=workload)
     query_id = validated_client_query_id()
@@ -167,19 +165,19 @@ def sync_execute(
         **CLICKHOUSE_PER_TEAM_QUERY_SETTINGS.get(str(team_id), {}),
         **(settings or {}),
     }
-    tags["query_settings"] = core_settings
-    query_type = tags.get("query_type", "Other")
+    tags.query_settings = core_settings
+    query_type = tags.query_type or "Other"
     if ch_user == ClickHouseUser.DEFAULT:
         if is_personal_api_key:
             ch_user = ClickHouseUser.API
-        elif tags.get("kind", "") == "request" and "api/" in tag_id and "capture" not in tag_id:
+        elif tags.kind == "request" and "api/" in tags_id and "capture" not in tags_id:
             # process requests made to API from the PH app
             ch_user = ClickHouseUser.APP
 
     while True:
         settings = {
             **core_settings,
-            "log_comment": json.dumps(tags, separators=(",", ":")),
+            "log_comment": tags.to_json(),
             "query_id": query_id,
         }
         if workload == Workload.OFFLINE:
@@ -191,9 +189,9 @@ def sync_execute(
         start_time = perf_counter()
         try:
             QUERY_STARTED_COUNTER.labels(
-                team_id=str(tags.get("team_id", "0")),
-                access_method=tags.get("access_method", "other"),
-                chargeable=str(tags.get("chargeable", "0")),
+                team_id=str(team_id or ""),
+                access_method=tags.access_method or "other",
+                chargeable=str(tags.chargeable or "0"),
             ).inc()
             with sync_client or get_client_from_pool(workload, team_id, readonly, ch_user) as client:
                 result = client.execute(
@@ -211,22 +209,22 @@ def sync_execute(
                 exception_type=exception_type,
                 query_type=query_type,
                 workload=workload.value if workload else "None",
-                chargeable=chargeable,
+                chargeable=str(tags.chargeable or "0"),
             ).inc()
             err = wrap_query_error(e)
             if isinstance(err, ClickhouseAtCapacity) and is_personal_api_key and workload == Workload.OFFLINE:
                 workload = Workload.ONLINE
-                tags["clickhouse_exception_type"] = exception_type
-                tags["workload"] = str(workload)
+                tags.clickhouse_exception_type = exception_type
+                tags.workload = str(workload)
                 continue
             raise err from e
         finally:
             execution_time = perf_counter() - start_time
 
             QUERY_FINISHED_COUNTER.labels(
-                team_id=str(tags.get("team_id", "0")),
-                access_method=tags.get("access_method", "other"),
-                chargeable=str(tags.get("chargeable", "0")),
+                team_id=str(team_id or ""),
+                access_method=tags.access_method or "other",
+                chargeable=str(tags.chargeable or "0"),
             ).inc()
 
             if query_counter := getattr(thread_local_storage, "query_counter", None):
@@ -272,7 +270,7 @@ def _prepare_query(
     query: str,
     args: QueryArgs,
     workload: Workload = Workload.DEFAULT,
-):
+) -> tuple[str, Optional[QueryArgs], QueryTags]:
     """
     Given a string query with placeholders we do one of two things:
 
@@ -294,7 +292,7 @@ def _prepare_query(
     clickhouse_driver at this moment in time decides based on the
     below predicate.
     """
-    prepared_args: Any = QueryArgs
+    prepared_args: Optional[QueryArgs] = None
     if isinstance(args, list | tuple | types.GeneratorType):
         # If we get one of these it means we have an insert, let the clickhouse
         # client handle substitution here.
@@ -305,12 +303,10 @@ def _prepare_query(
         # clickhouse client uses to signal no substitution is desired. Expected
         # args balue are `None` or `{}` for instance
         rendered_sql = query
-        prepared_args = None
     else:
         # Else perform the substitution so we can perform operations on the raw
         # non-templated SQL
         rendered_sql = substitute_params(query, args)
-        prepared_args = None
 
     if "--" in rendered_sql or "/*" in rendered_sql:
         # This can take a very long time with e.g. large funnel queries
@@ -326,16 +322,17 @@ def _prepare_query(
     return annotated_sql, prepared_args, tags
 
 
-def _annotate_tagged_query(query, workload: Workload):
+def _annotate_tagged_query(query, workload: Workload) -> tuple[str, QueryTags]:
     """
     Adds in a /* */ so we can look in clickhouses `system.query_log`
     to easily marry up to the generating code.
     """
-    tags = {**get_query_tags(), "workload": str(workload)}
+    tags = get_query_tags()
+    tags.workload = workload
     # Annotate the query with information on the request/task
-    if "kind" in tags:
-        user_id = f" user_id:{tags['user_id']}" if "user_id" in tags else ""
-        query = f"/*{user_id} {tags.get('kind')}:{tags.get('id', '').replace('/', '_')} */ {query}"
+    if tags.kind:
+        user_id = f" user_id:{tags.user_id}" if tags.user_id else ""
+        query = f"/*{user_id} {tags.kind}:{tags.id.replace('/', '_') if tags.id else ''} */ {query}"
 
     return query, tags
 

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -1,67 +1,187 @@
 # This module is responsible for adding tags/metadata to outgoing clickhouse queries in a thread-safe manner
-
 import threading
-from typing import Any, Optional
+import uuid
+from enum import StrEnum
 from collections.abc import Generator
 from contextlib import contextmanager
+from pydantic import BaseModel, ConfigDict
+from typing import Any, Optional
+
+# from posthog.clickhouse.client.connection import Workload
+# from posthog.schema import PersonsOnEventsMode
 
 from cachetools import cached
 
 thread_local_storage = threading.local()
 
 
+class AccessMethod(StrEnum):
+    PERSONAL_API_KEY = "personal_api_key"
+    OAUTH = "oauth"
+
+
+class Product(StrEnum):
+    BATCH_EXPORT = "batch_export"
+    PRODUCT_ANALYTICS = "product_analytics"
+    FEATURE_FLAGS = "feature_flags"
+    API = "api"
+
+
+class Feature(StrEnum):
+    COHORT = "cohort"
+    QUERY = "query"
+    INSIGHT = "insight"
+    DASHBOARD = "dashboard"
+
+
+class QueryTags(BaseModel):
+    team_id: Optional[int] = None
+    user_id: Optional[int] = None
+    access_method: Optional[AccessMethod] = None
+    org_id: Optional[uuid.UUID] = None
+    product: Optional[Product] = None
+    kind: Optional[str] = None
+    id: Optional[str] = None
+    session_id: Optional[uuid.UUID] = None
+
+    query: Optional[object] = None
+    query_settings: Optional[object] = None
+    query_time_range_days: Optional[int] = None
+    query_type: Optional[str] = None
+
+    route_id: Optional[str] = None
+    workload: Optional[str] = None  # enum connection.Workload
+    dashboard_id: Optional[int] = None
+    insight_id: Optional[int] = None
+    chargeable: Optional[int] = None
+    name: Optional[str] = None
+
+    http_referer: Optional[str] = None
+    http_request_id: Optional[uuid.UUID] = None
+    http_user_agent: Optional[str] = None
+
+    alert_config_id: Optional[uuid.UUID] = None
+    batch_export_id: Optional[uuid.UUID] = None
+    cache_key: Optional[str] = None
+    celery_task_id: Optional[uuid.UUID] = None
+    clickhouse_exception_type: Optional[str] = None
+    client_query_id: Optional[str] = None
+    cohort_id: Optional[int] = None
+    entity_math: Optional[list[str]] = None
+
+    experiment_feature_flag_key: Optional[str] = None
+    experiment_id: Optional[int] = None
+    experiment_name: Optional[str] = None
+    experiment_is_data_warehouse_query: Optional[bool] = None
+
+    feature: Optional[Feature] = None
+    filter: Optional[object] = None
+    filter_by_type: Optional[list[str]] = None
+    breakdown_by: Optional[list[str]] = None
+
+    # data warehouse
+    trend_volume_display: Optional[str] = None
+    table_id: Optional[uuid.UUID] = None
+    warehouse_query: Optional[bool] = None
+
+    trend_volume_type: Optional[str] = None
+
+    has_joins: Optional[bool] = None
+    has_json_operations: Optional[bool] = None
+
+    modifiers: Optional[object] = None
+    number_of_entities: Optional[int] = None
+    person_on_events_mode: Optional[str] = None  # PersonsOnEventsMode
+
+    timings: Optional[dict[str, float]] = None
+    trigger: Optional[str] = None
+
+    # used by billing
+    usage_report: Optional[str] = None
+
+    user_email: Optional[str] = None
+
+    # constant query tags
+    git_commit: str
+    container_hostname: str
+    service_name: str
+
+    model_config = ConfigDict(validate_assignment=True)
+
+    def update(self, **kwargs):
+        for field, value in kwargs.items():
+            setattr(self, field, value)
+
+    def to_json(self) -> str:
+        return self.model_dump_json(exclude_none=True)
+
+
 @cached(cache={})
-def get_constant_tags():
+def __get_constant_tags() -> dict[str, str]:
     # import locally to avoid circular imports
-    from posthog.git import get_git_commit_short
     from posthog.settings import CONTAINER_HOSTNAME, TEST, OTEL_SERVICE_NAME
 
     if TEST:
-        return {
-            "git_commit": "test",
-            "container_hostname": "test",
-            "service_name": "test",
-        }
+        return {"git_commit": "test", "container_hostname": "test", "service_name": "test"}
+
+    from posthog.git import get_git_commit_short
 
     return {
-        "git_commit": get_git_commit_short(),
+        "git_commit": get_git_commit_short() or "",
         "container_hostname": CONTAINER_HOSTNAME,
-        "service_name": OTEL_SERVICE_NAME,
+        "service_name": OTEL_SERVICE_NAME or "",
     }
 
 
-def get_query_tags():
+def create_base_tags(**kwargs) -> QueryTags:
+    return QueryTags(**{**kwargs, **__get_constant_tags()})
+
+
+def get_query_tags() -> QueryTags:
     try:
-        tags = thread_local_storage.query_tags
+        return thread_local_storage.query_tags
     except AttributeError:
-        tags = {}
-    return {**tags, **get_constant_tags()}
+        return create_base_tags()
 
 
 def get_query_tag_value(key: str) -> Optional[Any]:
     try:
-        return thread_local_storage.query_tags[key]
+        return getattr(thread_local_storage.query_tags, key)
     except (AttributeError, KeyError):
         return None
 
 
-def tag_queries(**kwargs):
-    tags = {key: value for key, value in kwargs.items() if value is not None}
+def update_tags(query_tags: QueryTags):
     try:
-        thread_local_storage.query_tags.update(tags)
+        thread_local_storage.query_tags.update(**query_tags.model_dump(exclude_none=True))
     except AttributeError:
-        thread_local_storage.query_tags = tags
+        new_tags = query_tags.model_copy(deep=True)
+        new_tags.update(**__get_constant_tags())
+        thread_local_storage.query_tags = new_tags
+
+
+def tag_queries(**kwargs) -> None:
+    """
+    The purpose of tag_queries is to pass additional context for ClickHouse executed queries. The tags
+    are serialized into ClickHouse' system.query_log.log_comment column.
+
+    :param kwargs: Key->value pairs of tags to be set.
+    """
+    try:
+        thread_local_storage.query_tags.update(**kwargs)
+    except AttributeError:
+        thread_local_storage.query_tags = create_base_tags(**kwargs)
 
 
 def clear_tag(key):
     try:
-        thread_local_storage.query_tags.pop(key, None)
+        setattr(thread_local_storage.query_tags, key, None)
     except AttributeError:
         pass
 
 
 def reset_query_tags():
-    thread_local_storage.query_tags = {}
+    thread_local_storage.query_tags = create_base_tags()
 
 
 class QueryCounter:
@@ -97,10 +217,12 @@ def tags_context(**tags_to_set: Any) -> Generator[None, None, None]:
         # tags will be restored to original state after context
     ```
     """
+    tags_copy: Optional[QueryTags] = None
     try:
-        original_tags = dict(get_query_tags())  # Make a copy of current tags
+        tags_copy = get_query_tags().model_copy(deep=True)
         if tags_to_set:
             tag_queries(**tags_to_set)
         yield
     finally:
-        thread_local_storage.query_tags = original_tags
+        if tags_copy:
+            thread_local_storage.query_tags = tags_copy

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -12,8 +12,6 @@ from typing import Any, Optional
 
 from cachetools import cached
 
-query_tags = contextvars.ContextVar("query_tags")
-
 
 class AccessMethod(StrEnum):
     PERSONAL_API_KEY = "personal_api_key"
@@ -114,6 +112,9 @@ class QueryTags(BaseModel):
 
     def to_json(self) -> str:
         return self.model_dump_json(exclude_none=True)
+
+
+query_tags: contextvars.ContextVar = contextvars.ContextVar("query_tags")
 
 
 @cached(cache={})

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -3,7 +3,7 @@ import contextvars
 import uuid
 from enum import StrEnum
 from collections.abc import Generator
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from pydantic import BaseModel, ConfigDict
 from typing import Any, Optional
 
@@ -138,8 +138,9 @@ def create_base_tags(**kwargs) -> QueryTags:
 
 
 def get_query_tags() -> QueryTags:
-    qt = query_tags.get()
-    if qt is None:
+    try:
+        qt = query_tags.get()
+    except LookupError:
         qt = create_base_tags()
         query_tags.set(qt)
     return qt
@@ -167,7 +168,9 @@ def tag_queries(**kwargs) -> None:
 
 
 def clear_tag(key):
-    setattr(get_query_tags(), key, None)
+    with suppress(LookupError):
+        qt = query_tags.get()
+        setattr(qt, key, None)
 
 
 def reset_query_tags():

--- a/posthog/clickhouse/test/test_query_tagging.py
+++ b/posthog/clickhouse/test/test_query_tagging.py
@@ -1,50 +1,101 @@
-from posthog.clickhouse.query_tagging import tag_queries, get_query_tags, tags_context, clear_tag, reset_query_tags
+import uuid
+
+from posthog.clickhouse.query_tagging import (
+    tag_queries,
+    get_query_tags,
+    tags_context,
+    clear_tag,
+    reset_query_tags,
+    QueryTags,
+    Product,
+    get_query_tag_value,
+    create_base_tags,
+)
+import pytest
+from pydantic import ValidationError
 
 
-expected_constant_tags = {
-    "git_commit": "test",
-    "container_hostname": "test",
-    "service_name": "test",
-}
+def test_create_base_tags():
+    qt = create_base_tags(container_hostname="my-new-hostname")
+    assert qt.container_hostname == "test"
+
+
+def test_simple_query_tags():
+    uid = uuid.UUID("f3065cb7-10a5-4707-8910-a7c777896ac8")
+    qt = QueryTags(
+        team_id=1,
+        name="my name",
+        product=Product.API,
+        http_request_id=uid,
+        git_commit="",
+        container_hostname="",
+        service_name="",
+    )
+    assert qt.team_id == 1
+    assert qt.user_id is None
+    assert qt.org_id is None
+    assert qt.name == "my name"
+    assert qt.access_method is None
+    assert qt.product == "api"
+    assert qt.http_request_id == uid
+
+    data = qt.to_json()
+    assert (
+        data
+        == '{"team_id":1,"product":"api","name":"my name","http_request_id":"f3065cb7-10a5-4707-8910-a7c777896ac8","git_commit":"","container_hostname":"","service_name":""}'
+    )
+
+
+def test_constant_tags():
+    reset_query_tags()
+    want = QueryTags(git_commit="test", container_hostname="test", service_name="test")
+    assert create_base_tags() == want
+    assert get_query_tags() == want
+
+
+def test_set_get():
+    reset_query_tags()
+    tag_queries(team_id=1, product=Product.API)
+
+    assert get_query_tag_value("team_id") == 1
+    assert get_query_tag_value("product") == "api"
+
+
+def test_failure_on_incorrect_type():
+    reset_query_tags()
+    with pytest.raises(ValidationError):
+        tag_queries(team_id="jeden")
+    assert get_query_tags() == create_base_tags()
 
 
 def test_clear_tag():
-    clear_tag("some")
     reset_query_tags()
-    assert get_query_tags() == {**expected_constant_tags}
-    tag_queries(another=True)
-    assert get_query_tags() == {"another": True, **expected_constant_tags}
-    clear_tag("some")
-    assert get_query_tags() == {"another": True, **expected_constant_tags}
-    clear_tag("another")
-    assert get_query_tags() == {**expected_constant_tags}
+    clear_tag("team_id")
+    assert get_query_tags() == create_base_tags()
+    reset_query_tags()
+    assert get_query_tags() == create_base_tags()
+    tag_queries(team_id=123)
+    assert get_query_tags() == create_base_tags(team_id=123)
+    clear_tag("user_id")
+    assert get_query_tags() == create_base_tags(team_id=123)
+    clear_tag("team_id")
+    assert get_query_tags() == create_base_tags()
 
 
 def test_tags_context():
     reset_query_tags()
     # Set initial tags
-    tag_queries(initial="value")
-    assert get_query_tags() == {"initial": "value", **expected_constant_tags}
+    tag_queries(team_id=123)
+    assert get_query_tags() == create_base_tags(team_id=123)
 
     # Modify tags within context
-    with tags_context(in_context="true"):
-        tag_queries(test="test_value")
-        assert get_query_tags() == {
-            "initial": "value",
-            "test": "test_value",
-            "in_context": "true",
-            **expected_constant_tags,
-        }
+    with tags_context(user_id=312):
+        tag_queries(cohort_id=777)
+        assert get_query_tags() == create_base_tags(team_id=123, user_id=312, cohort_id=777)
 
         # Modify more
-        tag_queries(another="another_value", initial="not a value")
-        assert get_query_tags() == {
-            "initial": "not a value",
-            "test": "test_value",
-            "another": "another_value",
-            "in_context": "true",
-            **expected_constant_tags,
-        }
+        tag_queries(name="another_value", team_id=1234)
+        assert get_query_tags() == create_base_tags(team_id=1234, user_id=312, cohort_id=777, name="another_value")
 
     # Verify tags are restored
-    assert get_query_tags() == {"initial": "value", **expected_constant_tags}
+    assert get_query_tags() == create_base_tags(team_id=123)

--- a/posthog/clickhouse/test/test_query_tagging.py
+++ b/posthog/clickhouse/test/test_query_tagging.py
@@ -47,9 +47,9 @@ def test_simple_query_tags():
 
 
 def test_constant_tags():
-    reset_query_tags()
     want = QueryTags(git_commit="test", container_hostname="test", service_name="test")
     assert create_base_tags() == want
+    reset_query_tags()
     assert get_query_tags() == want
 
 

--- a/posthog/exceptions.py
+++ b/posthog/exceptions.py
@@ -69,7 +69,7 @@ def exception_reporting(exception: Exception, context: ExceptionContext) -> Opti
     Used through drf-exceptions-hog
     """
     if not isinstance(exception, APIException):
-        tags = get_query_tags()
+        tags = get_query_tags().model_dump(exclude_none=True)
         logger.exception(exception, path=context["request"].path, **tags)
         return capture_exception(exception)
     return None

--- a/posthog/exceptions_capture.py
+++ b/posthog/exceptions_capture.py
@@ -7,7 +7,7 @@ def capture_exception(error=None, additional_properties=None):
 
     logger = structlog.get_logger(__name__)
 
-    properties = get_query_tags()
+    properties = get_query_tags().model_dump(exclude_none=True)
 
     if additional_properties:
         properties.update(additional_properties)

--- a/posthog/exceptions_capture.py
+++ b/posthog/exceptions_capture.py
@@ -1,11 +1,10 @@
-from posthog.clickhouse.query_tagging import get_query_tags
-
-
 def capture_exception(error=None, additional_properties=None):
     from posthoganalytics import api_key, capture_exception as posthog_capture_exception
     import structlog
 
     logger = structlog.get_logger(__name__)
+
+    from posthog.clickhouse.query_tagging import get_query_tags
 
     properties = get_query_tags().model_dump(exclude_none=True)
 

--- a/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
@@ -200,7 +200,7 @@ class ExperimentExposuresQueryRunner(QueryRunner):
         # Adding experiment specific tags to the tag collection
         # This will be available as labels in Prometheus
         tag_queries(
-            experiment_id=str(self.query.experiment_id),
+            experiment_id=self.query.experiment_id,
             experiment_name=self.query.experiment_name,
             experiment_feature_flag_key=self.feature_flag_key,
         )

--- a/posthog/hogql_queries/experiments/experiment_funnels_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_funnels_query_runner.py
@@ -57,7 +57,7 @@ class ExperimentFunnelsQueryRunner(QueryRunner):
         # This will be available as labels in Prometheus
         tag_queries(
             query_type="ExperimentFunnelsQuery",
-            experiment_id=str(self.experiment.id),
+            experiment_id=self.experiment.id,
             experiment_name=self.experiment.name,
             experiment_feature_flag_key=self.feature_flag.key,
         )

--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -620,7 +620,7 @@ class ExperimentQueryRunner(QueryRunner):
         # Adding experiment specific tags to the tag collection
         # This will be available as labels in Prometheus
         tag_queries(
-            experiment_id=str(self.experiment.id),
+            experiment_id=self.experiment.id,
             experiment_name=self.experiment.name,
             experiment_feature_flag_key=self.feature_flag.key,
             experiment_is_data_warehouse_query=self.is_data_warehouse_query,

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -16,6 +16,7 @@ from posthog.caching.insights_api import (
     REDUCED_MINIMUM_INSIGHT_REFRESH_INTERVAL,
 )
 from posthog.clickhouse import query_tagging
+from posthog.clickhouse.query_tagging import QueryTags
 from posthog.hogql import ast
 from posthog.hogql.constants import MAX_SELECT_RETURNED_ROWS, LimitContext
 from posthog.hogql.printer import to_printed_hogql
@@ -351,11 +352,11 @@ class TrendsQueryRunner(QueryRunner):
             query: ast.SelectQuery | ast.SelectSetQuery,
             timings: HogQLTimings,
             is_parallel: bool,
-            query_tags: Optional[dict] = None,
+            query_tags: Optional[QueryTags] = None,
         ):
             try:
                 if query_tags:
-                    query_tagging.tag_queries(**query_tags)
+                    query_tagging.update_tags(query_tags)
 
                 series_with_extra = self.series[index]
 
@@ -399,7 +400,7 @@ class TrendsQueryRunner(QueryRunner):
                             query,
                             self.timings.clone_for_subquery(index),
                             True,
-                            query_tagging.get_query_tags(),
+                            query_tagging.get_query_tags().model_copy(deep=True),
                         ),
                     )
                     for index, query in enumerate(queries)

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -409,7 +409,6 @@ class ShortCircuitMiddleware:
                     kind="request",
                     id=request.path,
                     route_id=resolve(request.path).route,
-                    container_hostname=settings.CONTAINER_HOSTNAME,
                     http_referer=request.META.get("HTTP_REFERER"),
                     http_user_agent=request.META.get("HTTP_USER_AGENT"),
                 )
@@ -483,7 +482,6 @@ class CaptureMiddleware:
                     kind="request",
                     id=request.path,
                     route_id=resolve(request.path).route,
-                    container_hostname=settings.CONTAINER_HOSTNAME,
                     http_referer=request.META.get("HTTP_REFERER"),
                     http_user_agent=request.META.get("HTTP_USER_AGENT"),
                 )

--- a/posthog/queries/trends/trends.py
+++ b/posthog/queries/trends/trends.py
@@ -197,7 +197,7 @@ class Trends(TrendsTotalVolume, Lifecycle, TrendsFormula):
                     query_type,
                     sql,
                     query_params,
-                    get_query_tags().model_copy(),
+                    get_query_tags().model_copy(deep=True),
                     adjusted_filter,
                     team.pk,
                 ),

--- a/posthog/queries/trends/trends.py
+++ b/posthog/queries/trends/trends.py
@@ -9,7 +9,7 @@ from zoneinfo import ZoneInfo
 
 from dateutil import parser
 
-from posthog.clickhouse.query_tagging import get_query_tags, tag_queries
+from posthog.clickhouse.query_tagging import get_query_tags, QueryTags, update_tags
 from posthog.constants import (
     INSIGHT_LIFECYCLE,
     NON_BREAKDOWN_DISPLAY_TYPES,
@@ -167,11 +167,11 @@ class Trends(TrendsTotalVolume, Lifecycle, TrendsFormula):
         query_type,
         sql,
         params,
-        query_tags: dict,
+        query_tags: QueryTags,
         filter: Filter,
         team_id: int,
     ):
-        tag_queries(**query_tags)
+        update_tags(query_tags)
         with posthoganalytics.new_context():
             posthoganalytics.tag("query", {"sql": sql, "params": params})
             result[index] = insight_sync_execute(sql, params, query_type=query_type, filter=filter, team_id=team_id)
@@ -197,7 +197,7 @@ class Trends(TrendsTotalVolume, Lifecycle, TrendsFormula):
                     query_type,
                     sql,
                     query_params,
-                    get_query_tags(),
+                    get_query_tags().model_copy(),
                     adjusted_filter,
                     team.pk,
                 ),

--- a/posthog/warehouse/models/table.py
+++ b/posthog/warehouse/models/table.py
@@ -186,7 +186,7 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDModel, Delete
             capture_exception(chdb_error)
 
             try:
-                tag_queries(team_id=str(self.team.pk), table_id=str(self.id), warehouse_query=True)
+                tag_queries(team_id=self.team.pk, table_id=self.id, warehouse_query=True)
 
                 result = sync_execute(
                     f"""DESCRIBE TABLE (
@@ -263,7 +263,7 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDModel, Delete
             capture_exception(chdb_error)
 
             try:
-                tag_queries(team_id=str(self.team.pk), table_id=str(self.id), warehouse_query=True)
+                tag_queries(team_id=self.team.pk, table_id=self.id, warehouse_query=True)
 
                 result = sync_execute(
                     f"SELECT count() FROM {s3_table_func}",


### PR DESCRIPTION
add all tags based on query_log, tests and fix issues remove redundant container_hostname setting

## Problem

We want to use typed log_comment

## Changes

* Add QueryTags type.
* switch from threading.local to contextvars

## Did you write or update any docs for this change?


- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [X] No docs needed for this change

## How did you test this code?

Add even more tests. Send some requests with curl