### PR TITLE
chore(managed_migrations): adds event to trigger slack hook

### DIFF
--- a/posthog/api/batch_imports.py
+++ b/posthog/api/batch_imports.py
@@ -3,6 +3,8 @@ from rest_framework import filters, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.request import Request
 from rest_framework.response import Response
+import posthoganalytics
+import uuid
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
@@ -328,6 +330,22 @@ class BatchImportViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         migration = serializer.save()
+
+        # Track successful batch import creation
+        source_type = request.data.get("source_type", "unknown")
+        content_type = request.data.get("content_type", "unknown")
+
+        posthoganalytics.capture(
+            str(uuid.uuid4()),
+            "batch import created",
+            properties={
+                "batch_import_id": migration.id,
+                "source_type": source_type,
+                "content_type": content_type,
+                "team_id": self.team_id,
+                "$process_person_profile": False,
+            },
+        )
 
         response_serializer = BatchImportResponseSerializer(migration)
         return Response(response_serializer.data, status=status.HTTP_201_CREATED)

--- a/posthog/api/batch_imports.py
+++ b/posthog/api/batch_imports.py
@@ -334,7 +334,12 @@ class BatchImportViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         source_type = request.data.get("source_type", "unknown")
         content_type = request.data.get("content_type", "unknown")
 
-        distinct_id = request.user.distinct_id or str(uuid.uuid4())
+        distinct_id = (
+            request.user.distinct_id
+            if request.user.is_authenticated and request.user.distinct_id
+            else str(uuid.uuid4())
+        )
+
         posthoganalytics.capture(
             distinct_id,
             "batch import created",

--- a/posthog/api/batch_imports.py
+++ b/posthog/api/batch_imports.py
@@ -331,12 +331,12 @@ class BatchImportViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         serializer.is_valid(raise_exception=True)
         migration = serializer.save()
 
-        # Track successful batch import creation
         source_type = request.data.get("source_type", "unknown")
         content_type = request.data.get("content_type", "unknown")
 
+        distinct_id = request.user.distinct_id or str(uuid.uuid4())
         posthoganalytics.capture(
-            str(uuid.uuid4()),
+            distinct_id,
             "batch import created",
             properties={
                 "batch_import_id": migration.id,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Ingestion team should be alerted when someone creates a Managed Migration. Send a custom event on managed migration creation so that we can trigger a call to a slack webhook.

## Changes

Analytics events call on batch import job creation.

## Did you write or update any docs for this change?


## How did you test this code?

Tested locally by creating an S3 managed migration and seeing an event come through
