### PR TITLE
fix(managed_migrations): clear display message on resume

### DIFF
--- a/rust/batch-import-worker/src/job/mod.rs
+++ b/rust/batch-import-worker/src/job/mod.rs
@@ -156,7 +156,7 @@ impl Job {
                     .pause(
                         self.context.clone(),
                         format!("Failed to fetch and parse chunk: {:?}", e),
-                        user_facing_error_message.to_string(),
+                        Some(user_facing_error_message.to_string()),
                     )
                     .await?;
                 return Ok(None);
@@ -341,7 +341,7 @@ impl Job {
             .pause(
                 self.context.clone(),
                 status_message,
-                "Job paused while committing events".to_string(),
+                Some("Job paused while committing events".to_string()),
             )
             .await
     }

--- a/rust/batch-import-worker/src/job/model.rs
+++ b/rust/batch-import-worker/src/job/model.rs
@@ -201,17 +201,18 @@ impl JobModel {
         &mut self,
         context: Arc<AppContext>,
         reason: String,
-        display_reason: String,
+        display_reason: Option<String>,
     ) -> Result<(), Error> {
         self.status = JobStatus::Paused;
         self.status_message = Some(reason);
-        self.display_status_message = Some(display_reason);
+        self.display_status_message = display_reason;
         self.flush(&context.db, true).await
     }
 
     pub async fn unpause(&mut self, context: Arc<AppContext>) -> Result<(), Error> {
         self.status = JobStatus::Running;
         self.status_message = None;
+        self.display_status_message = None;
         self.flush(&context.db, true).await
     }
 

--- a/rust/batch-import-worker/src/main.rs
+++ b/rust/batch-import-worker/src/main.rs
@@ -95,7 +95,7 @@ pub async fn main() -> Result<(), Error> {
                     .pause(
                         context.clone(),
                         error_msg,
-                        user_facing_error_message.to_string(),
+                        Some(user_facing_error_message.to_string()),
                     )
                     .await
                 {


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We should clear any display status messages we've set on a the job model when we resume a job because they are no longer relevant.

## Changes

Re-factored the dispaly_status_message to be optional and added a line to clear display_status_message in `unpause` method.

## Did you write or update any docs for this change?

## How did you test this code?

Locally
