### PR TITLE
fix(environmens): Flush events to avoid them being lost as the worker exits

### DIFF
--- a/posthog/tasks/environments_rollback.py
+++ b/posthog/tasks/environments_rollback.py
@@ -53,6 +53,8 @@ def _capture_environments_rollback_event(
         groups=groups(context.organization),
     )
 
+    posthoganalytics.flush()
+
 
 def environments_rollback_migration(organization_id: int, environment_mappings: dict[str, int], user_id: int) -> None:
     """


### PR DESCRIPTION
## Problem

- On short-life tasks events are sometimes buffered (and not sent), then they are lost as the worker exits

## Changes

- Add flush() to force-send the event