### PR TITLE
fix(plugin-server): Reduce person merge e2e flakyness

### DIFF
--- a/plugin-server/src/ingestion/ingestion-e2e.test.ts
+++ b/plugin-server/src/ingestion/ingestion-e2e.test.ts
@@ -1244,6 +1244,9 @@ describe('Event Pipeline E2E tests', () => {
     }
 
     const fetchEvents = async (hub: Hub, teamId: number) => {
+        // Force ClickHouse to merge parts to ensure FINAL consistency
+        await hub.db.clickhouse.querying(`OPTIMIZE TABLE person_distinct_id_overrides FINAL`)
+
         const queryResult = (await hub.db.clickhouse.querying(`
             SELECT *,
                    if(notEmpty(overrides.person_id), overrides.person_id, e.person_id) as person_id


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Person merge in E2E tests are sometimes flaky because person_distinct_id_overrides CH updates can take a whle 

## Changes

Force an optimize on clickhouse table before fetching events in order to ensure merges are complete

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
