### PR TITLE
fix: Only use curly braces on array ends

### DIFF
--- a/posthog/temporal/batch_exports/temporary_file.py
+++ b/posthog/temporal/batch_exports/temporary_file.py
@@ -697,10 +697,14 @@ class CSVBatchExportWriter(BatchExportWriter):
         """
         rows = []
         for record in record_batch.to_pylist():
-            rows.append(
-                {k: str(v).replace("[", "{").replace("]", "}") if isinstance(v, list) else v for k, v in record.items()}
-            )
+            rows.append({k: ensure_curly_brackets_array(v) if isinstance(v, list) else v for k, v in record.items()})
         self.csv_writer.writerows(rows)
+
+
+def ensure_curly_brackets_array(v: list[typing.Any]) -> str:
+    """Convert list to str and replace ends with curly braces."""
+    str_list = str(v)
+    return f"{{{str(v)[1:len(str_list)-1]}}}"
 
 
 class ParquetBatchExportWriter(BatchExportWriter):

--- a/posthog/temporal/batch_exports/temporary_file.py
+++ b/posthog/temporal/batch_exports/temporary_file.py
@@ -703,6 +703,7 @@ class CSVBatchExportWriter(BatchExportWriter):
 
 def ensure_curly_brackets_array(v: list[typing.Any]) -> str:
     """Convert list to str and replace ends with curly braces."""
+    # NOTE: This doesn't support nested arrays (i.e. multi-dimensional arrays).
     str_list = str(v)
     return f"{{{str_list[1:len(str_list)-1]}}}"
 

--- a/posthog/temporal/batch_exports/temporary_file.py
+++ b/posthog/temporal/batch_exports/temporary_file.py
@@ -704,7 +704,7 @@ class CSVBatchExportWriter(BatchExportWriter):
 def ensure_curly_brackets_array(v: list[typing.Any]) -> str:
     """Convert list to str and replace ends with curly braces."""
     str_list = str(v)
-    return f"{{{str(v)[1:len(str_list)-1]}}}"
+    return f"{{{str_list[1:len(str_list)-1]}}}"
 
 
 class ParquetBatchExportWriter(BatchExportWriter):


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

PostgreSQL arrays are enclosed in `{}`. We were naively replacing all `[]` with `{}`, which leads to issues if the lists have any strings with `[]` in them.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Only replace the ends of the list with `{}`, not anything inside. This likely doesn't work with nested lists, but I don't think we have any right now.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
