### PR TITLE
fix: close connections before quota limiting runs

### DIFF
--- a/posthog/temporal/quota_limiting/run_quota_limiting.py
+++ b/posthog/temporal/quota_limiting/run_quota_limiting.py
@@ -9,6 +9,7 @@ from posthog.temporal.common.base import PostHogWorkflow
 from posthog.exceptions_capture import capture_exception
 from posthog.temporal.common.heartbeat import Heartbeater
 from asgiref.sync import sync_to_async
+from django.db import close_old_connections
 
 
 logger = structlog.get_logger()
@@ -35,6 +36,7 @@ async def run_quota_limiting_all_orgs(
 
             @sync_to_async
             def async_update_all_orgs_billing_quotas():
+                close_old_connections()
                 update_all_orgs_billing_quotas()
 
             await async_update_all_orgs_billing_quotas()
@@ -42,7 +44,8 @@ async def run_quota_limiting_all_orgs(
             pass
         except Exception as e:
             capture_exception(e)
-            raise
+            # Raise exception without large context to avoid "Failure exceeds size limit"
+            raise Exception(f"Quota limiting failed: {type(e).__name__}: {str(e)[:200]}...")
 
 
 @workflow.defn(name="run-quota-limiting")


### PR DESCRIPTION
## Problem

- Last 3 runs of quota limiting in US have been failing due to `the connection is closed`
- Error messages on Temporal are now shown properly at the top level due to `Failure exceeds size limit`

## Changes

- Close existing/stale connections at the beginning of a run (this is pattern used elsewhere in Temporal runs)
- Truncate the error - full details will be visible via stack trace anyway

## Did you write or update any docs for this change?

- [x] No docs needed for this change

## How did you test this code?

n/a
