### PR TITLE
chore(experiments): clean up experimentLogic

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm.tsx
@@ -33,14 +33,8 @@ import { featureFlagEligibleForExperiment } from './utils'
 const ExperimentFormFields = (): JSX.Element => {
     const { formMode, experiment, groupTypes, aggregationLabel, hasPrimaryMetricSet, validExistingFeatureFlag } =
         useValues(experimentLogic)
-    const {
-        addVariant,
-        removeExperimentGroup,
-        setExperiment,
-        submitExperiment,
-        setExperimentType,
-        validateFeatureFlag,
-    } = useActions(experimentLogic)
+    const { addVariant, removeVariant, setExperiment, submitExperiment, setExperimentType, validateFeatureFlag } =
+        useActions(experimentLogic)
     const { webExperimentsAvailable, unavailableFeatureFlagKeys } = useValues(experimentsLogic)
     const { groupsAccessStatus } = useValues(groupsAccessLogic)
 
@@ -294,7 +288,7 @@ const ExperimentFormFields = (): JSX.Element => {
                                                                 <LemonButton
                                                                     size="small"
                                                                     icon={<IconTrash />}
-                                                                    onClick={() => removeExperimentGroup(index)}
+                                                                    onClick={() => removeVariant(index)}
                                                                 />
                                                             </Tooltip>
                                                         )}

