### PR TITLE
fix(capture-rs): custom deserialize Compression enum to enable Axum form/param handling

### DIFF
--- a/rust/capture/src/utils.rs
+++ b/rust/capture/src/utils.rs
@@ -99,6 +99,7 @@ pub fn extract_compression(
         match ct.to_str().unwrap_or("UNKNOWN") {
             "gzip" | "gzip-js" => Compression::Gzip,
             "lz64" | "lz-string" => Compression::LZString,
+            "base64" | "b64" => Compression::Base64,
             _ => Compression::Unsupported,
         }
     } else {


### PR DESCRIPTION
## Problem
Support tickets have surfaced some errors on event submission with very old SDKs where Axum is attempting to deserialize `capture-rs`'s `Compression` enum prior to handler code seeing the corresponding form value or URL query param input, and failing the event submission.

## Changes
* Adds custom `Deserializer` implementation with proper handling of unexpected inputs to `Compression` enum
* Adds unit test suite to ensure this doesn't break existing handling code or Axum form and URL query param parsing

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Locally, and in CI (new unit tests)