### PR TITLE
fix(devex): duplicated "other" projects, + project disabled

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectDropdownMenu.tsx
+++ b/frontend/src/layout/panel-layout/ProjectDropdownMenu.tsx
@@ -36,7 +36,7 @@ export function ProjectDropdownMenu(): JSX.Element | null {
     const { closeAccountPopover } = useActions(navigationLogic)
     const { showCreateProjectModal } = useActions(globalModalsLogic)
     const { currentTeam } = useValues(teamLogic)
-    const { currentOrganization } = useValues(organizationLogic)
+    const { currentOrganization, projectCreationForbiddenReason } = useValues(organizationLogic)
 
     return isAuthenticatedTeam(currentTeam) ? (
         <PopoverPrimitive>
@@ -156,57 +156,6 @@ export function ProjectDropdownMenu(): JSX.Element | null {
                                     )
                                 })}
 
-                        {currentOrganization?.teams &&
-                            currentOrganization.teams
-                                .filter((team) => team.id !== currentTeam?.id)
-                                .sort((teamA, teamB) => teamA.name.localeCompare(teamB.name))
-                                .map((team) => {
-                                    const relativeOtherProjectPath = getProjectSwitchTargetUrl(
-                                        location.pathname,
-                                        team.id,
-                                        currentTeam?.project_id,
-                                        team.project_id
-                                    )
-
-                                    return (
-                                        <Combobox.Group value={[team.name]} key={team.id}>
-                                            <ButtonGroupPrimitive menuItem fullWidth>
-                                                <Combobox.Item asChild>
-                                                    <Link
-                                                        buttonProps={{
-                                                            menuItem: true,
-                                                            hasSideActionRight: true,
-                                                            className: 'pr-12',
-                                                        }}
-                                                        tooltip={`Switch to project: ${team.name}`}
-                                                        tooltipPlacement="right"
-                                                        to={relativeOtherProjectPath}
-                                                        data-attr="tree-navbar-project-dropdown-other-project-button"
-                                                    >
-                                                        <IconBlank />
-                                                        <ProjectName team={team} />
-                                                    </Link>
-                                                </Combobox.Item>
-
-                                                <Combobox.Item asChild>
-                                                    <Link
-                                                        buttonProps={{
-                                                            iconOnly: true,
-                                                            isSideActionRight: true,
-                                                        }}
-                                                        tooltip={`View settings for project: ${team.name}`}
-                                                        tooltipPlacement="right"
-                                                        to={urls.project(team.id, urls.settings('project'))}
-                                                        data-attr="tree-navbar-project-dropdown-other-project-settings-button"
-                                                    >
-                                                        <IconGear />
-                                                    </Link>
-                                                </Combobox.Item>
-                                            </ButtonGroupPrimitive>
-                                        </Combobox.Group>
-                                    )
-                                })}
-
                         {preflight?.can_create_org && (
                             <Combobox.Item
                                 asChild
@@ -223,6 +172,7 @@ export function ProjectDropdownMenu(): JSX.Element | null {
                                     tooltip="Create a new project"
                                     tooltipPlacement="right"
                                     className="shrink-0"
+                                    disabled={!!projectCreationForbiddenReason}
                                 >
                                     <IconPlusSmall className="text-tertiary" />
                                     New project


### PR DESCRIPTION
## Problem
I was dumb and pushed out debugging code— a duplicated list of Other projects in the dropdown
New Project wasn't guarded with `projectCreationForbiddenReason`

## Changes
Remove duplicates
Add disabled to "+ Project" if `!!projectCreationForbiddenReason`

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Manually