### PR TITLE
fix(persons): Populate store manager cache for fetchForUpdate

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -499,6 +499,10 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         return `${teamId}:${personUuid}`
     }
 
+    clearCacheByUuid(teamId: number, personUuid: string): void {
+        this.personUpdateCache.delete(this.getPersonUuidCacheKey(teamId, personUuid))
+    }
+
     clearCache(teamId: number, distinctId: string): void {
         const cacheKey = this.getDistinctCacheKey(teamId, distinctId)
         const personUuid = this.distinctIdToPersonUuid.get(cacheKey)
@@ -508,7 +512,7 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
 
         // Clear the person data if we have the UUID
         if (personUuid) {
-            this.personUpdateCache.delete(this.getPersonUuidCacheKey(teamId, personUuid))
+            this.clearCacheByUuid(teamId, personUuid)
         }
 
         // Clear the check cache

--- a/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
@@ -158,6 +158,10 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
             this.secondaryStore.setCachedPersonForUpdate(teamId, distinctId, null)
         }
 
+        if (mainResult) {
+            this.updateFinalState(teamId, distinctId, mainResult.uuid, mainResult, false, 'fetchForUpdate')
+        }
+
         return mainResult
     }
 
@@ -277,6 +281,7 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
 
         // Clear cache for the person
         this.secondaryStore.clearCache(person.team_id, distinctId)
+        this.secondaryStore.clearCacheByUuid(person.team_id, person.uuid)
         this.updateFinalState(person.team_id, distinctId, person.uuid, null, false, 'deletePerson')
 
         return kafkaMessages


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We were seeing some null vs object validation errors, I think it could be because we were not populating the final states correctly when we fetch.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
