### PR TITLE
fix: whitelist funnel correlation 

### DIFF
--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -293,6 +293,7 @@ def get_pk_or_uuid(queryset: QuerySet, key: Union[int, str]) -> QuerySet:
 INSIGHT_KINDS = {
     "TrendsQuery",
     "FunnelsQuery",
+    "FunnelCorrelationQuery",
     "RetentionQuery",
     "PathsQuery",
     "StickinessQuery",


### PR DESCRIPTION
Funnel correlation queries limited to 60 seconds whitelist them so they can have more time