### PR TITLE
fix(max): Fix input not focusing despite UI indication

### DIFF
--- a/frontend/src/scenes/max/QuestionInput.tsx
+++ b/frontend/src/scenes/max/QuestionInput.tsx
@@ -65,10 +65,16 @@ export function QuestionInput({ isFloating }: QuestionInputProps): JSX.Element {
                         className={clsx(
                             'flex flex-col',
                             'border border-[var(--border-primary)] rounded-[var(--radius)]',
-                            'bg-[var(--bg-fill-input)]',
+                            'bg-[var(--bg-fill-input)] cursor-text',
                             'hover:border-[var(--border-bold)] focus-within:border-[var(--border-bold)]',
                             isFloating && 'border-primary'
                         )}
+                        onClick={(e) => {
+                            // If user clicks anywhere with the area with a hover border, activate input - except on button clicks
+                            if (!(e.target as HTMLElement).closest('button')) {
+                                textAreaRef.current?.focus()
+                            }
+                        }}
                     >
                         <ContextDisplay />
                         <LemonTextArea


### PR DESCRIPTION
## Problem

Since we added the Max context bar in the same visual box as the question `textarea`, the hover border has not been accurately indicating the interactive area. Despite the border being highlighted, clicking doesn't do anything on parts of the box:

![2025-06-19 15 28 50](https://github.com/user-attachments/assets/53cdb9f8-b467-4242-a47b-fea2d9080eb6)

## Changes

Hover border now accurately indicates the interactive area, as it results in the expected input focus:

![2025-06-19 15 29 37](https://github.com/user-attachments/assets/de1a6d84-0f8a-4ad5-a1cb-ff8cc9b24614)