### PR TITLE
refactor(flags): Prepare DB cache for flag evaluation in advance if needed

### DIFF
--- a/rust/feature-flags/src/flags/flag_filters.rs
+++ b/rust/feature-flags/src/flags/flag_filters.rs
@@ -15,7 +15,9 @@ impl FlagFilters {
     }
 
     pub fn requires_cohort_filters(&self) -> bool {
-        any_group_requires_cohort_filters(Some(&self.groups))
+        Some(&self.groups).map_or(false, |groups| {
+            groups.iter().any(|group| group.requires_cohort_filters())
+        })
     }
 }
 
@@ -30,11 +32,7 @@ fn any_group_requires_db_properties(
     })
 }
 
-fn any_group_requires_cohort_filters(groups: Option<&Vec<FlagPropertyGroup>>) -> bool {
-    groups.map_or(false, |groups| {
-        groups.iter().any(|group| group.requires_cohort_filters())
-    })
-}
+
 
 #[cfg(test)]
 mod tests {

--- a/rust/feature-flags/src/flags/flag_filters.rs
+++ b/rust/feature-flags/src/flags/flag_filters.rs
@@ -18,9 +18,9 @@ impl FlagFilters {
     }
 
     pub fn requires_cohort_filters(&self) -> bool {
-        Some(&self.groups).map_or(false, |groups| {
-            groups.iter().any(|group| group.requires_cohort_filters())
-        })
+        self.groups
+            .iter()
+            .any(|group| group.requires_cohort_filters())
     }
 }
 

--- a/rust/feature-flags/src/flags/flag_filters.rs
+++ b/rust/feature-flags/src/flags/flag_filters.rs
@@ -7,19 +7,19 @@ use crate::flags::flag_models::{FlagFilters, FlagPropertyGroup};
 impl FlagFilters {
     pub fn requires_db_properties(&self, overrides: &HashMap<String, Value>) -> bool {
         self.aggregation_group_type_index.is_some()
-            || requires_db_properties(Some(&self.groups), overrides)
-            || requires_db_properties(self.super_groups.as_ref(), overrides)
-            || requires_db_properties(self.holdout_groups.as_ref(), overrides)
+            || any_group_requires_db_properties(Some(&self.groups), overrides)
+            || any_group_requires_db_properties(self.super_groups.as_ref(), overrides)
+            || any_group_requires_db_properties(self.holdout_groups.as_ref(), overrides)
     }
 
     pub fn requires_cohort_filters(&self) -> bool {
-        requires_cohort_filters(Some(&self.groups))
-            || requires_cohort_filters(self.super_groups.as_ref())
-            || requires_cohort_filters(self.holdout_groups.as_ref())
+        any_group_requires_cohort_filters(Some(&self.groups))
+            || any_group_requires_cohort_filters(self.super_groups.as_ref())
+            || any_group_requires_cohort_filters(self.holdout_groups.as_ref())
     }
 }
 
-fn requires_db_properties(
+fn any_group_requires_db_properties(
     groups: Option<&Vec<FlagPropertyGroup>>,
     overrides: &HashMap<String, Value>,
 ) -> bool {
@@ -30,7 +30,7 @@ fn requires_db_properties(
     })
 }
 
-fn requires_cohort_filters(groups: Option<&Vec<FlagPropertyGroup>>) -> bool {
+fn any_group_requires_cohort_filters(groups: Option<&Vec<FlagPropertyGroup>>) -> bool {
     groups.map_or(false, |groups| {
         groups.iter().any(|group| group.requires_cohort_filters())
     })
@@ -174,7 +174,7 @@ mod tests {
         {
             let overrides =
                 HashMap::from([("some_key".to_string(), Value::String("value".to_string()))]);
-            assert!(requires_db_properties(Some(&groups), &overrides));
+            assert!(any_group_requires_db_properties(Some(&groups), &overrides));
         }
         {
             let overrides = HashMap::from([
@@ -188,7 +188,7 @@ mod tests {
                     Value::String("value".to_string()),
                 ),
             ]);
-            assert!(!requires_db_properties(Some(&groups), &overrides));
+            assert!(!any_group_requires_db_properties(Some(&groups), &overrides));
         }
     }
 
@@ -230,7 +230,7 @@ mod tests {
                 ),
             ]);
 
-            assert!(requires_db_properties(Some(&groups), &overrides));
+            assert!(any_group_requires_db_properties(Some(&groups), &overrides));
         }
 
         {
@@ -247,7 +247,7 @@ mod tests {
                 ),
             ]);
 
-            assert!(!requires_db_properties(Some(&groups), &overrides));
+            assert!(!any_group_requires_db_properties(Some(&groups), &overrides));
         }
     }
 }

