### PR TITLE
feat: Stop disabling session replay when no allowed domains are set

### DIFF
--- a/rust/feature-flags/src/handler/config_response_builder.rs
+++ b/rust/feature-flags/src/handler/config_response_builder.rs
@@ -796,7 +796,7 @@ mod tests {
 
         // Should return config (enabled) when recording_domains is empty list
         if let Some(SessionRecordingField::Config(_)) = result {
-            assert!(true); // Dummy assertion, test passes if we get here
+            // Test passes if we reach this point
         } else {
             panic!("Expected SessionRecordingField::Config when recording_domains is empty list");
         }
@@ -814,7 +814,7 @@ mod tests {
 
         // Should return config (enabled) when recording_domains is empty list
         if let Some(SessionRecordingField::Config(_)) = result {
-            assert!(true); // Dummy assertion, test passes if we get here
+            // Test passes if we reach this point
         } else {
             panic!("Expected SessionRecordingField::Config when recording_domains is empty list");
         }

--- a/rust/feature-flags/src/handler/config_response_builder.rs
+++ b/rust/feature-flags/src/handler/config_response_builder.rs
@@ -783,4 +783,40 @@ mod tests {
             panic!("Expected SessionRecordingField::Config without script_config");
         }
     }
+
+    #[test]
+    fn test_session_recording_empty_domains_allowed() {
+        let config = Config::default_test_config();
+        let mut team = create_base_team();
+        team.session_recording_opt_in = true;
+        team.recording_domains = Some(vec![]); // Empty domains list
+
+        let headers = axum::http::HeaderMap::new();
+        let result = session_recording::session_recording_config_response(&team, &headers, &config);
+
+        // Should return config (enabled) when recording_domains is empty list
+        if let Some(SessionRecordingField::Config(_)) = result {
+            assert!(true); // Dummy assertion, test passes if we get here
+        } else {
+            panic!("Expected SessionRecordingField::Config when recording_domains is empty list");
+        }
+    }
+
+    #[test]
+    fn test_session_recording_no_domains_allowed() {
+        let config = Config::default_test_config();
+        let mut team = create_base_team();
+        team.session_recording_opt_in = true;
+        team.recording_domains = None; // No domains list
+
+        let headers = axum::http::HeaderMap::new();
+        let result = session_recording::session_recording_config_response(&team, &headers, &config);
+
+        // Should return config (enabled) when recording_domains is empty list
+        if let Some(SessionRecordingField::Config(_)) = result {
+            assert!(true); // Dummy assertion, test passes if we get here
+        } else {
+            panic!("Expected SessionRecordingField::Config when recording_domains is empty list");
+        }
+    }
 }

--- a/rust/feature-flags/src/handler/session_recording.rs
+++ b/rust/feature-flags/src/handler/session_recording.rs
@@ -203,7 +203,7 @@ mod tests {
     }
 
     #[test]
-    fn test_session_recording_domain_not_allowed_with_empty_domains() {
+    fn test_session_recording_domain_allowed_with_empty_domains() {
         use axum::http::HeaderMap;
 
         let mut team = Team::default();

--- a/rust/feature-flags/src/handler/session_recording.rs
+++ b/rust/feature-flags/src/handler/session_recording.rs
@@ -206,8 +206,10 @@ mod tests {
     fn test_session_recording_domain_allowed_with_empty_domains() {
         use axum::http::HeaderMap;
 
-        let mut team = Team::default();
-        team.recording_domains = Some(vec![]);
+        let team = Team {
+            recording_domains: Some(vec![]),
+            ..Team::default()
+        };
 
         let headers = HeaderMap::new();
 

--- a/rust/feature-flags/src/handler/session_recording.rs
+++ b/rust/feature-flags/src/handler/session_recording.rs
@@ -128,7 +128,7 @@ pub fn session_recording_config_response(
 }
 
 fn session_recording_domain_not_allowed(team: &Team, headers: &HeaderMap) -> bool {
-    matches!(&team.recording_domains, Some(domains) if !on_permitted_recording_domain(domains, headers))
+    matches!(&team.recording_domains, Some(domains) if !domains.is_empty() && !on_permitted_recording_domain(domains, headers))
 }
 
 fn hostname_in_allowed_url_list(allowed: &Vec<String>, hostname: Option<&str>) -> bool {
@@ -200,5 +200,18 @@ mod tests {
         let result = get_linked_flag_value(Some(config));
 
         assert_eq!(result, Some(Value::String("record_sessions".to_string())));
+    }
+
+    #[test]
+    fn test_session_recording_domain_not_allowed_with_empty_domains() {
+        use axum::http::HeaderMap;
+
+        let mut team = Team::default();
+        team.recording_domains = Some(vec![]);
+
+        let headers = HeaderMap::new();
+
+        // Empty domains list should allow recording (return false)
+        assert!(!session_recording_domain_not_allowed(&team, &headers));
     }
 }


### PR DESCRIPTION
The behavior is different to the one we have on /decide. Let's put them in sync.

We're now enabling session recording by default when no domains are listed.

