### PR TITLE
fix: consistently serialize assignee json

### DIFF
--- a/rust/cymbal/src/assignment_rules.rs
+++ b/rust/cymbal/src/assignment_rules.rs
@@ -78,6 +78,32 @@ pub struct Assignment {
     pub created_at: DateTime<Utc>,
 }
 
+#[derive(Serialize)]
+#[serde(tag = "type", content = "id", rename_all = "lowercase")]
+pub enum Assignee {
+    User(i32),
+    Role(Uuid),
+}
+
+impl TryFrom<&Assignment> for Assignee {
+    type Error = UnhandledError;
+
+    fn try_from(a: &Assignment) -> Result<Self, Self::Error> {
+        match (a.user_id, a.role_id) {
+            (Some(user_id), None) => Ok(Assignee::User(user_id)),
+            (None, Some(role_id)) => Ok(Assignee::Role(role_id)),
+            (None, None) => Err(UnhandledError::Other(format!(
+                "No assignee specified in assignment {}",
+                a.id
+            ))),
+            _ => Err(UnhandledError::Other(format!(
+                "Multiple assignee types set in assignment {}",
+                a.id
+            ))),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct AssignmentRule {
     pub id: Uuid,

--- a/rust/cymbal/src/issue_resolution.rs
+++ b/rust/cymbal/src/issue_resolution.rs
@@ -453,6 +453,7 @@ impl Display for IssueStatus {
 
 #[cfg(test)]
 mod test {
+    use crate::sanitize_string;
 
     #[test]
     fn it_replaces_null_characters() {


### PR DESCRIPTION
## Problem

Based on this thread https://posthog.slack.com/archives/C06GG249PR6/p1750409547899519

## Changes

Makes sure to serialize in the correct order