### PR TITLE
feat: split out frontend ci

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -53,13 +53,56 @@ jobs:
                         - webpack.config.js
                         - stylelint*
 
-    frontend-code-quality:
-        name: Code quality checks
+    frontend-linting:
+        name: Linting checks
         needs: changes
-        # kea typegen and typescript:check need some more oomph
-        runs-on: depot-ubuntu-24.04-4
+        runs-on: depot-ubuntu-24.04
         steps:
             # we need at least one thing to run to make sure we include everything for required jobs
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+
+            - name: Install pnpm
+              if: needs.changes.outputs.frontend == 'true'
+              uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+
+            - name: Set up Node.js
+              if: needs.changes.outputs.frontend == 'true'
+              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+              with:
+                  node-version: 18.12.1
+                  cache: 'pnpm'
+
+            - name: Get pnpm cache directory path
+              if: needs.changes.outputs.frontend == 'true'
+              id: pnpm-cache-dir
+              run: echo "PNPM_STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+            - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+              if: needs.changes.outputs.frontend == 'true'
+              id: pnpm-cache
+              with:
+                  path: ${{ steps.pnpm-cache-dir.outputs.PNPM_STORE_PATH }}
+                  key: ${{ runner.os }}-pnpm-cypress-${{ hashFiles('pnpm-lock.yaml') }}
+                  restore-keys: ${{ runner.os }}-pnpm-cypress-
+
+            - name: Install package.json dependencies with pnpm
+              if: needs.changes.outputs.frontend == 'true'
+              run: |
+                  pnpm --filter=@posthog/frontend... install --frozen-lockfile
+
+            - name: Check formatting with prettier
+              if: needs.changes.outputs.frontend == 'true'
+              run: pnpm --filter=@posthog/frontend prettier:check
+
+            - name: Lint with Stylelint
+              if: needs.changes.outputs.frontend == 'true'
+              run: pnpm --filter=@posthog/frontend lint:css
+
+    frontend-build-and-typegen:
+        name: Build and generate types
+        needs: changes
+        runs-on: depot-ubuntu-24.04-8 # kea typegen needs a lot of oomph
+        steps:
             - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
             - name: Install pnpm
@@ -92,14 +135,6 @@ jobs:
                   pnpm --filter=@posthog/playwright... install --frozen-lockfile
                   bin/turbo --filter=@posthog/frontend prepare
 
-            - name: Check formatting with prettier
-              if: needs.changes.outputs.frontend == 'true'
-              run: pnpm --filter=@posthog/frontend prettier:check
-
-            - name: Lint with Stylelint
-              if: needs.changes.outputs.frontend == 'true'
-              run: pnpm --filter=@posthog/frontend lint:css
-
             - name: Build products
               if: needs.changes.outputs.frontend == 'true'
               run: pnpm --filter=@posthog/frontend build:products
@@ -108,11 +143,44 @@ jobs:
               if: needs.changes.outputs.frontend == 'true'
               run: pnpm --filter=@posthog/frontend typegen:write
 
-            - name: Run typescript with strict
+            - name: Upload frontend build artifacts
               if: needs.changes.outputs.frontend == 'true'
-              run: pnpm --filter=@posthog/frontend typescript:check
-              env:
-                  NODE_OPTIONS: --max-old-space-size=16384
+              uses: actions/upload-artifact@v3
+              with:
+                  name: frontend-build
+                  path: |
+                      frontend/
+                      products/
+                  retention-days: 1
+
+    frontend-eslint:
+        name: ESLint checks
+        needs: [changes, frontend-build-and-typegen]
+        runs-on: depot-ubuntu-24.04
+        steps:
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+
+            - name: Download frontend build artifacts
+              if: needs.changes.outputs.frontend == 'true'
+              uses: actions/download-artifact@v3
+              with:
+                  name: frontend-build
+
+            - name: Install pnpm
+              if: needs.changes.outputs.frontend == 'true'
+              uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+
+            - name: Set up Node.js
+              if: needs.changes.outputs.frontend == 'true'
+              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+              with:
+                  node-version: 18.12.1
+                  cache: 'pnpm'
+
+            - name: Install package.json dependencies with pnpm
+              if: needs.changes.outputs.frontend == 'true'
+              run: |
+                  pnpm --filter=@posthog/frontend... install --frozen-lockfile
 
             - name: Lint with ESLint
               if: needs.changes.outputs.frontend == 'true'
