### PR TITLE
fix(batch-exports): Add Prometheus metrics and improve logging

### DIFF
--- a/posthog/temporal/batch_exports/pre_export_stage.py
+++ b/posthog/temporal/batch_exports/pre_export_stage.py
@@ -401,7 +401,7 @@ async def _get_query(
             logger.info("Using unbounded events query for batch export")
             query_template = EXPORT_TO_S3_FROM_EVENTS_UNBOUNDED
         elif is_backfill:
-            logger.info("Using events_batch_export_backfill view for batch export")
+            logger.info("Using events_batch_export_backfill query for batch export")
             query_template = EXPORT_TO_S3_FROM_EVENTS_BACKFILL
         else:
             logger.info("Using events table for batch export")
@@ -610,7 +610,7 @@ class ProducerFromInternalS3Stage:
                 await self.logger.ainfo("No files found in S3 -> assuming no data to export")
                 return
             keys = [obj["Key"] for obj in contents if "Key" in obj]
-            await self.logger.ainfo(f"Found {len(keys)} files in S3")
+            await self.logger.ainfo(f"Producer found {len(keys)} files in S3 stage")
 
             # Read in batches
             try:

--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -1212,7 +1212,7 @@ class ConcurrentS3Consumer(ConsumerFromStage):
             upload_speed_mbps = part_size_mb / upload_time if upload_time > 0 else 0
 
             await self.logger.ainfo(
-                "Finished uploading file number %s part %s with upload id %s. File size: %sMB, upload time: %s, speed: %s MB/s",
+                "Finished uploading file number %s part %s with upload id %s. File size: %.2f MB, upload time: %.2fs, speed: %.2f MB/s",
                 self.current_file_index,
                 part_number,
                 self.upload_id,

--- a/posthog/temporal/batch_exports/spmc.py
+++ b/posthog/temporal/batch_exports/spmc.py
@@ -51,9 +51,7 @@ from posthog.temporal.batch_exports.temporary_file import (
     WriterFormat,
     get_batch_export_writer,
 )
-from posthog.temporal.batch_exports.transformer import (
-    get_stream_transformer,
-)
+from posthog.temporal.batch_exports.transformer import get_stream_transformer
 from posthog.temporal.batch_exports.utils import (
     cast_record_batch_json_columns,
     cast_record_batch_schema_json_columns,
@@ -1205,9 +1203,14 @@ class ConsumerFromStage:
     ) -> int:
         """Start consuming record batches from queue.
 
-        Record batches will be written to a temporary file defined by `writer_format`
-        and the file will be flushed upon reaching at least `max_bytes`.
+        Record batches will be processed by the `transformer`, which transforms the record batch into chunks of bytes,
+        depending on the `file_format` and `compression`.
 
+        Each of these chunks will be consumed by the `consume_chunk` method, which is implemented by subclasses.
+
+        If `max_file_size_bytes` is set, we split the file into multiples if the file size exceeds this value.
+
+        # TODO - we may need to support `multiple_files` here in future.
         Callers can control whether a new file is created for each flush or whether we
         continue flushing to the same file by setting `multiple_files`. File data is
         reset regardless, so this is not meant to impact total file size, but rather

--- a/posthog/temporal/batch_exports/spmc.py
+++ b/posthog/temporal/batch_exports/spmc.py
@@ -1228,31 +1228,28 @@ class ConsumerFromStage:
             schema=schema,
             include_inserted_at=include_inserted_at,
         )
-        record_batches_count = 0
-        records_count = 0
-        bytes_count = 0
+        num_records_in_batch = 0
+        num_bytes_in_batch = 0
+        total_record_batches_count = 0
+        total_records_count = 0
+        total_file_bytes_count = 0
 
         async def track_iteration_of_record_batches():
             """Wrap generator of record batches to track execution."""
-            nonlocal record_batches_count
-            nonlocal records_count
-            nonlocal bytes_count
+            nonlocal num_records_in_batch
+            nonlocal num_bytes_in_batch
+            nonlocal total_record_batches_count
+            nonlocal total_records_count
 
             async for record_batch in self.generate_record_batches_from_queue(queue, producer_task):
                 record_batch = cast_record_batch_json_columns(record_batch, json_columns=json_columns)
 
-                record_batches_count += 1
-                records_count += record_batch.num_rows
-                bytes_count += record_batch.nbytes
+                total_record_batches_count += 1
+                num_records_in_batch = record_batch.num_rows
+                total_records_count += num_records_in_batch
+                num_bytes_in_batch = record_batch.nbytes
 
-                await self.logger.adebug(
-                    "Consuming %s records, %s bytes from record batch %s; total records so far: %s, total MiB so far: %s",
-                    record_batch.num_rows,
-                    record_batch.nbytes,
-                    record_batches_count,
-                    records_count,
-                    bytes_count / 1024**2,
-                )
+                self.rows_exported_counter.add(num_records_in_batch)
 
                 yield record_batch
 
@@ -1261,12 +1258,23 @@ class ConsumerFromStage:
                 track_iteration_of_record_batches(),
                 max_file_size_bytes,
             ):
+                chunk_size = len(chunk)
+                total_file_bytes_count += chunk_size
+
+                await self.logger.adebug(
+                    "Consuming transformed chunk. Record batch num rows: %s, record batch MiB: %s, data chunk size: %s. Total records so far: %s, total file MiB so far: %s",
+                    num_records_in_batch,
+                    num_bytes_in_batch / 1024**2,
+                    chunk_size,
+                    total_records_count,
+                    total_file_bytes_count / 1024**2,
+                )
                 await self.consume_chunk(data=chunk)
+                self.bytes_exported_counter.add(chunk_size)
 
                 if is_eof:
                     await self.finalize_file()
 
-            # Finalize upload
             await self.finalize()
 
         except Exception:
@@ -1274,12 +1282,12 @@ class ConsumerFromStage:
             raise
 
         await self.logger.adebug(
-            "Finished consuming %s records, %s MiB from %s record batches",
-            records_count,
-            bytes_count / 1024**2,
-            record_batches_count,
+            "Finished consuming %s records from %s record batches. Total file MiB: %s",
+            total_records_count,
+            total_record_batches_count,
+            total_file_bytes_count / 1024**2,
         )
-        return records_count
+        return total_records_count
 
     async def generate_record_batches_from_queue(
         self,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We're not tracking a couple of metrics in the new consumer that we were in the previous version.

We don't log anywhere the number of bytes of actual data we're consuming.

## Changes

- Update Prometheus counters
- Improve logging

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
