### PR TITLE
fix(experiments): tweak exposure criteria text

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExposureCriteria.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExposureCriteria.tsx
@@ -103,7 +103,7 @@ export function ExposureCriteriaModal(): JSX.Element {
                     <div className="text-secondary text-sm leading-relaxed mt-1">
                         If you can't rely on the <LemonTag>$feature_flag_called</LemonTag> event, you can select a
                         custom event to signal that users reached the part of your app where the experiment runs. You
-                        can also filter out users you would like to exlucde from the analysis.
+                        can also filter out users you would like to exclude from the analysis.
                     </div>
                 </LemonButton>
             </div>

--- a/frontend/src/scenes/experiments/ExperimentView/ExposureCriteria.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExposureCriteria.tsx
@@ -74,9 +74,8 @@ export function ExposureCriteriaModal(): JSX.Element {
                         )}
                     </div>
                     <div className="text-secondary text-sm leading-relaxed mt-1">
-                        Uses the number of unique users who trigger the <LemonTag>$feature_flag_called</LemonTag> event
-                        as your exposure count. This is the recommended setting for most experiments, as it accurately
-                        tracks variant exposure.
+                        When a <LemonTag>$feature_flag_called</LemonTag> event is recorded, a user is considered{' '}
+                        <strong>exposed</strong> to the experiment and included in the analysis.
                     </div>
                 </LemonButton>
                 <LemonButton
@@ -102,8 +101,9 @@ export function ExposureCriteriaModal(): JSX.Element {
                         )}
                     </div>
                     <div className="text-secondary text-sm leading-relaxed mt-1">
-                        Define your own exposure metric for specific use cases, such as counting by sessions instead of
-                        users. This gives you full control but requires careful configuration.
+                        If you for some reason can't rely on the <LemonTag>$feature_flag_called</LemonTag> event, you
+                        can select a custom event to signal that users reached the part of your app where the experiment
+                        runs.
                     </div>
                 </LemonButton>
             </div>

--- a/frontend/src/scenes/experiments/ExperimentView/ExposureCriteria.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExposureCriteria.tsx
@@ -101,9 +101,9 @@ export function ExposureCriteriaModal(): JSX.Element {
                         )}
                     </div>
                     <div className="text-secondary text-sm leading-relaxed mt-1">
-                        If you for some reason can't rely on the <LemonTag>$feature_flag_called</LemonTag> event, you
-                        can select a custom event to signal that users reached the part of your app where the experiment
-                        runs.
+                        If you can't rely on the <LemonTag>$feature_flag_called</LemonTag> event, you can select a
+                        custom event to signal that users reached the part of your app where the experiment runs. You
+                        can also filter out users you would like to exlucde from the analysis.
                     </div>
                 </LemonButton>
             </div>

--- a/frontend/src/scenes/experiments/MetricsView/new/ResultDetails.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/ResultDetails.tsx
@@ -43,17 +43,17 @@ export function ResultDetails({
             render: (_, item) => <div className="font-semibold">{item.key}</div>,
         },
         {
+            key: 'total-users',
+            title: 'Total users',
+            render: (_, item) => humanFriendlyNumber(item.number_of_samples),
+        },
+        {
             key: 'value',
             title: metric.metric_type === 'mean' ? 'Mean' : 'Conversion rate',
             render: (_, item) => {
                 const value = item.sum / item.number_of_samples
                 return metric.metric_type === 'mean' ? value.toFixed(2) : `${(value * 100).toFixed(2)}%`
             },
-        },
-        {
-            key: 'samples',
-            title: 'Samples',
-            render: (_, item) => humanFriendlyNumber(item.number_of_samples),
         },
         {
             key: 'statistical_measure',


### PR DESCRIPTION
## Problem
The old text was a copy from the old engine and was no longer a good description of the feature.

## Changes
Update exposure criteria options text to something better.
![Screenshot 2025-06-27 at 11 32 15](https://github.com/user-attachments/assets/ab2df9df-4ae7-4802-97b4-31f03c045d1a)

Also rename "Sample" to "Total users" in the summary table.
![Screenshot 2025-06-27 at 11 32 25](https://github.com/user-attachments/assets/e1d59b7b-3ecb-46d9-9418-d88c5e5ae4f0)

## How did you test this code?
- 👀 
