### PR TITLE
chore: move cinema mode

### DIFF
--- a/frontend/src/scenes/session-recordings/SessionRecordings.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordings.tsx
@@ -1,6 +1,6 @@
 import { IconEllipsis, IconGear } from '@posthog/icons'
 import { IconOpenSidebar } from '@posthog/icons'
-import { LemonBadge, LemonButton, LemonMenu, LemonSwitch } from '@posthog/lemon-ui'
+import { LemonBadge, LemonButton, LemonMenu } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import {
@@ -28,7 +28,6 @@ import { urls } from 'scenes/urls'
 import { NotebookNodeType, ReplayTab, ReplayTabs } from '~/types'
 import { ProductKey } from '~/types'
 
-import { playerSettingsLogic } from './player/playerSettingsLogic'
 import { createPlaylist } from './playlist/playlistUtils'
 import { SessionRecordingsPlaylist } from './playlist/SessionRecordingsPlaylist'
 import { SavedSessionRecordingPlaylists } from './saved-playlists/SavedSessionRecordingPlaylists'
@@ -250,44 +249,29 @@ const ReplayPageTabs: ReplayTab[] = [
 
 function PageTabs(): JSX.Element {
     const { tab, shouldShowNewBadge } = useValues(sessionReplaySceneLogic)
-    const { isZenMode } = useValues(playerSettingsLogic)
-    const { setIsZenMode } = useActions(playerSettingsLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     return (
-        <div className={`${featureFlags[FEATURE_FLAGS.REPLAY_ZEN_MODE] && 'flex justify-between items-center'}`}>
-            <LemonTabs
-                activeKey={tab}
-                className="flex"
-                onChange={(t) => router.actions.push(urls.replay(t as ReplayTabs))}
-                tabs={ReplayPageTabs.map((replayTab): LemonTab<string> => {
-                    return {
-                        label: (
-                            <>
-                                {replayTab.label}
-                                {replayTab.label === ReplayTabs.Templates && shouldShowNewBadge && (
-                                    <LemonBadge className="ml-1" size="small" />
-                                )}
-                            </>
-                        ),
-                        key: replayTab.key,
-                        tooltip: replayTab.tooltip,
-                        tooltipDocLink: replayTab.tooltipDocLink,
-                        'data-attr': replayTab['data-attr'],
-                    }
-                })}
-            />
-            {featureFlags[FEATURE_FLAGS.REPLAY_ZEN_MODE] && (
-                <div className="flex items-center gap-2">
-                    <LemonSwitch
-                        data-attr="opt-in-cinema-mode-switch"
-                        onChange={setIsZenMode}
-                        checked={isZenMode}
-                        label="Cinema mode"
-                    />
-                </div>
-            )}
-        </div>
+        <LemonTabs
+            activeKey={tab}
+            className="flex"
+            onChange={(t) => router.actions.push(urls.replay(t as ReplayTabs))}
+            tabs={ReplayPageTabs.map((replayTab): LemonTab<string> => {
+                return {
+                    label: (
+                        <>
+                            {replayTab.label}
+                            {replayTab.label === ReplayTabs.Templates && shouldShowNewBadge && (
+                                <LemonBadge className="ml-1" size="small" />
+                            )}
+                        </>
+                    ),
+                    key: replayTab.key,
+                    tooltip: replayTab.tooltip,
+                    tooltipDocLink: replayTab.tooltipDocLink,
+                    'data-attr': replayTab['data-attr'],
+                }
+            })}
+        />
     )
 }
 export function SessionsRecordings(): JSX.Element {

--- a/frontend/src/scenes/session-recordings/player/controller/PlayerController.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/PlayerController.tsx
@@ -1,4 +1,4 @@
-import { IconPause, IconPlay, IconRewindPlay } from '@posthog/icons'
+import { IconPause, IconPlay, IconRewindPlay, IconVideoCamera } from '@posthog/icons'
 import { useActions, useValues } from 'kea'
 import { FlaggedFeature } from 'lib/components/FlaggedFeature'
 import { useResizeBreakpoints } from 'lib/hooks/useResizeObserver'
@@ -13,6 +13,8 @@ import { SessionPlayerState } from '~/types'
 import { playerSettingsLogic } from '../playerSettingsLogic'
 import { SeekSkip, Timestamp } from './PlayerControllerTime'
 import { Seekbar } from './Seekbar'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 function PlayPauseButton(): JSX.Element {
     const { playingState, endReached } = useValues(sessionRecordingPlayerLogic)
@@ -61,6 +63,25 @@ function FullScreen(): JSX.Element {
     )
 }
 
+function CinemaMode(): JSX.Element {
+    const { isZenMode } = useValues(playerSettingsLogic)
+    const { setIsZenMode } = useActions(playerSettingsLogic)
+    return (
+        <LemonButton
+            size="xsmall"
+            onClick={() => setIsZenMode(!isZenMode)}
+            tooltip={
+                <>
+                    <span>{!isZenMode ? 'Go' : 'Exit'}</span> cinema mode
+                </>
+            }
+            status={isZenMode ? 'danger' : 'default'}
+            icon={<IconVideoCamera className="text-2xl" />}
+            data-attr={isZenMode ? 'exit-zen-mode' : 'zen-mode'}
+        />
+    )
+}
+
 function AnnotateRecording(): JSX.Element {
     const { setIsCommenting } = useActions(sessionRecordingPlayerLogic)
     const { isCommenting } = useValues(sessionRecordingPlayerLogic)
@@ -92,6 +113,7 @@ function AnnotateRecording(): JSX.Element {
 export function PlayerController(): JSX.Element {
     const { playlistLogic } = useValues(sessionRecordingPlayerLogic)
     const { isZenMode } = useValues(playerSettingsLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     const { ref, size } = useResizeBreakpoints({
         0: 'small',
@@ -117,6 +139,7 @@ export function PlayerController(): JSX.Element {
                             {playlistLogic ? <PlayerUpNext playlistLogic={playlistLogic} /> : undefined}
                         </>
                     )}
+                    {featureFlags[FEATURE_FLAGS.REPLAY_ZEN_MODE] && <CinemaMode />}
                     <FullScreen />
                 </div>
             </div>

--- a/frontend/src/scenes/session-recordings/player/controller/PlayerController.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/PlayerController.tsx
@@ -72,7 +72,7 @@ function CinemaMode(): JSX.Element {
             onClick={() => setIsZenMode(!isZenMode)}
             tooltip={
                 <>
-                    <span>{!isZenMode ? 'Go' : 'Exit'}</span> cinema mode
+                    <span>{!isZenMode ? 'Enter' : 'Exit'}</span> cinema mode
                 </>
             }
             status={isZenMode ? 'danger' : 'default'}


### PR DESCRIPTION
Let's move the cinema mode to the player so it does not affect shared recordings.

Also, as we are planning to experiment with a tabless approach, we need  to clear that space


Before:
<img width="1234" alt="Screenshot 2025-06-24 at 13 39 21" src="https://github.com/user-attachments/assets/1efa5d12-2ed5-40f7-a3b7-55263d113c6a" />


After:

<img width="417" alt="Screenshot 2025-06-24 at 13 39 00" src="https://github.com/user-attachments/assets/575fd959-65c2-438e-96a1-c4f7abf7db01" />
<img width="255" alt="Screenshot 2025-06-24 at 13 38 54" src="https://github.com/user-attachments/assets/19f8ccf5-f3d3-47e5-a360-bc113d17544b" />
