### PR TITLE
fix(flags): remove group_key filtering

### DIFF
--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -275,15 +275,9 @@ pub fn locally_computable_property_overrides(
         return None;
     }
 
-    // Filter out metadata that isn't a real property override
-    let real_overrides = extract_real_property_overrides(overrides);
-    if real_overrides.is_empty() {
-        return None;
-    }
-
     // Only return overrides if they're useful for this flag
-    if are_overrides_useful_for_flag(&real_overrides, property_filters) {
-        Some(real_overrides)
+    if are_overrides_useful_for_flag(overrides, property_filters) {
+        Some(overrides.clone())
     } else {
         None
     }
@@ -294,15 +288,6 @@ fn has_cohort_filters(property_filters: &[PropertyFilter]) -> bool {
     property_filters
         .iter()
         .any(|prop| prop.prop_type == PropertyType::Cohort)
-}
-
-/// Extracts real property overrides, filtering out metadata like $group_key
-fn extract_real_property_overrides(overrides: &HashMap<String, Value>) -> HashMap<String, Value> {
-    overrides
-        .iter()
-        .filter(|(key, _)| *key != "$group_key")
-        .map(|(key, value)| (key.clone(), value.clone()))
-        .collect()
 }
 
 /// Determines if the provided overrides contain properties that the flag actually needs

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -4307,3 +4307,82 @@ async fn test_returns_empty_flags_when_no_active_flags_configured() -> Result<()
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_group_key_property_matching() -> Result<()> {
+    let config = DEFAULT_TEST_CONFIG.clone();
+    let distinct_id = "user_distinct_id".to_string();
+
+    let client = setup_redis_client(Some(config.redis_url.clone()));
+    let pg_client = setup_pg_reader_client(None).await;
+    let team = insert_new_team_in_redis(client.clone()).await.unwrap();
+    let team = insert_new_team_in_pg(pg_client.clone(), Some(team.id))
+        .await
+        .unwrap();
+    let token = team.api_token;
+
+    // Create a flag that filters on $group_key property
+    let flag_json = json!([{
+        "id": 1,
+        "key": "group-key-flag",
+        "name": "Group Key Flag",
+        "active": true,
+        "deleted": false,
+        "team_id": team.id,
+        "filters": {
+            "groups": [
+                {
+                    "properties": [
+                        {
+                            "key": "$group_key",
+                            "value": "test_company_id",
+                            "operator": "exact",
+                            "type": "group",
+                            "group_type_index": 0
+                        }
+                    ],
+                    "rollout_percentage": 100
+                }
+            ],
+            "aggregation_group_type_index": 0
+        },
+    }]);
+
+    insert_flags_for_team_in_redis(
+        client,
+        team.id,
+        team.project_id,
+        Some(flag_json.to_string()),
+    )
+    .await?;
+
+    let server = ServerHandle::for_config(config).await;
+
+    // Test with group_key that should match the filter
+    let payload = json!({
+        "token": token,
+        "distinct_id": distinct_id,
+        "groups": {
+            "project": "test_company_id"
+        }
+    });
+
+    let res = server
+        .send_flags_request(payload.to_string(), None, None)
+        .await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    let json_data = res.json::<Value>().await?;
+
+    assert_json_include!(
+        actual: json_data,
+        expected: json!({
+            "errorsWhileComputingFlags": false,
+            "featureFlags": {
+                "group-key-flag": true
+            }
+        })
+    );
+
+    Ok(())
+}

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -4384,5 +4384,54 @@ async fn test_group_key_property_matching() -> Result<()> {
         })
     );
 
+    // Test with non-matching group key
+    let payload = json!({
+        "token": token,
+        "distinct_id": distinct_id,
+        "groups": {
+            "project": "wrong_company_id"
+        }
+    });
+
+    let res = server
+        .send_flags_request(payload.to_string(), None, None)
+        .await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    let json_data = res.json::<Value>().await?;
+
+    assert_json_include!(
+        actual: json_data,
+        expected: json!({
+            "errorsWhileComputingFlags": false,
+            "featureFlags": {
+                "group-key-flag": false
+            }
+        })
+    );
+
+    // Test with missing groups entirely
+    let payload = json!({
+        "token": token,
+        "distinct_id": distinct_id
+    });
+
+    let res = server
+        .send_flags_request(payload.to_string(), None, None)
+        .await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    let json_data = res.json::<Value>().await?;
+
+    assert_json_include!(
+        actual: json_data,
+        expected: json!({
+            "errorsWhileComputingFlags": false,
+            "featureFlags": {
+                "group-key-flag": false
+            }
+        })
+    );
+
     Ok(())
 }


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
https://posthoghelp.zendesk.com/agent/tickets/32814 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/35174)

We don't do this filtering in `/decide`, so we shouldn't in `/flags` as well. 

We add group_key here in Python:

https://github.com/PostHog/posthog/blob/d52e9ba4f6dd145da8071a3e7480ea3a4743db04/posthog/models/feature_flag/flag_matching.py#L1202-L1213


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [x] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
