### PR TITLE
fix(experiments): force refresh of results on edit end_date

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1040,7 +1040,7 @@ export const experimentLogic = kea<experimentLogicType>([
         updateExperimentSuccess: async ({ experiment, payload }) => {
             actions.updateExperiments(experiment)
             if (experiment.start_date) {
-                const forceRefresh = payload?.start_date !== undefined
+                const forceRefresh = payload?.start_date !== undefined || payload?.end_date !== undefined
                 actions.refreshExperimentResults(forceRefresh)
             }
         },


### PR DESCRIPTION
## Problem
When editing `end_date`, only exposure results are updated, not metric results. So they are out of sync.

## Changes
Change the `force_refresh` condition to check if `end_date` is in the payload.

## How did you test this code?
👀 
