### PR TITLE
feat(unschedule-materialization-items-with-missing-table-refs): Handle missing table ref error for materialization

### DIFF
--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -43,6 +43,7 @@ from posthog.warehouse.models import (
 )
 from posthog.warehouse.models.data_modeling_job import DataModelingJob
 from posthog.warehouse.util import database_sync_to_async
+from posthog.warehouse.data_load.saved_query_service import delete_saved_query_schedule
 
 # preserve casing since we are already coming from a sql dialect, we don't need to worry about normalizing
 os.environ["SCHEMA__NAMING"] = "direct"
@@ -477,6 +478,12 @@ async def materialize_model(
             raise CannotCoerceColumnException(
                 f"Data type not supported in model {model_label}: {error_message}. This is likely due to decimal precision."
             ) from e
+        elif "Unknown table" in error_message:
+            saved_query.latest_error = f"Table reference no longer exists for model {model_label}"
+            await logger.ainfo("Table reference no longer exists for model %s, reverting materialization", model_label)
+            await revert_materialization(saved_query, logger)
+            await mark_job_as_failed(job, error_message, logger)
+            raise Exception(f"Table reference missing for model {model_label}: {error_message}") from e
         else:
             saved_query.latest_error = f"Failed to materialize model {model_label}"
             error_message = "Your query failed to materialize. If this query ran for a long time, try optimizing it."
@@ -522,6 +529,24 @@ async def mark_job_as_failed(job: DataModelingJob, error_message: str, logger: F
     job.status = DataModelingJob.Status.FAILED
     job.error = error_message
     await database_sync_to_async(job.save)()
+
+
+async def revert_materialization(saved_query: DataWarehouseSavedQuery, logger: FilteringBoundLogger) -> None:
+    """
+    This stops the temporal workflow for a materialization view. Expected to be used in the case of an
+    unrecoverable error, like a table reference no longer existing.
+    """
+    try:
+        await database_sync_to_async(delete_saved_query_schedule)(str(saved_query.id))
+
+        saved_query.sync_frequency_interval = None
+        saved_query.status = None
+        await database_sync_to_async(saved_query.save)()
+
+        await logger.ainfo("Successfully reverted materialization for saved query %s", saved_query.name)
+
+    except Exception as e:
+        await logger.aexception("Failed to revert materialization for saved query %s: %s", saved_query.name, str(e))
 
 
 async def update_table_row_count(

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -1192,7 +1192,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             ExternalDataSource.Type.MSSQL,
         ]:
             # Importing pymssql requires mssql drivers to be installed locally - see posthog/warehouse/README.md
-            from pymssql import OperationalError as MSSQLOperationalError
+            # from pymssql import OperationalError as MSSQLOperationalError
 
             host = request.data.get("host", None)
             port = request.data.get("port", None)
@@ -1307,17 +1307,17 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                     status=status.HTTP_400_BAD_REQUEST,
                     data={"message": exposed_error or get_generic_sql_error(source_type)},
                 )
-            except MSSQLOperationalError as e:
-                error_msg = " ".join(str(n) for n in e.args)
-                exposed_error = self._expose_mssql_error(error_msg)
+            # except MSSQLOperationalError as e:
+            #     error_msg = " ".join(str(n) for n in e.args)
+            #     exposed_error = self._expose_mssql_error(error_msg)
 
-                if exposed_error is None:
-                    capture_exception(e)
+            #     if exposed_error is None:
+            #         capture_exception(e)
 
-                return Response(
-                    status=status.HTTP_400_BAD_REQUEST,
-                    data={"message": exposed_error or get_generic_sql_error(source_type)},
-                )
+            #     return Response(
+            #         status=status.HTTP_400_BAD_REQUEST,
+            #         data={"message": exposed_error or get_generic_sql_error(source_type)},
+            #     )
             except BaseSSHTunnelForwarderError as e:
                 return Response(
                     status=status.HTTP_400_BAD_REQUEST,

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -1192,7 +1192,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             ExternalDataSource.Type.MSSQL,
         ]:
             # Importing pymssql requires mssql drivers to be installed locally - see posthog/warehouse/README.md
-            # from pymssql import OperationalError as MSSQLOperationalError
+            from pymssql import OperationalError as MSSQLOperationalError
 
             host = request.data.get("host", None)
             port = request.data.get("port", None)
@@ -1307,17 +1307,17 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                     status=status.HTTP_400_BAD_REQUEST,
                     data={"message": exposed_error or get_generic_sql_error(source_type)},
                 )
-            # except MSSQLOperationalError as e:
-            #     error_msg = " ".join(str(n) for n in e.args)
-            #     exposed_error = self._expose_mssql_error(error_msg)
+            except MSSQLOperationalError as e:
+                error_msg = " ".join(str(n) for n in e.args)
+                exposed_error = self._expose_mssql_error(error_msg)
 
-            #     if exposed_error is None:
-            #         capture_exception(e)
+                if exposed_error is None:
+                    capture_exception(e)
 
-            #     return Response(
-            #         status=status.HTTP_400_BAD_REQUEST,
-            #         data={"message": exposed_error or get_generic_sql_error(source_type)},
-            #     )
+                return Response(
+                    status=status.HTTP_400_BAD_REQUEST,
+                    data={"message": exposed_error or get_generic_sql_error(source_type)},
+                )
             except BaseSSHTunnelForwarderError as e:
                 return Response(
                     status=status.HTTP_400_BAD_REQUEST,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Users can remove table references out from under a materialized view which causes it to fail forever in an unrecoverable way. There is no way to recover this, but the schedule will keep trying resulting in more and more errors that go on forever.

<img width="1057" alt="image" src="https://github.com/user-attachments/assets/a2458ebb-f298-438b-bcc3-d060cd17ab80" />


## Changes
- [x] Destroy schedules and reset view when we detect this missing table ref issue.


## Did you write or update any docs for this change?

## How did you test this code?
Added a table, materialized from the table, then deleted the table and waited for the next sync to clean it up.
