### PR TITLE
refactor: Remove shared memory for serialization of record batches

### DIFF
--- a/posthog/temporal/batch_exports/transformer.py
+++ b/posthog/temporal/batch_exports/transformer.py
@@ -329,7 +329,7 @@ class ParquetStreamTransformer(StreamTransformer):
 def transform_record_batch(record_batch, transformer: StreamTransformer):
     """Top level function to run transformers in multiprocessing.
 
-    Record batches are accessed from shared memory.
+    Record batches are processed in separate processes.
     """
     processed = list(transformer.transform_batch(record_batch))
     return processed


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Maintaining a shared memory comes with some infrastructure challenges that we are not ready to face yet. It's good to keep this code around for the future, but in the meantime we'll remove shared memory from the multiprocessing transformer

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Instead, we pass record batches along to the multiprocessing tasks. This means some deserializing and serializing that could impact performance, although in local testing results seem to maintain similar performance.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
