### PR TITLE
chore(report): Update health.py

### DIFF
--- a/posthog/health.py
+++ b/posthog/health.py
@@ -34,10 +34,12 @@ from posthog.kafka_client.client import can_connect as can_connect_to_kafka
 
 logger = get_logger(__name__)
 
-ServiceRole = Literal["events", "web", "worker", "decide"]
+ServiceRole = Literal["events", "report", "web", "worker", "decide"]
 
 service_dependencies: dict[ServiceRole, list[str]] = {
     "events": ["http", "kafka_connected"],
+    # TODO: remove kafka_connected after capture_internal is refactored
+    "report": ["http", "kafka_connected"],
     "web": [
         "http",
         # NOTE: we include Postgres because the way we use django means every request hits the DB


### PR DESCRIPTION
## Problem
Need to expose health checks for `posthog-report-django` deployments

## Changes
Register healthchecks appropriate for new deploy. Note which ones will go away after the migration off old `capture_internal` is complete

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Locally and in CI