### PR TITLE
chore(persons): Make shadow comparison not use distinct id

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -538,10 +538,7 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         return result
     }
 
-    getCachedPersonForUpdate(teamId: number, distinctId: string): PersonUpdate | null | undefined {
-        const cacheKey = this.getDistinctCacheKey(teamId, distinctId)
-        const personUuid = this.distinctIdToPersonUuid.get(cacheKey)
-
+    getCachedPersonForUpdateByUuid(teamId: number, personUuid: string | undefined): PersonUpdate | null | undefined {
         if (personUuid === undefined) {
             this.cacheMetrics.updateCacheMisses++
             return undefined
@@ -566,6 +563,13 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
             this.cacheMetrics.updateCacheMisses++
             return undefined
         }
+    }
+
+    getCachedPersonForUpdate(teamId: number, distinctId: string): PersonUpdate | null | undefined {
+        const cacheKey = this.getDistinctCacheKey(teamId, distinctId)
+        const personUuid = this.distinctIdToPersonUuid.get(cacheKey)
+
+        return this.getCachedPersonForUpdateByUuid(teamId, personUuid)
     }
 
     setCachedPersonForUpdate(teamId: number, distinctId: string, person: PersonUpdate | null): void {


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Distinct Id based operations make it hard to track if we are doing the same operations for the same person. To that end, I have updated the logic to work with the person id, making comparisons direct between the cache and the final state map in the store manager

## Changes



## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
