### PR TITLE
feat: tag temporal jobs ClickHouse queries

### DIFF
--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -25,6 +25,7 @@ from posthog.cloud_utils import is_cloud
 from posthog.errors import wrap_query_error, ch_error_type
 from posthog.exceptions import ClickhouseAtCapacity
 from posthog.settings import CLICKHOUSE_PER_TEAM_QUERY_SETTINGS, TEST, API_QUERIES_ON_ONLINE_CLUSTER
+from posthog.temporal.common.clickhouse import update_query_tags_with_temporal_info
 from posthog.utils import generate_short_id, patchable
 
 QUERY_STARTED_COUNTER = Counter(
@@ -173,6 +174,9 @@ def sync_execute(
         elif tags.kind == "request" and "api/" in tags_id and "capture" not in tags_id:
             # process requests made to API from the PH app
             ch_user = ClickHouseUser.APP
+
+    # update tags if inside temporal (should not)
+    update_query_tags_with_temporal_info()
 
     while True:
         settings = {

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -42,6 +42,13 @@ class QueryTags(BaseModel):
     id: Optional[str] = None
     session_id: Optional[uuid.UUID] = None
 
+    # temporalio tags
+    workflow: Optional[str] = None
+    workflow_id: Optional[str] = None
+    workflow_run_id: Optional[str] = None
+    activity: Optional[str] = None
+    activity_id: Optional[str] = None
+
     query: Optional[object] = None
     query_settings: Optional[object] = None
     query_time_range_days: Optional[int] = None

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -4,6 +4,7 @@ import uuid
 from enum import StrEnum
 from collections.abc import Generator
 from contextlib import contextmanager, suppress
+
 from pydantic import BaseModel, ConfigDict
 from typing import Any, Optional
 
@@ -32,6 +33,22 @@ class Feature(StrEnum):
     DASHBOARD = "dashboard"
 
 
+class TemporalTags(BaseModel):
+    """
+    Tags for temporalio workflows and activities.
+    """
+
+    workflow_namespace: Optional[str] = None
+    workflow_type: Optional[str] = None
+    workflow_id: Optional[str] = None
+    workflow_run_id: Optional[str] = None
+    activity_type: Optional[str] = None
+    activity_id: Optional[str] = None
+    attempt: Optional[int] = None
+
+    model_config = ConfigDict(validate_assignment=True, use_enum_values=True)
+
+
 class QueryTags(BaseModel):
     team_id: Optional[int] = None
     user_id: Optional[int] = None
@@ -43,11 +60,7 @@ class QueryTags(BaseModel):
     session_id: Optional[uuid.UUID] = None
 
     # temporalio tags
-    workflow: Optional[str] = None
-    workflow_id: Optional[str] = None
-    workflow_run_id: Optional[str] = None
-    activity: Optional[str] = None
-    activity_id: Optional[str] = None
+    temporal: Optional[TemporalTags] = None
 
     query: Optional[object] = None
     query_settings: Optional[object] = None
@@ -111,11 +124,15 @@ class QueryTags(BaseModel):
     container_hostname: str
     service_name: str
 
-    model_config = ConfigDict(validate_assignment=True)
+    model_config = ConfigDict(validate_assignment=True, use_enum_values=True)
 
     def update(self, **kwargs):
         for field, value in kwargs.items():
             setattr(self, field, value)
+
+    def with_temporal(self, temporal_tags: TemporalTags):
+        self.kind = "temporal"
+        self.temporal = temporal_tags
 
     def to_json(self) -> str:
         return self.model_dump_json(exclude_none=True)

--- a/posthog/clickhouse/test/test_query_tagging.py
+++ b/posthog/clickhouse/test/test_query_tagging.py
@@ -10,6 +10,7 @@ from posthog.clickhouse.query_tagging import (
     Product,
     get_query_tag_value,
     create_base_tags,
+    TemporalTags,
 )
 import pytest
 from pydantic import ValidationError
@@ -18,6 +19,18 @@ from pydantic import ValidationError
 def test_create_base_tags():
     qt = create_base_tags(container_hostname="my-new-hostname")
     assert qt.container_hostname == "test"
+
+
+def test_with_temporal():
+    qt = create_base_tags()
+    qt.with_temporal(TemporalTags(workflow_type="wt"))
+    assert qt.model_dump(exclude_none=True) == {
+        "container_hostname": "test",
+        "git_commit": "test",
+        "kind": "temporal",
+        "service_name": "test",
+        "temporal": {"workflow_type": "wt"},
+    }
 
 
 def test_simple_query_tags():

--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -11,6 +11,7 @@ with workflow.unsafe.imports_passed_through():
     from django.conf import settings
     from django.core.management.base import BaseCommand
 
+from posthog.clickhouse.query_tagging import tag_queries
 from posthog.constants import (
     BATCH_EXPORTS_TASK_QUEUE,
     DATA_MODELING_TASK_QUEUE,
@@ -177,6 +178,8 @@ class Command(BaseCommand):
         metrics_port = int(options["metrics_port"])
 
         shutdown_task = None
+
+        tag_queries(kind="temporal")
 
         def shutdown_worker_on_signal(worker: Worker, sig: signal.Signals, loop: asyncio.events.AbstractEventLoop):
             """Shutdown Temporal worker on receiving signal."""

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -16,7 +16,10 @@ import pyarrow as pa
 import requests
 import structlog
 from django.conf import settings
+from temporalio import activity
 
+from posthog.clickhouse import query_tagging
+from posthog.clickhouse.query_tagging import get_query_tags, QueryTags
 from posthog.exceptions_capture import capture_exception
 import posthog.temporal.common.asyncpa as asyncpa
 from posthog.temporal.common.logger import get_internal_logger
@@ -236,6 +239,32 @@ class ClickHouseQueryNotFound(ClickHouseError):
         super().__init__(query, f"Query with ID '{query_id}' was not found in query log")
 
 
+def update_query_tags_with_temporal_info(query_tags: typing.Optional[QueryTags] = None):
+    """
+    Updates query_tags with a temporal workflow's properties.
+
+    :param query_tags: QueryTags object to update, if None, then the global object is updated.
+    :return:
+    """
+    if not activity.in_activity():
+        return
+    if not query_tags:
+        query_tags = get_query_tags()
+    info = activity.info()
+    query_tags.kind = "temporal"
+    query_tags.workflow = info.workflow_type
+    query_tags.workflow_id = info.workflow_id
+    query_tags.workflow_run_id = info.workflow_run_id
+    query_tags.activity = info.activity_type
+    query_tags.activity_id = info.activity_id
+
+
+def add_log_comment_param(params: dict[str, typing.Any]):
+    query_tags = query_tagging.get_query_tags().model_copy()
+    update_query_tags_with_temporal_info(query_tags)
+    params["log_comment"] = query_tags.to_json()
+
+
 class ClickHouseClient:
     """An asynchronous client to access ClickHouse via HTTP.
 
@@ -405,6 +434,8 @@ class ClickHouseClient:
                 if key in query:
                     params[f"param_{key}"] = str(value)
 
+        add_log_comment_param(params)
+
         async with self.session.get(url=self.url, headers=self.headers, params=params) as response:
             await self.acheck_response(response, query)
             yield response
@@ -444,6 +475,7 @@ class ClickHouseClient:
             for key, value in query_parameters.items():
                 if key in query:
                     params[f"param_{key}"] = str(value)
+        add_log_comment_param(params)
 
         request_data = self.prepare_request_data(data)
 
@@ -501,6 +533,7 @@ class ClickHouseClient:
             for key, value in query_parameters.items():
                 if key in query:
                     params[f"param_{key}"] = str(value)
+        add_log_comment_param(params)
 
         with requests.Session() as s:
             response = s.post(


### PR DESCRIPTION
## Problem

Some resource intensive queries are not tagged.

## Changes

1. Add `log_comment` HTTP request parameter with encoded `QueryTags`.
2. When a query is made from withing a Temporal worker, add temporal activity details to QueryTags.

## Did you write or update any docs for this change?

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [X] No docs needed for this change

## How did you test this code?

