### PR TITLE
fix: add flags service to hobby deploy

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -152,6 +152,8 @@ mkdir -p ./share &&
 if [ ! -f ./share/GeoLite2-City.mmdb ]; then 
     curl -L 'https://mmdbcdn.posthog.net/' --http1.1 | brotli --decompress --output=./share/GeoLite2-City.mmdb && 
     echo '{\"date\": \"'$(date +%Y-%m-%d)'\"}' > ./share/GeoLite2-City.json; 
+    chmod 644 ./share/GeoLite2-City.mmdb &&
+    chmod 644 ./share/GeoLite2-City.json
 fi
 
 # write entrypoint

--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -144,6 +144,14 @@ ENCRYPTION_SALT_KEYS=$ENCRYPTION_SALT_KEYS
 DOMAIN=$DOMAIN
 EOF
 
+# Download GeoLite2-City.mmdb if it doesn't exist
+echo "Downloading GeoIP database file"
+mkdir -p /share && 
+if [ ! -f /share/GeoLite2-City.mmdb ]; then 
+    curl -L 'https://mmdbcdn.posthog.net/' --http1.1 | brotli --decompress --output=/share/GeoLite2-City.mmdb && 
+    echo '{\"date\": \"'$(date +%Y-%m-%d)'\"}' > /share/GeoLite2-City.json; 
+fi
+
 # write entrypoint
 # NOTE: this is duplicated in bin/upgrade-hobby, so if you change it here,
 # change it there too.

--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -146,10 +146,12 @@ EOF
 
 # Download GeoLite2-City.mmdb if it doesn't exist
 echo "Downloading GeoIP database file"
-mkdir -p /share && 
-if [ ! -f /share/GeoLite2-City.mmdb ]; then 
-    curl -L 'https://mmdbcdn.posthog.net/' --http1.1 | brotli --decompress --output=/share/GeoLite2-City.mmdb && 
-    echo '{\"date\": \"'$(date +%Y-%m-%d)'\"}' > /share/GeoLite2-City.json; 
+apt-get update && 
+apt-get install -y --no-install-recommends curl ca-certificates brotli && 
+mkdir -p ./share && 
+if [ ! -f ./share/GeoLite2-City.mmdb ]; then 
+    curl -L 'https://mmdbcdn.posthog.net/' --http1.1 | brotli --decompress --output=./share/GeoLite2-City.mmdb && 
+    echo '{\"date\": \"'$(date +%Y-%m-%d)'\"}' > ./share/GeoLite2-City.json; 
 fi
 
 # write entrypoint

--- a/bin/upgrade-hobby
+++ b/bin/upgrade-hobby
@@ -86,10 +86,12 @@ cd ../
 
 # Download GeoLite2-City.mmdb if it doesn't exist
 echo "Downloading GeoIP database file"
-mkdir -p /share && 
-if [ ! -f /share/GeoLite2-City.mmdb ]; then 
-    curl -L 'https://mmdbcdn.posthog.net/' --http1.1 | brotli --decompress --output=/share/GeoLite2-City.mmdb && 
-    echo '{\"date\": \"'$(date +%Y-%m-%d)'\"}' > /share/GeoLite2-City.json; 
+apt-get update && 
+apt-get install -y --no-install-recommends curl ca-certificates brotli && 
+mkdir -p ./share && 
+if [ ! -f ./share/GeoLite2-City.mmdb ]; then 
+    curl -L 'https://mmdbcdn.posthog.net/' --http1.1 | brotli --decompress --output=./share/GeoLite2-City.mmdb && 
+    echo '{\"date\": \"'$(date +%Y-%m-%d)'\"}' > ./share/GeoLite2-City.json; 
 fi
 
 # Upgrade Docker Compose to version 2.33.1

--- a/bin/upgrade-hobby
+++ b/bin/upgrade-hobby
@@ -84,6 +84,14 @@ cd posthog
 git pull --prune
 cd ../
 
+# Download GeoLite2-City.mmdb if it doesn't exist
+echo "Downloading GeoIP database file"
+mkdir -p /share && 
+if [ ! -f /share/GeoLite2-City.mmdb ]; then 
+    curl -L 'https://mmdbcdn.posthog.net/' --http1.1 | brotli --decompress --output=/share/GeoLite2-City.mmdb && 
+    echo '{\"date\": \"'$(date +%Y-%m-%d)'\"}' > /share/GeoLite2-City.json; 
+fi
+
 # Upgrade Docker Compose to version 2.33.1
 echo "Setting up Docker Compose"
 sudo rm /usr/local/bin/docker-compose

--- a/bin/upgrade-hobby
+++ b/bin/upgrade-hobby
@@ -91,7 +91,9 @@ apt-get install -y --no-install-recommends curl ca-certificates brotli &&
 mkdir -p ./share && 
 if [ ! -f ./share/GeoLite2-City.mmdb ]; then 
     curl -L 'https://mmdbcdn.posthog.net/' --http1.1 | brotli --decompress --output=./share/GeoLite2-City.mmdb && 
-    echo '{\"date\": \"'$(date +%Y-%m-%d)'\"}' > ./share/GeoLite2-City.json; 
+    echo '{\"date\": \"'$(date +%Y-%m-%d)'\"}' > ./share/GeoLite2-City.json && 
+    chmod 644 ./share/GeoLite2-City.mmdb &&
+    chmod 644 ./share/GeoLite2-City.json
 fi
 
 # Upgrade Docker Compose to version 2.33.1

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -292,6 +292,9 @@ services:
         extends:
             file: docker-compose.base.yml
             service: feature-flags
+        depends_on:
+            - db
+            - redis
 
 volumes:
     zookeeper-data:

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -288,6 +288,11 @@ services:
         volumes:
             - ./posthog/docker/livestream/configs-hobby.yml:/configs/configs.yml
 
+    feature-flags:
+        extends:
+            file: docker-compose.base.yml
+            service: feature-flags
+
 volumes:
     zookeeper-data:
     zookeeper-datalog:

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -291,6 +291,8 @@ services:
             - ./posthog/docker/livestream/configs-hobby.yml:/configs/configs.yml
 
     feature-flags:
+        build:
+            context: ./posthog/rust
         extends:
             file: docker-compose.base.yml
             service: feature-flags

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -278,8 +278,6 @@ services:
             service: property-defs-rs
 
     livestream:
-        build:
-            context: ./posthog/rust
         extends:
             file: docker-compose.base.yml
             service: livestream

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -278,6 +278,8 @@ services:
             service: property-defs-rs
 
     livestream:
+        build:
+            context: ./posthog/rust
         extends:
             file: docker-compose.base.yml
             service: livestream


### PR DESCRIPTION
when installing a new self-hosted posthog and trying to use it to track then i get errors in the front end

<img width="968" alt="Screenshot 2025-06-24 at 10 31 20" src="https://github.com/user-attachments/assets/5931dec7-fe07-4794-9ebf-afe0136f580f" />

I'm assuming that means we need to add the flags service to the hobby install stack