### PR TITLE
refactor(experiments): removing metricToQuery from metric form.

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1176,6 +1176,9 @@ export const experimentLogic = kea<experimentLogicType>([
                         ...sharedMetrics.map((m) => ({ name: m.name, ...m.query })),
                     ].reverse()
 
+                    /**
+                     * TODO: replace with a queryBuilder composed from getQuery
+                     */
                     for (const query of metrics) {
                         const insightQuery = toInsightVizNode(query)
 

--- a/frontend/src/scenes/experiments/metricQueryUtils.ts
+++ b/frontend/src/scenes/experiments/metricQueryUtils.ts
@@ -92,7 +92,7 @@ export const getMathProperties = (source: ExperimentMetricSource): MathPropertie
         .with({ math: ExperimentMetricMathType.UniqueSessions }, ({ math }) => ({ math }))
         .otherwise(() => ({ math: ExperimentMetricMathType.TotalCount, math_property: undefined }))
 
-type MetricToQueryOptions = {
+type GetQueryOptions = {
     breakdownFilter: BreakdownFilter
     filterTestAccounts: boolean
     trendsFilter: TrendsFilter
@@ -111,7 +111,7 @@ type MetricToQueryOptions = {
  * - Results Breakdowns
  */
 export const getQuery =
-    (options?: Partial<MetricToQueryOptions>) =>
+    (options?: Partial<GetQueryOptions>) =>
     (metric: ExperimentMetric): FunnelsQuery | TrendsQuery | undefined => {
         /**
          * we get all the options or their defaults. There's no overrides that could
@@ -211,6 +211,7 @@ const createSourceNode = (step: ExperimentFunnelMetricStep): ExperimentMetricSou
         type: step.kind === NodeKind.EventsNode ? 'events' : 'actions',
         id: step.kind === NodeKind.EventsNode ? step.event : step.id,
         name: step.kind === NodeKind.EventsNode ? step.event : step.name,
+        custom_name: step.custom_name,
         math: step.math,
         math_property: step.math_property,
         math_hogql: step.math_hogql,

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -301,6 +301,9 @@ export function featureFlagEligibleForExperiment(featureFlag: FeatureFlagType): 
     throw new Error('Feature flag must use multiple variants with control as the first variant.')
 }
 
+/**
+ * TODO: review. Probably deprecated
+ */
 export function getDefaultTrendsMetric(): ExperimentTrendsQuery {
     return {
         kind: NodeKind.ExperimentTrendsQuery,
@@ -360,6 +363,9 @@ export function getDefaultFunnelsMetric(): ExperimentFunnelsQuery {
     }
 }
 
+/**
+ * TODO: review. Probably deprecated
+ */
 export function getDefaultFunnelMetric(): ExperimentMetric {
     return {
         kind: NodeKind.ExperimentMetric,
@@ -374,6 +380,9 @@ export function getDefaultFunnelMetric(): ExperimentMetric {
     }
 }
 
+/**
+ * @deprecated
+ */
 export function getDefaultCountMetric(): ExperimentMetric {
     return {
         kind: NodeKind.ExperimentMetric,
@@ -386,6 +395,9 @@ export function getDefaultCountMetric(): ExperimentMetric {
     }
 }
 
+/**
+ * @deprecated
+ */
 export function getDefaultContinuousMetric(): ExperimentMetric {
     return {
         kind: NodeKind.ExperimentMetric,
@@ -398,6 +410,9 @@ export function getDefaultContinuousMetric(): ExperimentMetric {
     }
 }
 
+/**
+ * TODO: review. Probably deprecated
+ */
 export function getDefaultExperimentMetric(metricType: ExperimentMetricType): ExperimentMetric {
     switch (metricType) {
         case ExperimentMetricType.FUNNEL:
@@ -458,6 +473,9 @@ export function getExperimentMetricFromInsight(
     return undefined
 }
 
+/**
+ * Used when setting a custom exposure criteria
+ */
 export function exposureConfigToFilter(exposure_config: ExperimentEventExposureConfig): FilterType {
     if (exposure_config.kind === NodeKind.ExperimentEventExposureConfig) {
         return {
@@ -478,6 +496,9 @@ export function exposureConfigToFilter(exposure_config: ExperimentEventExposureC
     return {}
 }
 
+/**
+ * Used when setting a custom exposure criteria
+ */
 export function filterToExposureConfig(
     entity: Record<string, any> | undefined
 ): ExperimentEventExposureConfig | undefined {
@@ -498,6 +519,9 @@ export function filterToExposureConfig(
     return undefined
 }
 
+/**
+ * @deprecated in favot of getFilter
+ */
 export function metricToFilter(metric: ExperimentMetric): FilterType {
     const createSourceNode = (source: any, type: string): ExperimentMetricSource => {
         return {
@@ -561,6 +585,9 @@ export function metricToFilter(metric: ExperimentMetric): FilterType {
     return { events: [], actions: [], data_warehouse: [] }
 }
 
+/**
+ * TODO: review for refactor.
+ */
 export function filterToMetricConfig(
     metricType: ExperimentMetricType,
     actions: Record<string, any>[] | undefined,
@@ -672,6 +699,9 @@ export function filterToMetricConfig(
     )
 }
 
+/**
+ * @deprecated create a query builder with getQuery instead
+ */
 export function metricToQuery(
     metric: ExperimentMetric,
     filterTestAccounts: boolean
@@ -738,11 +768,17 @@ export function metricToQuery(
     }
 }
 
+/**
+ * @deprecated
+ */
 const shiftOrderRight = (step: ActionFilter): ActionFilter => ({
     ...step,
     order: (step.order ?? 0) + 1,
 })
 
+/**
+ * @deprecated
+ */
 export function getFunnelPreviewSeries(
     metric: ExperimentFunnelMetric
 ): (EventsNode | ActionsNode | DataWarehouseNode)[] {
@@ -807,6 +843,9 @@ type AllowedQuery = { kind: AllowedNodeKind } & Record<string, any>
 
 type QueryHandler = (query: AllowedQuery) => InsightQueryNode | undefined
 
+/**
+ * @deprecated
+ */
 const queryKindtoSource: Record<AllowedNodeKind, QueryHandler> = {
     /**
      * Legacy Experiments
@@ -823,6 +862,9 @@ const queryKindtoSource: Record<AllowedNodeKind, QueryHandler> = {
     [NodeKind.ExperimentQuery]: ({ metric }) => metricToQuery(metric, false),
 }
 
+/**
+ * @deprecated
+ */
 export const toInsightVizNode = <T extends AllowedQuery>(query: T): InsightVizNode => {
     const handler = queryKindtoSource[query.kind]
     if (!handler) {
@@ -873,6 +915,9 @@ export const isLegacyExperiment = ({ metrics, metrics_secondary, saved_metrics }
 
 export const isLegacySharedMetric = ({ query }: SharedMetric): boolean => isLegacyExperimentQuery(query)
 
+/**
+ * TODO: remove since rollout is complete.
+ */
 export const shouldUseNewQueryRunnerForNewObjects = (featureFlags: FeatureFlagsSet, billing: BillingType): boolean => {
     // For non-paying users, we use dedicated flag to control the rollout of the new query runner
     const isOnFreePlan = billing?.subscription_level === 'free'


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We have too many metric-to-and-from conversion functions, so we are working on having a single source of truth as far as metric conversions go.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We are updating the experiment metric form, used in the _Add New Metric_ dialog for single-use metrics, and the _New Shared Metric_ and _Edit Shared Metric_ pages.

This PR also marks many functions from the `utils` file as deprecated. We can't remove the code just yet, because there is still one place that indirectly uses the `metricToQuery` function and needs to be updated.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/82013138-e350-4842-9b62-76d84353d29f)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
