### PR TITLE
feat(capture): remove capture.py route assignments

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -44,21 +44,11 @@ from .utils_cors import cors_response
 
 ALWAYS_ALLOWED_ENDPOINTS = [
     "decide",
-    "engage",
-    "track",
-    "capture",
-    "batch",
-    "e",
-    "s",
     "static",
     "_health",
     "flags",
     "messaging-preferences",
 ]
-
-if DEBUG:
-    # /i/ is the new root path for capture endpoints
-    ALWAYS_ALLOWED_ENDPOINTS.append("i")
 
 default_cookie_options = {
     "max_age": 365 * 24 * 60 * 60,  # one year
@@ -69,7 +59,7 @@ default_cookie_options = {
     "samesite": "Strict",
 }
 
-cookie_api_paths_to_ignore = {"e", "s", "capture", "batch", "decide", "api", "track", "flags"}
+cookie_api_paths_to_ignore = {"decide", "api", "flags"}
 
 
 class AllowIPMiddleware:

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -224,12 +224,6 @@ urlpatterns = [
     # ingestion
     # NOTE: When adding paths here that should be public make sure to update ALWAYS_ALLOWED_ENDPOINTS in middleware.py
     opt_slash_path("decide", decide.get_decide),
-    opt_slash_path("e", capture.get_event),
-    opt_slash_path("engage", capture.get_event),
-    opt_slash_path("track", capture.get_event),
-    opt_slash_path("capture", capture.get_event),
-    opt_slash_path("batch", capture.get_event),
-    opt_slash_path("s", capture.get_event),  # session recordings
     opt_slash_path("report", capture.get_csp_event),  # CSP violation reports
     opt_slash_path("robots.txt", robots_txt),
     opt_slash_path(".well-known/security.txt", security_txt),


### PR DESCRIPTION
## Problem
`capture.py` Django routes are idle now in all deploy and local dev envs. Let's remove them entirely from the app ✅ 

## Changes
* Remove `capture.py` endpoints from `urls.py`:
    * `capture`
    * `track`
    * `engage`
    * `e`
    * `s`
    * `batch`

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Local dev & CI