### PR TITLE
feat(persons): Person Batch Shadow Mode improvements

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
@@ -334,7 +334,6 @@ describe('BatchWritingPersonStore', () => {
                     existing_prop: 'existing_value',
                     new_prop: 'new_value',
                     shared_prop: 'new_value',
-                    test: 'test',
                 },
             }),
             undefined,

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
@@ -157,8 +157,8 @@ describe('BatchWritingPersonStore', () => {
         const assertVersionStore = new BatchWritingPersonsStore(db, { dbWriteMode: 'ASSERT_VERSION' })
         const personStoreForBatch = assertVersionStore.forBatch()
 
-        // Mock optimistic update to fail
-        db.updatePersonAssertVersion = jest.fn().mockResolvedValue(undefined) // version mismatch
+        // Mock optimistic update to fail (version mismatch)
+        db.updatePersonAssertVersion = jest.fn().mockResolvedValue(undefined)
 
         // Add a person update to cache
         await personStoreForBatch.updatePersonForUpdate(person, { properties: { new_value: 'new_value' } }, 'test')
@@ -689,5 +689,78 @@ describe('BatchWritingPersonStore', () => {
                 expect(db.updatePersonAssertVersion).toHaveBeenCalledTimes(1) // ASSERT_VERSION mode
             })
         })
+    })
+
+    it('should handle concurrent updates with ASSERT_VERSION mode and preserve both properties', async () => {
+        // Use ASSERT_VERSION mode for this test since it tests optimistic behavior
+        const assertVersionStore = new BatchWritingPersonsStore(db, {
+            dbWriteMode: 'ASSERT_VERSION',
+        })
+        const personStoreForBatch = assertVersionStore.forBatch()
+
+        // Initial person in database with 2 properties
+        const initialPerson = {
+            ...person,
+            version: 1,
+            properties: {
+                existing_prop1: 'initial_value1',
+                existing_prop2: 'initial_value2',
+            },
+        }
+
+        // Simulate that another pod directly writes to the database
+        // This increases the version and updates one property
+        const updatedByOtherPod = {
+            ...initialPerson,
+            version: 2,
+            properties: {
+                existing_prop1: 'updated_by_other_pod',
+                existing_prop2: 'initial_value2', // This property stays the same
+            },
+        }
+
+        // Mock optimistic update to fail on first try, succeed on retry
+        // Completely replace the mock from beforeEach
+        db.updatePersonAssertVersion = jest
+            .fn()
+            .mockResolvedValueOnce(undefined) // First call fails (version mismatch)
+            .mockResolvedValueOnce(3) // Second call succeeds with new version
+
+        // Mock fetchPerson to return the updated person when called during conflict resolution
+        db.fetchPerson = jest.fn().mockResolvedValue(updatedByOtherPod)
+
+        // Process an event that will override one of the properties
+        // We pass the initial person directly, so no initial fetch is needed
+        await personStoreForBatch.updatePersonForUpdate(
+            initialPerson,
+            { properties: { existing_prop2: 'updated_by_this_pod' } },
+            'test'
+        )
+
+        // Flush should trigger optimistic update, fail, then merge and retry
+        await personStoreForBatch.flush()
+
+        // Verify the optimistic update was attempted (should be called twice: once initially, once on retry)
+        expect(db.updatePersonAssertVersion).toHaveBeenCalledTimes(2)
+
+        // Verify fetchPerson was called once during conflict resolution
+        expect(db.fetchPerson).toHaveBeenCalledTimes(1)
+
+        // Since the second retry succeeds, there should be no fallback to updatePerson
+        expect(db.updatePerson).not.toHaveBeenCalled()
+
+        // Verify the second call to updatePersonAssertVersion had the merged properties
+        expect(db.updatePersonAssertVersion).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                version: 3, // Should use the latest version from the database
+                properties: {
+                    existing_prop1: 'updated_by_other_pod', // Preserved from other pod's update
+                    existing_prop2: 'updated_by_this_pod', // Updated by this pod
+                },
+                property_changeset: {
+                    existing_prop2: 'updated_by_this_pod', // Only the changed property should be in changeset
+                },
+            })
+        )
     })
 })

