### PR TITLE
chore(batch-exports): Add env var for transformer max workers

### DIFF
--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -82,3 +82,4 @@ BATCH_EXPORT_OBJECT_STORAGE_REGION: str = os.getenv("BATCH_EXPORT_OBJECT_STORAGE
 BATCH_EXPORT_INTERNAL_STAGING_BUCKET: str = os.getenv("BATCH_EXPORT_INTERNAL_STAGING_BUCKET", "posthog")
 # The number of partitions controls how many files ClickHouse writes to concurrently
 BATCH_EXPORT_CLICKHOUSE_S3_PARTITIONS: int = get_from_env("BATCH_EXPORT_CLICKHOUSE_S3_PARTITIONS", 5, type_cast=int)
+BATCH_EXPORT_TRANSFORMER_MAX_WORKERS: int = get_from_env("BATCH_EXPORT_TRANSFORMER_MAX_WORKERS", 2, type_cast=int)

--- a/posthog/temporal/batch_exports/transformer.py
+++ b/posthog/temporal/batch_exports/transformer.py
@@ -13,10 +13,9 @@ import orjson
 import pyarrow as pa
 import pyarrow.parquet as pq
 import structlog
+from django.conf import settings
 
-from posthog.temporal.batch_exports.utils import (
-    cast_record_batch_json_columns,
-)
+from posthog.temporal.batch_exports.utils import cast_record_batch_json_columns
 
 logger = structlog.get_logger()
 
@@ -220,7 +219,7 @@ class JSONLStreamTransformer(StreamTransformer):
                 yield t
             return
 
-        max_workers = 2
+        max_workers = settings.BATCH_EXPORT_TRANSFORMER_MAX_WORKERS
         task_queue: asyncio.Queue[asyncio.Future[list[bytes]]] = asyncio.Queue(max_workers)
         loop = asyncio.get_running_loop()
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

It's not possible to configure max workers in the transformer without making code changes.

## Changes

Add `BATCH_EXPORT_TRANSFORMER_MAX_WORKERS` environment variable to control this.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Relying on existing tests