--- a/rust/feature-flags/src/flags/flag_filters.rs
+++ b/rust/feature-flags/src/flags/flag_filters.rs
@@ -1,0 +1,253 @@
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+use crate::flags::flag_models::{FlagFilters, FlagPropertyGroup};
+
+impl FlagFilters {
+    pub fn requires_db_properties(&self, overrides: &HashMap<String, Value>) -> bool {
+        self.aggregation_group_type_index.is_some()
+            || requires_db_properties(Some(&self.groups), overrides)
+            || requires_db_properties(self.super_groups.as_ref(), overrides)
+            || requires_db_properties(self.holdout_groups.as_ref(), overrides)
+    }
+
+    pub fn requires_cohort_filters(&self) -> bool {
+        requires_cohort_filters(Some(&self.groups))
+            || requires_cohort_filters(self.super_groups.as_ref())
+            || requires_cohort_filters(self.holdout_groups.as_ref())
+    }
+}
+
+fn requires_db_properties(
+    groups: Option<&Vec<FlagPropertyGroup>>,
+    overrides: &HashMap<String, Value>,
+) -> bool {
+    groups.map_or(false, |groups| {
+        groups
+            .iter()
+            .any(|group| group.requires_db_properties(overrides))
+    })
+}
+
+fn requires_cohort_filters(groups: Option<&Vec<FlagPropertyGroup>>) -> bool {
+    groups.map_or(false, |groups| {
+        groups.iter().any(|group| group.requires_cohort_filters())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use crate::{
+        flags::test_helpers::{
+            create_simple_flag_filters, create_simple_flag_property_group,
+            create_simple_property_filter,
+        },
+        properties::property_models::{OperatorType, PropertyType},
+    };
+
+    use super::*;
+
+    #[rstest]
+    #[case(100.0, true)]
+    #[case(50.0, true)]
+    #[case(0.0, false)]
+    fn test_requires_cohort_filters_if_cohort_filter_set_and_rollout_percentage_not_zero(
+        #[case] rollout_percentage: f64,
+        #[case] expected: bool,
+    ) {
+        let filters = create_simple_flag_filters(vec![create_simple_flag_property_group(
+            vec![create_simple_property_filter(
+                "cohort",
+                PropertyType::Cohort,
+                OperatorType::Exact,
+            )],
+            rollout_percentage,
+        )]);
+
+        assert_eq!(filters.requires_cohort_filters(), expected);
+    }
+
+    #[test]
+    fn test_requires_db_properties_when_overrides_not_enough() {
+        let filters = create_simple_flag_filters(vec![
+            create_simple_flag_property_group(
+                vec![
+                    create_simple_property_filter(
+                        "some_key",
+                        PropertyType::Person,
+                        OperatorType::Exact,
+                    ),
+                    create_simple_property_filter(
+                        "another_key",
+                        PropertyType::Person,
+                        OperatorType::Exact,
+                    ),
+                ],
+                100.0,
+            ),
+            create_simple_flag_property_group(
+                vec![create_simple_property_filter(
+                    "yet_another_key",
+                    PropertyType::Person,
+                    OperatorType::Exact,
+                )],
+                100.0,
+            ),
+        ]);
+
+        {
+            // Not enough overrides to evaluate locally
+            let overrides = HashMap::from([
+                ("some_key".to_string(), Value::String("value".to_string())),
+                (
+                    "another_key".to_string(),
+                    Value::String("value".to_string()),
+                ),
+            ]);
+
+            assert!(filters.requires_db_properties(&overrides));
+        }
+
+        {
+            // Enough overrides to evaluate locally
+            let overrides = HashMap::from([
+                ("some_key".to_string(), Value::String("value".to_string())),
+                (
+                    "another_key".to_string(),
+                    Value::String("value".to_string()),
+                ),
+                (
+                    "yet_another_key".to_string(),
+                    Value::String("value".to_string()),
+                ),
+            ]);
+
+            assert!(!filters.requires_db_properties(&overrides));
+        }
+    }
+
+    #[test]
+    fn test_requires_cohorts_when_groups_have_cohorts() {
+        let filters = create_simple_flag_filters(vec![create_simple_flag_property_group(
+            vec![create_simple_property_filter(
+                "some_key",
+                PropertyType::Cohort,
+                OperatorType::Exact,
+            )],
+            100.0,
+        )]);
+
+        assert!(filters.requires_cohort_filters());
+    }
+
+    #[test]
+    fn test_requires_db_properties_when_aggregation_group_type_index_set() {
+        let mut filters = create_simple_flag_filters(vec![]);
+        filters.aggregation_group_type_index = Some(1);
+
+        // Even though there are no properties, we still need to evaluate the DB properties
+        // because the group type index is set.
+        assert!(filters.requires_db_properties(&HashMap::new()));
+    }
+
+    #[test]
+    fn test_requires_db_properties_when_not_enough_overrides_single_group() {
+        let groups = vec![create_simple_flag_property_group(
+            vec![
+                create_simple_property_filter(
+                    "some_key",
+                    PropertyType::Person,
+                    OperatorType::Exact,
+                ),
+                create_simple_property_filter(
+                    "another_key",
+                    PropertyType::Person,
+                    OperatorType::Exact,
+                ),
+            ],
+            100.0,
+        )];
+
+        {
+            let overrides =
+                HashMap::from([("some_key".to_string(), Value::String("value".to_string()))]);
+            assert!(requires_db_properties(Some(&groups), &overrides));
+        }
+        {
+            let overrides = HashMap::from([
+                ("some_key".to_string(), Value::String("value".to_string())),
+                (
+                    "another_key".to_string(),
+                    Value::String("value".to_string()),
+                ),
+                (
+                    "yet_another_key".to_string(),
+                    Value::String("value".to_string()),
+                ),
+            ]);
+            assert!(!requires_db_properties(Some(&groups), &overrides));
+        }
+    }
+
+    #[test]
+    fn test_requires_db_properties_when_overrides_not_enough_for_multiple_groups() {
+        let groups = vec![
+            create_simple_flag_property_group(
+                vec![
+                    create_simple_property_filter(
+                        "some_key",
+                        PropertyType::Person,
+                        OperatorType::Exact,
+                    ),
+                    create_simple_property_filter(
+                        "another_key",
+                        PropertyType::Person,
+                        OperatorType::Exact,
+                    ),
+                ],
+                100.0,
+            ),
+            create_simple_flag_property_group(
+                vec![create_simple_property_filter(
+                    "yet_another_key",
+                    PropertyType::Person,
+                    OperatorType::Exact,
+                )],
+                100.0,
+            ),
+        ];
+
+        {
+            // Not enough overrides to evaluate locally
+            let overrides = HashMap::from([
+                ("some_key".to_string(), Value::String("value".to_string())),
+                (
+                    "another_key".to_string(),
+                    Value::String("value".to_string()),
+                ),
+            ]);
+
+            assert!(requires_db_properties(Some(&groups), &overrides));
+        }
+
+        {
+            // Enough overrides to evaluate locally
+            let overrides = HashMap::from([
+                ("some_key".to_string(), Value::String("value".to_string())),
+                (
+                    "another_key".to_string(),
+                    Value::String("value".to_string()),
+                ),
+                (
+                    "yet_another_key".to_string(),
+                    Value::String("value".to_string()),
+                ),
+            ]);
+
+            assert!(!requires_db_properties(Some(&groups), &overrides));
+        }
+    }
+}

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -169,6 +169,12 @@ pub struct FeatureFlagMatcher {
     /// State maintained during flag evaluation, including cached DB lookups
     pub(crate) flag_evaluation_state: FlagEvaluationState,
     /// Group key mappings for group-based flag evaluation
+    /// Maps group type name to the group key (identifier customer supplies for the group)
+    /// ex. "project" → "123"
+    ///     "organization" → "456"
+    ///     "instance" → "789"
+    ///     "customer" → "101"
+    ///     "team" → "112"
     groups: HashMap<String, Value>,
 }
 
@@ -1426,7 +1432,7 @@ impl FeatureFlagMatcher {
         }
     }
 
-    /// Get group properties from the `FlagEvaluationState` only. Returns empty HashMap if not found.
+    /// Get group properties for the given group type index from the `FlagEvaluationState` only. Returns empty HashMap if not found.
     fn get_group_properties_from_evaluation_state(
         &self,
         group_type_index: GroupTypeIndex,
@@ -1452,7 +1458,8 @@ impl FeatureFlagMatcher {
         }
     }
 
-    // If experience continuity is enabled, we need to process the hash key override if it's provided.
+    /// If experience continuity is enabled, we need to process the hash key override if it's provided.
+    /// See [`FeatureFlagMatcher::process_hash_key_override`] for more details.
     async fn process_hash_key_override_if_needed(
         &self,
         flags_have_experience_continuity_enabled: bool,
@@ -1501,6 +1508,10 @@ impl FeatureFlagMatcher {
         (hash_key_overrides, flag_hash_key_override_error)
     }
 
+    /// Initializes the group type mapping cache if needed.
+    ///
+    /// This function checks if any of the feature flags have group type indices and initializes the group type mapping cache if needed.
+    /// It returns a boolean indicating if there were any errors while initializing the group type mapping cache.
     async fn initialize_group_type_mappings_if_needed(
         &mut self,
         feature_flags: &FeatureFlagList,

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -531,18 +531,11 @@ impl FeatureFlagMatcher {
             precomputed_property_overrides.insert(flag.key.clone(), relevant_property_overrides);
         }
 
-        // Evaluate remaining flags with cached properties using pre-computed overrides
+        // Evaluate flags with cached properties using pre-computed overrides
         let flag_get_match_timer = timing_guard(FLAG_GET_MATCH_TIME, &[]);
 
         let flags_map: HashMap<&String, &FeatureFlag> =
             flags.iter().map(|flag| (&flag.key, flag)).collect();
-
-        if !flags_map.is_empty() {
-            println!(
-                "FLAGS NEED DB PROPERTIES!!!!!!flags_map: {:?}",
-                flags_map.keys().collect::<Vec<_>>()
-            );
-        }
 
         let results: Vec<(String, Result<FeatureFlagMatch, FlagError>)> = flags
             .par_iter()

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -441,7 +441,7 @@ impl FeatureFlagMatcher {
 
         if !flags_requiring_db_preparation.is_empty() {
             if let Err(e) = self
-                .prepare_flag_evaluation_state(&flags_requiring_db_preparation)
+                .prepare_flag_evaluation_state(flags_requiring_db_preparation.as_slice())
                 .await
             {
                 errors_while_computing_flags = true;
@@ -1171,7 +1171,7 @@ impl FeatureFlagMatcher {
     /// during subsequent flag evaluations.
     pub async fn prepare_flag_evaluation_state(
         &mut self,
-        flags: &[FeatureFlag],
+        flags: &[&FeatureFlag],
     ) -> Result<(), FlagError> {
         // Get cohorts first since we need the IDs
         let cohorts = self.cohort_cache.get_cohorts(self.project_id).await?;
@@ -1225,7 +1225,7 @@ impl FeatureFlagMatcher {
     /// - Mapping group names to group_type_index and group_keys
     fn prepare_group_data(
         &mut self,
-        flags: &[FeatureFlag],
+        flags: &[&FeatureFlag],
     ) -> Result<GroupEvaluationData, FlagError> {
         // Extract required group type indexes from flags
         let type_indexes: HashSet<GroupTypeIndex> = flags

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -499,7 +499,7 @@ impl FeatureFlagMatcher {
     ) -> (HashMap<String, FlagDetails>, bool) {
         // initialize some state
         let mut errors_while_computing_flags = false;
-        let mut flag_details_map = HashMap::new();
+        let mut level_flag_details_map = HashMap::new();
         let mut flags_needing_db_properties = Vec::new();
         let mut precomputed_property_overrides: HashMap<String, Option<HashMap<String, Value>>> =
             HashMap::new();
@@ -556,7 +556,7 @@ impl FeatureFlagMatcher {
                 Ok(Some(flag_match)) => {
                     self.flag_evaluation_state
                         .add_flag_evaluation_result(flag.id, flag_match.get_flag_value());
-                    flag_details_map
+                    level_flag_details_map
                         .insert(flag.key.clone(), FlagDetails::create(flag, &flag_match));
                 }
                 Ok(None) => {
@@ -607,7 +607,7 @@ impl FeatureFlagMatcher {
                 // Handle database errors
                 errors_while_computing_flags = true;
                 let reason = parse_exception_for_prometheus_label(&e);
-                flag_details_map.extend(
+                level_flag_details_map.extend(
                     flags_needing_db_properties
                         .iter()
                         .map(|flag| (flag.key.clone(), FlagDetails::create_error(flag, reason, None)))
@@ -618,7 +618,7 @@ impl FeatureFlagMatcher {
                     &[("reason".to_string(), reason.to_string())],
                     1,
                 );
-                return (flag_details_map, errors_while_computing_flags);
+                return (level_flag_details_map, errors_while_computing_flags);
             }
         }
 
@@ -661,7 +661,7 @@ impl FeatureFlagMatcher {
                 Ok(flag_match) => {
                     self.flag_evaluation_state
                         .add_flag_evaluation_result(flag.id, flag_match.get_flag_value());
-                    flag_details_map.insert(flag_key, FlagDetails::create(flag, &flag_match));
+                    level_flag_details_map.insert(flag_key, FlagDetails::create(flag, &flag_match));
                 }
                 Err(e) => {
                     errors_while_computing_flags = true;
@@ -685,7 +685,7 @@ impl FeatureFlagMatcher {
                         &[("reason".to_string(), reason.to_string())],
                         1,
                     );
-                    flag_details_map
+                    level_flag_details_map
                         .insert(flag_key, FlagDetails::create_error(flag, reason, None));
                 }
             }
@@ -701,7 +701,7 @@ impl FeatureFlagMatcher {
             )
             .fin();
 
-        (flag_details_map, errors_while_computing_flags)
+        (level_flag_details_map, errors_while_computing_flags)
     }
 
     /// Attempts to match a feature flag using only property overrides (no database access).

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -23,7 +23,7 @@ use crate::{
     },
     properties::{
         property_matching::match_property,
-        property_models::{OperatorType, PropertyFilter, PropertyType},
+        property_models::{OperatorType, PropertyFilter},
     },
 };
 
@@ -309,9 +309,7 @@ pub fn locally_computable_property_overrides(
 
 /// Checks if any property filters involve cohorts that require database lookup
 fn has_cohort_filters(property_filters: &[PropertyFilter]) -> bool {
-    property_filters
-        .iter()
-        .any(|prop| prop.prop_type == PropertyType::Cohort)
+    property_filters.iter().any(|prop| prop.is_cohort())
 }
 
 /// Determines if the provided overrides contain properties that the flag actually needs
@@ -640,7 +638,7 @@ mod tests {
 
     use crate::{
         flags::flag_models::{FeatureFlagRow, FlagFilters},
-        properties::property_models::{OperatorType, PropertyFilter},
+        properties::property_models::{OperatorType, PropertyFilter, PropertyType},
         utils::test_utils::{
             create_test_flag, insert_flag_for_team_in_pg, insert_new_team_in_pg,
             insert_person_for_team_in_pg, setup_pg_reader_client, setup_pg_writer_client,

--- a/rust/feature-flags/src/flags/flag_models.rs
+++ b/rust/feature-flags/src/flags/flag_models.rs
@@ -34,12 +34,25 @@ pub struct FlagFilters {
     pub groups: Vec<FlagPropertyGroup>,
     #[serde(default)]
     pub multivariate: Option<MultivariateFlagOptions>,
+    /// The group type index is used to determine which group type to use for the flag.
+    ///
+    /// Typical group type mappings are:
+    /// - 0 → "project"
+    /// - 1 → "organization"
+    /// - 2 → "instance"
+    /// - 3 → "customer"
+    /// - 4 → "team"
     #[serde(default)]
     pub aggregation_group_type_index: Option<i32>,
     #[serde(default)]
     pub payloads: Option<serde_json::Value>,
+    /// Super groups are a special group of feature flag conditions that act as a gate that must be
+    /// satisfied before any other conditions are evaluated. If they match, the flag is enabled and no
+    /// other conditions are evaluated. If they don't match, fallback to regular conditions.
     #[serde(default)]
     pub super_groups: Option<Vec<FlagPropertyGroup>>,
+    /// Holdout groups are conditions that define a set of users intentionally excluded from a test
+    /// or experiment to serve as a baseline or control group
     #[serde(default)]
     pub holdout_groups: Option<Vec<FlagPropertyGroup>>,
 }

--- a/rust/feature-flags/src/flags/flag_models.rs
+++ b/rust/feature-flags/src/flags/flag_models.rs
@@ -48,7 +48,16 @@ pub struct FlagFilters {
     pub payloads: Option<serde_json::Value>,
     /// Super groups are a special group of feature flag conditions that act as a gate that must be
     /// satisfied before any other conditions are evaluated. If they match, the flag is enabled and no
-    /// other conditions are evaluated. If they don't match, fallback to regular conditions.
+    /// other conditions are evaluated. If they don't match, fallback to regular conditions. Right now,
+    /// these are only used for early access features which is a key and a boolean like so:
+    /// {
+    ///   "key": "$feature_enrollment/feature-flags-flag-dependency",
+    ///   "type": "person",
+    ///   "value": [
+    ///     "true"
+    ///   ],
+    ///   "operator": "exact"
+    /// }
     #[serde(default)]
     pub super_groups: Option<Vec<FlagPropertyGroup>>,
     /// Holdout groups are conditions that define a set of users intentionally excluded from a test

--- a/rust/feature-flags/src/flags/flag_models.rs
+++ b/rust/feature-flags/src/flags/flag_models.rs
@@ -47,9 +47,8 @@ pub struct FlagFilters {
     #[serde(default)]
     pub payloads: Option<serde_json::Value>,
     /// Super groups are a special group of feature flag conditions that act as a gate that must be
-    /// satisfied before any other conditions are evaluated. If they match, the flag is enabled and no
-    /// other conditions are evaluated. If they don't match, fallback to regular conditions. Right now,
-    /// these are only used for early access features which is a key and a boolean like so:
+    /// satisfied before any other conditions are evaluated. Currently, we only ever evaluate the first
+    /// super group. This is used for early access features which is a key and a boolean like so:
     /// {
     ///   "key": "$feature_enrollment/feature-flags-flag-dependency",
     ///   "type": "person",
@@ -58,10 +57,21 @@ pub struct FlagFilters {
     ///   ],
     ///   "operator": "exact"
     /// }
+    /// If they match, the flag is enabled and no other conditions are evaluated. If they don't match,
+    /// fallback to regular conditions.
     #[serde(default)]
     pub super_groups: Option<Vec<FlagPropertyGroup>>,
-    /// Holdout groups are conditions that define a set of users intentionally excluded from a test
-    /// or experiment to serve as a baseline or control group
+    /// The holdout group (though the type can hold multiple, we only evaluate the first one)
+    /// is a condition that defines a set of users intentionally excluded from a test or
+    /// experiment to serve as a baseline or control group. The group is defined as a percentage
+    /// which is held back by hashing the distinct identifier of the user. Here's an example:
+    /// "holdout_groups": [
+    /// {
+    ///     "variant": "holdout-1",
+    ///     "properties": [],
+    ///     "rollout_percentage": 10
+    ///   }
+    /// ]
     #[serde(default)]
     pub holdout_groups: Option<Vec<FlagPropertyGroup>>,
 }

--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -116,6 +116,18 @@ impl FeatureFlag {
     }
 }
 
+/// Returns the set of flags that require DB preparation
+pub fn flags_require_db_preparation(
+    flags: &[FeatureFlag],
+    overrides: &HashMap<String, Value>,
+) -> Vec<FeatureFlag> {
+    flags
+        .iter()
+        .filter(|flag| flag.requires_db_preparation(overrides))
+        .cloned()
+        .collect()
+}
+
 impl DependencyProvider for FeatureFlag {
     type Id = FeatureFlagId;
     type Error = FlagError;

--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -1738,9 +1738,15 @@ mod tests {
     }
 
     #[test]
-    fn test_requires_db_preparation_if_holdout_groups_set_and_not_enough_overrides() {
+    fn test_does_not_require_db_preparation_if_holdout_groups_set() {
         let mut flag = create_simple_flag(vec![], 100.0);
         flag.filters.holdout_groups = Some(vec![
+            FlagPropertyGroup {
+                properties: Some(vec![]),
+                variant: Some("holdout-1".to_string()),
+                rollout_percentage: Some(10.0),
+            },
+            // Ignored, but here for testing.
             FlagPropertyGroup {
                 properties: Some(vec![create_simple_property_filter(
                     "some_property",
@@ -1748,42 +1754,11 @@ mod tests {
                     OperatorType::Exact,
                 )]),
                 rollout_percentage: Some(100.0),
-                variant: None,
-            },
-            FlagPropertyGroup {
-                properties: Some(vec![create_simple_property_filter(
-                    "another_property",
-                    PropertyType::Person,
-                    OperatorType::Exact,
-                )]),
-                rollout_percentage: Some(100.0),
-                variant: None,
+                variant: Some("holdout-2".to_string()),
             },
         ]);
 
-        {
-            // Not enough overrides to evaluate locally
-            let overrides = HashMap::from([(
-                "some_property".to_string(),
-                Value::String("value".to_string()),
-            )]);
-
-            assert!(flag.requires_db_preparation(&overrides));
-        }
-        {
-            // Sufficient overrides to evaluate locally
-            let overrides = HashMap::from([
-                (
-                    "some_property".to_string(),
-                    Value::String("value".to_string()),
-                ),
-                (
-                    "another_property".to_string(),
-                    Value::String("value".to_string()),
-                ),
-            ]);
-            assert!(!flag.requires_db_preparation(&overrides));
-        }
+        assert!(!flag.requires_db_preparation(&HashMap::new()));
     }
 
     #[test]

--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -50,6 +50,9 @@ fn extract_feature_flag_dependency(filter: &PropertyFilter) -> Option<FeatureFla
 }
 
 impl FeatureFlag {
+    /// Returns the group type index for the flag, or None if it's not set.
+    ///
+    /// See [`FlagFilters::aggregation_group_type_index`] for more details about group type mappings.
     pub fn get_group_type_index(&self) -> Option<i32> {
         self.filters.aggregation_group_type_index
     }

--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -117,14 +117,13 @@ impl FeatureFlag {
 }
 
 /// Returns the set of flags that require DB preparation
-pub fn flags_require_db_preparation(
-    flags: &[FeatureFlag],
+pub fn flags_require_db_preparation<'a>(
+    flags: &'a [FeatureFlag],
     overrides: &HashMap<String, Value>,
-) -> Vec<FeatureFlag> {
+) -> Vec<&'a FeatureFlag> {
     flags
         .iter()
         .filter(|flag| flag.requires_db_preparation(overrides))
-        .cloned()
         .collect()
 }
 

--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -1738,52 +1738,6 @@ mod tests {
     }
 
     #[test]
-    fn test_requires_db_preparation_if_super_group_set_and_not_enough_overrides() {
-        let mut flag = create_simple_flag(vec![], 1.0);
-        flag.filters.super_groups = Some(vec![FlagPropertyGroup {
-            properties: Some(vec![
-                create_simple_property_filter(
-                    "some_property",
-                    PropertyType::Person,
-                    OperatorType::Exact,
-                ),
-                create_simple_property_filter(
-                    "another_property",
-                    PropertyType::Person,
-                    OperatorType::Exact,
-                ),
-            ]),
-            rollout_percentage: Some(1.0),
-            variant: None,
-        }]);
-
-        {
-            let overrides = HashMap::from([
-                // Not enough overrides to evaluate locally
-                (
-                    "some_property".to_string(),
-                    Value::String("value".to_string()),
-                ),
-            ]);
-            assert!(flag.requires_db_preparation(&overrides));
-        }
-
-        {
-            let overrides = HashMap::from([
-                (
-                    "some_property".to_string(),
-                    Value::String("value".to_string()),
-                ),
-                (
-                    "another_property".to_string(),
-                    Value::String("value".to_string()),
-                ),
-            ]);
-            assert!(!flag.requires_db_preparation(&overrides));
-        }
-    }
-
-    #[test]
     fn test_requires_db_preparation_if_holdout_groups_set_and_not_enough_overrides() {
         let mut flag = create_simple_flag(vec![], 100.0);
         flag.filters.holdout_groups = Some(vec![

--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -93,11 +93,10 @@ impl FeatureFlag {
     /// This is true if the flag has a rollout percentage set and the flag has cohort filters
     ///
     pub fn requires_cohort_filters(&self) -> bool {
-        self.filters.groups.iter().any(|group| {
-            group.rollout_percentage.is_some()
-                && group.rollout_percentage.unwrap() > 0.0
-                && self.has_cohort_filters()
-        })
+        self.filters
+            .groups
+            .iter()
+            .any(|group| group.is_rolled_out_to_to_some() && self.has_cohort_filters())
     }
 
     /// Extracts dependent FeatureFlagIds from the feature flag's filters

--- a/rust/feature-flags/src/flags/flag_property_group.rs
+++ b/rust/feature-flags/src/flags/flag_property_group.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 impl FlagPropertyGroup {
     /// Returns true if the group is rolled out to some percentage greater than 0.0
-    pub fn is_rolled_out_to_to_some(&self) -> bool {
+    pub fn is_rolled_out_to_some(&self) -> bool {
         self.rollout_percentage_unwrapped() > 0.0
     }
 
@@ -18,7 +18,7 @@ impl FlagPropertyGroup {
     /// This is true if the group is rolled out to some percentage greater than 0.0
     /// and all the properties in the group require DB properties to be evaluated.
     pub fn requires_db_properties(&self, overrides: &HashMap<String, Value>) -> bool {
-        self.is_rolled_out_to_to_some()
+        self.is_rolled_out_to_some()
             && self.properties.as_ref().map_or(false, |properties| {
                 properties
                     .iter()
@@ -35,7 +35,7 @@ impl FlagPropertyGroup {
 
     /// Returns true if the group is rolled out to some percentage greater than 0.0 and has a cohort filter.
     pub fn requires_cohort_filters(&self) -> bool {
-        self.is_rolled_out_to_to_some() && self.has_cohort_filters()
+        self.is_rolled_out_to_some() && self.has_cohort_filters()
     }
 }
 
@@ -66,7 +66,7 @@ mod tests {
             rollout_percentage,
             variant: None,
         };
-        assert_eq!(group.is_rolled_out_to_to_some(), expected);
+        assert_eq!(group.is_rolled_out_to_some(), expected);
     }
 
     #[test]

--- a/rust/feature-flags/src/flags/flag_property_group.rs
+++ b/rust/feature-flags/src/flags/flag_property_group.rs
@@ -57,10 +57,7 @@ mod tests {
     #[case(Some(1.0), true)]
     #[case(Some(0.0), false)]
     #[case(None, true)] // If no rollout percentage is set, we assume it's 100%
-    fn test_is_rolled_out_to_to_some(
-        #[case] rollout_percentage: Option<f64>,
-        #[case] expected: bool,
-    ) {
+    fn test_is_rolled_out_to_some(#[case] rollout_percentage: Option<f64>, #[case] expected: bool) {
         let group = FlagPropertyGroup {
             properties: None,
             rollout_percentage,

--- a/rust/feature-flags/src/flags/flag_property_group.rs
+++ b/rust/feature-flags/src/flags/flag_property_group.rs
@@ -1,0 +1,31 @@
+use crate::flags::flag_models::FlagPropertyGroup;
+
+impl FlagPropertyGroup {
+    /// Returns true if the group is rolled out to some percentage greater than 0.0
+    pub fn is_rolled_out_to_to_some(&self) -> bool {
+        self.rollout_percentage.is_some() && self.rollout_percentage.unwrap() > 0.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(Some(100.0), true)]
+    #[case(Some(1.0), true)]
+    #[case(Some(0.0), false)]
+    #[case(None, false)]
+    fn test_is_rolled_out_to_to_some(
+        #[case] rollout_percentage: Option<f64>,
+        #[case] expected: bool,
+    ) {
+        let group = FlagPropertyGroup {
+            properties: None,
+            rollout_percentage,
+            variant: None,
+        };
+        assert_eq!(group.is_rolled_out_to_to_some(), expected);
+    }
+}

--- a/rust/feature-flags/src/flags/flag_property_group.rs
+++ b/rust/feature-flags/src/flags/flag_property_group.rs
@@ -1,22 +1,62 @@
 use crate::flags::flag_models::FlagPropertyGroup;
+use serde_json::Value;
+use std::collections::HashMap;
 
 impl FlagPropertyGroup {
     /// Returns true if the group is rolled out to some percentage greater than 0.0
     pub fn is_rolled_out_to_to_some(&self) -> bool {
-        self.rollout_percentage.is_some() && self.rollout_percentage.unwrap() > 0.0
+        self.rollout_percentage_unwrapped() > 0.0
+    }
+
+    /// Gets and unwraps the rollout percentage, defaulting to 100.0 if not set.
+    pub fn rollout_percentage_unwrapped(&self) -> f64 {
+        self.rollout_percentage.unwrap_or(100.0)
+    }
+
+    /// Returns true if the overrides are not enough to evaluate the group locally.
+    ///
+    /// This is true if the group is rolled out to some percentage greater than 0.0
+    /// and all the properties in the group require DB properties to be evaluated.
+    pub fn requires_db_properties(&self, overrides: &HashMap<String, Value>) -> bool {
+        self.is_rolled_out_to_to_some()
+            && self.properties.as_ref().map_or(false, |properties| {
+                properties
+                    .iter()
+                    .any(|prop| prop.requires_db_property(overrides))
+            })
+    }
+
+    /// Returns true if the group has any cohort filters.
+    pub fn has_cohort_filters(&self) -> bool {
+        self.properties.as_ref().map_or(false, |properties| {
+            properties.iter().any(|prop| prop.is_cohort())
+        })
+    }
+
+    /// Returns true if the group is rolled out to some percentage greater than 0.0 and has a cohort filter.
+    pub fn requires_cohort_filters(&self) -> bool {
+        self.is_rolled_out_to_to_some() && self.has_cohort_filters()
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
+    use crate::{
+        flags::test_helpers::create_simple_property_filter,
+        properties::property_models::{OperatorType, PropertyType},
+    };
+
     use super::*;
     use rstest::rstest;
+    use serde_json::Value;
 
     #[rstest]
     #[case(Some(100.0), true)]
     #[case(Some(1.0), true)]
     #[case(Some(0.0), false)]
-    #[case(None, false)]
+    #[case(None, true)] // If no rollout percentage is set, we assume it's 100%
     fn test_is_rolled_out_to_to_some(
         #[case] rollout_percentage: Option<f64>,
         #[case] expected: bool,
@@ -27,5 +67,130 @@ mod tests {
             variant: None,
         };
         assert_eq!(group.is_rolled_out_to_to_some(), expected);
+    }
+
+    #[test]
+    fn test_does_not_require_db_properties_when_no_properties() {
+        let group = FlagPropertyGroup {
+            properties: None,
+            rollout_percentage: Some(100.0),
+            variant: None,
+        };
+        assert!(!group.requires_db_properties(&HashMap::new()));
+    }
+
+    #[test]
+    fn test_requires_db_properties_when_overrides_for_every_condition_not_present() {
+        let group = FlagPropertyGroup {
+            properties: Some(vec![
+                create_simple_property_filter("key", PropertyType::Person, OperatorType::Exact),
+                create_simple_property_filter(
+                    "another_key",
+                    PropertyType::Person,
+                    OperatorType::Exact,
+                ),
+            ]),
+            rollout_percentage: Some(100.0),
+            variant: None,
+        };
+
+        {
+            // Not enough overrides to evaluate locally
+            let overrides = HashMap::from([(
+                "another_key".to_string(),
+                Value::String("another_value".to_string()),
+            )]);
+            assert!(group.requires_db_properties(&overrides));
+        }
+
+        {
+            // Enough overrides to evaluate locally
+            let overrides = HashMap::from([
+                ("key".to_string(), Value::String("value".to_string())),
+                (
+                    "another_key".to_string(),
+                    Value::String("another_value".to_string()),
+                ),
+            ]);
+            assert!(!group.requires_db_properties(&overrides));
+        }
+    }
+
+    #[test]
+    fn test_does_not_require_db_properties_when_not_rolled_out() {
+        let group = FlagPropertyGroup {
+            properties: Some(vec![
+                create_simple_property_filter("key", PropertyType::Person, OperatorType::Exact),
+                create_simple_property_filter(
+                    "another_key",
+                    PropertyType::Person,
+                    OperatorType::Exact,
+                ),
+            ]),
+            rollout_percentage: Some(0.0),
+            variant: None,
+        };
+
+        assert!(!group.requires_db_properties(&HashMap::new()));
+    }
+
+    #[test]
+    fn test_has_cohort_filters_when_cohort_filter_present() {
+        let group = FlagPropertyGroup {
+            properties: Some(vec![create_simple_property_filter(
+                "cohort",
+                PropertyType::Cohort,
+                OperatorType::Exact,
+            )]),
+            rollout_percentage: Some(100.0),
+            variant: None,
+        };
+
+        assert!(group.has_cohort_filters());
+    }
+
+    #[test]
+    fn test_does_not_have_cohort_filters_when_no_cohort_filter_present() {
+        let group = FlagPropertyGroup {
+            properties: Some(vec![create_simple_property_filter(
+                "key",
+                PropertyType::Person,
+                OperatorType::Exact,
+            )]),
+            rollout_percentage: Some(100.0),
+            variant: None,
+        };
+
+        assert!(!group.has_cohort_filters());
+    }
+
+    #[test]
+    fn test_requires_cohort_filters_when_rolled_out_and_cohort_filter_present() {
+        let group = FlagPropertyGroup {
+            properties: Some(vec![create_simple_property_filter(
+                "cohort",
+                PropertyType::Cohort,
+                OperatorType::Exact,
+            )]),
+            rollout_percentage: Some(100.0),
+            variant: None,
+        };
+
+        assert!(group.requires_cohort_filters());
+    }
+
+    #[test]
+    fn test_does_not_require_cohort_filters_when_not_rolled_out() {
+        let group = FlagPropertyGroup {
+            properties: Some(vec![create_simple_property_filter(
+                "cohort",
+                PropertyType::Cohort,
+                OperatorType::Exact,
+            )]),
+            rollout_percentage: Some(0.0),
+            variant: None,
+        };
+
+        assert!(!group.requires_cohort_filters());
     }
 }

--- a/rust/feature-flags/src/flags/mod.rs
+++ b/rust/feature-flags/src/flags/mod.rs
@@ -5,6 +5,7 @@ pub mod flag_matching;
 pub mod flag_matching_utils;
 pub mod flag_models;
 pub mod flag_operations;
+pub mod flag_property_group;
 pub mod flag_request;
 pub mod flag_service;
 

--- a/rust/feature-flags/src/flags/mod.rs
+++ b/rust/feature-flags/src/flags/mod.rs
@@ -1,4 +1,5 @@
 pub mod flag_analytics;
+pub mod flag_filters;
 pub mod flag_group_type_mapping;
 pub mod flag_match_reason;
 pub mod flag_matching;
@@ -11,3 +12,5 @@ pub mod flag_service;
 
 #[cfg(test)]
 mod test_flag_matching;
+#[cfg(test)]
+mod test_helpers;

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -91,7 +91,7 @@ mod tests {
         );
 
         matcher
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 
@@ -112,7 +112,7 @@ mod tests {
         );
 
         matcher
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 
@@ -133,7 +133,7 @@ mod tests {
         );
 
         matcher
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 
@@ -703,7 +703,7 @@ mod tests {
         );
 
         matcher
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 
@@ -1105,7 +1105,7 @@ mod tests {
         );
 
         matcher
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 
@@ -1335,7 +1335,7 @@ mod tests {
             );
 
             matcher
-                .prepare_flag_evaluation_state(&[flag.clone()])
+                .prepare_flag_evaluation_state(&[&flag])
                 .await
                 .unwrap();
 
@@ -1467,17 +1467,17 @@ mod tests {
         );
 
         matcher_test_id
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 
         matcher_example_id
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 
         matcher_another_id
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 
@@ -1580,7 +1580,7 @@ mod tests {
         );
 
         matcher
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 
@@ -1708,17 +1708,17 @@ mod tests {
         );
 
         matcher_test_id
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 
         matcher_example_id
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 
         matcher_another_id
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 
@@ -1832,7 +1832,7 @@ mod tests {
         );
 
         matcher
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 
@@ -1925,7 +1925,7 @@ mod tests {
         );
 
         matcher
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 
@@ -2132,7 +2132,7 @@ mod tests {
         );
 
         matcher
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 
@@ -2213,7 +2213,7 @@ mod tests {
             None,
         );
 
-        let matcher = FeatureFlagMatcher::new(
+        let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
             team.project_id,
@@ -2223,6 +2223,11 @@ mod tests {
             None,
             None,
         );
+
+        matcher
+            .prepare_flag_evaluation_state(&[&flag])
+            .await
+            .unwrap();
 
         let result = matcher.get_match(&flag, None, None).unwrap();
 
@@ -2311,7 +2316,7 @@ mod tests {
         );
 
         matcher
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 
@@ -2476,7 +2481,7 @@ mod tests {
         );
 
         matcher
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 
@@ -2963,7 +2968,7 @@ mod tests {
         );
 
         matcher
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 
@@ -3018,7 +3023,7 @@ mod tests {
         );
 
         matcher
-            .prepare_flag_evaluation_state(&[flag_invalid_override.clone()])
+            .prepare_flag_evaluation_state(&[&flag_invalid_override])
             .await
             .unwrap();
 
@@ -3191,7 +3196,7 @@ mod tests {
         );
 
         matcher
-            .prepare_flag_evaluation_state(&[flag_with_holdout.clone()])
+            .prepare_flag_evaluation_state(&[&flag_with_holdout])
             .await
             .unwrap();
 
@@ -3214,9 +3219,9 @@ mod tests {
 
         matcher2
             .prepare_flag_evaluation_state(&[
-                flag_with_holdout.clone(),
-                flag_without_holdout.clone(),
-                other_flag_with_holdout.clone(),
+                &flag_with_holdout,
+                &flag_without_holdout,
+                &other_flag_with_holdout,
             ])
             .await
             .unwrap();
@@ -3457,7 +3462,7 @@ mod tests {
         );
 
         matcher
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 
@@ -3584,7 +3589,7 @@ mod tests {
         );
 
         matcher_numeric
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 
@@ -3604,7 +3609,7 @@ mod tests {
         );
 
         matcher_string
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 
@@ -3636,7 +3641,7 @@ mod tests {
         );
 
         matcher_float
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 
@@ -3657,7 +3662,7 @@ mod tests {
         );
 
         matcher_bool
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 
@@ -3798,7 +3803,7 @@ mod tests {
         );
 
         matcher
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 
@@ -3823,7 +3828,7 @@ mod tests {
         );
 
         matcher
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 
@@ -3848,7 +3853,7 @@ mod tests {
         );
 
         matcher
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 
@@ -3915,7 +3920,7 @@ mod tests {
         );
 
         matcher
-            .prepare_flag_evaluation_state(&[flag.clone()])
+            .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
 

--- a/rust/feature-flags/src/flags/test_helpers.rs
+++ b/rust/feature-flags/src/flags/test_helpers.rs
@@ -1,0 +1,62 @@
+/* Test Helpers specifically for the flags module */
+
+use serde_json::Value;
+
+use crate::{
+    flags::flag_models::{FeatureFlag, FlagFilters, FlagPropertyGroup},
+    properties::property_models::{OperatorType, PropertyFilter, PropertyType},
+};
+
+pub fn create_simple_property_filter(
+    key: &str,
+    prop_type: PropertyType,
+    operator: OperatorType,
+) -> PropertyFilter {
+    PropertyFilter {
+        key: key.to_string(),
+        value: Some(Value::String("value".to_string())),
+        operator: Some(operator),
+        group_type_index: None,
+        negation: None,
+        prop_type,
+    }
+}
+
+pub fn create_simple_flag_filters(groups: Vec<FlagPropertyGroup>) -> FlagFilters {
+    FlagFilters {
+        groups,
+        multivariate: None,
+        aggregation_group_type_index: None,
+        payloads: None,
+        super_groups: None,
+        holdout_groups: None,
+    }
+}
+
+pub fn create_simple_flag_property_group(
+    properties: Vec<PropertyFilter>,
+    rollout_percentage: f64,
+) -> FlagPropertyGroup {
+    FlagPropertyGroup {
+        properties: Some(properties),
+        rollout_percentage: Some(rollout_percentage),
+        variant: None,
+    }
+}
+
+pub fn create_simple_flag(properties: Vec<PropertyFilter>, rollout_percentage: f64) -> FeatureFlag {
+    FeatureFlag {
+        filters: create_simple_flag_filters(vec![create_simple_flag_property_group(
+            properties,
+            rollout_percentage,
+        )]),
+        id: 1,
+        team_id: 1,
+        name: Some("Flag 1".to_string()),
+        key: "flag_1".to_string(),
+        deleted: false,
+        active: true,
+        ensure_experience_continuity: false,
+        version: Some(1),
+    }
+}


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Prior to this PR, the code would lazily query the DB and cache properties needed for flag evaluation when a flag couldn't be evaluated solely with provided properties. This worked great, but has a few issues:

1. The logic can be difficult to follow as we evaluate flags in multiple passes (those that don't require DB, then those that do).
2. The logic to determine if a flag needs db properties isn't explicit. It's basically if a flag couldn't be evaluated with overrides.
3. To support flags that depend on other flags (see #34014), we will evaluate flags in levels. But we don't want to call the DB once per level.

## Changes

This PR prepares the DB cache _before_ flag evaluation, but only if needed. It does this by making the conditions for when we need to access the database explicit. It then scans all flags that need DB properties and calls our existing `prepare_flag_evaluation_state` method.

It also removes the two-stage evaluation because we know we have all the data we need to evaluate flags ahead of time.

This simplifies some of the evaluation code quite a bit as the logic is now simpler with regards to overrides.

When reviewing, pay particular attention for how we determine if a flag needs the DB to be prepared.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Unit/Integration tests
Manual testing in Postman