### PR TITLE
chore: split typegen and ts check out to view times seperately

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -101,9 +101,17 @@ jobs:
               if: needs.changes.outputs.frontend == 'true'
               run: pnpm --filter=@posthog/frontend lint:css
 
-            - name: Generate logic types and run typescript with strict
+            - name: Build products
               if: needs.changes.outputs.frontend == 'true'
-              run: pnpm --filter=@posthog/frontend build:products && pnpm --filter=@posthog/frontend typegen:write && pnpm --filter=@posthog/frontend typescript:check
+              run: pnpm --filter=@posthog/frontend build:products
+
+            - name: Kea typegen
+              if: needs.changes.outputs.frontend == 'true'
+              run: pnpm --filter=@posthog/frontend typegen:write
+
+            - name: Run typescript with strict
+              if: needs.changes.outputs.frontend == 'true'
+              run: pnpm --filter=@posthog/frontend typescript:check
               env:
                   NODE_OPTIONS: --max-old-space-size=16384
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

This is the longest step, want to see the times clearly for the different commands it runs.

## Changes

Split out the steps in the workflow