### PR TITLE
perf(batch-exports): Read larger chunks of data from S3 at a time

### DIFF
--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -964,7 +964,7 @@ async def insert_into_s3_activity_from_stage(inputs: S3InsertInputs) -> RecordsC
             batch_export_id=inputs.batch_export_id,
             data_interval_start=inputs.data_interval_start,
             data_interval_end=inputs.data_interval_end,
-            max_record_batch_size_bytes=1024 * 1024 * 10,  # 10MB
+            max_record_batch_size_bytes=1024 * 1024 * 60,  # 60MB
         )
 
         record_batch_schema = await wait_for_schema_or_producer(queue, producer_task)


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

After profiling our producer + consumer code locally, I could see a lot of calls being made to `aiobotocore/response.py:107(iter_chunks)` (373,188 in the test I was running locally). This was the bulk of the time.

## Changes

Use a chunk iterator where we can specify the chunk size. The chunk size didn't seem to matter too much from local testing but 128kB seemed to be enough for a considerable speed up.

In local testing this reduced the time to run the consumer from 1.933 seconds to 0.759 seconds, so a fairly significant speed up. Obviously this may not manifest itself in production, but since there seems to be a bottleneck in the producer in many cases (such as with Parquet where the concurrent consumer is only able to run a single upload at once) it seems worth doing.

I also increased the `max_record_batch_size_bytes` from 10MB to 60MB so the `slice_record_batch` isn't called as often, which also seems to have a small impact on performance. We have a limit on the async queue size, so I don't think should affect actually memory consumption (we're still keeping all the slices of batches in memory anyway).

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Existing tests
