### PR TITLE
fix(hogql): Preserve join type in global joins

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -134,7 +134,6 @@ posthog/hogql/resolver.py:0: error: Incompatible types in assignment (expression
 posthog/hogql/resolver.py:0: error: Incompatible types in assignment (expression has type "TableType", variable has type "LazyTableType")  [assignment]
 posthog/hogql/resolver.py:0: error: Incompatible types in assignment (expression has type "Type | Any | None", variable has type "BaseTableType | SelectSetQueryType | SelectQueryType | SelectQueryAliasType | SelectViewType | None")  [assignment]
 posthog/hogql/resolver.py:0: error: Item "None" of "Database | None" has no attribute "get_table_by_chain"  [union-attr]
-posthog/hogql/resolver.py:0: error: Item "None" of "JoinExpr | None" has no attribute "join_type"  [union-attr]
 posthog/hogql/resolver.py:0: error: Item "None" of "SelectQuery | SelectSetQuery | Placeholder | HogQLXTag | Field | None" has no attribute "type"  [union-attr]
 posthog/hogql/resolver.py:0: error: Item "None" of "SelectQuery | SelectSetQuery | Placeholder | HogQLXTag | Field | None" has no attribute "type"  [union-attr]
 posthog/hogql/resolver.py:0: error: Item "None" of "Type | None" has no attribute "resolve_constant_type"  [union-attr]

--- a/posthog/hogql/database/test/test_s3_table.py
+++ b/posthog/hogql/database/test/test_s3_table.py
@@ -147,6 +147,26 @@ class TestS3Table(BaseTest):
             f"SELECT aapl_stock.High AS High, aapl_stock.Low AS Low FROM events GLOBAL JOIN (SELECT * FROM s3(%(hogql_val_0_sensitive)s, %(hogql_val_1)s)) AS aapl_stock ON equals(aapl_stock.High, events.event) WHERE equals(events.team_id, {self.team.pk}) LIMIT 10",
         )
 
+        clickhouse = self._select(
+            query="SELECT aapl_stock.High, aapl_stock.Low FROM events LEFT JOIN aapl_stock ON aapl_stock.High = events.event LIMIT 10",
+            dialect="clickhouse",
+        )
+
+        self.assertEqual(
+            clickhouse,
+            f"SELECT aapl_stock.High AS High, aapl_stock.Low AS Low FROM events GLOBAL LEFT JOIN (SELECT * FROM s3(%(hogql_val_2_sensitive)s, %(hogql_val_3)s)) AS aapl_stock ON equals(aapl_stock.High, events.event) WHERE equals(events.team_id, {self.team.pk}) LIMIT 10",
+        )
+
+        clickhouse = self._select(
+            query="SELECT aapl_stock.High, aapl_stock.Low FROM events RIGHT JOIN aapl_stock ON aapl_stock.High = events.event LIMIT 10",
+            dialect="clickhouse",
+        )
+
+        self.assertEqual(
+            clickhouse,
+            f"SELECT aapl_stock.High AS High, aapl_stock.Low AS Low FROM events GLOBAL RIGHT JOIN (SELECT * FROM s3(%(hogql_val_4_sensitive)s, %(hogql_val_5)s)) AS aapl_stock ON equals(aapl_stock.High, events.event) WHERE equals(events.team_id, {self.team.pk}) LIMIT 10",
+        )
+
     def test_s3_table_select_alias_escaped(self):
         self._init_database()
 

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -532,7 +532,9 @@ class _Printer(Visitor):
 
                 # Edge case. If we are joining an s3 table, we must wrap it in a subquery for the join to work
                 if isinstance(table_type.table, S3Table) and (
-                    node.next_join or node.join_type == "JOIN" or node.join_type == "GLOBAL JOIN"
+                    node.next_join
+                    or node.join_type == "JOIN"
+                    or (node.join_type and node.join_type.startswith("GLOBAL "))
                 ):
                     sql = f"(SELECT * FROM {sql})"
             else:

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -377,8 +377,8 @@ class Resolver(CloningVisitor):
             else:
                 is_global = isinstance(node.type.table, EventsTable) and self._is_next_s3(node.next_join)
 
-            if is_global:
-                node.next_join.join_type = "GLOBAL JOIN"
+            if is_global and node.next_join is not None:
+                node.next_join.join_type = f"GLOBAL {node.next_join.join_type}"
 
             if node.constraint and node.constraint.constraint_type == "ON":
                 node.constraint = self.visit_join_constraint(node.constraint)


### PR DESCRIPTION
## Problem
- When joining a S3/warehouse table onto a distributed table (`events`), we replace the join with a `GLOBAL JOIN`, ignoring whatever the initial join type was (e.g. we'd drop the `LEFT` in a left join) - this means users queries dont respond the way they should
- https://posthog.slack.com/archives/C019RAX2XBN/p1750425125456929

## Changes
- Preserve the join type when upgrading the join to a global join

## How did you test this code?
Unit tests