### PR TITLE
fix(data-modeling): Only run .format if the query has that style params

### DIFF
--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -4,6 +4,7 @@ import contextlib
 import datetime as dt
 import enum
 import json
+import re
 import ssl
 import typing
 import uuid
@@ -353,9 +354,13 @@ class ClickHouseClient:
         if not query_parameters:
             return query
 
+        has_format_placeholders = re.search(r"(?<!{){[^{}]+}(?!})", query)
+
         format_parameters = {k: encode_clickhouse_data(v).decode("utf-8") for k, v in query_parameters.items()}
         query = query % format_parameters
-        query = query.format(**format_parameters)
+
+        if has_format_placeholders:
+            query = query.format(**format_parameters)
 
         return query
 

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -354,7 +354,7 @@ class ClickHouseClient:
         if not query_parameters:
             return query
 
-        has_format_placeholders = re.search(r"(?<!{){[^{}]+}(?!})", query)
+        has_format_placeholders = re.search(r"(?<!{){[^{}]*}(?!})", query)
 
         format_parameters = {k: encode_clickhouse_data(v).decode("utf-8") for k, v in query_parameters.items()}
         query = query % format_parameters

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -354,7 +354,7 @@ class ClickHouseClient:
         if not query_parameters:
             return query
 
-        has_format_placeholders = re.search(r"(?<!{){[^{}]*}(?!})", query)
+        has_format_placeholders = re.search(r"(?<!{){[^{}]*}(?!})|{{[^{}]*}}", query)
 
         format_parameters = {k: encode_clickhouse_data(v).decode("utf-8") for k, v in query_parameters.items()}
         query = query % format_parameters


### PR DESCRIPTION
## Problem
- When materializing, I have a query that uses the string `{}`, this is replaced by a `%(hogql_val_1)s` variable which is then swapped out via string formatting, but we then also run `query.format(...)` over the new query with the replaced variables, causing it to think `{}` is a variable that needs replacing

## Changes
- Check whether we need to use `.format(...)` before processing the `%(...)s` variables, if not, then skip the `.format()` 

## How did you test this code?
Tested a query locally