### PR TITLE
feat: rate limit signups by ip address

### DIFF
--- a/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
+++ b/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
@@ -108,12 +108,23 @@ export const signupLogic = kea<signupLogicType>([
 
                     location.href = res.redirect_url || '/'
                 } catch (e) {
-                    actions.setSignupPanel2ManualErrors({
-                        generic: {
-                            code: (e as Record<string, any>).code,
-                            detail: (e as Record<string, any>).detail,
-                        },
-                    })
+                    const error = e as Record<string, any>
+
+                    if (error.code === 'throttled') {
+                        actions.setSignupPanel2ManualErrors({
+                            generic: {
+                                code: error.code,
+                                detail: 'Too many signup attempts. Please try again later.',
+                            },
+                        })
+                    } else {
+                        actions.setSignupPanel2ManualErrors({
+                            generic: {
+                                code: error.code,
+                                detail: error.detail,
+                            },
+                        })
+                    }
                     throw e
                 }
             },

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -34,6 +34,7 @@ from posthog.models import (
     User,
 )
 from posthog.permissions import CanCreateOrg
+from posthog.rate_limit import SignupIPThrottle
 from posthog.utils import get_can_create_org, is_relative_url
 
 logger = structlog.get_logger(__name__)
@@ -196,6 +197,7 @@ class SignupViewset(generics.CreateAPIView):
     serializer_class = SignupSerializer
     # Enables E2E testing of signup flow
     permission_classes = (permissions.AllowAny,) if settings.E2E_TESTING else (CanCreateOrg,)
+    throttle_classes = [SignupIPThrottle]
 
 
 class InviteSignupSerializer(serializers.Serializer):

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -197,7 +197,7 @@ class SignupViewset(generics.CreateAPIView):
     serializer_class = SignupSerializer
     # Enables E2E testing of signup flow
     permission_classes = (permissions.AllowAny,) if settings.E2E_TESTING else (CanCreateOrg,)
-    throttle_classes = [SignupIPThrottle]
+    throttle_classes = [] if settings.E2E_TESTING else [SignupIPThrottle]
 
 
 class InviteSignupSerializer(serializers.Serializer):

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -7,6 +7,7 @@ from zoneinfo import ZoneInfo
 
 import pytest
 from django.core import mail
+from django.core.cache import cache
 from django.urls.base import reverse
 from django.utils import timezone
 from rest_framework import status
@@ -963,6 +964,65 @@ class TestSignupAPI(APIBaseTest):
             )
         else:
             self.assertEqual(response_data["redirect_url"], "/next_path")
+
+    @pytest.mark.skip_on_multitenancy
+    def test_signup_rate_limit_by_ip(self):
+        """Test that signup is rate limited by IP address to 5 signups per day"""
+        # Ensure the internal system metrics org doesn't prevent org-creation
+        Organization.objects.create(name="PostHog Internal Metrics", for_internal_metrics=True)
+
+        # Clear any existing rate limit cache
+        cache.clear()
+
+        for i in range(6):
+            response = self.client.post(
+                "/api/signup/",
+                {
+                    "first_name": f"User{i}",
+                    "email": f"user{i}@example.com",
+                    "password": VALID_TEST_PASSWORD,
+                    "organization_name": f"Org{i}",
+                },
+                HTTP_X_FORWARDED_FOR="192.168.1.100",
+            )
+
+            if i < 5:
+                self.assertEqual(response.status_code, status.HTTP_201_CREATED, f"Request {i+1} should succeed")
+                # Clean up the created org and user to allow next signup
+                Organization.objects.filter(for_internal_metrics=False).delete()
+                User.objects.filter(email=f"user{i}@example.com").delete()
+            else:
+                self.assertEqual(
+                    response.status_code, status.HTTP_429_TOO_MANY_REQUESTS, "6th request should be rate limited"
+                )
+
+    @pytest.mark.skip_on_multitenancy
+    def test_signup_rate_limit_different_ips(self):
+        """Test that different IPs can signup independently"""
+        # Ensure the internal system metrics org doesn't prevent org-creation
+        Organization.objects.create(name="PostHog Internal Metrics", for_internal_metrics=True)
+
+        # Clear any existing rate limit cache
+        cache.clear()
+
+        # Test that different IPs can each make 5 signups
+        for ip_suffix in range(2):
+            ip = f"192.168.1.{100 + ip_suffix}"
+            for i in range(5):
+                response = self.client.post(
+                    "/api/signup/",
+                    {
+                        "first_name": f"User{ip_suffix}_{i}",
+                        "email": f"user{ip_suffix}_{i}@example.com",
+                        "password": VALID_TEST_PASSWORD,
+                        "organization_name": f"Org{ip_suffix}_{i}",
+                    },
+                    HTTP_X_FORWARDED_FOR=ip,
+                )
+                self.assertEqual(response.status_code, status.HTTP_201_CREATED, f"Request from IP {ip} should succeed")
+                # Clean up the created org and user to allow next signup
+                Organization.objects.filter(for_internal_metrics=False).delete()
+                User.objects.filter(email=f"user{ip_suffix}_{i}@example.com").delete()
 
 
 class TestInviteSignupAPI(APIBaseTest):

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -280,6 +280,21 @@ class UserOrEmailRateThrottle(SimpleRateThrottle):
         return self.cache_format % {"scope": self.scope, "ident": ident}
 
 
+class SignupIPThrottle(SimpleRateThrottle):
+    """
+    Rate limit signups by IP address to avoid a single IP address from creating too many accounts.
+    """
+
+    scope = "signup_ip"
+    rate = "5/day"
+
+    def get_cache_key(self, request, view):
+        from posthog.utils import get_ip_address
+
+        ip = get_ip_address(request)
+        return self.cache_format % {"scope": self.scope, "ident": ip}
+
+
 class BurstRateThrottle(PersonalApiKeyRateThrottle):
     # Throttle class that's applied on all endpoints (except for capture + decide)
     # Intended to block quick bursts of requests, per project


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We've been getting a lot of bot signups recently.

## Changes

Adds IP based rate limiting to `/api/signup` to reduce the possibility of creating lots of accounts from a single IP address.

## How did you test this code?

Unit tests, ran locally.