@@ -120,13 +188,34 @@ jobs:
               env:
                   NODE_OPTIONS: --max-old-space-size=16384
 
-            - name: Check if "schema.json" is up to date
-              if: needs.changes.outputs.frontend == 'true'
-              run: pnpm --filter=@posthog/frontend schema:build:json && git diff --exit-code
+    frontend-toolbar-checks:
+        name: Toolbar checks
+        needs: [changes, frontend-build-and-typegen]
+        runs-on: depot-ubuntu-24.04
+        steps:
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-            - name: Check if mobile replay "schema.json" is up to date
+            - name: Download frontend build artifacts
               if: needs.changes.outputs.frontend == 'true'
-              run: pnpm --filter=@posthog/ee mobile-replay:schema:build:json && git diff --exit-code
+              uses: actions/download-artifact@v3
+              with:
+                  name: frontend-build
+
+            - name: Install pnpm
+              if: needs.changes.outputs.frontend == 'true'
+              uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+
+            - name: Set up Node.js
+              if: needs.changes.outputs.frontend == 'true'
+              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+              with:
+                  node-version: 18.12.1
+                  cache: 'pnpm'
+
+            - name: Install package.json dependencies with pnpm
+              if: needs.changes.outputs.frontend == 'true'
+              run: |
+                  pnpm --filter=@posthog/frontend... install --frozen-lockfile
 
             - name: Check toolbar bundle size
               if: needs.changes.outputs.frontend == 'true'
@@ -142,6 +231,49 @@ jobs:
             - name: Check toolbar for CSP eval violations
               if: needs.changes.outputs.frontend == 'true'
               run: pnpm --filter=@posthog/frontend check-toolbar-csp-eval
+
+    frontend-typescript-checks:
+        name: TypeScript and schema checks
+        needs: [changes, frontend-build-and-typegen]
+        runs-on: depot-ubuntu-24.04
+        steps:
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+
+            - name: Download frontend build artifacts
+              if: needs.changes.outputs.frontend == 'true'
+              uses: actions/download-artifact@v3
+              with:
+                  name: frontend-build
+
+            - name: Install pnpm
+              if: needs.changes.outputs.frontend == 'true'
+              uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+
+            - name: Set up Node.js
+              if: needs.changes.outputs.frontend == 'true'
+              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+              with:
+                  node-version: 18.12.1
+                  cache: 'pnpm'
+
+            - name: Install package.json dependencies with pnpm
+              if: needs.changes.outputs.frontend == 'true'
+              run: |
+                  pnpm --filter=@posthog/frontend... install --frozen-lockfile
+
+            - name: Run typescript with strict
+              if: needs.changes.outputs.frontend == 'true'
+              run: pnpm --filter=@posthog/frontend typescript:check
+              env:
+                  NODE_OPTIONS: --max-old-space-size=16384
+
+            - name: Check if "schema.json" is up to date
+              if: needs.changes.outputs.frontend == 'true'
+              run: pnpm --filter=@posthog/frontend schema:build:json && git diff --exit-code
+
+            - name: Check if mobile replay "schema.json" is up to date
+              if: needs.changes.outputs.frontend == 'true'
+              run: pnpm --filter=@posthog/ee mobile-replay:schema:build:json && git diff --exit-code
 
     jest:
         runs-on: depot-ubuntu-24.04
@@ -188,7 +320,7 @@ jobs:
 
     calculate-running-time:
         name: Calculate running time
-        needs: [jest, frontend-code-quality, changes]
+        needs: [jest, frontend-typescript-checks, frontend-linting, frontend-toolbar-checks, frontend-eslint, changes]
         runs-on: depot-ubuntu-24.04
         if: needs.changes.outputs.frontend == 'true'
         steps:

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -149,8 +149,8 @@ jobs:
               with:
                   name: frontend-build
                   path: |
-                      frontend/
-                      products/
+                      frontend/**/*Type.ts
+                      frontend/src/products.tsx
                   retention-days: 1
 
     frontend-eslint:
@@ -180,7 +180,8 @@ jobs:
             - name: Install package.json dependencies with pnpm
               if: needs.changes.outputs.frontend == 'true'
               run: |
