### PR TITLE
fix: flaky billing_limits e2e tests in CI

### DIFF
--- a/playwright/e2e/billing/billing-limits.spec.ts
+++ b/playwright/e2e/billing/billing-limits.spec.ts
@@ -10,13 +10,21 @@ type BillingRouteHandlers = {
 }
 
 async function setupBillingRoutes(page: Page, handlers: BillingRouteHandlers): Promise<void> {
+    const filePath = path.join(__dirname, '../../mocks/billing/billing.json')
+    let billingContent = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
+    let isInitialized = false
+
     await page.route('**/api/billing/', async (route) => {
         const method = route.request().method()
-        const filePath = path.join(__dirname, '../../mocks/billing/billing.json')
-        let billingContent = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
 
         if (method === 'GET') {
-            billingContent = handlers.getResponse(billingContent)
+            // Only apply getResponse transformation on first GET request.
+            // This prevents the mock from resetting to initial state after a PATCH update.
+            // Without this, the second GET after form submission would reset the limit back to initial value.
+            if (!isInitialized) {
+                billingContent = handlers.getResponse(billingContent)
+                isInitialized = true
+            }
             await route.fulfill({
                 status: 200,
                 body: JSON.stringify(billingContent),
@@ -57,6 +65,9 @@ test.describe('Billing Limits', () => {
             .click()
         await page.fill('[data-attr="billing-limit-input-product_analytics"]', '100')
         await page.locator('[data-attr="save-billing-limit-product_analytics"]').click()
+
+        // Wait for form to exit edit mode (indicates async flow completed)
+        await expect(page.locator('[data-attr="save-billing-limit-product_analytics"]')).not.toBeVisible()
         await expect(page.locator('[data-attr="billing-limit-set-product_analytics"]')).toContainText(
             'You have a $100 billing limit set'
         )
@@ -81,6 +92,9 @@ test.describe('Billing Limits', () => {
         await page.locator('text=Edit limit').click()
         await page.fill('[data-attr="billing-limit-input-product_analytics"]', '200')
         await page.locator('[data-attr="save-billing-limit-product_analytics"]').click()
+
+        // Wait for form to exit edit mode (indicates async flow completed)
+        await expect(page.locator('[data-attr="save-billing-limit-product_analytics"]')).not.toBeVisible()
         await expect(page.locator('[data-attr="billing-limit-set-product_analytics"]')).toContainText(
             'You have a $200 billing limit set'
         )
@@ -105,6 +119,9 @@ test.describe('Billing Limits', () => {
         await page.locator('text=Edit limit').click()
         await page.fill('[data-attr="billing-limit-input-product_analytics"]', '0')
         await page.locator('[data-attr="save-billing-limit-product_analytics"]').click()
+
+        // Wait for form to exit edit mode (indicates async flow completed)
+        await expect(page.locator('[data-attr="save-billing-limit-product_analytics"]')).not.toBeVisible()
         await expect(page.locator('[data-attr="billing-limit-set-product_analytics"]')).toContainText(
             'You have a $0 billing limit set'
         )


### PR DESCRIPTION
## Problem

E2E `billing_limits` tests were flaky (or most likely haven't worked for quite some time?) due to the mock state that wasn't persisting between get/patch requests.

## Changes

Fixed mock route handler to maintain state between requests using `isInitialized`.

Also added UI state checks (wait for save button to disappear) to ensure async flow completed before assertions (tests worked locally without it, but best to have this, might be flaky in CI).

## Did you write or update any docs for this change?

- [x] No docs needed for this change

## How did you test this code?

Ran `billing_limits` e2e tests before (failing) and after (passed)
