### PR TITLE
fix(max): Include project/org/user info in root prompt

### DIFF
--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -84,7 +84,7 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelM
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
-        context["assistant_graph"] = AssistantGraph(self.team).compile_full_graph()
+        context["assistant_graph"] = AssistantGraph(self.team, cast(User, self.request.user)).compile_full_graph()
         return context
 
     def create(self, request: Request, *args, **kwargs):

--- a/ee/hogai/api/test/test_serializers.py
+++ b/ee/hogai/api/test/test_serializers.py
@@ -46,7 +46,7 @@ class TestConversationSerializers(APIBaseTest):
             mock_get_state.return_value = MockSnapshot()
 
             data = ConversationSerializer(
-                conversation, context={"assistant_graph": AssistantGraph(self.team).compile_full_graph()}
+                conversation, context={"assistant_graph": AssistantGraph(self.team, self.user).compile_full_graph()}
             ).data
 
             # Check that only the expected messages are included

--- a/ee/hogai/assistant.py
+++ b/ee/hogai/assistant.py
@@ -132,9 +132,9 @@ class Assistant:
         self._mode = mode
         match mode:
             case AssistantMode.ASSISTANT:
-                self._graph = AssistantGraph(team).compile_full_graph()
+                self._graph = AssistantGraph(team, user).compile_full_graph()
             case AssistantMode.INSIGHTS_TOOL:
-                self._graph = InsightsAssistantGraph(team).compile_full_graph()
+                self._graph = InsightsAssistantGraph(team, user).compile_full_graph()
             case _:
                 raise ValueError(f"Invalid assistant mode: {mode}")
         self._chunks = AIMessageChunk(content="")

--- a/ee/hogai/assistant.py
+++ b/ee/hogai/assistant.py
@@ -99,7 +99,7 @@ logger = structlog.get_logger(__name__)
 class Assistant:
     _team: Team
     _graph: CompiledStateGraph
-    _user: Optional[User]
+    _user: User
     _contextual_tools: dict[str, Any]
     _conversation: Conversation
     _latest_message: Optional[HumanMessage]
@@ -115,7 +115,7 @@ class Assistant:
         *,
         new_message: Optional[HumanMessage] = None,
         mode: AssistantMode = AssistantMode.ASSISTANT,
-        user: Optional[User] = None,
+        user: User,
         contextual_tools: Optional[dict[str, Any]] = None,
         is_new_conversation: bool = False,
         trace_id: Optional[str | UUID] = None,
@@ -261,7 +261,8 @@ class Assistant:
                 "trace_id": self._trace_id,
                 "distinct_id": self._user.distinct_id if self._user else None,
                 "contextual_tools": self._contextual_tools,
-                "team_id": self._team.id,
+                "team": self._team,
+                "user": self._user,
             },
         }
         return config

