### PR TITLE
fix: Parse property name with whitespaces in GroupsQueryRunner

### DIFF
--- a/posthog/hogql_queries/groups/groups_query_runner.py
+++ b/posthog/hogql_queries/groups/groups_query_runner.py
@@ -1,6 +1,6 @@
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.parser import parse_order_expr
+from posthog.hogql.parser import parse_order_expr, parse_expr
 from posthog.hogql.property import property_to_expr
 from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
 from posthog.hogql_queries.query_runner import QueryRunner
@@ -82,7 +82,7 @@ class GroupsQueryRunner(QueryRunner):
         return ast.SelectQuery(
             select=[
                 ast.Call(name="coalesce", args=[ast.Field(chain=["properties", "name"]), ast.Field(chain=["key"])]),
-                *[ast.Field(chain=list(col.split("."))) for col in self.columns[1:]],
+                *[parse_expr(col) for col in self.columns[1:]],
             ],
             select_from=ast.JoinExpr(table=ast.Field(chain=["groups"])),
             where=where,

--- a/posthog/hogql_queries/groups/test/__snapshots__/test_groups_query_runner.ambr
+++ b/posthog/hogql_queries/groups/test/__snapshots__/test_groups_query_runner.ambr
@@ -286,3 +286,33 @@
                     allow_experimental_join_condition=1
   '''
 # ---
+# name: TestGroupsQueryRunner.test_select_property_name_with_whitespaces
+  '''
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
+         groups.key AS key,
+         groups.`properties___prop with whitespace` AS `prop with whitespace`
+  FROM
+    (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
+            argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'prop with whitespace'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS `properties___prop with whitespace`,
+            argMax(toTimeZone(groups.created_at, 'UTC'), toTimeZone(groups._timestamp, 'UTC')) AS created_at,
+            groups.group_type_index AS index,
+            groups.group_key AS key
+     FROM groups
+     WHERE equals(groups.team_id, 99999)
+     GROUP BY groups.group_type_index,
+              groups.group_key) AS groups
+  WHERE ifNull(equals(groups.index, 0), 0)
+  ORDER BY groups.created_at DESC
+  LIMIT 11
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1
+  '''
+# ---

--- a/posthog/hogql_queries/test/test_actors_query_runner.py
+++ b/posthog/hogql_queries/test/test_actors_query_runner.py
@@ -679,3 +679,17 @@ class TestActorsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         response = runner.calculate()
         display_names = [row[0]["display_name"] for row in response.results]
         assert set(display_names) == {"Test User With Spaces"}
+
+    def test_select_property_name_with_spaces(self):
+        _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["id_email", "id_anon"],
+            properties={"email": "user@email.com", "Property With Spaces": "Test User With Spaces"},
+        )
+        flush_persons_and_events()
+        query = ActorsQuery(select=['properties."Property With Spaces"'])
+        runner = self._create_runner(query)
+
+        response = runner.calculate()
+
+        self.assertEqual(response.results[0][0], "Test User With Spaces")


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
When adding a property name with whitespace in groups query, the results were retuning all null, despite of the property having non-null values.
This was happening because we were parsing the column names too naively on `GroupsQueryRunner` and not removing the escaped double quotes added by the frontend.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
fixes https://posthoghelp.zendesk.com/agent/tickets/32990 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/34721)
## Changes
Use `parse_expr` function to parse property names.
Also added a test to ensure the bug does not exist in `ActorsQueryRunner`
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
Added a group property with whitespaces and added the field to the table then checked it returned a non-null value.