### PR TITLE
fix(managed_migrations): renames error field to status message

### DIFF
--- a/posthog/api/batch_imports.py
+++ b/posthog/api/batch_imports.py
@@ -220,7 +220,7 @@ class BatchImportResponseSerializer(serializers.ModelSerializer):
     start_date = serializers.SerializerMethodField()
     end_date = serializers.SerializerMethodField()
     content_type = serializers.SerializerMethodField()
-    error = serializers.CharField(source="display_status_message", allow_null=True)
+    status_message = serializers.CharField(source="display_status_message", allow_null=True)
 
     class Meta:
         model = BatchImport
@@ -233,7 +233,7 @@ class BatchImportResponseSerializer(serializers.ModelSerializer):
             "end_date",
             "created_by",
             "created_at",
-            "error",
+            "status_message",
             "state",
         ]
 

--- a/products/managed_migrations/frontend/ManagedMigration.tsx
+++ b/products/managed_migrations/frontend/ManagedMigration.tsx
@@ -315,9 +315,9 @@ export function ManagedMigrations(): JSX.Element {
                         align: 'right',
                     },
                     {
-                        title: 'Error',
-                        dataIndex: 'error',
-                        render: (_: any, migration: ManagedMigration) => migration.error || '-',
+                        title: 'Status Message',
+                        dataIndex: 'status_message',
+                        render: (_: any, migration: ManagedMigration) => migration.status_message || '-',
                     },
                 ]}
                 emptyState="No migrations found. Create a new migration to get started."

--- a/products/managed_migrations/frontend/types.ts
+++ b/products/managed_migrations/frontend/types.ts
@@ -12,7 +12,7 @@ export interface BaseManagedMigration {
         email: string
     }
     created_at: string
-    error: string | null
+    status_message: string | null
     state?: {
         parts?: Array<{
             key: string

--- a/rust/batch-import-worker/src/job/model.rs
+++ b/rust/batch-import-worker/src/job/model.rs
@@ -229,6 +229,7 @@ impl JobModel {
 
     pub async fn complete(&mut self, pool: &PgPool) -> Result<(), Error> {
         self.status = JobStatus::Completed;
+        self.display_status_message = None;
         self.flush(pool, false).await
     }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

The Error field in the Managed Migration UI is misleading as it reports a job status message, which are not necessarily errors. Also, if a job completes successfully, we should clear this status as it is no longer relevant.

## Changes

Changes the serializer field from error to status_message. Changes the UI name for the field to Status Message. Adds logic in hte complete job phase to clear any display_status_message fields on the job model if they exist.

## Did you write or update any docs for this change?

## How did you test this code?

Tested this locally, by importing data from a mixpanel export endpoint and seeing the result.
