### PR TITLE
fix: tag query state leak

### DIFF
--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -83,8 +83,8 @@ class MaterializedColumn:
                 ch_user=ClickHouseUser.HOGQL,
             )
 
-            for name, comment, is_nullable in rows:
-                yield MaterializedColumn(name, MaterializedColumnDetails.from_column_comment(comment), is_nullable)
+        for name, comment, is_nullable in rows:
+            yield MaterializedColumn(name, MaterializedColumnDetails.from_column_comment(comment), is_nullable)
 
     @staticmethod
     def get(table: TablesWithMaterializedColumns, column_name: ColumnName) -> MaterializedColumn:


### PR DESCRIPTION
## Problem

the tag has been leaking to queries not related to this name

## Changes

yield must be used after the context is exited, otherwise the tags leak to outer queries
