### PR TITLE
feat(experiments): breakdown configuration for custom exposure.

### DIFF
--- a/frontend/src/scenes/experiments/components/ResultsBreakdown/resultsBreakdownLogic.ts
+++ b/frontend/src/scenes/experiments/components/ResultsBreakdown/resultsBreakdownLogic.ts
@@ -99,7 +99,10 @@ export const resultsBreakdownLogic = kea<resultsBreakdownLogicType>([
                         filterTestAccounts: !!experiment.exposure_criteria?.filterTestAccounts,
                         dateRange: getExperimentDateRange(experiment),
                         breakdownFilter: {
-                            breakdown: `$feature/${experiment.feature_flag_key}`,
+                            breakdown:
+                                exposureEventNode.event === '$feature_flag_called'
+                                    ? '$feature_flag_response'
+                                    : `$feature/${experiment.feature_flag_key}`,
                             breakdown_type: 'event',
                         },
                         funnelsFilter: {


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We always use the same breakdown configuration regardless of the experiment exposure criteria. This change should help balance breakdowns.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Conditionally set the breakdown configuration based on the exposure criteria.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/283329d5-e6bb-4beb-8cea-7c4bf064f3e8)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
