### PR TITLE
perf(batch-exports): Improve performance of ParquetWriter

### DIFF
--- a/posthog/temporal/batch_exports/transformer.py
+++ b/posthog/temporal/batch_exports/transformer.py
@@ -301,6 +301,7 @@ class ParquetStreamTransformer(StreamTransformer):
                 schema=self.schema,
                 compression="none" if self.compression is None else self.compression,  # type: ignore
                 compression_level=self.compression_level,
+                write_statistics=False,  # Disable statistics to improve performance
             )
         assert self._parquet_writer is not None
         return self._parquet_writer


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Writing Parquet data is the most CPU intensive part of batch exports that use Parquet as a format. This is currently a bottleneck.

## Changes

Set `write_statistics=False`, which seems to improve speed by around 2x.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

Running existing tests