-                  pnpm --filter=@posthog/frontend... install --frozen-lockfile
+                  pnpm --filter=@posthog/playwright... install --frozen-lockfile
+                  bin/turbo --filter=@posthog/frontend prepare
 
             - name: Lint with ESLint
               if: needs.changes.outputs.frontend == 'true'
@@ -215,7 +216,8 @@ jobs:
             - name: Install package.json dependencies with pnpm
               if: needs.changes.outputs.frontend == 'true'
               run: |
-                  pnpm --filter=@posthog/frontend... install --frozen-lockfile
+                  pnpm --filter=@posthog/playwright... install --frozen-lockfile
+                  bin/turbo --filter=@posthog/frontend prepare
 
             - name: Check toolbar bundle size
               if: needs.changes.outputs.frontend == 'true'
@@ -259,7 +261,8 @@ jobs:
             - name: Install package.json dependencies with pnpm
               if: needs.changes.outputs.frontend == 'true'
               run: |
-                  pnpm --filter=@posthog/frontend... install --frozen-lockfile
+                  pnpm --filter=@posthog/playwright... install --frozen-lockfile
+                  bin/turbo --filter=@posthog/frontend prepare
 
             - name: Run typescript with strict
               if: needs.changes.outputs.frontend == 'true'

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -54,7 +54,7 @@ jobs:
                         - stylelint*
 
     frontend-linting:
-        name: Linting checks
+        name: Frontend linting checks
         needs: changes
         runs-on: depot-ubuntu-24.04
         steps:
@@ -100,7 +100,7 @@ jobs:
               run: pnpm --filter=@posthog/frontend lint:css
 
     frontend-build-and-typegen:
-        name: Build and generate types
+        name: Frontend build and typegen
         needs: changes
         runs-on: depot-ubuntu-24.04-8 # kea typegen needs a lot of oomph
         steps:
@@ -155,7 +155,7 @@ jobs:
                   retention-days: 1
 
     frontend-eslint:
-        name: ESLint checks
+        name: Frontend ESLint checks
         needs: [changes, frontend-build-and-typegen]
         runs-on: depot-ubuntu-24.04-4
         steps:
@@ -204,17 +204,11 @@ jobs:
                   NODE_OPTIONS: --max-old-space-size=16384
 
     frontend-toolbar-checks:
-        name: Toolbar checks
-        needs: [changes, frontend-build-and-typegen]
+        name: Frontend toolbar checks
+        needs: [changes]
         runs-on: depot-ubuntu-24.04
         steps:
             - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
-
-            - name: Download frontend build artifacts
-              if: needs.changes.outputs.frontend == 'true'
-              uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
-              with:
-                  name: frontend-build
 
             - name: Install pnpm
               if: needs.changes.outputs.frontend == 'true'
@@ -246,6 +240,10 @@ jobs:
                   pnpm --filter=@posthog/playwright... install --frozen-lockfile
                   bin/turbo --filter=@posthog/frontend prepare
 
+            - name: Build products
+              if: needs.changes.outputs.frontend == 'true'
+              run: pnpm --filter=@posthog/frontend build:products
+
             - name: Check toolbar bundle size
               if: needs.changes.outputs.frontend == 'true'
               uses: preactjs/compressed-size-action@946a292cd35bd1088e0d7eb92b69d1a8d5b5d76a # v2
@@ -262,7 +260,7 @@ jobs:
               run: pnpm --filter=@posthog/frontend check-toolbar-csp-eval
 
     frontend-typescript-checks:
-        name: TypeScript and schema checks
+        name: Frontend typescript and schema checks
         needs: [changes, frontend-build-and-typegen]
         runs-on: depot-ubuntu-24.04
         steps:

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -88,7 +88,7 @@ jobs:
             - name: Install package.json dependencies with pnpm
               if: needs.changes.outputs.frontend == 'true'
               run: |
-                  pnpm --filter=@posthog/frontend... install --frozen-lockfile
+                  pnpm --filter=@posthog/playwright... install --frozen-lockfile
                   bin/turbo --filter=@posthog/frontend prepare
 
             - name: Check formatting with prettier

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -15,7 +15,7 @@ jobs:
     # we skip each step individually, so   they are still reported as success
     # because many of them are required for CI checks to be green
     changes:
-        runs-on: depot-ubuntu-24.04
+        runs-on: depot-ubuntu-24.04-small
         timeout-minutes: 5
         name: Determine need to run frontend checks
         outputs:
