### PR TITLE
fix(batch-exports): Add additional non-retryable errors

### DIFF
--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -886,6 +886,10 @@ class PostgresBatchExportWorkflow(PostHogWorkflow):
                 "ForeignKeyViolation",
                 # Data (usually event properties) contains garbage that we cannot clean.
                 "UntranslatableCharacter",
+                "InvalidTextRepresentation",
+                # Can be raised when merging tables with an incompatible schema (eg if the destination table has been
+                # created manually)
+                "DatatypeMismatch",
             ],
             finish_inputs=finish_inputs,
         )

--- a/posthog/temporal/batch_exports/redshift_batch_export.py
+++ b/posthog/temporal/batch_exports/redshift_batch_export.py
@@ -624,6 +624,10 @@ class RedshiftBatchExportWorkflow(PostHogWorkflow):
                 "PostgreSQLConnectionError",
                 # Column missing in Redshift, likely the schema was altered.
                 "UndefinedColumn",
+                # Raised by our PostgreSQL client when a given feature is not supported.
+                # This can also happen when merging tables with a different number of columns:
+                # "Target relation and source relation must have the same number of columns"
+                "FeatureNotSupported",
             ],
             finish_inputs=finish_inputs,
         )


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Some batch exports are failing due to errors we cannot do anything about:

- [`InvalidTextRepresentation`](https://cloud.temporal.io/namespaces/posthog-prod-us.usz2o/workflows/019559d3-890d-0001-d2a3-72b04e2b3fab-2025-01-23T00%3A00%3A00Z/0197541c-9d81-7319-a637-50c58f5974bf/history)
- [`FeatureNotSupported`](https://cloud.temporal.io/namespaces/posthog-prod-us.usz2o/workflows/01979d6b-c975-0001-0ca7-9d87ec5d465c-2025-06-20T00%3A00%3A00Z/01979d6c-4870-7bd0-97e6-57df28367dbf/history)
- [`DatatypeMismatch`](https://cloud.temporal.io/namespaces/posthog-prod-eu.usz2o/workflows/0197829c-a58e-0001-4135-9eb9ad81ff4a-2025-04-29T20%3A00%3A00Z/019782ac-f366-70f8-92b4-8520277d37b6/history)

Sometimes, we retry these activities and they succeed the second time when resuming from a Temporal heartbeat, which is not what we want.

## Changes

Add new non-retryable errors

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
