### PR TITLE
fix(persons): Ignore fetchForUpdate overrides

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
@@ -445,8 +445,10 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
             // Skip entries that only have fetchForUpdate operations (read-only, no modifications)
             if (mainUpdate && mainUpdate.operations.length > 0) {
                 const hasNonFetchOperations = mainUpdate.operations.some((op) => op.type !== 'fetchForUpdate')
-                if (!hasNonFetchOperations) {
-                    continue // Skip this entry as it's only fetch operations
+                const lastOperationIsFetch =
+                    mainUpdate.operations[mainUpdate.operations.length - 1].type === 'fetchForUpdate'
+                if (!hasNonFetchOperations || lastOperationIsFetch) {
+                    continue // Skip this entry as it's only fetch operations or last operation overwrote
                 }
             }
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

When we have a `fetchForUpdate` after other actions, it overrides the cache, making a weird comparison that we can't be sure to validate

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
