### PR TITLE
fix(devex): project dropdown with project name + truncate

### DIFF
--- a/frontend/src/layout/panel-layout/PanelLayoutPanel.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutPanel.tsx
@@ -105,7 +105,7 @@ export function PanelLayoutPanel({
             )}
             ref={containerRef}
         >
-            <div className="flex justify-between p-1 bg-surface-tertiary">
+            <div className="flex justify-between p-1 gap-px bg-surface-tertiary">
                 <ProjectDropdownMenu />
 
                 <div className="flex gap-px items-center justify-end shrink-0">

--- a/frontend/src/layout/panel-layout/ProjectDropdownMenu.tsx
+++ b/frontend/src/layout/panel-layout/ProjectDropdownMenu.tsx
@@ -41,9 +41,9 @@ export function ProjectDropdownMenu(): JSX.Element | null {
     return isAuthenticatedTeam(currentTeam) ? (
         <PopoverPrimitive>
             <PopoverPrimitiveTrigger asChild>
-                <ButtonPrimitive data-attr="tree-navbar-project-dropdown-button">
+                <ButtonPrimitive data-attr="tree-navbar-project-dropdown-button" className="flex-1 min-w-0 max-w-fit">
                     <IconFolderOpen className="text-tertiary" />
-                    Project
+                    <span className="truncate font-semibold">{currentTeam.name ?? 'Project'}</span>
                     <IconChevronRight
                         className={`
                         size-3 
@@ -59,11 +59,11 @@ export function ProjectDropdownMenu(): JSX.Element | null {
             </PopoverPrimitiveTrigger>
             <PopoverPrimitiveContent
                 align="start"
-                className="w-[var(--project-panel-inner-width)] max-w-[var(--project-panel-inner-width)]"
+                className="w-[var(--project-panel-inner-width)] max-w-[var(--project-panel-inner-width)] max-h-[calc(90vh)]"
             >
                 <Combobox>
                     <Combobox.Search placeholder="Search projects..." />
-                    <Combobox.Content className="max-h-[300px]">
+                    <Combobox.Content>
                         <Label intent="menu" className="px-2">
                             Projects
                         </Label>
@@ -104,57 +104,6 @@ export function ProjectDropdownMenu(): JSX.Element | null {
                                 </Combobox.Item>
                             </ButtonGroupPrimitive>
                         </Combobox.Group>
-
-                        {currentOrganization?.teams &&
-                            currentOrganization.teams
-                                .filter((team) => team.id !== currentTeam?.id)
-                                .sort((teamA, teamB) => teamA.name.localeCompare(teamB.name))
-                                .map((team) => {
-                                    const relativeOtherProjectPath = getProjectSwitchTargetUrl(
-                                        location.pathname,
-                                        team.id,
-                                        currentTeam?.project_id,
-                                        team.project_id
-                                    )
-
-                                    return (
-                                        <Combobox.Group value={[team.name]} key={team.id}>
-                                            <ButtonGroupPrimitive menuItem fullWidth>
-                                                <Combobox.Item asChild>
-                                                    <Link
-                                                        buttonProps={{
-                                                            menuItem: true,
-                                                            hasSideActionRight: true,
-                                                            className: 'pr-12',
-                                                        }}
-                                                        tooltip={`Switch to project: ${team.name}`}
-                                                        tooltipPlacement="right"
-                                                        to={relativeOtherProjectPath}
-                                                        data-attr="tree-navbar-project-dropdown-other-project-button"
-                                                    >
-                                                        <IconBlank />
-                                                        <ProjectName team={team} />
-                                                    </Link>
-                                                </Combobox.Item>
-
-                                                <Combobox.Item asChild>
-                                                    <Link
-                                                        buttonProps={{
-                                                            iconOnly: true,
-                                                            isSideActionRight: true,
-                                                        }}
-                                                        tooltip={`View settings for project: ${team.name}`}
-                                                        tooltipPlacement="right"
-                                                        to={urls.project(team.id, urls.settings('project'))}
-                                                        data-attr="tree-navbar-project-dropdown-other-project-settings-button"
-                                                    >
-                                                        <IconGear />
-                                                    </Link>
-                                                </Combobox.Item>
-                                            </ButtonGroupPrimitive>
-                                        </Combobox.Group>
-                                    )
-                                })}
 
                         {currentOrganization?.teams &&
                             currentOrganization.teams


### PR DESCRIPTION
## Problem
* Project dropdown trigger just had the word "project", had no meaning
* Project dropdown trigger now with a dynamic name, caused causes panel actions (buttons) to overflow out of panel at small widths
* Project dropdown can get LONG

![2025-06-19 14 57 13](https://github.com/user-attachments/assets/4274904b-7efe-4f19-9534-bf284f216385)

## Changes
* Project dropdown trigger now shows project name as trigger
* Project dropdown trigger now has clever flex box/max widths to accommodate a longer project name + changing panel width
* Project dropdown now has a max height of 90% viewport to accommodate.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Manually