### PR TITLE
fix(capture): add sampled logging for base64 bug candidate detection

### DIFF
--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -92,6 +92,10 @@ pub struct Config {
 
     #[envconfig(default = "info")]
     pub log_level: Level,
+
+    // temporary: gates some chatty debug logging
+    #[envconfig(default = "0.0")]
+    pub base64_detect_percent: f32,
 }
 
 #[derive(Envconfig, Clone)]

--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -36,6 +36,7 @@ pub struct State {
     pub event_size_limit: usize,
     pub historical_cfg: HistoricalConfig,
     pub is_mirror_deploy: bool,
+    pub base64_detect_percent: f32,
 }
 
 #[derive(Clone)]
@@ -110,6 +111,7 @@ pub fn router<
     historical_rerouting_threshold_days: i64,
     historical_tokens_keys: Option<String>,
     is_mirror_deploy: bool,
+    base64_detect_percent: f32,
 ) -> Router {
     let state = State {
         sink: Arc::new(sink),
@@ -124,6 +126,7 @@ pub fn router<
             historical_tokens_keys,
         ),
         is_mirror_deploy,
+        base64_detect_percent,
     };
 
     // Very permissive CORS policy, as old SDK versions

--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -184,6 +184,7 @@ where
         config.historical_rerouting_threshold_days,
         config.historical_tokens_keys,
         config.is_mirror_deploy,
+        config.base64_detect_percent,
     );
 
     // run our app with hyper

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -12,9 +13,11 @@ use chrono::{DateTime, Duration, Utc};
 use common_types::{CapturedEvent, RawEvent};
 use limiters::token_dropper::TokenDropper;
 use metrics::counter;
+use rand::Rng;
+use rand::{rngs::ThreadRng, thread_rng};
 use serde_json::json;
 use serde_json::Value;
-use tracing::{debug, error, instrument, warn, Span};
+use tracing::{debug, error, info, instrument, warn, Span};
 
 use crate::prometheus::{report_dropped_events, report_internal_error_metrics};
 use crate::v0_request::{
@@ -30,6 +33,11 @@ use crate::{
     },
     v0_request::{EventFormData, EventQuery},
 };
+
+// TEMPORARY: used to trigger sampling of chatty log line
+thread_local! {
+    static RNG: RefCell<ThreadRng> = RefCell::new(thread_rng());
+}
 
 /// handle_legacy owns the /e, /capture, /track, and /engage capture endpoints
 #[instrument(
@@ -209,6 +217,13 @@ async fn handle_legacy(
         }
     };
     Span::current().record("token", &token);
+
+    // TEMPORARY: conditionally sample targeted event submissions
+    let roll = RNG.with(|rng| rng.borrow_mut().gen_range(0.0..100.0));
+    if compression == Compression::Base64 && roll < state.base64_detect_percent {
+        // API token, req path etc. should be logged here by tracing lib
+        info!("handle_legacy: candidate team for base64 issue")
+    }
 
     counter!("capture_events_received_total", &[("legacy", "true")]).increment(events.len() as u64);
 

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -219,7 +219,7 @@ async fn handle_legacy(
     Span::current().record("token", &token);
 
     // TEMPORARY: conditionally sample targeted event submissions
-    let roll = RNG.with(|rng| rng.borrow_mut().gen_range(0.0..100.0));
+    let roll = RNG.with_borrow_mut(|rng| rng.gen_range(0.0..100.0));
     if compression == Compression::Base64 && roll < state.base64_detect_percent {
         // API token, req path etc. should be logged here by tracing lib
         info!("handle_legacy: candidate team for base64 issue")

--- a/rust/capture/tests/common.rs
+++ b/rust/capture/tests/common.rs
@@ -45,6 +45,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     historical_tokens_keys: None,
     is_mirror_deploy: false,
     log_level: Level::INFO,
+    base64_detect_percent: 0.0_f32,
     kafka: KafkaConfig {
         kafka_producer_linger_ms: 0, // Send messages as soon as possible
         kafka_producer_queue_mib: 10,

--- a/rust/capture/tests/django_compat.rs
+++ b/rust/capture/tests/django_compat.rs
@@ -124,6 +124,7 @@ async fn it_matches_django_capture_behaviour() -> anyhow::Result<()> {
         let historical_rerouting_threshold_days = 1_i64;
         let historical_tokens_keys = None;
         let is_mirror_deploy = false; // TODO: remove after migration to 100% capture-rs backend
+        let base64_detect_percent = 0.0_f32;
 
         let app = router(
             timesource,
@@ -140,6 +141,7 @@ async fn it_matches_django_capture_behaviour() -> anyhow::Result<()> {
             historical_rerouting_threshold_days,
             historical_tokens_keys,
             is_mirror_deploy,
+            base64_detect_percent,
         );
 
         let client = TestClient::new(app);


### PR DESCRIPTION
## Problem
We need to collect tokens mapping to teams effected by a `capture-rs` [bug remediated last week](https://github.com/PostHog/posthog/pull/33992). In order to do so, we must log tokens of interest in a very hot codepath.

## Changes
* Add sampling mechanism to `capture-rs` usable from the target codepath
* Add a sampled log to the target codepath to identify tokens of interest

_Note: because the default for the sampling threshold is `0.0` this PR will land as a no-op_

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Locally and in CI