### PR TITLE
fix(cdp): Show deprecated templates when retrieved directly

### DIFF
--- a/posthog/api/test/test_hog_function_templates.py
+++ b/posthog/api/test/test_hog_function_templates.py
@@ -191,12 +191,6 @@ class TestDatabaseHogFunctionTemplates(ClickhouseTestMixin, APIBaseTest, QueryMa
         # Verify it has the expected name
         assert response.json()["name"] == template.name
 
-        # Verify non-existent template returns 404
-        response_missing = self.client.get(
-            "/api/projects/@current/hog_function_templates/non-existent-template?db_templates=true"
-        )
-        assert response_missing.status_code == status.HTTP_404_NOT_FOUND
-
     def test_get_specific_missing_template_from_db(self):
         """Test retrieving a specific template from the database via API"""
         # Verify non-existent template returns 404

--- a/posthog/api/test/test_hog_function_templates.py
+++ b/posthog/api/test/test_hog_function_templates.py
@@ -197,6 +197,25 @@ class TestDatabaseHogFunctionTemplates(ClickhouseTestMixin, APIBaseTest, QueryMa
         )
         assert response_missing.status_code == status.HTTP_404_NOT_FOUND
 
+    def test_get_specific_missing_template_from_db(self):
+        """Test retrieving a specific template from the database via API"""
+        # Verify non-existent template returns 404
+        response_missing = self.client.get(
+            "/api/projects/@current/hog_function_templates/non-existent-template?db_templates=true"
+        )
+        assert response_missing.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_get_specific_deprecated_template_from_db(self):
+        """Test retrieving a specific template from the database via API"""
+        # Test getting a specific template via API endpoint
+        response = self.client.get(
+            f"/api/projects/@current/hog_function_templates/template-deprecated?db_templates=true"
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        # Verify it has the expected name
+        assert response.json()["name"] == self.deprecated_template.name
+
     def test_template_updates_are_reflected(self):
         """Test that template updates are reflected in API responses"""
         from posthog.cdp.templates.hog_function_template import HogFunctionTemplate as DataclassTemplate

--- a/posthog/models/hog_function_template.py
+++ b/posthog/models/hog_function_template.py
@@ -104,13 +104,8 @@ class HogFunctionTemplate(UUIDModel):
                 ).first()
             else:
                 # Get the latest sha by created_at timestamp
-                # Only include active templates (not deprecated)
-                return (
-                    cls.objects.filter(template_id=template_id)
-                    .exclude(status="deprecated")
-                    .order_by("-created_at")
-                    .first()
-                )
+                # We allow all templates to be loaded, even deprecated ones as they might still be used by customers - they just aren't listable in the UI
+                return cls.objects.filter(template_id=template_id).order_by("-created_at").first()
         except Exception as e:
             logger.error(
                 "Failed to get template from database",


### PR DESCRIPTION
## Problem

Some customers still rely on deprecated templates but we accidentally don't show them.

## Changes

* Fixes it

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