--- a/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
@@ -133,11 +133,11 @@ export function DistributionModal({ experimentId }: { experimentId: Experiment['
 
 export function DistributionTable(): JSX.Element {
     const { openDistributionModal } = useActions(experimentLogic)
-    const { experimentId, experiment, legacyMetricResults } = useValues(experimentLogic)
+    const { experimentId, experiment, legacyPrimaryMetricsResults } = useValues(experimentLogic)
     const { reportExperimentReleaseConditionsViewed } = useActions(experimentLogic)
     const { isDarkModeOn } = useValues(themeLogic)
 
-    const result = legacyMetricResults?.[0]
+    const result = legacyPrimaryMetricsResults?.[0]
 
     const onSelectElement = (variant: string): void => {
         LemonDialog.open({

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -43,26 +43,26 @@ import { SummaryTable } from './SummaryTable'
 const ResultsTab = (): JSX.Element => {
     const {
         experiment,
-        legacyMetricResults,
+        legacyPrimaryMetricsResults,
         firstPrimaryMetric,
         primaryMetricsLengthWithSharedMetrics,
-        metricResultsLoading,
+        primaryMetricsResultsLoading,
         hasMinimumExposureForResults,
         statsMethod,
     } = useValues(experimentLogic)
     /**
      * we still use the legacy metric results here. Results on the new format are loaded
-     * in the metricResults state key. We'll eventually move into using the new state.
+     * in the primaryMetricsResults state key. We'll eventually move into using the new state.
      */
-    const hasSomeResults = legacyMetricResults?.some((result) => result?.insight)
+    const hasSomeResults = legacyPrimaryMetricsResults?.some((result) => result?.insight)
 
     const hasSinglePrimaryMetric = primaryMetricsLengthWithSharedMetrics === 1
 
-    const firstPrimaryMetricResult = legacyMetricResults?.[0]
+    const firstPrimaryMetricResult = legacyPrimaryMetricsResults?.[0]
 
     return (
         <>
-            {!experiment.start_date && !metricResultsLoading && (
+            {!experiment.start_date && !primaryMetricsResultsLoading && (
                 <>
                     {experiment.type === 'web' ? (
                         <WebExperimentImplementationDetails experiment={experiment} />

--- a/frontend/src/scenes/experiments/ExperimentView/Info.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Info.tsx
@@ -24,9 +24,9 @@ export function Info(): JSX.Element {
     const {
         experiment,
         featureFlags,
-        legacyMetricResults,
-        metricResultsLoading,
-        secondaryMetricResultsLoading,
+        legacyPrimaryMetricsResults,
+        primaryMetricsResultsLoading,
+        secondaryMetricsResultsLoading,
         isDescriptionModalOpen,
         statsMethod,
         usesNewQueryRunner,
@@ -56,7 +56,7 @@ export function Info(): JSX.Element {
 
     const currentStatsVersion = experiment.stats_config?.version || 1
 
-    const lastRefresh = legacyMetricResults?.[0]?.last_refresh
+    const lastRefresh = legacyPrimaryMetricsResults?.[0]?.last_refresh
 
     return (
         <div>
@@ -165,7 +165,7 @@ export function Info(): JSX.Element {
                                                 : ''
                                         }`}
                                     >
-                                        {metricResultsLoading || secondaryMetricResultsLoading
+                                        {primaryMetricsResultsLoading || secondaryMetricsResultsLoading
                                             ? 'Loading…'
                                             : lastRefresh
                                             ? dayjs(lastRefresh).fromNow()

--- a/frontend/src/scenes/experiments/ExperimentView/Overview.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Overview.tsx
@@ -71,9 +71,9 @@ export function SignificanceText({
 }
 
 export function Overview({ metricIndex = 0 }: { metricIndex?: number }): JSX.Element {
-    const { experimentId, legacyMetricResults } = useValues(experimentLogic)
+    const { experimentId, legacyPrimaryMetricsResults } = useValues(experimentLogic)
 
-    const result = legacyMetricResults?.[metricIndex]
+    const result = legacyPrimaryMetricsResults?.[metricIndex]
     if (!result) {
         return <></>
     }

--- a/frontend/src/scenes/experiments/ExperimentView/SummaryTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SummaryTable.tsx
@@ -48,15 +48,17 @@ export function SummaryTable({
     const {
         experimentId,
         experiment,
-        legacyMetricResults,
-        legacySecondaryMetricResults,
+        legacyPrimaryMetricsResults,
+        legacySecondaryMetricsResults,
         tabularExperimentResults,
         getInsightType,
         experimentMathAggregationForTrends,
         featureFlags,
     } = useValues(experimentLogic)
     const insightType = getInsightType(metric)
-    const result = isSecondary ? legacySecondaryMetricResults?.[metricIndex] : legacyMetricResults?.[metricIndex]
+    const result = isSecondary
+        ? legacySecondaryMetricsResults?.[metricIndex]
+        : legacyPrimaryMetricsResults?.[metricIndex]
     if (!result) {
         return <></>
     }

--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -65,7 +65,7 @@ export function VariantTag({
     fontSize?: number
     className?: string
 }): JSX.Element {
-    const { experiment, legacyMetricResults, getInsightType } = useValues(experimentLogic({ experimentId }))
+    const { experiment, legacyPrimaryMetricsResults, getInsightType } = useValues(experimentLogic({ experimentId }))
 
     if (variantKey === EXPERIMENT_VARIANT_MULTIPLE) {
         return (
@@ -75,7 +75,7 @@ export function VariantTag({
         )
     }
 
-    if (!legacyMetricResults) {
+    if (!legacyPrimaryMetricsResults) {
         return <></>
     }
 
@@ -88,7 +88,7 @@ export function VariantTag({
                     style={{
                         backgroundColor: getExperimentInsightColour(
                             getIndexForVariant(
-                                legacyMetricResults[0],
+                                legacyPrimaryMetricsResults[0],
                                 variantKey,
                                 getInsightType(experiment.metrics[0])
                             )
@@ -222,9 +222,9 @@ export function LegacyExploreButton({
 }
 
 export function ResultsHeader(): JSX.Element {
-    const { legacyMetricResults } = useValues(experimentLogic)
+    const { legacyPrimaryMetricsResults } = useValues(experimentLogic)
 
-    const result = legacyMetricResults?.[0]
+    const result = legacyPrimaryMetricsResults?.[0]
 
     return (
         <div className="flex">

--- a/frontend/src/scenes/experiments/MetricsView/legacy/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/legacy/DeltaChart.tsx
@@ -507,8 +507,8 @@ export function DeltaChart({
     const {
         experimentId,
         experiment,
-        metricResultsLoading,
-        secondaryMetricResultsLoading,
+        primaryMetricsResultsLoading,
+        secondaryMetricsResultsLoading,
         featureFlags,
         primaryMetricsLengthWithSharedMetrics,
         hasMinimumExposureForResults,
@@ -517,7 +517,7 @@ export function DeltaChart({
     const { openVariantDeltaTimeseriesModal, duplicateMetric, updateExperimentMetrics } = useActions(experimentLogic)
 
     // Loading state
-    const resultsLoading = isSecondary ? secondaryMetricResultsLoading : metricResultsLoading
+    const resultsLoading = isSecondary ? secondaryMetricsResultsLoading : primaryMetricsResultsLoading
 
     // Chart dimensions
     const dimensions = useChartDimensions(variants)

--- a/frontend/src/scenes/experiments/MetricsView/legacy/MetricsViewLegacy.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/legacy/MetricsViewLegacy.tsx
@@ -14,10 +14,10 @@ export function MetricsViewLegacy({ isSecondary }: { isSecondary?: boolean }): J
     const {
         experiment,
         getInsightType,
-        legacyMetricResults,
-        legacySecondaryMetricResults,
-        primaryMetricsResultErrors,
-        secondaryMetricsResultErrors,
+        legacyPrimaryMetricsResults,
+        legacySecondaryMetricsResults,
+        primaryMetricsResultsErrors,
+        secondaryMetricsResultsErrors,
     } = useValues(experimentLogic)
 
     const variants = experiment?.feature_flag?.filters?.multivariate?.variants
@@ -25,9 +25,9 @@ export function MetricsViewLegacy({ isSecondary }: { isSecondary?: boolean }): J
         return <></>
     }
 
-    const results = isSecondary ? legacySecondaryMetricResults : legacyMetricResults
+    const results = isSecondary ? legacySecondaryMetricsResults : legacyPrimaryMetricsResults
 
-    const errors = isSecondary ? secondaryMetricsResultErrors : primaryMetricsResultErrors
+    const errors = isSecondary ? secondaryMetricsResultsErrors : primaryMetricsResultsErrors
     const hasSomeResults = results?.some((result) => result?.insight)
 
     let metrics = isSecondary ? experiment.metrics_secondary : experiment.metrics

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRow.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRow.tsx
@@ -35,10 +35,10 @@ export function MetricRow({
     chartRadius: number
     error: any
 }): JSX.Element {
-    const { experiment, secondaryMetricResultsLoading, metricResultsLoading, hasMinimumExposureForResults } =
+    const { experiment, secondaryMetricsResultsLoading, primaryMetricsResultsLoading, hasMinimumExposureForResults } =
         useValues(experimentLogic)
     const { duplicateMetric, updateExperimentMetrics } = useActions(experimentLogic)
-    const resultsLoading = isSecondary ? secondaryMetricResultsLoading : metricResultsLoading
+    const resultsLoading = isSecondary ? secondaryMetricsResultsLoading : primaryMetricsResultsLoading
 
     const variantResults = result?.variant_results || []
 

--- a/frontend/src/scenes/experiments/MetricsView/new/Metrics.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/Metrics.tsx
@@ -16,10 +16,10 @@ export function Metrics({ isSecondary }: { isSecondary?: boolean }): JSX.Element
     const {
         experiment,
         getInsightType,
-        metricResults,
-        secondaryMetricResultsNew,
-        secondaryMetricsResultErrors,
-        primaryMetricsResultErrors,
+        primaryMetricsResults,
+        secondaryMetricsResults,
+        secondaryMetricsResultsErrors,
+        primaryMetricsResultsErrors,
         hasMinimumExposureForResults,
     } = useValues(experimentLogic)
 
@@ -28,8 +28,8 @@ export function Metrics({ isSecondary }: { isSecondary?: boolean }): JSX.Element
         return <></>
     }
 
-    const results = isSecondary ? secondaryMetricResultsNew : metricResults
-    const errors = isSecondary ? secondaryMetricsResultErrors : primaryMetricsResultErrors
+    const results = isSecondary ? secondaryMetricsResults : primaryMetricsResults
+    const errors = isSecondary ? secondaryMetricsResultsErrors : primaryMetricsResultsErrors
 
     let metrics = isSecondary ? experiment.metrics_secondary : experiment.metrics
     const sharedMetrics = experiment.saved_metrics

--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -198,7 +198,7 @@ describe('experimentLogic', () => {
             const promise = logic.asyncActions.loadSecondaryMetricsResults(true)
 
             await expectLogic(logic)
-                .toDispatchActions(['setSecondaryMetricsResultsLoading', 'setLegacySecondaryMetricResults'])
+                .toDispatchActions(['setSecondaryMetricsResultsLoading', 'setLegacySecondaryMetricsResults'])
                 .toMatchValues({
                     legacySecondaryMetricsResults: [],
                     secondaryMetricsResultsLoading: true,

--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -84,7 +84,7 @@ describe('experimentLogic', () => {
         await expectLogic(userLogic).toFinishAllListeners()
     })
 
-    describe('loadMetricResults', () => {
+    describe('loadPrimaryMetricsResults', () => {
         it('given a refresh, loads the metric results', async () => {
             logic.actions.setExperiment(experiment)
 
@@ -120,30 +120,30 @@ describe('experimentLogic', () => {
                 },
             })
 
-            const promise = logic.asyncActions.loadMetricResults(true)
+            const promise = logic.asyncActions.loadPrimaryMetricsResults(true)
 
             await expectLogic(logic)
-                .toDispatchActions(['setMetricResultsLoading', 'setLegacyMetricResults'])
+                .toDispatchActions(['setPrimaryMetricsResultsLoading', 'setLegacyPrimaryMetricsResults'])
                 .toMatchValues({
-                    legacyMetricResults: [],
-                    metricResultsLoading: true,
-                    primaryMetricsResultErrors: [],
+                    legacyPrimaryMetricsResults: [],
+                    primaryMetricsResultsLoading: true,
+                    primaryMetricsResultsErrors: [],
                 })
 
             await promise
 
             await expectLogic(logic)
-                .toDispatchActions(['setMetricResultsLoading'])
+                .toDispatchActions(['setPrimaryMetricsResultsLoading'])
                 .toMatchValues({
-                    legacyMetricResults: [
+                    legacyPrimaryMetricsResults: [
                         {
                             ...experimentMetricResultsSuccessJson.query_status.results,
                             fakeInsightId: expect.any(String),
                         },
                         null,
                     ],
-                    metricResultsLoading: false,
-                    primaryMetricsResultErrors: [
+                    primaryMetricsResultsLoading: false,
+                    primaryMetricsResultsErrors: [
                         null,
                         {
                             detail: {
@@ -159,7 +159,7 @@ describe('experimentLogic', () => {
         })
     })
 
-    describe('loadSecondaryMetricResults', () => {
+    describe('loadSecondaryMetricsResults', () => {
         it('given a refresh, loads the secondary metric results', async () => {
             logic.actions.setExperiment(experiment)
 
@@ -195,30 +195,30 @@ describe('experimentLogic', () => {
                 },
             })
 
-            const promise = logic.asyncActions.loadSecondaryMetricResults(true)
+            const promise = logic.asyncActions.loadSecondaryMetricsResults(true)
 
             await expectLogic(logic)
-                .toDispatchActions(['setSecondaryMetricResultsLoading', 'setLegacySecondaryMetricResults'])
+                .toDispatchActions(['setSecondaryMetricsResultsLoading', 'setLegacySecondaryMetricResults'])
                 .toMatchValues({
-                    legacySecondaryMetricResults: [],
-                    secondaryMetricResultsLoading: true,
-                    secondaryMetricsResultErrors: [],
+                    legacySecondaryMetricsResults: [],
+                    secondaryMetricsResultsLoading: true,
+                    secondaryMetricsResultsErrors: [],
                 })
 
             await promise
 
             await expectLogic(logic)
-                .toDispatchActions(['setSecondaryMetricResultsLoading'])
+                .toDispatchActions(['setSecondaryMetricsResultsLoading'])
                 .toMatchValues({
-                    legacySecondaryMetricResults: [
+                    legacySecondaryMetricsResults: [
                         null,
                         {
                             ...experimentMetricResultsSuccessJson.query_status.results,
                             fakeInsightId: expect.any(String),
                         },
                     ],
-                    secondaryMetricResultsLoading: false,
-                    secondaryMetricsResultErrors: [
+                    secondaryMetricsResultsLoading: false,
+                    secondaryMetricsResultsErrors: [
                         {
                             detail: {
                                 'no-control-variant': true,

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -465,7 +465,7 @@ export const experimentLogic = kea<experimentLogicType>([
         loadSecondaryMetricsResults: (refresh?: boolean) => ({ refresh }),
         setSecondaryMetricsResultsErrors: (errors: any[]) => ({ errors }),
         setSecondaryMetricsResultsLoading: (loading: boolean) => ({ loading }),
-        setLegacySecondaryMetricResults: (
+        setLegacySecondaryMetricsResults: (
             results: (
                 | CachedLegacyExperimentQueryResponse
                 | CachedExperimentTrendsQueryResponse
@@ -814,7 +814,7 @@ export const experimentLogic = kea<experimentLogicType>([
                 | null
             )[],
             {
-                setLegacySecondaryMetricResults: (_, { results }) => results,
+                setLegacySecondaryMetricsResults: (_, { results }) => results,
             },
         ],
         secondaryMetricsResults: [
@@ -1151,7 +1151,7 @@ export const experimentLogic = kea<experimentLogicType>([
             })
             values.experiment && actions.reportExperimentReset(values.experiment)
             actions.setLegacyPrimaryMetricsResults([])
-            actions.setLegacySecondaryMetricResults([])
+            actions.setLegacySecondaryMetricsResults([])
         },
         updateExperimentSuccess: async ({ experiment, payload }) => {
             actions.updateExperiments(experiment)
@@ -1404,7 +1404,7 @@ export const experimentLogic = kea<experimentLogicType>([
         },
         loadSecondaryMetricsResults: async ({ refresh }: { refresh?: boolean }) => {
             actions.setSecondaryMetricsResultsLoading(true)
-            actions.setLegacySecondaryMetricResults([])
+            actions.setLegacySecondaryMetricsResults([])
             actions.setSecondaryMetricsResults([])
 
             let secondaryMetrics = values.experiment?.metrics_secondary
@@ -1419,7 +1419,7 @@ export const experimentLogic = kea<experimentLogicType>([
                 metrics: secondaryMetrics,
                 experimentId: values.experimentId,
                 refresh,
-                onSetLegacyResults: actions.setLegacySecondaryMetricResults,
+                onSetLegacyResults: actions.setLegacySecondaryMetricsResults,
                 onSetResults: actions.setSecondaryMetricsResults,
                 onSetErrors: actions.setSecondaryMetricsResultsErrors,
                 onTimeout: actions.reportExperimentMetricTimeout,

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -334,9 +334,9 @@ export const experimentLogic = kea<experimentLogicType>([
         setExperiment: (experiment: Partial<Experiment>) => ({ experiment }),
         createExperiment: (draft?: boolean, folder?: string | null) => ({ draft, folder }),
         setExperimentType: (type?: string) => ({ type }),
-        removeExperimentGroup: (idx: number) => ({ idx }),
+        addVariant: true,
+        removeVariant: (idx: number) => ({ idx }),
         setEditExperiment: (editing: boolean) => ({ editing }),
-        setFlagImplementationWarning: (warning: boolean) => ({ warning }),
         setExposureAndSampleSize: (exposure: number, sampleSize: number) => ({ exposure, sampleSize }),
         refreshExperimentResults: (forceRefresh?: boolean) => ({ forceRefresh }),
         updateExperimentMetrics: true,
@@ -347,32 +347,21 @@ export const experimentLogic = kea<experimentLogicType>([
         setExperimentStatsVersion: (version: number) => ({ version }),
         launchExperiment: true,
         endExperiment: true,
-        addVariant: true,
         archiveExperiment: true,
         resetRunningExperiment: true,
-        checkFlagImplementationWarning: true,
-        openExperimentCollectionGoalModal: true,
-        closeExperimentCollectionGoalModal: true,
-        openExposureCriteriaModal: true,
-        closeExposureCriteriaModal: true,
-        openShipVariantModal: true,
-        closeShipVariantModal: true,
-        openStopExperimentModal: true,
-        closeStopExperimentModal: true,
-        openEditConclusionModal: true,
-        closeEditConclusionModal: true,
-        openDistributionModal: true,
-        closeDistributionModal: true,
-        openReleaseConditionsModal: true,
-        closeReleaseConditionsModal: true,
-        openDescriptionModal: true,
-        closeDescriptionModal: true,
-        openStatsEngineModal: true,
-        closeStatsEngineModal: true,
         updateExperimentVariantImages: (variantPreviewMediaIds: Record<string, string[]>) => ({
             variantPreviewMediaIds,
         }),
         setExposureCriteria: (exposureCriteria: ExperimentExposureCriteria) => ({ exposureCriteria }),
+        setTabKey: (tabKey: string) => ({ tabKey }),
+        createExperimentDashboard: true,
+        setIsCreatingExperimentDashboard: (isCreating: boolean) => ({ isCreating }),
+        setUnmodifiedExperiment: (experiment: Experiment) => ({ experiment }),
+        restoreUnmodifiedExperiment: true,
+        setValidExistingFeatureFlag: (featureFlag: FeatureFlagType | null) => ({ featureFlag }),
+        setFeatureFlagValidationError: (error: string) => ({ error }),
+        validateFeatureFlag: (featureFlagKey: string) => ({ featureFlagKey }),
+        // METRICS
         setMetric: ({
             metricIdx,
             name,
@@ -447,47 +436,6 @@ export const experimentLogic = kea<experimentLogicType>([
             funnelAggregateByHogQL,
             isSecondary,
         }),
-        setTabKey: (tabKey: string) => ({ tabKey }),
-        openPrimaryMetricModal: (index: number) => ({ index }),
-        closePrimaryMetricModal: true,
-        setMetricResultsLoading: (loading: boolean) => ({ loading }),
-        setLegacyMetricResults: (
-            results: (
-                | CachedLegacyExperimentQueryResponse
-                | CachedExperimentTrendsQueryResponse
-                | CachedExperimentFunnelsQueryResponse
-                | null
-            )[]
-        ) => ({ results }),
-        setMetricResults: (results: CachedNewExperimentQueryResponse[]) => ({ results }),
-        loadMetricResults: (refresh?: boolean) => ({ refresh }),
-        setPrimaryMetricsResultErrors: (errors: any[]) => ({ errors }),
-        setEditingPrimaryMetricIndex: (index: number | null) => ({ index }),
-        updateDistributionModal: (featureFlag: FeatureFlagType) => ({ featureFlag }),
-        openSecondaryMetricModal: (index: number) => ({ index }),
-        closeSecondaryMetricModal: true,
-        setSecondaryMetricResultsLoading: (loading: boolean) => ({ loading }),
-        setLegacySecondaryMetricResults: (
-            results: (
-                | CachedLegacyExperimentQueryResponse
-                | CachedExperimentTrendsQueryResponse
-                | CachedExperimentFunnelsQueryResponse
-                | null
-            )[]
-        ) => ({ results }),
-        setSecondaryMetricResults: (results: CachedNewExperimentQueryResponse[]) => ({ results }),
-        loadSecondaryMetricResults: (refresh?: boolean) => ({ refresh }),
-        setSecondaryMetricsResultErrors: (errors: any[]) => ({ errors }),
-        openPrimaryMetricSourceModal: true,
-        closePrimaryMetricSourceModal: true,
-        openSecondaryMetricSourceModal: true,
-        closeSecondaryMetricSourceModal: true,
-        openPrimarySharedMetricModal: (sharedMetricId: SharedMetric['id'] | null) => ({ sharedMetricId }),
-        closePrimarySharedMetricModal: true,
-        openSecondarySharedMetricModal: (sharedMetricId: SharedMetric['id'] | null) => ({ sharedMetricId }),
-        closeSecondarySharedMetricModal: true,
-        openVariantDeltaTimeseriesModal: true,
-        closeVariantDeltaTimeseriesModal: true,
         addSharedMetricsToExperiment: (
             sharedMetricIds: SharedMetric['id'][],
             metadata: { type: 'primary' | 'secondary' }
@@ -500,13 +448,66 @@ export const experimentLogic = kea<experimentLogicType>([
             metricIndex,
             isSecondary,
         }),
-        createExperimentDashboard: true,
-        setIsCreatingExperimentDashboard: (isCreating: boolean) => ({ isCreating }),
-        setUnmodifiedExperiment: (experiment: Experiment) => ({ experiment }),
-        restoreUnmodifiedExperiment: true,
-        setValidExistingFeatureFlag: (featureFlag: FeatureFlagType | null) => ({ featureFlag }),
-        setFeatureFlagValidationError: (error: string) => ({ error }),
-        validateFeatureFlag: (featureFlagKey: string) => ({ featureFlagKey }),
+        // METRICS RESULTS
+        setLegacyPrimaryMetricsResults: (
+            results: (
+                | CachedLegacyExperimentQueryResponse
+                | CachedExperimentTrendsQueryResponse
+                | CachedExperimentFunnelsQueryResponse
+                | null
+            )[]
+        ) => ({ results }),
+        setPrimaryMetricsResults: (results: CachedNewExperimentQueryResponse[]) => ({ results }),
+        setPrimaryMetricsResultsLoading: (loading: boolean) => ({ loading }),
+        loadPrimaryMetricsResults: (refresh?: boolean) => ({ refresh }),
+        setPrimaryMetricsResultsErrors: (errors: any[]) => ({ errors }),
+        setSecondaryMetricsResults: (results: CachedNewExperimentQueryResponse[]) => ({ results }),
+        loadSecondaryMetricsResults: (refresh?: boolean) => ({ refresh }),
+        setSecondaryMetricsResultsErrors: (errors: any[]) => ({ errors }),
+        setSecondaryMetricsResultsLoading: (loading: boolean) => ({ loading }),
+        setLegacySecondaryMetricResults: (
+            results: (
+                | CachedLegacyExperimentQueryResponse
+                | CachedExperimentTrendsQueryResponse
+                | CachedExperimentFunnelsQueryResponse
+                | null
+            )[]
+        ) => ({ results }),
+        setEditingPrimaryMetricIndex: (index: number | null) => ({ index }),
+        openPrimaryMetricModal: (index: number) => ({ index }),
+        // MODALS
+        openExperimentCollectionGoalModal: true,
+        closeExperimentCollectionGoalModal: true,
+        openExposureCriteriaModal: true,
+        closeExposureCriteriaModal: true,
+        openShipVariantModal: true,
+        closeShipVariantModal: true,
+        openStopExperimentModal: true,
+        closeStopExperimentModal: true,
+        openEditConclusionModal: true,
+        closeEditConclusionModal: true,
+        openDistributionModal: true,
+        closeDistributionModal: true,
+        openReleaseConditionsModal: true,
+        closeReleaseConditionsModal: true,
+        openDescriptionModal: true,
+        closeDescriptionModal: true,
+        openStatsEngineModal: true,
+        closeStatsEngineModal: true,
+        closePrimaryMetricModal: true,
+        updateDistributionModal: (featureFlag: FeatureFlagType) => ({ featureFlag }),
+        openSecondaryMetricModal: (index: number) => ({ index }),
+        closeSecondaryMetricModal: true,
+        openPrimaryMetricSourceModal: true,
+        closePrimaryMetricSourceModal: true,
+        openSecondaryMetricSourceModal: true,
+        closeSecondaryMetricSourceModal: true,
+        openPrimarySharedMetricModal: (sharedMetricId: SharedMetric['id'] | null) => ({ sharedMetricId }),
+        closePrimarySharedMetricModal: true,
+        openSecondarySharedMetricModal: (sharedMetricId: SharedMetric['id'] | null) => ({ sharedMetricId }),
+        closeSecondarySharedMetricModal: true,
+        openVariantDeltaTimeseriesModal: true,
+        closeVariantDeltaTimeseriesModal: true,
         openCalculateRunningTimeModal: true,
         closeCalculateRunningTimeModal: true,
     }),
@@ -544,7 +545,7 @@ export const experimentLogic = kea<experimentLogicType>([
                     }
                     return state
                 },
-                removeExperimentGroup: (state, { idx }) => {
+                removeVariant: (state, { idx }) => {
                     if (!state) {
                         return { ...NEW_EXPERIMENT }
                     }
@@ -702,12 +703,6 @@ export const experimentLogic = kea<experimentLogicType>([
                 setExperimentMissing: () => true,
             },
         ],
-        flagImplementationWarning: [
-            false as boolean,
-            {
-                setFlagImplementationWarning: (_, { warning }) => warning,
-            },
-        ],
         isExperimentCollectionGoalModalOpen: [
             false,
             {
@@ -757,14 +752,6 @@ export const experimentLogic = kea<experimentLogicType>([
                 closeReleaseConditionsModal: () => false,
             },
         ],
-        experimentValuesChangedLocally: [
-            false,
-            {
-                setExperiment: () => true,
-                loadExperiment: () => false,
-                updateExperiment: () => false,
-            },
-        ],
         unmodifiedExperiment: [
             null as Experiment | null,
             {
@@ -784,13 +771,8 @@ export const experimentLogic = kea<experimentLogicType>([
                 closePrimaryMetricModal: () => false,
             },
         ],
-        metricResultsLoading: [
-            false,
-            {
-                setMetricResultsLoading: (_, { loading }) => loading,
-            },
-        ],
-        legacyMetricResults: [
+        // PRIMARY METRICS
+        legacyPrimaryMetricsResults: [
             [] as (
                 | CachedLegacyExperimentQueryResponse
                 | CachedExperimentTrendsQueryResponse
@@ -798,24 +780,33 @@ export const experimentLogic = kea<experimentLogicType>([
                 | null
             )[],
             {
-                setLegacyMetricResults: (_, { results }) => results,
+                setLegacyPrimaryMetricsResults: (_, { results }) => results,
             },
         ],
-        metricResults: [
+        primaryMetricsResults: [
             [] as CachedNewExperimentQueryResponse[],
             {
-                setMetricResults: (_, { results }) => results,
-                loadMetricResults: () => [],
+                setPrimaryMetricsResults: (_, { results }) => results,
+                loadPrimaryMetricsResults: () => [],
                 loadExperiment: () => [],
             },
         ],
-        secondaryMetricResultsLoading: [
+        primaryMetricsResultsLoading: [
             false,
             {
-                setSecondaryMetricResultsLoading: (_, { loading }) => loading,
+                setPrimaryMetricsResultsLoading: (_, { loading }) => loading,
             },
         ],
-        legacySecondaryMetricResults: [
+        primaryMetricsResultsErrors: [
+            [] as any[],
+            {
+                setPrimaryMetricsResultsErrors: (_, { errors }) => errors,
+                loadPrimaryMetricsResults: () => [],
+                loadExperiment: () => [],
+            },
+        ],
+        // SECONDARY METRICS
+        legacySecondaryMetricsResults: [
             [] as (
                 | CachedLegacyExperimentQueryResponse
                 | CachedExperimentTrendsQueryResponse
@@ -826,12 +817,33 @@ export const experimentLogic = kea<experimentLogicType>([
                 setLegacySecondaryMetricResults: (_, { results }) => results,
             },
         ],
-        secondaryMetricResultsNew: [
+        secondaryMetricsResults: [
             [] as CachedNewExperimentQueryResponse[],
             {
-                setSecondaryMetricResults: (_, { results }) => results,
-                loadSecondaryMetricResults: () => [],
+                setSecondaryMetricsResults: (_, { results }) => results,
+                loadSecondaryMetricsResults: () => [],
                 loadExperiment: () => [],
+            },
+        ],
+        secondaryMetricsResultsLoading: [
+            false,
+            {
+                setSecondaryMetricsResultsLoading: (_, { loading }) => loading,
+            },
+        ],
+        secondaryMetricsResultsErrors: [
+            [] as any[],
+            {
+                setSecondaryMetricsResultsErrors: (_, { errors }) => errors,
+                loadSecondaryMetricsResults: () => [],
+                loadExperiment: () => [],
+            },
+        ],
+        isSecondaryMetricModalOpen: [
+            false,
+            {
+                openSecondaryMetricModal: () => true,
+                closeSecondaryMetricModal: () => false,
             },
         ],
         editingPrimaryMetricIndex: [
@@ -841,21 +853,6 @@ export const experimentLogic = kea<experimentLogicType>([
                 closePrimaryMetricModal: () => null,
                 updateExperimentMetrics: () => null,
                 setEditingPrimaryMetricIndex: (_, { index }) => index,
-            },
-        ],
-        primaryMetricsResultErrors: [
-            [] as any[],
-            {
-                setPrimaryMetricsResultErrors: (_, { errors }) => errors,
-                loadMetricResults: () => [],
-                loadExperiment: () => [],
-            },
-        ],
-        isSecondaryMetricModalOpen: [
-            false,
-            {
-                openSecondaryMetricModal: () => true,
-                closeSecondaryMetricModal: () => false,
             },
         ],
         editingSecondaryMetricIndex: [
@@ -872,14 +869,6 @@ export const experimentLogic = kea<experimentLogicType>([
                 openPrimarySharedMetricModal: (_, { sharedMetricId }) => sharedMetricId,
                 openSecondarySharedMetricModal: (_, { sharedMetricId }) => sharedMetricId,
                 updateExperimentMetrics: () => null,
-            },
-        ],
-        secondaryMetricsResultErrors: [
-            [] as any[],
-            {
-                setSecondaryMetricsResultErrors: (_, { errors }) => errors,
-                loadSecondaryMetricResults: () => [],
-                loadExperiment: () => [],
             },
         ],
         isPrimaryMetricSourceModalOpen: [
@@ -1122,8 +1111,8 @@ export const experimentLogic = kea<experimentLogicType>([
             values.experiment && actions.reportExperimentArchived(values.experiment)
         },
         refreshExperimentResults: async ({ forceRefresh }) => {
-            actions.loadMetricResults(forceRefresh)
-            actions.loadSecondaryMetricResults(forceRefresh)
+            actions.loadPrimaryMetricsResults(forceRefresh)
+            actions.loadSecondaryMetricsResults(forceRefresh)
             actions.loadExposures(forceRefresh)
         },
         updateExperimentMetrics: async () => {
@@ -1161,7 +1150,7 @@ export const experimentLogic = kea<experimentLogicType>([
                 conclusion_comment: null,
             })
             values.experiment && actions.reportExperimentReset(values.experiment)
-            actions.setLegacyMetricResults([])
+            actions.setLegacyPrimaryMetricsResults([])
             actions.setLegacySecondaryMetricResults([])
         },
         updateExperimentSuccess: async ({ experiment, payload }) => {
@@ -1169,86 +1158,6 @@ export const experimentLogic = kea<experimentLogicType>([
             if (experiment.start_date) {
                 const forceRefresh = payload?.start_date !== undefined
                 actions.refreshExperimentResults(forceRefresh)
-            }
-        },
-        setExperiment: async ({ experiment }) => {
-            const experimentEntitiesChanged =
-                (experiment.filters?.events && experiment.filters.events.length > 0) ||
-                (experiment.filters?.actions && experiment.filters.actions.length > 0) ||
-                (experiment.filters?.data_warehouse && experiment.filters.data_warehouse.length > 0)
-
-            if (!experiment.filters || Object.keys(experiment.filters).length === 0) {
-                return
-            }
-
-            if (experimentEntitiesChanged) {
-                actions.checkFlagImplementationWarning()
-            }
-        },
-        setExperimentValue: async ({ name, value }, breakpoint) => {
-            if (Array.isArray(name) && name[0] === 'feature_flag_key') {
-                actions.validateFeatureFlag(value)
-            }
-
-            await breakpoint(100)
-
-            if (name === 'filters') {
-                const experimentEntitiesChanged =
-                    (value?.events && value.events.length > 0) ||
-                    (value?.actions && value.actions.length > 0) ||
-                    (value?.data_warehouse && value.data_warehouse.length > 0)
-
-                if (!value || Object.keys(value).length === 0) {
-                    return
-                }
-
-                if (experimentEntitiesChanged) {
-                    actions.checkFlagImplementationWarning()
-                }
-            }
-        },
-        setExperimentValues: async ({ values }, breakpoint) => {
-            await breakpoint(100)
-
-            const experiment = values
-
-            const experimentEntitiesChanged =
-                (experiment.filters?.events && experiment.filters.events.length > 0) ||
-                (experiment.filters?.actions && experiment.filters.actions.length > 0) ||
-                (experiment.filters?.data_warehouse && experiment.filters.data_warehouse.length > 0)
-
-            if (!experiment.filters || Object.keys(experiment.filters).length === 0) {
-                return
-            }
-
-            if (experimentEntitiesChanged) {
-                actions.checkFlagImplementationWarning()
-            }
-        },
-        checkFlagImplementationWarning: async (_, breakpoint) => {
-            const experiment = values.experiment
-            const experimentEntitiesChanged =
-                (experiment.filters?.events && experiment.filters.events.length > 0) ||
-                (experiment.filters?.actions && experiment.filters.actions.length > 0) ||
-                (experiment.filters?.data_warehouse && experiment.filters.data_warehouse.length > 0)
-
-            if (!experiment.filters || Object.keys(experiment.filters).length === 0) {
-                return
-            }
-
-            if (experimentEntitiesChanged) {
-                const url = `/api/projects/${
-                    values.currentProjectId
-                }/experiments/requires_flag_implementation?${toParams(experiment.filters || {})}`
-                await breakpoint(100)
-
-                try {
-                    const response = await api.get(url)
-                    actions.setFlagImplementationWarning(response.result)
-                } catch (e) {
-                    // default to not showing the warning
-                    actions.setFlagImplementationWarning(false)
-                }
             }
         },
         createExposureCohortSuccess: ({ exposureCohort }) => {
@@ -1468,10 +1377,10 @@ export const experimentLogic = kea<experimentLogicType>([
                 })
             }
         },
-        loadMetricResults: async ({ refresh }: { refresh?: boolean }) => {
-            actions.setMetricResultsLoading(true)
-            actions.setLegacyMetricResults([])
-            actions.setMetricResults([])
+        loadPrimaryMetricsResults: async ({ refresh }: { refresh?: boolean }) => {
+            actions.setPrimaryMetricsResultsLoading(true)
+            actions.setLegacyPrimaryMetricsResults([])
+            actions.setPrimaryMetricsResults([])
 
             let metrics = values.experiment?.metrics
             const sharedMetrics = values.experiment?.saved_metrics
@@ -1485,18 +1394,18 @@ export const experimentLogic = kea<experimentLogicType>([
                 metrics,
                 experimentId: values.experimentId,
                 refresh,
-                onSetLegacyResults: actions.setLegacyMetricResults,
-                onSetResults: actions.setMetricResults,
-                onSetErrors: actions.setPrimaryMetricsResultErrors,
+                onSetLegacyResults: actions.setLegacyPrimaryMetricsResults,
+                onSetResults: actions.setPrimaryMetricsResults,
+                onSetErrors: actions.setPrimaryMetricsResultsErrors,
                 onTimeout: actions.reportExperimentMetricTimeout,
             })
 
-            actions.setMetricResultsLoading(false)
+            actions.setPrimaryMetricsResultsLoading(false)
         },
-        loadSecondaryMetricResults: async ({ refresh }: { refresh?: boolean }) => {
-            actions.setSecondaryMetricResultsLoading(true)
+        loadSecondaryMetricsResults: async ({ refresh }: { refresh?: boolean }) => {
+            actions.setSecondaryMetricsResultsLoading(true)
             actions.setLegacySecondaryMetricResults([])
-            actions.setSecondaryMetricResults([])
+            actions.setSecondaryMetricsResults([])
 
             let secondaryMetrics = values.experiment?.metrics_secondary
             const sharedMetrics = values.experiment?.saved_metrics
@@ -1511,12 +1420,12 @@ export const experimentLogic = kea<experimentLogicType>([
                 experimentId: values.experimentId,
                 refresh,
                 onSetLegacyResults: actions.setLegacySecondaryMetricResults,
-                onSetResults: actions.setSecondaryMetricResults,
-                onSetErrors: actions.setSecondaryMetricsResultErrors,
+                onSetResults: actions.setSecondaryMetricsResults,
+                onSetErrors: actions.setSecondaryMetricsResultsErrors,
                 onTimeout: actions.reportExperimentMetricTimeout,
             })
 
-            actions.setSecondaryMetricResultsLoading(false)
+            actions.setSecondaryMetricsResultsLoading(false)
         },
         openReleaseConditionsModal: () => {
             const numericFlagId = values.experiment.feature_flag?.id
@@ -1754,9 +1663,9 @@ export const experimentLogic = kea<experimentLogicType>([
             },
         ],
         isPrimaryMetricSignificant: [
-            (s) => [s.legacyMetricResults],
+            (s) => [s.legacyPrimaryMetricsResults],
             (
-                    legacyMetricResults: (
+                    legacyPrimaryMetricsResults: (
                         | CachedLegacyExperimentQueryResponse
                         | CachedExperimentFunnelsQueryResponse
                         | CachedExperimentTrendsQueryResponse
@@ -1764,7 +1673,7 @@ export const experimentLogic = kea<experimentLogicType>([
                     )[]
                 ) =>
                 (metricIndex: number = 0): boolean => {
-                    const result = legacyMetricResults?.[metricIndex]
+                    const result = legacyPrimaryMetricsResults?.[metricIndex]
                     if (!result) {
                         return false
                     }
@@ -1773,9 +1682,9 @@ export const experimentLogic = kea<experimentLogicType>([
                 },
         ],
         isSecondaryMetricSignificant: [
-            (s) => [s.legacySecondaryMetricResults],
+            (s) => [s.legacySecondaryMetricsResults],
             (
-                    legacySecondaryMetricResults: (
+                    legacySecondaryMetricsResults: (
                         | CachedLegacyExperimentQueryResponse
                         | CachedExperimentFunnelsQueryResponse
                         | CachedExperimentTrendsQueryResponse
@@ -1783,7 +1692,7 @@ export const experimentLogic = kea<experimentLogicType>([
                     )[]
                 ) =>
                 (metricIndex: number = 0): boolean => {
-                    const result = legacySecondaryMetricResults?.[metricIndex]
+                    const result = legacySecondaryMetricsResults?.[metricIndex]
                     if (!result) {
                         return false
                     }
@@ -1792,9 +1701,9 @@ export const experimentLogic = kea<experimentLogicType>([
                 },
         ],
         significanceDetails: [
-            (s) => [s.legacyMetricResults],
+            (s) => [s.legacyPrimaryMetricsResults],
             (
-                    legacyMetricResults: (
+                    legacyPrimaryMetricsResults: (
                         | CachedLegacyExperimentQueryResponse
                         | CachedExperimentFunnelsQueryResponse
                         | CachedExperimentTrendsQueryResponse
@@ -1802,7 +1711,7 @@ export const experimentLogic = kea<experimentLogicType>([
                     )[]
                 ) =>
                 (metricIndex: number = 0): string => {
-                    const results = legacyMetricResults?.[metricIndex]
+                    const results = legacyPrimaryMetricsResults?.[metricIndex]
                     return getSignificanceDetails(results)
                 },
         ],
@@ -1862,16 +1771,16 @@ export const experimentLogic = kea<experimentLogicType>([
             },
         ],
         tabularExperimentResults: [
-            (s) => [s.experiment, s.legacyMetricResults, s.legacySecondaryMetricResults, s.getInsightType],
+            (s) => [s.experiment, s.legacyPrimaryMetricsResults, s.legacySecondaryMetricsResults, s.getInsightType],
             (
                     experiment,
-                    legacyMetricResults: (
+                    legacyPrimaryMetricsResults: (
                         | CachedLegacyExperimentQueryResponse
                         | CachedExperimentFunnelsQueryResponse
                         | CachedExperimentTrendsQueryResponse
                         | null
                     )[],
-                    legacySecondaryMetricResults: (
+                    legacySecondaryMetricsResults: (
                         | CachedLegacyExperimentQueryResponse
                         | CachedExperimentFunnelsQueryResponse
                         | CachedExperimentTrendsQueryResponse
@@ -1885,8 +1794,8 @@ export const experimentLogic = kea<experimentLogicType>([
                         ? getInsightType(experiment.metrics_secondary[metricIndex])
                         : getInsightType(experiment.metrics[metricIndex])
                     const result = isSecondary
-                        ? legacySecondaryMetricResults[metricIndex]
-                        : legacyMetricResults[metricIndex]
+                        ? legacySecondaryMetricsResults[metricIndex]
+                        : legacyPrimaryMetricsResults[metricIndex]
 
                     if (result) {
                         for (const variantObj of result.variants) {
@@ -1918,9 +1827,9 @@ export const experimentLogic = kea<experimentLogicType>([
                 },
         ],
         sortedWinProbabilities: [
-            (s) => [s.legacyMetricResults],
+            (s) => [s.legacyPrimaryMetricsResults],
             (
-                    legacyMetricResults: (
+                    legacyPrimaryMetricsResults: (
                         | CachedLegacyExperimentQueryResponse
                         | CachedExperimentFunnelsQueryResponse
                         | CachedExperimentTrendsQueryResponse
@@ -1928,7 +1837,7 @@ export const experimentLogic = kea<experimentLogicType>([
                     )[]
                 ) =>
                 (metricIndex: number = 0) => {
-                    const result = legacyMetricResults?.[metricIndex]
+                    const result = legacyPrimaryMetricsResults?.[metricIndex]
 
                     if (!result) {
                         return []
@@ -1944,10 +1853,10 @@ export const experimentLogic = kea<experimentLogicType>([
                 },
         ],
         funnelResultsPersonsTotal: [
-            (s) => [s.experiment, s.legacyMetricResults, s.getInsightType],
+            (s) => [s.experiment, s.legacyPrimaryMetricsResults, s.getInsightType],
             (
                     experiment,
-                    legacyMetricResults: (
+                    legacyPrimaryMetricsResults: (
                         | CachedLegacyExperimentQueryResponse
                         | CachedExperimentFunnelsQueryResponse
                         | CachedExperimentTrendsQueryResponse
@@ -1956,7 +1865,7 @@ export const experimentLogic = kea<experimentLogicType>([
                     getInsightType
                 ) =>
                 (metricIndex: number = 0): number => {
-                    const result = legacyMetricResults?.[metricIndex]
+                    const result = legacyPrimaryMetricsResults?.[metricIndex]
 
                     if (getInsightType(experiment.metrics[metricIndex]) !== InsightType.FUNNELS || !result) {
                         return 0
@@ -2103,38 +2012,6 @@ export const experimentLogic = kea<experimentLogicType>([
             (experiment: Experiment): ExperimentStatsMethod => {
                 return experiment.stats_config?.method || ExperimentStatsMethod.Bayesian
             },
-        ],
-        // New format selectors
-        hasPrimaryMetricNewResults: [
-            (s) => [s.metricResults],
-            (metricResults: CachedNewExperimentQueryResponse[]): boolean => {
-                return (
-                    metricResults.length > 0 && metricResults.some((result) => result !== null && result !== undefined)
-                )
-            },
-        ],
-        hasSecondaryMetricNewResults: [
-            (s) => [s.secondaryMetricResultsNew],
-            (secondaryMetricResultsNew: CachedNewExperimentQueryResponse[]): boolean => {
-                return (
-                    secondaryMetricResultsNew.length > 0 &&
-                    secondaryMetricResultsNew.some((result) => result !== null && result !== undefined)
-                )
-            },
-        ],
-        primaryMetricNewResult: [
-            (s) => [s.metricResults],
-            (metricResults: CachedNewExperimentQueryResponse[]) =>
-                (metricIndex: number = 0): CachedNewExperimentQueryResponse | null => {
-                    return metricResults?.[metricIndex] || null
-                },
-        ],
-        secondaryMetricNewResult: [
-            (s) => [s.secondaryMetricResultsNew],
-            (secondaryMetricResultsNew: CachedNewExperimentQueryResponse[]) =>
-                (metricIndex: number = 0): CachedNewExperimentQueryResponse | null => {
-                    return secondaryMetricResultsNew?.[metricIndex] || null
-                },
         ],
     }),
     forms(({ actions, values, props }) => ({

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeExperiment.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeExperiment.tsx
@@ -18,9 +18,8 @@ import { INTEGER_REGEX_MATCH_GROUPS } from './utils'
 
 const Component = ({ attributes }: NotebookNodeProps<NotebookNodeExperimentAttributes>): JSX.Element => {
     const { id } = attributes
-    const { experiment, experimentLoading, experimentMissing, isExperimentRunning, legacyMetricResults } = useValues(
-        experimentLogic({ experimentId: id })
-    )
+    const { experiment, experimentLoading, experimentMissing, isExperimentRunning, legacyPrimaryMetricsResults } =
+        useValues(experimentLogic({ experimentId: id }))
     const { loadExperiment } = useActions(experimentLogic({ experimentId: id }))
     const { expanded } = useValues(notebookNodeLogic)
     const { insertAfter, setActions } = useActions(notebookNodeLogic)
@@ -41,7 +40,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeExperimentAttri
         return <NotFound object="experiment" />
     }
 
-    if (!legacyMetricResults) {
+    if (!legacyPrimaryMetricsResults) {
         return <></>
     }
 
@@ -83,10 +82,13 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeExperimentAttri
                                 <div className="p-2">
                                     <SummaryTable metric={experiment.metrics[0]} />
                                     {/* TODO: Only show results if the metric is a trends or funnels query. Not supported yet with new query runner */}
-                                    {legacyMetricResults[0] &&
-                                        (legacyMetricResults[0].kind === 'ExperimentTrendsQuery' ||
-                                            legacyMetricResults[0].kind === 'ExperimentFunnelsQuery') && (
-                                            <LegacyResultsQuery result={legacyMetricResults[0]} showTable={true} />
+                                    {legacyPrimaryMetricsResults[0] &&
+                                        (legacyPrimaryMetricsResults[0].kind === 'ExperimentTrendsQuery' ||
+                                            legacyPrimaryMetricsResults[0].kind === 'ExperimentFunnelsQuery') && (
+                                            <LegacyResultsQuery
+                                                result={legacyPrimaryMetricsResults[0]}
+                                                showTable={true}
+                                            />
                                         )}
                                 </div>
                             </>


### PR DESCRIPTION
## Changes
I'm soon going to split `experimentLogic` and move metric-related methods into a new file called `metricsLogic`. This file will handle all logic for setting metrics and loading their results.

As a preliminary step, I'm cleaning up parts of `experimentLogic` to make the split easier.

- Fixed some inconsistent naming, mainly the use of singular vs. plural. We were mixing "metric" and "metrics", "result" and "results" etc.
- Removed some old values/actions/reducers that are no longer used
- Reordered actions and reducers for better readability

## How did you test this code?
TS not complaining