### PR TITLE
feat(capture-rs): repoint local dev reverse proxy to external-to-Docker capture-rs processes

### DIFF
--- a/bin/mprocs-minimal.yaml
+++ b/bin/mprocs-minimal.yaml
@@ -24,6 +24,18 @@ procs:
             bin/check_kafka_clickhouse_up && \
             bin/start-rust-service property-defs-rs
 
+    capture:
+        shell: |-
+            bin/check_postgres_up && \
+            bin/check_kafka_clickhouse_up && \
+            bin/start-rust-service capture
+
+    capture-replay:
+        shell: |-
+            bin/check_postgres_up && \
+            bin/check_kafka_clickhouse_up && \
+            bin/start-rust-service capture-replay
+
     migrate-clickhouse:
         # These migrations are not in the `backend` service, because they typically aren't blocking for backend startup,
         # but unfortunately they DO take 10-30 s just to check if there's any migration to run (haven't profiled why)

--- a/bin/start-rust-service
+++ b/bin/start-rust-service
@@ -36,7 +36,7 @@ case "$RS_SVC" in
     SQLX_QUERY_LEVEL=${SQLX_QUERY_LEVEL:-warn}
     export RUST_LOG=debug,sqlx::query=$SQLX_QUERY_LEVEL,rdkafka=warn
     export RUST_BACKTRACE=1
-    export ADDRESS=0.0.0.0:3303 # avoid port conflict in local dev
+    export ADDRESS=0.0.0.0:3307 # avoid port conflict in local dev
     export KAFKA_HOSTS=localhost:9092
     export REDIS_URL=redis://localhost:6379
     export DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -20,7 +20,7 @@ services:
             - 'web:host-gateway'
             - 'plugins:host-gateway'
             - 'capture:host-gateway'
-            - 'capture-replay:host-gateway'
+            - 'replay-capture:host-gateway'
         environment:
             CADDYFILE: |
                 http://localhost:8000 {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,12 +15,61 @@ services:
         ports:
             - 8010:8000
         depends_on:
-            - replay-capture
-            - capture
             - feature-flags
         extra_hosts:
             - 'web:host-gateway'
             - 'plugins:host-gateway'
+            - 'capture:host-gateway'
+            - 'capture-replay:host-gateway'
+        environment:
+            CADDYFILE: |
+                http://localhost:8000 {
+                    @replay-capture {
+                        path /s
+                        path /s/*
+                    }
+
+                    @capture {
+                        path /e
+                        path /e/*
+                        path /i/v0/*
+                        path /batch
+                        path /batch*
+                        path /capture
+                        path /capture*
+                    }
+
+                    @flags {
+                        path /flags
+                        path /flags*
+                    }
+
+                    @webhooks {
+                        path /public/webhooks
+                        path /public/webhooks/*
+                    }
+
+                    handle @capture {
+                        reverse_proxy capture:3303
+                    }
+
+                    handle @replay-capture {
+                        reverse_proxy replay-capture:3304
+                    }
+
+                    handle @flags {
+                        reverse_proxy feature-flags:3001
+                    }
+
+                    handle @webhooks {
+                        reverse_proxy plugins:6738
+                    }
+
+                    handle {
+                        reverse_proxy web:8000
+                    }
+                }
+
     db:
         extends:
             file: docker-compose.base.yml
@@ -128,26 +177,6 @@ services:
             - '2080:2080'
         environment:
             - LISTEN_PORT=2080
-
-    # capture-rs
-    capture:
-        extends:
-            file: docker-compose.base.yml
-            service: capture
-        environment:
-            - DEBUG=1
-        depends_on:
-            - redis
-            - kafka
-
-    # replay capture-rs
-    replay-capture:
-        extends:
-            file: docker-compose.base.yml
-            service: replay-capture
-        depends_on:
-            - redis
-            - kafka
 
     feature-flags:
         extends:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -50,11 +50,11 @@ services:
                     }
 
                     handle @capture {
-                        reverse_proxy capture:3303
+                        reverse_proxy capture:3307
                     }
 
                     handle @replay-capture {
-                        reverse_proxy replay-capture:3304
+                        reverse_proxy replay-capture:3306
                     }
 
                     handle @flags {


### PR DESCRIPTION
## Problem
Our local dev Docker Compose should route capture traffic to "live" (local checkout based) `capture-rs` instances managed by `bin/start`, not fixed versions of production Docker images. This unlocks a fast inner dev loop for folks hacking on `capture-rs` in the future.

## Changes

* Override the default Docker Compose `Caddyfile` in `docker-compose.dev.yml`
    * Update the reverse proxy handlers to point to external-to-Docker (local machine) `capture-rs` processes
    * Update `docker-compose.dev.yml`'s Caddy service `extra_hosts` to enable routing to `capture-rs` instances running outside the Docker network

## But wait...I hate this!

For folks that do not currently use `Flox` or `bin/start` in their local dev loop, this change will add dev friction for you. To avoid ruining your dev experience, I'd be happy to update this PR. Some options that occur to me:

#### Option 1
* Leave the image-backed `capture-rs` instances in `docker-compose.dev.yml` as they are now
* Add a new dev-override Docker Compose layer and optional argument to `bin/start`:
    * New layer adds override routing to the "live" `capture-rs` instances
    * New `bin/start` argument includes the new DC layer _optionally when needed_

_Upside: the change is transparent for end users._ If you don't need to hack on your local checkout of `capture-rs`, nothing changes in your local dev workflow.

_Downside: potential for user confusion._ Both the Docker Compose dev rig _and_ `bin/start` will execute duplicate `capture-rs` instances. Only one of the above will have live traffic routed to it at any given time...

#### Option 2
A couple variants of the same idea:

* Add a new, _very minimal_ `bin/start-capture-only` script (or `mprocs` config) for folks that don't like to use all of `bin/start` in their dev loop
* Implement thin, bespoke startup script (`pnpm` target, etc.) that fits alternate dev setups better, for those that just don't like `bin/start`
   * Please share your preferred dev bootstrap details so I can flesh this idea out!

Personally, I like Option 1 if the current PR appears too heavy, but I'm curious to hear your feedback 🙇 

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Locally and in CI