### PR TITLE
chore(flags): Add counter for total flag requests

### DIFF
--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -10,11 +10,13 @@ pub mod properties;
 pub mod session_recording;
 pub mod types;
 
+use common_metrics::inc;
 pub use types::*;
 
 use crate::{
     api::{errors::FlagError, types::FlagsResponse},
     flags::flag_service::FlagService,
+    metrics::consts::FLAG_REQUESTS_COUNTER,
 };
 use tracing::{info, warn};
 
@@ -95,6 +97,17 @@ pub async fn process_request(context: RequestContext) -> Result<FlagsResponse, F
         if !request.is_flags_disabled() {
             billing::record_usage(&context, &filtered_flags, team.id).await;
         }
+        inc(
+            FLAG_REQUESTS_COUNTER,
+            &[
+                (
+                    "flags_disabled".to_string(),
+                    request.is_flags_disabled().to_string(),
+                ),
+                ("team_id".to_string(), team.id.to_string()),
+            ],
+            1,
+        );
 
         let total_duration = start_time.elapsed();
 

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -16,6 +16,7 @@ pub const PROPERTY_CACHE_HITS_COUNTER: &str = "flags_property_cache_hits_total";
 pub const PROPERTY_CACHE_MISSES_COUNTER: &str = "flags_property_cache_misses_total";
 pub const DB_PERSON_AND_GROUP_PROPERTIES_READS_COUNTER: &str =
     "flags_db_person_and_group_properties_reads_total";
+pub const FLAG_REQUESTS_COUNTER: &str = "flags_requests_total";
 
 // Performance monitoring
 pub const DB_CONNECTION_POOL_ACTIVE_COUNTER: &str = "flags_db_connection_pool_active_total";


### PR DESCRIPTION
## Problem

We just want more data about flags usage.

## Changes

Adds a counter for total flag requests with labels for disabled flags so we can filter them out and another for team_id so we can look at individual team requests should we decide to.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Manually with Postman.