### PR TITLE
chore: add mypy to pre-push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -12,7 +12,8 @@ fi
 
 echo "Running mypy checks..."
 flox activate -- pnpm mypy-check
-if [ $? -ne 0 ]; then
+exit_code=$?
+if [ $exit_code -ne 0 ]; then
     echo "MyPy checks failed. Please fix the issues before pushing."
     exit 1
 fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -8,6 +8,14 @@ if [ $protected_branch = $current_branch ]
 then
     echo "Pushing to $protected_branch is a sin! Instead, create a pull request and repent."
     exit 1 # push will not execute
-else
-    exit 0 # push will execute
 fi
+
+echo "Running mypy checks..."
+flox activate -- pnpm mypy-check
+if [ $? -ne 0 ]; then
+    echo "MyPy checks failed. Please fix the issues before pushing."
+    exit 1
+fi
+
+echo "All checks passed!"
+exit 0


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
I always forget to run mypy. It's also the most re-run action in CI. Let's run it on pre-push to avoid pushing broken Python types and potentially running useless CI jobs.

## Changes
- Add mypy check to pre-push hook

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [X] No docs needed for this change

## How did you test this code?
- Tested locally by trying to push broken types