### PR TITLE
fix(trigger-on-correct-message): Fix materialization trigger message

### DIFF
--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -509,7 +509,7 @@ async def materialize_model(
             await revert_materialization(saved_query, logger)
             await mark_job_as_failed(job, error_message, logger)
             raise Exception(f"Table reference missing for model {model_label}: {error_message}") from e
-        elif "TableNotFoundError" in error_message:
+        elif "no log files" in error_message:
             error_message = f"Query did not return rows. Try changing your time range or query."
             saved_query.latest_error = error_message
             await logger.ainfo("Query did not return results for model %s, reverting materialization", model_label)


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
We're currently triggering on the wrong log line to dematerialize, and some of our schedules are not getting shut down like we would wish for them to. The type name of the error is stripped out by the stringification process.
