### PR TITLE
fix(cohorts): Query timeouts when uploading a static cohort.

### DIFF
--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -280,8 +280,9 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
                                 Persons in this cohort
                                 <span className="text-secondary ml-2">
                                     {!cohort.is_calculating &&
+                                        cohort.count !== undefined &&
                                         `(${cohort.count} matching ${pluralize(
-                                            cohort.count ?? 0,
+                                            cohort.count,
                                             'person',
                                             'persons',
                                             false

--- a/posthog/helpers/batch_iterators.py
+++ b/posthog/helpers/batch_iterators.py
@@ -1,0 +1,62 @@
+from abc import ABC, abstractmethod
+from typing import Generic, TypeVar
+from collections.abc import Callable
+from collections.abc import Iterator
+
+T = TypeVar("T")
+
+
+class BatchIterator(ABC, Generic[T]):
+    """
+    Abstract base class for lazily yielding batches of data with their batch index.
+    """
+
+    def __init__(self, batch_size: int):
+        if batch_size < 1:
+            raise ValueError("batch_size must be >= 1")
+        self.batch_size = batch_size
+
+    @abstractmethod
+    def __iter__(self) -> Iterator[tuple[int, list[T]]]: ...
+
+
+class ArrayBatchIterator(BatchIterator[T]):
+    """
+    Batches an in-memory list into (batch_index, batch_data) pairs.
+    """
+
+    def __init__(self, data: list[T], batch_size: int):
+        super().__init__(batch_size)
+        self.data = data
+        self._delegate = FunctionBatchIterator(self._batch_fn, batch_size)
+
+    def _batch_fn(self, batch_index: int, batch_size: int) -> list[T]:
+        start = batch_index * batch_size
+        end = start + batch_size
+        return self.data[start:end] if start < len(self.data) else []
+
+    def __iter__(self):
+        return iter(self._delegate)
+
+
+class FunctionBatchIterator(BatchIterator[T]):
+    """
+    Lazily yields batches by calling a function that produces each batch.
+    Useful for complex querying scenarios where each batch requires custom logic.
+
+    The function should take (batch_index: int, batch_size: int) and return a list of items.
+    Return an empty list to signal completion.
+    """
+
+    def __init__(self, batch_function: Callable[[int, int], list[T]], batch_size: int):
+        super().__init__(batch_size)
+        self.batch_function = batch_function
+
+    def __iter__(self) -> Iterator[tuple[int, list[T]]]:
+        batch_index = 0
+        while True:
+            batch_data = self.batch_function(batch_index, self.batch_size)
+            if not batch_data:
+                break
+            yield batch_index, batch_data
+            batch_index += 1

--- a/posthog/helpers/tests/test_batch_iterator.py
+++ b/posthog/helpers/tests/test_batch_iterator.py
@@ -67,23 +67,6 @@ class TestFunctionBatchIterator:
         assert len(batches) == 1
         assert batches[0] == (0, [1, 2, 3])
 
-    def test_function_batch_iterator_variable_batch_sizes(self):
-        def create_variable_batch(batch_index: int, batch_size: int) -> list[int]:
-            if batch_index == 0:
-                return [1, 2]  # Smaller than batch_size
-            elif batch_index == 1:
-                return [3, 4, 5, 6]  # Larger than batch_size
-            elif batch_index == 2:
-                return [7]  # Single item
-            return []
-
-        batch_iterator = FunctionBatchIterator(create_variable_batch, batch_size=3)
-        batches = list(batch_iterator)
-        assert len(batches) == 3
-        assert batches[0] == (0, [1, 2])
-        assert batches[1] == (1, [3, 4, 5, 6])
-        assert batches[2] == (2, [7])
-
     def test_function_batch_iterator_with_early_termination(self):
         def create_batch_with_gaps(batch_index: int, batch_size: int) -> list[int]:
             if batch_index == 0:

--- a/posthog/helpers/tests/test_batch_iterator.py
+++ b/posthog/helpers/tests/test_batch_iterator.py
@@ -19,7 +19,6 @@ class TestArrayBatchIterator:
         batch_iterator = ArrayBatchIterator(data, batch_size=3)
         for _, _ in batch_iterator:
             raise AssertionError("Should not have any batches")
-        assert True
 
     def test_array_batch_iterator_batch_size_bigger_than_data(self):
         data = [1, 2, 3]
@@ -27,7 +26,6 @@ class TestArrayBatchIterator:
         for batch_index, batch in batch_iterator:
             assert batch == [1, 2, 3]
             assert batch_index == 0
-        assert True
 
 
 class TestFunctionBatchIterator:

--- a/posthog/helpers/tests/test_batch_iterator.py
+++ b/posthog/helpers/tests/test_batch_iterator.py
@@ -4,7 +4,7 @@ import pytest
 
 class TestArrayBatchIterator:
     def test_array_batch_iterator(self):
-        data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        data: list[int] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         expected_batches = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10]]
         batch_iterator = ArrayBatchIterator(data, batch_size=3)
         iteration_count = 0
@@ -15,13 +15,13 @@ class TestArrayBatchIterator:
         assert iteration_count == len(expected_batches)
 
     def test_array_batch_iterator_empty(self):
-        data = []
+        data: list[int] = []
         batch_iterator = ArrayBatchIterator(data, batch_size=3)
         for _, _ in batch_iterator:
             raise AssertionError("Should not have any batches")
 
     def test_array_batch_iterator_batch_size_bigger_than_data(self):
-        data = [1, 2, 3]
+        data: list[int] = [1, 2, 3]
         batch_iterator = ArrayBatchIterator(data, batch_size=4)
         for batch_index, batch in batch_iterator:
             assert batch == [1, 2, 3]
@@ -54,7 +54,7 @@ class TestFunctionBatchIterator:
         batch_iterator = FunctionBatchIterator(create_empty_batch, batch_size=3)
         for _, _ in batch_iterator:
             raise AssertionError("Should not have any batches")
-        assert True
+        return
 
     def test_function_batch_iterator_single_batch(self):
         def create_single_batch(batch_index: int, batch_size: int) -> list[int]:
@@ -75,6 +75,7 @@ class TestFunctionBatchIterator:
                 return []  # Empty batch should terminate
             elif batch_index == 2:
                 return [4, 5, 6]  # This should never be reached
+            return []  # Keep mypy happy
 
         batch_iterator = FunctionBatchIterator(create_batch_with_gaps, batch_size=3)
         batches = list(batch_iterator)

--- a/posthog/helpers/tests/test_batch_iterator.py
+++ b/posthog/helpers/tests/test_batch_iterator.py
@@ -1,0 +1,124 @@
+from posthog.helpers.batch_iterators import ArrayBatchIterator, FunctionBatchIterator
+import pytest
+
+
+class TestArrayBatchIterator:
+    def test_array_batch_iterator(self):
+        data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        expected_batches = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10]]
+        batch_iterator = ArrayBatchIterator(data, batch_size=3)
+        iteration_count = 0
+        for batch_index, batch in batch_iterator:
+            assert batch == expected_batches[iteration_count]
+            assert batch_index == iteration_count
+            iteration_count += 1
+        assert iteration_count == len(expected_batches)
+
+    def test_array_batch_iterator_empty(self):
+        data = []
+        batch_iterator = ArrayBatchIterator(data, batch_size=3)
+        for _, _ in batch_iterator:
+            raise AssertionError("Should not have any batches")
+        assert True
+
+    def test_array_batch_iterator_batch_size_bigger_than_data(self):
+        data = [1, 2, 3]
+        batch_iterator = ArrayBatchIterator(data, batch_size=4)
+        for batch_index, batch in batch_iterator:
+            assert batch == [1, 2, 3]
+            assert batch_index == 0
+        assert True
+
+
+class TestFunctionBatchIterator:
+    def test_function_batch_iterator_basic(self):
+        # Test with a simple function that returns batches of numbers
+        def create_batch(batch_index: int, batch_size: int) -> list[int]:
+            start = batch_index * batch_size
+            end = start + batch_size
+            data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+            return data[start:end] if start < len(data) else []
+
+        expected_batches = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10]]
+        batch_iterator = FunctionBatchIterator(create_batch, batch_size=3)
+
+        iteration_count = 0
+        for batch_index, batch in batch_iterator:
+            assert batch == expected_batches[iteration_count]
+            assert batch_index == iteration_count
+            iteration_count += 1
+        assert iteration_count == len(expected_batches)
+
+    def test_function_batch_iterator_empty(self):
+        def create_empty_batch(batch_index: int, batch_size: int) -> list[int]:
+            return []
+
+        batch_iterator = FunctionBatchIterator(create_empty_batch, batch_size=3)
+        for _, _ in batch_iterator:
+            raise AssertionError("Should not have any batches")
+        assert True
+
+    def test_function_batch_iterator_single_batch(self):
+        def create_single_batch(batch_index: int, batch_size: int) -> list[int]:
+            if batch_index == 0:
+                return [1, 2, 3]
+            return []
+
+        batch_iterator = FunctionBatchIterator(create_single_batch, batch_size=3)
+        batches = list(batch_iterator)
+        assert len(batches) == 1
+        assert batches[0] == (0, [1, 2, 3])
+
+    def test_function_batch_iterator_variable_batch_sizes(self):
+        def create_variable_batch(batch_index: int, batch_size: int) -> list[int]:
+            if batch_index == 0:
+                return [1, 2]  # Smaller than batch_size
+            elif batch_index == 1:
+                return [3, 4, 5, 6]  # Larger than batch_size
+            elif batch_index == 2:
+                return [7]  # Single item
+            return []
+
+        batch_iterator = FunctionBatchIterator(create_variable_batch, batch_size=3)
+        batches = list(batch_iterator)
+        assert len(batches) == 3
+        assert batches[0] == (0, [1, 2])
+        assert batches[1] == (1, [3, 4, 5, 6])
+        assert batches[2] == (2, [7])
+
+    def test_function_batch_iterator_with_early_termination(self):
+        def create_batch_with_gaps(batch_index: int, batch_size: int) -> list[int]:
+            if batch_index == 0:
+                return [1, 2, 3]
+            elif batch_index == 1:
+                return []  # Empty batch should terminate
+            elif batch_index == 2:
+                return [4, 5, 6]  # This should never be reached
+
+        batch_iterator = FunctionBatchIterator(create_batch_with_gaps, batch_size=3)
+        batches = list(batch_iterator)
+        assert len(batches) == 1
+        assert batches[0] == (0, [1, 2, 3])
+
+    def test_function_batch_iterator_batch_size_validation(self):
+        def create_batch(batch_index: int, batch_size: int) -> list[int]:
+            return [1, 2, 3]
+
+        # Test that batch_size validation works
+        with pytest.raises(ValueError, match="batch_size must be >= 1"):
+            FunctionBatchIterator(create_batch, batch_size=0)
+
+        with pytest.raises(ValueError, match="batch_size must be >= 1"):
+            FunctionBatchIterator(create_batch, batch_size=-1)
+
+
+class TestBatchIterator:
+    def test_batch_size_must_be_positive(self):
+        with pytest.raises(ValueError, match="batch_size must be >= 1"):
+            ArrayBatchIterator([1, 2, 3], batch_size=0)
+
+        def create_batch(batch_index: int, batch_size: int) -> list[int]:
+            return [1, 2, 3]
+
+        with pytest.raises(ValueError, match="batch_size must be >= 1"):
+            FunctionBatchIterator(create_batch, batch_size=-5)

--- a/posthog/management/commands/export_distinct_ids.py
+++ b/posthog/management/commands/export_distinct_ids.py
@@ -1,0 +1,135 @@
+import random
+from django.core.management.base import BaseCommand
+from posthog.models import Person, PersonDistinctId, Team
+
+
+class Command(BaseCommand):
+    help = "Export distinct IDs to a text file for static cohort import"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--team-id",
+            type=int,
+            help="Team ID to export distinct IDs for (default: first team)",
+        )
+        parser.add_argument(
+            "--output",
+            type=str,
+            default="distinct_ids.csv",
+            help="Output file path (default: distinct_ids.csv)",
+        )
+        parser.add_argument(
+            "--identified-only",
+            action="store_true",
+            help="Only export distinct IDs for identified persons",
+        )
+        parser.add_argument(
+            "--demo-only",
+            action="store_true",
+            help="Only export distinct IDs for demo persons (with is_demo=True)",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            help="Limit the number of distinct IDs to export",
+        )
+        parser.add_argument(
+            "--random",
+            type=int,
+            help="Pick N distinct IDs at random from the database",
+        )
+
+    def handle(self, *args, **options):
+        team_id = options["team_id"]
+        output_file = options["output"]
+        identified_only = options["identified_only"]
+        demo_only = options["demo_only"]
+        limit = options["limit"]
+        random_count = options["random"]
+
+        # Get or create team
+        if team_id:
+            try:
+                team = Team.objects.get(pk=team_id)
+            except Team.DoesNotExist:
+                self.stdout.write(self.style.ERROR(f"Team with ID {team_id} does not exist!"))
+                return
+        else:
+            team = Team.objects.first()
+            if not team:
+                self.stdout.write(self.style.ERROR("No teams found! Please create a team first."))
+                return
+
+        self.stdout.write(self.style.SUCCESS(f"Exporting distinct IDs for team: {team.name}"))
+
+        # Build the query
+        distinct_ids_query = PersonDistinctId.objects.filter(team=team)
+
+        if identified_only:
+            distinct_ids_query = distinct_ids_query.filter(person__is_identified=True)
+            self.stdout.write("Filtering for identified persons only")
+
+        if demo_only:
+            distinct_ids_query = distinct_ids_query.filter(person__properties__is_demo=True)
+            self.stdout.write("Filtering for demo persons only")
+
+        # Get distinct IDs
+        distinct_ids = list(distinct_ids_query.values_list("distinct_id", flat=True))
+
+        if not distinct_ids:
+            self.stdout.write(self.style.WARNING("No distinct IDs found matching the criteria!"))
+            return
+
+        # Handle random selection
+        if random_count:
+            if random_count > len(distinct_ids):
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"Requested {random_count} random distinct IDs, but only {len(distinct_ids)} available. "
+                        f"Using all {len(distinct_ids)} distinct IDs."
+                    )
+                )
+                random_count = len(distinct_ids)
+
+            distinct_ids = random.sample(distinct_ids, random_count)
+            self.stdout.write(f"Randomly selected {len(distinct_ids)} distinct IDs")
+        elif limit:
+            distinct_ids = distinct_ids[:limit]
+            self.stdout.write(f"Limited to {len(distinct_ids)} distinct IDs")
+
+        # Write to file
+        try:
+            with open(output_file, "w") as f:
+                # Write header
+                f.write("distinct_id\n")
+
+                # Write distinct IDs
+                for distinct_id in distinct_ids:
+                    f.write(f"{distinct_id}\n")
+
+            self.stdout.write(
+                self.style.SUCCESS(f"Successfully exported {len(distinct_ids)} distinct IDs to {output_file}")
+            )
+
+            # Show some sample distinct IDs
+            sample_size = min(5, len(distinct_ids))
+            self.stdout.write(f"Sample distinct IDs:")
+            for i in range(sample_size):
+                self.stdout.write(f"  {distinct_ids[i]}")
+
+            if len(distinct_ids) > sample_size:
+                self.stdout.write(f"  ... and {len(distinct_ids) - sample_size} more")
+
+        except Exception as e:
+            self.stdout.write(self.style.ERROR(f"Error writing to file: {e}"))
+
+        # Also show some stats
+        total_persons = Person.objects.filter(team=team).count()
+        identified_persons = Person.objects.filter(team=team, is_identified=True).count()
+        demo_persons = Person.objects.filter(team=team, properties__is_demo=True).count()
+
+        self.stdout.write(f"\nTeam statistics:")
+        self.stdout.write(f"  Total persons: {total_persons}")
+        self.stdout.write(f"  Identified persons: {identified_persons}")
+        self.stdout.write(f"  Demo persons: {demo_persons}")
+        self.stdout.write(f"  Exported distinct IDs: {len(distinct_ids)}")

--- a/posthog/management/commands/generate_persons.py
+++ b/posthog/management/commands/generate_persons.py
@@ -1,0 +1,884 @@
+import random
+from typing import Any
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from posthog.models import Person, PersonDistinctId, Team
+from posthog.models.utils import UUIDT
+
+
+class Command(BaseCommand):
+    help = "Generate a bunch of persons with realistic properties for development/testing"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--count",
+            type=int,
+            default=100,
+            help="Number of persons to generate (default: 100)",
+        )
+        parser.add_argument(
+            "--team-id",
+            type=int,
+            help="Team ID to create persons for (default: first team)",
+        )
+        parser.add_argument(
+            "--identified",
+            type=float,
+            default=0.7,
+            help="Percentage of identified persons (0.0-1.0, default: 0.7)",
+        )
+        parser.add_argument(
+            "--with-events",
+            action="store_true",
+            help="Also generate some basic events for each person",
+        )
+        parser.add_argument(
+            "--skip-sync",
+            action="store_true",
+            help="Skip syncing to ClickHouse (useful for testing)",
+        )
+
+    def handle(self, *args, **options):
+        count = options["count"]
+        team_id = options["team_id"]
+        identified_ratio = options["identified"]
+        with_events = options["with_events"]
+        skip_sync = options["skip_sync"]
+
+        # Get or create team
+        if team_id:
+            try:
+                team = Team.objects.get(pk=team_id)
+            except Team.DoesNotExist:
+                self.stdout.write(self.style.ERROR(f"Team with ID {team_id} does not exist!"))
+                return
+        else:
+            team = Team.objects.first()
+            if not team:
+                self.stdout.write(self.style.ERROR("No teams found! Please create a team first."))
+                return
+
+        self.stdout.write(self.style.SUCCESS(f"Generating {count} persons for team: {team.name}"))
+
+        # Generate persons
+        persons_created = 0
+        with transaction.atomic():
+            for i in range(count):
+                person_data = self._generate_person_data(i, identified_ratio)
+
+                # Create person in Django only
+                person = Person.objects.create(
+                    team=team,
+                    properties=person_data["properties"],
+                    is_identified=person_data["is_identified"],
+                )
+
+                # Create distinct ID
+                distinct_id = str(UUIDT())
+                PersonDistinctId.objects.create(
+                    team=team,
+                    person=person,
+                    distinct_id=distinct_id,
+                )
+
+                persons_created += 1
+
+                if persons_created % 10 == 0:
+                    self.stdout.write(f"Created {persons_created} persons...")
+
+        self.stdout.write(self.style.SUCCESS(f"Successfully created {persons_created} persons for team '{team.name}'"))
+
+        # Sync to ClickHouse
+        if not skip_sync:
+            self.stdout.write("Syncing persons to ClickHouse...")
+            from django.core.management import call_command
+
+            call_command("sync_persons_to_clickhouse", team_id=team.pk, person=True, live_run=True)
+            self.stdout.write(self.style.SUCCESS("Persons synced to ClickHouse successfully!"))
+
+        if with_events:
+            self.stdout.write("Generating events for persons...")
+            self._generate_events_for_persons(team, persons_created)
+
+    def _generate_person_data(self, index: int, identified_ratio: float) -> dict[str, Any]:
+        """Generate realistic person data"""
+        is_identified = random.random() < identified_ratio
+
+        if is_identified:
+            first_name, last_name = self._generate_name()
+            # Generate identified person with more properties
+            properties = {
+                "email": self._generate_email(first_name, last_name),
+                "name": f"{first_name} {last_name}",
+                "username": self._generate_username(first_name, last_name),
+                "company": self._generate_company(),
+                "plan": random.choice(["free", "pro", "enterprise"]),
+                "country": random.choice(["US", "UK", "CA", "AU", "DE", "FR", "JP", "IN"]),
+                "city": self._generate_city(),
+                "utm_source": random.choice(["google", "twitter", "linkedin", "direct", "github"]),
+                "utm_medium": random.choice(["cpc", "social", "email", "organic"]),
+                "utm_campaign": random.choice(["summer2024", "product_launch", "black_friday", None]),
+                "signup_date": self._generate_date_string(),
+                "last_login": self._generate_date_string(),
+                "total_events": random.randint(1, 1000),
+                "sessions_count": random.randint(1, 50),
+                "is_demo": True,
+            }
+        else:
+            # Generate anonymous person with minimal properties
+            properties = {
+                "utm_source": random.choice(["google", "twitter", "linkedin", "direct", "github", None]),
+                "utm_medium": random.choice(["cpc", "social", "email", "organic", None]),
+                "utm_campaign": random.choice(["summer2024", "product_launch", "black_friday", None]),
+                "is_demo": True,
+            }
+
+        return {
+            "properties": properties,
+            "is_identified": is_identified,
+        }
+
+    def _generate_email(self, first_name: str, last_name: str) -> str:
+        """Generate a realistic email address"""
+        domains = [
+            "gmail.com",
+            "yahoo.com",
+            "hotmail.com",
+            "outlook.com",
+            "icloud.com",
+            "protonmail.com",
+            "aol.com",
+            "company.com",
+            "startup.io",
+            "posthog.com",
+            "microsoft.com",
+            "apple.com",
+            "google.com",
+            "amazon.com",
+            "meta.com",
+            "netflix.com",
+            "spotify.com",
+            "uber.com",
+            "airbnb.com",
+            "slack.com",
+            "zoom.us",
+            "notion.so",
+            "openai.com",
+            "anthropic.com",
+            "supabase.com",
+            "vercel.com",
+            "cloudflare.com",
+            "heroku.com",
+            "digitalocean.com",
+        ]
+
+        first = first_name.lower()
+        last = last_name.lower()
+
+        domain = random.choice(domains)
+
+        # Add some variety
+        if random.random() < 0.3:
+            email = f"{first}.{last}@{domain}"
+        elif random.random() < 0.5:
+            email = f"{first}{random.randint(1, 999)}@{domain}"
+        else:
+            email = f"{first}_{last}@{domain}"
+
+        return email
+
+    def _generate_name(self) -> tuple[str, str]:
+        """Generate a realistic name"""
+        first_names = [
+            "Jon",
+            "Daenerys",
+            "Tyrion",
+            "Cersei",
+            "Arya",
+            "Sansa",
+            "Bran",
+            "Jaime",
+            "Theon",
+            "Robb",
+            "Ned",
+            "Robert",
+            "Joffrey",
+            "Tommen",
+            "Myrcella",
+            "Stannis",
+            "Renly",
+            "Margaery",
+            "Olenna",
+            "Tywin",
+            "Varys",
+            "Littlefinger",
+            "Samwell",
+            "Gilly",
+            "Ygritte",
+            "Tormund",
+            "Brienne",
+            "Podrick",
+            "Bronn",
+            "Sandor",
+            "Gregor",
+            "Oberyn",
+            "Ellaria",
+            "Doran",
+            "Arianne",
+            "Quentyn",
+            "Trystane",
+            "Melisandre",
+            "Davos",
+            "Shireen",
+            "Gendry",
+            "Hot Pie",
+            "Jaqen",
+            "Syrio",
+            "Hodor",
+            "Meera",
+            "Jojen",
+            "Rickon",
+            "Roose",
+            "Ramsay",
+            "Walder",
+            "Lysa",
+            "Robin",
+            "Edmure",
+            "Brynden",
+            "Catelyn",
+            "Petyr",
+            "Lancel",
+            "Kevan",
+            "Loras",
+            "Walter",
+            "Jesse",
+            "Skyler",
+            "Hank",
+            "Marie",
+            "Saul",
+            "Gus",
+            "Mike",
+            "Todd",
+            "Lydia",
+            "Andrea",
+            "Brock",
+            "Huell",
+            "Victor",
+            "Tyrus",
+            "Gale",
+            "Badger",
+            "Skinny Pete",
+            "Combo",
+            "Tortuga",
+            "Don Eladio",
+            "Juan Bolsa",
+            "Tuco",
+            "Hector",
+            "Marco",
+            "Leonel",
+            "Wendy",
+            "Carmen",
+            "Gretchen",
+            "Wilma",
+            "Barney",
+            "Betty",
+            "Pebbles",
+            "Bamm-Bamm",
+            "Hoppy",
+            "Mr. Slate",
+            "Joe Rockhead",
+            "Arnold",
+            "Pearl",
+            "Roxy",
+            "Chip",
+            "Shale",
+            "Gazoo",
+            "Captain Caveman",
+            "Snagglepuss",
+            "Huckleberry",
+            "Daphne",
+            "Velma",
+            "Shaggy",
+            "Scooby",
+            "Scrappy",
+            "Scooby-Dum",
+            "Scooby-Dee",
+            "Vincent",
+            "Marlena",
+            "Crystal",
+            "Alma",
+            "Thorn",
+            "Dusk",
+            "Luna",
+            "Professor Pericles",
+            "Hot Dog Water",
+            "Dee Dee",
+            "Dum Dum",
+            "John",
+            "Jane",
+            "Michael",
+            "Sarah",
+            "David",
+            "Emma",
+            "Alex",
+            "Lisa",
+            "Chris",
+            "Anna",
+            "Phil",
+            "Jose",
+            "Raul",
+            "Juan",
+            "Maria",
+            "Pedro",
+            "Ana",
+            "Luis",
+            "Elena",
+            "Carlos",
+            "Laura",
+            "Miguel",
+            "Mine",
+            "Patricio",
+            "Pawel",
+            "Daniel",
+            "Lottie",
+            "Eli",
+            "Cory",
+            "Joe",
+            "Meikel",
+            "Marcus",
+            "Ben",
+            "Ted",
+            "James",
+            "Edwin",
+            "Vincent",
+            "Ian",
+            "Lior",
+            "Andy",
+            "Tyler",
+            "Kaya",
+            "Magda",
+            "Steven",
+            "Cameron",
+            "Dana",
+            "Anna",
+            "Ross",
+            "Tomás",
+            "Peter",
+            "Tom",
+            "Eric",
+            "Adam",
+            "Tim",
+            "Marius",
+            "Hugues",
+            "Oliver",
+            "David",
+            "Scott",
+            "Raquel",
+            "Charles",
+            "Rodrigo",
+            "Anders",
+            "Annika",
+            "Juraj",
+            "Dylan",
+            "Danilo",
+            "Joshua",
+            "Bryan",
+            "Frank",
+            "Daniel",
+            "Michael",
+            "José",
+            "Nick",
+            "Eli",
+            "Paweł",
+            "Peter",
+            "Alex",
+            "Emanuele",
+            "Georgiy",
+            "Mahamad",
+            "Moustafa",
+            "Abe",
+            "Haven",
+            "Hector",
+            "Júlia",
+            "Kendal",
+            "Coua",
+            "Fraser",
+            "Yasen",
+            "Zach",
+            "Nima",
+            "Anirudh",
+            "Thomas",
+            "Julian",
+            "Sandy",
+            "Aleks",
+            "Paul",
+            "Rafael",
+            "Ben",
+            "Leon",
+            "Seb",
+            "Simon",
+            "Max",
+            "Abigail",
+            "Lucas",
+            "Ioannis",
+            "Manoel",
+            "Javier",
+            "Robbie",
+        ]
+        last_names = [
+            "Stark",
+            "Lannister",
+            "Targaryen",
+            "Baratheon",
+            "Greyjoy",
+            "Tyrell",
+            "Martell",
+            "Arryn",
+            "Tully",
+            "Frey",
+            "Bolton",
+            "Karstark",
+            "Umber",
+            "Mormont",
+            "Reed",
+            "Glover",
+            "Manderly",
+            "Cerwyn",
+            "Hornwood",
+            "Tallhart",
+            "Dustin",
+            "Ryswell",
+            "Flint",
+            "Norrey",
+            "Wull",
+            "Liddle",
+            "Burley",
+            "Harclay",
+            "Knott",
+            "Bracken",
+            "Blackwood",
+            "Mallister",
+            "Vance",
+            "Piper",
+            "Smallwood",
+            "Ryger",
+            "Mooton",
+            "Darry",
+            "Whent",
+            "Lothston",
+            "Hightower",
+            "Redwyne",
+            "Rowan",
+            "Oakheart",
+            "Tarly",
+            "Crane",
+            "Fossoway",
+            "Mullendore",
+            "Cuy",
+            "Beesbury",
+            "Florent",
+            "Clegane",
+            "Payne",
+            "Swyft",
+            "Spicer",
+            "Westerling",
+            "Crakehall",
+            "Marbrand",
+            "Lefford",
+            "Sarsfield",
+            "White",
+            "Pinkman",
+            "Schrader",
+            "Goodman",
+            "Fring",
+            "Ehrmantraut",
+            "Varga",
+            "Rodarte-Quayle",
+            "Margolis",
+            "Esposito",
+            "Cranston",
+            "Paul",
+            "Gunn",
+            "Norris",
+            "Brandt",
+            "Odenkirk",
+            "Banks",
+            "Plemons",
+            "Todd",
+            "Rodriguez",
+            "Cruz",
+            "Garcia",
+            "Martinez",
+            "Lopez",
+            "Gonzalez",
+            "Perez",
+            "Sanchez",
+            "Ramirez",
+            "Torres",
+            "Flintstone",
+            "Rubble",
+            "Slate",
+            "Rockhead",
+            "Gazoo",
+            "Caveman",
+            "Snagglepuss",
+            "Huckleberry",
+            "Pebble",
+            "Boulder",
+            "Stone",
+            "Rock",
+            "Granite",
+            "Marble",
+            "Quartz",
+            "Obsidian",
+            "Basalt",
+            "Limestone",
+            "Sandstone",
+            "Shale",
+            "Jones",
+            "Blake",
+            "Dinkley",
+            "Rogers",
+            "Dooby",
+            "Van Ghoul",
+            "Crystal",
+            "Alma",
+            "Thorn",
+            "Dusk",
+            "Luna",
+            "Pericles",
+            "Water",
+            "Dum",
+            "Dee",
+            "Dooby",
+            "Smith",
+            "Johnson",
+            "Williams",
+            "Brown",
+            "Jones",
+            "Garcia",
+            "Miller",
+            "Davis",
+            "Rodriguez",
+            "Martinez",
+            "Nguyen",
+            "Lee",
+            "Park",
+            "Huynh",
+            "Tran",
+            "Pham",
+            "Le",
+            "Cruz",
+            "Santos",
+            "Ng",
+            "Yu",
+            "Haack",
+            "Glaser",
+            "Andra",
+            "Puusepp",
+            "D'Amico",
+            "Agarwal",
+            "Coxon",
+            "Watilo",
+            "Nicklas",
+            "Hawkins",
+            "Majuri",
+            "Ungless",
+            "Tannergoods",
+            "Caspus",
+            "Munayyer",
+            "Sanket",
+            "Thakur",
+            "Morley",
+            "Popovici",
+            "White",
+            "Serhey",
+            "Madsen",
+            "Piemets",
+            "Helene",
+            "Anand",
+            "Bernt",
+            "Fakela",
+            "Packham",
+            "Gzog",
+            "Oshura",
+            "Abo7atm",
+            "Etaveras",
+            "Gare",
+            "RedFrez",
+            "Cirdes",
+            "Ben",
+            "Sj26",
+            "Nunda",
+            "Rosales",
+            "Sagar",
+            "Wadenick",
+            "Gannondo",
+            "Adhruv",
+            "Grellyd",
+            "Berrelleza",
+            "Annanay",
+            "Cohix",
+            "Goutham",
+            "Alexellis",
+            "Prologic",
+            "Gustie",
+            "Kubemq",
+            "Vania",
+            "Irespaldiza",
+            "Croomes",
+            "Snormore",
+            "Faik",
+            "Andryashin",
+            "Something",
+            "Ferroin",
+            "Panato",
+            "Cakrit",
+            "Henry",
+            "Oxplot",
+            "Barry",
+            "Moabu",
+            "Dhandala",
+            "Mehta",
+            "Morris",
+            "Bitdeli",
+            "Sidartha",
+            "Mirra",
+            "Avila",
+            "Saunderson",
+            "Lai",
+            "McKeaveney",
+            "Harress",
+            "Brault",
+            "Leggetter",
+            "Shu",
+            "Clarke",
+            "Balasko",
+            "Huang",
+            "Hu",
+            "Afterwind",
+            "Wong",
+            "Rajie",
+            "Developer",
+            "Esposito",
+            "Sinha",
+            "Trivedi",
+            "Fuentes",
+            "Agarwal",
+            "Qiu",
+            "Kurth",
+            "Avorio",
+            "Tornros",
+            "Ghate",
+            "Calvin",
+            "Mazarakis",
+            "Piccini",
+            "Gill",
+            "Dufour",
+            "Bojlen",
+            "Hyett",
+            "Borges",
+            "Kakkar",
+            "Binetti",
+            "Kinsey",
+            "Chen",
+            "Redl",
+            "Lopez",
+            "Vasquez",
+            "Ismail",
+            "Bryan",
+            "Banfield",
+            "Harty",
+            "Greenberg",
+            "Banagale",
+            "Kabbes",
+            "Sykes",
+            "Stefan",
+            "Munro",
+            "Shah",
+            "Geary",
+            "Yuvaraj",
+            "Etherington",
+            "Singh",
+            "Ding",
+            "Samek",
+            "Sagar",
+            "Roman",
+            "Pixlwave",
+            "Chasovskiy",
+            "StackoverFrog",
+            "Muller",
+            "Sharp",
+            "Campuzano",
+            "Louis",
+            "Abtin",
+            "Shehu",
+            "Tharun",
+            "Spotorno",
+            "Meilick",
+            "Rahul",
+            "Sheridan",
+            "Cavallaro",
+            "Crispin",
+            "Johannsson",
+            "Trollo",
+            "Xu",
+            "Kuber",
+            "Zihnioglu",
+            "Savoy",
+            "Zombie",
+            "Marty",
+            "Krylov",
+            "Olek",
+            "Klink",
+            "Mierzwiak",
+            "GitStart",
+            "Tyler",
+            "Everett",
+            "Abgrall",
+            "Stuposluns",
+            "Charles",
+            "Dent",
+            "Eagan",
+            "Turban",
+            "Obermuller",
+            "Jafarli",
+            "Rozanski",
+            "Schakaki",
+            "Behabadi",
+            "Ashton",
+            "Venkatesh",
+            "Onyishi",
+            "Mader",
+            "Zackelan",
+            "Marron",
+            "Maglangit",
+            "Jones",
+            "Moussa",
+            "Chaturvedi",
+            "Ballerine",
+            "Taleno",
+            "William",
+            "Tarpara",
+            "Ghosh",
+        ]
+
+        return random.choice(first_names), random.choice(last_names)
+
+    def _generate_username(self, first_name: str, last_name: str) -> str:
+        """Generate a realistic username"""
+        first = first_name.lower()
+        last = last_name.lower()
+
+        if random.random() < 0.2:
+            username = f"{first}.{last}"
+        elif random.random() < 0.4:
+            username = f"{first}{random.randint(1, 999)}"
+        elif random.random() < 0.8:
+            username = f"{last}.{first}{random.randint(1, 999)}"
+        elif random.random() < 0.9:
+            username = f"{first}{last[0]}"
+        else:
+            username = f"{first}{random.randint(1, 999)}"
+
+        return username
+
+    def _generate_company(self) -> str:
+        """Generate a realistic company name"""
+        companies = [
+            "Acme Corp",
+            "TechStart Inc",
+            "Global Solutions",
+            "Innovation Labs",
+            "Digital Dynamics",
+            "Future Systems",
+            "Creative Agency",
+            "DataWorks",
+            "CloudTech",
+            "Smart Solutions",
+            "NextGen Industries",
+            "Elite Consulting",
+            "Peak Performance",
+            "Visionary Ventures",
+            "Strategic Partners",
+            "Dynamic Solutions",
+            "Progressive Systems",
+            "Advanced Analytics",
+            "Initech",
+            "Dunder Mifflin",
+            "Staples",
+            "Wayne Enterprises",
+            "Stark Industries",
+            "Serenity",
+        ]
+        return random.choice(companies)
+
+    def _generate_city(self) -> str:
+        """Generate a realistic city name"""
+        cities = [
+            "New York",
+            "London",
+            "San Francisco",
+            "Berlin",
+            "Tokyo",
+            "Sydney",
+            "Toronto",
+            "Paris",
+            "Chicago",
+            "Los Angeles",
+            "Boston",
+            "Seattle",
+            "Austin",
+            "Denver",
+            "Miami",
+            "Portland",
+        ]
+        return random.choice(cities)
+
+    def _generate_date_string(self) -> str:
+        """Generate a realistic date string"""
+        import datetime
+
+        days_ago = random.randint(1, 365)
+        date = datetime.datetime.now() - datetime.timedelta(days=days_ago)
+        return date.strftime("%Y-%m-%d")
+
+    def _generate_events_for_persons(self, team: Team, person_count: int):
+        """Generate some basic events for the persons"""
+        from posthog.models.event.util import create_event
+        from uuid import uuid4
+
+        event_types = ["pageview", "click", "form_submit", "signup", "purchase", "download"]
+        pages = ["/", "/pricing", "/features", "/about", "/contact", "/blog", "/docs"]
+
+        events_created = 0
+        for _i in range(min(person_count, 50)):  # Limit events to avoid overwhelming
+            person = Person.objects.filter(team=team).order_by("?").first()
+            if not person:
+                continue
+
+            distinct_id = person.distinct_ids[0] if person.distinct_ids else str(UUIDT())
+
+            # Generate 1-5 events per person
+            for _j in range(random.randint(1, 5)):
+                event_type = random.choice(event_types)
+                properties = {
+                    "page": random.choice(pages),
+                    "is_demo": True,
+                }
+
+                if event_type == "pageview":
+                    properties["$current_url"] = f"https://example.com{properties['page']}"
+                elif event_type == "click":
+                    properties["$el_text"] = random.choice(["Sign Up", "Learn More", "Get Started", "Contact Us"])
+
+                create_event(
+                    event=event_type,
+                    distinct_id=distinct_id,
+                    team=team,
+                    properties=properties,
+                    event_uuid=uuid4(),
+                )
+                events_created += 1
+
+        self.stdout.write(self.style.SUCCESS(f"Created {events_created} events for persons"))

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -394,7 +394,7 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
         batch_iterator = FunctionBatchIterator(create_uuid_batch, batch_size=batch_size)
 
         # Call the batching method with ClickHouse insertion enabled
-        self.insert_users_list_with_batching(batch_iterator, insert_in_clickhouse=True, team_id=team_id)
+        self._insert_users_list_with_batching(batch_iterator, insert_in_clickhouse=True, team_id=team_id)
 
     def insert_users_list_by_uuid(
         self,
@@ -415,9 +415,9 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
         """
 
         batch_iterator = ArrayBatchIterator(items, batch_size=batchsize)
-        self.insert_users_list_with_batching(batch_iterator, insert_in_clickhouse, team_id=team_id)
+        self._insert_users_list_with_batching(batch_iterator, insert_in_clickhouse, team_id=team_id)
 
-    def insert_users_list_with_batching(
+    def _insert_users_list_with_batching(
         self, batch_iterator: BatchIterator[str], insert_in_clickhouse: bool = False, *, team_id: int
     ) -> None:
         """

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -352,12 +352,13 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
         )
 
         # Grab uuids for this batch of distinct IDs
-        uuids = list(
-            Person.objects.db_manager(READ_DB_FOR_PERSONS)
+        uuids = [
+            str(uuid)
+            for uuid in Person.objects.db_manager(READ_DB_FOR_PERSONS)
             .filter(team_id=team_id, id__in=person_ids_qs)
             .exclude(id__in=CohortPeople.objects.filter(cohort_id=self.id).values_list("person_id", flat=True))
             .values_list("uuid", flat=True)
-        )
+        ]
 
         return uuids
 
@@ -475,7 +476,7 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
 
             self.save()
             # Add batch index context to the exception
-            capture_exception(err, extra={"batch_index": current_batch_index})
+            capture_exception(err, additional_properties={"batch_index": current_batch_index})
 
     def to_dict(self) -> dict:
         people_data = [

--- a/posthog/test/test_cohort_model.py
+++ b/posthog/test/test_cohort_model.py
@@ -33,6 +33,27 @@ class TestCohort(BaseTest):
         self.assertEqual(cohort.people.count(), 2)
         self.assertEqual(cohort.is_calculating, False)
 
+    def test_insert_by_distinct_id_in_batches(self):
+        Person.objects.create(team=self.team, distinct_ids=["000"])
+        Person.objects.create(team=self.team, distinct_ids=["001"])
+        Person.objects.create(team=self.team, distinct_ids=["002", "011"])
+        Person.objects.create(team=self.team, distinct_ids=["003", "012"])
+        Person.objects.create(team=self.team, distinct_ids=["004"])
+        Person.objects.create(team=self.team, distinct_ids=["005"])
+        Person.objects.create(team=self.team, distinct_ids=["006"])
+        Person.objects.create(team=self.team, distinct_ids=["007"])
+        Person.objects.create(team=self.team, distinct_ids=["008"])
+        Person.objects.create(team=self.team, distinct_ids=["009"])
+        Person.objects.create(team=self.team, distinct_ids=["010"])
+
+        cohort = Cohort.objects.create(team=self.team, groups=[], is_static=True)
+        cohort.insert_users_by_list(
+            ["000", "001", "002", "003", "004", "005", "006", "007", "008", "009", "010", "011", "012"], batch_size=3
+        )
+        cohort = Cohort.objects.get()
+        self.assertEqual(cohort.people.count(), 11)
+        self.assertEqual(cohort.is_calculating, False)
+
     @pytest.mark.ee
     def test_calculating_cohort_clickhouse(self):
         cohort = Cohort.objects.create(

--- a/posthog/test/test_cohort_model.py
+++ b/posthog/test/test_cohort_model.py
@@ -9,7 +9,7 @@ from posthog.test.base import BaseTest
 class TestCohort(BaseTest):
     CLASS_DATA_LEVEL_SETUP = False  # So that each test gets a different team_id, ensuring separation of CH data
 
-    def test_insert_by_distinct_id_or_email(self):
+    def test_insert_by_distinct_id(self):
         Person.objects.create(team=self.team, distinct_ids=["000"])
         Person.objects.create(team=self.team, distinct_ids=["123"])
         Person.objects.create(team=self.team)


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Ticket: https://posthoghelp.zendesk.com/agent/tickets/32633 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/35170)

Uploading a large static cohort sometimes fails with a stack trace that looks something like:

```
psycopg.errors.ProtocolViolation: query timeout

The above exception was the direct cause of the following exception:

django.db.utils.OperationalError: query timeout

Traceback (most recent call last):
  File "posthog/models/cohort/cohort.py", line 361, in insert_users_by_list
    list(persons_query.values_list("uuid", flat=True))
```

The query in question attempts to query the `posthog_person` table to get the `uuid` column. It does a join on `posthog_persondistinctid` where the `distinct_id` is in the batch of distinct IDs (aka 1000 entries).

This results in a query that looks like:

```sql
SELECT "posthog_person"."uuid"
FROM "posthog_person"
INNER JOIN "posthog_persondistinctid"
    ON "posthog_person"."id" = "posthog_persondistinctid"."person_id"
WHERE
    "posthog_person"."team_id" = {team_id}
    AND "posthog_persondistinctid"."distinct_id" IN (
		'distinct_id_001',
        'distinct_id_002',
        'distinct_id_003',
        ...
        'distinct_id_1000',
	)
    AND "posthog_persondistinctid"."team_id" = {team_id}
    AND NOT EXISTS (
        SELECT 1
        FROM "posthog_cohortpeople"
        WHERE "cohort_id" = {cohort_id}
        AND "person_id" = "posthog_person"."id"
        LIMIT 1
    );
``` 

It seems this query times out.

While investigating this, I also noticed that `insert_users_by_list` is very similar to `insert_users_list_by_uuid` and could probably be combined to share logic.

## Changes

I refactored `insert_users_by_list` and `insert_users_list_by_uuid` to call a new method, `_insert_users_list_with_batching`. I implemented a `FunctionBatchIterator` to produce batches of UUIDs to insert. That way both original methods could share the same logic.

I then updated `insert_users_list_by_uuid` to produce a batch of UUIDs by calling two queries instead of one. More DB round trips, but each query is simpler and should hopefully not time out.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

* Unit tests
* UI testing - uploaded a 30,000 row static cohort import file.