### PR TITLE
feat: User create/update and auth flow use case-insens emails

### DIFF
--- a/frontend/src/scenes/authentication/signup/signupForm/panels/SignupPanel1.tsx
+++ b/frontend/src/scenes/authentication/signup/signupForm/panels/SignupPanel1.tsx
@@ -13,7 +13,7 @@ import { signupLogic } from '../signupLogic'
 
 export function SignupPanel1(): JSX.Element | null {
     const { preflight, socialAuthAvailable } = useValues(preflightLogic)
-    const { isSignupPanel1Submitting, validatedPassword, loginUrl } = useValues(signupLogic)
+    const { isSignupPanel1Submitting, validatedPassword, loginUrl, emailCaseNotice } = useValues(signupLogic)
     const emailInputRef = useRef<HTMLInputElement | null>(null)
 
     useEffect(() => {
@@ -31,7 +31,11 @@ export function SignupPanel1(): JSX.Element | null {
                 </>
             )}
             <Form logic={signupLogic} formKey="signupPanel1" className="deprecated-space-y-4" enableFormOnSubmit>
-                <LemonField name="email" label="Email">
+                <LemonField
+                    name="email"
+                    label="Email"
+                    help={emailCaseNotice && <span className="text-warning">{emailCaseNotice}</span>}
+                >
                     <LemonInput
                         className="ph-ignore-input"
                         autoFocus

--- a/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
+++ b/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
@@ -148,7 +148,7 @@ export const signupLogic = kea<signupLogicType>([
         emailCaseNotice: [
             (s) => [s.emailWasNormalized],
             (emailWasNormalized): string | undefined => {
-                return emailWasNormalized ? '⚠ Your email was converted to lowercase!' : undefined
+                return emailWasNormalized ? '⚠ Your email was changed to lowercase!' : undefined
             },
         ],
         loginUrl: [

--- a/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
+++ b/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
@@ -148,7 +148,7 @@ export const signupLogic = kea<signupLogicType>([
         emailCaseNotice: [
             (s) => [s.emailWasNormalized],
             (emailWasNormalized): string | undefined => {
-                return emailWasNormalized ? '⚠ Your email was changed to lowercase!' : undefined
+                return emailWasNormalized ? '⚠ Your email was automatically converted to lowercase' : undefined
             },
         ],
         loginUrl: [

--- a/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
+++ b/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
@@ -1,6 +1,6 @@
 import { lemonToast } from '@posthog/lemon-ui'
 import { isString } from '@tiptap/core'
-import { actions, connect, kea, path, reducers, selectors } from 'kea'
+import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
 import { router, urlToAction } from 'kea-router'
 import api from 'lib/api'
@@ -40,17 +40,25 @@ export const signupLogic = kea<signupLogicType>([
     connect(() => ({
         values: [preflightLogic, ['preflight'], featureFlagLogic, ['featureFlags']],
     })),
-    actions({
+    actions(() => ({
         setPanel: (panel: number) => ({ panel }),
-    }),
-    reducers({
+        normalizeEmailWithDelay: (email: string) => ({ email }),
+        setEmailNormalized: (wasNormalized: boolean) => ({ wasNormalized }),
+    })),
+    reducers(() => ({
         panel: [
             0,
             {
                 setPanel: (_, { panel }) => panel,
             },
         ],
-    }),
+        emailWasNormalized: [
+            false,
+            {
+                setEmailNormalized: (_, { wasNormalized }) => wasNormalized,
+            },
+        ],
+    })),
     forms(({ actions, values }) => ({
         signupPanel1: {
             alwaysShowErrors: true,
@@ -137,6 +145,12 @@ export const signupLogic = kea<signupLogicType>([
                 return validatePassword(password)
             },
         ],
+        emailCaseNotice: [
+            (s) => [s.emailWasNormalized],
+            (emailWasNormalized): string | undefined => {
+                return emailWasNormalized ? '⚠ Your email was converted to lowercase!' : undefined
+            },
+        ],
         loginUrl: [
             () => [router.selectors.searchParams],
             (searchParams: Record<string, string>) => {
@@ -145,6 +159,24 @@ export const signupLogic = kea<signupLogicType>([
             },
         ],
     }),
+    listeners(({ actions }) => ({
+        normalizeEmailWithDelay: async ({ email }, breakpoint) => {
+            await breakpoint(500)
+
+            const hasUppercase = /[A-Z]/.test(email)
+            if (hasUppercase) {
+                const normalizedEmail = email.toLowerCase()
+                actions.setSignupPanel1Value('email', normalizedEmail)
+                actions.setEmailNormalized(true)
+            }
+        },
+        setSignupPanel1Value: ({ name, value }) => {
+            if (name.toString() === 'email' && typeof value === 'string') {
+                actions.setEmailNormalized(false)
+                actions.normalizeEmailWithDelay(value)
+            }
+        },
+    })),
     urlToAction(({ actions, values }) => ({
         '/signup': (_, { email, maintenanceRedirect }) => {
             if (values.preflight?.cloud) {
@@ -165,7 +197,7 @@ export const signupLogic = kea<signupLogicType>([
                     regionOverrideFlag !== values.preflight?.region?.toLowerCase()
                 ) {
                     window.location.href = `https://${
-                        CLOUD_HOSTNAMES[regionOverrideFlag.toUpperCase()]
+                        CLOUD_HOSTNAMES[regionOverrideFlag.toUpperCase() as keyof typeof CLOUD_HOSTNAMES]
                     }${urls.signup()}?maintenanceRedirect=true`
                 }
                 if (maintenanceRedirect && isRegionOverrideValid) {

--- a/posthog/api/organization_invite.py
+++ b/posthog/api/organization_invite.py
@@ -128,7 +128,7 @@ class OrganizationInviteSerializer(serializers.ModelSerializer):
         extra_kwargs = {"target_email": {"required": True, "allow_null": False}}
 
     def validate_target_email(self, email: str):
-        return EmailNormalizer.normalize_case_insensitive(email)
+        return EmailNormalizer.normalize(email)
 
     def validate_level(self, level: int) -> int:
         # Validate that the user can't invite someone with a higher permission level than their own

--- a/posthog/api/organization_invite.py
+++ b/posthog/api/organization_invite.py
@@ -13,6 +13,7 @@ from posthog.api.utils import action
 from posthog.constants import INVITE_DAYS_VALIDITY
 from posthog.email import is_email_available
 from posthog.event_usage import report_bulk_invited, report_team_member_invited
+from posthog.helpers.email_utils import EmailNormalizer
 from posthog.models import OrganizationInvite, OrganizationMembership
 from posthog.models.organization import Organization
 from posthog.models.team.team import Team
@@ -54,7 +55,7 @@ class OrganizationInviteManager:
     ) -> QuerySet:
         filters: dict[str, Any] = {
             "organization_id": organization_id,
-            "target_email": target_email,
+            "target_email__iexact": target_email,
         }
 
         if not include_expired:
@@ -127,8 +128,7 @@ class OrganizationInviteSerializer(serializers.ModelSerializer):
         extra_kwargs = {"target_email": {"required": True, "allow_null": False}}
 
     def validate_target_email(self, email: str):
-        local_part, domain = email.split("@")
-        return f"{local_part}@{domain.lower()}"
+        return EmailNormalizer.normalize_case_insensitive(email)
 
     def validate_level(self, level: int) -> int:
         # Validate that the user can't invite someone with a higher permission level than their own
@@ -233,7 +233,7 @@ class OrganizationInviteSerializer(serializers.ModelSerializer):
     def create(self, validated_data: dict[str, Any], *args: Any, **kwargs: Any) -> OrganizationInvite:
         if OrganizationMembership.objects.filter(
             organization_id=self.context["organization_id"],
-            user__email=validated_data["target_email"],
+            user__email__iexact=validated_data["target_email"],
         ).exists():
             raise exceptions.ValidationError("A user with this email address already belongs to the organization.")
 
@@ -308,13 +308,6 @@ class OrganizationInviteViewSet(
 
     def safely_get_queryset(self, queryset):
         return queryset.select_related("created_by").order_by(self.ordering)
-
-    def lowercase_email_domain(self, email: str):
-        # According to the email RFC https://www.rfc-editor.org/rfc/rfc1035, anything before the @ can be
-        # case-sensitive but the domain should not be. There have been a small number of customers who type in their emails
-        # with a capitalized domain. We shouldn't prevent them from inviting teammates because of this.
-        local_part, domain = email.split("@")
-        return f"{local_part}@{domain.lower()}"
 
     def create(self, request: request.Request, **kwargs) -> response.Response:
         data = cast(Any, request.data.copy())

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -123,14 +123,6 @@ class SignupSerializer(serializers.Serializer):
 
         is_instance_first_user: bool = not User.objects.exists()
 
-        email = validated_data.get("email", "")
-        user_exists = EmailValidationHelper.user_exists(email)
-        if user_exists:
-            raise exceptions.ValidationError(
-                {"email": "There is already an account with this email address."},
-                code="unique",
-            )
-
         organization_name = validated_data.pop("organization_name", f"{validated_data['first_name']}'s Organization")
         role_at_organization = validated_data.pop("role_at_organization", "")
         referral_source = validated_data.pop("referral_source", "")

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -110,7 +110,7 @@ class SignupSerializer(serializers.Serializer):
         return value
 
     def validate_email(self, value):
-        if EmailValidationHelper.user_exists(value):
+        if not settings.DEMO and EmailValidationHelper.user_exists(value):
             raise serializers.ValidationError("There is already an account with this email address.", code="unique")
         return value
 

--- a/posthog/helpers/email_utils.py
+++ b/posthog/helpers/email_utils.py
@@ -90,4 +90,4 @@ class EmailMultiRecordHandler:
 class EmailValidationHelper:
     @staticmethod
     def user_exists(email: str) -> bool:
-        return EmailLookupHandler.get_user_by_email(email, is_active=None) is not None
+        return EmailLookupHandler.get_user_by_email(email) is not None

--- a/posthog/helpers/email_utils.py
+++ b/posthog/helpers/email_utils.py
@@ -1,0 +1,93 @@
+"""
+Provides utilities for handling email addresses with case-insensitive behavior
+while maintaining backwards compatibility with existing data that may have mixed casing.
+"""
+
+import logging
+from typing import Optional, TYPE_CHECKING
+from django.core.exceptions import MultipleObjectsReturned
+from django.db.models import QuerySet
+from django.contrib.auth.models import BaseUserManager
+
+if TYPE_CHECKING:
+    from posthog.models.user import User
+
+logger = logging.getLogger(__name__)
+
+
+class EmailNormalizer:
+    @staticmethod
+    def normalize_case_insensitive(email: str) -> str:
+        if not email:
+            return email
+
+        return BaseUserManager.normalize_email(email).lower()
+
+
+class EmailLookupHandler:
+    @staticmethod
+    def get_user_by_email(email: str, is_active: Optional[bool] = True) -> Optional["User"]:
+        """
+        Get user by email with backwards compatibility.
+        First tries exact match (for existing users), then case-insensitive fallback.
+
+        Handles the edge case where multiple users exist with case variations of the same email
+        (e.g., test@email.com, Test@email.com, TEST@email.com) by:
+        1. Preferring exact case match if it exists
+        2. Returning the first case-insensitive match deterministically if no exact match
+        """
+        from posthog.models.user import User
+
+        queryset = User.objects.filter(is_active=is_active) if is_active else User.objects.all()
+
+        # First try: exact match (preserves existing behavior)
+        try:
+            return queryset.get(email=email)
+        except User.DoesNotExist:
+            pass
+
+        # Second try: case-insensitive match
+        try:
+            return queryset.get(email__iexact=email)
+        except User.DoesNotExist:
+            return None
+        except MultipleObjectsReturned:
+            # Handle multiple case variations of the same email
+            return EmailMultiRecordHandler.handle_multiple_users(
+                queryset.filter(email__iexact=email), email, "user_lookup"
+            )
+
+
+class EmailMultiRecordHandler:
+    """
+    Utility class for handling cases where multiple records exist with case variations of the same email.
+    Provides deterministic behavior and comprehensive logging for monitoring and cleanup.
+    """
+
+    @staticmethod
+    def handle_multiple_users(queryset: QuerySet, email: str, context: str) -> Optional["User"]:
+        """
+        Handle multiple user records with case variations of the same email.
+
+        Returns:
+            Last logged in user deterministically
+        """
+        case_insensitive_matches = queryset.order_by("-last_login")
+        user_count = case_insensitive_matches.count()
+        last_logged_in_user = case_insensitive_matches.first()
+
+        if user_count > 1:
+            email_variations = list(case_insensitive_matches.values_list("email", flat=True))
+            logger.warning(
+                f"Multiple users with case variations of email '{email}' during {context}. "
+                f"Found {user_count} variations: {email_variations}. "
+                f"Returning last logged in user (ID: {last_logged_in_user.id if last_logged_in_user else 'None'})"
+            )
+
+        return last_logged_in_user
+
+
+class EmailValidationHelper:
+    @staticmethod
+    def user_exists(email: str) -> bool:
+        return EmailLookupHandler.get_user_by_email(email, is_active=None) is not None

--- a/posthog/helpers/tests/test_email_utils.py
+++ b/posthog/helpers/tests/test_email_utils.py
@@ -1,0 +1,76 @@
+from django.test import TestCase
+from posthog.helpers.email_utils import (
+    EmailNormalizer,
+    EmailLookupHandler,
+    EmailValidationHelper,
+)
+from posthog.models.user import User
+
+
+class TestEmailNormalizer(TestCase):
+    def test_normalize_case_insensitive(self):
+        """Test that email normalization works correctly."""
+        test_cases = [
+            ("test@EXAMPLE.COM", "test@example.com"),
+            ("TEST@example.com", "test@example.com"),
+            ("Test@Example.Com", "test@example.com"),
+            ("USER@GMAIL.COM", "user@gmail.com"),
+            ("user@gmail.com", "user@gmail.com"),
+            ("User.Name+Tag@Example.ORG", "user.name+tag@example.org"),
+            ("", ""),
+        ]
+
+        for input_email, expected in test_cases:
+            with self.subTest(input_email=input_email):
+                result = EmailNormalizer.normalize_case_insensitive(input_email)
+                self.assertEqual(result, expected)
+
+
+class TestEmailLookupHandler(TestCase):
+    def test_get_user_by_email_no_user(self):
+        """Test getting user by email when none exists."""
+        result = EmailLookupHandler.get_user_by_email("nonexistent@example.com")
+        self.assertIsNone(result)
+
+    def test_get_user_by_email_case_insensitive(self):
+        """Test getting user by email with case variations."""
+        user = User(email="Test@Example.COM", first_name="Test", last_name="User")
+        user.set_password("testpass123")
+        user.save()
+
+        try:
+            test_variations = ["test@example.com", "Test@Example.COM", "TEST@EXAMPLE.COM", "test@EXAMPLE.com"]
+
+            for email_variation in test_variations:
+                with self.subTest(email=email_variation):
+                    found_user = EmailLookupHandler.get_user_by_email(email_variation)
+                    self.assertIsNotNone(found_user)
+                    self.assertEqual(found_user.id, user.id)
+        finally:
+            user.delete()
+
+
+class TestEmailValidationHelper(TestCase):
+    def test_user_exists_no_user(self):
+        """Test checking if user exists when none exists."""
+        result = EmailValidationHelper.user_exists("nonexistent@example.com")
+        self.assertFalse(result)
+
+    def test_user_exists_with_user(self):
+        """Test checking if user exists when user exists."""
+        user = User.objects.create_user(email="TestExists@Example.COM", password="testpass123", first_name="Test")
+
+        try:
+            test_variations = [
+                "testexists@example.com",
+                "TestExists@Example.COM",
+                "TESTEXISTS@EXAMPLE.COM",
+                "testexists@EXAMPLE.com",
+            ]
+
+            for email_variation in test_variations:
+                with self.subTest(email=email_variation):
+                    result = EmailValidationHelper.user_exists(email_variation)
+                    self.assertTrue(result)
+        finally:
+            user.delete()

--- a/posthog/helpers/tests/test_email_utils.py
+++ b/posthog/helpers/tests/test_email_utils.py
@@ -8,7 +8,7 @@ from posthog.models.user import User
 
 
 class TestEmailNormalizer(TestCase):
-    def test_normalize_case_insensitive(self):
+    def test_normalize(self):
         """Test that email normalization works correctly."""
         test_cases = [
             ("test@EXAMPLE.COM", "test@example.com"),
@@ -22,7 +22,7 @@ class TestEmailNormalizer(TestCase):
 
         for input_email, expected in test_cases:
             with self.subTest(input_email=input_email):
-                result = EmailNormalizer.normalize_case_insensitive(input_email)
+                result = EmailNormalizer.normalize(input_email)
                 self.assertEqual(result, expected)
 
 

--- a/posthog/helpers/tests/test_email_utils.py
+++ b/posthog/helpers/tests/test_email_utils.py
@@ -45,7 +45,8 @@ class TestEmailLookupHandler(TestCase):
                 with self.subTest(email=email_variation):
                     found_user = EmailLookupHandler.get_user_by_email(email_variation)
                     self.assertIsNotNone(found_user)
-                    found_user is not None and self.assertEqual(found_user.id, user.id)
+                    if found_user is not None:
+                        self.assertEqual(found_user.id, user.id)
         finally:
             user.delete()
 

--- a/posthog/helpers/tests/test_email_utils.py
+++ b/posthog/helpers/tests/test_email_utils.py
@@ -45,7 +45,7 @@ class TestEmailLookupHandler(TestCase):
                 with self.subTest(email=email_variation):
                     found_user = EmailLookupHandler.get_user_by_email(email_variation)
                     self.assertIsNotNone(found_user)
-                    self.assertEqual(found_user.id, user.id)
+                    found_user is not None and self.assertEqual(found_user.id, user.id)
         finally:
             user.delete()
 

--- a/posthog/models/organization_invite.py
+++ b/posthog/models/organization_invite.py
@@ -86,8 +86,7 @@ class OrganizationInvite(UUIDModel):
         if (
             _email
             and self.target_email
-            and EmailNormalizer.normalize_case_insensitive(_email)
-            != EmailNormalizer.normalize_case_insensitive(self.target_email)
+            and EmailNormalizer.normalize(_email) != EmailNormalizer.normalize(self.target_email)
         ):
             raise exceptions.ValidationError(
                 "This invite is intended for another email address.",

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -64,7 +64,7 @@ class UserManager(BaseUserManager):
         """Create and save a User with the given email and password."""
         if email is None:
             raise ValueError("Email must be provided!")
-        email = EmailNormalizer.normalize_case_insensitive(email)
+        email = EmailNormalizer.normalize(email)
         extra_fields.setdefault("distinct_id", generate_random_token())
         user = self.model(email=email, first_name=first_name, **extra_fields)
         if password is not None:

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -13,6 +13,7 @@ from posthog.cloud_utils import get_cached_instance_license, is_cloud
 from posthog.constants import AvailableFeature
 from posthog.settings import INSTANCE_TAG, SITE_URL
 from posthog.utils import get_instance_realm
+from posthog.helpers.email_utils import EmailNormalizer
 
 from .organization import Organization, OrganizationMembership
 from .personal_api_key import PersonalAPIKey, hash_key_value
@@ -63,7 +64,7 @@ class UserManager(BaseUserManager):
         """Create and save a User with the given email and password."""
         if email is None:
             raise ValueError("Email must be provided!")
-        email = self.normalize_email(email)
+        email = EmailNormalizer.normalize_case_insensitive(email)
         extra_fields.setdefault("distinct_id", generate_random_token())
         user = self.model(email=email, first_name=first_name, **extra_fields)
         if password is not None:


### PR DESCRIPTION
## Problem

- Email signup is case-sensitive, that's nuts.

## Changes

- Makes all new signups to be lowercase emails only.
- On the signup form, if you start typing uppercase letters, it will auto-correct them to lowercase and will pop you a little warning.
<img width="400" alt="image" src="https://github.com/user-attachments/assets/2c1aa42a-d5fe-4475-aeeb-ee6c987a7e4d" />

- For cases where the logic finds multiple old accounts for the same email (different case) it would default to picking the user that logged in most recently.
- Invites are now case-insensitive as well.

TODO:

- Update all users in the db to be lowercase
   - Check for duplicates (multiple users with the same email, just different letter casing). Figure out a way to dedupe them.
- Change authentication to be case-insensitive after that.
- Check how Social auth works if you have an email registration with weird casing, and then Google SSO with a normal email (or vise-versa).

## How did you test this code?

- Manually & automated
