### PR TITLE
chore: add comment button to header

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/discussion/sidePanelDiscussionLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/discussion/sidePanelDiscussionLogic.ts
@@ -40,6 +40,9 @@ export const sidePanelDiscussionLogic = kea<sidePanelDiscussionLogicType>([
 
                     return response
                 },
+                incrementCommentCount: () => {
+                    return values.commentCount + 1
+                },
                 resetCommentCount: () => {
                     return 0
                 },

--- a/frontend/src/scenes/comments/commentsLogic.ts
+++ b/frontend/src/scenes/comments/commentsLogic.ts
@@ -1,4 +1,4 @@
-import { actions, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { subscriptions } from 'kea-subscriptions'
 import api from 'lib/api'
@@ -7,6 +7,7 @@ import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import { CommentType } from '~/types'
 
 import type { commentsLogicType } from './commentsLogicType'
+import { sidePanelDiscussionLogic } from '~/layout/navigation-3000/sidepanel/panels/discussion/sidePanelDiscussionLogic'
 
 export type CommentsLogicProps = {
     scope: CommentType['scope']
@@ -30,7 +31,10 @@ export const commentsLogic = kea<commentsLogicType>([
     props({} as CommentsLogicProps),
     key((props) => `${props.scope}-${props.item_id || ''}`),
 
-    // TODO: Connect to sidePanelDiscussionLogic and update the commentCount
+    connect(() => ({
+        actions: [sidePanelDiscussionLogic, ['incrementCommentCount']],
+    })),
+
     actions({
         loadComments: true,
         maybeLoadComments: true,
@@ -165,6 +169,9 @@ export const commentsLogic = kea<commentsLogicType>([
             if (!values.comments && !values.commentsLoading) {
                 actions.loadComments()
             }
+        },
+        sendComposedContentSuccess: () => {
+            actions.incrementCommentCount()
         },
     })),
 

--- a/products/error_tracking/frontend/ErrorTrackingIssueScene.tsx
+++ b/products/error_tracking/frontend/ErrorTrackingIssueScene.tsx
@@ -20,6 +20,9 @@ import { errorTrackingIssueSceneLogic } from './errorTrackingIssueSceneLogic'
 import { useErrorTagRenderer } from './hooks/use-error-tag-renderer'
 import { Metadata } from './issue/Metadata'
 import { ISSUE_STATUS_OPTIONS } from './utils'
+import { sidePanelLogic } from '~/layout/navigation-3000/sidepanel/sidePanelLogic'
+import { SidePanelTab } from '~/types'
+import { SidePanelDiscussionIcon } from '~/layout/navigation-3000/sidepanel/panels/discussion/SidePanelDiscussion'
 
 export const scene: SceneExport = {
     component: ErrorTrackingIssueScene,
@@ -44,6 +47,7 @@ export function ErrorTrackingIssueScene(): JSX.Element {
     const { loadIssue } = useActions(errorTrackingIssueSceneLogic)
     const { updateIssueAssignee, updateIssueStatus } = useActions(issueActionsLogic)
     const tagRenderer = useErrorTagRenderer()
+    const { openSidePanel } = useActions(sidePanelLogic)
 
     useEffect(() => {
         loadIssue()
@@ -54,6 +58,13 @@ export function ErrorTrackingIssueScene(): JSX.Element {
             <PageHeader
                 buttons={
                     <div className="flex gap-x-2">
+                        <LemonButton
+                            type="secondary"
+                            onClick={() => openSidePanel(SidePanelTab.Discussion)}
+                            icon={<SidePanelDiscussionIcon />}
+                        >
+                            Comment
+                        </LemonButton>
                         {!issueLoading && issue?.status === 'active' && (
                             <AssigneeSelect
                                 assignee={issue?.assignee}


### PR DESCRIPTION
Make comments more prominent in error tracking

See https://posthog.slack.com/archives/C07AA937K9A/p1750956076507659


![comments](https://github.com/user-attachments/assets/03dcaf19-8ddd-477a-ae9d-d6c0bb1bf043)
