### PR TITLE
chore(ci): build storybook in test mode

### DIFF
--- a/.github/workflows/storybook-chromatic.yml
+++ b/.github/workflows/storybook-chromatic.yml
@@ -206,7 +206,6 @@ jobs:
         steps:
             - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               with:
-                  fetch-depth: 0
                   repository: ${{ github.event.pull_request.head.repo.full_name }}
                   ref: ${{ github.event.pull_request.head.ref }}
                   # Use PostHog Bot token when not on forks to enable proper snapshot updating

--- a/.github/workflows/storybook-chromatic.yml
+++ b/.github/workflows/storybook-chromatic.yml
@@ -233,7 +233,7 @@ jobs:
 
             - name: Build Storybook
               if: needs.changes.outputs.frontend == 'true'
-              run: bin/turbo --filter=@posthog/storybook build --test
+              run: bin/turbo --filter=@posthog/storybook build -- --test
 
             - name: Serve Storybook in the background
               if: needs.changes.outputs.frontend == 'true'

--- a/.github/workflows/storybook-chromatic.yml
+++ b/.github/workflows/storybook-chromatic.yml
@@ -233,7 +233,9 @@ jobs:
 
             - name: Build Storybook
               if: needs.changes.outputs.frontend == 'true'
-              run: bin/turbo --filter=@posthog/storybook build -- --test
+              run: |
+                  bin/turbo --filter=@posthog/storybook prepare
+                  pnpm --filter=@posthog/storybook build
 
             - name: Serve Storybook in the background
               if: needs.changes.outputs.frontend == 'true'

--- a/.github/workflows/storybook-chromatic.yml
+++ b/.github/workflows/storybook-chromatic.yml
@@ -233,7 +233,7 @@ jobs:
 
             - name: Build Storybook
               if: needs.changes.outputs.frontend == 'true'
-              run: bin/turbo --filter=@posthog/storybook build
+              run: bin/turbo --filter=@posthog/storybook build --test
 
             - name: Serve Storybook in the background
               if: needs.changes.outputs.frontend == 'true'

--- a/.github/workflows/storybook-chromatic.yml
+++ b/.github/workflows/storybook-chromatic.yml
@@ -235,7 +235,7 @@ jobs:
               if: needs.changes.outputs.frontend == 'true'
               run: |
                   bin/turbo --filter=@posthog/storybook prepare
-                  pnpm --filter=@posthog/storybook build
+                  pnpm --filter=@posthog/storybook build --test
 
             - name: Serve Storybook in the background
               if: needs.changes.outputs.frontend == 'true'


### PR DESCRIPTION
## Problem

Since storybook 7.6 there is a new ["test" mode](https://storybook.js.org/blog/optimize-storybook-7-6/) to make builds faster that we're not using.

The "checkout all of time" step was unneccesary

## Changes

Before - checkout takes 1min, build takes 2min 22sec:

![image](https://github.com/user-attachments/assets/d82f722e-380d-4854-9d38-a2b643c60a41)

After - checkout takes 4sec, build takes 1min 51sec:

![image](https://github.com/user-attachments/assets/24ab63ee-f363-4040-8b02-8b09dfeb9f9c)


## How did you test this code?

👀 