### PR TITLE
fix(activity): Make changelog notifications payload an array

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelActivityLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelActivityLogic.tsx
@@ -33,6 +33,7 @@ export interface ChangelogFlagPayload {
     // For optimal display, ensure images are reasonably sized (e.g., width < 800px)
     // and optimized for web (e.g., < 500KB).
     // We suggest you upload it to a CDN to reduce load times/server load.
+    // If you're a PostHog employee, check https://posthog.com/handbook/engineering/posthog-com/assets out
     markdown: string
 
     // Optional fields used if you wanna override this to a specific person rather than Joe

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelActivityLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelActivityLogic.tsx
@@ -7,7 +7,7 @@ import { ActivityLogItem, humanize, HumanizedActivityLogItem } from 'lib/compone
 import { dayjs } from 'lib/dayjs'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { toParams } from 'lib/utils'
-import posthog from 'posthog-js'
+import posthog, { JsonRecord } from 'posthog-js'
 import { projectLogic } from 'scenes/projectLogic'
 
 import { ActivityScope, UserBasicType } from '~/types'
@@ -27,11 +27,17 @@ export type ActivityFilters = {
 
 export interface ChangelogFlagPayload {
     notificationDate: dayjs.Dayjs
-    markdown: string
+
     // Images can be embedded directly in the markdown using ![alt text](url) syntax.
     // LemonMarkdown will render them.
     // For optimal display, ensure images are reasonably sized (e.g., width < 800px)
     // and optimized for web (e.g., < 500KB).
+    // We suggest you upload it to a CDN to reduce load times/server load.
+    markdown: string
+
+    // Optional fields used if you wanna override this to a specific person rather than Joe
+    name?: string
+    email?: string
 }
 
 export interface ChangesResponse {
@@ -221,47 +227,53 @@ export const sidePanelActivityLogic = kea<sidePanelActivityLogicType>([
             (s) => [s.importantChanges],
             (importantChanges): HumanizedActivityLogItem[] => {
                 try {
-                    const importantChangesHumanized = humanize(importantChanges?.results || [], describerFor, true)
+                    let importantChangesHumanized = humanize(importantChanges?.results || [], describerFor, true)
 
-                    let changelogNotification: ChangelogFlagPayload | null = null
                     const flagPayload = posthog.getFeatureFlagPayload('changelog-notification')
-                    if (flagPayload) {
-                        changelogNotification = {
-                            markdown: flagPayload['markdown'],
-                            notificationDate: dayjs(flagPayload['notificationDate']),
-                            // The separate image field is no longer used.
-                            // Images should be embedded in the markdown string.
-                        } as ChangelogFlagPayload
-                    }
+                    const changelogNotifications = flagPayload
+                        ? (flagPayload as JsonRecord[]).map(
+                              (notification) =>
+                                  ({
+                                      markdown: notification.markdown,
+                                      notificationDate: dayjs(notification.notificationDate as string),
+                                      email: notification.email,
+                                      name: notification.name,
+                                  } as ChangelogFlagPayload)
+                          )
+                        : null
 
-                    if (changelogNotification) {
+                    if (changelogNotifications) {
                         const lastRead = importantChanges?.last_read ? dayjs(importantChanges.last_read) : null
-                        const changeLogIsUnread =
-                            !!lastRead &&
-                            (lastRead.isBefore(changelogNotification.notificationDate) ||
-                                lastRead == changelogNotification.notificationDate)
 
-                        const changelogNotificationHumanized: HumanizedActivityLogItem = {
-                            email: 'joe@posthog.com',
-                            name: 'Joe',
-                            isSystem: true,
-                            description: <LemonMarkdown>{changelogNotification.markdown}</LemonMarkdown>,
-                            created_at: changelogNotification.notificationDate,
-                            unread: changeLogIsUnread,
-                        }
-                        const notifications = [changelogNotificationHumanized, ...importantChangesHumanized]
-                        notifications.sort((a, b) => {
+                        importantChangesHumanized = [
+                            ...importantChangesHumanized,
+                            ...changelogNotifications.map(
+                                (changelogNotification) =>
+                                    ({
+                                        email: changelogNotification.email || 'joe@posthog.com',
+                                        name: changelogNotification.name || 'Joe',
+                                        isSystem: true,
+                                        description: <LemonMarkdown>{changelogNotification.markdown}</LemonMarkdown>,
+                                        created_at: changelogNotification.notificationDate,
+                                        unread: lastRead?.isSameOrBefore(changelogNotification.notificationDate),
+                                    } as HumanizedActivityLogItem)
+                            ),
+                        ]
+
+                        // Sorting this inside the `if` case because there's no need to sort the changelog notifications
+                        // if there are no changelog notifications, since they come from the backend sorted already.
+                        importantChangesHumanized.sort((a: HumanizedActivityLogItem, b: HumanizedActivityLogItem) => {
                             if (a.created_at.isBefore(b.created_at)) {
                                 return 1
                             } else if (a.created_at.isAfter(b.created_at)) {
                                 return -1
                             }
+
                             return 0
                         })
-                        return notifications
                     }
 
-                    return humanize(importantChanges?.results || [], describerFor, true)
+                    return importantChangesHumanized
                 } catch {
                     // swallow errors as this isn't user initiated
                     return []

--- a/frontend/src/lib/lemon-ui/ProfilePicture/ProfilePicture.tsx
+++ b/frontend/src/lib/lemon-ui/ProfilePicture/ProfilePicture.tsx
@@ -51,12 +51,12 @@ export const ProfilePicture = React.forwardRef<HTMLSpanElement, ProfilePicturePr
             return // There are no guarantees on how long it takes to fetch a Gravatar, so we skip this in snapshots
         }
         // Check if Gravatar exists
-        const emailOrNameWithEmail = email || (name?.includes('@') ? name : undefined)
-        if (emailOrNameWithEmail) {
-            const emailHash = md5(emailOrNameWithEmail.trim().toLowerCase())
-            return `https://www.gravatar.com/avatar/${emailHash}?s=96&d=404`
+        const identifier = email || (name?.includes('@') ? name : undefined)
+        if (identifier) {
+            const hash = md5(identifier.trim().toLowerCase())
+            return `https://www.gravatar.com/avatar/${hash}?s=96&d=404`
         }
-    }, [email, hedgehogProfile])
+    }, [email, hedgehogProfile, name])
 
     const pictureComponent = (
         <span className={clsx('ProfilePicture', size, className)} ref={ref}>


### PR DESCRIPTION
Let's make the `changelog-notification` FF payload an array to allow for multiple notifications. Let's also allow us to change a message so that it can come from anyone, not always by Joe - it'll use Gravatar, so we need to be aware of that

Yes, I'm aware this is a breaking change, I'll take care of updating the existing payload to the new format when we merge this