### PR TITLE
fix(cohorts): reset stuck cohorts

### DIFF
--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -89,7 +89,8 @@ def reset_stuck_cohorts() -> None:
         # A stuck cohort never has its errors_calculating incremented, so we need to do it here
         # This will ensure that we don't keep retrying that will never calculate successfully
         cohort.errors_calculating = F("errors_calculating") + 1
-        cohort.save(update_fields=["is_calculating", "errors_calculating"])
+        cohort.last_error_at = timezone.now()
+        cohort.save(update_fields=["is_calculating", "errors_calculating", "last_error_at"])
         reset_cohort_ids.append(cohort.pk)
 
     COHORT_STUCK_RESETS_COUNTER.inc(len(reset_cohort_ids))

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -77,7 +77,7 @@ def reset_stuck_cohorts() -> None:
     # A stuck cohort is a cohort that has is_calculating set to true but the query/task failed and
     # the field was never set back to false. These cohorts will never get pick up again for
     # recalculation by our periodic celery task and need to be reset.
-    # After reseting, these cohorts will be picked up by the next cohort calculation but we need to limit the number
+    # After resetting, these cohorts will be picked up by the next cohort calculation but we need to limit the number
     # of stuck cohorts that are reset at once to avoid overwhelming ClickHouse with too many
     # calculations for stuck cohorts
     reset_cohort_ids = []

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -87,7 +87,7 @@ def reset_stuck_cohorts() -> None:
         cohort.is_calculating = False
 
         # A stuck cohort never has its errors_calculating incremented, so we need to do it here
-        # This will ensure that we don't keep retrying that will never calculate successfully
+        # This will ensure that we don't keep retrying cohorts that will never calculate successfully
         cohort.errors_calculating = F("errors_calculating") + 1
         cohort.last_error_at = timezone.now()
         cohort.save(update_fields=["is_calculating", "errors_calculating", "last_error_at"])

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -507,8 +507,8 @@ def clean_stale_partials() -> None:
 def calculate_cohort(parallel_count: int) -> None:
     from posthog.tasks.calculate_cohort import enqueue_cohorts_to_calculate, reset_stuck_cohorts
 
-    reset_stuck_cohorts()
     enqueue_cohorts_to_calculate(parallel_count)
+    reset_stuck_cohorts()
 
 
 class Polling:

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -505,8 +505,9 @@ def clean_stale_partials() -> None:
 
 @shared_task(ignore_result=True)
 def calculate_cohort(parallel_count: int) -> None:
-    from posthog.tasks.calculate_cohort import enqueue_cohorts_to_calculate
+    from posthog.tasks.calculate_cohort import enqueue_cohorts_to_calculate, reset_stuck_cohorts
 
+    reset_stuck_cohorts()
     enqueue_cohorts_to_calculate(parallel_count)
 
 

--- a/posthog/tasks/test/test_calculate_cohort.py
+++ b/posthog/tasks/test/test_calculate_cohort.py
@@ -369,13 +369,13 @@ def calculate_cohort_test_factory(event_factory: Callable, person_factory: Calla
         def test_reset_stuck_cohorts_respects_limit(self, mock_logger: MagicMock) -> None:
             now = timezone.now()
 
-            # Create more stuck cohorts than the limit (MAX_STUCK_COHORTS_TO_RESET = 5)
+            # Create more stuck cohorts than the limit (MAX_STUCK_COHORTS_TO_RESET)
             stuck_cohorts = []
-            for i in range(MAX_STUCK_COHORTS_TO_RESET + 3):  # Create 8 stuck cohorts
+            for i in range(MAX_STUCK_COHORTS_TO_RESET + 3):
                 cohort = Cohort.objects.create(
                     team_id=self.team.pk,
                     name=f"stuck_cohort_{i}",
-                    last_calculation=now - relativedelta(hours=25, minutes=i),  # Different times for ordering
+                    last_calculation=now - relativedelta(hours=25),
                     deleted=False,
                     is_calculating=True,
                     errors_calculating=0,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

A stuck cohort is a cohort that has `is_calculating` set to true but the query/task failed and the field was never set back to false. These cohorts will never get pick up again for recalculation by our periodic celery task. 

My previous attempt at restarting stuck cohorts submitted them for calculation once they were found by the periodic task https://github.com/PostHog/posthog/pull/33814#issuecomment-2984846601 This change didn't account for the fact that all the workers would try to recalculate the stuck cohort because the filter was looking for `is_calculating=true` which is the case for a stuck cohort but also a stuck cohort that _really_ is calculating. 

Instead of calculating right away, I want to reset the `is_calculating` back to false so that the cohort can be picked up again in the next run of the `calculate_cohort` task. I am only reseting 5 at a time to minimize how many stuck cohort's clickhouse has to calculate at once.

The main downside of this approach is that I am reseting cohorts only if its been stuck for ~24 hours~ 1 hour which is not a great user experience. The accompany fix to this is not letting a cohort get stuck in the first place which I am investigating here: https://posthog.slack.com/archives/C07Q2U4BH4L/p1749841936710429

https://github.com/PostHog/posthog/issues/32745

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [x] No docs needed for this change

## How did you test this code?

Unit tests but to really see how this affects CH, I will need to monitor prod metrics
