### PR TITLE
fix: Order person column by index

### DIFF
--- a/posthog/hogql_queries/test/test_actors_query_runner.py
+++ b/posthog/hogql_queries/test/test_actors_query_runner.py
@@ -180,6 +180,80 @@ class TestActorsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         results = runner.calculate().results
         self.assertEqual(results[0], [f"jacob0@{self.random_uuid}.posthog.com"])
 
+    def test_persons_query_order_by_person_display_name(self):
+        _create_person(
+            properties={"email": "tom@posthog.com"},
+            distinct_ids=["2", "some-random-uid"],
+            team=self.team,
+        )
+        _create_person(
+            properties={"email": "arthur@posthog.com"},
+            distinct_ids=["7", "another-random-uid"],
+            team=self.team,
+        )
+        _create_person(
+            properties={"email": "chris@posthog.com"},
+            distinct_ids=["3", "yet-another-random-uid"],
+            team=self.team,
+        )
+        flush_persons_and_events()
+        test_cases = [
+            (
+                "ascending",
+                ["person_display_name -- Person ASC"],
+                ["arthur@posthog.com", "chris@posthog.com", "tom@posthog.com"],
+            ),
+            (
+                "descending",
+                ["person_display_name -- Person DESC"],
+                ["tom@posthog.com", "chris@posthog.com", "arthur@posthog.com"],
+            ),
+            ("no ordering", [], ["tom@posthog.com", "arthur@posthog.com", "chris@posthog.com"]),
+        ]
+        for msg, order_by, expected in test_cases:
+            with self.subTest(msg):
+                runner = self._create_runner(ActorsQuery(select=["person_display_name -- Person"], orderBy=order_by))
+                results = runner.calculate().results
+                response_order = [person[0]["display_name"] for person in results]
+                self.assertEqual(response_order, expected)
+
+    def test_persons_query_order_by_person_display_name_when_column_is_not_selected(self):
+        _create_person(
+            properties={"email": "tom@posthog.com", "name": "Tom"},
+            distinct_ids=["2", "some-random-uid"],
+            team=self.team,
+        )
+        _create_person(
+            properties={"email": "arthur@posthog.com", "name": "Arthur"},
+            distinct_ids=["7", "another-random-uid"],
+            team=self.team,
+        )
+        _create_person(
+            properties={"email": "chris@posthog.com", "name": "Chris"},
+            distinct_ids=["3", "yet-another-random-uid"],
+            team=self.team,
+        )
+        flush_persons_and_events()
+        test_cases = [
+            (
+                "ascending",
+                ["person_display_name -- Person ASC"],
+                ["Arthur", "Chris", "Tom"],
+            ),
+            (
+                "descending",
+                ["person_display_name -- Person DESC"],
+                ["Tom", "Chris", "Arthur"],
+            ),
+            ("no ordering", [], ["Tom", "Arthur", "Chris"]),
+        ]
+        for msg, order_by, expected in test_cases:
+            with self.subTest(msg):
+                runner = self._create_runner(ActorsQuery(select=["properties.name"], orderBy=order_by))
+                results = runner.calculate().results
+                response_order = [person[0] for person in results]
+                self.assertEqual(response_order, expected)
+
     def test_persons_query_limit(self):
         self.random_uuid = self._create_random_persons()
         runner = self._create_runner(


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
Ordering was broken in Persons query. The frontend would pass in an ordering string containing an alias for the column name. E.g.: `person_display_name -- Person ASC`. The parser would remove the "comment" from the column name, causing a mismatch between the column name (`person_display_name -- Person`) and the ordering key (`person_display_name`).

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
closes #32726 

## Changes
Order `ActorsQuery` by index instead of column name when ordering by `person_display_name` . This is a hacky solution, but it looks better than handling the alias/renaming the column in different places.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Wrote a unit test reproducing the error, with the same parameters used in the UI.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
