### PR TITLE
chore(admin): query tagging mixin

### DIFF
--- a/posthog/admin/admins/person_admin.py
+++ b/posthog/admin/admins/person_admin.py
@@ -1,9 +1,10 @@
 from django.contrib import admin
+from posthog.admin.mixins import QueryTaggingMixin
 
 from posthog.admin.paginators.no_count_paginator import NoCountPaginator
 
 
-class PersonAdmin(admin.ModelAdmin):
+class PersonAdmin(QueryTaggingMixin, admin.ModelAdmin):
     show_full_result_count = False  # prevent count() queries to show the no of filtered results
     paginator = NoCountPaginator  # prevent count() queries and return a fix page count instead
     list_display = (

--- a/posthog/admin/mixins.py
+++ b/posthog/admin/mixins.py
@@ -1,0 +1,45 @@
+from django.db import models
+
+
+class QueryTaggingMixin:
+    """
+    Mixin to add SQL comment tags to queries originating from Django admin
+    """
+
+    query_tag_prefix: str = "django_admin"
+
+    def _get_model_name(self) -> str:
+        return self.model._meta.model_name.lower()
+
+    def _add_query_tag(self, queryset: models.QuerySet, operation: str, **kwargs) -> models.QuerySet:
+        model_name = self._get_model_name()
+
+        tag_parts = [f"source={self.query_tag_prefix}", f"model={model_name}", f"operation={operation}"]
+
+        for key, value in kwargs.items():
+            if value:
+                clean_value = str(value).replace("'", "").replace("/*", "").replace("*/", "")[:20]
+                tag_parts.append(f"{key}='{clean_value}'")
+
+        tag_comment = "/* " + ",".join(tag_parts) + " */"
+
+        # apparently this is the best way to hack a query tag into a query via the django ORM
+        return queryset.extra(where=[f"1=1 {tag_comment}"])
+
+    def get_queryset(self, request):
+        queryset = super().get_queryset(request)
+
+        if request.GET.get("q"):
+            operation = "search"
+            search_term = request.GET.get("q", "")
+            queryset = self._add_query_tag(queryset, operation, term=search_term)
+        elif any(key not in ["o", "p", "q"] for key in request.GET.keys()):
+            operation = "filter"
+            filters = {k: v for k, v in request.GET.items() if k not in ["o", "p", "q"]}
+            filter_summary = f"{len(filters)} filters"
+            queryset = self._add_query_tag(queryset, operation, filters=filter_summary)
+        else:
+            operation = "list"
+            queryset = self._add_query_tag(queryset, operation)
+
+        return queryset

--- a/posthog/admin/mixins.py
+++ b/posthog/admin/mixins.py
@@ -1,4 +1,9 @@
 from django.db import models
+from typing import Protocol
+
+
+class AdminQuerySetProvider(Protocol):
+    def get_queryset(self, request) -> models.QuerySet: ...
 
 
 class QueryTaggingMixin:
@@ -26,7 +31,7 @@ class QueryTaggingMixin:
         # apparently this is the best way to hack a query tag into a query via the django ORM
         return queryset.extra(where=[f"1=1 {tag_comment}"])
 
-    def get_queryset(self, request):
+    def get_queryset(self: AdminQuerySetProvider, request):
         queryset = super().get_queryset(request)
 
         if request.GET.get("q"):

--- a/posthog/admin/mixins.py
+++ b/posthog/admin/mixins.py
@@ -3,6 +3,8 @@ from typing import Protocol
 
 
 class AdminQuerySetProvider(Protocol):
+    model: type[models.Model]
+
     def get_queryset(self, request) -> models.QuerySet: ...
 
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Queries generated/triggered from django admin are sneaky and hard to track down.

## Changes

Create a django admin mixin that tags a query with tags that pganalyze can parse. Add the mixin to the Persons django admin model.

## Did you write or update any docs for this change?

## How did you test this code?

I loaded the Persons page in django admin and checked the query logs from my local Postgres instance. Here is an example that would've caught an offensive query that was previously generated by loading this page:

2025-06-26 23:22:20.086 UTC [183034] LOG:  statement: SELECT DISTINCT "posthog_person"."version" FROM "posthog_person" WHERE (1=1 /* source=django_admin,model=person,operation=list */) ORDER BY "posthog_person"."version" ASC
