### PR TITLE
fix(batch-exports): Bump start to close timeout for new stage activity

### DIFF
--- a/posthog/temporal/batch_exports/pre_export_stage.py
+++ b/posthog/temporal/batch_exports/pre_export_stage.py
@@ -113,7 +113,8 @@ async def execute_batch_export_insert_activity_using_s3_stage(
         heartbeat_timeout_seconds = settings.BATCH_EXPORT_HEARTBEAT_TIMEOUT_SECONDS
 
     if interval == "hour":
-        start_to_close_timeout = dt.timedelta(hours=1)
+        # TODO - we should reduce this to 1 hour once we are more confident about hitting 1 hour SLAs.
+        start_to_close_timeout = dt.timedelta(hours=2)
     elif interval == "day":
         start_to_close_timeout = dt.timedelta(days=1)
     elif interval.startswith("every"):


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Some very large backfills still do not complete in 1 hour 😢 

## Changes

Bump the start to close timeout for hourly batch exports from 1 to 2 hours until we are confident we can meet the 1 hour time limit

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

n/a
