### PR TITLE
fix: Adding descriptions to webhook.template.ts

### DIFF
--- a/plugin-server/src/cdp/templates/_destinations/webhook/webhook.template.ts
+++ b/plugin-server/src/cdp/templates/_destinations/webhook/webhook.template.ts
@@ -37,6 +37,7 @@ if (inputs.debug) {
             label: 'Webhook URL',
             secret: false,
             required: true,
+            description: 'Endpoint URL to send event data to.',
         },
         {
             key: 'method',
@@ -67,6 +68,7 @@ if (inputs.debug) {
             ],
             default: 'POST',
             required: false,
+            description: 'HTTP method to use for the request.',
         },
         {
             key: 'body',
@@ -75,6 +77,7 @@ if (inputs.debug) {
             default: { event: '{event}', person: '{person}' },
             secret: false,
             required: false,
+            description: 'JSON payload to send in the request body.',
         },
         {
             key: 'headers',
@@ -83,6 +86,7 @@ if (inputs.debug) {
             secret: false,
             required: false,
             default: { 'Content-Type': 'application/json' },
+            description: 'HTTP headers to send in the request.',
         },
         {
             key: 'debug',


### PR DESCRIPTION
## Changes

Adding descriptions to `webhook.template.ts`

![image](https://github.com/user-attachments/assets/b9182464-5f3b-45f6-b9ce-de6a98774fae)

## How did you test this code?

ran `npm test -- --testPathPattern=webhook.template.test.ts`
