### PR TITLE
fix: Add retry loop to test event generation

### DIFF
--- a/posthog/temporal/tests/utils/events.py
+++ b/posthog/temporal/tests/utils/events.py
@@ -1,11 +1,14 @@
 """Test utilities that deal with test event generation."""
 
+import asyncio
 import datetime as dt
 import itertools
 import json
 import random
 import typing
 import uuid
+
+import aiohttp.client_exceptions
 
 from posthog.models.raw_sessions.sql import RAW_SESSION_TABLE_BACKFILL_SELECT_SQL
 from posthog.temporal.common.clickhouse import ClickHouseClient
@@ -104,44 +107,59 @@ async def insert_event_values_in_clickhouse(
     client: ClickHouseClient, events: list[EventValues], table: str = "sharded_events", insert_sessions: bool = False
 ):
     """Execute an insert query to insert provided EventValues into sharded_events."""
-    await client.execute_query(
-        f"""
-        INSERT INTO `{table}` (
-            uuid,
-            event,
-            timestamp,
-            _timestamp,
-            person_id,
-            team_id,
-            properties,
-            elements_chain,
-            distinct_id,
-            inserted_at,
-            created_at,
-            person_properties
-        )
-        VALUES
-        """,
-        *[
-            (
-                event["uuid"],
-                event["event"],
-                event["timestamp"],
-                event["_timestamp"],
-                event["person_id"],
-                event["team_id"],
-                json.dumps(event["properties"]) if isinstance(event["properties"], dict) else event["properties"],
-                event["elements_chain"],
-                event["distinct_id"],
-                event["inserted_at"],
-                event["created_at"],
-                json.dumps(event["person_properties"])
-                if isinstance(event["person_properties"], dict)
-                else event["person_properties"],
-            )
-            for event in events
-        ],
-    )
+    for event in events:
+        max_attempts = 3
+        attempt = 1
+        backoff = 2
+
+        while True:
+            try:
+                await client.execute_query(
+                    f"""
+                INSERT INTO `{table}` (
+                    uuid,
+                    event,
+                    timestamp,
+                    _timestamp,
+                    person_id,
+                    team_id,
+                    properties,
+                    elements_chain,
+                    distinct_id,
+                    inserted_at,
+                    created_at,
+                    person_properties
+                )
+                VALUES
+                """,
+                    *[
+                        (
+                            event["uuid"],
+                            event["event"],
+                            event["timestamp"],
+                            event["_timestamp"],
+                            event["person_id"],
+                            event["team_id"],
+                            json.dumps(event["properties"])
+                            if isinstance(event["properties"], dict)
+                            else event["properties"],
+                            event["elements_chain"],
+                            event["distinct_id"],
+                            event["inserted_at"],
+                            event["created_at"],
+                            json.dumps(event["person_properties"])
+                            if isinstance(event["person_properties"], dict)
+                            else event["person_properties"],
+                        )
+                    ],
+                )
+            except aiohttp.client_exceptions.ClientOSError:
+                if attempt >= max_attempts:
+                    raise
+
+                attempt += 1
+                await asyncio.sleep(backoff)
+                backoff = backoff**2
 
 
 async def insert_sessions_in_clickhouse(client: ClickHouseClient, table: str = "sharded_events"):

--- a/posthog/temporal/tests/utils/events.py
+++ b/posthog/temporal/tests/utils/events.py
@@ -107,59 +107,60 @@ async def insert_event_values_in_clickhouse(
     client: ClickHouseClient, events: list[EventValues], table: str = "sharded_events", insert_sessions: bool = False
 ):
     """Execute an insert query to insert provided EventValues into sharded_events."""
-    for event in events:
-        max_attempts = 3
-        attempt = 1
-        backoff = 2
+    max_attempts = 3
+    attempt = 1
+    backoff = 2
 
-        while True:
-            try:
-                await client.execute_query(
-                    f"""
-                INSERT INTO `{table}` (
-                    uuid,
-                    event,
-                    timestamp,
-                    _timestamp,
-                    person_id,
-                    team_id,
-                    properties,
-                    elements_chain,
-                    distinct_id,
-                    inserted_at,
-                    created_at,
-                    person_properties
-                )
-                VALUES
-                """,
-                    *[
-                        (
-                            event["uuid"],
-                            event["event"],
-                            event["timestamp"],
-                            event["_timestamp"],
-                            event["person_id"],
-                            event["team_id"],
-                            json.dumps(event["properties"])
-                            if isinstance(event["properties"], dict)
-                            else event["properties"],
-                            event["elements_chain"],
-                            event["distinct_id"],
-                            event["inserted_at"],
-                            event["created_at"],
-                            json.dumps(event["person_properties"])
-                            if isinstance(event["person_properties"], dict)
-                            else event["person_properties"],
-                        )
-                    ],
-                )
-            except aiohttp.client_exceptions.ClientOSError:
-                if attempt >= max_attempts:
-                    raise
+    while True:
+        try:
+            await client.execute_query(
+                f"""
+            INSERT INTO `{table}` (
+                uuid,
+                event,
+                timestamp,
+                _timestamp,
+                person_id,
+                team_id,
+                properties,
+                elements_chain,
+                distinct_id,
+                inserted_at,
+                created_at,
+                person_properties
+            )
+            VALUES
+            """,
+                *[
+                    (
+                        event["uuid"],
+                        event["event"],
+                        event["timestamp"],
+                        event["_timestamp"],
+                        event["person_id"],
+                        event["team_id"],
+                        json.dumps(event["properties"])
+                        if isinstance(event["properties"], dict)
+                        else event["properties"],
+                        event["elements_chain"],
+                        event["distinct_id"],
+                        event["inserted_at"],
+                        event["created_at"],
+                        json.dumps(event["person_properties"])
+                        if isinstance(event["person_properties"], dict)
+                        else event["person_properties"],
+                    )
+                    for event in events
+                ],
+            )
+            break  # Success, exit the loop
+        except aiohttp.client_exceptions.ClientOSError:
+            if attempt >= max_attempts:
+                raise
 
-                attempt += 1
-                await asyncio.sleep(backoff)
-                backoff = backoff**2
+            attempt += 1
+            await asyncio.sleep(backoff)
+            backoff = backoff**2
 
 
 async def insert_sessions_in_clickhouse(client: ClickHouseClient, table: str = "sharded_events"):


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Occasionally, when generating test events for batch export tests we will run into Broken Pipe errors. It's not clear what's causing the connection to drop to the local ClickHouse instance, but a simple retry should aid with the problem.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Add a retry loop when generating test events.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
