### PR TITLE
feat: split web analytics data in first job

### DIFF
--- a/dags/definitions.py
+++ b/dags/definitions.py
@@ -70,8 +70,6 @@ defs = dagster.Definitions(
         web_preaggregated_daily.web_bounces_daily_export,
         web_preaggregated_hourly.web_stats_hourly,
         web_preaggregated_hourly.web_bounces_hourly,
-        web_preaggregated_daily.split_stats_export_by_team,
-        web_preaggregated_daily.split_bounces_export_by_team,
     ],
     asset_checks=[
         web_preaggregated_asset_checks.web_analytics_accuracy_check,

--- a/posthog/hogql/database/schema/web_analytics_s3.py
+++ b/posthog/hogql/database/schema/web_analytics_s3.py
@@ -21,16 +21,16 @@ def get_s3_function_args(s3_path: str) -> str:
         return f"'{s3_path}', 'Native'"
 
 
-def get_s3_url(table_name: str, team_id: int | None = None) -> str:
+def get_s3_url(table_name: str, team_id: int) -> str:
     if settings.DEBUG:
         s3_endpoint = "http://objectstorage:19000"
         bucket = "posthog"
-        key = f"{table_name}"
+        key = f"{table_name}/{team_id}/data.native"
         return f"{s3_endpoint}/{bucket}/{key}"
 
     base_url = f"https://{OBJECT_STORAGE_EXTERNAL_WEB_ANALYTICS_BUCKET}.s3.amazonaws.com"
 
-    return f"{base_url}/{team_id}/{table_name}" if team_id else f"{base_url}/{table_name}"
+    return f"{base_url}/{table_name}/{team_id}/data.native"
 
 
 def get_s3_web_stats_structure() -> str:
@@ -76,7 +76,7 @@ WEB_BOUNCES_S3_FIELDS: dict[str, FieldOrTable] = {
 
 
 def create_s3_web_stats_table(team_id: int) -> S3Table:
-    url = get_s3_url(table_name="web_stats_daily_export.native", team_id=team_id)
+    url = get_s3_url(table_name="web_stats_daily_export", team_id=team_id)
 
     return S3Table(
         name="web_stats_daily_s3",
@@ -90,7 +90,7 @@ def create_s3_web_stats_table(team_id: int) -> S3Table:
 
 
 def create_s3_web_bounces_table(team_id: int) -> S3Table:
-    url = get_s3_url(table_name="web_bounces_daily_export.native", team_id=team_id)
+    url = get_s3_url(table_name="web_bounces_daily_export", team_id=team_id)
 
     return S3Table(
         name="web_bounces_daily_s3",


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

This splits the data immediately rather than trying to load all the data in one query from ClickHouse - let's try this for now and then think about how it's best to split these queries when we have a lot more teams.

## Changes

- Remove split step, export directly.
