### PR TITLE
chore(experiments): remove usage of experimentStatsVersion

### DIFF
--- a/frontend/src/scenes/experiments/experimentCalculations.tsx
+++ b/frontend/src/scenes/experiments/experimentCalculations.tsx
@@ -405,10 +405,7 @@ export function getVariantCalculationResult(
 /**
  * Generate significance details text based on experiment results
  */
-export function getSignificanceDetails(
-    metricResult: LegacyExperimentMetricResult,
-    experimentStatsVersion: number
-): string {
+export function getSignificanceDetails(metricResult: LegacyExperimentMetricResult): string {
     if (!metricResult) {
         return ''
     }
@@ -426,10 +423,7 @@ export function getSignificanceDetails(
     }
 
     if (metricResult.significance_code === ExperimentSignificanceCode.LowWinProbability) {
-        if (experimentStatsVersion === 2) {
-            return 'This is because no variant (control or test) has a win probability higher than 90%.'
-        }
-        return 'This is because the win probability of all test variants combined is less than 90%.'
+        return 'This is because no variant (control or test) has a win probability higher than 90%.'
     }
 
     if (metricResult.significance_code === ExperimentSignificanceCode.NotEnoughExposure) {

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1786,19 +1786,18 @@ export const experimentLogic = kea<experimentLogicType>([
                 },
         ],
         significanceDetails: [
-            (s) => [s.legacyMetricResults, s.experimentStatsVersion],
+            (s) => [s.legacyMetricResults],
             (
                     legacyMetricResults: (
                         | CachedLegacyExperimentQueryResponse
                         | CachedExperimentFunnelsQueryResponse
                         | CachedExperimentTrendsQueryResponse
                         | null
-                    )[],
-                    experimentStatsVersion: number
+                    )[]
                 ) =>
                 (metricIndex: number = 0): string => {
                     const results = legacyMetricResults?.[metricIndex]
-                    return getSignificanceDetails(results, experimentStatsVersion)
+                    return getSignificanceDetails(results)
                 },
         ],
         recommendedSampleSize: [
@@ -2011,12 +2010,6 @@ export const experimentLogic = kea<experimentLogicType>([
                 if (primaryMetric) {
                     return primaryMetric.query
                 }
-            },
-        ],
-        experimentStatsVersion: [
-            (s) => [s.experiment],
-            (experiment: Experiment): number => {
-                return experiment.stats_config?.version || 1
             },
         ],
         primaryMetricsLengthWithSharedMetrics: [


### PR DESCRIPTION
## Problem
Cleaning up some code we no longer need.

## Changes
Removed usage of `experimentStatsVersion` in the frontend.

## How did you test this code?
- 👀 
- tests passes
