### PR TITLE
fix: avoid foss sync from running concurrently

### DIFF
--- a/.github/workflows/foss-sync.yml
+++ b/.github/workflows/foss-sync.yml
@@ -6,6 +6,10 @@ on:
             - master
             - main
 
+concurrency:
+    group: foss-sync
+    cancel-in-progress: false
+
 jobs:
     repo-sync:
         name: Sync posthog-foss with posthog


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We ship stuff too often and sometimes this is failing - I think one of the reasons is due to it running concurrently.

## Changes

- Add a concurrency group to avoid this running concurrently.
