### PR TITLE
Change Enhanced persons to Identified

### DIFF
--- a/frontend/src/mocks/fixtures/_billing_with_billing_limits.json
+++ b/frontend/src/mocks/fixtures/_billing_with_billing_limits.json
@@ -400,7 +400,7 @@
         },
         {
             "key": "enhanced_persons",
-            "name": "Enhanced persons",
+            "name": "Identified",
             "description": "Enhance your user data with properties and attribution data. Great for tracking user behavior across devices and sessions and tracking person changes over time.",
             "unit": null,
             "limit": null,
@@ -1323,7 +1323,7 @@
                     "usage_limit": null
                 },
                 {
-                    "name": "Enhanced persons",
+                    "name": "Identified",
                     "description": "Enhance your user data with properties and attribution data. Great for tracking user behavior across devices and sessions and tracking person changes over time.",
                     "price_description": null,
                     "image_url": "None",
@@ -1355,7 +1355,7 @@
                             "features": [
                                 {
                                     "key": "enhanced_persons",
-                                    "name": "Enhanced persons",
+                                    "name": "Identified",
                                     "description": "Enhance your user data with properties and attribution data. Great for tracking user behavior across devices and sessions and tracking person changes over time.",
                                     "unit": null,
                                     "limit": null,
@@ -1383,7 +1383,7 @@
                             "features": [
                                 {
                                     "key": "enhanced_persons",
-                                    "name": "Enhanced persons",
+                                    "name": "Identified",
                                     "description": "Enhance your user data with properties and attribution data. Great for tracking user behavior across devices and sessions and tracking person changes over time.",
                                     "unit": null,
                                     "limit": null,
@@ -1404,7 +1404,7 @@
                     "features": [
                         {
                             "key": "enhanced_persons",
-                            "name": "Enhanced persons",
+                            "name": "Identified",
                             "description": "Enhance your user data with properties and attribution data. Great for tracking user behavior across devices and sessions and tracking person changes over time.",
                             "images": null,
                             "icon_key": null,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We call the event types Anonymous events and Identified events. Enhanced persons is not anywhere on website or docs, thus confusing. 

https://posthog.com/events#:~:text=By%20default%2C%20events%20are%20anonymous,location%2C%20and%20any%20UTM%20parameters.

## Changes

Renames the names

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