--- a/plugin-server/src/worker/ingestion/persons/metrics.ts
+++ b/plugin-server/src/worker/ingestion/persons/metrics.ts
@@ -103,6 +103,12 @@ export const personShadowModeComparisonCounter = new Counter({
     labelNames: ['outcome_type'],
 })
 
+export const personShadowModeReturnIntermediateOutcomeCounter = new Counter({
+    name: 'person_shadow_mode_return_intermediate_outcome_total',
+    help: 'Person shadow mode intermediate comparison results for updatePersonForUpdate and updatePersonForMerge methods',
+    labelNames: ['method', 'outcome'],
+})
+
 export function getVersionBucketLabel(version: number): string {
     if (version === 0) {
         return 'v0'

--- a/plugin-server/src/worker/ingestion/persons/person-store-manager.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-store-manager.test.ts
@@ -714,4 +714,234 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
             )
         })
     })
+
+    describe('compareUpdateResults', () => {
+        const logger = require('../../../utils/logger').logger
+        const { personShadowModeReturnStepOutcomeCounter } = require('./metrics')
+
+        beforeEach(() => {
+            jest.clearAllMocks()
+            // Mock the metric counter
+            personShadowModeReturnStepOutcomeCounter.labels = jest.fn().mockReturnValue({
+                inc: jest.fn(),
+            })
+        })
+
+        it('should track consistent results and log debug message', async () => {
+            const update = { properties: { test_prop: 'test_value' } }
+
+            // Mock both stores to return the same result
+            const expectedPerson = { ...person, properties: { test: 'test', test_prop: 'test_value' }, version: 2 }
+            db.updatePerson = jest.fn().mockResolvedValue([expectedPerson, [], false])
+
+            await shadowManager.updatePersonForUpdate(person, update, 'test-distinct')
+
+            // Verify metric was incremented for consistent outcome
+            expect(personShadowModeReturnStepOutcomeCounter.labels).toHaveBeenCalledWith(
+                'updatePersonForUpdate',
+                'consistent'
+            )
+        })
+
+        it('should track inconsistent results and log error message for updatePersonForUpdate', async () => {
+            const update = { properties: { test_prop: 'test_value' } }
+
+            // Mock main store to return one result
+            const mainPerson = { ...person, properties: { test: 'test', test_prop: 'test_value' }, version: 2 }
+            db.updatePerson = jest.fn().mockResolvedValue([mainPerson, [], false])
+
+            // Mock secondary store to return different result by manipulating its internal state
+            const secondaryPerson = {
+                ...person,
+                properties: { test: 'test', different_prop: 'different_value' },
+                version: 2,
+            }
+
+            // We'll need to manually set up the secondary store to return different data
+            // Since the secondary store doesn't actually call the DB, we need to mock its updatePersonForUpdate method
+            const originalUpdatePersonForUpdate = batchStoreForBatch.updatePersonForUpdate
+            batchStoreForBatch.updatePersonForUpdate = jest.fn().mockResolvedValue([secondaryPerson, [], false])
+
+            await shadowManager.updatePersonForUpdate(person, update, 'test-distinct')
+
+            // Restore original method
+            batchStoreForBatch.updatePersonForUpdate = originalUpdatePersonForUpdate
+
+            // Verify metric was incremented for inconsistent outcome
+            expect(personShadowModeReturnStepOutcomeCounter.labels).toHaveBeenCalledWith(
+                'updatePersonForUpdate',
+                'inconsistent'
+            )
+
+            // Verify error log was called with detailed information
+            expect(logger.error).toHaveBeenCalledWith(
+                'updatePersonForUpdate returned inconsistent results between stores',
+                expect.objectContaining({
+                    key: '1:test-distinct',
+                    teamId: 1,
+                    distinctId: 'test-distinct',
+                    methodName: 'updatePersonForUpdate',
+                    samePersonResult: false,
+                    differences: expect.arrayContaining([expect.stringContaining('person.properties')]),
+                    mainPersonUuid: mainPerson.uuid,
+                    secondaryPersonUuid: secondaryPerson.uuid,
+                    mainVersionDisparity: false,
+                })
+            )
+        })
+
+        it('should track inconsistent results and log error message for updatePersonForMerge', async () => {
+            const update = { properties: { merge_prop: 'merge_value' } }
+
+            // Mock main store to return one result
+            const mainPerson = { ...person, properties: { test: 'test', merge_prop: 'merge_value' }, version: 2 }
+            db.updatePerson = jest.fn().mockResolvedValue([mainPerson, [], false])
+
+            // Mock secondary store to return different result
+            const secondaryPerson = { ...person, properties: { test: 'test', wrong_merge: 'wrong_value' }, version: 2 }
+            const originalUpdatePersonForMerge = batchStoreForBatch.updatePersonForMerge
+            batchStoreForBatch.updatePersonForMerge = jest.fn().mockResolvedValue([secondaryPerson, [], false])
+
+            await shadowManager.updatePersonForMerge(person, update, 'test-distinct')
+
+            // Restore original method
+            batchStoreForBatch.updatePersonForMerge = originalUpdatePersonForMerge
+
+            // Verify metric was incremented for inconsistent outcome
+            expect(personShadowModeReturnStepOutcomeCounter.labels).toHaveBeenCalledWith(
+                'updatePersonForMerge',
+                'inconsistent'
+            )
+
+            // Verify error log was called
+            expect(logger.error).toHaveBeenCalledWith(
+                'updatePersonForMerge returned inconsistent results between stores',
+                expect.objectContaining({
+                    key: '1:test-distinct',
+                    teamId: 1,
+                    distinctId: 'test-distinct',
+                    methodName: 'updatePersonForMerge',
+                    samePersonResult: false,
+                    differences: expect.arrayContaining([expect.stringContaining('person.properties')]),
+                    mainPersonUuid: mainPerson.uuid,
+                    secondaryPersonUuid: secondaryPerson.uuid,
+                })
+            )
+        })
+
+        it('should handle null vs non-null person comparison', async () => {
+            const update = { properties: { test_prop: 'test_value' } }
+
+            // Mock main store to return a person
+            const mainPerson = { ...person, properties: { test: 'test', test_prop: 'test_value' }, version: 2 }
+            db.updatePerson = jest.fn().mockResolvedValue([mainPerson, [], false])
+
+            // Mock secondary store to return null (no person found)
+            const originalUpdatePersonForUpdate = batchStoreForBatch.updatePersonForUpdate
+            batchStoreForBatch.updatePersonForUpdate = jest.fn().mockResolvedValue([null as any, [], false])
+
+            await shadowManager.updatePersonForUpdate(person, update, 'test-distinct')
+
+            // Restore original method
+            batchStoreForBatch.updatePersonForUpdate = originalUpdatePersonForUpdate
+
+            // Verify metric was incremented for inconsistent outcome
+            expect(personShadowModeReturnStepOutcomeCounter.labels).toHaveBeenCalledWith(
+                'updatePersonForUpdate',
+                'inconsistent'
+            )
+
+            // Verify error log includes null comparison
+            expect(logger.error).toHaveBeenCalledWith(
+                'updatePersonForUpdate returned inconsistent results between stores',
+                expect.objectContaining({
+                    samePersonResult: false,
+                    mainPersonUuid: mainPerson.uuid,
+                    secondaryPersonUuid: undefined,
+                })
+            )
+        })
+
+        it('should detect differences in nested properties', async () => {
+            const update = {
+                properties: {
+                    nested: {
+                        deep: {
+                            prop: 'value',
+                        },
+                    },
+                },
+            }
+
+            // Mock main store result
+            const mainPerson = {
+                ...person,
+                properties: {
+                    test: 'test',
+                    nested: {
+                        deep: {
+                            prop: 'value',
+                        },
+                    },
+                },
+                version: 2,
+            }
+            db.updatePerson = jest.fn().mockResolvedValue([mainPerson, [], false])
+
+            // Mock secondary store with different nested value
+            const secondaryPerson = {
+                ...person,
+                properties: {
+                    test: 'test',
+                    nested: {
+                        deep: {
+                            prop: 'different_value',
+                        },
+                    },
+                },
+                version: 2,
+            }
+            const originalUpdatePersonForUpdate = batchStoreForBatch.updatePersonForUpdate
+            batchStoreForBatch.updatePersonForUpdate = jest.fn().mockResolvedValue([secondaryPerson, [], false])
+
+            await shadowManager.updatePersonForUpdate(person, update, 'test-distinct')
+
+            // Restore original method
+            batchStoreForBatch.updatePersonForUpdate = originalUpdatePersonForUpdate
+
+            // Verify specific nested property difference is captured
+            expect(logger.error).toHaveBeenCalledWith(
+                'updatePersonForUpdate returned inconsistent results between stores',
+                expect.objectContaining({
+                    differences: expect.arrayContaining([
+                        expect.stringContaining('person.properties.nested.deep.prop'),
+                    ]),
+                })
+            )
+        })
+
+        it('should ignore version differences in comparison', async () => {
+            const update = { properties: { test_prop: 'test_value' } }
+
+            // Mock main store to return person with version 2
+            const mainPerson = { ...person, properties: { test: 'test', test_prop: 'test_value' }, version: 2 }
+            db.updatePerson = jest.fn().mockResolvedValue([mainPerson, [], false])
+
+            // Mock secondary store to return same person but with version 3 (should be ignored)
+            const secondaryPerson = { ...person, properties: { test: 'test', test_prop: 'test_value' }, version: 3 }
+            const originalUpdatePersonForUpdate = batchStoreForBatch.updatePersonForUpdate
+            batchStoreForBatch.updatePersonForUpdate = jest.fn().mockResolvedValue([secondaryPerson, [], false])
+
+            await shadowManager.updatePersonForUpdate(person, update, 'test-distinct')
+
+            // Restore original method
+            batchStoreForBatch.updatePersonForUpdate = originalUpdatePersonForUpdate
+
+            // Verify result is considered consistent despite version difference
+            expect(personShadowModeReturnStepOutcomeCounter.labels).toHaveBeenCalledWith(
+                'updatePersonForUpdate',
+                'consistent'
+            )
+        })
+    })
 })

