### PR TITLE
fix(no-code experiments): set max height on text area fields

### DIFF
--- a/frontend/src/scenes/experiments/components/ResultsBreakdown/resultsBreakdownLogic.ts
+++ b/frontend/src/scenes/experiments/components/ResultsBreakdown/resultsBreakdownLogic.ts
@@ -142,6 +142,9 @@ export const resultsBreakdownLogic = kea<resultsBreakdownLogicType>([
                         const { experiment } = props
                         const query = values.query
 
+                        // wait for 10000ms
+                        await new Promise((resolve) => setTimeout(resolve, 20000))
+
                         if (!query) {
                             throw new Error('No query returned from queryBuilder')
                         }

--- a/frontend/src/scenes/experiments/components/ResultsBreakdown/resultsBreakdownLogic.ts
+++ b/frontend/src/scenes/experiments/components/ResultsBreakdown/resultsBreakdownLogic.ts
@@ -142,9 +142,6 @@ export const resultsBreakdownLogic = kea<resultsBreakdownLogicType>([
                         const { experiment } = props
                         const query = values.query
 
-                        // wait for 10000ms
-                        await new Promise((resolve) => setTimeout(resolve, 20000))
-
                         if (!query) {
                             throw new Error('No query returned from queryBuilder')
                         }

--- a/frontend/src/toolbar/experiments/WebExperimentTransformField.tsx
+++ b/frontend/src/toolbar/experiments/WebExperimentTransformField.tsx
@@ -85,6 +85,7 @@ export function WebExperimentTransformField({
                                 }
                             }}
                             value={transform.html}
+                            maxRows={8}
                         />
                     </div>
                     <div className="mt-4">
@@ -114,6 +115,7 @@ export function WebExperimentTransformField({
                                 }
                             }}
                             value={transform.css || ''}
+                            maxRows={8}
                         />
                     </div>
                 </div>


### PR DESCRIPTION
Closes https://github.com/PostHog/posthog/issues/30184

## Changes
Set max height on text area fields.

|Before|After|
|----|----|
|![image](https://github.com/user-attachments/assets/117be282-fba3-490b-9395-24c3a3c0169d)|![image](https://github.com/user-attachments/assets/268a158e-663a-4612-bdd8-a20dbdd76d8f)|

## How did you test this code?
👀 