### PR TITLE
fix(flags): add missing environment config variables

### DIFF
--- a/rust/common/limiters/src/redis.rs
+++ b/rust/common/limiters/src/redis.rs
@@ -61,6 +61,7 @@ impl QuotaResource {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Display)]
 pub enum ServiceName {
+    SessionReplay,
     FeatureFlags,
     Capture,
     Cymbal,
@@ -69,6 +70,7 @@ pub enum ServiceName {
 impl ServiceName {
     pub fn as_string(&self) -> String {
         match self {
+            ServiceName::SessionReplay => "session_replay".to_string(),
             ServiceName::FeatureFlags => "feature_flags".to_string(),
             ServiceName::Capture => "capture".to_string(),
             ServiceName::Cymbal => "cymbal".to_string(),

--- a/rust/feature-flags/src/billing_limiters.rs
+++ b/rust/feature-flags/src/billing_limiters.rs
@@ -6,14 +6,6 @@ use std::time::Duration;
 ///
 /// This type wrapper ensures you can't accidentally create a feature flags limiter
 /// with the wrong quota resource type. It always uses QuotaResource::FeatureFlags.
-///
-/// # Example
-/// ```
-/// // This is the only way to create a feature flags limiter:
-/// let limiter = FeatureFlagsLimiter::new(ttl, redis_client, cache_key, None)?;
-///
-/// // You can't accidentally use the wrong quota resource because it's hardcoded
-/// ```
 #[derive(Clone)]
 pub struct FeatureFlagsLimiter {
     inner: RedisLimiter,
@@ -46,14 +38,6 @@ impl FeatureFlagsLimiter {
 ///
 /// This type wrapper ensures you can't accidentally create a session replay limiter
 /// with the wrong quota resource type. It always uses QuotaResource::Recordings.
-///
-/// # Example
-/// ```
-/// // This is the only way to create a session replay limiter:
-/// let limiter = SessionReplayLimiter::new(ttl, redis_client, cache_key, None)?;
-///
-/// // You can't accidentally use QuotaResource::FeatureFlags because it's hardcoded
-/// ```
 #[derive(Clone)]
 pub struct SessionReplayLimiter {
     inner: RedisLimiter,

--- a/rust/feature-flags/src/billing_limiters.rs
+++ b/rust/feature-flags/src/billing_limiters.rs
@@ -1,0 +1,83 @@
+use limiters::redis::{QuotaResource, RedisLimiter, ServiceName};
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Feature flags specific billing limiter that always uses QuotaResource::FeatureFlags
+///
+/// This type wrapper ensures you can't accidentally create a feature flags limiter
+/// with the wrong quota resource type. It always uses QuotaResource::FeatureFlags.
+///
+/// # Example
+/// ```rust
+/// // This is the only way to create a feature flags limiter:
+/// let limiter = FeatureFlagsLimiter::new(ttl, redis_client, cache_key, None)?;
+///
+/// // You can't accidentally use the wrong quota resource because it's hardcoded
+/// ```
+#[derive(Clone)]
+pub struct FeatureFlagsLimiter {
+    inner: RedisLimiter,
+}
+
+impl FeatureFlagsLimiter {
+    pub fn new(
+        ttl: Duration,
+        redis_client: Arc<dyn common_redis::Client + Send + Sync>,
+        cache_key: String,
+        cache_prefix: Option<String>,
+    ) -> Result<Self, anyhow::Error> {
+        let inner = RedisLimiter::new(
+            ttl,
+            redis_client,
+            cache_key,
+            cache_prefix,
+            QuotaResource::FeatureFlags,
+            ServiceName::FeatureFlags,
+        )?;
+        Ok(Self { inner })
+    }
+
+    pub async fn is_limited(&self, token: &str) -> bool {
+        self.inner.is_limited(token).await
+    }
+}
+
+/// Session replay specific billing limiter that always uses QuotaResource::Recordings
+///
+/// This type wrapper ensures you can't accidentally create a session replay limiter
+/// with the wrong quota resource type. It always uses QuotaResource::Recordings.
+///
+/// # Example
+/// ```rust
+/// // This is the only way to create a session replay limiter:
+/// let limiter = SessionReplayLimiter::new(ttl, redis_client, cache_key, None)?;
+///
+/// // You can't accidentally use QuotaResource::FeatureFlags because it's hardcoded
+/// ```
+#[derive(Clone)]
+pub struct SessionReplayLimiter {
+    inner: RedisLimiter,
+}
+
+impl SessionReplayLimiter {
+    pub fn new(
+        ttl: Duration,
+        redis_client: Arc<dyn common_redis::Client + Send + Sync>,
+        cache_key: String,
+        cache_prefix: Option<String>,
+    ) -> Result<Self, anyhow::Error> {
+        let inner = RedisLimiter::new(
+            ttl,
+            redis_client,
+            cache_key,
+            cache_prefix,
+            QuotaResource::Recordings,
+            ServiceName::FeatureFlags,
+        )?;
+        Ok(Self { inner })
+    }
+
+    pub async fn is_limited(&self, token: &str) -> bool {
+        self.inner.is_limited(token).await
+    }
+}

--- a/rust/feature-flags/src/billing_limiters.rs
+++ b/rust/feature-flags/src/billing_limiters.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 /// with the wrong quota resource type. It always uses QuotaResource::FeatureFlags.
 ///
 /// # Example
-/// ```rust
+/// ```
 /// // This is the only way to create a feature flags limiter:
 /// let limiter = FeatureFlagsLimiter::new(ttl, redis_client, cache_key, None)?;
 ///
@@ -48,7 +48,7 @@ impl FeatureFlagsLimiter {
 /// with the wrong quota resource type. It always uses QuotaResource::Recordings.
 ///
 /// # Example
-/// ```rust
+/// ```
 /// // This is the only way to create a session replay limiter:
 /// let limiter = SessionReplayLimiter::new(ttl, redis_client, cache_key, None)?;
 ///

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -158,7 +158,7 @@ pub struct Config {
     #[envconfig(from = "COOKIELESS_SALT_TTL_SECONDS", default = "86400")]
     pub cookieless_salt_ttl_seconds: u64,
 
-    #[envconfig(from = "NEW_ANALYTICS_CAPTURE_ENDPOINT", default = "")]
+    #[envconfig(from = "NEW_ANALYTICS_CAPTURE_ENDPOINT", default = "/i/v0/e/")]
     pub new_analytics_capture_endpoint: String,
 
     #[envconfig(from = "NEW_ANALYTICS_CAPTURE_EXCLUDED_TEAM_IDS", default = "none")]
@@ -199,7 +199,7 @@ impl Config {
             cookieless_force_stateless: false,
             cookieless_identifies_ttl_seconds: 7200,
             cookieless_salt_ttl_seconds: 86400,
-            new_analytics_capture_endpoint: "".to_string(),
+            new_analytics_capture_endpoint: "/i/v0/e/".to_string(),
             new_analytics_capture_excluded_team_ids: TeamIdCollection::None,
             element_chain_as_string_excluded_teams: TeamIdCollection::None,
             debug: FlexBool(false),
@@ -290,6 +290,8 @@ mod tests {
             config.element_chain_as_string_excluded_teams,
             TeamIdCollection::None
         );
+        assert_eq!(config.new_analytics_capture_endpoint, "/i/v0/e/");
+        assert_eq!(config.debug, FlexBool(false));
     }
 
     #[test]

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -175,6 +175,9 @@ pub struct Config {
 
     #[envconfig(from = "SESSION_REPLAY_RRWEB_SCRIPT_ALLOWED_TEAMS", default = "none")]
     pub session_replay_rrweb_script_allowed_teams: TeamIdCollection,
+
+    #[envconfig(from = "DECIDE_SESSION_REPLAY_QUOTA_CHECK", default = "false")]
+    pub decide_session_replay_quota_check: bool,
 }
 
 impl Config {
@@ -205,6 +208,7 @@ impl Config {
             debug: FlexBool(false),
             session_replay_rrweb_script: "".to_string(),
             session_replay_rrweb_script_allowed_teams: TeamIdCollection::None,
+            decide_session_replay_quota_check: false,
         }
     }
 
@@ -292,6 +296,7 @@ mod tests {
         );
         assert_eq!(config.new_analytics_capture_endpoint, "/i/v0/e/");
         assert_eq!(config.debug, FlexBool(false));
+        assert_eq!(config.decide_session_replay_quota_check, false);
     }
 
     #[test]

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -176,8 +176,8 @@ pub struct Config {
     #[envconfig(from = "SESSION_REPLAY_RRWEB_SCRIPT_ALLOWED_TEAMS", default = "none")]
     pub session_replay_rrweb_script_allowed_teams: TeamIdCollection,
 
-    #[envconfig(from = "DECIDE_SESSION_REPLAY_QUOTA_CHECK", default = "false")]
-    pub decide_session_replay_quota_check: bool,
+    #[envconfig(from = "FLAGS_SESSION_REPLAY_QUOTA_CHECK", default = "false")]
+    pub flags_session_replay_quota_check: bool,
 }
 
 impl Config {
@@ -208,7 +208,7 @@ impl Config {
             debug: FlexBool(false),
             session_replay_rrweb_script: "".to_string(),
             session_replay_rrweb_script_allowed_teams: TeamIdCollection::None,
-            decide_session_replay_quota_check: false,
+            flags_session_replay_quota_check: false,
         }
     }
 
@@ -296,7 +296,7 @@ mod tests {
         );
         assert_eq!(config.new_analytics_capture_endpoint, "/i/v0/e/");
         assert_eq!(config.debug, FlexBool(false));
-        assert_eq!(config.decide_session_replay_quota_check, false);
+        assert_eq!(config.flags_session_replay_quota_check, false);
     }
 
     #[test]

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -296,7 +296,7 @@ mod tests {
         );
         assert_eq!(config.new_analytics_capture_endpoint, "/i/v0/e/");
         assert_eq!(config.debug, FlexBool(false));
-        assert_eq!(config.flags_session_replay_quota_check, false);
+        assert!(!config.flags_session_replay_quota_check);
     }
 
     #[test]

--- a/rust/feature-flags/src/handler/billing.rs
+++ b/rust/feature-flags/src/handler/billing.rs
@@ -21,7 +21,7 @@ pub async fn check_limits(
 ) -> Result<Option<FlagsResponse>, FlagError> {
     let billing_limited = context
         .state
-        .billing_limiter
+        .feature_flags_billing_limiter
         .is_limited(verified_token)
         .await;
 

--- a/rust/feature-flags/src/handler/config_response_builder.rs
+++ b/rust/feature-flags/src/handler/config_response_builder.rs
@@ -73,7 +73,7 @@ async fn apply_config_fields(
     team: &Team,
 ) -> Result<(), FlagError> {
     // Check for recordings quota limits only if enabled
-    let is_recordings_limited = if context.config.decide_session_replay_quota_check {
+    let is_recordings_limited = if context.config.flags_session_replay_quota_check {
         context.billing_limiter.is_limited(&team.api_token).await
     } else {
         false

--- a/rust/feature-flags/src/handler/config_response_builder.rs
+++ b/rust/feature-flags/src/handler/config_response_builder.rs
@@ -1,24 +1,26 @@
 use crate::{
     api::{
         errors::FlagError,
-        types::{AnalyticsConfig, ErrorTrackingConfig, FlagsResponse},
+        types::{AnalyticsConfig, ErrorTrackingConfig, FlagsResponse, SessionRecordingField},
     },
     config::Config,
     site_apps::get_decide_site_apps,
     team::team_models::Team,
 };
 use axum::http::HeaderMap;
+use limiters::redis::QuotaResource;
 use std::{collections::HashMap, sync::Arc};
 
 use super::{error_tracking, session_recording, types::RequestContext};
 
 /// Isolates the specific fields needed to build config responses from a RequestContext.
 /// This allows us to extract only the relevant dependencies (config, database client,
-/// redis client, and headers) rather than carrying around the entire RequestContext.
+/// redis client, billing limiter, and headers) rather than carrying around the entire RequestContext.
 pub struct ConfigContext {
     pub config: Config,
     pub reader: Arc<dyn common_database::Client + Send + Sync>,
     pub redis: Arc<dyn common_redis::Client + Send + Sync>,
+    pub billing_limiter: limiters::redis::RedisLimiter,
     pub headers: HeaderMap,
 }
 
@@ -28,6 +30,7 @@ impl ConfigContext {
             config: context.state.config.clone(),
             reader: context.state.reader.clone(),
             redis: context.state.redis_reader.clone(),
+            billing_limiter: context.state.billing_limiter.clone(),
             headers: context.headers.clone(),
         }
     }
@@ -36,12 +39,14 @@ impl ConfigContext {
         config: Config,
         reader: Arc<dyn common_database::Client + Send + Sync>,
         redis: Arc<dyn common_redis::Client + Send + Sync>,
+        billing_limiter: limiters::redis::RedisLimiter,
         headers: HeaderMap,
     ) -> Self {
         Self {
             config,
             reader,
             redis,
+            billing_limiter,
             headers,
         }
     }
@@ -67,16 +72,38 @@ async fn apply_config_fields(
     context: &ConfigContext,
     team: &Team,
 ) -> Result<(), FlagError> {
+    // Check for recordings quota limits only if enabled
+    let is_recordings_limited = if context.config.decide_session_replay_quota_check {
+        context.billing_limiter.is_limited(&team.api_token).await
+    } else {
+        false
+    };
+
+    if is_recordings_limited {
+        // Add recordings to quota_limited array, preserving any existing limitations
+        match &mut response.quota_limited {
+            Some(existing) => existing.push(QuotaResource::Recordings.as_str().to_string()),
+            None => {
+                response.quota_limited = Some(vec![QuotaResource::Recordings.as_str().to_string()])
+            }
+        }
+    }
+
     // Apply all the core config fields that don't require async operations
     apply_core_config_fields(response, &context.config, team);
 
     // Handle fields that require request context (headers, config, etc)
     // I test this config field in isolation in session_recording.rs, and have integration tests for it in tests/test_flags.rs
-    response.config.session_recording = session_recording::session_recording_config_response(
-        team,
-        &context.headers,
-        &context.config,
-    );
+    response.config.session_recording = if is_recordings_limited {
+        // Disable session recording when quota limited
+        Some(SessionRecordingField::Disabled(false))
+    } else {
+        session_recording::session_recording_config_response(
+            team,
+            &context.headers,
+            &context.config,
+        )
+    };
 
     // Handle fields that require database access
     // I test this config field in isolation in site_apps/mod.rs and have integration tests for it in tests/test_flags.rs

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -18,6 +18,7 @@ use crate::{
     flags::flag_service::FlagService,
     metrics::consts::FLAG_REQUESTS_COUNTER,
 };
+use limiters::redis::ServiceName;
 use tracing::{info, warn};
 
 /// Primary entry point for feature flag requests.
@@ -39,18 +40,12 @@ pub async fn process_request(context: RequestContext) -> Result<FlagsResponse, F
         let (original_distinct_id, verified_token, request) =
             authentication::parse_and_authenticate(&context, &flag_service).await?;
 
+        let distinct_id_for_logging = original_distinct_id.clone();
+
         tracing::debug!(
             "Authentication completed for distinct_id: {}",
             original_distinct_id
         );
-
-        // Check quota limits early
-        if let Some(quota_limited_response) =
-            billing::check_limits(&context, &verified_token).await?
-        {
-            warn!("Request quota limited");
-            return Ok(quota_limited_response);
-        }
 
         let team = flag_service
             .get_team_from_cache_or_pg(&verified_token)
@@ -62,42 +57,59 @@ pub async fn process_request(context: RequestContext) -> Result<FlagsResponse, F
             team.project_id
         );
 
-        let distinct_id =
-            cookieless::handle_distinct_id(&context, &request, &team, original_distinct_id).await?;
+        // Check quota limits - don't return early, just use quota limited response if needed
+        let flags_response = if let Some(quota_limited_response) =
+            billing::check_limits(&context, &verified_token).await?
+        {
+            warn!("Request quota limited");
+            quota_limited_response
+        } else {
+            let distinct_id =
+                cookieless::handle_distinct_id(&context, &request, &team, original_distinct_id)
+                    .await?;
 
-        tracing::debug!("Distinct ID resolved: {}", distinct_id);
+            tracing::debug!("Distinct ID resolved: {}", distinct_id);
 
-        let filtered_flags =
-            flags::fetch_and_filter(&flag_service, team.project_id, &request, &context.meta)
-                .await?;
+            let filtered_flags =
+                flags::fetch_and_filter(&flag_service, team.project_id, &request, &context.meta)
+                    .await?;
 
-        tracing::debug!("Flags filtered: {} flags found", filtered_flags.flags.len());
+            tracing::debug!("Flags filtered: {} flags found", filtered_flags.flags.len());
 
-        let property_overrides = properties::prepare_overrides(&context, &request)?;
+            let property_overrides = properties::prepare_overrides(&context, &request)?;
 
-        // Evaluate flags (this will return empty if is_flags_disabled is true)
-        let flags_response = flags::evaluate_for_request(
-            &context.state,
-            team.id,
-            team.project_id,
-            distinct_id.clone(),
-            filtered_flags.clone(),
-            property_overrides.person_properties,
-            property_overrides.group_properties,
-            property_overrides.groups,
-            property_overrides.hash_key,
-            context.request_id,
-            request.is_flags_disabled(),
-        )
-        .await;
+            // Evaluate flags (this will return empty if is_flags_disabled is true)
+            flags::evaluate_for_request(
+                &context.state,
+                team.id,
+                team.project_id,
+                distinct_id.clone(),
+                filtered_flags.clone(),
+                property_overrides.person_properties,
+                property_overrides.group_properties,
+                property_overrides.groups,
+                property_overrides.hash_key,
+                context.request_id,
+                request.is_flags_disabled(),
+            )
+            .await
+        };
 
         // build the rest of the FlagsResponse, since the caller may have passed in `&config=true` and may need additional fields
         // beyond just feature flags
         let response =
             config_response_builder::build_response(flags_response, &context, &team).await?;
 
-        // Only record billing if flags are not disabled
-        if !request.is_flags_disabled() {
+        // Only record billing if flags are not disabled and not quota limited
+        if !request.is_flags_disabled()
+            && !response.quota_limited.as_ref().map_or(false, |q| {
+                q.contains(&ServiceName::FeatureFlags.as_string())
+            })
+        {
+            // Re-fetch filtered flags for billing if we evaluated them
+            let filtered_flags =
+                flags::fetch_and_filter(&flag_service, team.project_id, &request, &context.meta)
+                    .await?;
             billing::record_usage(&context, &filtered_flags, team.id).await;
         }
         inc(
@@ -117,11 +129,12 @@ pub async fn process_request(context: RequestContext) -> Result<FlagsResponse, F
         // Comprehensive request summary
         info!(
             request_id = %context.request_id,
-            distinct_id = %distinct_id,
+            distinct_id = %distinct_id_for_logging,
             team_id = team.id,
             project_id = team.project_id,
-            flags_count = filtered_flags.flags.len(),
+            flags_count = response.flags.len(),
             flags_disabled = request.is_flags_disabled(),
+            quota_limited = response.quota_limited.is_some(),
             duration_ms = total_duration.as_millis(),
             slow_request = total_duration.as_millis() > 1000,
             "Request completed"

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -18,7 +18,6 @@ use crate::{
     flags::flag_service::FlagService,
     metrics::consts::FLAG_REQUESTS_COUNTER,
 };
-use limiters::redis::ServiceName;
 use tracing::{info, warn};
 
 /// Primary entry point for feature flag requests.

--- a/rust/feature-flags/src/lib.rs
+++ b/rust/feature-flags/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod billing_limiters;
 pub mod cohorts;
 pub mod config;
 pub mod db_monitor;

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -1,5 +1,6 @@
 use std::{future::ready, sync::Arc};
 
+use crate::billing_limiters::{FeatureFlagsLimiter, SessionReplayLimiter};
 use axum::{
     http::Method,
     routing::{get, post},
@@ -11,7 +12,6 @@ use common_geoip::GeoIpClient;
 use common_metrics::{setup_metrics_recorder, track_metrics};
 use common_redis::Client as RedisClient;
 use health::HealthRegistry;
-use limiters::redis::RedisLimiter;
 use tower::limit::ConcurrencyLimitLayer;
 use tower_http::{
     cors::{AllowHeaders, AllowOrigin, CorsLayer},
@@ -34,7 +34,8 @@ pub struct State {
     pub cohort_cache_manager: Arc<CohortCacheManager>,
     pub geoip: Arc<GeoIpClient>,
     pub team_ids_to_track: TeamIdCollection,
-    pub billing_limiter: RedisLimiter,
+    pub feature_flags_billing_limiter: FeatureFlagsLimiter,
+    pub session_replay_billing_limiter: SessionReplayLimiter,
     pub cookieless_manager: Arc<CookielessManager>,
     pub config: Config,
 }
@@ -48,7 +49,8 @@ pub fn router<RR, RW, D>(
     cohort_cache: Arc<CohortCacheManager>,
     geoip: Arc<GeoIpClient>,
     liveness: HealthRegistry,
-    billing_limiter: RedisLimiter,
+    feature_flags_billing_limiter: FeatureFlagsLimiter,
+    session_replay_billing_limiter: SessionReplayLimiter,
     cookieless_manager: Arc<CookielessManager>,
     config: Config,
 ) -> Router
@@ -65,7 +67,8 @@ where
         cohort_cache_manager: cohort_cache,
         geoip,
         team_ids_to_track: config.team_ids_to_track.clone(),
-        billing_limiter,
+        feature_flags_billing_limiter,
+        session_replay_billing_limiter,
         cookieless_manager,
         config: config.clone(),
     };

--- a/rust/feature-flags/tests/common/mod.rs
+++ b/rust/feature-flags/tests/common/mod.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use common_database::get_pool;
 use common_redis::MockRedisClient;
 use feature_flags::team::team_models::{Team, TEAM_TOKEN_CACHE_PREFIX};
-use limiters::redis::{QuotaResource, RedisLimiter, ServiceName, QUOTA_LIMITER_CACHE_KEY};
+use limiters::redis::QUOTA_LIMITER_CACHE_KEY;
 use reqwest::header::CONTENT_TYPE;
 use tokio::net::TcpListener;
 use tokio::sync::Notify;
@@ -115,15 +115,23 @@ impl ServerHandle {
                 .await;
             tokio::spawn(liveness_loop(simple_loop));
 
-            let billing_limiter = RedisLimiter::new(
-                Duration::from_secs(5),
-                redis_reader_client.clone(),
-                QUOTA_LIMITER_CACHE_KEY.to_string(),
-                None,
-                QuotaResource::FeatureFlags,
-                ServiceName::FeatureFlags,
-            )
-            .unwrap();
+            let feature_flags_billing_limiter =
+                feature_flags::billing_limiters::FeatureFlagsLimiter::new(
+                    Duration::from_secs(5),
+                    redis_reader_client.clone(),
+                    QUOTA_LIMITER_CACHE_KEY.to_string(),
+                    None,
+                )
+                .unwrap();
+
+            let session_replay_billing_limiter =
+                feature_flags::billing_limiters::SessionReplayLimiter::new(
+                    Duration::from_secs(5),
+                    redis_reader_client.clone(),
+                    QUOTA_LIMITER_CACHE_KEY.to_string(),
+                    None,
+                )
+                .unwrap();
 
             let cookieless_manager = Arc::new(common_cookieless::CookielessManager::new(
                 config.get_cookieless_config(),
@@ -138,7 +146,8 @@ impl ServerHandle {
                 cohort_cache,
                 geoip_service,
                 health,
-                billing_limiter,
+                feature_flags_billing_limiter,
+                session_replay_billing_limiter,
                 cookieless_manager,
                 config,
             );

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -1817,7 +1817,7 @@ async fn test_config_analytics_enabled_by_default() -> Result<()> {
     let json_data = res.json::<Value>().await?;
 
     assert!(json_data["analytics"].is_object());
-    assert_eq!(json_data["analytics"]["endpoint"], json!("/i/v0/e"));
+    assert_eq!(json_data["analytics"]["endpoint"], json!("/i/v0/e/"));
 
     Ok(())
 }

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -579,7 +579,6 @@ async fn it_handles_flag_with_property_filter() -> Result<()> {
     assert_eq!(StatusCode::OK, res.status());
 
     let json_data = res.json::<Value>().await?;
-    println!("json_data: {:?}", json_data);
     assert_json_include!(
         actual: json_data,
         expected: json!({
@@ -1662,7 +1661,6 @@ async fn it_only_includes_config_fields_when_requested() -> Result<()> {
         panic!("Non-200 response \nBody: {}", text);
     }
     let json_data = res.json::<Value>().await?;
-    println!("json_data: {:?}", json_data);
     assert!(json_data.get("supportedCompression").is_none());
     assert!(json_data.get("autocapture_opt_out").is_none());
 
@@ -1778,8 +1776,6 @@ async fn test_config_analytics_enabled() -> Result<()> {
 
     let json_data = res.json::<Value>().await?;
 
-    println!("json_data: {:?}", json_data);
-
     assert!(json_data["analytics"].is_object());
     assert_eq!(
         json_data["analytics"]["endpoint"],
@@ -1819,8 +1815,6 @@ async fn test_config_analytics_enabled_by_default() -> Result<()> {
     assert_eq!(StatusCode::OK, res.status());
 
     let json_data = res.json::<Value>().await?;
-
-    println!("json_data: {:?}", json_data);
 
     assert!(json_data["analytics"].is_object());
     assert_eq!(json_data["analytics"]["endpoint"], json!("/i/v0/e"));
@@ -2253,10 +2247,6 @@ async fn test_config_session_recording_with_rrweb_script() -> Result<()> {
     assert_eq!(StatusCode::OK, res.status());
 
     let json_data = res.json::<Value>().await?;
-    println!(
-        "Response JSON: {}",
-        serde_json::to_string_pretty(&json_data)?
-    );
 
     // Session recording should be configured
     assert!(json_data["sessionRecording"].is_object());
@@ -2328,10 +2318,6 @@ async fn test_config_session_recording_team_not_allowed_for_script() -> Result<(
     assert_eq!(StatusCode::OK, res.status());
 
     let json_data = res.json::<Value>().await?;
-    println!(
-        "Response JSON: {}",
-        serde_json::to_string_pretty(&json_data)?
-    );
 
     // Session recording should be configured but WITHOUT the script
     assert!(json_data["sessionRecording"].is_object());


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Context: https://posthog.slack.com/archives/C09316K9JS2/p1750958544227289

## Changes

- added in quota limiting for session recording to the `/flags?config=true` response.
- added a default `NEW_ANALYTICS_CAPTURE_ENDPOINT` that matches the actual new endpoint.

Ships with these environment variable changes: https://github.com/PostHog/charts/pull/4975

## Did you write or update any docs for this change?

- [x] No docs needed for this change

## How did you test this code?

- New tests for new configs
