### PR TITLE
chore: add team/product tags to temporal workloads and assistant queries

### DIFF
--- a/ee/hogai/graph/query_executor/query_executor.py
+++ b/ee/hogai/graph/query_executor/query_executor.py
@@ -7,6 +7,7 @@ from ee.hogai.graph.query_executor.format import (
     SQLResultsFormatter,
     TrendsResultsFormatter,
 )
+from posthog.clickhouse.query_tagging import tags_context, Product
 from posthog.models.team.team import Team
 from posthog.schema import (
     AssistantFunnelsQuery,
@@ -83,7 +84,8 @@ class AssistantQueryExecutor:
         Raises:
             Exception: If query execution fails with descriptive error messages
         """
-        response_dict = self._execute_query(query, execution_mode)
+        with tags_context(product=Product.MAX_AI, team_id=self._team.pk, org_id=self._team.organization_id):
+            response_dict = self._execute_query(query, execution_mode)
 
         try:
             # Attempt to format results using query-specific formatters

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -20,10 +20,14 @@ class AccessMethod(StrEnum):
 
 
 class Product(StrEnum):
-    BATCH_EXPORT = "batch_export"
-    PRODUCT_ANALYTICS = "product_analytics"
-    FEATURE_FLAGS = "feature_flags"
     API = "api"
+    BATCH_EXPORT = "batch_export"
+    FEATURE_FLAGS = "feature_flags"
+    MAX_AI = "max_ai"
+    SESSION_SUMMARY = "session_summary"
+    PRODUCT_ANALYTICS = "product_analytics"
+    REPLAY = "replay"
+    WAREHOUSE = "warehouse"
 
 
 class Feature(StrEnum):

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -24,9 +24,9 @@ class Product(StrEnum):
     BATCH_EXPORT = "batch_export"
     FEATURE_FLAGS = "feature_flags"
     MAX_AI = "max_ai"
-    SESSION_SUMMARY = "session_summary"
     PRODUCT_ANALYTICS = "product_analytics"
     REPLAY = "replay"
+    SESSION_SUMMARY = "session_summary"
     WAREHOUSE = "warehouse"
 
 

--- a/posthog/temporal/ai/session_summary/shared.py
+++ b/posthog/temporal/ai/session_summary/shared.py
@@ -10,6 +10,8 @@ from ee.session_recordings.session_summary.summarize_session import (
 import structlog
 from ee.session_recordings.session_summary import ExceptionToRetry
 import temporalio
+
+from posthog.clickhouse.query_tagging import tag_queries, Product
 from posthog.redis import get_client
 
 logger = structlog.get_logger(__name__)
@@ -34,6 +36,7 @@ class SingleSessionSummaryInputs:
 @temporalio.activity.defn
 async def fetch_session_data_activity(inputs: SingleSessionSummaryInputs) -> str | None:
     """Fetch data from DB for a single session and store in Redis (to avoid hitting Temporal memory limits), return Redis key"""
+    tag_queries(team_id=inputs.team_id, user_id=inputs.user_id, product=Product.SESSION_SUMMARY)
     summary_data = await prepare_data_for_single_session_summary(
         session_id=inputs.session_id,
         user_id=inputs.user_id,

--- a/posthog/temporal/ai/sync_vectors.py
+++ b/posthog/temporal/ai/sync_vectors.py
@@ -17,6 +17,7 @@ from openai import APIError as OpenAIAPIError
 
 from ee.hogai.summarizers.chains import abatch_summarize_actions
 from ee.hogai.utils.embeddings import aembed_documents, get_async_azure_embeddings_client
+from posthog.clickhouse.query_tagging import tag_queries, Product
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Action
 from posthog.models.ai.pg_embeddings import INSERT_BULK_PG_EMBEDDINGS_SQL
@@ -252,6 +253,7 @@ async def batch_embed_and_sync_actions(inputs: BatchEmbedAndSyncActionsInputs) -
     Returns:
         Outputs for the activity: whether there are more actions to sync.
     """
+    tag_queries(product=Product.MAX_AI)
     workflow_start_dt = datetime.fromisoformat(inputs.start_dt)
 
     query = (

--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -301,7 +301,7 @@ def get_temporal_context() -> dict[str, str | int]:
     * workflow_type: The name of the Temporal Workflow.
 
     We attempt to fetch the context from the activity information. If undefined, an empty dict
-    is returned. When running this in an activity the context will be defined.
+    is returned. When running this in an activity, the context will be defined.
     """
     activity_info = attempt_to_fetch_activity_info()
 

--- a/posthog/temporal/delete_persons/delete_persons_workflow.py
+++ b/posthog/temporal/delete_persons/delete_persons_workflow.py
@@ -10,6 +10,7 @@ import temporalio.common
 import temporalio.workflow
 from django.conf import settings
 
+from posthog.clickhouse.query_tagging import tag_queries
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_internal_logger
@@ -130,6 +131,7 @@ async def delete_persons_activity(inputs: DeletePersonsActivityInputs) -> tuple[
     """Run queries to delete persons and associated entities."""
     async with Heartbeater():
         logger = get_internal_logger()
+        tag_queries(team_id=inputs.team_id)
 
         select_query = SELECT_QUERY.format(
             person_ids_filter=f"AND id IN {tuple(inputs.person_ids)}" if inputs.person_ids else ""

--- a/posthog/temporal/session_recordings/compare_recording_console_logs_workflow.py
+++ b/posthog/temporal/session_recordings/compare_recording_console_logs_workflow.py
@@ -9,6 +9,7 @@ import temporalio.common
 import temporalio.workflow
 
 from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.query_tagging import tag_queries, Product
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_internal_logger
@@ -100,6 +101,7 @@ async def compare_recording_console_logs_activity(inputs: CompareRecordingConsol
     """Compare console logs between v1 and v2 storage for a sample of sessions."""
     logger = get_internal_logger()
     start_time = dt.datetime.now()
+    tag_queries(product=Product.REPLAY)
 
     await logger.ainfo(
         "Starting console logs comparison activity",

--- a/posthog/temporal/session_recordings/compare_recording_events_workflow.py
+++ b/posthog/temporal/session_recordings/compare_recording_events_workflow.py
@@ -9,6 +9,7 @@ import temporalio.common
 import temporalio.workflow
 from asgiref.sync import sync_to_async
 
+from posthog.clickhouse.query_tagging import tag_queries, Product
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_internal_logger
@@ -46,6 +47,7 @@ async def compare_recording_snapshots_activity(inputs: CompareRecordingSnapshots
         "Starting snapshot comparison activity for session %s",
         inputs.session_id,
     )
+    tag_queries(team_id=inputs.team_id, product=Product.REPLAY)
 
     async with Heartbeater():
         team = await sync_to_async(Team.objects.get)(id=inputs.team_id)

--- a/posthog/temporal/session_recordings/compare_recording_metadata_workflow.py
+++ b/posthog/temporal/session_recordings/compare_recording_metadata_workflow.py
@@ -10,6 +10,7 @@ import temporalio.common
 import temporalio.workflow
 
 from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.query_tagging import tag_queries, Product
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_internal_logger
@@ -127,6 +128,7 @@ async def compare_recording_metadata_activity(inputs: CompareRecordingMetadataAc
     """Compare session recording metadata between storage backends."""
     logger = get_internal_logger()
     start_time = dt.datetime.now()
+    tag_queries(product=Product.REPLAY)
     await logger.ainfo(
         "Starting comparison activity for time range %s to %s%s%s",
         inputs.started_after,

--- a/posthog/temporal/session_recordings/compare_sampled_recording_events_workflow.py
+++ b/posthog/temporal/session_recordings/compare_sampled_recording_events_workflow.py
@@ -9,6 +9,7 @@ import temporalio.common
 import temporalio.workflow
 from asgiref.sync import sync_to_async
 
+from posthog.clickhouse.query_tagging import tag_queries, Product
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_internal_logger
@@ -53,6 +54,7 @@ async def compare_sampled_recording_events_activity(inputs: CompareSampledRecord
     """Compare recording events between v1 and v2 storage for a sample of sessions."""
     logger = get_internal_logger()
     start_time = dt.datetime.now()
+    tag_queries(product=Product.REPLAY)
 
     await logger.ainfo(
         "Starting sampled events comparison activity",


### PR DESCRIPTION
## Problem

Chargeback for ClickHouse use.

## Changes

Add `product` tag to temporal queries

## Did you write or update any docs for this change?

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [X] No docs needed for this change