### PR TITLE
chore: skip old migration tests

### DIFF
--- a/posthog/test/test_migration_0273.py
+++ b/posthog/test/test_migration_0273.py
@@ -13,6 +13,10 @@ from posthog.models.organization import Organization
 from posthog.models.plugin import Plugin, PluginConfig, PluginStorage
 from posthog.models.team.team import Team
 
+import pytest
+
+pytestmark = pytest.mark.skip("old migrations slow overall test run down")
+
 
 @freeze_time("2021-08-25T13:00:00Z")
 class MarkInactiveExportsAsFinished(TestCase):

--- a/posthog/test/test_migration_0287.py
+++ b/posthog/test/test_migration_0287.py
@@ -1,5 +1,9 @@
 from posthog.test.base import NonAtomicTestMigrations
 
+import pytest
+
+pytestmark = pytest.mark.skip("old migrations slow overall test run down")
+
 
 class CreatingSessionRecordingModelMigrationTestCase(NonAtomicTestMigrations):
     migrate_from = "0286_index_insightcachingstate_lookup"

--- a/posthog/test/test_migration_0385.py
+++ b/posthog/test/test_migration_0385.py
@@ -1,5 +1,9 @@
 from posthog.test.base import NonAtomicTestMigrations
 
+import pytest
+
+pytestmark = pytest.mark.skip("old migrations slow overall test run down")
+
 
 class FixingExceptionAutocaptureMigration(NonAtomicTestMigrations):
     migrate_from = "0384_activity_log_was_impersonated"

--- a/posthog/test/test_migration_0421.py
+++ b/posthog/test/test_migration_0421.py
@@ -2,6 +2,10 @@ from typing import Any
 
 from posthog.test.base import NonAtomicTestMigrations
 
+import pytest
+
+pytestmark = pytest.mark.skip("old migrations slow overall test run down")
+
 
 class UpdateSurveyResponseMigrationTest(NonAtomicTestMigrations):
     migrate_from = "0420_alert"

--- a/posthog/test/test_migration_0459.py
+++ b/posthog/test/test_migration_0459.py
@@ -2,6 +2,10 @@ from typing import Any
 
 from posthog.test.base import NonAtomicTestMigrations
 
+import pytest
+
+pytestmark = pytest.mark.skip("old migrations slow overall test run down")
+
 
 class ConvertPersonsNodeInsightsToActorsQueryMigrationTest(NonAtomicTestMigrations):
     migrate_from = "0458_alter_insightviewed_team_alter_insightviewed_user"

--- a/posthog/test/test_migration_0766.py
+++ b/posthog/test/test_migration_0766.py
@@ -3,6 +3,10 @@ import uuid
 
 from posthog.test.base import NonAtomicTestMigrations
 
+import pytest
+
+pytestmark = pytest.mark.skip("old migrations slow overall test run down")
+
 
 class FixSubTemplateIdsToTemplateIdsMigrationTest(NonAtomicTestMigrations):
     migrate_from = "0765_hogflows"


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We don't need to run these, and they are some of the worst offendors on time.

## Changes

Skip them
