### PR TITLE
feat: add tracing for clickhouse queries

### DIFF
--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -27,7 +27,7 @@ from posthog.exceptions import ClickhouseAtCapacity
 from posthog.settings import CLICKHOUSE_PER_TEAM_QUERY_SETTINGS, TEST, API_QUERIES_ON_ONLINE_CLUSTER
 from posthog.temporal.common.clickhouse import update_query_tags_with_temporal_info
 from posthog.utils import generate_short_id, patchable
-from posthog.clickhouse.client.tracing import trace_clickhouse_query_decorator, add_clickhouse_span_attributes
+from posthog.clickhouse.client.tracing import trace_clickhouse_query_decorator
 from opentelemetry import trace
 
 QUERY_STARTED_COUNTER = Counter(
@@ -159,7 +159,7 @@ def sync_execute(
     if workload == Workload.DEFAULT:
         workload = get_default_clickhouse_workload_type()
 
-    add_clickhouse_span_attributes(trace.get_current_span(), final_workload=workload.value)
+    trace.get_current_span().set_attribute("clickhouse.final_workload", workload.value)
 
     if team_id is not None:
         tags.team_id = team_id

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -192,7 +192,6 @@ def sync_execute(
             # more variable latency and a higher likelihood of query failures - but offline workloads should be tolerant to
             # these disruptions
             settings["use_hedged_requests"] = "0"
-
         start_time = perf_counter()
         try:
             QUERY_STARTED_COUNTER.labels(
@@ -200,7 +199,6 @@ def sync_execute(
                 access_method=tags.access_method or "other",
                 chargeable=str(tags.chargeable or "0"),
             ).inc()
-
             with sync_client or get_client_from_pool(workload, team_id, readonly, ch_user) as client:
                 result = client.execute(
                     prepared_sql,
@@ -211,7 +209,6 @@ def sync_execute(
                 )
                 if "INSERT INTO" in prepared_sql and client.last_query.progress.written_rows > 0:
                     result = client.last_query.progress.written_rows
-
         except Exception as e:
             exception_type = ch_error_type(e)
             QUERY_ERROR_COUNTER.labels(

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -180,8 +180,9 @@ def sync_execute(
     update_query_tags_with_temporal_info()
 
     # Add tracing context manager
+    # codeql: suppress[py/sql-injection] - This is tracing, not SQL execution
     with trace_clickhouse_query(
-        query=prepared_sql,
+        query=prepared_sql,  # This is for observability only
         args=prepared_args,
         workload=workload,
         team_id=team_id,

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -27,6 +27,7 @@ from posthog.exceptions import ClickhouseAtCapacity
 from posthog.settings import CLICKHOUSE_PER_TEAM_QUERY_SETTINGS, TEST, API_QUERIES_ON_ONLINE_CLUSTER
 from posthog.temporal.common.clickhouse import update_query_tags_with_temporal_info
 from posthog.utils import generate_short_id, patchable
+from posthog.clickhouse.client.tracing import trace_clickhouse_query
 
 QUERY_STARTED_COUNTER = Counter(
     "posthog_clickhouse_query_sent",
@@ -178,68 +179,89 @@ def sync_execute(
     # update tags if inside temporal (should not)
     update_query_tags_with_temporal_info()
 
-    while True:
-        settings = {
-            **core_settings,
-            "log_comment": tags.to_json(),
-            "query_id": query_id,
-        }
-        if workload == Workload.OFFLINE:
-            # disabling hedged requests for offline queries reduces the likelihood of these queries bleeding over into the
-            # online resource pool when the offline resource pool is under heavy load. this comes at the cost of higher and
-            # more variable latency and a higher likelihood of query failures - but offline workloads should be tolerant to
-            # these disruptions
-            settings["use_hedged_requests"] = "0"
-        start_time = perf_counter()
-        try:
-            QUERY_STARTED_COUNTER.labels(
-                team_id=str(team_id or ""),
-                access_method=tags.access_method or "other",
-                chargeable=str(tags.chargeable or "0"),
-            ).inc()
-            with sync_client or get_client_from_pool(workload, team_id, readonly, ch_user) as client:
-                result = client.execute(
-                    prepared_sql,
-                    params=prepared_args,
-                    settings=settings,
-                    with_column_types=with_column_types,
-                    query_id=query_id,
-                )
-                if "INSERT INTO" in prepared_sql and client.last_query.progress.written_rows > 0:
-                    result = client.last_query.progress.written_rows
-        except Exception as e:
-            exception_type = ch_error_type(e)
-            QUERY_ERROR_COUNTER.labels(
-                exception_type=exception_type,
-                query_type=query_type,
-                workload=workload.value if workload else "None",
-                chargeable=str(tags.chargeable or "0"),
-            ).inc()
-            err = wrap_query_error(e)
-            if isinstance(err, ClickhouseAtCapacity) and is_personal_api_key and workload == Workload.OFFLINE:
-                workload = Workload.ONLINE
-                tags.clickhouse_exception_type = exception_type
-                tags.workload = str(workload)
-                continue
-            raise err from e
-        finally:
-            execution_time = perf_counter() - start_time
+    # Add tracing context manager
+    with trace_clickhouse_query(
+        query=prepared_sql,
+        args=prepared_args,
+        workload=workload,
+        team_id=team_id,
+        readonly=readonly,
+        ch_user=ch_user,
+        query_type=query_type,
+        query_id=query_id,
+    ) as span:
+        while True:
+            settings = {
+                **core_settings,
+                "log_comment": tags.to_json(),
+                "query_id": query_id,
+            }
+            if workload == Workload.OFFLINE:
+                # disabling hedged requests for offline queries reduces the likelihood of these queries bleeding over into the
+                # online resource pool when the offline resource pool is under heavy load. this comes at the cost of higher and
+                # more variable latency and a higher likelihood of query failures - but offline workloads should be tolerant to
+                # these disruptions
+                settings["use_hedged_requests"] = "0"
 
-            QUERY_FINISHED_COUNTER.labels(
-                team_id=str(team_id or ""),
-                access_method=tags.access_method or "other",
-                chargeable=str(tags.chargeable or "0"),
-            ).inc()
+            start_time = perf_counter()
+            try:
+                QUERY_STARTED_COUNTER.labels(
+                    team_id=str(team_id or ""),
+                    access_method=tags.access_method or "other",
+                    chargeable=str(tags.chargeable or "0"),
+                ).inc()
 
-            if query_counter := getattr(thread_local_storage, "query_counter", None):
-                query_counter.total_query_time += execution_time
+                with sync_client or get_client_from_pool(workload, team_id, readonly, ch_user) as client:
+                    result = client.execute(
+                        prepared_sql,
+                        params=prepared_args,
+                        settings=settings,
+                        with_column_types=with_column_types,
+                        query_id=query_id,
+                    )
+                    if "INSERT INTO" in prepared_sql and client.last_query.progress.written_rows > 0:
+                        result = client.last_query.progress.written_rows
 
-            if app_settings.SHELL_PLUS_PRINT_SQL:
-                print("Execution time: %.6fs" % (execution_time,))  # noqa T201
+                    # Add result info to span
+                    if span.is_recording():
+                        if isinstance(result, list | tuple):
+                            span.set_attribute("clickhouse.result_rows", len(result))
+                        elif isinstance(result, int):
+                            span.set_attribute("clickhouse.written_rows", result)
 
-        break
+            except Exception as e:
+                exception_type = ch_error_type(e)
+                QUERY_ERROR_COUNTER.labels(
+                    exception_type=exception_type,
+                    query_type=query_type,
+                    workload=workload.value if workload else "None",
+                    chargeable=str(tags.chargeable or "0"),
+                ).inc()
+                err = wrap_query_error(e)
+                if isinstance(err, ClickhouseAtCapacity) and is_personal_api_key and workload == Workload.OFFLINE:
+                    workload = Workload.ONLINE
+                    tags.clickhouse_exception_type = exception_type
+                    tags.workload = str(workload)
+                    continue
+                raise err from e
+            finally:
+                execution_time = perf_counter() - start_time
 
-    return result
+                QUERY_FINISHED_COUNTER.labels(
+                    team_id=str(team_id or ""),
+                    access_method=tags.access_method or "other",
+                    chargeable=str(tags.chargeable or "0"),
+                ).inc()
+
+                if query_counter := getattr(thread_local_storage, "query_counter", None):
+                    query_counter.total_query_time += execution_time
+
+                if app_settings.SHELL_PLUS_PRINT_SQL:
+                    print("Execution time: %.6fs" % (execution_time,))  # noqa T201
+
+            break
+
+        return result
 
 
 def query_with_columns(

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -159,9 +159,7 @@ def sync_execute(
     if workload == Workload.DEFAULT:
         workload = get_default_clickhouse_workload_type()
 
-    # Add the final workload to the span
-    if trace.get_current_span().is_recording():
-        add_clickhouse_span_attributes(trace.get_current_span(), final_workload=workload.value)
+    add_clickhouse_span_attributes(trace.get_current_span(), final_workload=workload.value)
 
     if team_id is not None:
         tags.team_id = team_id

--- a/posthog/clickhouse/client/test/test_tracing.py
+++ b/posthog/clickhouse/client/test/test_tracing.py
@@ -3,7 +3,11 @@ from unittest.mock import Mock, patch, MagicMock
 from opentelemetry.trace import Status, StatusCode
 from clickhouse_driver.errors import ServerException
 
-from posthog.clickhouse.client.tracing import trace_clickhouse_query, add_clickhouse_span_attributes
+from posthog.clickhouse.client.tracing import (
+    trace_clickhouse_query,
+    add_clickhouse_span_attributes,
+    trace_clickhouse_query_decorator,
+)
 from posthog.clickhouse.client.connection import Workload, ClickHouseUser
 from posthog.settings import CLICKHOUSE_DATABASE, CLICKHOUSE_HOST
 
@@ -322,3 +326,253 @@ class TestAddClickhouseSpanAttributes:
 
         # Verify no attributes were set
         assert mock_span.set_attribute.call_count == 0
+
+
+class TestTraceClickhouseQueryDecorator:
+    """Test the trace_clickhouse_query_decorator decorator"""
+
+    def test_decorator_success(self):
+        """Test decorator with successful function execution"""
+
+        @trace_clickhouse_query_decorator
+        def test_function(
+            query, args=None, workload=Workload.DEFAULT, team_id=None, readonly=False, ch_user=ClickHouseUser.DEFAULT
+        ):
+            return [{"result": "success"}]
+
+        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
+            mock_span = Mock()
+            mock_span.is_recording.return_value = True
+
+            mock_context = MagicMock()
+            mock_context.__enter__.return_value = mock_span
+            mock_context.__exit__.return_value = None
+
+            mock_tracer = Mock()
+            mock_tracer.start_as_current_span.return_value = mock_context
+            mock_trace.get_tracer.return_value = mock_tracer
+
+            result = test_function(
+                "SELECT 1",
+                {"param": "value"},
+                workload=Workload.ONLINE,
+                team_id=123,
+                readonly=True,
+                ch_user=ClickHouseUser.APP,
+            )
+
+            # Verify result
+            assert result == [{"result": "success"}]
+
+            # Verify span attributes were set correctly
+            mock_span.set_attribute.assert_any_call("db.system", "clickhouse")
+            mock_span.set_attribute.assert_any_call("db.name", CLICKHOUSE_DATABASE)
+            mock_span.set_attribute.assert_any_call("db.user", ClickHouseUser.APP.value)
+            mock_span.set_attribute.assert_any_call("db.statement", "SELECT 1")
+            mock_span.set_attribute.assert_any_call("net.peer.name", CLICKHOUSE_HOST)
+            mock_span.set_attribute.assert_any_call("net.peer.port", 9000)
+            mock_span.set_attribute.assert_any_call("span.kind", "client")
+            mock_span.set_attribute.assert_any_call("clickhouse.workload", Workload.ONLINE.value)
+            mock_span.set_attribute.assert_any_call("clickhouse.team_id", "123")
+            mock_span.set_attribute.assert_any_call("clickhouse.readonly", True)
+            mock_span.set_attribute.assert_any_call("clickhouse.query_type", "Other")
+            mock_span.set_attribute.assert_any_call("clickhouse.args_count", 1)
+            mock_span.set_attribute.assert_any_call("clickhouse.args_keys", ["param"])
+            mock_span.set_attribute.assert_any_call("clickhouse.result_rows", 1)
+            mock_span.set_attribute.assert_any_call("clickhouse.success", True)
+
+            # Verify success status
+            status_call = mock_span.set_status.call_args[0][0]
+            assert isinstance(status_call, Status)
+            assert status_call.status_code == StatusCode.OK
+
+    def test_decorator_with_list_args(self):
+        """Test decorator with list/tuple arguments"""
+
+        @trace_clickhouse_query_decorator
+        def test_function(
+            query, args=None, workload=Workload.DEFAULT, team_id=None, readonly=False, ch_user=ClickHouseUser.DEFAULT
+        ):
+            return 5  # Simulate written rows
+
+        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
+            mock_span = Mock()
+            mock_span.is_recording.return_value = True
+
+            mock_context = MagicMock()
+            mock_context.__enter__.return_value = mock_span
+            mock_context.__exit__.return_value = None
+
+            mock_tracer = Mock()
+            mock_tracer.start_as_current_span.return_value = mock_context
+            mock_trace.get_tracer.return_value = mock_tracer
+
+            result = test_function("INSERT INTO table VALUES", [1, 2, 3])
+
+            # Verify result
+            assert result == 5
+
+            # Verify args_count is set for list args
+            mock_span.set_attribute.assert_any_call("clickhouse.args_count", 3)
+            mock_span.set_attribute.assert_any_call("clickhouse.written_rows", 5)
+
+    def test_decorator_with_no_args(self):
+        """Test decorator with no arguments"""
+
+        @trace_clickhouse_query_decorator
+        def test_function(
+            query, args=None, workload=Workload.DEFAULT, team_id=None, readonly=False, ch_user=ClickHouseUser.DEFAULT
+        ):
+            return []
+
+        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
+            mock_span = Mock()
+            mock_span.is_recording.return_value = True
+
+            mock_context = MagicMock()
+            mock_context.__enter__.return_value = mock_span
+            mock_context.__exit__.return_value = None
+
+            mock_tracer = Mock()
+            mock_tracer.start_as_current_span.return_value = mock_context
+            mock_trace.get_tracer.return_value = mock_tracer
+
+            result = test_function("SELECT 1")
+
+            # Verify result
+            assert result == []
+
+            # Verify no args-related attributes are set
+            args_calls = [call for call in mock_span.set_attribute.call_args_list if "args" in str(call)]
+            assert len(args_calls) == 0
+
+    def test_decorator_error_handling(self):
+        """Test decorator when function raises an exception"""
+
+        @trace_clickhouse_query_decorator
+        def test_function(
+            query, args=None, workload=Workload.DEFAULT, team_id=None, readonly=False, ch_user=ClickHouseUser.DEFAULT
+        ):
+            raise ServerException("Test error", code=500)
+
+        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
+            mock_span = Mock()
+            mock_span.is_recording.return_value = True
+
+            mock_context = MagicMock()
+            mock_context.__enter__.return_value = mock_span
+            mock_context.__exit__.return_value = None
+
+            mock_tracer = Mock()
+            mock_tracer.start_as_current_span.return_value = mock_context
+            mock_trace.get_tracer.return_value = mock_tracer
+
+            with pytest.raises(ServerException):
+                test_function("SELECT 1")
+
+            # Verify error attributes were set
+            mock_span.set_attribute.assert_any_call("clickhouse.success", False)
+            mock_span.set_attribute.assert_any_call("clickhouse.error_type", "ServerException")
+
+            # Check error message
+            found = False
+            for call in mock_span.set_attribute.call_args_list:
+                if call[0][0] == "clickhouse.error_message":
+                    found = True
+                    assert "Test error" in call[0][1]
+                    break
+            assert found, "clickhouse.error_message not set"
+
+            # Check StatusCode.ERROR
+            status_call = mock_span.set_status.call_args[0][0]
+            assert isinstance(status_call, Status)
+            assert status_call.status_code == StatusCode.ERROR
+            mock_span.record_exception.assert_called_once()
+
+    def test_decorator_default_values(self):
+        """Test decorator with default parameter values"""
+
+        @trace_clickhouse_query_decorator
+        def test_function(
+            query, args=None, workload=Workload.DEFAULT, team_id=None, readonly=False, ch_user=ClickHouseUser.DEFAULT
+        ):
+            return []
+
+        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
+            mock_span = Mock()
+            mock_span.is_recording.return_value = True
+
+            mock_context = MagicMock()
+            mock_context.__enter__.return_value = mock_span
+            mock_context.__exit__.return_value = None
+
+            mock_tracer = Mock()
+            mock_tracer.start_as_current_span.return_value = mock_context
+            mock_trace.get_tracer.return_value = mock_tracer
+
+            test_function("SELECT 1")
+
+            # Verify default values are used
+            mock_span.set_attribute.assert_any_call("clickhouse.workload", Workload.DEFAULT.value)
+            mock_span.set_attribute.assert_any_call("clickhouse.readonly", False)
+            mock_span.set_attribute.assert_any_call("clickhouse.query_type", "Other")
+            mock_span.set_attribute.assert_any_call("db.user", ClickHouseUser.DEFAULT.value)
+            mock_span.set_attribute.assert_any_call("clickhouse.team_id", "")
+
+    def test_decorator_execution_time(self):
+        """Test that execution time is recorded"""
+
+        @trace_clickhouse_query_decorator
+        def test_function(
+            query, args=None, workload=Workload.DEFAULT, team_id=None, readonly=False, ch_user=ClickHouseUser.DEFAULT
+        ):
+            return []
+
+        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
+            mock_span = Mock()
+            mock_span.is_recording.return_value = True
+
+            mock_context = MagicMock()
+            mock_context.__enter__.return_value = mock_span
+            mock_context.__exit__.return_value = None
+
+            mock_tracer = Mock()
+            mock_tracer.start_as_current_span.return_value = mock_context
+            mock_trace.get_tracer.return_value = mock_tracer
+
+            test_function("SELECT 1")
+
+            # Verify execution time was recorded
+            execution_time_calls = [
+                call for call in mock_span.set_attribute.call_args_list if "execution_time_ms" in str(call)
+            ]
+            assert len(execution_time_calls) == 1
+
+    def test_decorator_span_not_recording(self):
+        """Test behavior when span is not recording"""
+
+        @trace_clickhouse_query_decorator
+        def test_function(
+            query, args=None, workload=Workload.DEFAULT, team_id=None, readonly=False, ch_user=ClickHouseUser.DEFAULT
+        ):
+            return []
+
+        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
+            mock_span = Mock()
+            mock_span.is_recording.return_value = False
+
+            mock_context = MagicMock()
+            mock_context.__enter__.return_value = mock_span
+            mock_context.__exit__.return_value = None
+
+            mock_tracer = Mock()
+            mock_tracer.start_as_current_span.return_value = mock_context
+            mock_trace.get_tracer.return_value = mock_tracer
+
+            result = test_function("SELECT 1")
+
+            # Verify result is returned
+            assert result == []
+
+            # Verify no attributes were set
+            assert mock_span.set_attribute.call_count == 0

--- a/posthog/clickhouse/client/test/test_tracing.py
+++ b/posthog/clickhouse/client/test/test_tracing.py
@@ -52,7 +52,7 @@ class TestTraceClickhouseQueryDecorator:
             mock_span.set_attribute.assert_any_call("net.peer.name", CLICKHOUSE_HOST)
             mock_span.set_attribute.assert_any_call("net.peer.port", 9000)
             mock_span.set_attribute.assert_any_call("span.kind", "client")
-            mock_span.set_attribute.assert_any_call("clickhouse.workload", Workload.ONLINE.value)
+            mock_span.set_attribute.assert_any_call("clickhouse.initial_workload", Workload.ONLINE.value)
             mock_span.set_attribute.assert_any_call("clickhouse.team_id", "123")
             mock_span.set_attribute.assert_any_call("clickhouse.readonly", True)
             mock_span.set_attribute.assert_any_call("clickhouse.query_type", "Other")
@@ -193,7 +193,7 @@ class TestTraceClickhouseQueryDecorator:
             test_function("SELECT 1")
 
             # Verify default values are used
-            mock_span.set_attribute.assert_any_call("clickhouse.workload", Workload.DEFAULT.value)
+            mock_span.set_attribute.assert_any_call("clickhouse.initial_workload", Workload.DEFAULT.value)
             mock_span.set_attribute.assert_any_call("clickhouse.readonly", False)
             mock_span.set_attribute.assert_any_call("clickhouse.query_type", "Other")
             mock_span.set_attribute.assert_any_call("db.user", ClickHouseUser.DEFAULT.value)

--- a/posthog/clickhouse/client/test/test_tracing.py
+++ b/posthog/clickhouse/client/test/test_tracing.py
@@ -3,329 +3,9 @@ from unittest.mock import Mock, patch, MagicMock
 from opentelemetry.trace import Status, StatusCode
 from clickhouse_driver.errors import ServerException
 
-from posthog.clickhouse.client.tracing import (
-    trace_clickhouse_query,
-    add_clickhouse_span_attributes,
-    trace_clickhouse_query_decorator,
-)
+from posthog.clickhouse.client.tracing import trace_clickhouse_query_decorator, add_clickhouse_span_attributes
 from posthog.clickhouse.client.connection import Workload, ClickHouseUser
 from posthog.settings import CLICKHOUSE_DATABASE, CLICKHOUSE_HOST
-
-
-class TestTraceClickhouseQuery:
-    """Test the trace_clickhouse_query context manager"""
-
-    def test_basic_tracing_success(self):
-        """Test basic successful query tracing"""
-        query = "SELECT 1"
-        args = {"param": "value"}
-        team_id = 123
-        workload = Workload.ONLINE
-        ch_user = ClickHouseUser.APP
-        query_type = "test_query"
-        query_id = "test_123"
-
-        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
-            mock_span = Mock()
-            mock_span.is_recording.return_value = True
-
-            # Create a proper context manager mock
-            mock_context = MagicMock()
-            mock_context.__enter__.return_value = mock_span
-            mock_context.__exit__.return_value = None
-
-            mock_tracer = Mock()
-            mock_tracer.start_as_current_span.return_value = mock_context
-            mock_trace.get_tracer.return_value = mock_tracer
-
-            with trace_clickhouse_query(
-                query=query,
-                args=args,
-                workload=workload,
-                team_id=team_id,
-                readonly=True,
-                ch_user=ch_user,
-                query_type=query_type,
-                query_id=query_id,
-            ) as _:
-                # Simulate some work
-                pass
-
-            # Verify span attributes were set correctly
-            mock_span.set_attribute.assert_any_call("db.system", "clickhouse")
-            mock_span.set_attribute.assert_any_call("db.name", CLICKHOUSE_DATABASE)
-            mock_span.set_attribute.assert_any_call("db.user", ch_user.value)
-            mock_span.set_attribute.assert_any_call("db.statement", query)
-            mock_span.set_attribute.assert_any_call("net.peer.name", CLICKHOUSE_HOST)
-            mock_span.set_attribute.assert_any_call("net.peer.port", 9000)
-            mock_span.set_attribute.assert_any_call("span.kind", "client")
-            mock_span.set_attribute.assert_any_call("clickhouse.workload", workload.value)
-            mock_span.set_attribute.assert_any_call("clickhouse.team_id", str(team_id))
-            mock_span.set_attribute.assert_any_call("clickhouse.readonly", True)
-            mock_span.set_attribute.assert_any_call("clickhouse.query_type", query_type)
-            mock_span.set_attribute.assert_any_call("clickhouse.query_id", query_id)
-            mock_span.set_attribute.assert_any_call("clickhouse.args_count", 1)
-            mock_span.set_attribute.assert_any_call("clickhouse.args_keys", ["param"])
-
-            # Verify success attributes (check StatusCode, not object identity)
-            status_call = mock_span.set_status.call_args[0][0]
-            assert isinstance(status_call, Status)
-            assert status_call.status_code == StatusCode.OK
-
-    def test_tracing_with_list_args(self):
-        """Test tracing with list/tuple arguments"""
-        query = "INSERT INTO table VALUES"
-        args = [1, 2, 3]
-
-        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
-            mock_span = Mock()
-            mock_span.is_recording.return_value = True
-
-            mock_context = MagicMock()
-            mock_context.__enter__.return_value = mock_span
-            mock_context.__exit__.return_value = None
-
-            mock_tracer = Mock()
-            mock_tracer.start_as_current_span.return_value = mock_context
-            mock_trace.get_tracer.return_value = mock_tracer
-
-            with trace_clickhouse_query(query=query, args=args):
-                pass
-
-            # Verify args_count is set for list args
-            mock_span.set_attribute.assert_any_call("clickhouse.args_count", 3)
-
-    def test_tracing_with_no_args(self):
-        """Test tracing with no arguments"""
-        query = "SELECT 1"
-
-        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
-            mock_span = Mock()
-            mock_span.is_recording.return_value = True
-
-            mock_context = MagicMock()
-            mock_context.__enter__.return_value = mock_span
-            mock_context.__exit__.return_value = None
-
-            mock_tracer = Mock()
-            mock_tracer.start_as_current_span.return_value = mock_context
-            mock_trace.get_tracer.return_value = mock_tracer
-
-            with trace_clickhouse_query(query=query, args=None):
-                pass
-
-            # Verify no args-related attributes are set
-            args_calls = [call for call in mock_span.set_attribute.call_args_list if "args" in str(call)]
-            assert len(args_calls) == 0
-
-    def test_tracing_without_query_id(self):
-        """Test tracing without query_id"""
-        query = "SELECT 1"
-
-        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
-            mock_span = Mock()
-            mock_span.is_recording.return_value = True
-
-            mock_context = MagicMock()
-            mock_context.__enter__.return_value = mock_span
-            mock_context.__exit__.return_value = None
-
-            mock_tracer = Mock()
-            mock_tracer.start_as_current_span.return_value = mock_context
-            mock_trace.get_tracer.return_value = mock_tracer
-
-            with trace_clickhouse_query(query=query):
-                pass
-
-            # Verify query_id attribute is not set
-            query_id_calls = [call for call in mock_span.set_attribute.call_args_list if "query_id" in str(call)]
-            assert len(query_id_calls) == 0
-
-    def test_tracing_without_team_id(self):
-        """Test tracing without team_id"""
-        query = "SELECT 1"
-
-        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
-            mock_span = Mock()
-            mock_span.is_recording.return_value = True
-
-            mock_context = MagicMock()
-            mock_context.__enter__.return_value = mock_span
-            mock_context.__exit__.return_value = None
-
-            mock_tracer = Mock()
-            mock_tracer.start_as_current_span.return_value = mock_context
-            mock_trace.get_tracer.return_value = mock_tracer
-
-            with trace_clickhouse_query(query=query, team_id=None):
-                pass
-
-            # Verify team_id is set to empty string
-            mock_span.set_attribute.assert_any_call("clickhouse.team_id", "")
-
-    def test_tracing_execution_time(self):
-        """Test that execution time is recorded"""
-        query = "SELECT 1"
-
-        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
-            mock_span = Mock()
-            mock_span.is_recording.return_value = True
-
-            mock_context = MagicMock()
-            mock_context.__enter__.return_value = mock_span
-            mock_context.__exit__.return_value = None
-
-            mock_tracer = Mock()
-            mock_tracer.start_as_current_span.return_value = mock_context
-            mock_trace.get_tracer.return_value = mock_tracer
-
-            with trace_clickhouse_query(query=query):
-                # Simulate some work
-                pass
-
-            # Verify execution time was recorded
-            execution_time_calls = [
-                call for call in mock_span.set_attribute.call_args_list if "execution_time_ms" in str(call)
-            ]
-            assert len(execution_time_calls) == 1
-
-    def test_tracing_error_handling(self):
-        """Test tracing when an exception occurs"""
-        query = "SELECT 1"
-        test_exception = ServerException("Test error", code=500)
-
-        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
-            mock_span = Mock()
-            mock_span.is_recording.return_value = True
-
-            mock_context = MagicMock()
-            mock_context.__enter__.return_value = mock_span
-            mock_context.__exit__.return_value = None
-
-            mock_tracer = Mock()
-            mock_tracer.start_as_current_span.return_value = mock_context
-            mock_trace.get_tracer.return_value = mock_tracer
-
-            with pytest.raises(ServerException):
-                with trace_clickhouse_query(query=query):
-                    raise test_exception
-
-            # Verify error attributes were set
-            mock_span.set_attribute.assert_any_call("clickhouse.success", False)
-            mock_span.set_attribute.assert_any_call("clickhouse.error_type", "ServerException")
-            # Accept any error message, but check it contains the exception string
-            found = False
-            for call in mock_span.set_attribute.call_args_list:
-                if call[0][0] == "clickhouse.error_message":
-                    found = True
-                    assert "Test error" in call[0][1]
-                    break
-            assert found, "clickhouse.error_message not set"
-            # Check StatusCode.ERROR
-            status_call = mock_span.set_status.call_args[0][0]
-            assert isinstance(status_call, Status)
-            assert status_call.status_code == StatusCode.ERROR
-            mock_span.record_exception.assert_called_with(test_exception)
-
-    def test_tracing_span_not_recording(self):
-        """Test behavior when span is not recording"""
-        query = "SELECT 1"
-
-        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
-            mock_span = Mock()
-            mock_span.is_recording.return_value = False
-
-            mock_context = MagicMock()
-            mock_context.__enter__.return_value = mock_span
-            mock_context.__exit__.return_value = None
-
-            mock_tracer = Mock()
-            mock_tracer.start_as_current_span.return_value = mock_context
-            mock_trace.get_tracer.return_value = mock_tracer
-
-            with trace_clickhouse_query(query=query):
-                pass
-
-            # Verify no attributes were set
-            assert mock_span.set_attribute.call_count == 0
-
-    def test_tracing_yields_span(self):
-        """Test that the context manager yields the span"""
-        query = "SELECT 1"
-
-        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
-            mock_span = Mock()
-            mock_span.is_recording.return_value = True
-
-            mock_context = MagicMock()
-            mock_context.__enter__.return_value = mock_span
-            mock_context.__exit__.return_value = None
-
-            mock_tracer = Mock()
-            mock_tracer.start_as_current_span.return_value = mock_context
-            mock_trace.get_tracer.return_value = mock_tracer
-
-            with trace_clickhouse_query(query=query) as span:
-                assert span is mock_span
-
-    def test_tracing_default_values(self):
-        """Test tracing with default parameter values"""
-        query = "SELECT 1"
-
-        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
-            mock_span = Mock()
-            mock_span.is_recording.return_value = True
-
-            mock_context = MagicMock()
-            mock_context.__enter__.return_value = mock_span
-            mock_context.__exit__.return_value = None
-
-            mock_tracer = Mock()
-            mock_tracer.start_as_current_span.return_value = mock_context
-            mock_trace.get_tracer.return_value = mock_tracer
-
-            with trace_clickhouse_query(query=query):
-                pass
-
-            # Verify default values are used
-            mock_span.set_attribute.assert_any_call("clickhouse.workload", Workload.DEFAULT.value)
-            mock_span.set_attribute.assert_any_call("clickhouse.readonly", False)
-            mock_span.set_attribute.assert_any_call("clickhouse.query_type", "Other")
-            mock_span.set_attribute.assert_any_call("db.user", ClickHouseUser.DEFAULT.value)
-
-
-class TestAddClickhouseSpanAttributes:
-    """Test the add_clickhouse_span_attributes helper function"""
-
-    def test_add_attributes_recording_span(self):
-        """Test adding attributes to a recording span"""
-        mock_span = Mock()
-        mock_span.is_recording.return_value = True
-
-        add_clickhouse_span_attributes(mock_span, test_attr="test_value", another_attr=123)
-
-        mock_span.set_attribute.assert_any_call("clickhouse.test_attr", "test_value")
-        mock_span.set_attribute.assert_any_call("clickhouse.another_attr", 123)
-
-    def test_add_attributes_non_recording_span(self):
-        """Test adding attributes to a non-recording span"""
-        mock_span = Mock()
-        mock_span.is_recording.return_value = False
-
-        add_clickhouse_span_attributes(mock_span, test_attr="test_value")
-
-        # Verify no attributes were set
-        assert mock_span.set_attribute.call_count == 0
-
-    def test_add_attributes_no_attributes(self):
-        """Test adding no attributes"""
-        mock_span = Mock()
-        mock_span.is_recording.return_value = True
-
-        add_clickhouse_span_attributes(mock_span)
-
-        # Verify no attributes were set
-        assert mock_span.set_attribute.call_count == 0
 
 
 class TestTraceClickhouseQueryDecorator:
@@ -576,3 +256,37 @@ class TestTraceClickhouseQueryDecorator:
 
             # Verify no attributes were set
             assert mock_span.set_attribute.call_count == 0
+
+
+class TestAddClickhouseSpanAttributes:
+    """Test the add_clickhouse_span_attributes helper function"""
+
+    def test_add_attributes_recording_span(self):
+        """Test adding attributes to a recording span"""
+        mock_span = Mock()
+        mock_span.is_recording.return_value = True
+
+        add_clickhouse_span_attributes(mock_span, test_attr="test_value", another_attr=123)
+
+        mock_span.set_attribute.assert_any_call("clickhouse.test_attr", "test_value")
+        mock_span.set_attribute.assert_any_call("clickhouse.another_attr", 123)
+
+    def test_add_attributes_non_recording_span(self):
+        """Test adding attributes to a non-recording span"""
+        mock_span = Mock()
+        mock_span.is_recording.return_value = False
+
+        add_clickhouse_span_attributes(mock_span, test_attr="test_value")
+
+        # Verify no attributes were set
+        assert mock_span.set_attribute.call_count == 0
+
+    def test_add_attributes_no_attributes(self):
+        """Test adding no attributes"""
+        mock_span = Mock()
+        mock_span.is_recording.return_value = True
+
+        add_clickhouse_span_attributes(mock_span)
+
+        # Verify no attributes were set
+        assert mock_span.set_attribute.call_count == 0

--- a/posthog/clickhouse/client/test/test_tracing.py
+++ b/posthog/clickhouse/client/test/test_tracing.py
@@ -1,0 +1,324 @@
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from opentelemetry.trace import Status, StatusCode
+from clickhouse_driver.errors import ServerException
+
+from posthog.clickhouse.client.tracing import trace_clickhouse_query, add_clickhouse_span_attributes
+from posthog.clickhouse.client.connection import Workload, ClickHouseUser
+from posthog.settings import CLICKHOUSE_DATABASE, CLICKHOUSE_HOST
+
+
+class TestTraceClickhouseQuery:
+    """Test the trace_clickhouse_query context manager"""
+
+    def test_basic_tracing_success(self):
+        """Test basic successful query tracing"""
+        query = "SELECT 1"
+        args = {"param": "value"}
+        team_id = 123
+        workload = Workload.ONLINE
+        ch_user = ClickHouseUser.APP
+        query_type = "test_query"
+        query_id = "test_123"
+
+        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
+            mock_span = Mock()
+            mock_span.is_recording.return_value = True
+
+            # Create a proper context manager mock
+            mock_context = MagicMock()
+            mock_context.__enter__.return_value = mock_span
+            mock_context.__exit__.return_value = None
+
+            mock_tracer = Mock()
+            mock_tracer.start_as_current_span.return_value = mock_context
+            mock_trace.get_tracer.return_value = mock_tracer
+
+            with trace_clickhouse_query(
+                query=query,
+                args=args,
+                workload=workload,
+                team_id=team_id,
+                readonly=True,
+                ch_user=ch_user,
+                query_type=query_type,
+                query_id=query_id,
+            ) as _:
+                # Simulate some work
+                pass
+
+            # Verify span attributes were set correctly
+            mock_span.set_attribute.assert_any_call("db.system", "clickhouse")
+            mock_span.set_attribute.assert_any_call("db.name", CLICKHOUSE_DATABASE)
+            mock_span.set_attribute.assert_any_call("db.user", ch_user.value)
+            mock_span.set_attribute.assert_any_call("db.statement", query)
+            mock_span.set_attribute.assert_any_call("net.peer.name", CLICKHOUSE_HOST)
+            mock_span.set_attribute.assert_any_call("net.peer.port", 9000)
+            mock_span.set_attribute.assert_any_call("span.kind", "client")
+            mock_span.set_attribute.assert_any_call("clickhouse.workload", workload.value)
+            mock_span.set_attribute.assert_any_call("clickhouse.team_id", str(team_id))
+            mock_span.set_attribute.assert_any_call("clickhouse.readonly", True)
+            mock_span.set_attribute.assert_any_call("clickhouse.query_type", query_type)
+            mock_span.set_attribute.assert_any_call("clickhouse.query_id", query_id)
+            mock_span.set_attribute.assert_any_call("clickhouse.args_count", 1)
+            mock_span.set_attribute.assert_any_call("clickhouse.args_keys", ["param"])
+
+            # Verify success attributes (check StatusCode, not object identity)
+            status_call = mock_span.set_status.call_args[0][0]
+            assert isinstance(status_call, Status)
+            assert status_call.status_code == StatusCode.OK
+
+    def test_tracing_with_list_args(self):
+        """Test tracing with list/tuple arguments"""
+        query = "INSERT INTO table VALUES"
+        args = [1, 2, 3]
+
+        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
+            mock_span = Mock()
+            mock_span.is_recording.return_value = True
+
+            mock_context = MagicMock()
+            mock_context.__enter__.return_value = mock_span
+            mock_context.__exit__.return_value = None
+
+            mock_tracer = Mock()
+            mock_tracer.start_as_current_span.return_value = mock_context
+            mock_trace.get_tracer.return_value = mock_tracer
+
+            with trace_clickhouse_query(query=query, args=args):
+                pass
+
+            # Verify args_count is set for list args
+            mock_span.set_attribute.assert_any_call("clickhouse.args_count", 3)
+
+    def test_tracing_with_no_args(self):
+        """Test tracing with no arguments"""
+        query = "SELECT 1"
+
+        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
+            mock_span = Mock()
+            mock_span.is_recording.return_value = True
+
+            mock_context = MagicMock()
+            mock_context.__enter__.return_value = mock_span
+            mock_context.__exit__.return_value = None
+
+            mock_tracer = Mock()
+            mock_tracer.start_as_current_span.return_value = mock_context
+            mock_trace.get_tracer.return_value = mock_tracer
+
+            with trace_clickhouse_query(query=query, args=None):
+                pass
+
+            # Verify no args-related attributes are set
+            args_calls = [call for call in mock_span.set_attribute.call_args_list if "args" in str(call)]
+            assert len(args_calls) == 0
+
+    def test_tracing_without_query_id(self):
+        """Test tracing without query_id"""
+        query = "SELECT 1"
+
+        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
+            mock_span = Mock()
+            mock_span.is_recording.return_value = True
+
+            mock_context = MagicMock()
+            mock_context.__enter__.return_value = mock_span
+            mock_context.__exit__.return_value = None
+
+            mock_tracer = Mock()
+            mock_tracer.start_as_current_span.return_value = mock_context
+            mock_trace.get_tracer.return_value = mock_tracer
+
+            with trace_clickhouse_query(query=query):
+                pass
+
+            # Verify query_id attribute is not set
+            query_id_calls = [call for call in mock_span.set_attribute.call_args_list if "query_id" in str(call)]
+            assert len(query_id_calls) == 0
+
+    def test_tracing_without_team_id(self):
+        """Test tracing without team_id"""
+        query = "SELECT 1"
+
+        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
+            mock_span = Mock()
+            mock_span.is_recording.return_value = True
+
+            mock_context = MagicMock()
+            mock_context.__enter__.return_value = mock_span
+            mock_context.__exit__.return_value = None
+
+            mock_tracer = Mock()
+            mock_tracer.start_as_current_span.return_value = mock_context
+            mock_trace.get_tracer.return_value = mock_tracer
+
+            with trace_clickhouse_query(query=query, team_id=None):
+                pass
+
+            # Verify team_id is set to empty string
+            mock_span.set_attribute.assert_any_call("clickhouse.team_id", "")
+
+    def test_tracing_execution_time(self):
+        """Test that execution time is recorded"""
+        query = "SELECT 1"
+
+        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
+            mock_span = Mock()
+            mock_span.is_recording.return_value = True
+
+            mock_context = MagicMock()
+            mock_context.__enter__.return_value = mock_span
+            mock_context.__exit__.return_value = None
+
+            mock_tracer = Mock()
+            mock_tracer.start_as_current_span.return_value = mock_context
+            mock_trace.get_tracer.return_value = mock_tracer
+
+            with trace_clickhouse_query(query=query):
+                # Simulate some work
+                pass
+
+            # Verify execution time was recorded
+            execution_time_calls = [
+                call for call in mock_span.set_attribute.call_args_list if "execution_time_ms" in str(call)
+            ]
+            assert len(execution_time_calls) == 1
+
+    def test_tracing_error_handling(self):
+        """Test tracing when an exception occurs"""
+        query = "SELECT 1"
+        test_exception = ServerException("Test error", code=500)
+
+        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
+            mock_span = Mock()
+            mock_span.is_recording.return_value = True
+
+            mock_context = MagicMock()
+            mock_context.__enter__.return_value = mock_span
+            mock_context.__exit__.return_value = None
+
+            mock_tracer = Mock()
+            mock_tracer.start_as_current_span.return_value = mock_context
+            mock_trace.get_tracer.return_value = mock_tracer
+
+            with pytest.raises(ServerException):
+                with trace_clickhouse_query(query=query):
+                    raise test_exception
+
+            # Verify error attributes were set
+            mock_span.set_attribute.assert_any_call("clickhouse.success", False)
+            mock_span.set_attribute.assert_any_call("clickhouse.error_type", "ServerException")
+            # Accept any error message, but check it contains the exception string
+            found = False
+            for call in mock_span.set_attribute.call_args_list:
+                if call[0][0] == "clickhouse.error_message":
+                    found = True
+                    assert "Test error" in call[0][1]
+                    break
+            assert found, "clickhouse.error_message not set"
+            # Check StatusCode.ERROR
+            status_call = mock_span.set_status.call_args[0][0]
+            assert isinstance(status_call, Status)
+            assert status_call.status_code == StatusCode.ERROR
+            mock_span.record_exception.assert_called_with(test_exception)
+
+    def test_tracing_span_not_recording(self):
+        """Test behavior when span is not recording"""
+        query = "SELECT 1"
+
+        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
+            mock_span = Mock()
+            mock_span.is_recording.return_value = False
+
+            mock_context = MagicMock()
+            mock_context.__enter__.return_value = mock_span
+            mock_context.__exit__.return_value = None
+
+            mock_tracer = Mock()
+            mock_tracer.start_as_current_span.return_value = mock_context
+            mock_trace.get_tracer.return_value = mock_tracer
+
+            with trace_clickhouse_query(query=query):
+                pass
+
+            # Verify no attributes were set
+            assert mock_span.set_attribute.call_count == 0
+
+    def test_tracing_yields_span(self):
+        """Test that the context manager yields the span"""
+        query = "SELECT 1"
+
+        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
+            mock_span = Mock()
+            mock_span.is_recording.return_value = True
+
+            mock_context = MagicMock()
+            mock_context.__enter__.return_value = mock_span
+            mock_context.__exit__.return_value = None
+
+            mock_tracer = Mock()
+            mock_tracer.start_as_current_span.return_value = mock_context
+            mock_trace.get_tracer.return_value = mock_tracer
+
+            with trace_clickhouse_query(query=query) as span:
+                assert span is mock_span
+
+    def test_tracing_default_values(self):
+        """Test tracing with default parameter values"""
+        query = "SELECT 1"
+
+        with patch("posthog.clickhouse.client.tracing.trace") as mock_trace:
+            mock_span = Mock()
+            mock_span.is_recording.return_value = True
+
+            mock_context = MagicMock()
+            mock_context.__enter__.return_value = mock_span
+            mock_context.__exit__.return_value = None
+
+            mock_tracer = Mock()
+            mock_tracer.start_as_current_span.return_value = mock_context
+            mock_trace.get_tracer.return_value = mock_tracer
+
+            with trace_clickhouse_query(query=query):
+                pass
+
+            # Verify default values are used
+            mock_span.set_attribute.assert_any_call("clickhouse.workload", Workload.DEFAULT.value)
+            mock_span.set_attribute.assert_any_call("clickhouse.readonly", False)
+            mock_span.set_attribute.assert_any_call("clickhouse.query_type", "Other")
+            mock_span.set_attribute.assert_any_call("db.user", ClickHouseUser.DEFAULT.value)
+
+
+class TestAddClickhouseSpanAttributes:
+    """Test the add_clickhouse_span_attributes helper function"""
+
+    def test_add_attributes_recording_span(self):
+        """Test adding attributes to a recording span"""
+        mock_span = Mock()
+        mock_span.is_recording.return_value = True
+
+        add_clickhouse_span_attributes(mock_span, test_attr="test_value", another_attr=123)
+
+        mock_span.set_attribute.assert_any_call("clickhouse.test_attr", "test_value")
+        mock_span.set_attribute.assert_any_call("clickhouse.another_attr", 123)
+
+    def test_add_attributes_non_recording_span(self):
+        """Test adding attributes to a non-recording span"""
+        mock_span = Mock()
+        mock_span.is_recording.return_value = False
+
+        add_clickhouse_span_attributes(mock_span, test_attr="test_value")
+
+        # Verify no attributes were set
+        assert mock_span.set_attribute.call_count == 0
+
+    def test_add_attributes_no_attributes(self):
+        """Test adding no attributes"""
+        mock_span = Mock()
+        mock_span.is_recording.return_value = True
+
+        add_clickhouse_span_attributes(mock_span)
+
+        # Verify no attributes were set
+        assert mock_span.set_attribute.call_count == 0

--- a/posthog/clickhouse/client/tracing.py
+++ b/posthog/clickhouse/client/tracing.py
@@ -1,8 +1,6 @@
 import logging
-from contextlib import contextmanager
 from functools import wraps
 from time import perf_counter
-from typing import Any, Optional
 
 from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
@@ -105,77 +103,6 @@ def trace_clickhouse_query_decorator(func):
                 raise
 
     return wrapper
-
-
-@contextmanager
-def trace_clickhouse_query(
-    query: str,
-    args: Optional[Any] = None,
-    workload: Workload = Workload.DEFAULT,
-    team_id: Optional[int] = None,
-    readonly: bool = False,
-    ch_user: ClickHouseUser = ClickHouseUser.DEFAULT,
-    query_type: str = "Other",
-    query_id: Optional[str] = None,
-):
-    """
-    Context manager for tracing ClickHouse queries with OpenTelemetry.
-    """
-    tracer = trace.get_tracer(__name__)
-
-    with tracer.start_as_current_span("clickhouse.query") as span:
-        if span.is_recording():
-            # Set standard database attributes
-            span.set_attribute("db.system", "clickhouse")
-            span.set_attribute("db.name", CLICKHOUSE_DATABASE)
-            span.set_attribute("db.user", ch_user.value)
-            span.set_attribute("db.statement", query)
-
-            # Set network attributes
-            span.set_attribute("net.peer.name", CLICKHOUSE_HOST)
-            span.set_attribute("net.peer.port", 9000)  # Default ClickHouse port
-
-            # Set span kind
-            span.set_attribute("span.kind", "client")
-
-            # Add custom attributes for PostHog-specific context
-            span.set_attribute("clickhouse.workload", workload.value)
-            span.set_attribute("clickhouse.team_id", str(team_id or ""))
-            span.set_attribute("clickhouse.readonly", readonly)
-            span.set_attribute("clickhouse.query_type", query_type)
-            if query_id:
-                span.set_attribute("clickhouse.query_id", query_id)
-
-            # Add args info if present
-            if args:
-                if isinstance(args, dict):
-                    span.set_attribute("clickhouse.args_count", len(args))
-                    span.set_attribute("clickhouse.args_keys", list(args.keys()))
-                elif isinstance(args, list | tuple):
-                    span.set_attribute("clickhouse.args_count", len(args))
-
-        start_time = perf_counter()
-        try:
-            yield span
-            execution_time = perf_counter() - start_time
-
-            if span.is_recording():
-                span.set_attribute("clickhouse.execution_time_ms", execution_time * 1000)
-                span.set_attribute("clickhouse.success", True)
-                span.set_status(Status(StatusCode.OK))
-
-        except Exception as e:
-            execution_time = perf_counter() - start_time
-
-            if span.is_recording():
-                span.set_attribute("clickhouse.execution_time_ms", execution_time * 1000)
-                span.set_attribute("clickhouse.success", False)
-                span.set_attribute("clickhouse.error_type", type(e).__name__)
-                span.set_attribute("clickhouse.error_message", str(e))
-                span.set_status(Status(StatusCode.ERROR, str(e)))
-                span.record_exception(e)
-
-            raise
 
 
 def add_clickhouse_span_attributes(span, **attributes):

--- a/posthog/clickhouse/client/tracing.py
+++ b/posthog/clickhouse/client/tracing.py
@@ -1,0 +1,92 @@
+import logging
+from contextlib import contextmanager
+from time import perf_counter
+from typing import Any, Optional
+
+from opentelemetry import trace
+from opentelemetry.trace import Status, StatusCode
+
+from posthog.clickhouse.client.connection import Workload, ClickHouseUser
+from posthog.settings import CLICKHOUSE_DATABASE, CLICKHOUSE_HOST
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def trace_clickhouse_query(
+    query: str,
+    args: Optional[Any] = None,
+    workload: Workload = Workload.DEFAULT,
+    team_id: Optional[int] = None,
+    readonly: bool = False,
+    ch_user: ClickHouseUser = ClickHouseUser.DEFAULT,
+    query_type: str = "Other",
+    query_id: Optional[str] = None,
+):
+    """
+    Context manager for tracing ClickHouse queries with OpenTelemetry.
+    """
+    tracer = trace.get_tracer(__name__)
+
+    with tracer.start_as_current_span("clickhouse.query") as span:
+        if span.is_recording():
+            # Set standard database attributes
+            span.set_attribute("db.system", "clickhouse")
+            span.set_attribute("db.name", CLICKHOUSE_DATABASE)
+            span.set_attribute("db.user", ch_user.value)
+            span.set_attribute("db.statement", query)
+
+            # Set network attributes
+            span.set_attribute("net.peer.name", CLICKHOUSE_HOST)
+            span.set_attribute("net.peer.port", 9000)  # Default ClickHouse port
+
+            # Set span kind
+            span.set_attribute("span.kind", "client")
+
+            # Add custom attributes for PostHog-specific context
+            span.set_attribute("clickhouse.workload", workload.value)
+            span.set_attribute("clickhouse.team_id", str(team_id or ""))
+            span.set_attribute("clickhouse.readonly", readonly)
+            span.set_attribute("clickhouse.query_type", query_type)
+            if query_id:
+                span.set_attribute("clickhouse.query_id", query_id)
+
+            # Add args info if present
+            if args:
+                if isinstance(args, dict):
+                    span.set_attribute("clickhouse.args_count", len(args))
+                    span.set_attribute("clickhouse.args_keys", list(args.keys()))
+                elif isinstance(args, list | tuple):
+                    span.set_attribute("clickhouse.args_count", len(args))
+
+        start_time = perf_counter()
+        try:
+            yield span
+            execution_time = perf_counter() - start_time
+
+            if span.is_recording():
+                span.set_attribute("clickhouse.execution_time_ms", execution_time * 1000)
+                span.set_attribute("clickhouse.success", True)
+                span.set_status(Status(StatusCode.OK))
+
+        except Exception as e:
+            execution_time = perf_counter() - start_time
+
+            if span.is_recording():
+                span.set_attribute("clickhouse.execution_time_ms", execution_time * 1000)
+                span.set_attribute("clickhouse.success", False)
+                span.set_attribute("clickhouse.error_type", type(e).__name__)
+                span.set_attribute("clickhouse.error_message", str(e))
+                span.set_status(Status(StatusCode.ERROR, str(e)))
+                span.record_exception(e)
+
+            raise
+
+
+def add_clickhouse_span_attributes(span, **attributes):
+    """
+    Helper function to add custom attributes to the current ClickHouse span.
+    """
+    if span.is_recording():
+        for key, value in attributes.items():
+            span.set_attribute(f"clickhouse.{key}", value)

--- a/posthog/clickhouse/client/tracing.py
+++ b/posthog/clickhouse/client/tracing.py
@@ -19,11 +19,6 @@ def trace_clickhouse_query_decorator(func):
     - Result tracking
     - Exception handling
     - Execution time measurement
-
-    Note: This decorator captures the initial workload value passed to the function.
-    The workload can change during function execution based on various conditions
-    (e.g., API keys, celery tasks, etc.). If you need the final workload value
-    in traces, you can add it manually using add_clickhouse_span_attributes().
     """
 
     @wraps(func)

--- a/posthog/clickhouse/client/tracing.py
+++ b/posthog/clickhouse/client/tracing.py
@@ -1,5 +1,6 @@
 import logging
 from contextlib import contextmanager
+from functools import wraps
 from time import perf_counter
 from typing import Any, Optional
 
@@ -10,6 +11,100 @@ from posthog.clickhouse.client.connection import Workload, ClickHouseUser
 from posthog.settings import CLICKHOUSE_DATABASE, CLICKHOUSE_HOST
 
 logger = logging.getLogger(__name__)
+
+
+def trace_clickhouse_query_decorator(func):
+    """
+    Decorator to add ClickHouse query tracing to sync_execute function.
+    This decorator handles the complex tracing requirements including:
+    - Workload changes during retries
+    - Result tracking
+    - Exception handling
+    - Execution time measurement
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        # Extract parameters for tracing - handle both positional and keyword args
+        query = args[0] if args else kwargs.get("query")
+        args_param = kwargs.get("args")
+        workload = kwargs.get("workload", Workload.DEFAULT)
+        team_id = kwargs.get("team_id")
+        readonly = kwargs.get("readonly", False)
+        ch_user = kwargs.get("ch_user", ClickHouseUser.DEFAULT)
+
+        # Handle positional arguments for sync_execute signature
+        # sync_execute has: query, args=None, settings=None, with_column_types=False, flush=True, *, workload, team_id, readonly, sync_client, ch_user
+        if len(args) > 1:
+            args_param = args[1]
+
+        # The keyword-only arguments (after *) must be passed as kwargs
+        # So we only extract from kwargs for these parameters
+
+        tracer = trace.get_tracer(__name__)
+
+        with tracer.start_as_current_span("clickhouse.query") as span:
+            if span.is_recording():
+                # Set standard database attributes
+                span.set_attribute("db.system", "clickhouse")
+                span.set_attribute("db.name", CLICKHOUSE_DATABASE)
+                span.set_attribute("db.user", ch_user.value)
+                span.set_attribute("db.statement", query)
+
+                # Set network attributes
+                span.set_attribute("net.peer.name", CLICKHOUSE_HOST)
+                span.set_attribute("net.peer.port", 9000)  # Default ClickHouse port
+
+                # Set span kind
+                span.set_attribute("span.kind", "client")
+
+                # Add custom attributes for PostHog-specific context
+                span.set_attribute("clickhouse.workload", workload.value)
+                span.set_attribute("clickhouse.team_id", str(team_id or ""))
+                span.set_attribute("clickhouse.readonly", readonly)
+                span.set_attribute("clickhouse.query_type", "Other")  # Will be updated by function
+
+                # Add args info if present
+                if args_param:
+                    if isinstance(args_param, dict):
+                        span.set_attribute("clickhouse.args_count", len(args_param))
+                        span.set_attribute("clickhouse.args_keys", list(args_param.keys()))
+                    elif isinstance(args_param, list | tuple):
+                        span.set_attribute("clickhouse.args_count", len(args_param))
+
+            start_time = perf_counter()
+            try:
+                # Call the original function
+                result = func(*args, **kwargs)
+                execution_time = perf_counter() - start_time
+
+                if span.is_recording():
+                    span.set_attribute("clickhouse.execution_time_ms", execution_time * 1000)
+                    span.set_attribute("clickhouse.success", True)
+                    span.set_status(Status(StatusCode.OK))
+
+                    # Add result info to span
+                    if isinstance(result, list | tuple):
+                        span.set_attribute("clickhouse.result_rows", len(result))
+                    elif isinstance(result, int):
+                        span.set_attribute("clickhouse.written_rows", result)
+
+                return result
+
+            except Exception as e:
+                execution_time = perf_counter() - start_time
+
+                if span.is_recording():
+                    span.set_attribute("clickhouse.execution_time_ms", execution_time * 1000)
+                    span.set_attribute("clickhouse.success", False)
+                    span.set_attribute("clickhouse.error_type", type(e).__name__)
+                    span.set_attribute("clickhouse.error_message", str(e))
+                    span.set_status(Status(StatusCode.ERROR, str(e)))
+                    span.record_exception(e)
+
+                raise
+
+    return wrapper
 
 
 @contextmanager


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Add dedicated spans for clickhouse queries so that those show up in our traces. 

## Changes

- add spans for clickhouse queries via decorator
- include basic information, add additional span logic for showing the final workload

## Did you write or update any docs for this change?

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

- unit tests + manual