### PR TITLE
feat(persons): Track operations in shadow mode

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
@@ -12,7 +12,7 @@ import { fromInternalPerson, toInternalPerson } from './person-update-batch'
 import { PersonsStoreForBatch } from './persons-store-for-batch'
 
 interface FinalStateEntry {
-    person: InternalPerson | null
+    person: InternalPerson
     versionDisparity: boolean
     operations: Array<{
         type: string

--- a/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
@@ -11,9 +11,14 @@ import { personShadowModeComparisonCounter, personShadowModeReturnIntermediateOu
 import { fromInternalPerson, toInternalPerson } from './person-update-batch'
 import { PersonsStoreForBatch } from './persons-store-for-batch'
 
-interface PersonUpdate {
-    person: InternalPerson
+interface FinalStateEntry {
+    person: InternalPerson | null
     versionDisparity: boolean
+    operations: Array<{
+        type: string
+        timestamp: number
+        distinctId: string
+    }>
 }
 
 export interface ShadowMetrics {
@@ -27,6 +32,11 @@ export interface ShadowMetrics {
         mainPerson: InternalPerson | null
         secondaryPerson: InternalPerson | null
         differences: string[]
+        operations: Array<{
+            type: string
+            timestamp: number
+            distinctId: string
+        }>
     }>
     concurrentModifications: Array<{
         key: string
@@ -62,7 +72,7 @@ export class PersonStoreManager {
 }
 
 export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
-    private finalStates: Map<string, PersonUpdate | null> = new Map()
+    private finalStates: Map<string, FinalStateEntry | null> = new Map()
     private shadowMetrics: ShadowMetrics
 
     constructor(
@@ -88,10 +98,27 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
         teamId: number,
         distinctId: string,
         person: InternalPerson | null,
-        versionDisparity: boolean
+        versionDisparity: boolean,
+        operationType: string
     ): void {
         const key = this.getPersonKey(teamId, distinctId)
-        this.finalStates.set(key, person ? { person, versionDisparity } : null)
+        const existing = this.finalStates.get(key)
+
+        const operation = {
+            type: operationType,
+            timestamp: Date.now(),
+            distinctId,
+        }
+
+        if (person) {
+            this.finalStates.set(key, {
+                person,
+                versionDisparity,
+                operations: existing ? [...existing.operations, operation] : [operation],
+            })
+        } else {
+            this.finalStates.set(key, null)
+        }
     }
 
     async inTransaction<T>(description: string, transaction: (tx: TransactionClient) => Promise<T>): Promise<T> {
@@ -153,7 +180,7 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
             )
         }
 
-        this.updateFinalState(teamId, distinctIds![0].distinctId, mainResult[0], false)
+        this.updateFinalState(teamId, distinctIds![0].distinctId, mainResult[0], false, 'createPerson')
 
         return mainResult
     }
@@ -180,7 +207,13 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
             mainVersionDisparity
         )
 
-        this.updateFinalState(person.team_id, distinctId, mainPersonResult, mainVersionDisparity)
+        this.updateFinalState(
+            person.team_id,
+            distinctId,
+            mainPersonResult,
+            mainVersionDisparity,
+            'updatePersonForUpdate'
+        )
         return [mainPersonResult, mainKafkaMessages, mainVersionDisparity]
     }
 
@@ -206,7 +239,13 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
             mainVersionDisparity
         )
 
-        this.updateFinalState(person.team_id, distinctId, mainPersonResult, mainVersionDisparity)
+        this.updateFinalState(
+            person.team_id,
+            distinctId,
+            mainPersonResult,
+            mainVersionDisparity,
+            'updatePersonForMerge'
+        )
         return [mainPersonResult, mainKafkaMessages, mainVersionDisparity]
     }
 
@@ -215,7 +254,7 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
 
         // Clear cache for the person
         this.secondaryStore.clearCache(person.team_id, distinctId)
-        this.updateFinalState(person.team_id, distinctId, null, false)
+        this.updateFinalState(person.team_id, distinctId, null, false, 'deletePerson')
 
         return kafkaMessages
     }
@@ -227,6 +266,10 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
         tx?: TransactionClient
     ): Promise<TopicMessage[]> {
         const mainResult = await this.mainStore.addDistinctId(person, distinctId, version, tx)
+
+        // Track that this distinct ID now points to the person
+        this.updateFinalState(person.team_id, distinctId, person, false, 'addDistinctId')
+
         return mainResult
     }
 
@@ -237,6 +280,13 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
         tx?: TransactionClient
     ): Promise<TopicMessage[]> {
         const mainResult = await this.mainStore.moveDistinctIds(source, target, distinctId, tx)
+
+        // Track the reassignment in final state - all distinct IDs from source now point to target
+        // This is the critical operation that causes cache key mismatches
+        this.updateFinalState(source.team_id, distinctId, target, false, 'moveDistinctIds')
+
+        // Also clear the cache for the source person to prevent stale data
+        this.secondaryStore.clearCache(source.team_id, distinctId)
 
         return mainResult
     }
@@ -322,6 +372,7 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
                         differences: error.differences,
                         mainPersonUuid: error.mainPerson?.uuid,
                         secondaryPersonUuid: error.secondaryPerson?.uuid,
+                        operations: error.operations,
                     })),
                 })
             }
@@ -390,6 +441,7 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
                     mainPerson,
                     secondaryPerson,
                     differences: this.findDifferences(mainComparable, secondaryComparable),
+                    operations: mainUpdate?.operations || [],
                 })
             } else if (!sameOutcome && versionDisparity) {
                 // Different outcome, different batch (concurrent modification by another pod)
@@ -603,7 +655,7 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
         return String(value)
     }
 
-    getFinalStates(): Map<string, PersonUpdate | null> {
+    getFinalStates(): Map<string, FinalStateEntry | null> {
         return this.finalStates
     }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We currently see only an average 66% equality rate between what we write to the DB and what we are validating.
The error is always the same, we are comparing a full person object with a null reference in the batching cache.

I believe this can have three main reasons:
1) We are actually computing the comparison for finalState wrongly when doing some operations, meaning that our validation logic has a bug and not necessarily the batching logic
2) We have a bug in our store manager, mainly on how we are handling cache populating for the batching store when doing certain types of operations that we do not batch (createPerson, merge, delete)
3) We have a bug in the batching logic that is providing us with wrong resultsd

## Changes

This PR adds tracking to the operation associated with a distinctId, that way we can know which types of operations are causing the failure.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
