### PR TITLE
feat(messaging): add support for mocking all time delays in hogflows

### DIFF
--- a/plugin-server/src/cdp/services/hogflows/actions/action.conditional_branch.test.ts
+++ b/plugin-server/src/cdp/services/hogflows/actions/action.conditional_branch.test.ts
@@ -102,6 +102,15 @@ describe('HogFlowActionRunnerCondition', () => {
                 })
             })
 
+            it('should return done immediately when mockDelays is enabled', () => {
+                action.config.delay_duration = '2h'
+                invocation.state.mockDelays = true
+                const result = runner.run(invocation, action)
+                expect(result).toEqual({
+                    done: true,
+                })
+            })
+
             it('should throw error if action started at timestamp is invalid', () => {
                 invocation.state.currentAction = undefined
                 action.config.delay_duration = '300s'

--- a/plugin-server/src/cdp/services/hogflows/actions/action.conditional_branch.ts
+++ b/plugin-server/src/cdp/services/hogflows/actions/action.conditional_branch.ts
@@ -46,7 +46,7 @@ export class HogFlowActionRunnerConditionalBranch {
                 DEFAULT_WAIT_DURATION_SECONDS
             )
 
-            if (scheduledAt) {
+            if (scheduledAt && !invocation.state.mockDelays) {
                 return {
                     done: false,
                     scheduledAt,

--- a/plugin-server/src/cdp/services/hogflows/actions/action.delay.ts
+++ b/plugin-server/src/cdp/services/hogflows/actions/action.delay.ts
@@ -14,7 +14,7 @@ export class HogFlowActionRunnerDelay {
             invocation.state.currentAction?.startedAtTimestamp
         )
 
-        if (scheduledAt && !invocation.state.mockDelays) {
+        if (scheduledAt) {
             return {
                 done: false,
                 scheduledAt,

--- a/plugin-server/src/cdp/services/hogflows/actions/action.wait_until_time_window.test.ts
+++ b/plugin-server/src/cdp/services/hogflows/actions/action.wait_until_time_window.test.ts
@@ -1,6 +1,8 @@
 import { DateTime } from 'luxon'
 
 import { FixtureHogFlowBuilder } from '~/cdp/_tests/builders/hogflow.builder'
+import { createExampleHogFlowInvocation } from '~/cdp/_tests/fixtures-hogflows'
+import { CyclotronJobInvocationHogFlow } from '~/cdp/types'
 import { HogFlowAction } from '~/schema/hogflow'
 
 import { HogFlowActionRunnerWaitUntilTimeWindow } from './action.wait_until_time_window'
@@ -8,6 +10,7 @@ import { findActionByType } from './utils'
 
 describe('HogFlowActionRunnerWaitUntilTimeWindow', () => {
     let runner: HogFlowActionRunnerWaitUntilTimeWindow
+    let invocation: CyclotronJobInvocationHogFlow
     let action: Extract<HogFlowAction, { type: 'wait_until_time_window' }>
 
     beforeEach(() => {
@@ -31,20 +34,29 @@ describe('HogFlowActionRunnerWaitUntilTimeWindow', () => {
             })
             .build()
         action = findActionByType(hogFlow, 'wait_until_time_window')!
+        invocation = createExampleHogFlowInvocation(hogFlow)
     })
 
     describe('time window scheduling', () => {
         it('should schedule for today if time window is in the future', () => {
-            const result = runner.run(action)
+            const result = runner.run(invocation, action)
             expect(result).toEqual({
                 done: true,
                 scheduledAt: DateTime.utc().set({ hour: 14, minute: 0, second: 0, millisecond: 0 }),
             })
         })
 
+        it('should return done immediately when mockDelays is enabled', () => {
+            invocation.state.mockDelays = true
+            const result = runner.run(invocation, action)
+            expect(result).toEqual({
+                done: true,
+            })
+        })
+
         it('should schedule immediately if current time is within window', () => {
             jest.setSystemTime(new Date('2025-01-01T15:00:00.000Z')) // Middle of window
-            const result = runner.run(action)
+            const result = runner.run(invocation, action)
             expect(result).toEqual({
                 done: true,
                 scheduledAt: undefined,
@@ -53,7 +65,7 @@ describe('HogFlowActionRunnerWaitUntilTimeWindow', () => {
 
         it('should schedule for tomorrow if time window has passed', () => {
             jest.setSystemTime(new Date('2025-01-01T17:00:00.000Z')) // After time window
-            const result = runner.run(action)
+            const result = runner.run(invocation, action)
             expect(result).toEqual({
                 done: true,
                 scheduledAt: DateTime.utc().plus({ days: 1 }).set({ hour: 14, minute: 0, second: 0, millisecond: 0 }),
@@ -62,7 +74,7 @@ describe('HogFlowActionRunnerWaitUntilTimeWindow', () => {
 
         it('should handle "any" time', () => {
             action.config.time = 'any'
-            const result = runner.run(action)
+            const result = runner.run(invocation, action)
             expect(result).toEqual({
                 done: true,
                 scheduledAt: DateTime.utc().plus({ days: 1 }).startOf('day'),
@@ -72,7 +84,7 @@ describe('HogFlowActionRunnerWaitUntilTimeWindow', () => {
         it('should handle time window spanning midnight', () => {
             action.config.time = ['23:00', '01:00']
             jest.setSystemTime(new Date('2025-01-01T22:00:00.000Z')) // Before window
-            const result = runner.run(action)
+            const result = runner.run(invocation, action)
             expect(result).toEqual({
                 done: true,
                 scheduledAt: DateTime.utc().set({ hour: 23, minute: 0, second: 0, millisecond: 0 }),
@@ -81,7 +93,7 @@ describe('HogFlowActionRunnerWaitUntilTimeWindow', () => {
 
         it('should handle time window with minutes', () => {
             action.config.time = ['14:30', '15:45']
-            const result = runner.run(action)
+            const result = runner.run(invocation, action)
             expect(result).toEqual({
                 done: true,
                 scheduledAt: DateTime.utc().set({ hour: 14, minute: 30, second: 0, millisecond: 0 }),
@@ -91,7 +103,7 @@ describe('HogFlowActionRunnerWaitUntilTimeWindow', () => {
         it('should handle time window with minutes when current time is within window', () => {
             action.config.time = ['14:30', '15:45']
             jest.setSystemTime(new Date('2025-01-01T15:00:00.000Z')) // Middle of window
-            const result = runner.run(action)
+            const result = runner.run(invocation, action)
             expect(result).toEqual({
                 done: true,
                 scheduledAt: undefined,
@@ -103,7 +115,7 @@ describe('HogFlowActionRunnerWaitUntilTimeWindow', () => {
         it('should handle weekday restriction', () => {
             action.config.date = 'weekday'
             jest.setSystemTime(new Date('2025-01-04T17:00:00.000Z')) // Saturday
-            const result = runner.run(action)
+            const result = runner.run(invocation, action)
             expect(result).toEqual({
                 done: true,
                 scheduledAt: DateTime.utc().plus({ days: 2 }).set({ hour: 14, minute: 0, second: 0, millisecond: 0 }), // Monday
@@ -113,7 +125,7 @@ describe('HogFlowActionRunnerWaitUntilTimeWindow', () => {
         it('should handle weekend restriction', () => {
             action.config.date = 'weekend'
             jest.setSystemTime(new Date('2025-01-01T17:00:00.000Z')) // Wednesday
-            const result = runner.run(action)
+            const result = runner.run(invocation, action)
             expect(result).toEqual({
                 done: true,
                 scheduledAt: DateTime.utc().plus({ days: 3 }).set({ hour: 14, minute: 0, second: 0, millisecond: 0 }), // Saturday
@@ -123,7 +135,7 @@ describe('HogFlowActionRunnerWaitUntilTimeWindow', () => {
         it('should handle specific days', () => {
             action.config.date = ['monday', 'wednesday', 'friday']
             jest.setSystemTime(new Date('2025-01-01T17:00:00.000Z')) // Wednesday
-            const result = runner.run(action)
+            const result = runner.run(invocation, action)
             expect(result).toEqual({
                 done: true,
                 scheduledAt: DateTime.utc().plus({ days: 2 }).set({ hour: 14, minute: 0, second: 0, millisecond: 0 }), // Friday
@@ -133,7 +145,7 @@ describe('HogFlowActionRunnerWaitUntilTimeWindow', () => {
         it('should handle single specific day', () => {
             action.config.date = ['monday']
             jest.setSystemTime(new Date('2025-01-01T17:00:00.000Z')) // Wednesday
-            const result = runner.run(action)
+            const result = runner.run(invocation, action)
             expect(result).toEqual({
                 done: true,
                 scheduledAt: DateTime.utc().plus({ days: 5 }).set({ hour: 14, minute: 0, second: 0, millisecond: 0 }), // Monday
@@ -143,7 +155,7 @@ describe('HogFlowActionRunnerWaitUntilTimeWindow', () => {
         it('should handle consecutive days', () => {
             action.config.date = ['monday', 'tuesday', 'wednesday']
             jest.setSystemTime(new Date('2025-01-01T17:00:00.000Z')) // Wednesday
-            const result = runner.run(action)
+            const result = runner.run(invocation, action)
             expect(result).toEqual({
                 done: true,
                 scheduledAt: DateTime.utc().plus({ days: 5 }).set({ hour: 14, minute: 0, second: 0, millisecond: 0 }), // Monday
@@ -154,7 +166,7 @@ describe('HogFlowActionRunnerWaitUntilTimeWindow', () => {
     describe('timezone handling', () => {
         it('should respect timezone setting', () => {
             action.config.timezone = 'America/New_York'
-            const result = runner.run(action)
+            const result = runner.run(invocation, action)
             // Compare to UTC for easier understanding
             expect(DateTime.utc().setZone('America/New_York').toISO()).toMatchInlineSnapshot(
                 `"2025-01-01T07:00:00.000-05:00"`
@@ -166,7 +178,7 @@ describe('HogFlowActionRunnerWaitUntilTimeWindow', () => {
         it('should handle timezone with DST', () => {
             action.config.timezone = 'America/New_York'
             jest.setSystemTime(new Date('2025-07-01T12:00:00.000Z')) // Summer time
-            const result = runner.run(action)
+            const result = runner.run(invocation, action)
             // Compare to UTC for easier understanding
             expect(DateTime.utc().setZone('America/New_York').toISO()).toMatchInlineSnapshot(
                 `"2025-07-01T08:00:00.000-04:00"`
@@ -178,7 +190,7 @@ describe('HogFlowActionRunnerWaitUntilTimeWindow', () => {
         it('should handle timezone with negative offset', () => {
             action.config.timezone = 'Asia/Tokyo'
 
-            const result = runner.run(action)
+            const result = runner.run(invocation, action)
             // Compare to UTC for easier understanding
             expect(DateTime.utc().setZone('Asia/Tokyo').toISO()).toMatchInlineSnapshot(
                 `"2025-01-01T21:00:00.000+09:00"`

--- a/plugin-server/src/cdp/services/hogflows/actions/action.wait_until_time_window.ts
+++ b/plugin-server/src/cdp/services/hogflows/actions/action.wait_until_time_window.ts
@@ -1,5 +1,6 @@
 import { DateTime } from 'luxon'
 
+import { CyclotronJobInvocationHogFlow } from '~/cdp/types'
 import { HogFlowAction } from '~/schema/hogflow'
 
 import { HogFlowActionResult } from './types'
@@ -9,9 +10,15 @@ type Action = Extract<HogFlowAction, { type: 'wait_until_time_window' }>
 const DAY_NAMES = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'] as const
 
 export class HogFlowActionRunnerWaitUntilTimeWindow {
-    run(action: Action): HogFlowActionResult {
+    run(invocation: CyclotronJobInvocationHogFlow, action: Action): HogFlowActionResult {
         const now = DateTime.utc().setZone(action.config.timezone)
         const nextTime = this.getNextValidTime(now, action.config)
+
+        if (invocation.state.mockDelays) {
+            return {
+                done: true,
+            }
+        }
 
         return {
             done: true,

--- a/plugin-server/src/cdp/services/hogflows/actions/hogflow-action-runner.ts
+++ b/plugin-server/src/cdp/services/hogflows/actions/hogflow-action-runner.ts
@@ -130,7 +130,7 @@ export class HogFlowActionRunner {
                     actionResult = this.hogFlowActionRunnerConditionalBranch.runWaitUntilCondition(invocation, action)
                     break
                 case 'wait_until_time_window':
-                    actionResult = this.hogFlowActionRunnerWaitUntilTimeWindow.run(action)
+                    actionResult = this.hogFlowActionRunnerWaitUntilTimeWindow.run(invocation, action)
                     break
                 case 'random_cohort_branch':
                     actionResult = this.hogFlowActionRunnerRandomCohortBranch.run(invocation, action)


### PR DESCRIPTION

## Problem

Adds `mockDelays` checks to all actions that might cause delays but not trigger an async function. `mockDelays` is always set to true when triggering a test invocation (https://github.com/PostHog/posthog/pull/34020/files)

## Changes

- mockDelays checks
- tests for new behavior

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

added unit tests
