### PR TITLE
fix(batch-exports): Update sessions model schema in UI

### DIFF
--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigurationLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigurationLogic.tsx
@@ -230,7 +230,7 @@ const sessionsTable: DatabaseSchemaBatchExportTable = {
         },
         session_id_v7: {
             name: 'session_id_v7',
-            type: 'integer',
+            type: 'string',
             hogql_value: 'session_id_v7',
             schema_valid: true,
         },


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We incorrectly display `session_id_v7` as an `integer` when it is in fact a `string`. We do the conversion [here](https://github.com/PostHog/posthog/blob/7f1e35d1a5269fe693c45c7c78d6d3ab6d49233d/posthog/temporal/batch_exports/sql.py#L431)

## Changes

Update schema

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
