### PR TITLE
feat(plugin-server): Test continuous consume (HACK)

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -49,6 +49,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         CONSUMER_MAX_HEARTBEAT_INTERVAL_MS: 30_000,
         CONSUMER_MAX_BACKGROUND_TASKS: 1,
         CONSUMER_AUTO_CREATE_TOPICS: true,
+        CONSUMER_CONTINUOUS_CONSUMPTION_ENABLED: false,
         KAFKA_HOSTS: 'kafka:9092', // KEEP IN SYNC WITH posthog/settings/data_stores.py
         KAFKA_CLIENT_CERT_B64: undefined,
         KAFKA_CLIENT_CERT_KEY_B64: undefined,

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -160,7 +160,11 @@ export class IngestionConsumer {
             optimisticUpdateRetryInterval: this.hub.GROUP_BATCH_WRITING_OPTIMISTIC_UPDATE_RETRY_INTERVAL_MS,
         })
 
-        this.kafkaConsumer = new KafkaConsumer({ groupId: this.groupId, topic: this.topic })
+        this.kafkaConsumer = new KafkaConsumer({
+            groupId: this.groupId,
+            topic: this.topic,
+            continuousConsumptionEnabled: this.hub.CONSUMER_CONTINUOUS_CONSUMPTION_ENABLED,
+        })
     }
 
     public get service(): PluginServerService {

--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -381,7 +381,7 @@ export class KafkaConsumer {
                             const newMessages = await retryIfRetriable(() =>
                                 promisifyCallback<Message[]>((cb) => this.rdKafkaConsumer.consume(batchSizeToFetch, cb))
                             )
-                            messageQueue.concat(newMessages)
+                            messageQueue.push(...newMessages)
                         }
                     } catch (error) {
                         logger.error('🔁', fromMainLoop ? 'main_loop_consume_error' : 'continuous_consume_error', {

--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -370,6 +370,12 @@ export class KafkaConsumer {
                     try {
                         const batchSizeToFetch = Math.min(1, this.fetchBatchSize - messageQueue.length)
                         if (batchSizeToFetch > 0) {
+                            const consumeStartTime = performance.now()
+                            if (lastConsumeTime > 0) {
+                                const intervalMs = consumeStartTime - lastConsumeTime
+                                histogramKafkaConsumeInterval.labels({ topic, groupId }).observe(intervalMs)
+                            }
+                            lastConsumeTime = consumeStartTime
                             const newMessages = await retryIfRetriable(() =>
                                 promisifyCallback<Message[]>((cb) => this.rdKafkaConsumer.consume(batchSizeToFetch, cb))
                             )

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -214,6 +214,7 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
     CONSUMER_MAX_HEARTBEAT_INTERVAL_MS: number // Primarily for kafka consumers the max heartbeat interval to use after which it will be considered unhealthy
     CONSUMER_MAX_BACKGROUND_TASKS: number
     CONSUMER_AUTO_CREATE_TOPICS: boolean
+    CONSUMER_CONTINUOUS_CONSUMPTION_ENABLED: boolean // Enable continuous consumption with 1s intervals for rebalance testing
 
     // Kafka params - identical for client and producer
     KAFKA_HOSTS: string // comma-delimited Kafka hosts


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

> [!IMPORTANT]
This PR is merely a hack to test out the hypothesis presented [here](https://posthog.slack.com/archives/C08JQTX5RRP/p1751016583422599). The objective is to revert this PR once we have understood if it has an impact or not

Our rebalancing seems to be pretty slow because we have a very large interval between poll/consume calls from the consumers to kafka. 



## Changes

- The objective of this PR is to force our consumer to read messages every one second in order to have a frequent consume call to the kafka broker, these messages are accumulated in memory and processed on the next batch.
- All of the logic is hidden behind a flag so it shouldn't affect the current processing

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
