### PR TITLE
fix(cdp): Ordering of shutdown logic

### DIFF
--- a/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
@@ -172,9 +172,11 @@ export class CdpCyclotronWorker extends CdpConsumerBase {
     }
 
     public async stop() {
-        await super.stop()
         logger.info('🔄', 'Stopping cyclotron worker consumer')
         await this.cyclotronJobQueue.stop()
+
+        // IMPORTANT: super always comes last
+        await super.stop()
     }
 
     public isHealthy() {

--- a/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
@@ -305,6 +305,7 @@ export class CdpEventsConsumer extends CdpConsumerBase {
         logger.info('💤', 'Stopping cyclotron job queue...')
         await this.cyclotronJobQueue.stop()
         logger.info('💤', 'Stopping consumer...')
+        // IMPORTANT: super always comes last
         await super.stop()
         logger.info('💤', 'Consumer stopped!')
     }

--- a/plugin-server/src/cdp/consumers/cdp-source-webhooks.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-source-webhooks.consumer.ts
@@ -142,9 +142,10 @@ export class CdpSourceWebhooksConsumer extends CdpConsumerBase {
     }
 
     public async stop(): Promise<void> {
-        await super.stop()
         await this.cyclotronJobQueue.stop()
         await this.promiseScheduler.waitForAllSettled()
+        // IMPORTANT: super always comes last
+        await super.stop()
     }
 
     public isHealthy() {

--- a/plugin-server/src/cdp/services/job-queue/job-queue-kafka.ts
+++ b/plugin-server/src/cdp/services/job-queue/job-queue-kafka.ts
@@ -52,8 +52,12 @@ export class CyclotronJobQueueKafka {
         })
     }
 
-    public async stop() {
-        await Promise.all([this.kafkaConsumer?.disconnect(), this.kafkaProducer?.disconnect()])
+    public async stopConsumer() {
+        await this.kafkaConsumer?.disconnect()
+    }
+
+    public async stopProducer() {
+        await this.kafkaProducer?.disconnect()
     }
 
     public isHealthy() {

--- a/plugin-server/src/cdp/services/job-queue/job-queue-postgres.ts
+++ b/plugin-server/src/cdp/services/job-queue/job-queue-postgres.ts
@@ -80,6 +80,11 @@ export class CyclotronJobQueuePostgres {
         await this.cyclotronWorker?.disconnect()
     }
 
+    public async stopProducer() {
+        // NOTE: Currently doesn't do anything as there is no disconnect logic - just keeps the interfaces the same
+        return Promise.resolve()
+    }
+
     public isHealthy() {
         return this.getCyclotronWorker().isHealthy()
     }

--- a/plugin-server/src/cdp/services/job-queue/job-queue-postgres.ts
+++ b/plugin-server/src/cdp/services/job-queue/job-queue-postgres.ts
@@ -76,7 +76,7 @@ export class CyclotronJobQueuePostgres {
         await this.cyclotronWorker.connect((jobs) => this.consumeCyclotronJobs(jobs))
     }
 
-    public async stop() {
+    public async stopConsumer() {
         await this.cyclotronWorker?.disconnect()
     }
 

--- a/plugin-server/src/cdp/services/job-queue/job-queue.ts
+++ b/plugin-server/src/cdp/services/job-queue/job-queue.ts
@@ -139,7 +139,11 @@ export class CyclotronJobQueue {
     }
 
     public async stop() {
-        await Promise.all([this.jobQueuePostgres.stop(), this.jobQueueKafka.stop()])
+        // Important - first shut down the consumers so we aren't processing anything
+        await Promise.all([this.jobQueuePostgres.stopConsumer(), this.jobQueueKafka.stopConsumer()])
+
+        // Only then do we shut down the producers
+        await this.jobQueueKafka.stopProducer()
     }
 
     public isHealthy() {

--- a/plugin-server/src/cdp/services/job-queue/job-queue.ts
+++ b/plugin-server/src/cdp/services/job-queue/job-queue.ts
@@ -143,7 +143,7 @@ export class CyclotronJobQueue {
         await Promise.all([this.jobQueuePostgres.stopConsumer(), this.jobQueueKafka.stopConsumer()])
 
         // Only then do we shut down the producers
-        await this.jobQueueKafka.stopProducer()
+        await Promise.all([this.jobQueuePostgres.stopProducer(), this.jobQueueKafka.stopProducer()])
     }
 
     public isHealthy() {


### PR DESCRIPTION
## Problem

Found some errors due to the producers being shutdown before the consumers (meaning we could consume a message and try to produce a result after the producer is shutdown).

This led to unhandled errors and messier shutdowns.

## Changes

* Swaps the logic around so we are always shutting down consumers first.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
