### PR TITLE
fix(mm): makes amplitude event parsing more flexbile

### DIFF
--- a/rust/batch-import-worker/src/parse/content/amplitude.rs
+++ b/rust/batch-import-worker/src/parse/content/amplitude.rs
@@ -20,7 +20,7 @@ pub struct AmplitudeData {
     pub group_ids: HashMap<String, Value>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AmplitudeEvent {
     #[serde(rename = "$insert_id")]
     pub insert_id: Option<String>,
@@ -370,41 +370,359 @@ fn get_distinct_id(amp: &AmplitudeEvent) -> String {
     Uuid::now_v7().to_string()
 }
 
+fn parse_timestamp_string(time_str: &str) -> Result<chrono::DateTime<Utc>, chrono::ParseError> {
+    chrono::NaiveDateTime::parse_from_str(time_str, "%Y-%m-%d %H:%M:%S%.f")
+        .or_else(|_| chrono::NaiveDateTime::parse_from_str(time_str, "%Y-%m-%d %H:%M:%S"))
+        .map(|dt| dt.and_utc())
+}
+
 fn parse_timestamp(amp: &AmplitudeEvent) -> Result<chrono::DateTime<Utc>, Error> {
     if let Some(event_time) = &amp.event_time {
-        if let Ok(timestamp) =
-            chrono::NaiveDateTime::parse_from_str(event_time, "%Y-%m-%d %H:%M:%S%.f")
-                .or_else(|_| chrono::NaiveDateTime::parse_from_str(event_time, "%Y-%m-%d %H:%M:%S"))
-                .map(|dt| dt.and_utc())
-        {
+        if let Ok(timestamp) = parse_timestamp_string(event_time) {
             return Ok(timestamp);
         }
     }
 
     if let Some(client_event_time) = &amp.client_event_time {
-        if let Ok(timestamp) =
-            chrono::NaiveDateTime::parse_from_str(client_event_time, "%Y-%m-%d %H:%M:%S%.f")
-                .or_else(|_| {
-                    chrono::NaiveDateTime::parse_from_str(client_event_time, "%Y-%m-%d %H:%M:%S")
-                })
-                .map(|dt| dt.and_utc())
-        {
+        if let Ok(timestamp) = parse_timestamp_string(client_event_time) {
             return Ok(timestamp);
         }
     }
 
     if let Some(server_received_time) = &amp.server_received_time {
-        if let Ok(timestamp) =
-            chrono::NaiveDateTime::parse_from_str(server_received_time, "%Y-%m-%d %H:%M:%S%.f")
-                .or_else(|_| {
-                    chrono::NaiveDateTime::parse_from_str(server_received_time, "%Y-%m-%d %H:%M:%S")
-                })
-                .map(|dt| dt.and_utc())
-        {
+        if let Ok(timestamp) = parse_timestamp_string(server_received_time) {
             return Ok(timestamp);
         }
     }
 
     // If all timestamp parsing fails, use current time as last resort
     Ok(Utc::now())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn create_test_context() -> TransformContext {
+        TransformContext {
+            team_id: 123,
+            token: "test_token".to_string(),
+        }
+    }
+
+    fn identity_transform(event: RawEvent) -> Result<Option<RawEvent>, Error> {
+        Ok(Some(event))
+    }
+
+    #[test]
+    fn test_basic_amplitude_event() {
+        let amp_event = AmplitudeEvent {
+            insert_id: Some("test_insert_id".to_string()),
+            event_type: Some("button_click".to_string()),
+            user_id: Some("user123".to_string()),
+            device_id: Some("device456".to_string()),
+            event_time: Some("2023-10-15 14:30:00".to_string()),
+            event_properties: [("action".to_string(), json!("click"))]
+                .iter()
+                .cloned()
+                .collect(),
+            ..Default::default()
+        };
+
+        let parser = AmplitudeEvent::parse_fn(create_test_context(), identity_transform);
+        let result = parser(amp_event).unwrap().unwrap();
+
+        assert_eq!(result.team_id, 123);
+        assert_eq!(result.inner.token, "test_token");
+        assert_eq!(result.inner.distinct_id, "user123");
+
+        let data: RawEvent = serde_json::from_str(&result.inner.data).unwrap();
+        assert_eq!(data.event, "button_click");
+        assert_eq!(data.properties.get("action"), Some(&json!("click")));
+        assert_eq!(
+            data.properties.get("historical_migration"),
+            Some(&json!(true))
+        );
+        assert_eq!(
+            data.properties.get("analytics_source"),
+            Some(&json!("amplitude"))
+        );
+    }
+
+    #[test]
+    fn test_pageview_event_transformation() {
+        let amp_event = AmplitudeEvent {
+            event_type: Some("[Amplitude] Page Viewed".to_string()),
+            user_id: Some("user123".to_string()),
+            event_properties: [
+                (
+                    "[Amplitude] Page URL".to_string(),
+                    json!("https://example.com/page"),
+                ),
+                ("[Amplitude] Page Domain".to_string(), json!("example.com")),
+                ("[Amplitude] Page Path".to_string(), json!("/page")),
+            ]
+            .iter()
+            .cloned()
+            .collect(),
+            ..Default::default()
+        };
+
+        let parser = AmplitudeEvent::parse_fn(create_test_context(), identity_transform);
+        let result = parser(amp_event).unwrap().unwrap();
+
+        let data: RawEvent = serde_json::from_str(&result.inner.data).unwrap();
+        assert_eq!(data.event, "$pageview");
+        assert_eq!(
+            data.properties.get("$current_url"),
+            Some(&json!("https://example.com/page"))
+        );
+        assert_eq!(data.properties.get("$host"), Some(&json!("example.com")));
+        assert_eq!(data.properties.get("$pathname"), Some(&json!("/page")));
+    }
+
+    #[test]
+    fn test_autocapture_event_transformation() {
+        let amp_event = AmplitudeEvent {
+            event_type: Some("[Amplitude] Element Clicked".to_string()),
+            user_id: Some("user123".to_string()),
+            ..Default::default()
+        };
+
+        let parser = AmplitudeEvent::parse_fn(create_test_context(), identity_transform);
+        let result = parser(amp_event).unwrap().unwrap();
+
+        let data: RawEvent = serde_json::from_str(&result.inner.data).unwrap();
+        assert_eq!(data.event, "$autocapture");
+    }
+
+    #[test]
+    fn test_session_start_filtered_out() {
+        let amp_event = AmplitudeEvent {
+            event_type: Some("session_start".to_string()),
+            user_id: Some("user123".to_string()),
+            ..Default::default()
+        };
+
+        let parser = AmplitudeEvent::parse_fn(create_test_context(), identity_transform);
+        let result = parser(amp_event).unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_device_and_location_properties() {
+        let amp_event = AmplitudeEvent {
+            event_type: Some("test_event".to_string()),
+            user_id: Some("user123".to_string()),
+            device_type: Some("iOS".to_string()),
+            os_name: Some("iOS".to_string()),
+            os_version: Some("15.0".to_string()),
+            country: Some("United States".to_string()),
+            city: Some("San Francisco".to_string()),
+            region: Some("California".to_string()),
+            ip_address: Some("192.168.1.1".to_string()),
+            ..Default::default()
+        };
+
+        let parser = AmplitudeEvent::parse_fn(create_test_context(), identity_transform);
+        let result = parser(amp_event).unwrap().unwrap();
+
+        let data: RawEvent = serde_json::from_str(&result.inner.data).unwrap();
+        assert_eq!(data.properties.get("$device_type"), Some(&json!("Mobile")));
+        assert_eq!(data.properties.get("$browser"), Some(&json!("iOS")));
+        assert_eq!(
+            data.properties.get("$browser_version"),
+            Some(&json!("15.0"))
+        );
+        assert_eq!(
+            data.properties.get("$geoip_country_name"),
+            Some(&json!("United States"))
+        );
+        assert_eq!(
+            data.properties.get("$geoip_city_name"),
+            Some(&json!("San Francisco"))
+        );
+        assert_eq!(
+            data.properties.get("$geoip_subdivision_1_name"),
+            Some(&json!("California"))
+        );
+        assert_eq!(data.properties.get("$ip"), Some(&json!("192.168.1.1")));
+        assert_eq!(result.inner.ip, "192.168.1.1");
+    }
+
+    #[test]
+    fn test_user_properties_set_once() {
+        let amp_event = AmplitudeEvent {
+            event_type: Some("test_event".to_string()),
+            user_id: Some("user123".to_string()),
+            user_properties: [
+                ("initial_referrer".to_string(), json!("https://google.com")),
+                ("initial_utm_source".to_string(), json!("google")),
+                ("initial_utm_medium".to_string(), json!("cpc")),
+                ("initial_utm_campaign".to_string(), json!("winter_sale")),
+            ]
+            .iter()
+            .cloned()
+            .collect(),
+            ..Default::default()
+        };
+
+        let parser = AmplitudeEvent::parse_fn(create_test_context(), identity_transform);
+        let result = parser(amp_event).unwrap().unwrap();
+
+        let data: RawEvent = serde_json::from_str(&result.inner.data).unwrap();
+        let set_once = data.set_once.unwrap();
+        assert_eq!(
+            set_once.get("$initial_referrer"),
+            Some(&json!("https://google.com"))
+        );
+        assert_eq!(set_once.get("$initial_utm_source"), Some(&json!("google")));
+        assert_eq!(set_once.get("$initial_utm_medium"), Some(&json!("cpc")));
+        assert_eq!(
+            set_once.get("$initial_utm_campaign"),
+            Some(&json!("winter_sale"))
+        );
+    }
+
+    #[test]
+    fn test_empty_user_properties_filtered() {
+        let amp_event = AmplitudeEvent {
+            event_type: Some("test_event".to_string()),
+            user_id: Some("user123".to_string()),
+            user_properties: [
+                ("initial_referrer".to_string(), json!("EMPTY")),
+                ("initial_utm_source".to_string(), json!("google")),
+            ]
+            .iter()
+            .cloned()
+            .collect(),
+            ..Default::default()
+        };
+
+        let parser = AmplitudeEvent::parse_fn(create_test_context(), identity_transform);
+        let result = parser(amp_event).unwrap().unwrap();
+
+        let data: RawEvent = serde_json::from_str(&result.inner.data).unwrap();
+        let set_once = data.set_once.unwrap();
+        assert!(!set_once.contains_key("$initial_referrer"));
+        assert_eq!(set_once.get("$initial_utm_source"), Some(&json!("google")));
+    }
+
+    #[test]
+    fn test_timestamp_parsing_multiple_formats() {
+        let test_cases = vec![
+            ("2023-10-15 14:30:00", true),
+            ("2023-10-15 14:30:00.123", true),
+            ("invalid-timestamp", false),
+        ];
+
+        for (timestamp_str, should_parse) in test_cases {
+            let amp_event = AmplitudeEvent {
+                event_type: Some("test_event".to_string()),
+                user_id: Some("user123".to_string()),
+                event_time: Some(timestamp_str.to_string()),
+                ..Default::default()
+            };
+
+            let parser = AmplitudeEvent::parse_fn(create_test_context(), identity_transform);
+            let result = parser(amp_event).unwrap();
+
+            if should_parse {
+                assert!(result.is_some());
+                let data: RawEvent = serde_json::from_str(&result.unwrap().inner.data).unwrap();
+                assert!(data.timestamp.is_some());
+            }
+        }
+    }
+
+    #[test]
+    fn test_distinct_id_fallback() {
+        // Test with user_id
+        let amp_event = AmplitudeEvent {
+            event_type: Some("test_event".to_string()),
+            user_id: Some("user123".to_string()),
+            device_id: Some("device456".to_string()),
+            ..Default::default()
+        };
+
+        let parser = AmplitudeEvent::parse_fn(create_test_context(), identity_transform);
+        let result = parser(amp_event).unwrap().unwrap();
+        assert_eq!(result.inner.distinct_id, "user123");
+
+        // Test with device_id only
+        let amp_event = AmplitudeEvent {
+            event_type: Some("test_event".to_string()),
+            user_id: None,
+            device_id: Some("device456".to_string()),
+            ..Default::default()
+        };
+
+        let parser = AmplitudeEvent::parse_fn(create_test_context(), identity_transform);
+        let result = parser(amp_event).unwrap().unwrap();
+        assert_eq!(result.inner.distinct_id, "device456");
+
+        // Test with neither (should generate UUID)
+        let amp_event = AmplitudeEvent {
+            event_type: Some("test_event".to_string()),
+            user_id: None,
+            device_id: None,
+            ..Default::default()
+        };
+
+        let parser = AmplitudeEvent::parse_fn(create_test_context(), identity_transform);
+        let result = parser(amp_event).unwrap().unwrap();
+        assert!(!result.inner.distinct_id.is_empty());
+        assert!(Uuid::parse_str(&result.inner.distinct_id).is_ok());
+    }
+
+    #[test]
+    fn test_amplitude_specific_properties() {
+        let amp_event = AmplitudeEvent {
+            event_type: Some("test_event".to_string()),
+            user_id: Some("user123".to_string()),
+            device_id: Some("device456".to_string()),
+            amplitude_id: 789,
+            event_id: 101112,
+            session_id: 131415,
+            ..Default::default()
+        };
+
+        let parser = AmplitudeEvent::parse_fn(create_test_context(), identity_transform);
+        let result = parser(amp_event).unwrap().unwrap();
+
+        let data: RawEvent = serde_json::from_str(&result.inner.data).unwrap();
+        assert_eq!(
+            data.properties.get("$amplitude_user_id"),
+            Some(&json!("user123"))
+        );
+        assert_eq!(
+            data.properties.get("$amplitude_device_id"),
+            Some(&json!("device456"))
+        );
+        assert_eq!(data.properties.get("$device_id"), Some(&json!("device456")));
+        assert_eq!(
+            data.properties.get("$amplitude_event_id"),
+            Some(&json!(101112))
+        );
+        assert_eq!(
+            data.properties.get("$amplitude_session_id"),
+            Some(&json!(131415))
+        );
+    }
+
+    #[test]
+    fn test_missing_event_type() {
+        let amp_event = AmplitudeEvent {
+            event_type: None,
+            user_id: Some("user123".to_string()),
+            ..Default::default()
+        };
+
+        let parser = AmplitudeEvent::parse_fn(create_test_context(), identity_transform);
+        let result = parser(amp_event).unwrap();
+
+        assert!(result.is_none());
+    }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

The previous iteration of amplitude parsing for MM required a whole bunch of fields to be set in order for them to be properly parsed. Migrations for many customers exporting from amplitude failed.

## Changes

Supply fallbacks for necessary fields when creating a captured event so that we can support migrating more amplitude event schemas. An event should only need to have the event_type field on the incoming event to be transformed to a capture event.

Tests added to show the behaviour.

## Did you write or update any docs for this change?

## How did you test this code?

Added unit tests to show the new behaviour.
