### PR TITLE
fix: actually stringify assignee

### DIFF
--- a/rust/cymbal/src/issue_resolution.rs
+++ b/rust/cymbal/src/issue_resolution.rs
@@ -393,9 +393,10 @@ async fn send_internal_event(
 
     if let Some(assignment) = new_assignment {
         let assignee = Assignee::try_from(&assignment)?;
+        let stringified_assignee = serde_json::to_string(&assignee)?;
 
         event
-            .insert_prop("assignee", assignee)
+            .insert_prop("assignee", stringified_assignee)
             .expect("Strings are serializable");
     }
 


### PR DESCRIPTION
## Problem

Follow up to https://github.com/PostHog/posthog/pull/33979

## Changes

Actually serialize the assignee, not pass it through as an object 🤦 