### PR TITLE
feat(data-warehouse): Add option to provide a different project ID for the dataset

### DIFF
--- a/frontend/src/scenes/data-warehouse/external/forms/SourceForm.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SourceForm.tsx
@@ -86,7 +86,7 @@ const sourceFieldToElement = (
                     const isEnabled = value === undefined || value === null || value === 'False' ? enabled : value
                     return (
                         <>
-                            {!!field.caption && <p>{field.caption}</p>}
+                            {!!field.caption && <p className="mb-0">{field.caption}</p>}
                             <LemonSwitch checked={isEnabled} onChange={onChange} />
                             {isEnabled && (
                                 <Group name={field.name}>

--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -729,6 +729,23 @@ export const SOURCE_DETAILS: Record<ExternalDataSourceType, SourceConfig> = {
                     },
                 ],
             },
+            {
+                type: 'switch-group',
+                name: 'dataset_project',
+                label: 'Use a different project for the dataset than your service account project?',
+                caption:
+                    "If the dataset you're wanting to sync exists in a different project than that of your service account, use this to provide the project ID of the BigQuery dataset.",
+                default: false,
+                fields: [
+                    {
+                        type: 'text',
+                        name: 'dataset_project_id',
+                        label: 'Project ID for dataset',
+                        required: true,
+                        placeholder: '',
+                    },
+                ],
+            },
         ],
         caption: '',
     },

--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -589,6 +589,7 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
                 dataset_id=bq_config.dataset_id,
                 table_prefix=destination_table_prefix,
                 project_id=bq_config.project_id,
+                dataset_project_id=bq_config.dataset_project_id,
                 private_key=bq_config.private_key,
                 private_key_id=bq_config.private_key_id,
                 client_email=bq_config.client_email,
@@ -600,6 +601,7 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
                 source = bigquery_source(
                     dataset_id=bq_config.dataset_id,
                     project_id=bq_config.project_id,
+                    dataset_project_id=bq_config.dataset_project_id,
                     private_key=bq_config.private_key,
                     private_key_id=bq_config.private_key_id,
                     client_email=bq_config.client_email,

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -1066,7 +1066,13 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         elif source_type == ExternalDataSource.Type.BIGQUERY:
             dataset_id = request.data.get("dataset_id", "")
             key_file = request.data.get("key_file", {})
-            if not validate_bigquery_credentials(dataset_id=dataset_id, key_file=key_file):
+
+            dataset_project = request.data.get("dataset_project", {})
+            dataset_project_id = dataset_project.get("dataset_project_id", None)
+
+            if not validate_bigquery_credentials(
+                dataset_id=dataset_id, key_file=key_file, dataset_project_id=dataset_project_id
+            ):
                 return Response(
                     status=status.HTTP_400_BAD_REQUEST,
                     data={"message": "Invalid credentials: BigQuery credentials are incorrect"},
@@ -1616,6 +1622,10 @@ def parse_bigquery_job_inputs(payload: dict[str, Any]) -> dict[str, Any]:
     using_temporary_dataset = temporary_dataset.get("enabled", False)
     temporary_dataset_id = temporary_dataset.get("temporary_dataset_id", None)
 
+    dataset_project = payload.get("dataset_project", {})
+    using_custom_dataset_project = dataset_project.get("enabled", False)
+    dataset_project_id = dataset_project.get("dataset_project_id", None)
+
     job_inputs = {
         "dataset_id": dataset_id,
         "project_id": project_id,
@@ -1625,6 +1635,8 @@ def parse_bigquery_job_inputs(payload: dict[str, Any]) -> dict[str, Any]:
         "token_uri": token_uri,
         "using_temporary_dataset": using_temporary_dataset,
         "temporary_dataset_id": temporary_dataset_id,
+        "using_custom_dataset_project": using_custom_dataset_project,
+        "dataset_project_id": dataset_project_id,
     }
 
     required_inputs = {"private_key", "private_key_id", "client_email", "dataset_id", "project_id", "token_uri"}


### PR DESCRIPTION
## Problem
- The bigquery dataset we want to sync may not be in the same project as the service account provided
- Request from: https://posthog.slack.com/archives/C08N8MKDUBU/p1750194510338279?thread_ts=1749598275.685259&cid=C08N8MKDUBU

## Changes
- Allow users to provide a project ID for the dataset they're wanting to sync if it's different from the service account project id


## How did you test this code?
Tested a bigquery sync