### PR TITLE
[SUPPORT SUPERDAY] Add report a bug button to support panel

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
@@ -1,8 +1,8 @@
-import { IconFeatures, IconHelmet, IconMap } from '@posthog/icons'
+import { IconBug, IconFeatures, IconHelmet, IconMap } from '@posthog/icons'
 import { LemonButton, Link } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { SupportForm } from 'lib/components/Support/SupportForm'
-import { supportLogic } from 'lib/components/Support/supportLogic'
+import { getPublicSupportSnippet, supportLogic } from 'lib/components/Support/supportLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -16,6 +16,8 @@ import { AvailableFeature, BillingFeatureType, BillingType, ProductKey, SidePane
 
 import { SidePanelPaneHeader } from '../components/SidePanelPaneHeader'
 import { sidePanelLogic } from '../sidePanelLogic'
+import { teamLogic } from 'scenes/teamLogic'
+import { organizationLogic } from 'scenes/organizationLogic'
 
 const Section = ({ title, children }: { title: string; children: React.ReactNode }): React.ReactElement => {
     return (
@@ -180,6 +182,17 @@ export function SidePanelSupport(): JSX.Element {
     const { closeEmailForm, openEmailForm, closeSupportForm, resetSendSupportRequest } = useActions(supportLogic)
     const { billing, billingLoading } = useValues(billingLogic)
     const { openSidePanel } = useActions(sidePanelLogic)
+
+    const isCloud = preflight?.cloud
+    const region = preflight?.region
+    const { currentTeam } = useValues(teamLogic)
+    const { currentOrganization } = useValues(organizationLogic)
+
+    const bugReportURL =
+        'https://github.com/PostHog/posthog/issues/new?template=bug_report.yml' +
+        (isCloud
+            ? `&debug-info=${encodeURIComponent(getPublicSupportSnippet(region, currentOrganization, currentTeam))}`
+            : '')
 
     const canEmail =
         billing?.subscription_level === 'paid' ||
@@ -389,6 +402,17 @@ export function SidePanelSupport(): JSX.Element {
                                             targetBlank
                                         >
                                             Request a feature
+                                        </LemonButton>
+                                    </li>
+                                    <li>
+                                        <LemonButton
+                                            type="secondary"
+                                            status="alt"
+                                            to={bugReportURL}
+                                            icon={<IconBug />}
+                                            targetBlank
+                                        >
+                                            Report a bug
                                         </LemonButton>
                                     </li>
                                 </ul>


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

We'd like users to be able to self service reporting a bug in PostHog. To do this we'll add a "Report A Bug" link in the Share Feedback section of the Help menu in the Sidebar.

Tagging @abigailbramble 

## Changes

<img width="512" alt="Screenshot 2025-06-26 at 11 54 24 AM" src="https://github.com/user-attachments/assets/0c61b654-3f89-4bab-9b33-cad0265a888e" />

## Did you write or update any docs for this change?

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

Tests were all performed in local dev environment. 

#### Non-cloud 

For the non-cloud version of PostHog this change should only send the user to the Bug Report template in GitHub. Which it does. This is based on whether `isCloud` returns true or false.

#### Cloud

For cloud versions of PostHog this change should send users to the Bug Report template in GitHub with the debug-info field filled with the support snippet details. It does this based on whether `isCloud` returns true or false. To test this I set `isCloud` to true (in local dev environment) and commented out the early return in getPublicSupportSnippet, instead sending it a `US` region. The links will be invalid from a local dev environment but the structure of the URL appears accurate, without being able to actually test that as an external member.