### PR TITLE
fix(admin): rm version list fitler from persons

### DIFF
--- a/posthog/admin/admins/person_admin.py
+++ b/posthog/admin/admins/person_admin.py
@@ -15,5 +15,5 @@ class PersonAdmin(admin.ModelAdmin):
         "is_identified",
         "version",
     )
-    list_filter = ("created_at", "is_identified", "version")
+    list_filter = ("created_at", "is_identified")
     search_fields = ("id",)


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Loading the Persons admin page runs a full table scan against the Persons table so that it can create the version filter list. This hurts DB performance and creates operational issues for ingestion.

## Changes

Removes the version list filter from the Persons django admin page

## Did you write or update any docs for this change?

## How did you test this code?

Tested locally
