### PR TITLE
refactor: New transformer interface for batch exports

### DIFF
--- a/posthog/temporal/batch_exports/spmc.py
+++ b/posthog/temporal/batch_exports/spmc.py
@@ -1254,15 +1254,14 @@ class ConsumerFromStage:
                 yield record_batch
 
         try:
-            async for chunk, is_eof in transformer.iter_transformed_record_batches(
+            async for chunk, is_eof in transformer.iter(
                 track_iteration_of_record_batches(),
                 max_file_size_bytes,
             ):
-                if is_eof and not chunk:
-                    await self.finalize_file()
-                    continue
-
                 await self.consume_chunk(data=chunk)
+
+                if is_eof:
+                    await self.finalize_file()
 
             # Finalize upload
             await self.finalize()

--- a/posthog/temporal/batch_exports/transformer.py
+++ b/posthog/temporal/batch_exports/transformer.py
@@ -67,7 +67,7 @@ class JSONLStreamTransformer:
         self.compression = compression
         self.max_workers = max_workers
 
-        self._futures_pending = set()
+        self._futures_pending: set[asyncio.Future[list[bytes]]] = set()
         self._semaphore = asyncio.Semaphore(max_workers)
 
     async def iter(
@@ -156,7 +156,7 @@ class JSONLBrotliStreamTransformer:
         self.include_inserted_at = include_inserted_at
         self.max_workers = max_workers
 
-        self._futures_pending = set()
+        self._futures_pending: set[asyncio.Future[list[bytes]]] = set()
         self._semaphore = asyncio.Semaphore(max_workers)
         self._brotli_compressor = brotli.Compressor()
 

--- a/posthog/temporal/batch_exports/transformer.py
+++ b/posthog/temporal/batch_exports/transformer.py
@@ -1,11 +1,12 @@
-import abc
 import asyncio
+import collections
 import collections.abc
 import concurrent.futures
+import contextlib
 import gzip
+import io
 import json
 import typing
-from io import BytesIO
 
 import brotli
 import orjson
@@ -15,6 +16,327 @@ import structlog
 from django.conf import settings
 
 logger = structlog.get_logger()
+
+
+class Chunk(typing.NamedTuple):
+    """A chunk of bytes indicating if they are at the end of a file."""
+
+    data: bytes
+    is_eof: bool
+
+
+class Transformer(typing.Protocol):
+    """Transformer protocol iterating record batches into chunks of bytes."""
+
+    async def iter(
+        self, record_batches: collections.abc.AsyncIterable[pa.RecordBatch], max_file_size_bytes: int = 0
+    ) -> collections.abc.AsyncGenerator[Chunk]: ...
+
+
+def get_stream_transformer(
+    format: str, compression: str | None = None, schema: pa.Schema | None = None, include_inserted_at: bool = False
+) -> Transformer:
+    match format.lower():
+        case "jsonlines" if compression != "brotli":
+            return JSONLStreamTransformer(compression=compression, include_inserted_at=include_inserted_at)
+        case "jsonlines" if compression == "brotli":
+            return JSONLBrotliStreamTransformer(include_inserted_at=include_inserted_at)
+        case "parquet":
+            if schema is None:
+                raise ValueError("Schema is required for Parquet")
+            return ParquetStreamTransformer(
+                compression=compression, schema=schema, include_inserted_at=include_inserted_at
+            )
+        case _:
+            raise ValueError(f"Unsupported format: {format}")
+
+
+class JSONLStreamTransformer:
+    """A transformer to convert record batches into lines of JSON.
+
+    Each record in a record batch corresponds to one JSON line.
+    """
+
+    def __init__(
+        self,
+        compression: str | None = None,
+        include_inserted_at: bool = False,
+        max_workers: int = settings.BATCH_EXPORT_TRANSFORMER_MAX_WORKERS,
+    ):
+        self.include_inserted_at = include_inserted_at
+        self.compression = compression
+        self.max_workers = max_workers
+
+        self._futures_pending = set()
+        self._semaphore = asyncio.Semaphore(max_workers)
+
+    async def iter(
+        self, record_batches: collections.abc.AsyncIterable[pa.RecordBatch], max_file_size_bytes: int = 0
+    ) -> collections.abc.AsyncGenerator[Chunk]:
+        """Distribute transformation of record batches into multiple processes.
+
+        The multiprocess pipeline works as follows:
+        1. Start a `ProcessPoolExecutor` with a number of workers to distribute
+           the workload.
+        2. Spawn a producer asyncio task to iterate through record batches,
+           and spawn multiprocessing tasks for the workers.
+        3. We use a `asyncio.Semaphore` to block the producer loop to avoid
+           spawning up too many multiprocessing tasks at a time.
+        4. The consumer main thread waits on futures as they are done, and
+           iterates through chunks.
+        """
+        current_file_size = 0
+
+        with concurrent.futures.ProcessPoolExecutor(max_workers=self.max_workers) as executor:
+            async with self._record_batches_producer(record_batches, executor) as producer_task:
+                while True:
+                    try:
+                        done, _ = await asyncio.wait(self._futures_pending, return_when=asyncio.FIRST_COMPLETED)
+                    except ValueError:
+                        if producer_task.done():
+                            break
+
+                        await asyncio.sleep(0)
+                        continue
+
+                    for future in done:
+                        chunk = await future
+                        self._semaphore.release()
+                        self._futures_pending.remove(future)
+
+                        while chunk:
+                            if max_file_size_bytes and current_file_size + len(chunk) > max_file_size_bytes:
+                                remaining = max_file_size_bytes - current_file_size
+                                smaller_chunk, chunk = chunk[:remaining], chunk[remaining:]
+
+                                yield Chunk(smaller_chunk, False)
+                                yield Chunk(b"", True)
+
+                                current_file_size = 0
+
+                            else:
+                                yield Chunk(chunk, False)
+                                current_file_size += len(chunk)
+                                chunk = b""
+
+    @contextlib.asynccontextmanager
+    async def _record_batches_producer(
+        self,
+        record_batches: collections.abc.AsyncIterable[pa.RecordBatch],
+        executor: concurrent.futures.ProcessPoolExecutor,
+    ):
+        """Manage a task to produce record batches to run in executor."""
+        loop = asyncio.get_running_loop()
+
+        async def producer():
+            """Produce record batches to execute in process pool."""
+            async for record_batch in record_batches:
+                _ = await self._semaphore.acquire()
+
+                future = loop.run_in_executor(
+                    executor, dump_record_batch, record_batch, self.compression, self.include_inserted_at
+                )
+                self._futures_pending.add(future)
+
+        producer_task = asyncio.create_task(producer())
+
+        try:
+            yield producer_task
+        finally:
+            if not producer_task.done():
+                _ = producer_task.cancel()
+
+            try:
+                await producer_task
+            except asyncio.CancelledError:
+                pass
+
+
+class JSONLBrotliStreamTransformer:
+    def __init__(
+        self,
+        include_inserted_at: bool = False,
+        max_workers: int = settings.BATCH_EXPORT_TRANSFORMER_MAX_WORKERS,
+    ):
+        self.include_inserted_at = include_inserted_at
+        self.max_workers = max_workers
+
+        self._futures_pending = set()
+        self._semaphore = asyncio.Semaphore(max_workers)
+        self._brotli_compressor = brotli.Compressor()
+
+    async def iter(
+        self, record_batches: collections.abc.AsyncIterable[pa.RecordBatch], max_file_size_bytes: int = 0
+    ) -> collections.abc.AsyncGenerator[Chunk]:
+        """Distribute transformation of record batches into multiple processes.
+
+        This supports brotli compression by compressing only in the main
+        process. So, the brotli compressor keeps the necessary state to finalize
+        every file.
+
+        See `JSONLStreamTransformer` for an outline of the pipeline.
+        """
+        current_file_size = 0
+
+        with concurrent.futures.ProcessPoolExecutor(max_workers=self.max_workers) as executor:
+            async with self._record_batches_producer(record_batches, executor) as producer_task:
+                while True:
+                    try:
+                        done, _ = await asyncio.wait(self._futures_pending, return_when=asyncio.FIRST_COMPLETED)
+                    except ValueError:
+                        if producer_task.done():
+                            break
+
+                        await asyncio.sleep(0)
+                        continue
+
+                    for future in done:
+                        chunk = await future
+                        self._semaphore.release()
+                        self._futures_pending.remove(future)
+
+                        chunk = self._compress(chunk)
+                        await asyncio.sleep(0)  # In case compressing took too long.
+
+                        while chunk:
+                            if max_file_size_bytes and current_file_size + len(chunk) > max_file_size_bytes:
+                                remaining = max_file_size_bytes - current_file_size
+                                smaller_chunk, chunk = chunk[:remaining], chunk[remaining:]
+
+                                yield Chunk(smaller_chunk, False)
+
+                                data = await asyncio.to_thread(self._finish_brotli_compressor)
+
+                                yield Chunk(data, True)
+                                current_file_size = 0
+                            else:
+                                yield Chunk(chunk, False)
+                                current_file_size += len(chunk)
+                                chunk = b""
+
+        data = self._finish_brotli_compressor()
+        await asyncio.sleep(0)
+        yield Chunk(data, True)
+
+    @contextlib.asynccontextmanager
+    async def _record_batches_producer(
+        self,
+        record_batches: collections.abc.AsyncIterable[pa.RecordBatch],
+        executor: concurrent.futures.ProcessPoolExecutor,
+    ):
+        """Manage a task to produce record batches to run in executor."""
+        loop = asyncio.get_running_loop()
+
+        async def producer():
+            """Produce record batches to execute in process pool."""
+            async for record_batch in record_batches:
+                _ = await self._semaphore.acquire()
+
+                future = loop.run_in_executor(executor, dump_record_batch, record_batch, None, self.include_inserted_at)
+                self._futures_pending.add(future)
+
+        producer_task = asyncio.create_task(producer())
+
+        try:
+            yield producer_task
+        finally:
+            if not producer_task.done():
+                _ = producer_task.cancel()
+
+            try:
+                await producer_task
+            except asyncio.CancelledError:
+                pass
+
+    def _compress(self, content: bytes | str) -> bytes:
+        """Compress using brotli."""
+        if isinstance(content, str):
+            encoded = content.encode("utf-8")
+        else:
+            encoded = content
+
+        self._brotli_compressor.process(encoded)
+        return self._brotli_compressor.flush()
+
+    def _finish_brotli_compressor(self) -> bytes:
+        """Flush remaining brotli bytes."""
+        bytes = self._brotli_compressor.finish()
+        self._brotli_compressor = None
+        return bytes
+
+
+def dump_record_batch(
+    record_batch: pa.RecordBatch,
+    compression: str | None,
+    include_inserted_at: bool = False,
+) -> bytes:
+    """Dump all records in a record batch to JSON lines."""
+    column_names = record_batch.column_names
+    if not include_inserted_at:
+        _ = column_names.pop(column_names.index("_inserted_at"))
+
+    def compress(content: bytes):
+        match compression:
+            case "gzip":
+                return gzip.compress(content)
+            case None:
+                return content
+            case _:
+                raise ValueError(f"Unsupported compression: '{compression}'")
+
+    dumped = b""
+    for record_dict in record_batch.select(column_names).to_pylist():
+        if not record_dict:
+            continue
+
+        if compression:
+            dumped += compress(dump_dict(record_dict))
+        else:
+            dumped += dump_dict(record_dict)
+
+    return dumped
+
+
+def dump_dict(d: dict[str, typing.Any]) -> bytes:
+    """Dump a dictionary to a line of JSON."""
+    try:
+        dumped = orjson.dumps(d, default=str) + b"\n"
+    except orjson.JSONEncodeError as err:
+        # NOTE: `orjson.JSONEncodeError` is actually just an alias for `TypeError`.
+        # This handler will catch everything coming from orjson, so we have to
+        # awkwardly check error messages.
+        if str(err) == "Recursion limit reached":
+            # Orjson enforces an unmodifiable recursion limit (256), so we can't
+            # dump very nested dicts.
+            if d.get("event", None) == "$web_vitals":
+                # These are PostHog events that for a while included a bunch of
+                # nested DOM structures. Eventually, this was removed, but these
+                # events could still be present in database.
+                # Let's try to clear the key with nested elements first.
+                try:
+                    del d["properties"]["$web_vitals_INP_event"]["attribution"]["interactionTargetElement"]
+                except KeyError:
+                    # We tried, fallback to the slower but more permissive stdlib
+                    # json.
+                    logger.exception("PostHog $web_vitals event didn't match expected structure")
+                    dumped = json.dumps(d, default=str).encode("utf-8") + b"\n"
+                else:
+                    dumped = orjson.dumps(d, default=str) + b"\n"
+
+            else:
+                # In this case, we fallback to the slower but more permissive stdlib
+                # json.
+                logger.exception("Orjson detected a deeply nested dict: %s", d)
+                dumped = json.dumps(d, default=str).encode("utf-8") + b"\n"
+        else:
+            # Orjson is very strict about invalid unicode. This slow path protects us
+            # against things we've observed in practice, like single surrogate codes, e.g.
+            # "\ud83d"
+            logger.exception("Failed to encode with orjson: %s", d)
+            cleaned_content = replace_broken_unicode(d)
+            dumped = orjson.dumps(cleaned_content, default=str) + b"\n"
+
+    return dumped
 
 
 def replace_broken_unicode(obj):
@@ -39,245 +361,9 @@ def json_dumps_bytes(d) -> bytes:
         return orjson.dumps(cleaned_d, default=str)
 
 
-def get_stream_transformer(
-    format: str, compression: str | None = None, schema: pa.Schema | None = None, include_inserted_at: bool = False
-) -> "StreamTransformer":
-    match format.lower():
-        case "jsonlines":
-            return JSONLStreamTransformer(compression=compression, include_inserted_at=include_inserted_at)
-        case "parquet":
-            if schema is None:
-                raise ValueError("Schema is required for Parquet")
-            return ParquetStreamTransformer(
-                compression=compression, schema=schema, include_inserted_at=include_inserted_at
-            )
-        case _:
-            raise ValueError(f"Unsupported format: {format}")
+class ParquetStreamTransformer:
+    """A transformer to convert record batches into Parquet."""
 
-
-class StreamTransformer:
-    """Transforms PyArrow RecordBatches to different formats with compression"""
-
-    def __init__(self, compression: str | None = None, include_inserted_at: bool = False):
-        self.compression = compression.lower() if compression else None
-        self.include_inserted_at = include_inserted_at
-
-        self._brotli_compressor = None
-
-    def transform_batch(self, batch: pa.RecordBatch) -> typing.Generator[bytes, None, None]:
-        """Transform a single batch and yield compressed bytes"""
-        column_names = batch.column_names
-        if not self.include_inserted_at:
-            column_names.pop(column_names.index("_inserted_at"))
-
-        yield from self.write_batch(batch.select(column_names))
-
-    async def iter_transformed_record_batches(
-        self, record_batches: collections.abc.AsyncIterator[pa.RecordBatch], max_file_size_bytes: int = 0
-    ) -> collections.abc.AsyncIterator[tuple[bytes, bool]]:
-        """Iterate over record batches transforming them into chunks."""
-        current_file_size = 0
-
-        async for record_batch in record_batches:
-            for chunk in self.transform_batch(record_batch):
-                yield (chunk, False)
-
-                current_file_size += len(chunk)
-
-                if max_file_size_bytes and current_file_size > max_file_size_bytes:
-                    for chunk in self.finalize():
-                        yield (chunk, False)
-
-                    yield (b"", True)
-                    current_file_size = 0
-
-        for chunk in self.finalize():
-            yield (chunk, False)
-
-    def finalize(self) -> typing.Generator[bytes, None, None]:
-        """Finalize and yield any remaining data"""
-        if self.compression == "brotli":
-            yield self.brotli_compressor.finish()
-
-    @abc.abstractmethod
-    def write_batch(self, batch: pa.RecordBatch) -> typing.Generator[bytes, None, None]:
-        """Write a batch to the output format"""
-        raise NotImplementedError("Subclasses must implement write_batch")
-
-    def compress(self, content: bytes | str) -> bytes:
-        if isinstance(content, str):
-            encoded = content.encode("utf-8")
-        else:
-            encoded = content
-
-        match self.compression:
-            case "gzip":
-                return gzip.compress(encoded)
-            case "brotli":
-                self.brotli_compressor.process(encoded)
-                return self.brotli_compressor.flush()
-            case None:
-                return encoded
-            case _:
-                raise ValueError(f"Unsupported compression: '{self.compression}'")
-
-    @property
-    def brotli_compressor(self):
-        if self._brotli_compressor is None:
-            self._brotli_compressor = brotli.Compressor()
-        return self._brotli_compressor
-
-    def finish_brotli_compressor(self) -> typing.Generator[bytes, None, None]:
-        """Flush remaining brotli bytes."""
-        if self.compression != "brotli":
-            raise ValueError(f"Compression is '{self.compression}', not 'brotli'")
-
-        yield self.brotli_compressor.finish()
-        self._brotli_compressor = None
-
-
-class JSONLStreamTransformer(StreamTransformer):
-    def _write_dict(self, d: dict[str, typing.Any]) -> typing.Generator[bytes, None, None]:
-        """Write a single row of JSONL."""
-        try:
-            data_gen = self._write(orjson.dumps(d, default=str) + b"\n")
-        except orjson.JSONEncodeError as err:
-            # NOTE: `orjson.JSONEncodeError` is actually just an alias for `TypeError`.
-            # This handler will catch everything coming from orjson, so we have to
-            # awkwardly check error messages.
-            if str(err) == "Recursion limit reached":
-                # Orjson enforces an unmodifiable recursion limit (256), so we can't
-                # dump very nested dicts.
-                if d.get("event", None) == "$web_vitals":
-                    # These are PostHog events that for a while included a bunch of
-                    # nested DOM structures. Eventually, this was removed, but these
-                    # events could still be present in database.
-                    # Let's try to clear the key with nested elements first.
-                    try:
-                        del d["properties"]["$web_vitals_INP_event"]["attribution"]["interactionTargetElement"]
-                    except KeyError:
-                        # We tried, fallback to the slower but more permissive stdlib
-                        # json.
-                        logger.exception("PostHog $web_vitals event didn't match expected structure")
-                        dumped = json.dumps(d, default=str).encode("utf-8")
-                        data_gen = self._write(dumped + b"\n")
-                    else:
-                        dumped = orjson.dumps(d, default=str)
-                        data_gen = self._write(dumped + b"\n")
-
-                else:
-                    # In this case, we fallback to the slower but more permissive stdlib
-                    # json.
-                    logger.exception("Orjson detected a deeply nested dict: %s", d)
-                    dumped = json.dumps(d, default=str).encode("utf-8")
-                    data_gen = self._write(dumped + b"\n")
-            else:
-                # Orjson is very strict about invalid unicode. This slow path protects us
-                # against things we've observed in practice, like single surrogate codes, e.g.
-                # "\ud83d"
-                logger.exception("Failed to encode with orjson: %s", d)
-                cleaned_content = replace_broken_unicode(d)
-                data_gen = self._write(orjson.dumps(cleaned_content, default=str) + b"\n")
-        yield from data_gen
-
-    def write_batch(self, record_batch: pa.RecordBatch) -> typing.Generator[bytes, None, None]:
-        """Write records to a temporary file as JSONL."""
-        for record_dict in record_batch.to_pylist():
-            if not record_dict:
-                continue
-
-            yield from self._write_dict(record_dict)
-
-    def _write(self, content: bytes | str):
-        """Write bytes to underlying file keeping track of how many bytes were written."""
-        compressed_content = self.compress(content)
-        yield compressed_content
-
-    async def iter_transformed_record_batches(
-        self, record_batches: collections.abc.AsyncIterator[pa.RecordBatch], max_file_size_bytes: int = 0
-    ) -> collections.abc.AsyncIterator[tuple[bytes, bool]]:
-        """Distribute transformation of record batches into multiple processes.
-
-        This is only supported for non-brotli compressed batch exports, so we
-        default to the parent implementation when using brotli compression.
-
-        The multiprocess pipeline works as follows:
-        1. Start a `ProcessPoolExecutor` with a number of workers to distribute
-           the workload.
-        2. Spawn a producer asyncio task to iterate through record batches,
-           and spawn multiprocessing tasks for the workers.
-        3. We use a `asyncio.Semaphore` to block the producer loop to avoid
-           spawning up too many multiprocessing tasks at a time.
-        4. The consumer main thread waits on futures as they are done, and
-           iterates through chunks.
-        """
-        if self.compression == "brotli":
-            async for t in super().iter_transformed_record_batches(record_batches, max_file_size_bytes):
-                yield t
-            return
-
-        max_workers = settings.BATCH_EXPORT_TRANSFORMER_MAX_WORKERS
-        loop = asyncio.get_running_loop()
-        current_file_size = 0
-        futures_pending = set()
-        semaphore = asyncio.Semaphore(max_workers)
-
-        async def producer(executor: concurrent.futures.ProcessPoolExecutor):
-            nonlocal futures_pending
-
-            async for record_batch in record_batches:
-                _ = await semaphore.acquire()
-
-                future = loop.run_in_executor(executor, transform_record_batch, record_batch, self)
-                futures_pending.add(future)
-
-        with concurrent.futures.ProcessPoolExecutor(max_workers=max_workers) as executor:
-            producer_task = asyncio.create_task(producer(executor))
-
-            try:
-                while True:
-                    try:
-                        done, _ = await asyncio.wait(futures_pending, return_when=asyncio.FIRST_COMPLETED)
-                    except ValueError:
-                        if producer_task.done():
-                            if exception := producer_task.exception():
-                                raise exception
-                            else:
-                                break
-
-                        await asyncio.sleep(0)
-                        continue
-
-                    for future in done:
-                        chunks = await future
-                        semaphore.release()
-                        futures_pending.remove(future)
-
-                        for chunk in chunks:
-                            yield (chunk, False)
-
-                            current_file_size += len(chunk)
-
-                            if max_file_size_bytes and current_file_size > max_file_size_bytes:
-                                for chunk in self.finalize():
-                                    yield (chunk, False)
-
-                                yield (b"", True)
-                                current_file_size = 0
-
-                for chunk in self.finalize():
-                    yield (chunk, False)
-            finally:
-                if not producer_task.done():
-                    producer_task.cancel()
-
-                    try:
-                        await producer_task
-                    except asyncio.CancelledError:
-                        pass
-
-
-class ParquetStreamTransformer(StreamTransformer):
     def __init__(
         self,
         schema: pa.Schema,
@@ -285,13 +371,43 @@ class ParquetStreamTransformer(StreamTransformer):
         compression_level: int | None = None,
         include_inserted_at: bool = False,
     ):
-        super().__init__(compression=compression, include_inserted_at=include_inserted_at)
+        self.include_inserted_at = include_inserted_at
         self.schema = schema
+        self.compression = compression
         self.compression_level = compression_level
 
         # For Parquet, we need to handle schema and batching
         self._parquet_writer: pq.ParquetWriter | None = None
-        self._parquet_buffer = BytesIO()
+        self._parquet_buffer = io.BytesIO()
+
+    async def iter(
+        self, record_batches: collections.abc.AsyncIterable[pa.RecordBatch], max_file_size_bytes: int = 0
+    ) -> collections.abc.AsyncGenerator[Chunk]:
+        """Iterate over record batches transforming them into chunks."""
+        current_file_size = 0
+
+        async for record_batch in record_batches:
+            chunk = await asyncio.to_thread(self.write_record_batch, record_batch)
+
+            while chunk:
+                if max_file_size_bytes and current_file_size + len(chunk) > max_file_size_bytes:
+                    remaining = max_file_size_bytes - current_file_size
+                    smaller_chunk, chunk = chunk[:remaining], chunk[remaining:]
+
+                    yield Chunk(smaller_chunk, False)
+
+                    footer = await asyncio.to_thread(self.finish_parquet_file)
+
+                    yield Chunk(footer, True)
+                    current_file_size = 0
+
+                else:
+                    yield Chunk(chunk, False)
+                    current_file_size += len(chunk)
+                    chunk = b""
+
+        footer = await asyncio.to_thread(self.finish_parquet_file)
+        yield Chunk(footer, True)
 
     @property
     def parquet_writer(self) -> pq.ParquetWriter:
@@ -305,42 +421,26 @@ class ParquetStreamTransformer(StreamTransformer):
         assert self._parquet_writer is not None
         return self._parquet_writer
 
-    def finalize(self) -> typing.Generator[bytes, None, None]:
-        """Ensure underlying Parquet writer is closed before flushing and closing temporary file."""
-        yield from super().finalize()
+    def finish_parquet_file(self) -> bytes:
+        """Ensure underlying Parquet writer is closed before flushing buffer."""
+        self.parquet_writer.close()
 
-        if self._parquet_writer is not None:
-            self._parquet_writer.close()
-            self._parquet_writer = None
+        final_data = self._parquet_buffer.getvalue()
 
-            # Get final data without copying
-            final_data = self._parquet_buffer.getvalue()
-            if final_data:
-                yield final_data
+        self._parquet_buffer = io.BytesIO()
 
-            # Cleanup
-            self._parquet_buffer.close()
-            self._parquet_buffer = BytesIO()
+        return final_data
 
-    def write_batch(self, record_batch: pa.RecordBatch) -> typing.Generator[bytes, None, None]:
-        """Write records to a temporary file as Parquet."""
+    def write_record_batch(self, record_batch: pa.RecordBatch) -> bytes:
+        """Write record batch to buffer as Parquet."""
+        column_names = self.parquet_writer.schema.names
+        if not self.include_inserted_at:
+            column_names.pop(column_names.index("_inserted_at"))
 
-        self.parquet_writer.write_batch(record_batch.select(self.parquet_writer.schema.names))
+        self.parquet_writer.write_batch(record_batch.select(column_names))
         data = self._parquet_buffer.getvalue()
 
         self._parquet_buffer.seek(0)
         self._parquet_buffer.truncate(0)
 
-        yield data
-
-
-def transform_record_batch(record_batch, transformer: StreamTransformer):
-    """Top level function to run transformers in multiprocessing.
-
-    Record batches are processed in separate processes.
-    """
-    processed = list(transformer.transform_batch(record_batch))
-    return processed
-
-
-# TODO: Implement other transformers
+        return data

--- a/posthog/temporal/batch_exports/transformer.py
+++ b/posthog/temporal/batch_exports/transformer.py
@@ -367,6 +367,7 @@ class ParquetStreamTransformer:
         current_file_size = 0
 
         async for record_batch in record_batches:
+            # Running write in a thread to yield control back to event loop.
             chunk = await asyncio.to_thread(self.write_record_batch, record_batch)
 
             yield Chunk(chunk, False)

--- a/posthog/temporal/batch_exports/transformer.py
+++ b/posthog/temporal/batch_exports/transformer.py
@@ -25,7 +25,7 @@ class Chunk(typing.NamedTuple):
     is_eof: bool
 
 
-class Transformer(typing.Protocol):
+class _TransformerProtocol(typing.Protocol):
     """Transformer protocol iterating record batches into chunks of bytes."""
 
     async def iter(
@@ -35,7 +35,7 @@ class Transformer(typing.Protocol):
 
 def get_stream_transformer(
     format: str, compression: str | None = None, schema: pa.Schema | None = None, include_inserted_at: bool = False
-) -> Transformer:
+) -> _TransformerProtocol:
     match format.lower():
         case "jsonlines" if compression != "brotli":
             return JSONLStreamTransformer(compression=compression, include_inserted_at=include_inserted_at)

--- a/posthog/temporal/batch_exports/transformer.py
+++ b/posthog/temporal/batch_exports/transformer.py
@@ -406,6 +406,7 @@ class ParquetStreamTransformer:
     def finish_parquet_file(self) -> bytes:
         """Ensure underlying Parquet writer is closed before flushing buffer."""
         self.parquet_writer.close()
+        self._parquet_writer = None
 
         final_data = self._parquet_buffer.getvalue()
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

This PR changes the `StreamTransformer` interface introduced for batch exports. I mostly didn't like how inflexible it was, but there are a bunch of other things I've changed too.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

First of all, I am now using a protocol instead of subclassing. The name of the new protocol is `Transformer`. The reality is that each file format is doing its own thing, and protocols give us more flexibility.

The `Transformer` protocol is really simple: Just requires a method that iterates over record batches and delivers `Chunk`s.

Introduced a new tuple type `Chunk` which contains the bytes we are streaming and whether we are at EOF.

Brotli now does multiprocessing too, but compression happens in the main process due to the satteful compressor.

I think files may have been not finishing at the correct place if the record batches were too large, so this corrects that too. Not sure if this had any impact on anything, but essentially: If a record batch exceeded the `max_file_size_bytes` when converted to parquet, we would yield those bytes and then mark the end of the file. But that means the file would be larger than `max_file_size_bytes` by the difference between the parquet bytes and `max_file_size_bytes`.

EDIT: This is still a problem, can't fix it here.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
