### PR TITLE
feat(cdp): Parallelise consumer filtering

### DIFF
--- a/plugin-server/src/cdp/consumers/cdp-base.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-base.consumer.ts
@@ -67,16 +67,6 @@ export abstract class CdpConsumerBase {
         return res
     }
 
-    protected async runManyWithHeartbeat<T, R>(items: T[], func: (item: T) => Promise<R> | R): Promise<R[]> {
-        // Helper function to ensure that looping over lots of hog functions doesn't block up the event loop, leading to healthcheck failures
-        const results = []
-
-        for (const item of items) {
-            results.push(await this.runWithHeartbeat(() => func(item)))
-        }
-        return results
-    }
-
     public async start(): Promise<void> {
         // NOTE: This is only for starting shared services
         await Promise.all([

--- a/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
@@ -86,19 +86,22 @@ export class CdpEventsConsumer extends CdpConsumerBase {
             ])
 
             const possibleInvocations = (
-                await this.runManyWithHeartbeat(invocationGlobals, async (globals) => {
-                    const teamHogFunctions = hogFunctionsByTeam[globals.project.id]
+                await Promise.all(
+                    invocationGlobals.map(async (globals) => {
+                        const teamHogFunctions = hogFunctionsByTeam[globals.project.id]
 
-                    const { invocations, metrics, logs } = await this.hogExecutor.buildHogFunctionInvocations(
-                        teamHogFunctions,
-                        globals
-                    )
+                        const { invocations, metrics, logs } = await this.hogExecutor.buildHogFunctionInvocations(
+                            teamHogFunctions,
+                            globals
+                        )
 
-                    this.hogFunctionMonitoringService.queueAppMetrics(metrics, 'hog_function')
-                    this.hogFunctionMonitoringService.queueLogs(logs, 'hog_function')
+                        this.hogFunctionMonitoringService.queueAppMetrics(metrics, 'hog_function')
+                        this.hogFunctionMonitoringService.queueLogs(logs, 'hog_function')
+                        this.heartbeat()
 
-                    return invocations
-                })
+                        return invocations
+                    })
+                )
             ).flat()
 
             const states = await this.hogWatcher.getStates(possibleInvocations.map((x) => x.hogFunction.id))
@@ -186,19 +189,22 @@ export class CdpEventsConsumer extends CdpConsumerBase {
             const hogFlowsByTeam = await this.hogFlowManager.getHogFlowsForTeams(teamsToLoad)
 
             const possibleInvocations = (
-                await this.runManyWithHeartbeat(invocationGlobals, async (globals) => {
-                    const teamHogFlows = hogFlowsByTeam[globals.project.id]
+                await Promise.all(
+                    invocationGlobals.map(async (globals) => {
+                        const teamHogFlows = hogFlowsByTeam[globals.project.id]
 
-                    const { invocations, metrics, logs } = await this.hogFlowExecutor.buildHogFlowInvocations(
-                        teamHogFlows,
-                        globals
-                    )
+                        const { invocations, metrics, logs } = await this.hogFlowExecutor.buildHogFlowInvocations(
+                            teamHogFlows,
+                            globals
+                        )
 
-                    this.hogFunctionMonitoringService.queueAppMetrics(metrics, 'hog_flow')
-                    this.hogFunctionMonitoringService.queueLogs(logs, 'hog_flow')
+                        this.hogFunctionMonitoringService.queueAppMetrics(metrics, 'hog_flow')
+                        this.hogFunctionMonitoringService.queueLogs(logs, 'hog_flow')
+                        this.heartbeat()
 
-                    return invocations
-                })
+                        return invocations
+                    })
+                )
             ).flat()
 
             const states = await this.hogWatcher.getStates(possibleInvocations.map((x) => x.hogFlow.id))

--- a/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
@@ -51,8 +51,8 @@ export class CdpEventsConsumer extends CdpConsumerBase {
         }
 
         const invocationsToBeQueued = [
-            ...(await this.runWithHeartbeat(() => this.createHogFunctionInvocations(invocationGlobals))),
-            ...(await this.runWithHeartbeat(() => this.createHogFlowInvocations(invocationGlobals))),
+            ...(await this.createHogFunctionInvocations(invocationGlobals)),
+            ...(await this.createHogFlowInvocations(invocationGlobals)),
         ]
 
         return {

--- a/plugin-server/src/cdp/services/hog-executor.service.ts
+++ b/plugin-server/src/cdp/services/hog-executor.service.ts
@@ -28,7 +28,6 @@ import { LiquidRenderer } from '../utils/liquid'
 export const MAX_ASYNC_STEPS = 5
 export const MAX_HOG_LOGS = 25
 export const MAX_LOG_LENGTH = 10000
-
 export const EXTEND_OBJECT_KEY = '$$_extend_object'
 
 const hogExecutionDuration = new Histogram({
@@ -274,7 +273,6 @@ export class HogExecutorService {
 
                 await Promise.all(
                     hogFunction.mappings.map(async (mapping) => {
-                        // For mappings we want to match against both the mapping filters and the global filters
                         if (!(await _filterHogFunction(hogFunction, mapping.filters, filterGlobals))) {
                             return
                         }

--- a/plugin-server/src/cdp/services/hog-executor.service.ts
+++ b/plugin-server/src/cdp/services/hog-executor.service.ts
@@ -253,11 +253,13 @@ export class HogExecutorService {
 
         await Promise.all(
             hogFunctions.map(async (hogFunction) => {
+                // We always check the top level filters
+                if (!(await _filterHogFunction(hogFunction, hogFunction.filters, filterGlobals))) {
+                    return
+                }
+
                 // Check for non-mapping functions first
                 if (!hogFunction.mappings) {
-                    if (!(await _filterHogFunction(hogFunction, hogFunction.filters, filterGlobals))) {
-                        return
-                    }
                     const invocation = await _buildInvocation(hogFunction, {
                         ...hogFunction.inputs,
                         ...hogFunction.encrypted_inputs,
@@ -273,10 +275,7 @@ export class HogExecutorService {
                 await Promise.all(
                     hogFunction.mappings.map(async (mapping) => {
                         // For mappings we want to match against both the mapping filters and the global filters
-                        if (
-                            !(await _filterHogFunction(hogFunction, hogFunction.filters, filterGlobals)) ||
-                            !(await _filterHogFunction(hogFunction, mapping.filters, filterGlobals))
-                        ) {
+                        if (!(await _filterHogFunction(hogFunction, mapping.filters, filterGlobals))) {
                             return
                         }
 

--- a/plugin-server/src/cdp/services/job-queue/job-queue-postgres.ts
+++ b/plugin-server/src/cdp/services/job-queue/job-queue-postgres.ts
@@ -68,7 +68,7 @@ export class CyclotronJobQueuePostgres {
             },
             queueName: this.queue,
             includeVmState: true, // NOTE: We used to omit the vmstate but given we can requeue to kafka we need it
-            batchMaxSize: this.config.CDP_CYCLOTRON_BATCH_SIZE,
+            batchMaxSize: this.config.CONSUMER_BATCH_SIZE, // Use the common value
             pollDelayMs: this.config.CDP_CYCLOTRON_BATCH_DELAY_MS,
             includeEmptyBatches: true,
             shouldCompressVmState: this.config.CDP_CYCLOTRON_COMPRESS_VM_STATE,

--- a/plugin-server/src/cdp/services/job-queue/job-queue.ts
+++ b/plugin-server/src/cdp/services/job-queue/job-queue.ts
@@ -80,7 +80,7 @@ export class CyclotronJobQueue {
     ): Promise<{ backgroundTask: Promise<any> }> {
         cyclotronBatchUtilizationGauge
             .labels({ queue: this.queue, source })
-            .set(invocations.length / this.config.CDP_CYCLOTRON_BATCH_SIZE)
+            .set(invocations.length / this.config.CONSUMER_BATCH_SIZE)
 
         const result = await this._consumeBatch!(invocations)
         counterJobsProcessed.inc({ queue: this.queue, source }, invocations.length)

--- a/plugin-server/src/cdp/utils/hog-exec.test.ts
+++ b/plugin-server/src/cdp/utils/hog-exec.test.ts
@@ -1,0 +1,136 @@
+import { compileHog } from '../templates/compiler'
+import { execHog } from './hog-exec'
+
+describe('hog-exec', () => {
+    describe('thread relief', () => {
+        jest.setTimeout(10000)
+        let interval: NodeJS.Timeout
+
+        let lastCheck = Date.now()
+        let longestDelay = 0
+        const blockTime = 100
+
+        beforeEach(() => {
+            jest.spyOn(Date, 'now').mockRestore()
+            jest.useRealTimers()
+
+            interval = setInterval(() => {
+                // Sets up an interval loop so we can see how long the longest delay between ticks is
+                longestDelay = Math.max(longestDelay, Date.now() - lastCheck)
+                lastCheck = Date.now()
+            }, 0)
+        })
+
+        afterEach(() => {
+            clearInterval(interval)
+        })
+
+        it('should process batches in a way that does not block the main thread', async () => {
+            const evilFunctionCode = await compileHog(`
+                fn fibonacci(number) {
+                    print('I AM FIBONACCI. ')
+                    if (number < 2) {
+                        return number;
+                    } else {
+                        return fibonacci(number - 1) + fibonacci(number - 2);
+                    }
+                }
+                print(f'fib {fibonacci(64)}');
+            `)
+
+            const numberToTest = 10
+
+            const results = await Promise.all(
+                Array.from({ length: numberToTest }, () =>
+                    execHog(evilFunctionCode, {
+                        timeout: blockTime,
+                        functions: {
+                            print: () => {},
+                        },
+                    })
+                )
+            )
+
+            const timings = results.map((r) => r.durationMs)
+            const reliefs = results.map((r) => r.waitedForThreadRelief)
+            const total = timings.reduce((x, y) => x + y, 0)
+            // Every one of these should have triggered a thread relief
+            expect(reliefs.every((r) => r)).toBe(true)
+
+            // Timings is semi random so we can't test for exact values
+            expect(total).toBeGreaterThan(100 * numberToTest)
+            expect(total).toBeLessThan(200 * numberToTest) // the hog exec limiter isn't exact
+            await new Promise((resolve) => setTimeout(resolve, 1))
+            expect(longestDelay).toBeLessThan(blockTime * 2) // Rough upper bound of the hog exec limiter (2x the block time)
+        })
+
+        it('should only trigger thread relief if necessary', async () => {
+            const blockTime = 100
+
+            const evilFunctionCode = await compileHog(`
+                fn fibonacci(number) {
+                    print('I AM FIBONACCI. ')
+                    if (number < 2) {
+                        return number;
+                    } else {
+                        return fibonacci(number - 1) + fibonacci(number - 2);
+                    }
+                }
+                print(f'fib {fibonacci(64)}');
+            `)
+
+            const simpleCode = await compileHog(`
+                print('I AM SIMPLE.')
+            `)
+
+            const toTest = [
+                evilFunctionCode,
+                simpleCode,
+                simpleCode,
+                simpleCode,
+                simpleCode,
+                simpleCode,
+                evilFunctionCode,
+                simpleCode,
+                simpleCode,
+                simpleCode,
+                evilFunctionCode,
+            ]
+
+            const results = await Promise.all(
+                toTest.map((code) =>
+                    execHog(code, {
+                        timeout: blockTime,
+                        functions: {
+                            print: () => {},
+                        },
+                    })
+                )
+            )
+
+            const timings = results.map((r) => r.durationMs)
+            const reliefs = results.map((r) => r.waitedForThreadRelief)
+            const total = timings.reduce((x, y) => x + y, 0)
+            // Every one of these should have triggered a thread relief
+            expect(reliefs).toEqual([
+                true, // evil function
+                false,
+                false,
+                false,
+                false,
+                false,
+                true, // evil function
+                false,
+                false,
+                false,
+                true, // evil function
+            ])
+
+            // Timings is semi random so we can't test for exact values
+            expect(total).toBeGreaterThan(100 * 3) // The 3 slow ones
+            expect(total).toBeLessThan(200 * 3) // Double the 3 slow ones
+            await new Promise((resolve) => setTimeout(resolve, 1))
+            expect(longestDelay).toBeLessThan(blockTime * 2) // Rough upper bound of the hog exec limiter (2x the block time)
+        })
+    })
+})

--- a/plugin-server/src/cdp/utils/hog-exec.ts
+++ b/plugin-server/src/cdp/utils/hog-exec.ts
@@ -1,13 +1,50 @@
-import { exec, ExecOptions, ExecResult } from '@posthog/hogvm'
+import { DEFAULT_TIMEOUT_MS, exec, ExecOptions, ExecResult } from '@posthog/hogvm'
 import crypto from 'crypto'
+import { Counter } from 'prom-client'
 import RE2 from 're2'
 
 import { Semaphore } from './sempahore'
 
-export const DEFAULT_TIMEOUT_MS = 100
+export const MAX_THREAD_WAIT_TIME_MS = 200
+
+const hogExecThreadReliefCounter = new Counter({
+    name: 'cdp_hog_function_execution_thread_relief',
+    help: 'Whether the hog function execution was blocked by the thread relief',
+    // We have a timeout so we don't need to worry about much more than that
+    labelNames: ['waited'],
+})
 
 const semaphore = new Semaphore(1)
 
+let threadRelief: {
+    startedAt: number
+    promise: Promise<void>
+} | null = null
+
+const waitForThreadRelief = async (timeout: number = DEFAULT_TIMEOUT_MS): Promise<boolean> => {
+    if (!threadRelief) {
+        threadRelief = {
+            startedAt: performance.now(),
+            promise: new Promise((resolve) => {
+                setTimeout(() => {
+                    threadRelief = null
+                    resolve()
+                }, 0)
+            }),
+        }
+    }
+
+    if (performance.now() - threadRelief.startedAt < timeout) {
+        return false
+    }
+
+    await threadRelief.promise
+
+    return true
+}
+
+// NOTE: Hog execution can be expensive and in really bad cases can block the event loop for a long time.
+// To work around this we have a check when we run it to make sure that
 export async function execHog(
     bytecode: any,
     options?: ExecOptions
@@ -15,17 +52,24 @@ export async function execHog(
     execResult?: ExecResult
     error?: any
     durationMs: number
+    waitedForThreadRelief: boolean
 }> {
-    // Ensure we don't have more than one running in parallel
     return await semaphore.run(async () => {
-        // NOTE: The below is commented out whilst we expirment with it as it mostly tanks performance when enabled
-        // Note - the setTimeout here forces the event loop to run fully before the next call. This is important as we never want hog execution to block the event loop
-        // await new Promise((r) => setTimeout(r, 0))
-        return Promise.resolve(execHogImmediate(bytecode, options))
+        const waitedForInitialRelief = await waitForThreadRelief(options?.timeout)
+        const result = execHogImmediate(bytecode, options)
+        const waitedForFinalRelief = await waitForThreadRelief(options?.timeout)
+
+        const waitedForThreadRelief = waitedForInitialRelief || waitedForFinalRelief
+        hogExecThreadReliefCounter.inc({ waited: waitedForThreadRelief ? 'true' : 'false' })
+
+        return {
+            ...result,
+            waitedForThreadRelief,
+        }
     })
 }
 
-export function execHogImmediate(
+function execHogImmediate(
     bytecode: any,
     options?: ExecOptions
 ): {

--- a/plugin-server/src/cdp/utils/hog-exec.ts
+++ b/plugin-server/src/cdp/utils/hog-exec.ts
@@ -19,29 +19,40 @@ export async function execHog(
     // Ensure we don't have more than one running in parallel
     return await semaphore.run(async () => {
         // Note - the setTimeout here forces the event loop to run fully before the next call. This is important as we never want hog execution to block the event loop
-        await new Promise((r) => setTimeout(r, 0))
-        const now = performance.now()
-        let execResult: ExecResult | undefined
-        let error: any
-        try {
-            execResult = exec(bytecode, {
-                timeout: DEFAULT_TIMEOUT_MS,
-                maxAsyncSteps: 0,
-                ...options,
-                external: {
-                    regex: { match: (regex, str) => new RE2(regex).test(str) },
-                    crypto,
-                    ...options?.external,
-                },
-            })
-        } catch (e) {
-            error = e
-        }
-
-        return {
-            execResult,
-            error,
-            durationMs: performance.now() - now,
-        }
+        // await new Promise((r) => setTimeout(r, 0))
+        return execHogImmediate(bytecode, options)
     })
+}
+
+export function execHogImmediate(
+    bytecode: any,
+    options?: ExecOptions
+): {
+    execResult?: ExecResult
+    error?: any
+    durationMs: number
+} {
+    const now = performance.now()
+    let execResult: ExecResult | undefined
+    let error: any
+    try {
+        execResult = exec(bytecode, {
+            timeout: DEFAULT_TIMEOUT_MS,
+            maxAsyncSteps: 0,
+            ...options,
+            external: {
+                regex: { match: (regex, str) => new RE2(regex).test(str) },
+                crypto,
+                ...options?.external,
+            },
+        })
+    } catch (e) {
+        error = e
+    }
+
+    return {
+        execResult,
+        error,
+        durationMs: performance.now() - now,
+    }
 }

--- a/plugin-server/src/cdp/utils/hog-exec.ts
+++ b/plugin-server/src/cdp/utils/hog-exec.ts
@@ -18,9 +18,10 @@ export async function execHog(
 }> {
     // Ensure we don't have more than one running in parallel
     return await semaphore.run(async () => {
+        // NOTE: The below is commented out whilst we expirment with it as it mostly tanks performance when enabled
         // Note - the setTimeout here forces the event loop to run fully before the next call. This is important as we never want hog execution to block the event loop
         // await new Promise((r) => setTimeout(r, 0))
-        return execHogImmediate(bytecode, options)
+        return Promise.resolve(execHogImmediate(bytecode, options))
     })
 }
 

--- a/plugin-server/src/cdp/utils/hog-function-filtering.ts
+++ b/plugin-server/src/cdp/utils/hog-function-filtering.ts
@@ -167,6 +167,7 @@ export function convertToHogFunctionFilterGlobal(
     return response
 }
 
+const HOG_FILTERING_TIMEOUT_MS = 100
 /**
  * Shared utility to check if an event matches the filters of a HogFunction.
  * Used by both the HogExecutorService (for destinations) and HogTransformerService (for transformations).
@@ -184,7 +185,6 @@ export async function filterFunctionInstrumented(options: {
     const { fn, filters, filterGlobals, enabledTelemetry, eventUuid } = options
     const type = 'type' in fn ? fn.type : 'hogflow'
     const fnKind = 'type' in fn ? 'HogFunction' : 'HogFlow'
-    const start = performance.now()
     const logs: LogEntry[] = []
     const metrics: MinimalAppMetric[] = []
 
@@ -204,6 +204,20 @@ export async function filterFunctionInstrumented(options: {
             globals: filterGlobals,
             telemetry: enabledTelemetry,
         })
+
+        if (execHogOutcome) {
+            hogFunctionFilterDuration.observe({ type }, execHogOutcome.durationMs)
+        }
+
+        if (execHogOutcome.durationMs > HOG_FILTERING_TIMEOUT_MS) {
+            logger.error('🦔', `[${fnKind}] Filter took longer than expected`, {
+                functionId: fn.id,
+                functionName: fn.name,
+                teamId: fn.team_id,
+                duration: execHogOutcome.durationMs,
+                eventId: options?.eventUuid,
+            })
+        }
 
         execResult = execHogOutcome.execResult
 
@@ -249,24 +263,6 @@ export async function filterFunctionInstrumented(options: {
             message: `Error filtering event ${eventUuid}: ${error.message}`,
         })
         result.error = error.message
-    } finally {
-        const duration = performance.now() - start
-
-        // Re-using the constant from hog-executor.service.ts
-        const DEFAULT_TIMEOUT_MS = 100
-
-        hogFunctionFilterDuration.observe({ type }, duration)
-
-        if (duration > DEFAULT_TIMEOUT_MS) {
-            logger.error('🦔', `[${fnKind}] Filter took longer than expected`, {
-                functionId: fn.id,
-                functionName: fn.name,
-                teamId: fn.team_id,
-                duration,
-                eventId: options?.eventUuid,
-            })
-        }
     }
-
     return result
 }

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -172,7 +172,6 @@ export function getDefaultConfig(): PluginsServerConfig {
         CDP_REDIS_HOST: '',
         CDP_REDIS_PORT: 6479,
         CDP_CYCLOTRON_BATCH_DELAY_MS: 50,
-        CDP_CYCLOTRON_BATCH_SIZE: 300,
         CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN: '',
         CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_MODE: 'kafka',
         CDP_CYCLOTRON_JOB_QUEUE_PRODUCER_MAPPING: '*:kafka',

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -118,7 +118,6 @@ export type CdpConfig = {
     CDP_LEGACY_EVENT_CONSUMER_TOPIC: string
     CDP_LEGACY_EVENT_REDIRECT_TOPIC: string // If set then this consumer will emit to this topic instead of processing
 
-    CDP_CYCLOTRON_BATCH_SIZE: number
     CDP_CYCLOTRON_BATCH_DELAY_MS: number
     CDP_CYCLOTRON_INSERT_MAX_BATCH_SIZE: number
     CDP_CYCLOTRON_INSERT_PARALLEL_BATCHES: boolean


### PR DESCRIPTION
## Problem

The new async execHog function seems to work great in the worker but terrible in the filtering as there is such a high throughput of parallel filters (each function runs filters as well as mappings etc.

This part was incorrectly happening in a serial loop which caused throughput to drop considerably

## Changes

* Attempts to fix this with parallelisation

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
