### PR TITLE
fix(flags): fix property override bug in the `/flags` endpoint

### DIFF
--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -7,7 +7,11 @@ use crate::cohorts::cohort_models::{Cohort, CohortId};
 use crate::cohorts::cohort_operations::{apply_cohort_membership_logic, evaluate_dynamic_cohorts};
 use crate::flags::flag_group_type_mapping::{GroupTypeIndex, GroupTypeMappingCache};
 use crate::flags::flag_match_reason::FeatureFlagMatchReason;
-use crate::flags::flag_matching_utils::all_flag_condition_properties_match;
+use crate::flags::flag_matching_utils::{
+    all_flag_condition_properties_match, all_properties_match, calculate_hash,
+    fetch_and_locally_cache_all_relevant_properties, get_feature_flag_hash_key_overrides,
+    set_feature_flag_hash_key_overrides, should_write_hash_key_override,
+};
 use crate::flags::flag_models::{FeatureFlag, FeatureFlagId, FeatureFlagList, FlagPropertyGroup};
 use crate::metrics::consts::{
     DB_PERSON_AND_GROUP_PROPERTIES_READS_COUNTER, FLAG_DB_PROPERTIES_FETCH_TIME,
@@ -21,7 +25,7 @@ use crate::metrics::utils::parse_exception_for_prometheus_label;
 use crate::properties::property_models::PropertyFilter;
 use anyhow::Result;
 use common_database::Client as DatabaseClient;
-use common_metrics::inc;
+use common_metrics::{inc, timing_guard};
 use common_types::{PersonId, ProjectId, TeamId};
 use rayon::prelude::*;
 use serde_json::Value;
@@ -30,12 +34,6 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tracing::{error, warn};
 use uuid::Uuid;
-
-use super::flag_matching_utils::{
-    all_properties_match, calculate_hash, fetch_and_locally_cache_all_relevant_properties,
-    get_feature_flag_hash_key_overrides, locally_computable_property_overrides,
-    set_feature_flag_hash_key_overrides, should_write_hash_key_override,
-};
 
 pub type PostgresReader = Arc<dyn DatabaseClient + Send + Sync>;
 pub type PostgresWriter = Arc<dyn DatabaseClient + Send + Sync>;
@@ -355,7 +353,7 @@ impl FeatureFlagMatcher {
             Err(e) => {
                 error!("Failed to get feature flag hash key overrides for team {} project {} distinct_id {}: {:?}", self.team_id, self.project_id, self.distinct_id, e);
                 let reason = parse_exception_for_prometheus_label(&e);
-                common_metrics::inc(
+                inc(
                     FLAG_EVALUATION_ERROR_COUNTER,
                     &[("reason".to_string(), reason.to_string())],
                     1,
@@ -426,7 +424,7 @@ impl FeatureFlagMatcher {
                 &feature_flags.flags,
                 &person_property_overrides,
                 &group_property_overrides,
-                hash_key_overrides,
+                &hash_key_overrides,
             )
             .await;
         errors_while_computing_flags |= level_errors;
@@ -452,10 +450,36 @@ impl FeatureFlagMatcher {
         flags: &[FeatureFlag],
         person_property_overrides: &Option<HashMap<String, Value>>,
         group_property_overrides: &Option<HashMap<String, HashMap<String, Value>>>,
-        hash_key_overrides: Option<HashMap<String, String>>,
+        hash_key_overrides: &Option<HashMap<String, String>>,
     ) -> (HashMap<String, FlagDetails>, bool) {
         let mut errors_while_computing_flags = false;
         let mut flag_details_map = HashMap::new();
+
+        // Pre-compute property overrides for all flags upfront to avoid duplicate work
+        let mut flag_override_map: HashMap<String, Option<HashMap<String, Value>>> = HashMap::new();
+        for flag in flags {
+            // Skip disabled or deleted flags early
+            if !flag.active || flag.deleted {
+                continue;
+            }
+
+            let relevant_property_overrides = match flag.get_group_type_index() {
+                Some(group_type_index) => {
+                    // For group flags, extract the relevant group overrides
+                    match self.group_overrides_to_property_overrides(
+                        group_type_index,
+                        group_property_overrides,
+                    ) {
+                        Ok(overrides) => overrides,
+                        Err(_) => None, // If we can't get the mapping, pretend we have no overrides; we'll hit the DB later if needed.
+                                        // TODO ^ is that correct, or is that an error?
+                    }
+                }
+                None => person_property_overrides.clone(),
+            };
+            flag_override_map.insert(flag.key.clone(), relevant_property_overrides);
+        }
+
         let mut flags_needing_db_properties = Vec::new();
 
         // Step 1: Evaluate flags with locally computable property overrides first
@@ -468,10 +492,12 @@ impl FeatureFlagMatcher {
             let property_override_match_timer =
                 common_metrics::timing_guard(FLAG_LOCAL_PROPERTY_OVERRIDE_MATCH_TIME, &[]);
 
-            match self.match_flag_with_property_overrides(
+            // Use pre-computed overrides
+            let property_overrides = flag_override_map.get(&flag.key).unwrap_or(&None); // Safe fallback: if flag not in map, treat as no overrides
+
+            match self.match_flag_exclusively_with_overrides(
                 flag,
-                person_property_overrides,
-                group_property_overrides,
+                property_overrides,
                 hash_key_overrides.clone(),
             ) {
                 Ok(Some(flag_match)) => {
@@ -544,43 +570,39 @@ impl FeatureFlagMatcher {
             }
         }
 
-        // Step 3: Evaluate remaining flags with cached properties
-        let flag_get_match_timer = common_metrics::timing_guard(FLAG_GET_MATCH_TIME, &[]);
+        // Step 3: Evaluate remaining flags with cached properties using pre-computed overrides
+        let flag_get_match_timer = timing_guard(FLAG_GET_MATCH_TIME, &[]);
 
         // Create a HashMap for quick flag lookups
-        let flags_map: HashMap<_, _> = flags_needing_db_properties
+        let flags_map: HashMap<&String, &FeatureFlag> = flags_needing_db_properties
             .iter()
-            .map(|flag| (flag.key.clone(), flag))
+            .map(|flag| (&flag.key, flag))
             .collect();
 
+        // Use pre-computed overrides instead of recomputing them
         let results: Vec<(String, Result<FeatureFlagMatch, FlagError>)> =
             flags_needing_db_properties
                 .par_iter()
                 .map(|flag| {
-                    // For flags that need DB properties, we still pass person property overrides
-                    // but only for super condition evaluation. Regular conditions will use cached DB properties.
-                    let person_overrides_for_super_conditions =
-                        if flag.get_group_type_index().is_some() {
-                            // For group-based flags, don't pass person overrides
-                            None
-                        } else {
-                            // For person-based flags, pass person overrides for super condition evaluation
-                            person_property_overrides.clone()
-                        };
-
+                    // Safe access: if flag not in pre-computed map, treat as no overrides
+                    let property_overrides =
+                        flag_override_map.get(&flag.key).unwrap_or(&None).clone();
                     (
                         flag.key.clone(),
-                        self.get_match_for_db_path(
-                            flag,
-                            person_overrides_for_super_conditions,
-                            hash_key_overrides.clone(),
-                        ),
+                        self.get_match(flag, property_overrides, hash_key_overrides.clone()),
                     )
                 })
                 .collect();
 
         for (flag_key, result) in results {
-            let flag = flags_map.get(&flag_key).unwrap();
+            // Safe access: if flag not found in map, skip it (this shouldn't happen but is safe)
+            let Some(flag) = flags_map.get(&flag_key) else {
+                error!(
+                    "Flag '{}' not found in flags_map during evaluation - this shouldn't happen",
+                    flag_key
+                );
+                continue;
+            };
 
             match result {
                 Ok(flag_match) => {
@@ -596,12 +618,12 @@ impl FeatureFlagMatcher {
                     if let FlagError::DependencyNotFound(dependency_type, dependency_id) = &e {
                         warn!(
                             "Feature flag '{}' targeting deleted {} with id {} for distinct_id '{}': {:?}",
-                            flag_key, dependency_type, dependency_id, self.distinct_id, e
+                            flag.key, dependency_type, dependency_id, self.distinct_id, e
                         );
                     } else {
                         error!(
                             "Error evaluating feature flag '{}' for distinct_id '{}': {:?}",
-                            flag_key, self.distinct_id, e
+                            flag.key, self.distinct_id, e
                         );
                     }
 
@@ -629,160 +651,87 @@ impl FeatureFlagMatcher {
         (flag_details_map, errors_while_computing_flags)
     }
 
-    /// Matches a feature flag with property overrides.
+    /// Attempts to match a feature flag using only property overrides (no database access).
     ///
-    /// This function attempts to match a feature flag using either group or person property overrides,
-    /// depending on whether the flag is group-based or person-based. It first collects all property
-    /// filters from the flag's conditions, then retrieves the appropriate overrides, and finally
-    /// attempts to match the flag using these overrides.
-    fn match_flag_with_property_overrides(
+    /// This function tries to evaluate the flag using only the provided overrides,
+    /// without fetching any properties from the database. It returns Some(match) if
+    /// the overrides are sufficient, or None if database properties are needed.
+    ///
+    /// The logic is:
+    /// 1. If flag has super conditions and overrides contain all super condition properties -> use overrides only
+    /// 2. If flag has no super conditions and overrides contain all flag properties -> use overrides only  
+    /// 3. Otherwise -> return None to trigger DB fetch + merge path
+    fn match_flag_exclusively_with_overrides(
         &mut self,
         flag: &FeatureFlag,
-        person_property_overrides: &Option<HashMap<String, Value>>,
-        group_property_overrides: &Option<HashMap<String, HashMap<String, Value>>>,
+        property_overrides: &Option<HashMap<String, Value>>,
         hash_key_overrides: Option<HashMap<String, String>>,
     ) -> Result<Option<FeatureFlagMatch>, FlagError> {
-        // Collect ALL property filters - both from regular conditions and super conditions
-        let mut flag_property_filters: Vec<PropertyFilter> = flag
-            .get_conditions()
-            .iter()
-            .flat_map(|c| c.properties.clone().unwrap_or_default())
-            .collect();
-
-        // Add super condition properties
-        if let Some(super_groups) = &flag.filters.super_groups {
-            flag_property_filters.extend(
-                super_groups
-                    .iter()
-                    .flat_map(|c| c.properties.clone().unwrap_or_default()),
-            );
+        // Check if overrides are sufficient for independent evaluation
+        if self.are_overrides_sufficient_for_match_predicate(flag, property_overrides) {
+            // Fast path: evaluate using overrides only
+            self.get_match(flag, property_overrides.clone(), hash_key_overrides)
+                .map(Some)
+        } else {
+            // Overrides are insufficient, return None to trigger DB merge path
+            Ok(None)
         }
+    }
 
-        let overrides = match flag.get_group_type_index() {
-            Some(group_type_index) => self.get_group_overrides(
-                group_type_index,
-                group_property_overrides,
-                &flag_property_filters,
-            )?,
-            None => self.get_person_overrides(person_property_overrides, &flag_property_filters),
+    /// Checks if the provided overrides are sufficient to independently evaluate the flag.
+    ///
+    /// For flags with super conditions: overrides must contain all super condition properties
+    /// For flags without super conditions: overrides must contain ALL properties used by the flag
+    fn are_overrides_sufficient_for_match_predicate(
+        &self,
+        flag: &FeatureFlag,
+        overrides: &Option<HashMap<String, Value>>,
+    ) -> bool {
+        let Some(ref overrides_map) = overrides else {
+            return false;
         };
 
-        // For flags with super conditions, we need special logic to ensure super condition properties are available
+        // Check super conditions first (special case)
         if let Some(super_groups) = &flag.filters.super_groups {
-            self.evaluate_with_super_conditions(flag, overrides, hash_key_overrides, super_groups)
-        } else if flag.ensure_experience_continuity {
-            self.evaluate_with_experience_continuity(
-                flag,
-                overrides,
-                hash_key_overrides,
-                &flag_property_filters,
-            )
-        } else {
-            // Flag has no super conditions and no experience continuity - use the original override logic
-            // This preserves the existing behavior where overrides can be partial
-            match overrides {
-                Some(props) => self
-                    .get_match(flag, Some(props), hash_key_overrides)
-                    .map(Some),
-                None => Ok(None),
+            if !super_groups.is_empty() {
+                // For super conditions, we need ALL super condition properties
+                return super_groups.iter().all(|super_group| {
+                    super_group.properties.as_ref().map_or(true, |props| {
+                        props
+                            .iter()
+                            .all(|prop| overrides_map.contains_key(&prop.key))
+                    })
+                });
             }
         }
-    }
 
-    /// Evaluates flags with super conditions, ensuring all required properties are available in overrides
-    fn evaluate_with_super_conditions(
-        &mut self,
-        flag: &FeatureFlag,
-        overrides: Option<HashMap<String, Value>>,
-        hash_key_overrides: Option<HashMap<String, String>>,
-        super_groups: &[FlagPropertyGroup],
-    ) -> Result<Option<FeatureFlagMatch>, FlagError> {
-        let properties_available =
-            self.are_super_condition_properties_available(&overrides, super_groups);
+        // For regular conditions, check if ALL properties across ALL conditions are in overrides
+        // This is conservative but safe - we only use fast path when we have complete information
+        let all_properties: HashSet<String> = flag
+            .get_conditions()
+            .iter()
+            .flat_map(|condition| condition.properties.as_deref().unwrap_or(&[]).iter())
+            .map(|prop| prop.key.clone())
+            .collect();
 
-        match overrides {
-            Some(props) if properties_available => {
-                // Super condition properties are available in overrides
-                self.get_match(flag, Some(props), hash_key_overrides)
-                    .map(Some)
-            }
-            _ => {
-                // Super condition properties are missing from overrides, go to DB path
-                Ok(None)
-            }
+        // If no properties are needed, overrides are sufficient
+        if all_properties.is_empty() {
+            return true;
         }
+
+        // Check if overrides contain ALL properties the flag needs
+        all_properties
+            .iter()
+            .all(|prop_key| overrides_map.contains_key(prop_key))
     }
 
-    /// Evaluates flags with experience continuity, ensuring all flag properties are available in overrides
-    fn evaluate_with_experience_continuity(
-        &mut self,
-        flag: &FeatureFlag,
-        overrides: Option<HashMap<String, Value>>,
-        hash_key_overrides: Option<HashMap<String, String>>,
-        flag_property_filters: &[PropertyFilter],
-    ) -> Result<Option<FeatureFlagMatch>, FlagError> {
-        let properties_available =
-            self.are_all_properties_available(&overrides, flag_property_filters);
-
-        match overrides {
-            Some(props) if properties_available => {
-                // All flag properties are available in overrides for continuity flag
-                self.get_match(flag, Some(props), hash_key_overrides)
-                    .map(Some)
-            }
-            _ => {
-                // Required properties missing from overrides for continuity flag, go to DB path
-                Ok(None)
-            }
-        }
-    }
-
-    /// Checks if all super condition properties are available in the provided overrides
-    fn are_super_condition_properties_available(
-        &self,
-        overrides: &Option<HashMap<String, Value>>,
-        super_groups: &[FlagPropertyGroup],
-    ) -> bool {
-        if let Some(ref overrides_map) = overrides {
-            super_groups.iter().all(|super_group| {
-                super_group.properties.as_ref().map_or(true, |props| {
-                    props
-                        .iter()
-                        .all(|prop| overrides_map.contains_key(&prop.key))
-                })
-            })
-        } else {
-            false
-        }
-    }
-
-    /// Checks if all required properties are available in the provided overrides
-    fn are_all_properties_available(
-        &self,
-        overrides: &Option<HashMap<String, Value>>,
-        property_filters: &[PropertyFilter],
-    ) -> bool {
-        if let Some(ref overrides_map) = overrides {
-            property_filters
-                .iter()
-                .all(|prop| overrides_map.contains_key(&prop.key))
-        } else {
-            false
-        }
-    }
-
-    /// Retrieves group overrides for a specific group type index.
-    ///
-    /// This function attempts to find and return property overrides for a given group type.
-    /// It first maps the group type index to a group type, then checks if there are any
-    /// overrides for that group type in the provided group property overrides.
-    fn get_group_overrides(
+    /// Convert group overrides to property overrides
+    fn group_overrides_to_property_overrides(
         &mut self,
         group_type_index: GroupTypeIndex,
         group_property_overrides: &Option<HashMap<String, HashMap<String, Value>>>,
-        flag_property_filters: &[PropertyFilter],
     ) -> Result<Option<HashMap<String, Value>>, FlagError> {
-        // If we can't get the mapping, just return None instead of propagating the error
+        // If we can't get the mapping, just return None
         let index_to_type_map = match self
             .group_type_mapping_cache
             .get_group_type_index_to_type_map()
@@ -795,28 +744,12 @@ impl FeatureFlagMatcher {
         if let Some(group_type) = index_to_type_map.get(&group_type_index) {
             if let Some(group_overrides) = group_property_overrides {
                 if let Some(group_overrides_by_type) = group_overrides.get(group_type) {
-                    return Ok(locally_computable_property_overrides(
-                        &Some(group_overrides_by_type.clone()),
-                        flag_property_filters,
-                    ));
+                    return Ok(Some(group_overrides_by_type.clone()));
                 }
             }
         }
 
         Ok(None)
-    }
-
-    /// Retrieves person overrides for feature flag evaluation.
-    ///
-    /// This function attempts to find and return property overrides for a person.
-    /// It uses the provided person property overrides and filters them based on
-    /// the property filters defined in the feature flag.
-    fn get_person_overrides(
-        &self,
-        person_property_overrides: &Option<HashMap<String, Value>>,
-        flag_property_filters: &[PropertyFilter],
-    ) -> Option<HashMap<String, Value>> {
-        locally_computable_property_overrides(person_property_overrides, flag_property_filters)
     }
 
     /// Determines if a feature flag matches for the current context.
@@ -974,145 +907,6 @@ impl FeatureFlagMatcher {
         })
     }
 
-    /// Evaluates a feature flag in the DB path where regular conditions use cached DB properties
-    /// but super conditions can still access property overrides.
-    ///
-    /// This method is used when a flag has property filters that require DB access (like cohorts),
-    /// but we still want super conditions to be able to use property overrides.
-    fn get_match_for_db_path(
-        &self,
-        flag: &FeatureFlag,
-        super_condition_overrides: Option<HashMap<String, Value>>,
-        hash_key_overrides: Option<HashMap<String, String>>,
-    ) -> Result<FeatureFlagMatch, FlagError> {
-        if self
-            .hashed_identifier(flag, hash_key_overrides.clone())?
-            .is_empty()
-        {
-            return Ok(FeatureFlagMatch {
-                matches: false,
-                variant: None,
-                reason: FeatureFlagMatchReason::NoGroupType,
-                condition_index: None,
-                payload: None,
-            });
-        }
-
-        let mut highest_match = FeatureFlagMatchReason::NoConditionMatch;
-        let mut highest_index = None;
-
-        // Evaluate any super conditions first, with access to property overrides
-        if let Some(super_groups) = &flag.filters.super_groups {
-            if !super_groups.is_empty() {
-                let super_condition_evaluation = self.is_super_condition_match(
-                    flag,
-                    super_condition_overrides,
-                    hash_key_overrides.clone(),
-                )?;
-
-                if super_condition_evaluation.should_evaluate {
-                    let payload = self.get_matching_payload(None, flag);
-                    return Ok(FeatureFlagMatch {
-                        matches: super_condition_evaluation.is_match,
-                        variant: None,
-                        reason: super_condition_evaluation.reason,
-                        condition_index: Some(0),
-                        payload,
-                    });
-                } // if no match, continue to normal conditions
-            }
-        }
-
-        // Match for holdout super condition - same logic as regular get_match
-        if let Some(holdout_groups) = &flag.filters.holdout_groups {
-            if !holdout_groups.is_empty() {
-                let (is_match, holdout_value, evaluation_reason) =
-                    self.is_holdout_condition_match(flag)?;
-                if is_match {
-                    let payload = self.get_matching_payload(holdout_value.as_deref(), flag);
-                    return Ok(FeatureFlagMatch {
-                        matches: true,
-                        variant: holdout_value,
-                        reason: evaluation_reason,
-                        condition_index: None,
-                        payload,
-                    });
-                }
-            }
-        }
-
-        // Evaluate regular conditions using cached DB properties (no overrides)
-        let mut sorted_conditions: Vec<(usize, &FlagPropertyGroup)> =
-            flag.get_conditions().iter().enumerate().collect();
-
-        sorted_conditions
-            .sort_by_key(|(_, condition)| if condition.variant.is_some() { 0 } else { 1 });
-
-        let condition_timer = common_metrics::timing_guard(FLAG_EVALUATE_ALL_CONDITIONS_TIME, &[]);
-        for (index, condition) in sorted_conditions {
-            let (is_match, reason) = self.is_condition_match(
-                flag,
-                condition,
-                None, // Use cached DB properties instead of overrides
-                hash_key_overrides.clone(),
-            )?;
-
-            // Update highest_match and highest_index
-            let (new_highest_match, new_highest_index) = self
-                .get_highest_priority_match_evaluation(
-                    highest_match.clone(),
-                    highest_index,
-                    reason.clone(),
-                    Some(index),
-                );
-            highest_match = new_highest_match;
-            highest_index = new_highest_index;
-
-            if is_match {
-                if highest_match == FeatureFlagMatchReason::SuperConditionValue {
-                    break; // Exit early if we've found a super condition match
-                }
-
-                // Check for variant override in the condition
-                let variant = if let Some(variant_override) = &condition.variant {
-                    // Check if the override is a valid variant
-                    if flag
-                        .get_variants()
-                        .iter()
-                        .any(|v| &v.key == variant_override)
-                    {
-                        Some(variant_override.clone())
-                    } else {
-                        // If override isn't valid, fall back to computed variant
-                        self.get_matching_variant(flag, hash_key_overrides.clone())?
-                    }
-                } else {
-                    // No override, use computed variant
-                    self.get_matching_variant(flag, hash_key_overrides.clone())?
-                };
-                let payload = self.get_matching_payload(variant.as_deref(), flag);
-
-                return Ok(FeatureFlagMatch {
-                    matches: true,
-                    variant,
-                    reason: highest_match,
-                    condition_index: highest_index,
-                    payload,
-                });
-            }
-        }
-
-        condition_timer.label("outcome", "success").fin();
-        // Return with the highest_match reason and index even if no conditions matched
-        Ok(FeatureFlagMatch {
-            matches: false,
-            variant: None,
-            reason: highest_match,
-            condition_index: highest_index,
-            payload: None,
-        })
-    }
-
     /// This function determines the highest priority match evaluation for feature flag conditions.
     /// It compares the current match reason with a new match reason and returns the higher priority one.
     /// The priority is determined by the ordering of FeatureFlagMatchReason variants.
@@ -1206,63 +1000,62 @@ impl FeatureFlagMatcher {
         self.check_rollout(feature_flag, rollout_percentage, hash_key_overrides)
     }
 
-    /// Get properties to check for a feature flag.
-    ///
-    /// This function determines which properties to check based on the feature flag's group type index.
-    /// If the flag is group-based, it fetches group properties; otherwise, it fetches person properties.
+    /// Gets the properties to check for a feature flag condition, merging DB properties with overrides.
+    /// Overrides take precedence over DB properties when both are present.
     fn get_properties_to_check(
         &self,
         feature_flag: &FeatureFlag,
         property_overrides: Option<HashMap<String, Value>>,
         flag_property_filters: &[PropertyFilter],
     ) -> Result<HashMap<String, Value>, FlagError> {
-        if let Some(group_type_index) = feature_flag.get_group_type_index() {
-            self.get_group_properties(group_type_index, property_overrides, flag_property_filters)
-        } else {
-            self.get_person_properties(property_overrides, flag_property_filters)
+        match feature_flag.get_group_type_index() {
+            Some(group_type_index) => self.get_group_properties(
+                group_type_index,
+                property_overrides,
+                flag_property_filters,
+            ),
+            None => self.get_person_properties(property_overrides, flag_property_filters),
         }
     }
 
-    /// Get group properties from overrides, cache or database.
-    ///
-    /// This function attempts to retrieve group properties either from a cache or directly from the database.
-    /// It first checks if there are any locally computable property overrides. If so, it returns those.
-    /// Otherwise, it fetches the properties from the cache or database and returns them.
+    /// Gets group properties by merging DB properties with overrides (overrides take precedence).
     fn get_group_properties(
         &self,
         group_type_index: GroupTypeIndex,
         property_overrides: Option<HashMap<String, Value>>,
-        flag_property_filters: &[PropertyFilter],
+        _flag_property_filters: &[PropertyFilter],
     ) -> Result<HashMap<String, Value>, FlagError> {
-        if let Some(overrides) =
-            locally_computable_property_overrides(&property_overrides, flag_property_filters)
-        {
-            Ok(overrides)
-        } else {
-            self.get_group_properties_from_cache(group_type_index)
+        // Start with DB properties
+        let mut merged_properties =
+            self.get_group_properties_from_evaluation_state(group_type_index)?;
+
+        // Merge in overrides (overrides take precedence)
+        if let Some(overrides) = property_overrides {
+            merged_properties.extend(overrides);
         }
+
+        // Return all merged properties - let the caller filter as needed
+        Ok(merged_properties)
     }
 
-    /// Get person properties from overrides, cache or database.
-    ///
-    /// This function attempts to retrieve person properties either from a cache or directly from the database.
-    /// It first checks if there are any locally computable property overrides. If so, it returns those.
-    /// Otherwise, it fetches the properties from the cache or database and returns them.
+    /// Gets person properties by merging DB properties with overrides (overrides take precedence).
     fn get_person_properties(
         &self,
         property_overrides: Option<HashMap<String, Value>>,
-        flag_property_filters: &[PropertyFilter],
+        _flag_property_filters: &[PropertyFilter],
     ) -> Result<HashMap<String, Value>, FlagError> {
-        if let Some(overrides) =
-            locally_computable_property_overrides(&property_overrides, flag_property_filters)
-        {
-            Ok(overrides)
-        } else {
-            match self.get_person_properties_from_cache() {
-                Ok(props) => Ok(props),
-                Err(_e) => Ok(HashMap::new()), // NB: if we can't find the properties in the cache, we return an empty HashMap because we just treat this person as one with no properties, essentially an anonymous user
-            }
+        // Start with DB properties
+        let mut merged_properties = self
+            .get_person_properties_from_evaluation_state()
+            .unwrap_or_default();
+
+        // Merge in overrides (overrides take precedence)
+        if let Some(overrides) = property_overrides {
+            merged_properties.extend(overrides);
         }
+
+        // Return all merged properties - let the caller filter as needed
+        Ok(merged_properties)
     }
 
     fn is_holdout_condition_match(
@@ -1315,7 +1108,7 @@ impl FeatureFlagMatcher {
     /// Check if a super condition matches for a feature flag.
     ///
     /// This function evaluates the super conditions of a feature flag to determine if any of them should be enabled.
-    /// It first checks if there are any super conditions. If so, it evaluates the first condition.
+    /// It merges property overrides with cached DB properties, with overrides taking precedence.
     /// The function returns a struct indicating whether a super condition should be evaluated,
     /// whether it matches if evaluated, and the reason for the match.
     fn is_super_condition_match(
@@ -1330,50 +1123,32 @@ impl FeatureFlagMatcher {
             .as_ref()
             .and_then(|sc| sc.first())
         {
-            // For super conditions, we want to check if we can evaluate using ONLY the super condition properties
-            // We don't care about other properties on the flag (like cohort filters in regular conditions)
-            let super_condition_properties = super_condition.properties.as_deref().unwrap_or(&[]);
-
-            let person_properties = if let Some(ref overrides) = property_overrides {
-                // For super conditions, check if ALL required properties are present in overrides
-                let all_super_condition_props_in_overrides = super_condition_properties
-                    .iter()
-                    .all(|prop| overrides.contains_key(&prop.key));
-
-                if all_super_condition_props_in_overrides {
-                    // We can compute all super condition properties from overrides
-                    overrides.clone()
-                } else {
-                    // Fall back to cached properties since some super condition properties are missing
-                    self.get_person_properties_from_cache().unwrap_or_default()
-                }
-            } else {
-                // No overrides at all, fall back to cached properties
-                self.get_person_properties_from_cache().unwrap_or_default()
-            };
+            // Merge DB properties with overrides (overrides take precedence)
+            let merged_properties = self.get_person_properties(
+                property_overrides,
+                super_condition.properties.as_deref().unwrap_or(&[]),
+            )?;
 
             let has_relevant_super_condition_properties =
                 super_condition.properties.as_ref().map_or(false, |props| {
                     props
                         .iter()
-                        .any(|prop| person_properties.contains_key(&prop.key))
+                        .any(|prop| merged_properties.contains_key(&prop.key))
                 });
 
-            let (is_match, _) = self.is_condition_match(
-                feature_flag,
-                super_condition,
-                Some(person_properties),
-                hash_key_overrides,
-            )?;
-
             if has_relevant_super_condition_properties {
+                let (is_match, _) = self.is_condition_match(
+                    feature_flag,
+                    super_condition,
+                    Some(merged_properties),
+                    hash_key_overrides,
+                )?;
+
                 return Ok(SuperConditionEvaluation {
                     should_evaluate: true,
                     is_match,
                     reason: FeatureFlagMatchReason::SuperConditionValue,
                 });
-                // If there is a super condition evaluation, return early with those results.
-                // The reason is super condition value because we're not evaluating the rest of the conditions.
             }
         }
 
@@ -1614,8 +1389,10 @@ impl FeatureFlagMatcher {
         Ok(GroupEvaluationData { type_indexes, keys })
     }
 
-    /// Get person properties from cache only, returning empty HashMap if not found.
-    fn get_person_properties_from_cache(&self) -> Result<HashMap<String, Value>, FlagError> {
+    /// Get person properties from the `FlagEvaluationState` only, returning empty HashMap if not found.
+    fn get_person_properties_from_evaluation_state(
+        &self,
+    ) -> Result<HashMap<String, Value>, FlagError> {
         if let Some(properties) = self.flag_evaluation_state.get_person_properties() {
             inc(
                 PROPERTY_CACHE_HITS_COUNTER,
@@ -1642,8 +1419,8 @@ impl FeatureFlagMatcher {
         }
     }
 
-    /// Get group properties from cache only. Returns empty HashMap if not found.
-    fn get_group_properties_from_cache(
+    /// Get group properties from the `FlagEvaluationState` only. Returns empty HashMap if not found.
+    fn get_group_properties_from_evaluation_state(
         &self,
         group_type_index: GroupTypeIndex,
     ) -> Result<HashMap<String, Value>, FlagError> {

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -21,9 +21,9 @@ mod tests {
         },
         properties::property_models::{OperatorType, PropertyFilter, PropertyType},
         utils::test_utils::{
-            add_person_to_cohort, create_test_flag, get_person_id_by_distinct_id,
-            insert_cohort_for_team_in_pg, insert_new_team_in_pg, insert_person_for_team_in_pg,
-            setup_pg_reader_client, setup_pg_writer_client,
+            add_person_to_cohort, create_group_in_pg, create_test_flag,
+            get_person_id_by_distinct_id, insert_cohort_for_team_in_pg, insert_new_team_in_pg,
+            insert_person_for_team_in_pg, setup_pg_reader_client, setup_pg_writer_client,
         },
     };
 
@@ -3912,5 +3912,528 @@ mod tests {
         let match_result = matcher.get_match(&flag, None, None).unwrap();
         assert!(match_result.matches);
         assert_eq!(match_result.variant, None);
+    }
+
+    #[tokio::test]
+    async fn test_partial_property_overrides_fallback_behavior() {
+        let reader = setup_pg_reader_client(None).await;
+        let writer = setup_pg_writer_client(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
+        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+
+        let distinct_id = "test_user".to_string();
+
+        // Insert person with specific properties in DB that would match condition 1
+        insert_person_for_team_in_pg(
+            reader.clone(),
+            team.id,
+            distinct_id.clone(),
+            Some(json!({
+                "app_version": "1.3.6",
+                "focus": "all-of-the-above",
+                "os": "iOS",
+                "email": "test@example.com"
+            })),
+        )
+        .await
+        .expect("Failed to insert person");
+
+        // Create a flag with two conditions similar to the user's example
+        let flag = create_test_flag(
+            None,
+            Some(team.id),
+            None,
+            None,
+            Some(FlagFilters {
+                groups: vec![
+                    // Condition 1: Requires app_version, focus, os
+                    FlagPropertyGroup {
+                        properties: Some(vec![
+                            PropertyFilter {
+                                key: "app_version".to_string(),
+                                value: Some(json!("1\\.[23456789]\\.\\d{1,2}")),
+                                operator: Some(OperatorType::Regex),
+                                prop_type: PropertyType::Person,
+                                group_type_index: None,
+                                negation: None,
+                            },
+                            PropertyFilter {
+                                key: "focus".to_string(),
+                                value: Some(json!(["become-more-active", "all-of-the-above"])),
+                                operator: Some(OperatorType::Exact),
+                                prop_type: PropertyType::Person,
+                                group_type_index: None,
+                                negation: None,
+                            },
+                            PropertyFilter {
+                                key: "os".to_string(),
+                                value: Some(json!(["iOS"])),
+                                operator: Some(OperatorType::Exact),
+                                prop_type: PropertyType::Person,
+                                group_type_index: None,
+                                negation: None,
+                            },
+                        ]),
+                        rollout_percentage: Some(100.0),
+                        variant: None,
+                    },
+                    // Condition 2: Requires only email (100% rollout)
+                    FlagPropertyGroup {
+                        properties: Some(vec![PropertyFilter {
+                            key: "email".to_string(),
+                            value: Some(json!(["flag-test@example.com"])),
+                            operator: Some(OperatorType::Exact),
+                            prop_type: PropertyType::Person,
+                            group_type_index: None,
+                            negation: None,
+                        }]),
+                        rollout_percentage: Some(100.0),
+                        variant: None,
+                    },
+                ],
+                multivariate: None,
+                aggregation_group_type_index: None,
+                payloads: None,
+                super_groups: None,
+                holdout_groups: None,
+            }),
+            None,
+            None,
+            None,
+        );
+
+        // Test case 1: Partial overrides - missing 'focus' property
+        // This should fall back to DB for condition 1, but condition 2 should use overrides and not match
+        let partial_overrides = HashMap::from([
+            ("os".to_string(), json!("iOS")),
+            ("app_version".to_string(), json!("1.3.6")),
+            ("email".to_string(), json!("override-test@example.com")), // Different email, won't match condition 2
+        ]);
+
+        let mut matcher = FeatureFlagMatcher::new(
+            distinct_id.clone(),
+            team.id,
+            team.project_id,
+            reader.clone(),
+            writer.clone(),
+            cohort_cache.clone(),
+            None,
+            None,
+        );
+
+        let flags = FeatureFlagList {
+            flags: vec![flag.clone()],
+        };
+
+        let result = matcher
+            .evaluate_all_feature_flags(
+                flags.clone(),
+                Some(partial_overrides),
+                None,
+                None,
+                Uuid::new_v4(),
+            )
+            .await;
+
+        assert!(!result.errors_while_computing_flags);
+        // The flag should evaluate using DB properties for condition 1 (which has focus="all-of-the-above")
+        // and overrides for condition 2 (which won't match the email).
+        let flag_result = result.flags.get(&flag.key).unwrap();
+        assert_eq!(flag_result.enabled, true);
+
+        // Test case 2: Complete overrides for condition 2
+        // This should use overrides and match condition 2
+        let complete_overrides_match = HashMap::from([
+            ("email".to_string(), json!("flag-test@example.com")), // Matches condition 2
+        ]);
+
+        let mut matcher2 = FeatureFlagMatcher::new(
+            distinct_id.clone(),
+            team.id,
+            team.project_id,
+            reader.clone(),
+            writer.clone(),
+            cohort_cache.clone(),
+            None,
+            None,
+        );
+
+        let result2 = matcher2
+            .evaluate_all_feature_flags(
+                flags.clone(),
+                Some(complete_overrides_match),
+                None,
+                None,
+                Uuid::new_v4(),
+            )
+            .await;
+
+        assert!(!result2.errors_while_computing_flags);
+        let flag_result2 = result2.flags.get(&flag.key).unwrap();
+
+        // Should match condition 2 since email matches and rollout is 100%
+        assert_eq!(flag_result2.enabled, true);
+
+        // Test case 3: Complete overrides for condition 2 with non-matching value
+        // This should use overrides and not match condition 2
+        let complete_overrides_no_match = HashMap::from([
+            ("email".to_string(), json!("wrong@email.com")), // Doesn't match either email condition
+        ]);
+
+        let mut matcher3 = FeatureFlagMatcher::new(
+            distinct_id.clone(),
+            team.id,
+            team.project_id,
+            reader.clone(),
+            writer.clone(),
+            cohort_cache.clone(),
+            None,
+            None,
+        );
+
+        let result3 = matcher3
+            .evaluate_all_feature_flags(
+                flags.clone(),
+                Some(complete_overrides_no_match),
+                None,
+                None,
+                Uuid::new_v4(),
+            )
+            .await;
+
+        assert!(!result3.errors_while_computing_flags);
+        let flag_result3 = result3.flags.get(&flag.key).unwrap();
+        assert_eq!(flag_result3.enabled, true); // Should be true because condition 1 matches (email override doesn't affect condition 1 properties)
+
+        // Should not match condition 2 since email doesn't match, but condition 1 still matches
+        // because it only depends on app_version, focus, and os (which come from DB and still match)
+
+        // Test case 4: Complete overrides with all properties for condition 1
+        let complete_overrides_condition1 = HashMap::from([
+            ("app_version".to_string(), json!("1.3.6")),
+            ("focus".to_string(), json!("all-of-the-above")), // Now includes focus
+            ("os".to_string(), json!("iOS")),
+        ]);
+
+        let mut matcher4 = FeatureFlagMatcher::new(
+            distinct_id.clone(),
+            team.id,
+            team.project_id,
+            reader.clone(),
+            writer.clone(),
+            cohort_cache.clone(),
+            None,
+            None,
+        );
+
+        let result4 = matcher4
+            .evaluate_all_feature_flags(
+                flags,
+                Some(complete_overrides_condition1),
+                None,
+                None,
+                Uuid::new_v4(),
+            )
+            .await;
+
+        assert!(!result4.errors_while_computing_flags);
+        let flag_result4 = result4.flags.get(&flag.key).unwrap();
+        assert_eq!(flag_result4.enabled, true);
+    }
+
+    #[tokio::test]
+    async fn test_partial_group_property_overrides_fallback_behavior() {
+        let reader = setup_pg_reader_client(None).await;
+        let writer = setup_pg_writer_client(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
+        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+
+        let distinct_id = "test_user".to_string();
+
+        // Insert person (required for group flag evaluation)
+        insert_person_for_team_in_pg(reader.clone(), team.id, distinct_id.clone(), None)
+            .await
+            .expect("Failed to insert person");
+
+        // Create a group with specific properties in DB that would match condition 1
+        create_group_in_pg(
+            reader.clone(),
+            team.id,
+            "organization",
+            "test_org_123",
+            json!({
+                "plan": "enterprise",
+                "region": "us-east-1",
+                "feature_access": "full",
+                "billing_email": "billing@testorg.com"
+            }),
+        )
+        .await
+        .expect("Failed to create group");
+
+        // Create a group flag with two conditions similar to the person property test
+        let flag = create_test_flag(
+            None,
+            Some(team.id),
+            None,
+            None,
+            Some(FlagFilters {
+                groups: vec![
+                    // Condition 1: Requires plan, region, feature_access (group properties)
+                    FlagPropertyGroup {
+                        properties: Some(vec![
+                            PropertyFilter {
+                                key: "plan".to_string(),
+                                value: Some(json!(["enterprise", "pro"])),
+                                operator: Some(OperatorType::Exact),
+                                prop_type: PropertyType::Group,
+                                group_type_index: Some(1), // organization type
+                                negation: None,
+                            },
+                            PropertyFilter {
+                                key: "region".to_string(),
+                                value: Some(json!("us-.*")),
+                                operator: Some(OperatorType::Regex),
+                                prop_type: PropertyType::Group,
+                                group_type_index: Some(1),
+                                negation: None,
+                            },
+                            PropertyFilter {
+                                key: "feature_access".to_string(),
+                                value: Some(json!(["full", "premium"])),
+                                operator: Some(OperatorType::Exact),
+                                prop_type: PropertyType::Group,
+                                group_type_index: Some(1),
+                                negation: None,
+                            },
+                        ]),
+                        rollout_percentage: Some(100.0),
+                        variant: None,
+                    },
+                    // Condition 2: Requires only billing_email (100% rollout)
+                    FlagPropertyGroup {
+                        properties: Some(vec![PropertyFilter {
+                            key: "billing_email".to_string(),
+                            value: Some(json!(["special-billing@testorg.com"])),
+                            operator: Some(OperatorType::Exact),
+                            prop_type: PropertyType::Group,
+                            group_type_index: Some(1),
+                            negation: None,
+                        }]),
+                        rollout_percentage: Some(100.0),
+                        variant: None,
+                    },
+                ],
+                multivariate: None,
+                aggregation_group_type_index: Some(1), // This is a group-based flag
+                payloads: None,
+                super_groups: None,
+                holdout_groups: None,
+            }),
+            None,
+            None,
+            None,
+        );
+
+        let groups = HashMap::from([("organization".to_string(), json!("test_org_123"))]);
+
+        // Test case 1: Partial group overrides - missing 'feature_access' property
+        // This should fall back to DB for condition 1, but condition 2 should use overrides and not match
+        let partial_group_overrides = HashMap::from([(
+            "organization".to_string(),
+            HashMap::from([
+                ("plan".to_string(), json!("enterprise")),
+                ("region".to_string(), json!("us-east-1")),
+                (
+                    "billing_email".to_string(),
+                    json!("override-billing@testorg.com"),
+                ), // Different email, won't match condition 2
+                   // Missing 'feature_access' - should fall back to DB
+            ]),
+        )]);
+
+        let mut matcher = FeatureFlagMatcher::new(
+            distinct_id.clone(),
+            team.id,
+            team.project_id,
+            reader.clone(),
+            writer.clone(),
+            cohort_cache.clone(),
+            None,
+            Some(groups.clone()),
+        );
+
+        let flags = FeatureFlagList {
+            flags: vec![flag.clone()],
+        };
+
+        let result = matcher
+            .evaluate_all_feature_flags(
+                flags.clone(),
+                None,
+                Some(partial_group_overrides),
+                None,
+                Uuid::new_v4(),
+            )
+            .await;
+
+        assert!(!result.errors_while_computing_flags);
+        // The flag should evaluate using DB properties for condition 1 (which has feature_access="full")
+        // and overrides for condition 2 (which won't match the billing_email).
+        let flag_result = result.flags.get(&flag.key).unwrap();
+        assert_eq!(flag_result.enabled, true);
+
+        // Test case 2: Complete group overrides for condition 2
+        // This should use overrides and match condition 2
+        let complete_group_overrides_match = HashMap::from([(
+            "organization".to_string(),
+            HashMap::from([
+                (
+                    "billing_email".to_string(),
+                    json!("special-billing@testorg.com"),
+                ), // Matches condition 2
+            ]),
+        )]);
+
+        let mut matcher2 = FeatureFlagMatcher::new(
+            distinct_id.clone(),
+            team.id,
+            team.project_id,
+            reader.clone(),
+            writer.clone(),
+            cohort_cache.clone(),
+            None,
+            Some(groups.clone()),
+        );
+
+        let result2 = matcher2
+            .evaluate_all_feature_flags(
+                flags.clone(),
+                None,
+                Some(complete_group_overrides_match),
+                None,
+                Uuid::new_v4(),
+            )
+            .await;
+
+        assert!(!result2.errors_while_computing_flags);
+        let flag_result2 = result2.flags.get(&flag.key).unwrap();
+
+        // Should match condition 2 since billing_email matches and rollout is 100%
+        assert_eq!(flag_result2.enabled, true);
+
+        // Test case 3: Complete group overrides for condition 2 with non-matching value
+        // This should use overrides and not match condition 2
+        let complete_group_overrides_no_match = HashMap::from([(
+            "organization".to_string(),
+            HashMap::from([
+                (
+                    "billing_email".to_string(),
+                    json!("wrong-billing@testorg.com"),
+                ), // Doesn't match condition 2
+            ]),
+        )]);
+
+        let mut matcher3 = FeatureFlagMatcher::new(
+            distinct_id.clone(),
+            team.id,
+            team.project_id,
+            reader.clone(),
+            writer.clone(),
+            cohort_cache.clone(),
+            None,
+            Some(groups.clone()),
+        );
+
+        let result3 = matcher3
+            .evaluate_all_feature_flags(
+                flags.clone(),
+                None,
+                Some(complete_group_overrides_no_match),
+                None,
+                Uuid::new_v4(),
+            )
+            .await;
+
+        assert!(!result3.errors_while_computing_flags);
+        let flag_result3 = result3.flags.get(&flag.key).unwrap();
+        assert_eq!(flag_result3.enabled, true); // Should be true because condition 1 matches (billing_email override doesn't affect condition 1 properties)
+
+        // Test case 4: Complete group overrides with all properties for condition 1
+        let complete_group_overrides_condition1 = HashMap::from([(
+            "organization".to_string(),
+            HashMap::from([
+                ("plan".to_string(), json!("enterprise")),
+                ("region".to_string(), json!("us-east-1")),
+                ("feature_access".to_string(), json!("full")), // Now includes feature_access
+            ]),
+        )]);
+
+        let mut matcher4 = FeatureFlagMatcher::new(
+            distinct_id.clone(),
+            team.id,
+            team.project_id,
+            reader.clone(),
+            writer.clone(),
+            cohort_cache.clone(),
+            None,
+            Some(groups.clone()),
+        );
+
+        let result4 = matcher4
+            .evaluate_all_feature_flags(
+                flags.clone(),
+                None,
+                Some(complete_group_overrides_condition1),
+                None,
+                Uuid::new_v4(),
+            )
+            .await;
+
+        assert!(!result4.errors_while_computing_flags);
+        let flag_result4 = result4.flags.get(&flag.key).unwrap();
+        assert_eq!(flag_result4.enabled, true);
+
+        // Test case 5: Mixed overrides - some properties sufficient for fast path, others require DB merge
+        let mixed_group_overrides = HashMap::from([(
+            "organization".to_string(),
+            HashMap::from([
+                ("plan".to_string(), json!("pro")), // Different plan but still matches condition 1
+                ("region".to_string(), json!("us-west-2")), // Different region but still matches regex
+                // Missing feature_access - will need DB merge for condition 1
+                (
+                    "billing_email".to_string(),
+                    json!("special-billing@testorg.com"),
+                ), // Matches condition 2 exactly
+            ]),
+        )]);
+
+        let mut matcher5 = FeatureFlagMatcher::new(
+            distinct_id.clone(),
+            team.id,
+            team.project_id,
+            reader.clone(),
+            writer.clone(),
+            cohort_cache.clone(),
+            None,
+            Some(groups),
+        );
+
+        let result5 = matcher5
+            .evaluate_all_feature_flags(
+                flags,
+                None,
+                Some(mixed_group_overrides),
+                None,
+                Uuid::new_v4(),
+            )
+            .await;
+
+        assert!(!result5.errors_while_computing_flags);
+        let flag_result5 = result5.flags.get(&flag.key).unwrap();
+        // Should match because:
+        // - Condition 1: plan=pro (matches), region=us-west-2 (matches regex), feature_access=full (from DB merge)
+        // - Condition 2: billing_email matches exactly
+        assert_eq!(flag_result5.enabled, true);
     }
 }

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -4039,7 +4039,7 @@ mod tests {
         // The flag should evaluate using DB properties for condition 1 (which has focus="all-of-the-above")
         // and overrides for condition 2 (which won't match the email).
         let flag_result = result.flags.get(&flag.key).unwrap();
-        assert_eq!(flag_result.enabled, true);
+        assert!(flag_result.enabled);
 
         // Test case 2: Complete overrides for condition 2
         // This should use overrides and match condition 2
@@ -4072,7 +4072,7 @@ mod tests {
         let flag_result2 = result2.flags.get(&flag.key).unwrap();
 
         // Should match condition 2 since email matches and rollout is 100%
-        assert_eq!(flag_result2.enabled, true);
+        assert!(flag_result2.enabled);
 
         // Test case 3: Complete overrides for condition 2 with non-matching value
         // This should use overrides and not match condition 2
@@ -4103,7 +4103,7 @@ mod tests {
 
         assert!(!result3.errors_while_computing_flags);
         let flag_result3 = result3.flags.get(&flag.key).unwrap();
-        assert_eq!(flag_result3.enabled, true); // Should be true because condition 1 matches (email override doesn't affect condition 1 properties)
+        assert!(flag_result3.enabled); // Should be true because condition 1 matches (email override doesn't affect condition 1 properties)
 
         // Should not match condition 2 since email doesn't match, but condition 1 still matches
         // because it only depends on app_version, focus, and os (which come from DB and still match)
@@ -4138,7 +4138,7 @@ mod tests {
 
         assert!(!result4.errors_while_computing_flags);
         let flag_result4 = result4.flags.get(&flag.key).unwrap();
-        assert_eq!(flag_result4.enabled, true);
+        assert!(flag_result4.enabled);
     }
 
     #[tokio::test]
@@ -4281,7 +4281,7 @@ mod tests {
         // The flag should evaluate using DB properties for condition 1 (which has feature_access="full")
         // and overrides for condition 2 (which won't match the billing_email).
         let flag_result = result.flags.get(&flag.key).unwrap();
-        assert_eq!(flag_result.enabled, true);
+        assert!(flag_result.enabled);
 
         // Test case 2: Complete group overrides for condition 2
         // This should use overrides and match condition 2
@@ -4320,7 +4320,7 @@ mod tests {
         let flag_result2 = result2.flags.get(&flag.key).unwrap();
 
         // Should match condition 2 since billing_email matches and rollout is 100%
-        assert_eq!(flag_result2.enabled, true);
+        assert!(flag_result2.enabled);
 
         // Test case 3: Complete group overrides for condition 2 with non-matching value
         // This should use overrides and not match condition 2
@@ -4357,7 +4357,7 @@ mod tests {
 
         assert!(!result3.errors_while_computing_flags);
         let flag_result3 = result3.flags.get(&flag.key).unwrap();
-        assert_eq!(flag_result3.enabled, true); // Should be true because condition 1 matches (billing_email override doesn't affect condition 1 properties)
+        assert!(flag_result3.enabled); // Should be true because condition 1 matches (billing_email override doesn't affect condition 1 properties)
 
         // Test case 4: Complete group overrides with all properties for condition 1
         let complete_group_overrides_condition1 = HashMap::from([(
@@ -4392,7 +4392,7 @@ mod tests {
 
         assert!(!result4.errors_while_computing_flags);
         let flag_result4 = result4.flags.get(&flag.key).unwrap();
-        assert_eq!(flag_result4.enabled, true);
+        assert!(flag_result4.enabled);
 
         // Test case 5: Mixed overrides - some properties sufficient for fast path, others require DB merge
         let mixed_group_overrides = HashMap::from([(
@@ -4434,6 +4434,6 @@ mod tests {
         // Should match because:
         // - Condition 1: plan=pro (matches), region=us-west-2 (matches regex), feature_access=full (from DB merge)
         // - Condition 2: billing_email matches exactly
-        assert_eq!(flag_result5.enabled, true);
+        assert!(flag_result5.enabled);
     }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

With https://github.com/PostHog/posthog/pull/33777, we broke property overrides for feature flag evaluation for flags that were evaluating a subset of property overrides.  The goal was to fix super conditions, but this change didn't do it correctly.  Ouch.

## Changes

Refactored the property override flow to fix evaluation logic:

```
Property Overrides → Super Condition Overrides? 
                     ├─ Yes → Evaluate Flag
                     └─ No → Sufficient Overrides?
                             ├─ Yes → Evaluate Flag
                             └─ No → Merge with DB → Evaluate Flag
```

### Issues Fixed

This refactor addresses two key problems in the previous implementation:

1. **Premature flag evaluation** - Previously used too lenient conditions and attempted flag evaluation with incomplete property sets, causing the evaluation code to incorrectly treat missing properties as non-matches rather than missing overrides.

2. **Missing property merging** - Failed to merge overrides with database properties when overrides alone were insufficient for evaluation.

## Did you write or update any docs for this change?

- [x] No docs needed for this change

## How did you test this code?

Two new unit tests for testing property override behavior for person and group properties.
