### PR TITLE
feat(managed_migrations): adds import job id to msg header

### DIFF
--- a/rust/common/kafka/src/kafka_producer.rs
+++ b/rust/common/kafka/src/kafka_producer.rs
@@ -113,11 +113,25 @@ pub async fn send_keyed_iter_to_kafka<T, C: ClientContext>(
 where
     T: Serialize,
 {
+    send_keyed_iter_to_kafka_with_headers(kafka_producer, topic, key_extractor, |_| None, iter).await
+}
+
+pub async fn send_keyed_iter_to_kafka_with_headers<T, C: ClientContext>(
+    kafka_producer: &FutureProducer<C>,
+    topic: &str,
+    key_extractor: impl Fn(&T) -> Option<String>,
+    headers_extractor: impl Fn(&T) -> Option<Vec<(String, String)>>,
+    iter: impl IntoIterator<Item = T>,
+) -> Vec<Result<(), KafkaProduceError>>
+where
+    T: Serialize,
+{
     let mut results = Vec::new();
     let mut handles = Vec::new();
 
     for (index, item) in iter.into_iter().enumerate() {
         let key = key_extractor(&item);
+        let headers = headers_extractor(&item);
         let payload = match serde_json::to_string(&item)
             .map_err(|e| KafkaProduceError::SerializationError { error: e })
         {
@@ -128,13 +142,19 @@ where
             }
         };
 
+        let owned_headers = headers.map(|headers| {
+            headers.into_iter().fold(rdkafka::message::OwnedHeaders::new(), |acc, (k, v)| {
+                acc.insert(rdkafka::message::Header { key: &k, value: Some(&v) })
+            })
+        });
+
         let record = FutureRecord {
             topic,
             key: key.as_deref(),
             payload: Some(&payload),
             timestamp: None,
             partition: None,
-            headers: None,
+            headers: owned_headers,
         };
 
         let future_handle = match kafka_producer.send_result(record) {

--- a/rust/common/kafka/src/kafka_producer.rs
+++ b/rust/common/kafka/src/kafka_producer.rs
@@ -113,14 +113,14 @@ pub async fn send_keyed_iter_to_kafka<T, C: ClientContext>(
 where
     T: Serialize,
 {
-    send_keyed_iter_to_kafka_with_headers(kafka_producer, topic, key_extractor, |_| None, iter).await
+    send_keyed_iter_to_kafka_with_headers(kafka_producer, topic, key_extractor, None, iter).await
 }
 
 pub async fn send_keyed_iter_to_kafka_with_headers<T, C: ClientContext>(
     kafka_producer: &FutureProducer<C>,
     topic: &str,
     key_extractor: impl Fn(&T) -> Option<String>,
-    headers_extractor: impl Fn(&T) -> Option<Vec<(String, String)>>,
+    headers: Option<Vec<(String, String)>>,
     iter: impl IntoIterator<Item = T>,
 ) -> Vec<Result<(), KafkaProduceError>>
 where
@@ -129,9 +129,19 @@ where
     let mut results = Vec::new();
     let mut handles = Vec::new();
 
+    let owned_headers = headers.map(|headers| {
+        headers
+            .into_iter()
+            .fold(rdkafka::message::OwnedHeaders::new(), |acc, (k, v)| {
+                acc.insert(rdkafka::message::Header {
+                    key: &k,
+                    value: Some(&v),
+                })
+            })
+    });
+
     for (index, item) in iter.into_iter().enumerate() {
         let key = key_extractor(&item);
-        let headers = headers_extractor(&item);
         let payload = match serde_json::to_string(&item)
             .map_err(|e| KafkaProduceError::SerializationError { error: e })
         {
@@ -142,19 +152,13 @@ where
             }
         };
 
-        let owned_headers = headers.map(|headers| {
-            headers.into_iter().fold(rdkafka::message::OwnedHeaders::new(), |acc, (k, v)| {
-                acc.insert(rdkafka::message::Header { key: &k, value: Some(&v) })
-            })
-        });
-
         let record = FutureRecord {
             topic,
             key: key.as_deref(),
             payload: Some(&payload),
             timestamp: None,
             partition: None,
-            headers: owned_headers,
+            headers: owned_headers.clone(),
         };
 
         let future_handle = match kafka_producer.send_result(record) {


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We have control over the rate at which we consume events from Managed Migrations via the django admin. If we are flooding ourselves with events from a managed migration, it should be easy to figure out which job we want to control the send rate on. This adds the job id to the msg headers, so that an operator can reference messages in kafka UI and then use the django admin to make the relevant updates to the job.

## Changes

Changes to common kafka producer to allow for dynamically setting the headers on messages we sink to kafka.

Changes to the Kafka emitter in the batch import project to set the headers on the messages to the current job id

## Did you write or update any docs for this change?

## How did you test this code?

Tested this locally by running a batch import job against mixpanel data I have created through a mixpanel test account and checked to see if the incoming messages on the topic had the correct header.
