### PR TITLE
chore: don't overwrite billing alert

### DIFF
--- a/frontend/src/scenes/billing/billingLogic.tsx
+++ b/frontend/src/scenes/billing/billingLogic.tsx
@@ -632,6 +632,11 @@ export const billingLogic = kea<billingLogicType>([
             }
         },
         determineBillingAlert: () => {
+            // If we already have a billing alert, don't show another one
+            if (values.billingAlert) {
+                return
+            }
+
             if (values.productSpecificAlert) {
                 actions.setBillingAlert(values.productSpecificAlert)
                 return
@@ -809,6 +814,7 @@ export const billingLogic = kea<billingLogicType>([
                     status: 'error',
                     title: 'Error',
                     message: _search.billing_error,
+                    contactSupport: true,
                 })
             }
 

--- a/frontend/src/scenes/experiments/modalsLogic.ts
+++ b/frontend/src/scenes/experiments/modalsLogic.ts
@@ -1,4 +1,4 @@
-import { actions, connect, kea, reducers } from 'kea'
+import { actions, connect, kea, reducers, path } from 'kea'
 import { featureFlagsLogic } from 'scenes/feature-flags/featureFlagsLogic'
 import { projectLogic } from 'scenes/projectLogic'
 import { teamLogic } from 'scenes/teamLogic'
@@ -8,6 +8,7 @@ import { SharedMetric } from './SharedMetrics/sharedMetricLogic'
 import type { modalsLogicType } from './modalsLogicType'
 
 export const modalsLogic = kea<modalsLogicType>([
+    path(['scenes', 'experiments', 'modalsLogic']),
     connect(() => ({
         values: [projectLogic, ['currentProjectId'], teamLogic, ['currentTeamId']],
         actions: [featureFlagsLogic, ['updateFlag']],


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changes

We currently set billing alerts from the URL query param `billing_alert` and then also run checks when billing loads. Those checks overwrite any URL alerts so this makes sure the URL alerts take precedence. 

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

Manually. 