@@ -89,6 +89,7 @@ jobs:
               if: needs.changes.outputs.frontend == 'true'
               run: |
                   pnpm --filter=@posthog/frontend... install --frozen-lockfile
+                  bin/turbo --filter=@posthog/frontend prepare
 
             - name: Check formatting with prettier
               if: needs.changes.outputs.frontend == 'true'

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -157,7 +157,7 @@ jobs:
     frontend-eslint:
         name: ESLint checks
         needs: [changes, frontend-build-and-typegen]
-        runs-on: depot-ubuntu-24.04
+        runs-on: depot-ubuntu-24.04-4
         steps:
             - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
@@ -177,6 +177,19 @@ jobs:
               with:
                   node-version: 18.12.1
                   cache: 'pnpm'
+
+            - name: Get pnpm cache directory path
+              if: needs.changes.outputs.frontend == 'true'
+              id: pnpm-cache-dir
+              run: echo "PNPM_STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+            - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+              if: needs.changes.outputs.frontend == 'true'
+              id: pnpm-cache
+              with:
+                  path: ${{ steps.pnpm-cache-dir.outputs.PNPM_STORE_PATH }}
+                  key: ${{ runner.os }}-pnpm-cypress-${{ hashFiles('pnpm-lock.yaml') }}
+                  restore-keys: ${{ runner.os }}-pnpm-cypress-
 
             - name: Install package.json dependencies with pnpm
               if: needs.changes.outputs.frontend == 'true'
@@ -213,6 +226,19 @@ jobs:
               with:
                   node-version: 18.12.1
                   cache: 'pnpm'
+
+            - name: Get pnpm cache directory path
+              if: needs.changes.outputs.frontend == 'true'
+              id: pnpm-cache-dir
+              run: echo "PNPM_STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+            - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+              if: needs.changes.outputs.frontend == 'true'
+              id: pnpm-cache
+              with:
+                  path: ${{ steps.pnpm-cache-dir.outputs.PNPM_STORE_PATH }}
+                  key: ${{ runner.os }}-pnpm-cypress-${{ hashFiles('pnpm-lock.yaml') }}
+                  restore-keys: ${{ runner.os }}-pnpm-cypress-
 
             - name: Install package.json dependencies with pnpm
               if: needs.changes.outputs.frontend == 'true'
@@ -258,6 +284,19 @@ jobs:
               with:
                   node-version: 18.12.1
                   cache: 'pnpm'
+
+            - name: Get pnpm cache directory path
+              if: needs.changes.outputs.frontend == 'true'
+              id: pnpm-cache-dir
+              run: echo "PNPM_STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+            - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+              if: needs.changes.outputs.frontend == 'true'
+              id: pnpm-cache
+              with:
+                  path: ${{ steps.pnpm-cache-dir.outputs.PNPM_STORE_PATH }}
+                  key: ${{ runner.os }}-pnpm-cypress-${{ hashFiles('pnpm-lock.yaml') }}
+                  restore-keys: ${{ runner.os }}-pnpm-cypress-
 
             - name: Install package.json dependencies with pnpm
               if: needs.changes.outputs.frontend == 'true'

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -150,7 +150,7 @@ jobs:
               with:
                   name: frontend-build
                   path: |
-                      frontend/**/*Type.ts
+                      **/*Type.ts
                       frontend/src/products.tsx
                   retention-days: 1
 

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -145,7 +145,7 @@ jobs:
 
             - name: Upload frontend build artifacts
               if: needs.changes.outputs.frontend == 'true'
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
               with:
                   name: frontend-build
                   path: |
@@ -162,7 +162,7 @@ jobs:
 
             - name: Download frontend build artifacts
               if: needs.changes.outputs.frontend == 'true'
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
               with:
                   name: frontend-build
 
@@ -197,7 +197,7 @@ jobs:
 
             - name: Download frontend build artifacts
               if: needs.changes.outputs.frontend == 'true'
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
               with:
                   name: frontend-build
 
@@ -241,7 +241,7 @@ jobs:
 
             - name: Download frontend build artifacts
               if: needs.changes.outputs.frontend == 'true'
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
               with:
                   name: frontend-build
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Frontend CI is doing a bunch of stuff in series it could be doing in parallel, and we can allocate resources more efficiently

## Changes

- Split kea typegen into it's own job and give it more resources
- Run other longer checks in parallel in separate jobs that depend on typegen and use less resources
