### PR TITLE
feat(data-modeling): Batch modeling rows by size of rows

### DIFF
--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -10,6 +10,7 @@ import uuid
 import decimal
 import ipaddress
 from urllib.parse import urljoin
+from pympler import asizeof
 
 import aiohttp
 import pyarrow as pa
@@ -712,7 +713,8 @@ class ClickHouseClient:
         *data,
         query_parameters: dict[str, typing.Any] | None = None,
         query_id: str | None = None,
-        batch_size: int = 5000,
+        batch_size: typing.Optional[int] = None,
+        batch_size_mb: typing.Optional[int] = None,
         line_separator: bytes = b"\n",
     ) -> typing.AsyncGenerator[tuple[list[dict[str, typing.Any]], pa.Schema], None]:
         """Stream typed rows from a ClickHouse query using FORMAT TabSeparatedWithNamesAndTypes.
@@ -723,16 +725,22 @@ class ClickHouseClient:
             query: The SQL query to execute. Must end with FORMAT TabSeparatedWithNamesAndTypes.
             query_parameters: Optional query parameters to interpolate.
             query_id: Optional ClickHouse query ID.
-            batch_size: The number of rows per batch to yield.
+            batch_size: The number of rows per batch to yield. Either `batch_size` or `batch_size_mb` must be set.
+            batch_size_mb: The max size of the batch to yield. Either `batch_size` or `batch_size_mb` must be set.
             line_separator: The line separator used in the response (default: newline).
 
         Yields:
             Batches of parsed rows, each row as a dict[str, Any].
         """
+        if batch_size is None and batch_size_mb is None:
+            raise Exception("astream_query_in_batches: both batch_size and batch_size_mb is None")
+
         buffer = b""
         headers: list[str] | None = None
         types: list[str] | None = None
         rows: list[dict[str, typing.Any]] = []
+        bytes_in_batch = 0
+        batch_size_bytes = batch_size_mb * 1000 * 1000 if batch_size_mb else None
         line_index = 0
 
         async with self.apost_query(query, *data, query_parameters=query_parameters, query_id=query_id) as response:
@@ -760,11 +768,21 @@ class ClickHouseClient:
                             key: parse_clickhouse_value(value, ch_type)
                             for key, value, ch_type in zip(headers, raw_values, types)
                         }
+                        if batch_size_bytes:
+                            row_size = asizeof.asizeof(parsed)
+                            bytes_in_batch += row_size
+
                         rows.append(parsed)
 
-                        if len(rows) >= batch_size:
-                            yield (rows, pa_schema)
-                            rows = []
+                        if batch_size:
+                            if len(rows) >= batch_size:
+                                yield (rows, pa_schema)
+                                rows = []
+                        elif batch_size_bytes:
+                            if bytes_in_batch >= batch_size_bytes:
+                                yield (rows, pa_schema)
+                                rows = []
+                                bytes_in_batch = 0
 
                     line_index += 1
 

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -725,8 +725,8 @@ class ClickHouseClient:
             query: The SQL query to execute. Must end with FORMAT TabSeparatedWithNamesAndTypes.
             query_parameters: Optional query parameters to interpolate.
             query_id: Optional ClickHouse query ID.
-            batch_size: The number of rows per batch to yield. Either `batch_size` or `batch_size_mb` must be set.
-            batch_size_mb: The max size of the batch to yield. Either `batch_size` or `batch_size_mb` must be set.
+            batch_size: The number of rows per batch to yield. Either `batch_size` or `batch_size_mb` must be set. If both are set then `batch_size` wins.
+            batch_size_mb: The max size of the batch to yield. Either `batch_size` or `batch_size_mb` must be set. If both are set then `batch_size` wins.
             line_separator: The line separator used in the response (default: newline).
 
         Yields:

--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -616,7 +616,10 @@ async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger):
     await logger.adebug(f"Running clickhouse query: {printed}")
 
     async with get_client() as client:
-        async for batch, pa_schema in client.astream_query_in_batches(printed, query_parameters=context.values):
+        async for batch, pa_schema in client.astream_query_in_batches(
+            printed, query_parameters=context.values, batch_size_mb=50
+        ):
+            await logger.adebug(f"Processing 50 MB batch. Batch rows count: {len(batch)}")
             yield table_from_py_list(batch, pa_schema)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ dependencies = [
     "pyarrow==18.1.0",
     "pydantic==2.10.3",
     "pyjwt==2.4.0",
+    "pympler==1.1",
     "pymssql==2.3.1",
     "pymysql==1.1.1",
     "pyodbc==5.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3719,6 +3719,7 @@ dependencies = [
     { name = "pyarrow" },
     { name = "pydantic" },
     { name = "pyjwt" },
+    { name = "pympler" },
     { name = "pymssql" },
     { name = "pymysql" },
     { name = "pyodbc" },
@@ -3930,6 +3931,7 @@ requires-dist = [
     { name = "pyarrow", specifier = "==18.1.0" },
     { name = "pydantic", specifier = "==2.10.3" },
     { name = "pyjwt", specifier = "==2.4.0" },
+    { name = "pympler", specifier = "==1.1" },
     { name = "pymssql", specifier = "==2.3.1" },
     { name = "pymysql", specifier = "==1.1.1" },
     { name = "pyodbc", specifier = "==5.1.0" },
@@ -4376,6 +4378,18 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pympler"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/37/c384631908029676d8e7213dd956bb686af303a80db7afbc9be36bc49495/pympler-1.1.tar.gz", hash = "sha256:1eaa867cb8992c218430f1708fdaccda53df064144d1c5656b1e6f1ee6000424", size = 179954, upload-time = "2024-06-28T19:56:06.563Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/4f/a6a2e2b202d7fd97eadfe90979845b8706676b41cbd3b42ba75adf329d1f/Pympler-1.1-py3-none-any.whl", hash = "sha256:5b223d6027d0619584116a0cbc28e8d2e378f7a79c1e5e024f9ff3b673c58506", size = 165766, upload-time = "2024-06-28T19:56:05.087Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem
- Batching modeling rows in sets of 5000 takes very long for large jobs

## Changes
- Dynamocally batch rows from clickhouse according to a max size of rows in bytes (50 MB)
- Means we'll process 50 MB of rows at a time which could be more or less than 5000 rows (likely more for most queries) - allows us to cap memory usage when running the pipeline
