### PR TITLE
fix(flags): longer redis timeouts

### DIFF
--- a/rust/common/redis/src/lib.rs
+++ b/rust/common/redis/src/lib.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use thiserror::Error;
 use tokio::time::timeout;
 
-const DEFAULT_REDIS_TIMEOUT_MILLISECS: u64 = 100;
+const DEFAULT_REDIS_TIMEOUT_MILLISECS: u64 = 1000;
 
 fn get_redis_timeout_ms() -> u64 {
     std::env::var("REDIS_TIMEOUT_MS")

--- a/rust/common/redis/src/lib.rs
+++ b/rust/common/redis/src/lib.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use thiserror::Error;
 use tokio::time::timeout;
 
-const DEFAULT_REDIS_TIMEOUT_MILLISECS: u64 = 1000;
+const DEFAULT_REDIS_TIMEOUT_MILLISECS: u64 = 3000;
 
 fn get_redis_timeout_ms() -> u64 {
     std::env::var("REDIS_TIMEOUT_MS")


### PR DESCRIPTION
## Problem

We're still seeing latency spikes in `/flags` that correspond to redis timeout issues.  Turns out even 100ms is still probably too aggressive, especially under high load.  I'm cranking the timeout up to 3s to see if that makes sense (this is common in popular client libs, e.g. `go-redis`).  If we still see high latency with no timeouts, then I'll try something else.  but i feel good about this after researching other timeout lengths and realizing how short ours is.
