### PR TITLE
chore: split roles for new deployments

### DIFF
--- a/posthog/health.py
+++ b/posthog/health.py
@@ -66,7 +66,7 @@ service_dependencies: dict[ServiceRole, list[str]] = {
     ],
     "decide": ["http"],
     "query": ["http", "postgres", "cache"],
-    "report": ["http", "postgres"],
+    "report": ["http", "kafka_connected"],
 }
 
 # if atleast one of the checks is True, then the service is considered healthy

--- a/posthog/health.py
+++ b/posthog/health.py
@@ -34,7 +34,7 @@ from posthog.kafka_client.client import can_connect as can_connect_to_kafka
 
 logger = get_logger(__name__)
 
-ServiceRole = Literal["events", "web", "worker", "decide"]
+ServiceRole = Literal["events", "web", "worker", "decide", "query", "report"]
 
 service_dependencies: dict[ServiceRole, list[str]] = {
     "events": ["http", "kafka_connected"],

--- a/posthog/health.py
+++ b/posthog/health.py
@@ -65,6 +65,8 @@ service_dependencies: dict[ServiceRole, list[str]] = {
         "celery_broker",
     ],
     "decide": ["http"],
+    "query": ["http", "postgres", "cache"],
+    "report": ["http", "postgres"],
 }
 
 # if atleast one of the checks is True, then the service is considered healthy


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

new query and report deployments added to ServiceRole. this was we can define the dependencies more granularly if necessary.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

add named roles to 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
