### PR TITLE
chore(cohorts): increase stuck cohort reset rate

### DIFF
--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -57,7 +57,7 @@ logger = structlog.get_logger(__name__)
 
 MAX_AGE_MINUTES = 15
 MAX_ERRORS_CALCULATING = 20
-MAX_STUCK_COHORTS_TO_RESET = 2
+MAX_STUCK_COHORTS_TO_RESET = 3
 
 
 def get_cohort_calculation_candidates_queryset() -> QuerySet:

--- a/posthog/tasks/test/test_calculate_cohort.py
+++ b/posthog/tasks/test/test_calculate_cohort.py
@@ -285,7 +285,7 @@ def calculate_cohort_test_factory(event_factory: Callable, person_factory: Calla
             not_stuck_cohort = Cohort.objects.create(
                 team_id=self.team.pk,
                 name="not_stuck_cohort",
-                last_calculation=now - relativedelta(hours=1),  # Recent calculation
+                last_calculation=now - relativedelta(minutes=10),  # Recent calculation
                 deleted=False,
                 is_calculating=True,
                 errors_calculating=0,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Resets are working and clickhouse isn't on fire so increasing because I'm inpatient. 

<img width="849" alt="Screenshot 2025-06-26 at 11 26 17 AM" src="https://github.com/user-attachments/assets/5a266989-34bd-4c71-bbc1-838130800ad6" />


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
