### PR TITLE
fix: Show group categories when filtering action events

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -36,6 +36,14 @@ import { OperandTag } from './OperandTag'
 import { taxonomicPropertyFilterLogic } from './taxonomicPropertyFilterLogic'
 
 let uniqueMemoizedIndex = 0
+export const defaultTaxonomicGroupTypes = [
+    TaxonomicFilterGroupType.EventProperties,
+    TaxonomicFilterGroupType.PersonProperties,
+    TaxonomicFilterGroupType.EventFeatureFlags,
+    TaxonomicFilterGroupType.Cohorts,
+    TaxonomicFilterGroupType.Elements,
+    TaxonomicFilterGroupType.HogQLExpression,
+]
 
 export function TaxonomicPropertyFilter({
     pageKey: pageKeyInput,
@@ -63,14 +71,7 @@ export function TaxonomicPropertyFilter({
     editable = true,
 }: PropertyFilterInternalProps): JSX.Element {
     const pageKey = useMemo(() => pageKeyInput || `filter-${uniqueMemoizedIndex++}`, [pageKeyInput])
-    const groupTypes = taxonomicGroupTypes || [
-        TaxonomicFilterGroupType.EventProperties,
-        TaxonomicFilterGroupType.PersonProperties,
-        TaxonomicFilterGroupType.EventFeatureFlags,
-        TaxonomicFilterGroupType.Cohorts,
-        TaxonomicFilterGroupType.Elements,
-        TaxonomicFilterGroupType.HogQLExpression,
-    ]
+    const groupTypes = taxonomicGroupTypes || defaultTaxonomicGroupTypes
     const taxonomicOnChange: (
         group: TaxonomicFilterGroup,
         value: TaxonomicFilterValue,

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -36,7 +36,7 @@ import { OperandTag } from './OperandTag'
 import { taxonomicPropertyFilterLogic } from './taxonomicPropertyFilterLogic'
 
 let uniqueMemoizedIndex = 0
-export const defaultTaxonomicGroupTypes = [
+export const DEFAULT_TAXONOMIC_GROUP_TYPES = [
     TaxonomicFilterGroupType.EventProperties,
     TaxonomicFilterGroupType.PersonProperties,
     TaxonomicFilterGroupType.EventFeatureFlags,
@@ -71,7 +71,7 @@ export function TaxonomicPropertyFilter({
     editable = true,
 }: PropertyFilterInternalProps): JSX.Element {
     const pageKey = useMemo(() => pageKeyInput || `filter-${uniqueMemoizedIndex++}`, [pageKeyInput])
-    const groupTypes = taxonomicGroupTypes || defaultTaxonomicGroupTypes
+    const groupTypes = taxonomicGroupTypes || DEFAULT_TAXONOMIC_GROUP_TYPES
     const taxonomicOnChange: (
         group: TaxonomicFilterGroup,
         value: TaxonomicFilterValue,

--- a/frontend/src/scenes/actions/ActionStep.tsx
+++ b/frontend/src/scenes/actions/ActionStep.tsx
@@ -10,10 +10,13 @@ import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { LemonLabel } from 'lib/lemon-ui/LemonLabel/LemonLabel'
 import { useState } from 'react'
 import { URL_MATCHING_HINTS } from 'scenes/actions/hints'
+import { useValues } from 'kea'
+import { groupsModel } from '~/models/groupsModel'
 
 import { ActionStepStringMatching, ActionStepType } from '~/types'
 
 import { LemonEventName } from './EventName'
+import { defaultTaxonomicGroupTypes } from 'lib/components/PropertyFilters/components/TaxonomicPropertyFilter'
 
 const learnMoreLink = 'https://posthog.com/docs/data/actions?utm_medium=in-product&utm_campaign=action-page'
 
@@ -31,6 +34,7 @@ export function ActionStep({ step, actionId, isOnlyStep, index, identifier, onDe
     const sendStep = (stepToSend: ActionStepType): void => {
         onChange(stepToSend)
     }
+    const { groupsTaxonomicTypes } = useValues(groupsModel)
 
     return (
         <div className="bg-surface-primary rounded border p-3 relative">
@@ -102,6 +106,7 @@ export function ActionStep({ step, actionId, isOnlyStep, index, identifier, onDe
                         propertyFilters={step.properties}
                         pageKey={identifier}
                         eventNames={step.event ? [step.event] : []}
+                        taxonomicGroupTypes={[...defaultTaxonomicGroupTypes, ...groupsTaxonomicTypes]}
                         onChange={(properties) => {
                             sendStep({
                                 ...step,

--- a/frontend/src/scenes/actions/ActionStep.tsx
+++ b/frontend/src/scenes/actions/ActionStep.tsx
@@ -16,7 +16,7 @@ import { groupsModel } from '~/models/groupsModel'
 import { ActionStepStringMatching, ActionStepType } from '~/types'
 
 import { LemonEventName } from './EventName'
-import { defaultTaxonomicGroupTypes } from 'lib/components/PropertyFilters/components/TaxonomicPropertyFilter'
+import { DEFAULT_TAXONOMIC_GROUP_TYPES } from 'lib/components/PropertyFilters/components/TaxonomicPropertyFilter'
 
 const learnMoreLink = 'https://posthog.com/docs/data/actions?utm_medium=in-product&utm_campaign=action-page'
 
@@ -106,7 +106,7 @@ export function ActionStep({ step, actionId, isOnlyStep, index, identifier, onDe
                         propertyFilters={step.properties}
                         pageKey={identifier}
                         eventNames={step.event ? [step.event] : []}
-                        taxonomicGroupTypes={[...defaultTaxonomicGroupTypes, ...groupsTaxonomicTypes]}
+                        taxonomicGroupTypes={[...DEFAULT_TAXONOMIC_GROUP_TYPES, ...groupsTaxonomicTypes]}
                         onChange={(properties) => {
                             sendStep({
                                 ...step,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
https://posthog.slack.com/archives/C045L1VEG87/p1748540595556469
We were not allowing to configure group filters in actions. 
~Also, when viewing a group tab in people section, we were not allowing to add left/right group properties.~ Will be handled in a new PR.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
~Added groups taxonomic types to the above mentioned places we were missing them.~ Will be handled in a new PR
Added groups columns as options for filtering actions.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?
| Before | After |
|----------|----------|
| ![image](https://github.com/user-attachments/assets/931f57db-9286-4fc7-938a-5455d21b8ed9) | <img width="1195" alt="image" src="https://github.com/user-attachments/assets/d9774be5-3740-4ac4-94db-d23d522bac9c" /> |

### Account (group_0)
Breakdown data | Action filter | Person details
:----------:|:----------:|:----------:
![image](https://github.com/user-attachments/assets/c8c95928-0944-4efe-8613-32d5dd672b06) | ![image](https://github.com/user-attachments/assets/1f3c1160-08d0-4542-b1c8-82fadb08af65) | ![image](https://github.com/user-attachments/assets/8144651c-dde6-49da-b16c-c9ead2cc00cf)

### Project (group_1)
Breakdown data | Action filter | Person details
:----------:|:----------:|:----------:
![image](https://github.com/user-attachments/assets/61bceba7-49e4-475a-b46c-fd1a48996d2e) | ![image](https://github.com/user-attachments/assets/d3f8bcc2-1e9c-455e-af83-8f73ca0d03c7) | ![image](https://github.com/user-attachments/assets/77578994-0746-4843-bce4-02cd9ce67aa3)

### Organization (group_2)
Breakdown data | Action filter | Person details
:----------:|:----------:|:----------:
![image](https://github.com/user-attachments/assets/7093822f-0e3c-4ed4-93bd-e857cc0fa4bd) | ![image](https://github.com/user-attachments/assets/76822dc0-9ebb-4869-9aa8-7d89d4e474a3) | ![image](https://github.com/user-attachments/assets/77578994-0746-4843-bce4-02cd9ce67aa3)

### Instance (group_3)
Breakdown data | Action filter | Person details
:----------:|:----------:|:----------:
![image](https://github.com/user-attachments/assets/6a124e65-6177-43e6-8489-ba16fd416ab1) | ![image](https://github.com/user-attachments/assets/ce50c3fb-67c3-4e18-93c4-3b7cc7c650ca) | ![image](https://github.com/user-attachments/assets/77578994-0746-4843-bce4-02cd9ce67aa3)

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
In the UI, by filtering an action by a property of each group and ensuring the results matched.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
