### PR TITLE
chore: Rename cors_response to cors_response_allow_all

### DIFF
--- a/posthog/api/csp.py
+++ b/posthog/api/csp.py
@@ -8,7 +8,7 @@ from rest_framework import status
 
 from posthog.exceptions import generate_exception_response
 from posthog.sampling import sample_on_property
-from posthog.utils_cors import cors_response
+from posthog.utils_cors import cors_response_allow_all
 from posthog.models.utils import uuid7
 
 from django.utils.html import escape
@@ -180,7 +180,7 @@ def process_csp_report(request):
                     document_url=properties.get("document_url"),
                     sample_rate=sample_rate,
                 )
-                return None, cors_response(request, HttpResponse(status=status.HTTP_204_NO_CONTENT))
+                return None, cors_response_allow_all(request, HttpResponse(status=status.HTTP_204_NO_CONTENT))
 
             return (
                 build_csp_event(
@@ -209,7 +209,7 @@ def process_csp_report(request):
                     total_violations=len(violations_props),
                     sample_rate=sample_rate,
                 )
-                return None, cors_response(request, HttpResponse(status=status.HTTP_204_NO_CONTENT))
+                return None, cors_response_allow_all(request, HttpResponse(status=status.HTTP_204_NO_CONTENT))
 
             return [
                 build_csp_event(prop, distinct_id, session_id, version, user_agent) for prop in sampled_violations
@@ -220,13 +220,13 @@ def process_csp_report(request):
 
     except json.JSONDecodeError as e:
         logger.exception("Invalid CSP report JSON format", error=e)
-        return None, cors_response(
+        return None, cors_response_allow_all(
             request,
             generate_exception_response("capture", "Invalid CSP report format", code="invalid_csp_payload"),
         )
     except ValueError as e:
         logger.exception("Invalid CSP report properties", error=e)
-        return None, cors_response(
+        return None, cors_response_allow_all(
             request,
             generate_exception_response(
                 "capture", "Invalid CSP report properties provided", code="invalid_csp_payload"

--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -47,7 +47,7 @@ from posthog.models.feature_flag import FeatureFlag
 from posthog.models.surveys.survey import Survey, MAX_ITERATION_COUNT
 from posthog.models.team.team import Team
 from posthog.models.user import User
-from posthog.utils_cors import cors_response
+from posthog.utils_cors import cors_response_allow_all
 from posthog.models.surveys.util import (
     SurveyFeatureFlags,
     get_unique_survey_event_uuids_sql_subquery,
@@ -1359,10 +1359,10 @@ def get_surveys_response(team: Team):
 def surveys(request: Request):
     token = get_token(None, request)
     if request.method == "OPTIONS":
-        return cors_response(request, HttpResponse(""))
+        return cors_response_allow_all(request, HttpResponse(""))
 
     if not token:
-        return cors_response(
+        return cors_response_allow_all(
             request,
             generate_exception_response(
                 "surveys",
@@ -1375,7 +1375,7 @@ def surveys(request: Request):
 
     team = Team.objects.get_team_from_cache_or_token(token)
     if team is None:
-        return cors_response(
+        return cors_response_allow_all(
             request,
             generate_exception_response(
                 "surveys",
@@ -1386,7 +1386,7 @@ def surveys(request: Request):
             ),
         )
 
-    return cors_response(request, JsonResponse(get_surveys_response(team)))
+    return cors_response_allow_all(request, JsonResponse(get_surveys_response(team)))
 
 
 @contextmanager

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -35,7 +35,7 @@ from posthog.models.filters.filter import Filter
 from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.schema import QueryTiming
 from posthog.utils import load_data_from_request
-from posthog.utils_cors import cors_response
+from posthog.utils_cors import cors_response_allow_all
 from posthoganalytics import capture_exception
 
 logger = structlog.get_logger(__name__)
@@ -207,7 +207,7 @@ def get_data(request):
         logger.exception(f"Invalid payload", error=error)
         return (
             None,
-            cors_response(
+            cors_response_allow_all(
                 request,
                 generate_exception_response(
                     "capture",
@@ -220,7 +220,7 @@ def get_data(request):
     except RequestDataTooBig:
         return (
             None,
-            cors_response(
+            cors_response_allow_all(
                 request,
                 generate_exception_response(
                     endpoint="capture",
@@ -235,7 +235,7 @@ def get_data(request):
     if not data:
         return (
             None,
-            cors_response(
+            cors_response_allow_all(
                 request,
                 generate_exception_response(
                     "capture",

--- a/posthog/api/web_experiment.py
+++ b/posthog/api/web_experiment.py
@@ -17,7 +17,7 @@ from posthog.auth import (
 )
 from posthog.exceptions import generate_exception_response
 from posthog.models import Team, WebExperiment
-from posthog.utils_cors import cors_response
+from posthog.utils_cors import cors_response_allow_all
 
 
 class WebExperimentsAPISerializer(serializers.ModelSerializer):
@@ -162,9 +162,9 @@ class WebExperimentViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 def web_experiments(request: Request):
     token = get_token(None, request)
     if request.method == "OPTIONS":
-        return cors_response(request, HttpResponse(""))
+        return cors_response_allow_all(request, HttpResponse(""))
     if not token:
-        return cors_response(
+        return cors_response_allow_all(
             request,
             generate_exception_response(
                 "experiments",
@@ -178,7 +178,7 @@ def web_experiments(request: Request):
     if request.method == "GET":
         team = Team.objects.get_team_from_cache_or_token(token)
         if team is None:
-            return cors_response(
+            return cors_response_allow_all(
                 request,
                 generate_exception_response(
                     "experiments",
@@ -199,4 +199,4 @@ def web_experiments(request: Request):
             many=True,
         ).data
 
-        return cors_response(request, JsonResponse({"experiments": result}))
+        return cors_response_allow_all(request, JsonResponse({"experiments": result}))

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -40,7 +40,7 @@ from posthog.rate_limit import DecideRateThrottle
 from posthog.settings import SITE_URL, PROJECT_SWITCHING_TOKEN_ALLOWLIST
 from posthog.user_permissions import UserPermissions
 from .auth import PersonalAPIKeyAuthentication
-from .utils_cors import cors_response
+from .utils_cors import cors_response_allow_all
 
 ALWAYS_ALLOWED_ENDPOINTS = [
     "decide",
@@ -404,7 +404,7 @@ class ShortCircuitMiddleware:
                 if self.decide_throttler.allow_request(request, None):
                     return get_decide(request)
                 else:
-                    return cors_response(
+                    return cors_response_allow_all(
                         request,
                         generate_exception_response(
                             "decide",

--- a/posthog/test/test_utils_cors.py
+++ b/posthog/test/test_utils_cors.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from django.http import HttpResponse, HttpRequest
 
-from posthog.utils_cors import cors_response
+from posthog.utils_cors import cors_response_allow_all
 
 
 class FakeRequest(HttpRequest):
@@ -29,6 +29,6 @@ class TestCorsResponse(TestCase):
                 request = FakeRequest(META={"HTTP_ORIGIN": origin})
                 self.assertEqual(
                     expected,
-                    cors_response(request, HttpResponse()).get("Access-Control-Allow-Origin"),
+                    cors_response_allow_all(request, HttpResponse()).get("Access-Control-Allow-Origin"),
                     msg=f"with origin='{origin}', actual did not equal {expected}",
                 )

--- a/posthog/utils_cors.py
+++ b/posthog/utils_cors.py
@@ -33,7 +33,7 @@ KNOWN_ORIGINS = {
 }
 
 
-def cors_response(request: HttpRequest, response: HttpResponse) -> HttpResponse:
+def cors_response_allow_all(request: HttpRequest, response: HttpResponse) -> HttpResponse:
     """
     Returns a HttpResponse with CORS headers set to allow all origins.
     Only use this for endpoints that get called by the PostHog JS SDK.

--- a/products/early_access_features/backend/api.py
+++ b/products/early_access_features/backend/api.py
@@ -19,7 +19,7 @@ from posthog.models.team.team import Team
 from django.utils.text import slugify
 from django.views.decorators.csrf import csrf_exempt
 
-from posthog.utils_cors import cors_response
+from posthog.utils_cors import cors_response_allow_all
 from typing import Any
 from posthog.cdp.internal_events import InternalEventEvent, InternalEventPerson, produce_internal_event
 from posthog.api.shared import UserBasicSerializer
@@ -286,7 +286,7 @@ def early_access_features(request: Request):
     stages = request.GET.getlist("stage", [EarlyAccessFeature.Stage.BETA])
 
     if not token:
-        return cors_response(
+        return cors_response_allow_all(
             request,
             generate_exception_response(
                 "early_access_features",
@@ -299,7 +299,7 @@ def early_access_features(request: Request):
 
     team = Team.objects.get_team_from_cache_or_token(token)
     if team is None:
-        return cors_response(
+        return cors_response_allow_all(
             request,
             generate_exception_response(
                 "decide",
@@ -317,4 +317,4 @@ def early_access_features(request: Request):
         many=True,
     ).data
 
-    return cors_response(request, JsonResponse({"earlyAccessFeatures": early_access_features}))
+    return cors_response_allow_all(request, JsonResponse({"earlyAccessFeatures": early_access_features}))


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

When looking at the [cors issue](https://github.com/PostHog/posthog/pull/34215) I got quite confused about what cors_response was for. This makes it more obvious

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
