### PR TITLE
fix(flags): Only show super groups when they exist

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -163,9 +163,14 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                             {!featureFlag.is_remote_configuration && (
                                 <>
                                     {/* TODO: In a follow up, clean up super_groups and combine into regular ReleaseConditions component */}
-                                    {featureFlag.filters.super_groups && (
-                                        <FeatureFlagReleaseConditions readOnly isSuper filters={featureFlag.filters} />
-                                    )}
+                                    {featureFlag.filters.super_groups &&
+                                        featureFlag.filters.super_groups.length > 0 && (
+                                            <FeatureFlagReleaseConditions
+                                                readOnly
+                                                isSuper
+                                                filters={featureFlag.filters}
+                                            />
+                                        )}
 
                                     <div className="flex gap-x-8">
                                         <div className="grow">

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -588,9 +588,13 @@ export function FeatureFlagReleaseConditions({
                 )}
             </div>
             <div className="FeatureConditionCard">
-                {filterGroups.map((group, index) =>
-                    isSuper ? renderSuperReleaseConditionGroup(group, index) : renderReleaseConditionGroup(group, index)
-                )}
+                {filterGroups.map((group, index) => (
+                    <div key={group.sort_key || index}>
+                        {isSuper
+                            ? renderSuperReleaseConditionGroup(group, index)
+                            : renderReleaseConditionGroup(group, index)}
+                    </div>
+                ))}
             </div>
             {!readOnly && (
                 <LemonButton type="secondary" className="mt-0 w-max" onClick={addConditionSet} icon={<IconPlus />}>

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsLogic.ts
@@ -303,7 +303,7 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
         // Get the appropriate groups based on isSuper
         filterGroups: [
             (s) => [s.filters, (_, props) => props.isSuper],
-            (filters: FeatureFlagFilters, isSuper: boolean) => (isSuper ? filters.super_groups : filters.groups),
+            (filters: FeatureFlagFilters, isSuper: boolean) => (isSuper ? filters.super_groups : filters.groups) || [],
         ],
         taxonomicGroupTypes: [
             (s) => [s.filters, s.groupTypes],

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -257,15 +257,18 @@ function cleanFlag(flag: Partial<FeatureFlagType>): Partial<FeatureFlagType> {
         ...cleanedFlag,
         filters: {
             ...cleanedFlag.filters,
-            groups: cleanFilterGroups(cleanedFlag.filters?.groups || []),
-            super_groups: cleanFilterGroups(cleanedFlag.filters?.super_groups || []),
+            groups: cleanFilterGroups(cleanedFlag.filters?.groups) || [],
+            super_groups: cleanFilterGroups(cleanedFlag.filters?.super_groups),
         },
     }
 }
 
 // Strip out sort_key from groups before saving. The sort_key is here for React to be able to
 // render the release conditions in the correct order.
-function cleanFilterGroups(groups: FeatureFlagGroupType[]): FeatureFlagGroupType[] {
+function cleanFilterGroups(groups?: FeatureFlagGroupType[]): FeatureFlagGroupType[] | undefined {
+    if (groups === undefined) {
+        return undefined
+    }
     return groups.map(({ sort_key, ...rest }: FeatureFlagGroupType) => rest)
 }
 


### PR DESCRIPTION
Fixes two bugs with super group rendering.

> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

1. When a flag doesn't have super groups, we were still seeing the super groups heading.
![image](https://github.com/user-attachments/assets/a485420f-219b-4d47-8e86-a923f636cddd)
2. When editing a flag, we get into an infinite props changed rendering loop. I added debug in my local branch so it could be seen:
<img width="501" alt="Screenshot 2025-06-30 at 10 30 55 AM" src="https://github.com/user-attachments/assets/8fecd83b-c1d3-46da-85cf-fc63f6b8ec31" />

## Changes

The first fix is easy. We check to make sure the super groups is not empty before rendering.
The second fix was to define the `isSuper` prop that we're passing in and use it as part of the Kea key for the `FeatureFlagReleaseConditionsLogic` because we can have multiple instances of the same logic.

Without a unique key, all usages of this logic would share the same state, which would cause bugs if a flag has both super/normal conditions on the same page.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Manual testing