### PR TITLE
feat: Added tracking of an event for hog function state changes

### DIFF
--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -124,6 +124,11 @@ export class CdpApi {
             const summary = await this.hogWatcher.getState(id)
             const hogFunction = await this.hogFunctionManager.fetchHogFunction(id)
 
+            if (!hogFunction) {
+                res.status(404).json({ error: 'Hog function not found' })
+                return
+            }
+
             // Only allow patching the status if it is different from the current status
 
             if (summary.state !== state) {

--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -122,11 +122,12 @@ export class CdpApi {
             }
 
             const summary = await this.hogWatcher.getState(id)
+            const hogFunction = await this.hogFunctionManager.fetchHogFunction(id)
 
             // Only allow patching the status if it is different from the current status
 
             if (summary.state !== state) {
-                await this.hogWatcher.forceStateChange(id, state)
+                await this.hogWatcher.forceStateChange(hogFunction, state)
             }
 
             // Hacky - wait for a little to give a chance for the state to change

--- a/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
@@ -110,6 +110,9 @@ export class CdpCyclotronWorker extends CdpConsumerBase {
                     logger.info('⚠️', 'Skipping invocation due to hog function being deleted or disabled', {
                         id: item.functionId,
                     })
+
+                    failedInvocations.push(item)
+
                     return null
                 }
 

--- a/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
@@ -106,6 +106,13 @@ export class CdpCyclotronWorker extends CdpConsumerBase {
                     return null
                 }
 
+                if (!hogFunction.enabled || hogFunction.deleted) {
+                    logger.info('⚠️', 'Skipping invocation due to hog function being deleted or disabled', {
+                        id: item.functionId,
+                    })
+                    return null
+                }
+
                 loadedInvocations.push({
                     ...item,
                     state: item.state as CyclotronJobInvocationHogFunction['state'],

--- a/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.test.ts
+++ b/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.test.ts
@@ -187,5 +187,21 @@ describe('CdpCyclotronWorker', () => {
             expect(results).toEqual([])
             expect(dequeueInvocationsSpy).toHaveBeenCalledWith([invocation])
         })
+
+        it('should skip a loaded function if it is disabled', async () => {
+            const fn2 = await _insertHogFunction(
+                hub.postgres,
+                team.id,
+                createHogFunction({
+                    ...HOG_EXAMPLES.simple_fetch,
+                    ...HOG_INPUTS_EXAMPLES.simple_fetch,
+                    ...HOG_FILTERS_EXAMPLES.pageview_or_autocapture_filter,
+                    enabled: false,
+                })
+            )
+
+            const results = await processor['loadHogFunctions']([createExampleInvocation(fn2, globals)])
+            expect(results).toEqual([])
+        })
     })
 })

--- a/plugin-server/src/cdp/consumers/cdp-events-consumer.test.ts
+++ b/plugin-server/src/cdp/consumers/cdp-events-consumer.test.ts
@@ -222,8 +222,8 @@ describe.each([
                 [HogWatcherState.disabledForPeriod, 'disabled_temporarily'],
                 [HogWatcherState.disabledIndefinitely, 'disabled_permanently'],
             ])('should filter out functions that are disabled', async (state, metric_name) => {
-                await processor.hogWatcher.forceStateChange(fnFetchNoFilters.id, state)
-                await processor.hogWatcher.forceStateChange(fnPrinterPageviewFilters.id, state)
+                await processor.hogWatcher.forceStateChange(fnFetchNoFilters, state)
+                await processor.hogWatcher.forceStateChange(fnPrinterPageviewFilters, state)
 
                 const { invocations } = await processor.processBatch([globals])
 


### PR DESCRIPTION
## Problem

Track an event for any hog function state changes so that we can do some alerting (internally to start with) and use this potentially as a first Messaging use case.

## Changes

* As on tin

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
