### PR TITLE
fix(mm): restrict timespan of MMs

### DIFF
--- a/products/managed_migrations/frontend/managedMigrationLogic.ts
+++ b/products/managed_migrations/frontend/managedMigrationLogic.ts
@@ -3,6 +3,7 @@ import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
 import { router, urlToAction } from 'kea-router'
 import api, { ApiConfig } from 'lib/api'
+import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { urls } from 'scenes/urls'
 
@@ -86,6 +87,18 @@ export const managedMigrationLogic = kea<managedMigrationLogicType>([
                 } else if (source_type === 'mixpanel' || source_type === 'amplitude') {
                     errors.start_date = !start_date ? 'Start date is required' : null
                     errors.end_date = !end_date ? 'End date is required' : null
+
+                    if (start_date && end_date) {
+                        const startDateParsed = dayjs(start_date)
+                        const endDateParsed = dayjs(end_date)
+
+                        if (endDateParsed.isBefore(startDateParsed)) {
+                            errors.end_date = 'End date must be after start date'
+                        } else if (endDateParsed.diff(startDateParsed, 'year', true) > 1) {
+                            errors.end_date =
+                                'Date range cannot exceed 1 year. Please create multiple migration jobs for longer periods.'
+                        }
+                    }
                 }
                 return errors
             },


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We should only allow customers to create a managed migration from a direct source over a 1 year time span. Multi year imports can be done in multiple jobs.

## Changes

Added date range validation on the API and added date range validation on the client.

## Did you write or update any docs for this change?

I'll update the docs to include this detail

## How did you test this code?

Locally
