### PR TITLE
feat(flags): Flag evaluation support for flags that depend on other flags

### DIFF
--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -555,6 +555,8 @@ impl FeatureFlagMatcher {
             Ok(stages) => stages,
             Err(e) => {
                 self.handle_dependency_graph_error("get evaluation stages", &e);
+                // This path should never happen. Normally I'd call unreachable here but if I'm wrong,
+                // I want the prod service to fail gracefully. But not while we're developing.
                 debug_assert!(
                     false,
                     "evaluation_stages() failed after dependency graph construction: {e:?}"

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -507,8 +507,9 @@ impl FeatureFlagMatcher {
                     &[("reason".to_string(), "evaluation_stages_error".to_string())],
                     1,
                 );
+                debug_assert!(false, "evaluation_stages() failed after dependency graph construction: {e:?}");
                 errors_while_computing_flags = true;
-                Vec::new() // Return an empty vector to allow the program to continue
+                Vec::new() // Return an empty vector to allow the program to continue, but this should never happen.
             }
         };
         for stage in evaluation_stages {

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -426,106 +426,35 @@ impl FeatureFlagMatcher {
         hash_key_overrides: Option<HashMap<String, String>>,
         request_id: Uuid,
     ) -> FlagsResponse {
-        // Initialize group type mappings if needed
-        let mut errors_while_computing_flags = self
+        let mut errors_while_computing_flags = false;
+        let mut evaluated_flags_map = HashMap::new();
+
+        // Step 1: Initialize group type mappings if needed
+        errors_while_computing_flags |= self
             .initialize_group_type_mappings_if_needed(&feature_flags)
             .await;
 
-        let flags_requiring_db_preparation = flags_require_db_preparation(
-            &feature_flags.flags,
-            person_property_overrides
-                .as_ref()
-                .unwrap_or(&HashMap::new()),
-        );
+        // Step 2: Prepare evaluation state for flags requiring DB properties
+        let db_prep_errors = self
+            .prepare_evaluation_state_if_needed(
+                &feature_flags,
+                &person_property_overrides,
+                &mut evaluated_flags_map,
+            )
+            .await;
+        errors_while_computing_flags |= db_prep_errors;
 
-        let mut evaluated_flags_map = HashMap::new();
-
-        if !flags_requiring_db_preparation.is_empty() {
-            if let Err(e) = self
-                .prepare_flag_evaluation_state(flags_requiring_db_preparation.as_slice())
-                .await
-            {
-                errors_while_computing_flags = true;
-                let reason = parse_exception_for_prometheus_label(&e);
-                evaluated_flags_map.extend(flags_requiring_db_preparation.iter().map(|flag| {
-                    (
-                        flag.key.clone(),
-                        FlagDetails::create_error(flag, reason, None),
-                    )
-                }));
-                error!("Error preparing flag evaluation state for team {} project {} distinct_id {}: {:?}", self.team_id, self.project_id, self.distinct_id, e);
-                inc(
-                    FLAG_EVALUATION_ERROR_COUNTER,
-                    &[("reason".to_string(), reason.to_string())],
-                    1,
-                );
-            }
-        }
-
-        let (flag_dependency_graph, errors) =
-            match DependencyGraph::from_nodes(&feature_flags.flags) {
-                Ok((graph, errors)) => (graph, errors),
-                Err(e) => {
-                    error!(
-                        "Failed to build feature flag dependency graph for team {}: {:?}",
-                        self.team_id, e
-                    );
-                    inc(
-                        FLAG_EVALUATION_ERROR_COUNTER,
-                        &[("reason".to_string(), "dependency_graph_error".to_string())],
-                        1,
-                    );
-                    return FlagsResponse {
-                        errors_while_computing_flags: true,
-                        flags: HashMap::new(),
-                        quota_limited: None,
-                        request_id,
-                        config: ConfigResponse::default(),
-                    };
-                }
-            };
-
-        if !errors.is_empty() {
-            errors_while_computing_flags = true;
-            inc(
-                FLAG_EVALUATION_ERROR_COUNTER,
-                &[("reason".to_string(), "dependency_graph_error".to_string())],
-                1,
-            );
-            error!("There were errors building the feature flag dependency graph for team {}. Will attempt to evaluate the rest of the flags: {:?}", self.team_id, errors);
-        }
-
-        let evaluation_stages = match flag_dependency_graph.evaluation_stages() {
-            Ok(stages) => stages,
-            Err(e) => {
-                error!(
-                    "Failed to get evaluation stages for team {}: {:?}",
-                    self.team_id, e
-                );
-                inc(
-                    FLAG_EVALUATION_ERROR_COUNTER,
-                    &[("reason".to_string(), "evaluation_stages_error".to_string())],
-                    1,
-                );
-                debug_assert!(false, "evaluation_stages() failed after dependency graph construction: {e:?}");
-                errors_while_computing_flags = true;
-                Vec::new() // Return an empty vector to allow the program to continue, but this should never happen.
-            }
-        };
-        for stage in evaluation_stages {
-            let stage_flags: Vec<FeatureFlag> = stage.iter().map(|&flag| flag.clone()).collect();
-            let (level_evaluated_flags_map, level_errors) = self
-                .evaluate_flags_in_level(
-                    &stage_flags,
-                    &mut evaluated_flags_map,
-                    &person_property_overrides,
-                    &group_property_overrides,
-                    &hash_key_overrides,
-                )
-                .await;
-            errors_while_computing_flags |= level_errors;
-            evaluated_flags_map.extend(level_evaluated_flags_map);
-        }
+        // Step 3: Build dependency graph and evaluate flags in stages
+        let graph_evaluation_errors = self
+            .evaluate_flags_with_dependency_graph(
+                &feature_flags,
+                &person_property_overrides,
+                &group_property_overrides,
+                &hash_key_overrides,
+                &mut evaluated_flags_map,
+            )
+            .await;
+        errors_while_computing_flags |= graph_evaluation_errors;
 
         FlagsResponse {
             errors_while_computing_flags,
@@ -534,6 +463,155 @@ impl FeatureFlagMatcher {
             request_id,
             config: ConfigResponse::default(),
         }
+    }
+
+    /// Prepares evaluation state for flags that require database properties.
+    /// Returns true if there were errors during preparation.
+    async fn prepare_evaluation_state_if_needed(
+        &mut self,
+        feature_flags: &FeatureFlagList,
+        person_property_overrides: &Option<HashMap<String, Value>>,
+        evaluated_flags_map: &mut HashMap<String, FlagDetails>,
+    ) -> bool {
+        let flags_requiring_db_preparation = flags_require_db_preparation(
+            &feature_flags.flags,
+            person_property_overrides
+                .as_ref()
+                .unwrap_or(&HashMap::new()),
+        );
+
+        if flags_requiring_db_preparation.is_empty() {
+            return false;
+        }
+
+        match self
+            .prepare_flag_evaluation_state(flags_requiring_db_preparation.as_slice())
+            .await
+        {
+            Ok(_) => false,
+            Err(e) => {
+                self.handle_db_preparation_error(
+                    &flags_requiring_db_preparation,
+                    &e,
+                    evaluated_flags_map,
+                );
+                true
+            }
+        }
+    }
+
+    /// Handles errors during database preparation by creating error responses for affected flags.
+    fn handle_db_preparation_error(
+        &self,
+        flags_requiring_db_preparation: &[&FeatureFlag],
+        error: &FlagError,
+        evaluated_flags_map: &mut HashMap<String, FlagDetails>,
+    ) {
+        let reason = parse_exception_for_prometheus_label(error);
+        evaluated_flags_map.extend(flags_requiring_db_preparation.iter().map(|flag| {
+            (
+                flag.key.clone(),
+                FlagDetails::create_error(flag, reason, None),
+            )
+        }));
+
+        error!(
+            "Error preparing flag evaluation state for team {} project {} distinct_id {}: {:?}",
+            self.team_id, self.project_id, self.distinct_id, error
+        );
+
+        inc(
+            FLAG_EVALUATION_ERROR_COUNTER,
+            &[("reason".to_string(), reason.to_string())],
+            1,
+        );
+    }
+
+    /// Evaluates flags using dependency graph to handle flag dependencies correctly.
+    /// Returns true if there were errors during evaluation.
+    async fn evaluate_flags_with_dependency_graph(
+        &mut self,
+        feature_flags: &FeatureFlagList,
+        person_property_overrides: &Option<HashMap<String, Value>>,
+        group_property_overrides: &Option<HashMap<String, HashMap<String, Value>>>,
+        hash_key_overrides: &Option<HashMap<String, String>>,
+        evaluated_flags_map: &mut HashMap<String, FlagDetails>,
+    ) -> bool {
+        let (flag_dependency_graph, errors) =
+            match DependencyGraph::from_nodes(&feature_flags.flags) {
+                Ok((graph, errors)) => (graph, errors),
+                Err(e) => {
+                    self.handle_dependency_graph_error("build feature flag dependency graph", &e);
+                    return true;
+                }
+            };
+
+        let mut errors_while_computing_flags = !errors.is_empty();
+        if errors_while_computing_flags {
+            self.handle_dependency_graph_errors(&errors);
+        }
+
+        let evaluation_stages = match flag_dependency_graph.evaluation_stages() {
+            Ok(stages) => stages,
+            Err(e) => {
+                self.handle_dependency_graph_error("get evaluation stages", &e);
+                debug_assert!(
+                    false,
+                    "evaluation_stages() failed after dependency graph construction: {e:?}"
+                );
+                return true;
+            }
+        };
+
+        // Evaluate flags in dependency order
+        for stage in evaluation_stages {
+            let stage_flags: Vec<FeatureFlag> = stage.iter().map(|&flag| flag.clone()).collect();
+            let (level_evaluated_flags_map, level_errors) = self
+                .evaluate_flags_in_level(
+                    &stage_flags,
+                    evaluated_flags_map,
+                    person_property_overrides,
+                    group_property_overrides,
+                    hash_key_overrides,
+                )
+                .await;
+            errors_while_computing_flags |= level_errors;
+            evaluated_flags_map.extend(level_evaluated_flags_map);
+        }
+
+        errors_while_computing_flags
+    }
+
+    /// Handles errors during dependency graph operations.
+    fn handle_dependency_graph_error(&self, error_type: &str, error: &dyn std::fmt::Debug) {
+        error!(
+            "Failed to {} for team {}: {:?}",
+            error_type, self.team_id, error
+        );
+        inc(
+            FLAG_EVALUATION_ERROR_COUNTER,
+            &[(
+                "reason".to_string(),
+                format!("{}_error", error_type.replace(" ", "_")),
+            )],
+            1,
+        );
+    }
+
+    /// Handles errors found during dependency graph construction.
+    fn handle_dependency_graph_errors(
+        &self,
+        errors: &[crate::utils::graph_utils::GraphError<i32>],
+    ) {
+        inc(
+            FLAG_EVALUATION_ERROR_COUNTER,
+            &[("reason".to_string(), "dependency_graph_error".to_string())],
+            1,
+        );
+        error!(
+            "There were errors building the feature flag dependency graph for team {}. Will attempt to evaluate the rest of the flags: {:?}",
+            self.team_id, errors
+        );
     }
 
     /// Evaluates a set of flags with a combination of property overrides and DB properties

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -284,6 +284,757 @@ mod tests {
         );
     }
 
+    pub fn create_test_flag_with_properties(
+        id: i32,
+        team_id: TeamId,
+        key: &str,
+        filters: Vec<PropertyFilter>,
+    ) -> FeatureFlag {
+        create_test_flag(
+            Some(id),
+            Some(team_id),
+            None,
+            Some(key.to_string()),
+            Some(FlagFilters {
+                groups: vec![FlagPropertyGroup {
+                    properties: Some(filters),
+                    rollout_percentage: Some(100.0),
+                    variant: None,
+                }],
+                multivariate: None,
+                aggregation_group_type_index: None,
+                payloads: None,
+                super_groups: None,
+                holdout_groups: None,
+            }),
+            None,
+            None,
+            None,
+        )
+    }
+
+    pub fn create_test_flag_with_property(
+        id: i32,
+        team_id: TeamId,
+        key: &str,
+        filter: PropertyFilter,
+    ) -> FeatureFlag {
+        create_test_flag_with_properties(id, team_id, key, vec![filter])
+    }
+
+    pub fn create_test_flag_that_depends_on_flag(
+        id: i32,
+        team_id: TeamId,
+        key: &str,
+        depends_on_flag_id: i32,
+        depends_on_flag_value: FlagValue,
+    ) -> FeatureFlag {
+        create_test_flag_with_property(
+            id,
+            team_id,
+            key,
+            PropertyFilter {
+                key: depends_on_flag_id.to_string(),
+                value: Some(json!(depends_on_flag_value)),
+                operator: Some(OperatorType::Exact),
+                prop_type: PropertyType::Flag,
+                group_type_index: None,
+                negation: None,
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn test_flags_that_depends_on_other_boolean_flag() {
+        let reader = setup_pg_reader_client(None).await;
+        let writer = setup_pg_writer_client(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
+        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+
+        let leaf_flag = create_test_flag_with_property(
+            23,
+            team.id,
+            "leaf_flag",
+            PropertyFilter {
+                key: "email".to_string(),
+                value: Some(json!("override@example.com")),
+                operator: Some(OperatorType::Exact),
+                prop_type: PropertyType::Person,
+                group_type_index: None,
+                negation: None,
+            },
+        );
+        let independent_flag = create_test_flag_with_property(
+            99,
+            team.id,
+            "independent_flag",
+            PropertyFilter {
+                key: "email".to_string(),
+                value: Some(json!("override@example.com")),
+                operator: Some(OperatorType::Exact),
+                prop_type: PropertyType::Person,
+                group_type_index: None,
+                negation: None,
+            },
+        );
+        let parent_flag = create_test_flag_that_depends_on_flag(
+            42,
+            team.id,
+            "parent_flag",
+            leaf_flag.id,
+            FlagValue::Boolean(true),
+        );
+
+        let mut matcher = FeatureFlagMatcher::new(
+            "test_user".to_string(),
+            team.id,
+            team.project_id,
+            reader,
+            writer,
+            cohort_cache,
+            None,
+            None,
+        );
+
+        let flags = FeatureFlagList {
+            flags: vec![
+                independent_flag.clone(),
+                leaf_flag.clone(),
+                parent_flag.clone(),
+            ],
+        };
+
+        {
+            let overrides = HashMap::from([("email".to_string(), json!("override@example.com"))]);
+            let result = matcher
+                .evaluate_all_feature_flags(
+                    flags.clone(),
+                    Some(overrides),
+                    None,
+                    None,
+                    Uuid::new_v4(),
+                )
+                .await;
+            assert!(!result.errors_while_computing_flags);
+            assert_eq!(
+                result.flags.get("independent_flag").unwrap().to_value(),
+                FlagValue::Boolean(true)
+            );
+            assert_eq!(
+                result.flags.get("leaf_flag").unwrap().to_value(),
+                FlagValue::Boolean(true)
+            );
+            assert_eq!(
+                result.flags.get("parent_flag").unwrap().to_value(),
+                FlagValue::Boolean(true)
+            );
+            assert!(!result.flags.contains_key("cycle_start_flag"));
+            assert!(!result.flags.contains_key("cycle_middle_flag"));
+            assert!(!result.flags.contains_key("cycle_node"));
+            assert!(!result.flags.contains_key("missing_dependency_flag"));
+        }
+        {
+            // Leaf flag evaluates to false
+            let result = matcher
+                .evaluate_all_feature_flags(flags.clone(), None, None, None, Uuid::new_v4())
+                .await;
+            assert!(!result.errors_while_computing_flags);
+            assert_eq!(
+                result.flags.get("independent_flag").unwrap().to_value(),
+                FlagValue::Boolean(false)
+            );
+            assert_eq!(
+                result.flags.get("leaf_flag").unwrap().to_value(),
+                FlagValue::Boolean(false)
+            );
+            assert_eq!(
+                result.flags.get("parent_flag").unwrap().to_value(),
+                FlagValue::Boolean(false)
+            );
+            assert!(!result.flags.contains_key("cycle_start_flag"));
+            assert!(!result.flags.contains_key("cycle_middle_flag"));
+            assert!(!result.flags.contains_key("cycle_node"));
+            assert!(!result.flags.contains_key("missing_dependency_flag"));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_flags_that_depends_on_other_multivariate_flag_variant_match() {
+        let reader = setup_pg_reader_client(None).await;
+        let writer = setup_pg_writer_client(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
+        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+
+        let leaf_flag = create_test_flag(
+            Some(2),
+            Some(team.id),
+            None,
+            Some("leaf_flag".to_string()),
+            Some(FlagFilters {
+                groups: vec![
+                    FlagPropertyGroup {
+                        properties: Some(vec![PropertyFilter {
+                            key: "email".to_string(),
+                            value: Some(json!("control@example.com")),
+                            operator: Some(OperatorType::Exact),
+                            prop_type: PropertyType::Person,
+                            group_type_index: None,
+                            negation: None,
+                        }]),
+                        rollout_percentage: Some(100.0),
+                        variant: Some("control".to_string()),
+                    },
+                    FlagPropertyGroup {
+                        properties: Some(vec![PropertyFilter {
+                            key: "email".to_string(),
+                            value: Some(json!("test@example.com")),
+                            operator: Some(OperatorType::Exact),
+                            prop_type: PropertyType::Person,
+                            group_type_index: None,
+                            negation: None,
+                        }]),
+                        rollout_percentage: Some(100.0),
+                        variant: Some("test".to_string()),
+                    },
+                    FlagPropertyGroup {
+                        properties: Some(vec![]),
+                        rollout_percentage: Some(100.0),
+                        variant: Some("other".to_string()),
+                    },
+                ],
+                multivariate: Some(MultivariateFlagOptions {
+                    variants: vec![
+                        MultivariateFlagVariant {
+                            name: None,
+                            key: "control".to_string(),
+                            rollout_percentage: 50.0,
+                        },
+                        MultivariateFlagVariant {
+                            name: None,
+                            key: "test".to_string(),
+                            rollout_percentage: 50.0,
+                        },
+                        MultivariateFlagVariant {
+                            name: None,
+                            key: "other".to_string(),
+                            rollout_percentage: 50.0,
+                        },
+                    ],
+                }),
+                aggregation_group_type_index: None,
+                payloads: None,
+                super_groups: None,
+                holdout_groups: None,
+            }),
+            None,
+            None,
+            None,
+        );
+
+        let parent_flag = create_test_flag_that_depends_on_flag(
+            1,
+            team.id,
+            "parent_flag",
+            leaf_flag.id,
+            FlagValue::String("control".to_string()),
+        );
+
+        let mut matcher = FeatureFlagMatcher::new(
+            "test_user".to_string(),
+            team.id,
+            team.project_id,
+            reader,
+            writer,
+            cohort_cache,
+            None,
+            None,
+        );
+        let flags = FeatureFlagList {
+            flags: vec![leaf_flag.clone(), parent_flag.clone()],
+        };
+
+        {
+            let overrides = HashMap::from([("email".to_string(), json!("control@example.com"))]);
+            let result = matcher
+                .evaluate_all_feature_flags(
+                    flags.clone(),
+                    Some(overrides),
+                    None,
+                    None,
+                    Uuid::new_v4(),
+                )
+                .await;
+            assert!(!result.errors_while_computing_flags);
+            assert_eq!(
+                result.flags.get("leaf_flag").unwrap().to_value(),
+                FlagValue::String("control".to_string())
+            );
+            assert_eq!(
+                result.flags.get("parent_flag").unwrap().to_value(),
+                FlagValue::Boolean(true)
+            );
+        }
+        {
+            let overrides = HashMap::from([("email".to_string(), json!("test@example.com"))]);
+            let result = matcher
+                .evaluate_all_feature_flags(
+                    flags.clone(),
+                    Some(overrides),
+                    None,
+                    None,
+                    Uuid::new_v4(),
+                )
+                .await;
+            assert!(!result.errors_while_computing_flags);
+            assert_eq!(
+                result.flags.get("leaf_flag").unwrap().to_value(),
+                FlagValue::String("test".to_string())
+            );
+            assert_eq!(
+                result.flags.get("parent_flag").unwrap().to_value(),
+                FlagValue::Boolean(false)
+            );
+        }
+        {
+            let overrides = HashMap::from([("email".to_string(), json!("random@example.com"))]);
+            let result = matcher
+                .evaluate_all_feature_flags(
+                    flags.clone(),
+                    Some(overrides),
+                    None,
+                    None,
+                    Uuid::new_v4(),
+                )
+                .await;
+            assert!(!result.errors_while_computing_flags);
+            assert_eq!(
+                result.flags.get("leaf_flag").unwrap().to_value(),
+                FlagValue::String("other".to_string())
+            );
+            assert_eq!(
+                result.flags.get("parent_flag").unwrap().to_value(),
+                FlagValue::Boolean(false)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_flags_with_deep_dependency_tree_only_calls_db_once_total() {
+        let reader = setup_pg_reader_client(None).await;
+        let writer = setup_pg_writer_client(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
+        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let _person_id = insert_person_for_team_in_pg(
+            reader.clone(),
+            team.id,
+            "test_user_distinct_id".to_string(),
+            Some(json!({ "email": "email-in-db@example.com", "is-cool": true })),
+        )
+        .await
+        .unwrap();
+
+        let leaf_flag = create_test_flag_with_property(
+            23,
+            team.id,
+            "leaf_flag",
+            PropertyFilter {
+                key: "is-cool".to_string(),
+                value: Some(json!(true)),
+                operator: Some(OperatorType::Exact),
+                prop_type: PropertyType::Person,
+                group_type_index: None,
+                negation: None,
+            },
+        );
+        let independent_flag = create_test_flag_with_property(
+            99,
+            team.id,
+            "independent_flag",
+            PropertyFilter {
+                key: "email".to_string(),
+                value: Some(json!("email-not-in-db@example.com")),
+                operator: Some(OperatorType::Exact),
+                prop_type: PropertyType::Person,
+                group_type_index: None,
+                negation: None,
+            },
+        );
+        let intermediate_flag = create_test_flag_with_properties(
+            43,
+            team.id,
+            "intermediate_flag",
+            vec![
+                PropertyFilter {
+                    key: "email".to_string(),
+                    value: Some(json!("email-in-db@example.com")),
+                    operator: Some(OperatorType::Exact),
+                    prop_type: PropertyType::Person,
+                    group_type_index: None,
+                    negation: None,
+                },
+                PropertyFilter {
+                    key: leaf_flag.id.to_string(),
+                    value: Some(json!(true)),
+                    operator: Some(OperatorType::Exact),
+                    prop_type: PropertyType::Flag,
+                    group_type_index: None,
+                    negation: None,
+                },
+            ],
+        );
+        let parent_flag = create_test_flag_that_depends_on_flag(
+            42,
+            team.id,
+            "parent_flag",
+            intermediate_flag.id,
+            FlagValue::Boolean(true),
+        );
+
+        let mut matcher = FeatureFlagMatcher::new(
+            "test_user_distinct_id".to_string(),
+            team.id,
+            team.project_id,
+            reader,
+            writer,
+            cohort_cache,
+            None,
+            None,
+        );
+
+        let flags = FeatureFlagList {
+            flags: vec![
+                independent_flag.clone(),
+                leaf_flag.clone(),
+                intermediate_flag.clone(),
+                parent_flag.clone(),
+            ],
+        };
+
+        reset_fetch_calls_count();
+
+        let result = matcher
+            .evaluate_all_feature_flags(flags.clone(), None, None, None, Uuid::new_v4())
+            .await;
+        // Add this assertion to check the call count
+        let fetch_calls = get_fetch_calls_count();
+        assert_eq!(fetch_calls, 1, "Expected fetch_and_locally_cache_all_relevant_properties to be called exactly 1 time, but it was called {} times", fetch_calls);
+        assert_eq!(
+            result.flags.get("leaf_flag").unwrap().to_value(),
+            FlagValue::Boolean(true)
+        );
+        assert_eq!(
+            result.flags.get("independent_flag").unwrap().to_value(),
+            FlagValue::Boolean(false)
+        );
+        assert_eq!(
+            result.flags.get("intermediate_flag").unwrap().to_value(),
+            FlagValue::Boolean(true)
+        );
+        assert_eq!(
+            result.flags.get("parent_flag").unwrap().to_value(),
+            FlagValue::Boolean(true)
+        );
+        assert!(!result.errors_while_computing_flags);
+    }
+
+    #[tokio::test]
+    async fn test_flags_with_dependency_cycle_and_missing_dependency_still_evaluates_independent_flags(
+    ) {
+        let reader = setup_pg_reader_client(None).await;
+        let writer = setup_pg_writer_client(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
+        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+
+        let leaf_flag = create_test_flag_with_property(
+            23,
+            team.id,
+            "leaf_flag",
+            PropertyFilter {
+                key: "email".to_string(),
+                value: Some(json!("override@example.com")),
+                operator: Some(OperatorType::Exact),
+                prop_type: PropertyType::Person,
+                group_type_index: None,
+                negation: None,
+            },
+        );
+        let independent_flag = create_test_flag_with_property(
+            99,
+            team.id,
+            "independent_flag",
+            PropertyFilter {
+                key: "email".to_string(),
+                value: Some(json!("override@example.com")),
+                operator: Some(OperatorType::Exact),
+                prop_type: PropertyType::Person,
+                group_type_index: None,
+                negation: None,
+            },
+        );
+        let parent_flag = create_test_flag_that_depends_on_flag(
+            42,
+            team.id,
+            "parent_flag",
+            leaf_flag.id,
+            FlagValue::Boolean(true),
+        );
+
+        let cycle_node = create_test_flag_that_depends_on_flag(
+            43,
+            team.id,
+            "self_referencing_flag",
+            44,
+            FlagValue::Boolean(true),
+        );
+
+        let cycle_middle_flag = create_test_flag_that_depends_on_flag(
+            44,
+            team.id,
+            "cycle_middle_flag",
+            45,
+            FlagValue::Boolean(true),
+        );
+
+        let cycle_start_flag = create_test_flag_that_depends_on_flag(
+            45,
+            team.id,
+            "cycle_start_flag",
+            43,
+            FlagValue::Boolean(true),
+        );
+
+        let missing_dependency_flag = create_test_flag_that_depends_on_flag(
+            46,
+            team.id,
+            "missing_dependency_flag",
+            999,
+            FlagValue::Boolean(true),
+        );
+
+        let mut matcher = FeatureFlagMatcher::new(
+            "test_user".to_string(),
+            team.id,
+            team.project_id,
+            reader,
+            writer,
+            cohort_cache,
+            None,
+            None,
+        );
+
+        let flags = FeatureFlagList {
+            flags: vec![
+                independent_flag.clone(),
+                leaf_flag.clone(),
+                cycle_node.clone(),
+                cycle_middle_flag.clone(),
+                cycle_start_flag.clone(),
+                parent_flag.clone(),
+                missing_dependency_flag.clone(),
+            ],
+        };
+
+        {
+            // Leaf flag evaluates to true
+            let overrides = HashMap::from([("email".to_string(), json!("override@example.com"))]);
+            let result = matcher
+                .evaluate_all_feature_flags(
+                    flags.clone(),
+                    Some(overrides),
+                    None,
+                    None,
+                    Uuid::new_v4(),
+                )
+                .await;
+            assert!(result.errors_while_computing_flags);
+            assert_eq!(
+                result.flags.get("independent_flag").unwrap().to_value(),
+                FlagValue::Boolean(true)
+            );
+            assert_eq!(
+                result.flags.get("leaf_flag").unwrap().to_value(),
+                FlagValue::Boolean(true)
+            );
+            assert_eq!(
+                result.flags.get("parent_flag").unwrap().to_value(),
+                FlagValue::Boolean(true)
+            );
+            assert!(!result.flags.contains_key("cycle_start_flag"));
+            assert!(!result.flags.contains_key("cycle_middle_flag"));
+            assert!(!result.flags.contains_key("cycle_node"));
+            assert!(!result.flags.contains_key("missing_dependency_flag"));
+        }
+        {
+            // Leaf flag evaluates to false
+            let result = matcher
+                .evaluate_all_feature_flags(flags.clone(), None, None, None, Uuid::new_v4())
+                .await;
+            assert!(result.errors_while_computing_flags);
+            assert_eq!(
+                result.flags.get("independent_flag").unwrap().to_value(),
+                FlagValue::Boolean(false)
+            );
+            assert_eq!(
+                result.flags.get("leaf_flag").unwrap().to_value(),
+                FlagValue::Boolean(false)
+            );
+            assert_eq!(
+                result.flags.get("parent_flag").unwrap().to_value(),
+                FlagValue::Boolean(false)
+            );
+            assert!(!result.flags.contains_key("cycle_start_flag"));
+            assert!(!result.flags.contains_key("cycle_middle_flag"));
+            assert!(!result.flags.contains_key("cycle_node"));
+            assert!(!result.flags.contains_key("missing_dependency_flag"));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_flags_that_depends_on_other_multivariate_flag_boolean_match() {
+        let reader = setup_pg_reader_client(None).await;
+        let writer = setup_pg_writer_client(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
+        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+
+        let leaf_flag = create_test_flag(
+            Some(3),
+            Some(team.id),
+            None,
+            Some("leaf_flag".to_string()),
+            Some(FlagFilters {
+                groups: vec![
+                    FlagPropertyGroup {
+                        properties: Some(vec![PropertyFilter {
+                            key: "email".to_string(),
+                            value: Some(json!("control@example.com")),
+                            operator: Some(OperatorType::Exact),
+                            prop_type: PropertyType::Person,
+                            group_type_index: None,
+                            negation: None,
+                        }]),
+                        rollout_percentage: Some(100.0),
+                        variant: Some("control".to_string()),
+                    },
+                    FlagPropertyGroup {
+                        properties: Some(vec![PropertyFilter {
+                            key: "email".to_string(),
+                            value: Some(json!("test@example.com")),
+                            operator: Some(OperatorType::Exact),
+                            prop_type: PropertyType::Person,
+                            group_type_index: None,
+                            negation: None,
+                        }]),
+                        rollout_percentage: Some(100.0),
+                        variant: Some("test".to_string()),
+                    },
+                ],
+                multivariate: Some(MultivariateFlagOptions {
+                    variants: vec![
+                        MultivariateFlagVariant {
+                            name: None,
+                            key: "control".to_string(),
+                            rollout_percentage: 50.0,
+                        },
+                        MultivariateFlagVariant {
+                            name: None,
+                            key: "test".to_string(),
+                            rollout_percentage: 50.0,
+                        },
+                    ],
+                }),
+                aggregation_group_type_index: None,
+                payloads: None,
+                super_groups: None,
+                holdout_groups: None,
+            }),
+            None,
+            None,
+            None,
+        );
+
+        let parent_flag = create_test_flag_that_depends_on_flag(
+            2,
+            team.id,
+            "parent_flag",
+            leaf_flag.id,
+            FlagValue::Boolean(true), // KEY DIFFERENCE FROM PREVIOUS TEST
+        );
+
+        let mut matcher = FeatureFlagMatcher::new(
+            "test_user".to_string(),
+            team.id,
+            team.project_id,
+            reader,
+            writer,
+            cohort_cache,
+            None,
+            None,
+        );
+        let flags = FeatureFlagList {
+            flags: vec![leaf_flag.clone(), parent_flag.clone()],
+        };
+
+        {
+            // Leaf flag evaluates to "control"
+            let overrides = HashMap::from([("email".to_string(), json!("control@example.com"))]);
+            let result = matcher
+                .evaluate_all_feature_flags(
+                    flags.clone(),
+                    Some(overrides),
+                    None,
+                    None,
+                    Uuid::new_v4(),
+                )
+                .await;
+            assert!(!result.errors_while_computing_flags);
+            assert_eq!(
+                result.flags.get("leaf_flag").unwrap().to_value(),
+                FlagValue::String("control".to_string())
+            );
+            assert_eq!(
+                result.flags.get("parent_flag").unwrap().to_value(),
+                FlagValue::Boolean(true)
+            );
+        }
+        {
+            // Leaf flag evaluates to "test"
+            let overrides = HashMap::from([("email".to_string(), json!("test@example.com"))]);
+            let result = matcher
+                .evaluate_all_feature_flags(
+                    flags.clone(),
+                    Some(overrides),
+                    None,
+                    None,
+                    Uuid::new_v4(),
+                )
+                .await;
+            assert!(!result.errors_while_computing_flags);
+            assert_eq!(
+                result.flags.get("leaf_flag").unwrap().to_value(),
+                FlagValue::String("test".to_string())
+            );
+            assert_eq!(
+                result.flags.get("parent_flag").unwrap().to_value(),
+                FlagValue::Boolean(true)
+            );
+        }
+        {
+            // Leaf flag evaluates to false
+            let result = matcher
+                .evaluate_all_feature_flags(flags.clone(), None, None, None, Uuid::new_v4())
+                .await;
+            assert!(!result.errors_while_computing_flags);
+            assert_eq!(
+                result.flags.get("leaf_flag").unwrap().to_value(),
+                FlagValue::Boolean(false)
+            );
+            assert_eq!(
+                result.flags.get("parent_flag").unwrap().to_value(),
+                FlagValue::Boolean(false)
+            );
+        }
+    }
+
     #[tokio::test]
     async fn test_get_matching_variant_with_cache() {
         let flag = create_test_flag_with_variants(1);


### PR DESCRIPTION
Remember all those refactoring PRs. Well this is what they were leading to!

[!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

This is the backend support for #29016. It does not include the UI for creating such flags. This enables us to have flags that depend on other flag evaluation results.

The next step is for me to update the UI to support creating such flags.

## Changes

Builds a dependency graph of flags and then evaluates flags by level.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

* Unit tests
* Manual tests via Postman
