### PR TITLE
fix(managed_migrations): display status msg if root error

### DIFF
--- a/rust/batch-import-worker/src/error/mod.rs
+++ b/rust/batch-import-worker/src/error/mod.rs
@@ -32,7 +32,7 @@ pub fn get_user_message(error: &anyhow::Error) -> &str {
         debug!("Found UserError at root: {}", user_error.msg);
         return &user_error.msg;
     }
-    
+
     let mut source = error.source();
     while let Some(err) = source {
         debug!("Checking source error: {}", err);
@@ -42,6 +42,6 @@ pub fn get_user_message(error: &anyhow::Error) -> &str {
         }
         source = err.source();
     }
-    
+
     DEFAULT_USER_ERROR_MESSAGE
 }

--- a/rust/batch-import-worker/src/error/mod.rs
+++ b/rust/batch-import-worker/src/error/mod.rs
@@ -1,5 +1,4 @@
 use thiserror::Error;
-use tracing::debug;
 
 #[derive(Error, Debug, Clone)]
 #[error("User Error: {msg}")]
@@ -29,15 +28,12 @@ const DEFAULT_USER_ERROR_MESSAGE: &str = "An unknown error occurred";
 
 pub fn get_user_message(error: &anyhow::Error) -> &str {
     if let Some(user_error) = error.downcast_ref::<UserError>() {
-        debug!("Found UserError at root: {}", user_error.msg);
         return &user_error.msg;
     }
 
     let mut source = error.source();
     while let Some(err) = source {
-        debug!("Checking source error: {}", err);
         if let Some(user_error) = err.downcast_ref::<UserError>() {
-            debug!("Found UserError in source chain: {}", user_error.msg);
             return &user_error.msg;
         }
         source = err.source();

--- a/rust/batch-import-worker/src/error/mod.rs
+++ b/rust/batch-import-worker/src/error/mod.rs
@@ -45,3 +45,99 @@ pub fn get_user_message(error: &anyhow::Error) -> &str {
 
     DEFAULT_USER_ERROR_MESSAGE
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::anyhow;
+
+    #[test]
+    fn test_user_error_as_root() {
+        let user_error = UserError::new("Root user error message");
+        let error = anyhow::Error::from(user_error);
+
+        let result = get_user_message(&error);
+        assert_eq!(result, "Root user error message");
+    }
+
+    #[test]
+    fn test_user_error_in_middle_of_chain() {
+        let io_error = std::io::Error::new(std::io::ErrorKind::NotFound, "File not found");
+        let user_error = UserError::new("User-friendly file error");
+
+        let error = anyhow::Error::from(io_error)
+            .context(user_error)
+            .context("High level operation failed");
+
+        let result = get_user_message(&error);
+        assert_eq!(result, "User-friendly file error");
+    }
+
+    #[test]
+    fn test_user_error_at_end_of_chain() {
+        let user_error = UserError::new("Deep user error");
+        let error = anyhow::Error::from(user_error)
+            .context("Middle layer error")
+            .context("Top level error");
+
+        let result = get_user_message(&error);
+        assert_eq!(result, "Deep user error");
+    }
+
+    #[test]
+    fn test_multiple_user_errors_in_chain() {
+        let deep_user_error = UserError::new("Deep user error");
+        let middle_user_error = UserError::new("Middle user error");
+
+        let error = anyhow::Error::from(deep_user_error)
+            .context("Some system error")
+            .context(middle_user_error)
+            .context("Top level error");
+
+        let result = get_user_message(&error);
+        assert_eq!(result, "Middle user error");
+    }
+
+    #[test]
+    fn test_multiple_user_errors_with_root_user_error() {
+        let deep_user_error = UserError::new("Deep user error");
+        let root_user_error = UserError::new("Root user error");
+
+        let error = anyhow::Error::from(deep_user_error)
+            .context("Some system error")
+            .context(root_user_error);
+
+        let result = get_user_message(&error);
+        assert_eq!(result, "Root user error");
+    }
+
+    #[test]
+    fn test_no_user_error_in_chain() {
+        let io_error = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "Access denied");
+        let error = anyhow::Error::from(io_error)
+            .context("Failed to read config")
+            .context("Application startup failed");
+
+        let result = get_user_message(&error);
+        assert_eq!(result, DEFAULT_USER_ERROR_MESSAGE);
+    }
+
+    #[test]
+    fn test_single_non_user_error() {
+        let simple_error = anyhow!("Simple error message");
+
+        let result = get_user_message(&simple_error);
+        assert_eq!(result, DEFAULT_USER_ERROR_MESSAGE);
+    }
+
+    #[test]
+    fn test_user_error_trait_integration() {
+        let io_error = std::io::Error::new(std::io::ErrorKind::NotFound, "File not found");
+        let result: anyhow::Result<()> =
+            Err(io_error).user_error("Could not find configuration file");
+
+        let error = result.unwrap_err();
+        let user_message = get_user_message(&error);
+        assert_eq!(user_message, "Could not find configuration file");
+    }
+}


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

If the root error in a chain was a UserError, our error extraction logic failed to retrieve it. This resulted in erroneously reporting the status as "An unknown error occurred".

## Changes

Add logic to user error extraction to ensure we get the error if it was the root cause.

## How did you test this code?

Tested locally by creating a batch import job through the UI that should fail when requesting from S3 due to invalid bucket