--- a/ee/hogai/eval/conftest.py
+++ b/ee/hogai/eval/conftest.py
@@ -58,10 +58,12 @@ def call_root_for_insight_generation(demo_org_team_user):
 
     insights_subgraph = (
         # Insights subgraph without query execution, so we only create the queries
-        InsightsAssistantGraph(demo_org_team_user[1]).add_query_creation_flow(next_node=AssistantNodeName.END).compile()
+        InsightsAssistantGraph(demo_org_team_user[1], demo_org_team_user[2])
+        .add_query_creation_flow(next_node=AssistantNodeName.END)
+        .compile()
     )
     graph = (
-        AssistantGraph(demo_org_team_user[1])
+        AssistantGraph(demo_org_team_user[1], demo_org_team_user[2])
         .add_edge(AssistantNodeName.START, AssistantNodeName.ROOT)
         .add_root(
             path_map={

--- a/ee/hogai/graph/base.py
+++ b/ee/hogai/graph/base.py
@@ -11,6 +11,7 @@ from ee.hogai.utils.exceptions import GenerationCanceled
 from ee.hogai.utils.helpers import find_last_ui_context
 from ee.models import Conversation, CoreMemory
 from posthog.models import Team
+from posthog.models.user import User
 from posthog.schema import AssistantMessage, AssistantToolCall, MaxContextShape
 
 from ..utils.types import AssistantMessageUnion, AssistantState, PartialAssistantState
@@ -18,9 +19,11 @@ from ..utils.types import AssistantMessageUnion, AssistantState, PartialAssistan
 
 class AssistantNode(ABC):
     _team: Team
+    _user: User
 
-    def __init__(self, team: Team):
+    def __init__(self, team: Team, user: User):
         self._team = team
+        self._user = user
 
     def __call__(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState | None:
         """

--- a/ee/hogai/graph/funnels/test/test_nodes.py
+++ b/ee/hogai/graph/funnels/test/test_nodes.py
@@ -16,7 +16,7 @@ from posthog.test.base import BaseTest
 
 class TestFunnelPlannerNode(BaseTest):
     def test_funnels_planner_prompt_has_tools(self):
-        node = FunnelPlannerNode(self.team)
+        node = FunnelPlannerNode(self.team, self.user)
         with patch.object(FunnelPlannerNode, "_model") as model_mock:
 
             def assert_prompt(prompt):
@@ -33,7 +33,7 @@ class TestFunnelsGeneratorNode(BaseTest):
         self.schema = AssistantFunnelsQuery(series=[])
 
     def test_node_runs(self):
-        node = FunnelGeneratorNode(self.team)
+        node = FunnelGeneratorNode(self.team, self.user)
         with patch.object(FunnelGeneratorNode, "_model") as generator_model_mock:
             generator_model_mock.return_value = RunnableLambda(
                 lambda _: FunnelsSchemaGeneratorOutput(query=self.schema).model_dump()

--- a/ee/hogai/graph/inkeep_docs/test/test_nodes.py
+++ b/ee/hogai/graph/inkeep_docs/test/test_nodes.py
@@ -25,7 +25,7 @@ class TestInkeepDocsNode(ClickhouseTestMixin, BaseTest):
                 lambda _: LangchainAIMessage(content="Here's what I found in the documentation...")
             ),
         ):
-            node = InkeepDocsNode(self.team)
+            node = InkeepDocsNode(self.team, self.user)
             state = AssistantState(
                 messages=[HumanMessage(content="How do I use feature flags?")],
                 root_tool_call_id=test_tool_call_id,
@@ -53,7 +53,7 @@ class TestInkeepDocsNode(ClickhouseTestMixin, BaseTest):
             "ee.hogai.graph.inkeep_docs.nodes.InkeepDocsNode._get_model",
             return_value=RunnableLambda(lambda _: LangchainAIMessage(content=response_with_continuation)),
         ):
-            node = InkeepDocsNode(self.team)
+            node = InkeepDocsNode(self.team, self.user)
             state = AssistantState(
                 messages=[HumanMessage(content="Show me user stats")],
                 root_tool_call_id=test_tool_call_id,
@@ -66,7 +66,7 @@ class TestInkeepDocsNode(ClickhouseTestMixin, BaseTest):
             self.assertEqual(second_message.content, response_with_continuation)
 
     def test_node_constructs_messages(self):
-        node = InkeepDocsNode(self.team)
+        node = InkeepDocsNode(self.team, self.user)
         state = AssistantState(
             messages=[
                 HumanMessage(content="First message"),
@@ -85,7 +85,7 @@ class TestInkeepDocsNode(ClickhouseTestMixin, BaseTest):
         self.assertIsInstance(messages[3], LangchainHumanMessage)
 
     def test_router_with_data_continuation(self):
-        node = InkeepDocsNode(self.team)
+        node = InkeepDocsNode(self.team, self.user)
         state = AssistantState(
             messages=[
                 HumanMessage(content="Explain PostHog trends, and show me an example trends insight"),
@@ -95,7 +95,7 @@ class TestInkeepDocsNode(ClickhouseTestMixin, BaseTest):
         self.assertEqual(node.router(state), "root")  # Going back to root, so that the agent can continue with the task
 
     def test_router_without_data_continuation(self):
-        node = InkeepDocsNode(self.team)
+        node = InkeepDocsNode(self.team, self.user)
         state = AssistantState(
             messages=[
                 HumanMessage(content="How do I use feature flags?"),
@@ -106,7 +106,7 @@ class TestInkeepDocsNode(ClickhouseTestMixin, BaseTest):
 
     def test_node_filters_empty_messages(self):
         """Test that messages with empty content are filtered out during message construction."""
-        node = InkeepDocsNode(self.team)
+        node = InkeepDocsNode(self.team, self.user)
         state = AssistantState(
             messages=[
                 HumanMessage(content=""),  # Empty message that should be filtered
@@ -130,7 +130,7 @@ class TestInkeepDocsNode(ClickhouseTestMixin, BaseTest):
             "ee.hogai.graph.inkeep_docs.nodes.InkeepDocsNode._get_model",
             return_value=RunnableLambda(lambda _: LangchainAIMessage(content="Response")),
         ):
-            node = InkeepDocsNode(self.team)
+            node = InkeepDocsNode(self.team, self.user)
             state = AssistantState(
                 messages=[HumanMessage(content="Question")],
                 root_tool_call_id=test_tool_call_id,
@@ -151,7 +151,7 @@ class TestInkeepDocsNode(ClickhouseTestMixin, BaseTest):
             "ee.hogai.graph.inkeep_docs.nodes.InkeepDocsNode._get_model",
             return_value=RunnableLambda(lambda _: LangchainAIMessage(content="Response")),
         ):
-            node = InkeepDocsNode(self.team)
+            node = InkeepDocsNode(self.team, self.user)
             state = AssistantState(
                 messages=[HumanMessage(content="Question")],
                 root_tool_call_id="test-id",

--- a/ee/hogai/graph/query_executor/test/test_nodes.py
+++ b/ee/hogai/graph/query_executor/test/test_nodes.py
@@ -35,7 +35,7 @@ class TestQueryExecutorNode(ClickhouseTestMixin, BaseTest):
 
     @patch("ee.hogai.graph.query_executor.query_executor.process_query_dict", side_effect=process_query_dict)
     def test_node_runs(self, mock_process_query_dict):
-        node = QueryExecutorNode(self.team)
+        node = QueryExecutorNode(self.team, self.user)
         new_state = node.run(
             AssistantState(
                 messages=[
@@ -83,7 +83,7 @@ class TestQueryExecutorNode(ClickhouseTestMixin, BaseTest):
         side_effect=ValueError("You have not glibbled the glorp before running this."),
     )
     def test_node_handles_internal_error(self, mock_process_query_dict):
-        node = QueryExecutorNode(self.team)
+        node = QueryExecutorNode(self.team, self.user)
         new_state = node.run(
             AssistantState(
                 messages=[
@@ -116,7 +116,7 @@ class TestQueryExecutorNode(ClickhouseTestMixin, BaseTest):
         ),
     )
     def test_node_handles_exposed_error(self, mock_process_query_dict):
-        node = QueryExecutorNode(self.team)
+        node = QueryExecutorNode(self.team, self.user)
         new_state = node.run(
             AssistantState(
                 messages=[
@@ -146,7 +146,7 @@ class TestQueryExecutorNode(ClickhouseTestMixin, BaseTest):
         self.assertIsNotNone(msg.id)
 
     def test_node_requires_a_viz_message_in_state(self):
-        node = QueryExecutorNode(self.team)
+        node = QueryExecutorNode(self.team, self.user)
 
         with self.assertRaisesMessage(
             ValueError, "Expected a visualization message, found <class 'posthog.schema.HumanMessage'>"
@@ -166,7 +166,7 @@ class TestQueryExecutorNode(ClickhouseTestMixin, BaseTest):
             )
 
     def test_fallback_to_json(self):
-        node = QueryExecutorNode(self.team)
+        node = QueryExecutorNode(self.team, self.user)
         with patch("ee.hogai.graph.query_executor.query_executor.process_query_dict") as mock_process_query_dict:
             mock_process_query_dict.return_value = QueryStatus(
                 id="test", team_id=self.team.pk, query_async=True, complete=True, results=[{"test": "test"}]
@@ -200,7 +200,7 @@ class TestQueryExecutorNode(ClickhouseTestMixin, BaseTest):
             self.assertIsNotNone(msg.id)
 
     def test_get_example_prompt(self):
-        node = QueryExecutorNode(self.team)
+        node = QueryExecutorNode(self.team, self.user)
 
         # Test Trends Query
         trends_message = VisualizationMessage(

--- a/ee/hogai/graph/rag/test/test_nodes.py
+++ b/ee/hogai/graph/rag/test/test_nodes.py
@@ -48,7 +48,7 @@ class TestInsightRagContextNode(ClickhouseTestMixin, BaseTest):
     def test_prewarm_queries(self, mock_team_taxonomy_query_runner, cohere_mock, embed_mock):
         # Arrange
         team = MagicMock()
-        retriever = InsightRagContextNode(team=team)
+        retriever = InsightRagContextNode(team=team, user=self.user)
 
         mock_runner_instance = MagicMock()
         mock_team_taxonomy_query_runner.return_value = mock_runner_instance
@@ -67,7 +67,7 @@ class TestInsightRagContextNode(ClickhouseTestMixin, BaseTest):
         mock_runner_instance.run.assert_called_once_with(ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE)
 
     def test_injects_action(self, cohere_mock, embed_mock):
-        retriever = InsightRagContextNode(team=self.team)
+        retriever = InsightRagContextNode(team=self.team, user=self.user)
         response = retriever.run(AssistantState(root_tool_insight_plan="Plan", messages=[]), {})
         self.assertIn("Action", response.rag_context)
         self.assertIn("Description", response.rag_context)

--- a/ee/hogai/graph/retention/test/test_nodes.py
+++ b/ee/hogai/graph/retention/test/test_nodes.py
@@ -19,7 +19,7 @@ from posthog.test.base import BaseTest
 
 class TestRetentionPlannerNode(BaseTest):
     def test_retention_planner_prompt_has_tools(self):
-        node = RetentionPlannerNode(self.team)
+        node = RetentionPlannerNode(self.team, self.user)
         with patch.object(RetentionPlannerNode, "_model") as model_mock:
 
             def assert_prompt(prompt):
@@ -44,7 +44,7 @@ class TestRetentionGeneratorNode(BaseTest):
         )
 
     def test_node_runs(self):
-        node = RetentionGeneratorNode(self.team)
+        node = RetentionGeneratorNode(self.team, self.user)
         with patch.object(RetentionGeneratorNode, "_model") as generator_model_mock:
             generator_model_mock.return_value = RunnableLambda(
                 lambda _: RetentionSchemaGeneratorOutput(query=self.schema).model_dump()

--- a/ee/hogai/graph/root/nodes.py
+++ b/ee/hogai/graph/root/nodes.py
@@ -1,4 +1,3 @@
-import datetime
 import importlib
 import math
 import pkgutil
@@ -19,6 +18,7 @@ from langchain_openai import ChatOpenAI
 from posthoganalytics import capture_exception
 from pydantic import BaseModel
 
+from ee.hogai.graph.shared_prompts import PROJECT_ORG_USER_CONTEXT_PROMPT
 import products
 from ee.hogai.graph.memory.nodes import should_run_onboarding_before_insights
 from ee.hogai.graph.query_executor.query_executor import AssistantQueryExecutor, SupportedQueryTypes
@@ -51,7 +51,7 @@ from .prompts import (
     ROOT_INSIGHT_CONTEXT_PROMPT,
     ROOT_INSIGHTS_CONTEXT_PROMPT,
     ROOT_SYSTEM_PROMPT,
-    ROOT_USER_CONTEXT_PROMPT,
+    ROOT_UI_CONTEXT_PROMPT,
 )
 
 # TRICKY: Dynamically import max_tools from all products
@@ -240,7 +240,7 @@ class RootNodeUIContextMixin(AssistantNode):
 
     def _render_user_context_template(self, dashboard_context: str, insights_context: str) -> str:
         """Render the user context template with the provided context strings."""
-        template = PromptTemplate.from_template(ROOT_USER_CONTEXT_PROMPT, template_format="mustache")
+        template = PromptTemplate.from_template(ROOT_UI_CONTEXT_PROMPT, template_format="mustache")
         return template.format_prompt(
             ui_context_dashboard=dashboard_context, ui_context_insights=insights_context
         ).to_string()
@@ -263,6 +263,7 @@ class RootNode(RootNodeUIContextMixin):
             ChatPromptTemplate.from_messages(
                 [
                     ("system", ROOT_SYSTEM_PROMPT),
+                    ("system", PROJECT_ORG_USER_CONTEXT_PROMPT),
                     *[
                         (
                             "system",
@@ -280,19 +281,18 @@ class RootNode(RootNodeUIContextMixin):
         )
         chain = prompt | self._get_model(state, config)
 
-        utc_now = datetime.datetime.now(datetime.UTC)
-        project_now = utc_now.astimezone(self._team.timezone_info)
-
-        ui_context = self._get_ui_context(state)
-        user_context = self._format_ui_context(ui_context)
+        ui_context = self._format_ui_context(self._get_ui_context(state))
 
         message = chain.invoke(
             {
                 "core_memory": self.core_memory_text,
-                "utc_datetime_display": utc_now.strftime("%Y-%m-%d %H:%M:%S"),
-                "project_datetime_display": project_now.strftime("%Y-%m-%d %H:%M:%S"),
-                "project_timezone": self._team.timezone_info.tzname(utc_now),
-                "user_context": user_context,
+                "project_datetime": self.project_now,
+                "project_timezone": self.project_timezone,
+                "project_name": self._team.name,
+                "organization_name": self._team.organization.name,
+                "user_full_name": self._user.get_full_name(),
+                "user_email": self._user.email,
+                "ui_context": ui_context,
             },
             config,
         )

--- a/ee/hogai/graph/root/prompts.py
+++ b/ee/hogai/graph/root/prompts.py
@@ -90,14 +90,7 @@ Follow these guidelines when searching documentation:
 - If the documentation search doesn't provide enough information, acknowledge this and suggest alternative resources or ways to get help
 </posthog_documentation>
 
-<user_context>
-The user can provide you with additional context in the <attached_context> tag.
-If the user's request is ambiguous, use the context to direct your answer as much as possible.
-If the user's provided context has nothing to do with previous interactions, ignore any past interaction and use this new context instead. The user probably wants to change topic.
-You can acknowledge that you are using this context to answer the user's request.
-</user_context>
-
-{{{user_context}}}
+{{{ui_context}}}
 """.strip()
 )
 
@@ -169,8 +162,11 @@ ROOT_HARD_LIMIT_REACHED_PROMPT = """
 You have reached the maximum number of iterations, a security measure to prevent infinite loops. Now, summarize the conversation so far and answer my question if you can. Then, ask me if I'd like to continue what you were doing.
 """.strip()
 
-ROOT_USER_CONTEXT_PROMPT = """
-Below are some potentially helpful/relevant pieces of information for figuring out to respond.
+ROOT_UI_CONTEXT_PROMPT = """
+The user can provide you with additional context in the <attached_context> tag.
+If the user's request is ambiguous, use the context to direct your answer as much as possible.
+If the user's provided context has nothing to do with previous interactions, ignore any past interaction and use this new context instead. The user probably wants to change topic.
+You can acknowledge that you are using this context to answer the user's request.
 <attached_context>
 {{{ui_context_dashboard}}}
 {{{ui_context_insights}}}

--- a/ee/hogai/graph/root/test/test_nodes.py
+++ b/ee/hogai/graph/root/test/test_nodes.py
@@ -628,7 +628,14 @@ class TestRootNodeTools(BaseTest):
             return_value=("Success", {}),
         ):
             result = node.run(
-                state, {"configurable": {"contextual_tools": {"search_session_recordings": {"current_filters": {}}}}}
+                state,
+                {
+                    "configurable": {
+                        "team": self.team,
+                        "user": self.user,
+                        "contextual_tools": {"search_session_recordings": {"current_filters": {}}},
+                    }
+                },
             )
 
         self.assertIsInstance(result, PartialAssistantState)

--- a/ee/hogai/graph/schema_generator/test/test_nodes.py
+++ b/ee/hogai/graph/schema_generator/test/test_nodes.py
@@ -42,7 +42,7 @@ class TestSchemaGeneratorNode(BaseTest):
         self.schema = AssistantTrendsQuery(series=[])
 
     def test_node_runs(self):
-        node = DummyGeneratorNode(self.team)
+        node = DummyGeneratorNode(self.team, self.user)
         with patch.object(DummyGeneratorNode, "_model") as generator_model_mock:
             generator_model_mock.return_value = RunnableLambda(lambda _: DummySchema(query=self.schema).model_dump())
             new_state = node.run(
@@ -60,7 +60,7 @@ class TestSchemaGeneratorNode(BaseTest):
             self.assertEqual(new_state.messages[0].answer, self.schema)
 
     def test_agent_reconstructs_conversation_and_does_not_add_an_empty_plan(self):
-        node = DummyGeneratorNode(self.team)
+        node = DummyGeneratorNode(self.team, self.user)
         history = node._construct_messages(
             AssistantState(messages=[HumanMessage(content="Text", id="0")], start_id="0")
         )
@@ -72,7 +72,7 @@ class TestSchemaGeneratorNode(BaseTest):
         self.assertNotIn("{{question}}", history[1].content)
 
     def test_agent_reconstructs_conversation_adds_plan(self):
-        node = DummyGeneratorNode(self.team)
+        node = DummyGeneratorNode(self.team, self.user)
         history = node._construct_messages(
             AssistantState(
                 messages=[HumanMessage(content="Text", id="0")],
@@ -94,7 +94,7 @@ class TestSchemaGeneratorNode(BaseTest):
         self.assertIn("Text", history[2].content)
 
     def test_agent_reconstructs_conversation_can_handle_follow_ups(self):
-        node = DummyGeneratorNode(self.team)
+        node = DummyGeneratorNode(self.team, self.user)
         history = node._construct_messages(
             AssistantState(
                 messages=[
@@ -130,7 +130,7 @@ class TestSchemaGeneratorNode(BaseTest):
         self.assertIn("Follow Up", history[5].content)
 
     def test_agent_reconstructs_typical_conversation(self):
-        node = DummyGeneratorNode(self.team)
+        node = DummyGeneratorNode(self.team, self.user)
         history = node._construct_messages(
             AssistantState(
                 messages=[
@@ -173,7 +173,7 @@ class TestSchemaGeneratorNode(BaseTest):
         self.assertIn("Query 3", history[8].content)
 
     def test_prompt_messages_merged(self):
-        node = DummyGeneratorNode(self.team)
+        node = DummyGeneratorNode(self.team, self.user)
         state = AssistantState(
             messages=[
                 HumanMessage(content="Question 1", id="0"),
@@ -202,7 +202,7 @@ class TestSchemaGeneratorNode(BaseTest):
             node.run(state, {})
 
     def test_failover_with_incorrect_schema(self):
-        node = DummyGeneratorNode(self.team)
+        node = DummyGeneratorNode(self.team, self.user)
         with patch.object(DummyGeneratorNode, "_model") as generator_model_mock:
             schema = DummySchema(query=None).model_dump()
             # Emulate an incorrect JSON. It should be an object.
@@ -222,7 +222,7 @@ class TestSchemaGeneratorNode(BaseTest):
             self.assertEqual(len(new_state.intermediate_steps), 2)
 
     def test_node_leaves_failover(self):
-        node = DummyGeneratorNode(self.team)
+        node = DummyGeneratorNode(self.team, self.user)
         with patch.object(
             DummyGeneratorNode,
             "_model",
@@ -250,7 +250,7 @@ class TestSchemaGeneratorNode(BaseTest):
             self.assertEqual(new_state.intermediate_steps, [])
 
     def test_node_leaves_failover_after_second_unsuccessful_attempt(self):
-        node = DummyGeneratorNode(self.team)
+        node = DummyGeneratorNode(self.team, self.user)
         with patch.object(DummyGeneratorNode, "_model") as generator_model_mock:
             schema = DummySchema(query=None).model_dump()
             # Emulate an incorrect JSON. It should be an object.
@@ -274,7 +274,7 @@ class TestSchemaGeneratorNode(BaseTest):
 
     def test_agent_reconstructs_conversation_with_failover(self):
         action = AgentAction(tool="fix", tool_input="validation error", log="exception")
-        node = DummyGeneratorNode(self.team)
+        node = DummyGeneratorNode(self.team, self.user)
         history = node._construct_messages(
             AssistantState(
                 messages=[HumanMessage(content="Text", id="0")],
@@ -300,7 +300,7 @@ class TestSchemaGeneratorNode(BaseTest):
         self.assertIn("uniqexception", history[3].content)
 
     def test_agent_reconstructs_conversation_with_failed_messages(self):
-        node = DummyGeneratorNode(self.team)
+        node = DummyGeneratorNode(self.team, self.user)
         history = node._construct_messages(
             AssistantState(
                 messages=[
@@ -324,7 +324,7 @@ class TestSchemaGeneratorNode(BaseTest):
         self.assertIn("Text", history[2].content)
 
     def test_router(self):
-        node = DummyGeneratorNode(self.team)
+        node = DummyGeneratorNode(self.team, self.user)
         state = node.router(AssistantState(messages=[], intermediate_steps=None))
         self.assertEqual(state, "next")
         state = node.router(
@@ -333,7 +333,7 @@ class TestSchemaGeneratorNode(BaseTest):
         self.assertEqual(state, "tools")
 
     def test_injects_insight_description(self):
-        node = DummyGeneratorNode(self.team)
+        node = DummyGeneratorNode(self.team, self.user)
         history = node._construct_messages(
             AssistantState(
                 messages=[HumanMessage(content="Text", id="0")],
@@ -350,7 +350,7 @@ class TestSchemaGeneratorNode(BaseTest):
         self.assertNotIn("{{question}}", history[1].content)
 
     def test_injects_insight_description_and_keeps_original_question(self):
-        node = DummyGeneratorNode(self.team)
+        node = DummyGeneratorNode(self.team, self.user)
         history = node._construct_messages(
             AssistantState(
                 messages=[
@@ -380,7 +380,7 @@ class TestSchemaGeneratorNode(BaseTest):
         self.assertNotIn("{{question}}", history[4].content)
 
     def test_keeps_maximum_number_of_viz_messages(self):
-        node = DummyGeneratorNode(self.team)
+        node = DummyGeneratorNode(self.team, self.user)
         query = AssistantTrendsQuery(series=[])
         history = node._construct_messages(
             AssistantState(
@@ -443,7 +443,7 @@ class TestSchemaGeneratorNode(BaseTest):
 
 class TestSchemaGeneratorToolsNode(BaseTest):
     def test_tools_node(self):
-        node = SchemaGeneratorToolsNode(self.team)
+        node = SchemaGeneratorToolsNode(self.team, self.user)
         action = AgentAction(tool="fix", tool_input="validationerror", log="pydanticexception")
         state = node.run(AssistantState(messages=[], intermediate_steps=[(action, None)]), {})
         self.assertIsNotNone("validationerror", state.intermediate_steps[0][1])

--- a/ee/hogai/graph/shared_prompts.py
+++ b/ee/hogai/graph/shared_prompts.py
@@ -1,5 +1,5 @@
 PROJECT_ORG_USER_CONTEXT_PROMPT = """
 You are currently in project {{{project_name}}}, which is part of the {{{organization_name}}} organization.
-The user's name is {{{user_full_name}}} ({{{user_email}}}). Feel free to refer by the first name when greeting them.
+The user's name appears to be {{{user_full_name}}} ({{{user_email}}}). Feel free to use their first name when greeting. DO NOT use this name if it appears possibly fake.
 Current time in the project's timezone, {{{project_timezone}}}: {{{project_datetime}}}.
 """.strip()

--- a/ee/hogai/graph/shared_prompts.py
+++ b/ee/hogai/graph/shared_prompts.py
@@ -1,0 +1,5 @@
+PROJECT_ORG_USER_CONTEXT_PROMPT = """
+You are currently in project {{{project_name}}}, which is part of the {{{organization_name}}} organization.
+The user's name is {{{user_full_name}}} ({{{user_email}}}). Feel free to refer by the first name when greeting them.
+Current time in the project's timezone, {{{project_timezone}}}: {{{project_datetime}}}.
+""".strip()

--- a/ee/hogai/graph/sql/test/test_nodes.py
+++ b/ee/hogai/graph/sql/test/test_nodes.py
@@ -15,7 +15,7 @@ from posthog.test.base import BaseTest
 
 class TestSQLPlannerNode(BaseTest):
     def test_sql_planner_prompt_has_tools(self):
-        node = SQLPlannerNode(self.team)
+        node = SQLPlannerNode(self.team, self.user)
         with patch.object(SQLPlannerNode, "_model") as model_mock:
 
             def assert_prompt(prompt):
@@ -30,7 +30,7 @@ class TestSQLGeneratorNode(BaseTest):
     maxDiff = None
 
     def test_node_runs(self):
-        node = SQLGeneratorNode(self.team)
+        node = SQLGeneratorNode(self.team, self.user)
         with patch.object(SQLGeneratorNode, "_model") as generator_model_mock:
             answer = AssistantHogQLQuery(query="SELECT 1")
             generator_model_mock.return_value = RunnableLambda(lambda _: answer.model_dump())

--- a/ee/hogai/graph/taxonomy_agent/test/test_nodes.py
+++ b/ee/hogai/graph/taxonomy_agent/test/test_nodes.py
@@ -42,7 +42,7 @@ class TestTaxonomyAgentPlannerNode(ClickhouseTestMixin, APIBaseTest):
                 toolkit = DummyToolkit(self._team)
                 return super()._run_with_prompt_and_toolkit(state, prompt, toolkit, config=config)
 
-        return Node(self.team)
+        return Node(self.team, self.user)
 
     def test_agent_reconstructs_conversation(self):
         node = self._get_node()
@@ -275,7 +275,7 @@ class TestTaxonomyAgentPlannerToolsNode(ClickhouseTestMixin, APIBaseTest):
                 toolkit = DummyToolkit(self._team)
                 return super()._run_with_toolkit(state, toolkit, config=config)
 
-        return Node(self.team)
+        return Node(self.team, self.user)
 
     def test_node_handles_action_name_validation_error(self):
         state = AssistantState(

--- a/ee/hogai/graph/title_generator/test/test_title_generator.py
+++ b/ee/hogai/graph/title_generator/test/test_title_generator.py
@@ -21,7 +21,7 @@ class TestTitleGenerator(BaseTest):
             "ee.hogai.graph.title_generator.nodes.TitleGeneratorNode._model",
             return_value=FakeChatOpenAI(responses=[LangchainAIMessage(content="Test Title")]),
         ):
-            node = TitleGeneratorNode(self.team)
+            node = TitleGeneratorNode(self.team, self.user)
             new_state = node.run(
                 AssistantState(messages=[HumanMessage(content="Test Message")]),
                 {"configurable": {"thread_id": self.conversation.id}},
@@ -40,7 +40,7 @@ class TestTitleGenerator(BaseTest):
             "ee.hogai.graph.title_generator.nodes.TitleGeneratorNode._model",
             return_value=FakeChatOpenAI(responses=[LangchainAIMessage(content="New Title")]),
         ):
-            node = TitleGeneratorNode(self.team)
+            node = TitleGeneratorNode(self.team, self.user)
             new_state = node.run(
                 AssistantState(messages=[HumanMessage(content="Test Message")]),
                 {"configurable": {"thread_id": self.conversation.id}},
@@ -55,7 +55,7 @@ class TestTitleGenerator(BaseTest):
         mock_model = FakeChatOpenAI(responses=[LangchainAIMessage(content="Conversation Title")])
 
         with patch.object(TitleGeneratorNode, "_model", new=Mock(return_value=mock_model)):
-            node = TitleGeneratorNode(self.team)
+            node = TitleGeneratorNode(self.team, self.user)
             new_state = node.run(
                 AssistantState(
                     messages=[
@@ -72,7 +72,7 @@ class TestTitleGenerator(BaseTest):
 
     def test_no_messages_should_skip(self):
         """Test that title generation is skipped when there are no messages in the conversation."""
-        node = TitleGeneratorNode(self.team)
+        node = TitleGeneratorNode(self.team, self.user)
         new_state = node.run(
             AssistantState(messages=[]),
             {"configurable": {"thread_id": self.conversation.id}},

--- a/ee/hogai/graph/trends/test/test_nodes.py
+++ b/ee/hogai/graph/trends/test/test_nodes.py
@@ -15,7 +15,7 @@ from posthog.test.base import BaseTest
 
 class TestTrendsPlannerNode(BaseTest):
     def test_trends_planner_prompt_has_tools(self):
-        node = TrendsPlannerNode(self.team)
+        node = TrendsPlannerNode(self.team, self.user)
         with patch.object(TrendsPlannerNode, "_model") as model_mock:
 
             def assert_prompt(prompt):
@@ -34,7 +34,7 @@ class TestTrendsGeneratorNode(BaseTest):
         self.schema = AssistantTrendsQuery(series=[])
 
     def test_node_runs(self):
-        node = TrendsGeneratorNode(self.team)
+        node = TrendsGeneratorNode(self.team, self.user)
         with patch.object(TrendsGeneratorNode, "_model") as generator_model_mock:
             generator_model_mock.return_value = RunnableLambda(
                 lambda _: TrendsSchemaGeneratorOutput(query=self.schema).model_dump()

--- a/ee/hogai/tool.py
+++ b/ee/hogai/tool.py
@@ -1,6 +1,6 @@
 import json
 from abc import abstractmethod
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import BaseTool
@@ -9,6 +9,10 @@ from pydantic import BaseModel, Field
 from ee.hogai.graph.root.prompts import ROOT_INSIGHT_DESCRIPTION_PROMPT
 from ee.hogai.utils.types import AssistantState
 from posthog.schema import AssistantContextualTool
+
+if TYPE_CHECKING:
+    from posthog.models.team.team import Team
+    from posthog.models.user import User
 
 MaxSupportedQueryKind = Literal["trends", "funnel", "retention", "sql"]
 
@@ -57,7 +61,8 @@ class MaxTool(BaseTool):
     """
 
     _context: dict[str, Any]
-    _team_id: int | None
+    _team: Optional["Team"]
+    _user: Optional["User"]
     _config: RunnableConfig
     _state: AssistantState
 
@@ -86,7 +91,8 @@ class MaxTool(BaseTool):
 
     def _run(self, *args, config: RunnableConfig, **kwargs):
         self._context = config["configurable"].get("contextual_tools", {}).get(self.get_name(), {})
-        self._team_id = config["configurable"].get("team_id", None)
+        self._team = config["configurable"]["team"]
+        self._user = config["configurable"]["user"]
         self._config = {
             "recursion_limit": 48,
             "callbacks": config.get("callbacks", []),
@@ -94,7 +100,8 @@ class MaxTool(BaseTool):
                 "thread_id": config["configurable"].get("thread_id"),
                 "trace_id": config["configurable"].get("trace_id"),
                 "distinct_id": config["configurable"].get("distinct_id"),
-                "team_id": self._team_id,
+                "team": self._team,
+                "user": self._user,
             },
         }
         return self._run_impl(*args, **kwargs)

--- a/ee/hogai/utils/test/test_assistant_node.py
+++ b/ee/hogai/utils/test/test_assistant_node.py
@@ -14,7 +14,7 @@ class TestAssistantNode(BaseTest):
             def run(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState | None:
                 raise NotImplementedError
 
-        self.node = Node(self.team)
+        self.node = Node(self.team, self.user)
 
     def test_core_memory_when_exists(self):
         core_memory = CoreMemory.objects.create(team=self.team, text="Test memory")

--- a/posthog/hogql/context.py
+++ b/posthog/hogql/context.py
@@ -61,6 +61,10 @@ class HogQLContext:
 
     property_swapper: Optional["PropertySwapper"] = None
 
+    def __post_init__(self):
+        if self.team:
+            self.team_id = self.team.id
+
     def add_value(self, value: Any) -> str:
         key = f"hogql_val_{len(self.values)}"
         self.values[key] = value

--- a/products/data_warehouse/backend/api/fix_hogql.py
+++ b/products/data_warehouse/backend/api/fix_hogql.py
@@ -39,7 +39,8 @@ class FixHogQLViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                         "error_message": error,
                     }
                 },
-                "team_id": self.team_id,
+                "team": self.team,
+                "user": user,
                 "trace_id": trace_id,
                 "distinct_id": user.distinct_id,
             },

--- a/products/data_warehouse/backend/hogql_fixer_ai.py
+++ b/products/data_warehouse/backend/hogql_fixer_ai.py
@@ -186,8 +186,8 @@ class HogQLQueryFixerTool(MaxTool):
     root_system_prompt_template: str = SQL_ASSISTANT_ROOT_SYSTEM_PROMPT
 
     def _run_impl(self) -> tuple[str, str | None]:
-        database = create_hogql_database(self._team_id)
-        hogql_context = HogQLContext(team_id=self._team_id, enable_select_queries=True, database=database)
+        database = create_hogql_database(team=self._team)
+        hogql_context = HogQLContext(team=self._team, enable_select_queries=True, database=database)
 
         all_tables = database.get_all_tables()
         schema_description = _get_schema_description(self.context, hogql_context, database)

--- a/products/data_warehouse/backend/max_tools.py
+++ b/products/data_warehouse/backend/max_tools.py
@@ -31,8 +31,8 @@ class HogQLGeneratorTool(MaxTool):
     root_system_prompt_template: str = SQL_ASSISTANT_ROOT_SYSTEM_PROMPT
 
     def _run_impl(self, instructions: str) -> tuple[str, str]:
-        database = create_hogql_database(self._team_id)
-        hogql_context = HogQLContext(team_id=self._team_id, enable_select_queries=True, database=database)
+        database = create_hogql_database(team=self._team)
+        hogql_context = HogQLContext(team=self._team, enable_select_queries=True, database=database)
 
         serialized_database = serialize_database(hogql_context)
         schema_description = "\n\n".join(

--- a/products/product_analytics/backend/max_tools.py
+++ b/products/product_analytics/backend/max_tools.py
@@ -3,7 +3,6 @@ from collections.abc import Iterator
 
 from ee.hogai.graph.root.prompts import ROOT_INSIGHT_DESCRIPTION_PROMPT
 from ee.hogai.utils.types import AssistantState
-from posthog.models.team.team import Team
 
 from posthog.schema import (
     AssistantFunnelsQuery,
@@ -48,8 +47,7 @@ class EditCurrentInsightTool(MaxTool):
         if "current_query" not in self.context:
             raise ValueError("Context `current_query` is required for the `create_and_query_insight` tool")
 
-        team = Team.objects.get(id=self._team_id)
-        graph = InsightsAssistantGraph(team).compile_full_graph()
+        graph = InsightsAssistantGraph(self._team, self._user).compile_full_graph()
         state = self._state
         last_message = state.messages[-1]
         if not isinstance(last_message, AssistantMessage):

--- a/products/user_interviews/backend/max_tools.py
+++ b/products/user_interviews/backend/max_tools.py
@@ -20,7 +20,7 @@ class AnalyzeUserInterviewsTool(MaxTool):
 
     def _run_impl(self, analysis_angle: str) -> tuple[str, Any]:
         # Get all interviews for the current team
-        interviews = UserInterview.objects.filter(team_id=self._team_id).order_by("-created_at")
+        interviews = UserInterview.objects.filter(team=self._team).order_by("-created_at")
 
         if not interviews:
             return "No user interviews found to analyze.", None


### PR DESCRIPTION
## Problem

Max didn't have the project or org name in the root node's prompt, resulting in confusion:

<img width="453" alt="image" src="https://github.com/user-attachments/assets/fb3391ea-c1bc-46f5-a123-d109cfdeb713" />

## Changes

Created `shared_prompts.py` starting with `PROJECT_ORG_USER_CONTEXT_PROMPT`. This is now included in the root node, and generally we should be including it in all nodes.

To include user info, the base `AssistantGraph` and `AssistantNode` classes now require the `user` argument, which I've added all over.

(Fly-by: Optimized `configurable["team_id"]` to instead pass the Team instance as `configurable["team"]`, avoiding redundant DB queries.)

## How did you test this code?

Added a unit test for prompt template contents. (Which has been painful to write the right mocks for – I'm taking improvement suggestions here.)