### PR TITLE
fix(llmo): replay URL builder

### DIFF
--- a/products/llm_observability/frontend/LLMObservabilityTraceScene.tsx
+++ b/products/llm_observability/frontend/LLMObservabilityTraceScene.tsx
@@ -16,7 +16,7 @@ import { BindLogic, useActions, useValues } from 'kea'
 import { JSONViewer } from 'lib/components/JSONViewer'
 import { NotFound } from 'lib/components/NotFound'
 import { FEATURE_FLAGS } from 'lib/constants'
-import { IconArrowDown, IconArrowUp, IconOpenInNew } from 'lib/lemon-ui/icons'
+import { IconArrowDown, IconArrowUp } from 'lib/lemon-ui/icons'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { identifierToHuman, isObject, pluralize } from 'lib/utils'
 import { cn } from 'lib/utils/css-classes'
@@ -47,6 +47,7 @@ import {
     isLLMTraceEvent,
     removeMilliseconds,
 } from './utils'
+import ViewRecordingButton from 'lib/components/ViewRecordingButton/ViewRecordingButton'
 
 export const scene: SceneExport = {
     component: LLMObservabilityTraceScene,
@@ -525,15 +526,14 @@ const EventContent = React.memo(
                                     </LemonButton>
                                 )}
                                 {hasSessionID(event) && (
-                                    <div className="flex flex-row items-center gap-2">
-                                        <Link
-                                            to={urls.replay(undefined, undefined, getSessionID(event) ?? '')}
-                                            className="flex flex-row gap-1 items-center"
-                                        >
-                                            <IconOpenInNew />
-                                            <span>View session recording</span>
-                                        </Link>
-                                    </div>
+                                    <ViewRecordingButton
+                                        inModal
+                                        type="secondary"
+                                        size="xsmall"
+                                        data-attr="llm-observability"
+                                        sessionId={getSessionID(event) || undefined}
+                                        timestamp={removeMilliseconds(event.createdAt)}
+                                    />
                                 )}
                             </div>
                         </header>


### PR DESCRIPTION
## Problem

The session replay backlinks in the LLM observability trace views are built with the `urls.replay` base function with undefined replay tabs and filters. The resulting URL (`/replay/home?sessionRecordingId={session_id}`) is problematic because the user's current filters may either filter that session out or bury the session so deep in the session list panel's infinite scroll that it's not selectable without scrolling. Clicking this link often results in the "No recording selected" screen, even though the recording exists.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Use the `ViewRecordingButton` component instead, which avoids the filter issues completely, and has a first-class modal option! Thanks @lshaowei18 for this idea.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Tested locally.

From a web app context where session recording is enabled:
1. Generate a UUID for use as a trace ID in steps 2 and 3.
2. [optional] Log several LLM generations to PostHog with manual capture.
3. Log a span with manual capture.
4. The span should show up inside the trace alongside the generations and have a session recording link.

![posthog_test_34311](https://github.com/user-attachments/assets/64fda8d7-52f0-413c-82a7-08417ee6a62f)


<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

## Acknowledgements
@lshaowei18 for multiple tests and improvements.

## Related
Re-attempt at https://github.com/PostHog/posthog/pull/33763