### PR TITLE
chore(flags): Update a couple tests to assert we hit the db the number of times we expect

### DIFF
--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -37,7 +37,7 @@ const LONG_SCALE: u64 = 0xfffffffffffffff;
 // Replace the static counter with thread-local storage
 #[cfg(test)]
 thread_local! {
-    static FETCH_CALLS: RefCell<u64> = RefCell::new(0);
+    static FETCH_CALLS: RefCell<u64> = const { RefCell::new(0) };
 }
 
 /// Calculates a deterministic hash value between 0 and 1 for a given identifier and salt.

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -77,9 +77,7 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
 ) -> Result<(), FlagError> {
     // Add the test-specific counter increment
     #[cfg(test)]
-    FETCH_CALLS.with(|counter| {
-        *counter.borrow_mut() += 1;
-    });
+    increment_fetch_calls_count();
 
     let conn_timer = common_metrics::timing_guard(FLAG_DB_CONNECTION_TIME, &[]);
     let mut conn = reader.as_ref().get_connection().await?;


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

In #34014, @dmarticus rightfully noted that we may be hitting the db more times with deeper dependency chains. Before I fix that, i want to make sure we have a way to test how many times we call the db to get person properties, etc.

I tried multiple things and regrettably spent too much time on it, but it was a good Rust learning experience. My goal was to try to count how often we're calling the db in a way that was pretty transparent so that production code didn't really need to change. Here's what I tried:

1. We use `sqlx` to query person properties. It turns out trying to wrap or extend `sqlx` is very challenging. I was trying to add a `query_as` method to the reader we pass on down to `fetch_and_locally_cache_all_relevant_properties`, but ran into object safety issues with trait objects and generic methods. This turned out to be a dead-end for now.
2.  I tried another approach by using a test metric recorder to record and count the `DB_PERSON_AND_GROUP_PROPERTIES_READS_COUNTER` metric. I could never get this to work. It would've been a brittle approach anyways as you can only have one test recorder registered per process.

## Changes

I ended up adding some thread-local test-only methods for counting when we call `fetch_and_locally_cache_all_relevant_properties`. This PR includes that and I use them to verify a couple of scenarios in existing tests.

It's a tiny bit ugly, but not as bad as other solutions I thought of. And, it doesn't affect production code.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Unit tests.