--- a/plugin-server/src/worker/ingestion/persons/person-store-manager.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-store-manager.test.ts
@@ -717,12 +717,12 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
 
     describe('compareUpdateResults', () => {
         const logger = require('../../../utils/logger').logger
-        const { personShadowModeReturnStepOutcomeCounter } = require('./metrics')
+        const { personShadowModeReturnIntermediateOutcomeCounter } = require('./metrics')
 
         beforeEach(() => {
             jest.clearAllMocks()
             // Mock the metric counter
-            personShadowModeReturnStepOutcomeCounter.labels = jest.fn().mockReturnValue({
+            personShadowModeReturnIntermediateOutcomeCounter.labels = jest.fn().mockReturnValue({
                 inc: jest.fn(),
             })
         })
@@ -737,7 +737,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
             await shadowManager.updatePersonForUpdate(person, update, 'test-distinct')
 
             // Verify metric was incremented for consistent outcome
-            expect(personShadowModeReturnStepOutcomeCounter.labels).toHaveBeenCalledWith(
+            expect(personShadowModeReturnIntermediateOutcomeCounter.labels).toHaveBeenCalledWith(
                 'updatePersonForUpdate',
                 'consistent'
             )
@@ -768,7 +768,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
             batchStoreForBatch.updatePersonForUpdate = originalUpdatePersonForUpdate
 
             // Verify metric was incremented for inconsistent outcome
-            expect(personShadowModeReturnStepOutcomeCounter.labels).toHaveBeenCalledWith(
+            expect(personShadowModeReturnIntermediateOutcomeCounter.labels).toHaveBeenCalledWith(
                 'updatePersonForUpdate',
                 'inconsistent'
             )
@@ -808,7 +808,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
             batchStoreForBatch.updatePersonForMerge = originalUpdatePersonForMerge
 
             // Verify metric was incremented for inconsistent outcome
-            expect(personShadowModeReturnStepOutcomeCounter.labels).toHaveBeenCalledWith(
+            expect(personShadowModeReturnIntermediateOutcomeCounter.labels).toHaveBeenCalledWith(
                 'updatePersonForMerge',
                 'inconsistent'
             )
@@ -838,7 +838,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
 
             // Mock secondary store to return null (no person found)
             const originalUpdatePersonForUpdate = batchStoreForBatch.updatePersonForUpdate
-            batchStoreForBatch.updatePersonForUpdate = jest.fn().mockResolvedValue([null as any, [], false])
+            batchStoreForBatch.updatePersonForUpdate = jest.fn().mockResolvedValue([null, [], false])
 
             await shadowManager.updatePersonForUpdate(person, update, 'test-distinct')
 
@@ -846,7 +846,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
             batchStoreForBatch.updatePersonForUpdate = originalUpdatePersonForUpdate
 
             // Verify metric was incremented for inconsistent outcome
-            expect(personShadowModeReturnStepOutcomeCounter.labels).toHaveBeenCalledWith(
+            expect(personShadowModeReturnIntermediateOutcomeCounter.labels).toHaveBeenCalledWith(
                 'updatePersonForUpdate',
                 'inconsistent'
             )
@@ -938,7 +938,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
             batchStoreForBatch.updatePersonForUpdate = originalUpdatePersonForUpdate
 
             // Verify result is considered consistent despite version difference
-            expect(personShadowModeReturnStepOutcomeCounter.labels).toHaveBeenCalledWith(
+            expect(personShadowModeReturnIntermediateOutcomeCounter.labels).toHaveBeenCalledWith(
                 'updatePersonForUpdate',
                 'consistent'
             )

--- a/plugin-server/src/worker/ingestion/persons/person-store-manager.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-store-manager.test.ts
@@ -469,7 +469,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
 
             // Test that reportBatch logs the errors
             shadowManager.reportBatch()
-            expect(logger.error).toHaveBeenCalledWith(
+            expect(logger.info).toHaveBeenCalledWith(
                 'Shadow mode detected logic errors in batch writing store',
                 expect.objectContaining({
                     logicErrorCount: 1,
@@ -677,7 +677,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
             )
 
             // Verify logic error was logged
-            expect(logger.error).toHaveBeenCalledWith(
+            expect(logger.info).toHaveBeenCalledWith(
                 'Shadow mode detected logic errors in batch writing store',
                 expect.objectContaining({
                     logicErrorCount: 1,
@@ -774,7 +774,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
             )
 
             // Verify error log was called with detailed information
-            expect(logger.error).toHaveBeenCalledWith(
+            expect(logger.info).toHaveBeenCalledWith(
                 'updatePersonForUpdate returned inconsistent results between stores',
                 expect.objectContaining({
                     key: '1:test-distinct',
@@ -814,7 +814,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
             )
 
             // Verify error log was called
-            expect(logger.error).toHaveBeenCalledWith(
+            expect(logger.info).toHaveBeenCalledWith(
                 'updatePersonForMerge returned inconsistent results between stores',
                 expect.objectContaining({
                     key: '1:test-distinct',
@@ -852,7 +852,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
             )
 
             // Verify error log includes null comparison
-            expect(logger.error).toHaveBeenCalledWith(
+            expect(logger.info).toHaveBeenCalledWith(
                 'updatePersonForUpdate returned inconsistent results between stores',
                 expect.objectContaining({
                     samePersonResult: false,
@@ -910,7 +910,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
             batchStoreForBatch.updatePersonForUpdate = originalUpdatePersonForUpdate
 
             // Verify specific nested property difference is captured
-            expect(logger.error).toHaveBeenCalledWith(
+            expect(logger.info).toHaveBeenCalledWith(
                 'updatePersonForUpdate returned inconsistent results between stores',
                 expect.objectContaining({
                     differences: expect.arrayContaining([

--- a/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
@@ -313,7 +313,7 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
 
             // Log logic errors with high priority
             if (this.shadowMetrics.logicErrors.length > 0) {
-                logger.error('Shadow mode detected logic errors in batch writing store', {
+                logger.info('Shadow mode detected logic errors in batch writing store', {
                     logicErrorCount: this.shadowMetrics.logicErrors.length,
                     totalComparisons: this.shadowMetrics.totalComparisons,
                     errorRate: logicErrorRate,
@@ -436,7 +436,7 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
             // Track inconsistent results in metrics
             personShadowModeReturnIntermediateOutcomeCounter.labels(methodName, 'inconsistent').inc()
 
-            logger.error(`${methodName} returned inconsistent results between stores`, {
+            logger.info(`${methodName} returned inconsistent results between stores`, {
                 key,
                 teamId,
                 distinctId,

--- a/plugin-server/src/worker/ingestion/persons/person-update-batch.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-update-batch.ts
@@ -16,6 +16,8 @@ export interface PersonUpdate {
     is_identified: boolean
     is_user_id: number | null
     needs_write: boolean
+    // Track only the properties that were changed in this batch
+    property_changeset: Properties
 }
 
 export interface PersonPropertyUpdate {
@@ -39,6 +41,7 @@ export function fromInternalPerson(person: InternalPerson, distinctId: string): 
         is_identified: person.is_identified,
         is_user_id: person.is_user_id,
         needs_write: false,
+        property_changeset: {},
     }
 }
 
@@ -89,4 +92,23 @@ export function calculatePersonPropertyUpdate(
     })
 
     return result
+}
+
+/**
+ * Merges properties using changeset-based approach for conflict resolution.
+ * Only applies properties that were actually changed in this batch.
+ */
+export function mergePersonPropertiesWithChangeset(
+    latestProperties: Properties,
+    personUpdate: PersonUpdate
+): Properties {
+    // Start with the latest properties from the database
+    const mergedProperties = { ...latestProperties }
+
+    // Apply only the properties that were changed in this batch
+    Object.entries(personUpdate.property_changeset).forEach(([key, value]) => {
+        mergedProperties[key] = value
+    })
+
+    return mergedProperties
 }

--- a/plugin-server/src/worker/ingestion/persons/person-update-batch.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-update-batch.ts
@@ -107,7 +107,11 @@ export function mergePersonPropertiesWithChangeset(
 
     // Apply only the properties that were changed in this batch
     Object.entries(personUpdate.property_changeset).forEach(([key, value]) => {
-        mergedProperties[key] = value
+        if (value === undefined || value === null) {
+            delete mergedProperties[key]
+        } else {
+            mergedProperties[key] = value
+        }
     })
 
     return mergedProperties


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem



## Changes

- Add metrics to evaluate changes every update called in a batch, this enables us to know if the intermediate returned values are correct
- Fix scenario where if we have another pod writing to the same row, we wouldn't reflect partial updates correctly, in order to solve this we introduced a partial changes variable to record partial changes in cache
- Fix writing shadow Metrics report when no comparisons were made 

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
