### PR TITLE
feat: Add materialization to generate_demo_data

### DIFF
--- a/posthog/management/commands/generate_demo_data.py
+++ b/posthog/management/commands/generate_demo_data.py
@@ -7,11 +7,13 @@ from typing import Optional
 from django.core import exceptions
 from django.core.management.base import BaseCommand
 
+from ee.clickhouse.materialized_columns.analyze import Suggestion, materialize_properties_task
 from posthog.demo.matrix import Matrix, MatrixManager
 from posthog.demo.products.hedgebox import HedgeboxMatrix
 from posthog.demo.products.spikegpt import SpikeGPTMatrix
 from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.models.team.team import Team
+from posthog.taxonomy.taxonomy import PERSON_PROPERTIES_ADAPTED_FROM_EVENT
 
 logging.getLogger("kafka").setLevel(logging.ERROR)  # Hide kafka-python's logspam
 
@@ -148,6 +150,8 @@ class Command(BaseCommand):
                     "If running demo mode (DEMO=1), log in instantly with this link:\n"
                     f"http://localhost:8000/signup?email={email}\n"
                 )
+            print("Materializing common columns...")
+            self.materialize_common_columns()
         else:
             print("Dry run - not saving results.")
 
@@ -198,3 +202,66 @@ class Command(BaseCommand):
             f"for a total of {total_event_count} event{'' if total_event_count == 1 else 's'} (of which {future_event_count} {'is' if future_event_count == 1 else 'are'} in the future)."
         )
         print("\n".join(summary_lines))
+
+    def materialize_common_columns(self) -> None:
+        event_properties = {
+            *PERSON_PROPERTIES_ADAPTED_FROM_EVENT,
+            "$prev_pageview_pathname",
+            "$prev_pageview_max_content_percentage",
+            "$prev_pageview_max_scroll_percentage",
+            "$screen_name",
+            "$geoip_country_code",
+            "$geoip_subdivision_1_code",
+            "$geoip_subdivision_1_name",
+            "$geoip_city_name",
+            "$browser_language",
+            "$timezone_offset",
+        }
+
+        person_properties = {
+            *PERSON_PROPERTIES_ADAPTED_FROM_EVENT,
+        }
+        for prop in person_properties.copy():
+            if prop.startswith("$initial_"):
+                continue
+            person_properties.add("$initial_" + prop[1:] if prop[0] == "$" else prop)
+
+        materialize_properties_task(
+            properties_to_materialize=[
+                Suggestion(
+                    (
+                        "events",
+                        "properties",
+                        prop,
+                    )
+                )
+                for prop in sorted(event_properties)
+            ],
+            backfill_period_days=365,
+        )
+        materialize_properties_task(
+            properties_to_materialize=[
+                Suggestion(
+                    (
+                        "events",
+                        "person_properties",
+                        prop,
+                    )
+                )
+                for prop in sorted(person_properties)
+            ],
+            backfill_period_days=365,
+        )
+        materialize_properties_task(
+            properties_to_materialize=[
+                Suggestion(
+                    (
+                        "person",
+                        "properties",
+                        prop,
+                    )
+                )
+                for prop in sorted(person_properties)
+            ],
+            backfill_period_days=365,
+        )

--- a/posthog/management/commands/generate_demo_data.py
+++ b/posthog/management/commands/generate_demo_data.py
@@ -224,7 +224,7 @@ class Command(BaseCommand):
         for prop in person_properties.copy():
             if prop.startswith("$initial_"):
                 continue
-            person_properties.add("$initial_" + prop[1:] if prop[0] == "$" else prop)
+            person_properties.add("$initial_" + (prop[1:] if prop[0] == "$" else prop))
 
         materialize_properties_task(
             properties_to_materialize=[

--- a/posthog/management/commands/generate_demo_data.py
+++ b/posthog/management/commands/generate_demo_data.py
@@ -7,7 +7,7 @@ from typing import Optional
 from django.core import exceptions
 from django.core.management.base import BaseCommand
 
-from ee.clickhouse.materialized_columns.analyze import Suggestion, materialize_properties_task
+from ee.clickhouse.materialized_columns.analyze import materialize_properties_task
 from posthog.demo.matrix import Matrix, MatrixManager
 from posthog.demo.products.hedgebox import HedgeboxMatrix
 from posthog.demo.products.spikegpt import SpikeGPTMatrix
@@ -228,12 +228,10 @@ class Command(BaseCommand):
 
         materialize_properties_task(
             properties_to_materialize=[
-                Suggestion(
-                    (
-                        "events",
-                        "properties",
-                        prop,
-                    )
+                (
+                    "events",
+                    "properties",
+                    prop,
                 )
                 for prop in sorted(event_properties)
             ],
@@ -241,12 +239,10 @@ class Command(BaseCommand):
         )
         materialize_properties_task(
             properties_to_materialize=[
-                Suggestion(
-                    (
-                        "events",
-                        "person_properties",
-                        prop,
-                    )
+                (
+                    "events",
+                    "person_properties",
+                    prop,
                 )
                 for prop in sorted(person_properties)
             ],
@@ -254,12 +250,10 @@ class Command(BaseCommand):
         )
         materialize_properties_task(
             properties_to_materialize=[
-                Suggestion(
-                    (
-                        "person",
-                        "properties",
-                        prop,
-                    )
+                (
+                    "person",
+                    "properties",
+                    prop,
                 )
                 for prop in sorted(person_properties)
             ],


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Columns aren't materialized by default in local dev. This makes some debugging tasks slightly more annyoing:
* I can't copy/paste queries from prod to local dev
* I can't visually diff queries between prod and dev

## Changes

Materialize properties at the end of generate_demo_data

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

n/a
