### PR TITLE
fix(frontend): Avoid `overflow: scroll`

### DIFF
--- a/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
+++ b/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
@@ -681,7 +681,7 @@ function Timing({ item }: { item: Query }): JSX.Element | null {
                                     <td>Slowest span</td>
                                     <td>
                                         <div
-                                            className="w-60 overflow-scroll"
+                                            className="w-60 overflow-auto"
                                             ref={(element) => element?.scrollTo({ left: element?.scrollWidth })}
                                         >
                                             {timingsSummary.slowestSpan.name}

--- a/frontend/src/lib/lemon-ui/LemonInput/RawInputAutosize.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInput/RawInputAutosize.tsx
@@ -61,6 +61,7 @@ export const RawInputAutosize = React.forwardRef<HTMLInputElement, RawInputAutos
                 }}
                 {...inputProps}
             />
+            {/* Intentionally using overflow-scroll below so that we can use these invisible elements for sizing */}
             <div ref={sizerRef} className="absolute top-0 left-0 h-0 overflow-scroll whitespace-pre invisible">
                 {inputProps.value}
             </div>

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -644,7 +644,7 @@ function InternalDataTableVisualization(
     return (
         <div className="DataVisualization h-full hide-scrollbar flex flex-1 gap-2">
             <div className="relative w-full flex flex-col gap-4 flex-1">
-                <div className="flex flex-1 flex-row gap-4 overflow-scroll hide-scrollbar">
+                <div className="flex flex-1 flex-row gap-4 overflow-auto hide-scrollbar">
                     {isChartSettingsPanelOpen && (
                         <div>
                             <SideBar />
@@ -667,7 +667,7 @@ const ErrorState = ({ responseError, sourceQuery, queryCancelled, response }: an
         : responseError
 
     return (
-        <div className={clsx('flex-1 absolute top-0 left-0 right-0 bottom-0 overflow-scroll')}>
+        <div className={clsx('flex-1 absolute top-0 left-0 right-0 bottom-0 overflow-auto')}>
             <InsightErrorState
                 query={sourceQuery}
                 excludeDetail

--- a/frontend/src/scenes/data-warehouse/editor/QueryTabs.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryTabs.tsx
@@ -36,7 +36,7 @@ export function QueryTabs({ models, onClear, onClick, onAdd, onRename, activeMod
         <>
             <div
                 // height is hardcoded to match implicit height from tree view nav bar
-                className="flex flex-row overflow-scroll hide-scrollbar h-[39px]"
+                className="flex flex-row overflow-auto hide-scrollbar h-[39px]"
                 ref={containerRef}
             >
                 {models.map((model: QueryTab) => (

--- a/frontend/src/scenes/session-recordings/components/OverviewGrid.tsx
+++ b/frontend/src/scenes/session-recordings/components/OverviewGrid.tsx
@@ -55,7 +55,7 @@ export function OverviewGridItem({
                 </Tooltip>
             </div>
             <Tooltip title={description}>
-                <div className="overflow-x-scroll">{children}</div>
+                <div className="overflow-x-auto">{children}</div>
             </Tooltip>
         </div>
     )

--- a/frontend/src/scenes/surveys/components/question-visualizations/MultipleChoiceQuestionViz.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/MultipleChoiceQuestionViz.tsx
@@ -18,7 +18,7 @@ interface Props {
 
 export function MultipleChoiceQuestionViz({ responseData }: Props): JSX.Element | null {
     return (
-        <div className="border rounded py-4 max-h-[600px] overflow-y-scroll">
+        <div className="border rounded py-4 max-h-[600px] overflow-y-auto">
             <BindLogic logic={insightLogic} props={insightProps}>
                 <LineGraph
                     inSurveyView={true}

--- a/frontend/src/scenes/surveys/components/question-visualizations/SurveyQuestionVisualization.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/SurveyQuestionVisualization.tsx
@@ -112,7 +112,7 @@ function QuestionLoadingSkeleton({ question }: { question: SurveyQuestion }): JS
             )
         case SurveyQuestionType.MultipleChoice:
             return (
-                <div className="border rounded py-4 max-h-[600px] overflow-y-scroll">
+                <div className="border rounded py-4 max-h-[600px] overflow-y-auto">
                     <div className="flex flex-col gap-1">
                         {question.choices.map((choice, i) => {
                             // Use decreasing widths to match typical survey result ordering

--- a/frontend/src/toolbar/actions/ActionsListView.tsx
+++ b/frontend/src/toolbar/actions/ActionsListView.tsx
@@ -16,7 +16,7 @@ export function ActionsListView({ actions }: ActionsListViewProps): JSX.Element 
     const { selectAction } = useActions(actionsTabLogic)
 
     return (
-        <div className="flex flex-col h-full overflow-y-scroll deprecated-space-y-px mb-2">
+        <div className="flex flex-col h-full overflow-y-auto deprecated-space-y-px mb-2">
             {actions.length ? (
                 actions.map((action, index) => (
                     <Fragment key={action.id}>

--- a/products/llm_observability/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
+++ b/products/llm_observability/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
@@ -33,7 +33,7 @@ export function ConversationMessagesDisplay({
     const outputNormalized = normalizeMessages(output, 'assistant')
 
     const outputDisplay = raisedError ? (
-        <div className="flex items-center gap-1.5 rounded border text-default p-2 font-medium bg-[var(--bg-fill-error-tertiary)] border-danger overflow-x-scroll">
+        <div className="flex items-center gap-1.5 rounded border text-default p-2 font-medium bg-[var(--bg-fill-error-tertiary)] border-danger overflow-x-auto">
             <IconExclamation className="text-base" />
             {isObject(output) ? (
                 <JSONViewer src={output} collapsed={4} />


### PR DESCRIPTION
## Problem

`overflow: scroll` almost never is what you want, because it ALWAYS shows the scrollbar, even when there's no overflow at all. In all likelihood you want `overflow: auto`, which means a scrollbar when there's overflow, and no scrollbar otherwise.

## Changes

This is a bulk fix for all the `overflow-scroll` cases, including `overflow-x-...` and `overflow-y-...`. Assuming we want auto for all of these. (With one exception where `overflow-scroll` makes sense.)

## How did you test this code?

To be honest I haven't checked all these places, because they're all across the app – please verify the change for your part of the app.