### PR TITLE
chore(cohorts): Add more details to the logs when uploading static cohorts

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -261,8 +261,8 @@ class CohortSerializer(serializers.ModelSerializer):
     def _calculate_static_by_csv(self, file, cohort: Cohort) -> None:
         decoded_file = file.read().decode("utf-8").splitlines()
         reader = csv.reader(decoded_file)
-        distinct_ids_and_emails = [row[0] for row in reader if len(row) > 0 and row]
-        calculate_cohort_from_list.delay(cohort.pk, distinct_ids_and_emails, team_id=self.context["team_id"])
+        distinct_ids = [row[0] for row in reader if len(row) > 0 and row]
+        calculate_cohort_from_list.delay(cohort.pk, distinct_ids, team_id=self.context["team_id"])
 
     def validate_query(self, query: Optional[dict]) -> Optional[dict]:
         if not query:

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -274,7 +274,11 @@ def calculate_cohort_from_list(cohort_id: int, items: list[str], team_id: Option
         team_id = cohort.team_id
 
     cohort.insert_users_by_list(items, team_id=team_id)
-    logger.warn("Calculating cohort {} from CSV took {:.2f} seconds".format(cohort.pk, (time.time() - start_time)))
+    logger.warn(
+        "Calculating cohort {} with {} items from CSV took {:.2f} seconds".format(
+            cohort.pk, len(items), (time.time() - start_time)
+        )
+    )
 
 
 @shared_task(ignore_result=True, max_retries=1)

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -273,10 +273,10 @@ def calculate_cohort_from_list(cohort_id: int, items: list[str], team_id: Option
     if team_id is None:
         team_id = cohort.team_id
 
-    cohort.insert_users_by_list(items, team_id=team_id)
+    batch_count = cohort.insert_users_by_list(items, team_id=team_id)
     logger.warn(
-        "Calculating cohort {} with {} items from CSV took {:.2f} seconds".format(
-            cohort.pk, len(items), (time.time() - start_time)
+        "Cohort {}: {:,} items in {} batches from CSV completed in {:.2f}s".format(
+            cohort.pk, len(items), batch_count, (time.time() - start_time)
         )
     )
 

--- a/posthog/test/test_cohort_model.py
+++ b/posthog/test/test_cohort_model.py
@@ -47,9 +47,10 @@ class TestCohort(BaseTest):
         Person.objects.create(team=self.team, distinct_ids=["010"])
 
         cohort = Cohort.objects.create(team=self.team, groups=[], is_static=True)
-        cohort.insert_users_by_list(
+        batch_count = cohort.insert_users_by_list(
             ["000", "001", "002", "003", "004", "005", "006", "007", "008", "009", "010", "011", "012"], batch_size=3
         )
+        self.assertEqual(batch_count, 5)
         cohort.refresh_from_db()
         self.assertEqual(cohort.people.count(), 11)
         self.assertEqual(cohort.is_calculating, False)


### PR DESCRIPTION
We don't support imports via emails yet> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changes

Adds the item count and batch count to the cohort completed message.

> 2025-06-21T19:45:24.920204Z [warning  ] Cohort 6: 10,000 items in 10 batches from CSV completed in 1.80s [posthog.tasks.calculate_cohort] ip=192.168.97.1 pid=71444 request_id=0ea7f1ce-d005-42a8-a655-b344dad0c0b5 task_id=b17b6546-6122-428c-8813-44d7d58fede6 task_name=posthog.tasks.calculate_cohort.calculate_cohort_from_list tid=14621470720

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

* Unit tests
* Manual testing