### PR TITLE
fix: Ensure that only AsyncDeletion objects considered for deletion are marked as validated

### DIFF
--- a/dags/deletes.py
+++ b/dags/deletes.py
@@ -260,7 +260,7 @@ class PendingDeletesDictionary(Dictionary):
 
     @property
     def query(self) -> str:
-        return f"SELECT team_id, deletion_type, key, created_at FROM {self.source.qualified_name} WHERE deletion_type IN ({DeletionType.Person}, {DeletionType.Team})"
+        return f"SELECT team_id, deletion_type, key, created_at FROM {self.source.qualified_name}"
 
     def create(self, client: Client, shards: int, max_execution_time: int, max_memory_usage: int) -> None:
         client.execute(
@@ -685,7 +685,6 @@ def mark_deletions_verified(
     adhoc_event_deletes_dictionary: AdhocEventDeletesDictionary,
 ) -> VerifiedDeletionResources:
     now = timezone.now()
-
     deletion_ids = [
         id
         for (id,) in cluster.any_host_by_role(

--- a/dags/tests/test_deletes.py
+++ b/dags/tests/test_deletes.py
@@ -128,11 +128,6 @@ def test_full_job_person_deletes(cluster: ClickhouseCluster):
     assert not any(cluster.map_all_hosts(table.exists).result().values())
     deletes_dict = PendingDeletesDictionary(source=table)
     assert not any(cluster.map_all_hosts(deletes_dict.exists).result().values())
-    report_table = PendingDeletesTable(timestamp=timestamp, is_reporting=True)
-    assert all(cluster.map_all_hosts(report_table.exists).result().values())
-
-    # clean up the reporting table
-    cluster.map_all_hosts(report_table.drop).result()
 
 
 @pytest.mark.django_db
@@ -325,11 +320,6 @@ def test_full_job_team_deletes(cluster: ClickhouseCluster):
     assert not any(cluster.map_all_hosts(table.exists).result().values())
     deletes_dict = PendingDeletesDictionary(source=table)
     assert not any(cluster.map_all_hosts(deletes_dict.exists).result().values())
-    report_table = PendingDeletesTable(timestamp=timestamp, is_reporting=True)
-    assert all(cluster.map_all_hosts(report_table.exists).result().values())
-
-    # clean up the reporting table
-    cluster.map_all_hosts(report_table.drop).result()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Problem

There is a race condition in deletion where rows that are inserted into `AsyncDeletion` during an already in-progress deletion can be marked as verified even though they were not run.

## Changes

Only mark deletions as verified if they were present in the pending deletions table used to build the dictionary that is used during the job run.

This also cleans up a few other things to make the job easier to read and understand, like removing the unused `pending_deletes_reporting` table.

## Did you write or update any docs for this change?

No docs needed for this change.

## How did you test this code?

TBD, covered to some extent by existing but still looking for ways to test the race condition behavior