### PR TITLE
fix: Take care of edge cases on env migration

### DIFF
--- a/posthog/tasks/test/test_environments_rollback.py
+++ b/posthog/tasks/test/test_environments_rollback.py
@@ -379,7 +379,7 @@ class TestEnvironmentsRollbackTask(TransactionTestCase):
 
         # Verify second scenario: Analytics team keeps original name
         self.assertEqual(analytics_env.name, "Analytics")
-        self.assertEqual(analytics_env.project.name, "Analytics - Analytics")  # New project gets dash format
+        self.assertEqual(analytics_env.project.name, "Analytics")
         self.assertNotEqual(analytics_env.project.id, project2.id)  # Should be in new project
 
         # Verify staging team gets renamed


### PR DESCRIPTION
## Changes

Takes care of the following cases:
- Where source env ID has the same ID as the containing project, then new project creation logic must be different.
- Adds renaming for envs and projects to reflect how the ProjectPicker renders project(env) names.

## How did you test this code?

- Manually and integration tests
