### PR TITLE
chore(cohorts): add metric to track cohorts with max errors

### DIFF
--- a/posthog/tasks/test/test_calculate_cohort.py
+++ b/posthog/tasks/test/test_calculate_cohort.py
@@ -14,7 +14,7 @@ from posthog.tasks.calculate_cohort import (
     MAX_ERRORS_CALCULATING,
     MAX_STUCK_COHORTS_TO_RESET,
     reset_stuck_cohorts,
-    update_stale_cohort_metrics,
+    update_cohort_metrics,
     COHORTS_STALE_COUNT_GAUGE,
     COHORT_STUCK_COUNT_GAUGE,
     increment_version_and_enqueue_calculate_cohort,
@@ -193,7 +193,7 @@ def calculate_cohort_test_factory(event_factory: Callable, person_factory: Calla
                 is_static=False,
             )
 
-            update_stale_cohort_metrics()
+            update_cohort_metrics()
 
             mock_labels.assert_any_call(hours="24")
             mock_labels.assert_any_call(hours="36")
@@ -252,7 +252,7 @@ def calculate_cohort_test_factory(event_factory: Callable, person_factory: Calla
                 is_static=False,
             )
 
-            update_stale_cohort_metrics()
+            update_cohort_metrics()
             mock_set.assert_called_with(2)
 
         @patch("posthog.tasks.calculate_cohort.logger")


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
If a cohort has more than 20 errors while calculating, we don't try recalculating it again automatically.
In https://github.com/PostHog/posthog/pull/33879, I added another code path where we increment the error count for a cohort if it was stuck. 

At the moment we have around ~600 https://metabase.prod-us.posthog.dev/question/1419-cohorts-with-maxed-errors

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Add a metric to keep track of the number of cohorts that won't be automatically recalculated. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->
- [x] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
