### PR TITLE
fix: Add CORS_ALLOWED_ORIGINS header

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -37,7 +37,7 @@ from posthog.cloud_utils import is_cloud
 from posthog.exceptions import generate_exception_response
 from posthog.models import Action, Cohort, Dashboard, FeatureFlag, Insight, Notebook, User, Team
 from posthog.rate_limit import DecideRateThrottle
-from posthog.settings import SITE_URL, DEBUG, PROJECT_SWITCHING_TOKEN_ALLOWLIST
+from posthog.settings import SITE_URL, PROJECT_SWITCHING_TOKEN_ALLOWLIST
 from posthog.user_permissions import UserPermissions
 from .auth import PersonalAPIKeyAuthentication
 from .utils_cors import cors_response
@@ -48,6 +48,7 @@ ALWAYS_ALLOWED_ENDPOINTS = [
     "_health",
     "flags",
     "messaging-preferences",
+    "i",
 ]
 
 default_cookie_options = {
@@ -122,8 +123,6 @@ class CsrfOrKeyViewMiddleware(CsrfViewMiddleware):
         result = super().process_view(request, callback, callback_args, callback_kwargs)  # None if request accepted
         # if super().process_view did not find a valid CSRF token, try looking for a personal API key
         if result is not None and PersonalAPIKeyAuthentication.find_key_with_source(request) is not None:
-            return self._accept(request)
-        if DEBUG and request.path.split("/")[1] in ALWAYS_ALLOWED_ENDPOINTS:
             return self._accept(request)
         return result
 

--- a/posthog/settings/access.py
+++ b/posthog/settings/access.py
@@ -80,6 +80,10 @@ SALT_KEY = get_list(os.getenv("SALT_KEY", "0123456789abcdefghijklmnopqrstuvwxyz"
 ENCRYPTION_SALT_KEYS = get_list(os.getenv("ENCRYPTION_SALT_KEYS", "00beef0000beef0000beef0000beef00"))
 
 INTERNAL_IPS = ["127.0.0.1", "172.18.0.1"]  # Docker IP
-CORS_ORIGIN_ALLOW_ALL = True
+if os.getenv("CORS_ALLOWED_ORIGINS", False):
+    CORS_ORIGIN_ALLOW_ALL = False
+    CORS_ALLOWED_ORIGINS = get_list(os.getenv("CORS_ALLOWED_ORIGINS", ""))
+else:
+    CORS_ORIGIN_ALLOW_ALL = True
 
 BLOCKED_GEOIP_REGIONS = get_list(os.getenv("BLOCKED_GEOIP_REGIONS", ""))

--- a/posthog/utils_cors.py
+++ b/posthog/utils_cors.py
@@ -34,6 +34,10 @@ KNOWN_ORIGINS = {
 
 
 def cors_response(request: HttpRequest, response: HttpResponse) -> HttpResponse:
+    """
+    Returns a HttpResponse with CORS headers set to allow all origins.
+    Only use this for endpoints that get called by the PostHog JS SDK.
+    """
     if not request.META.get("HTTP_ORIGIN"):
         return response
     url = urlparse(request.META["HTTP_ORIGIN"])


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We were always allowing any origin to hit any endpoint. Instead, set an env variable that sets specific origins to allow. This is bypassed by the `cors_response` function for all the /decide, /api/surveys, /capture etc endpoints

This PR is essentially a no-op but it'll be active once we roll out the env variables

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
