### PR TITLE
feat: Restrict reauth Google SSO popup to current email

### DIFF
--- a/ee/api/authentication.py
+++ b/ee/api/authentication.py
@@ -170,6 +170,16 @@ class MultitenantSAMLAuth(SAMLAuth):
 
 
 class CustomGoogleOAuth2(GoogleOAuth2):
+    def auth_extra_arguments(self):
+        extra_args = super().auth_extra_arguments()
+        email = self.strategy.request.GET.get("email")
+
+        if email:
+            extra_args["login_hint"] = email
+            extra_args["prompt"] = "select_account"
+
+        return extra_args
+
     def get_user_id(self, details, response):
         """
         Retrieve and migrate Google OAuth user identification.

--- a/ee/api/authentication.py
+++ b/ee/api/authentication.py
@@ -176,7 +176,6 @@ class CustomGoogleOAuth2(GoogleOAuth2):
 
         if email:
             extra_args["login_hint"] = email
-            extra_args["prompt"] = "select_account"
 
         return extra_args
 

--- a/ee/api/test/test_authentication.py
+++ b/ee/api/test/test_authentication.py
@@ -775,6 +775,42 @@ class TestCustomGoogleOAuth2(APILicensedTest):
         self.details = {"email": "test@posthog.com"}
         self.sub = "google-oauth2|123456789"
 
+    def test_auth_extra_arguments_without_email(self):
+        """Test that auth_extra_arguments returns base arguments when no email is provided."""
+        # Mock strategy to return empty GET parameters
+        mock_request = type("MockRequest", (), {})()
+        mock_request.GET = {}
+
+        mock_strategy = type("MockStrategy", (), {})()
+        mock_strategy.request = mock_request
+        mock_strategy.setting = lambda name, default=None, backend=None: default
+
+        self.google_oauth.strategy = mock_strategy
+
+        extra_args = self.google_oauth.auth_extra_arguments()
+
+        # Should only contain base arguments from parent class, no login_hint or prompt
+        self.assertNotIn("login_hint", extra_args)
+        self.assertNotIn("prompt", extra_args)
+
+    def test_auth_extra_arguments_with_email(self):
+        """Test that auth_extra_arguments adds login_hint and prompt when email is provided."""
+        # Mock strategy to return email in GET parameters
+        mock_request = type("MockRequest", (), {})()
+        mock_request.GET = {"email": "test@posthog.com"}
+
+        mock_strategy = type("MockStrategy", (), {})()
+        mock_strategy.request = mock_request
+        mock_strategy.setting = lambda name, default=None, backend=None: default
+
+        self.google_oauth.strategy = mock_strategy
+
+        extra_args = self.google_oauth.auth_extra_arguments()
+
+        # Should contain login_hint and prompt parameters
+        self.assertEqual(extra_args["login_hint"], "test@posthog.com")
+        self.assertEqual(extra_args["prompt"], "select_account")
+
     def test_get_user_id_existing_user_with_sub(self):
         """Test that a user with sub as uid continues using that sub."""
         # Create user with sub as uid

--- a/ee/api/test/test_authentication.py
+++ b/ee/api/test/test_authentication.py
@@ -793,7 +793,7 @@ class TestCustomGoogleOAuth2(APILicensedTest):
         self.assertNotIn("login_hint", extra_args)
 
     def test_auth_extra_arguments_with_email(self):
-        """Test that auth_extra_arguments adds login_hint and prompt when email is provided."""
+        """Test that auth_extra_arguments adds login_hint when email is provided."""
         # Mock strategy to return email in GET parameters
         mock_request = type("MockRequest", (), {})()
         mock_request.GET = {"email": "test@posthog.com"}
@@ -806,9 +806,7 @@ class TestCustomGoogleOAuth2(APILicensedTest):
 
         extra_args = self.google_oauth.auth_extra_arguments()
 
-        # Should contain login_hint and prompt parameters
         self.assertEqual(extra_args["login_hint"], "test@posthog.com")
-        self.assertEqual(extra_args["prompt"], "select_account")
 
     def test_get_user_id_existing_user_with_sub(self):
         """Test that a user with sub as uid continues using that sub."""

--- a/ee/api/test/test_authentication.py
+++ b/ee/api/test/test_authentication.py
@@ -789,9 +789,8 @@ class TestCustomGoogleOAuth2(APILicensedTest):
 
         extra_args = self.google_oauth.auth_extra_arguments()
 
-        # Should only contain base arguments from parent class, no login_hint or prompt
+        # Should only contain base arguments from parent class, no login_hint
         self.assertNotIn("login_hint", extra_args)
-        self.assertNotIn("prompt", extra_args)
 
     def test_auth_extra_arguments_with_email(self):
         """Test that auth_extra_arguments adds login_hint and prompt when email is provided."""

--- a/frontend/src/lib/components/TimeSensitiveAuthentication/TimeSensitiveAuthentication.tsx
+++ b/frontend/src/lib/components/TimeSensitiveAuthentication/TimeSensitiveAuthentication.tsx
@@ -23,6 +23,7 @@ export function TimeSensitiveAuthenticationModal(): JSX.Element {
 
     const extraQueryParams = {
         next: encodeURI(location.href.replace(location.origin, '')),
+        email: user?.email || '',
     }
 
     return (

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -208,7 +208,7 @@ LICENSE_SECRET_KEY = os.getenv("LICENSE_SECRET_KEY", "license-so-secret")
 SESSION_COOKIE_AGE = get_from_env("SESSION_COOKIE_AGE", 60 * 60 * 24 * 14, type_cast=int)
 
 # For sensitive actions we have an additional permission (default 2 hour)
-SESSION_SENSITIVE_ACTIONS_AGE = 60
+SESSION_SENSITIVE_ACTIONS_AGE = get_from_env("SESSION_SENSITIVE_ACTIONS_AGE", 60 * 60 * 2, type_cast=int)
 
 CSRF_COOKIE_NAME = "posthog_csrftoken"
 CSRF_COOKIE_AGE = get_from_env("CSRF_COOKIE_AGE", SESSION_COOKIE_AGE, type_cast=int)

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -208,7 +208,7 @@ LICENSE_SECRET_KEY = os.getenv("LICENSE_SECRET_KEY", "license-so-secret")
 SESSION_COOKIE_AGE = get_from_env("SESSION_COOKIE_AGE", 60 * 60 * 24 * 14, type_cast=int)
 
 # For sensitive actions we have an additional permission (default 2 hour)
-SESSION_SENSITIVE_ACTIONS_AGE = get_from_env("SESSION_SENSITIVE_ACTIONS_AGE", 60 * 60 * 2, type_cast=int)
+SESSION_SENSITIVE_ACTIONS_AGE = 60
 
 CSRF_COOKIE_NAME = "posthog_csrftoken"
 CSRF_COOKIE_AGE = get_from_env("CSRF_COOKIE_AGE", SESSION_COOKIE_AGE, type_cast=int)


### PR DESCRIPTION
## Problem

- When we pop up the reauthentication modal (on sensitive operations) and the user uses Google SSO, they have the option to choose not only the currently authenticated email, but others as well. This opens the flow to errors and bad UX.

## Changes

- Restrict reauth Google SSO popup window to only show the currently logged in email

## How did you test this code?

- Manually
- Unit tests