### PR TITLE
chore(experiments): remove use new runner logic

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -275,7 +275,6 @@ export const FEATURE_FLAGS = {
     REPLAY_SCREENSHOT: 'replay-screenshot', // owner: @veryayskiy #team-replay
     SCREENSHOT_EDITOR: 'screenshot-editor', // owner: @veryayskiy #team-replay
     ACTIVITY_OR_EXPLORE: 'activity-or-explore', // owner: @pauldambra #team-replay
-    EXPERIMENTS_NEW_QUERY_RUNNER_FOR_USERS_ON_FREE_PLAN: 'experiments-new-query-runner-for-users-on-free-plan', // owner: #team-experiments
     LINEAGE_DEPENDENCY_VIEW: 'lineage-dependency-view', // owner: @phixMe #team-data-warehouse
     TRACK_MEMORY_USAGE: 'track-memory-usage', // owner: @pauldambra #team-replay
     TAXONOMIC_EVENT_SORTING: 'taxonomic-event-sorting', // owner: @pauldambra #team-replay

--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -35,17 +35,8 @@ export const scene: SceneExport = {
 }
 
 export function Experiments(): JSX.Element {
-    const {
-        currentProjectId,
-        experiments,
-        experimentsLoading,
-        tab,
-        shouldShowEmptyState,
-        showLegacyBadge,
-        filters,
-        count,
-        pagination,
-    } = useValues(experimentsLogic)
+    const { currentProjectId, experiments, experimentsLoading, tab, shouldShowEmptyState, filters, count, pagination } =
+        useValues(experimentsLogic)
     const { loadExperiments, setExperimentsTab, archiveExperiment, setExperimentsFilters } =
         useActions(experimentsLogic)
 
@@ -82,7 +73,7 @@ export function Experiments(): JSX.Element {
                         title={
                             <>
                                 {stringWithWBR(experiment.name, 17)}
-                                {showLegacyBadge && isLegacyExperiment(experiment) && (
+                                {isLegacyExperiment(experiment) && (
                                     <Tooltip
                                         title="This experiment uses the legacy engine, so some features and improvements may be missing."
                                         docLink="https://posthog.com/docs/experiments/new-experimentation-engine"

--- a/frontend/src/scenes/experiments/SharedMetrics/SharedMetrics.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/SharedMetrics.tsx
@@ -30,7 +30,7 @@ export const scene: SceneExport = {
 }
 
 export function SharedMetrics(): JSX.Element {
-    const { sharedMetrics, sharedMetricsLoading, showLegacyBadge } = useValues(sharedMetricsLogic)
+    const { sharedMetrics, sharedMetricsLoading } = useValues(sharedMetricsLogic)
 
     const { hasAvailableFeature } = useValues(userLogic)
 
@@ -45,7 +45,7 @@ export function SharedMetrics(): JSX.Element {
                         title={
                             <>
                                 {stringWithWBR(sharedMetric.name, 17)}
-                                {showLegacyBadge && isLegacySharedMetric(sharedMetric) && (
+                                {isLegacySharedMetric(sharedMetric) && (
                                     <Tooltip
                                         title="This metric uses the legacy engine, so some features and improvements may be missing."
                                         docLink="https://posthog.com/docs/experiments/new-experimentation-engine"

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
@@ -3,13 +3,13 @@ import { actions, connect, kea, key, listeners, path, props, reducers, selectors
 import { loaders } from 'kea-loaders'
 import { router, urlToAction } from 'kea-router'
 import api from 'lib/api'
-import { featureFlagLogic, FeatureFlagsSet } from 'lib/logic/featureFlagLogic'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { billingLogic } from 'scenes/billing/billingLogic'
 
-import { BillingType, UserBasicType } from '~/types'
+import { UserBasicType } from '~/types'
 
-import { getDefaultFunnelMetric, getDefaultTrendsMetric, shouldUseNewQueryRunnerForNewObjects } from '../utils'
+import { getDefaultFunnelMetric } from '../utils'
 import type { sharedMetricLogicType } from './sharedMetricLogicType'
 import { sharedMetricsLogic } from './sharedMetricsLogic'
 
@@ -133,12 +133,10 @@ export const sharedMetricLogic = kea<sharedMetricLogicType>([
         ],
         action: [() => [(_, props) => props.action], (action: 'create' | 'update' | 'duplicate') => action],
         newSharedMetric: [
-            (s) => [s.featureFlags, s.billing],
-            (featureFlags: FeatureFlagsSet, billing: BillingType) => ({
+            () => [],
+            () => ({
                 ...NEW_SHARED_METRIC,
-                query: shouldUseNewQueryRunnerForNewObjects(featureFlags, billing)
-                    ? getDefaultFunnelMetric()
-                    : getDefaultTrendsMetric(),
+                query: getDefaultFunnelMetric(),
             }),
         ],
     }),

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.tsx
@@ -2,7 +2,6 @@ import { actions, connect, events, kea, listeners, path, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
 import { router } from 'kea-router'
 import api from 'lib/api'
-import { featureFlagsLogic } from 'scenes/feature-flags/featureFlagsLogic'
 
 import type { SharedMetric } from './sharedMetricLogic'
 import type { sharedMetricsLogicType } from './sharedMetricsLogicType'
@@ -15,9 +14,7 @@ export enum SharedMetricsTabs {
 
 export const sharedMetricsLogic = kea<sharedMetricsLogicType>([
     path(['scenes', 'experiments', 'sharedMetricsLogic']),
-    connect(() => ({
-        values: [featureFlagsLogic, ['featureFlags']],
-    })),
+    connect(() => ({})),
     actions({
         setSharedMetricsTab: (tabKey: SharedMetricsTabs) => ({ tabKey }),
     }),

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.tsx
@@ -2,7 +2,6 @@ import { actions, connect, events, kea, listeners, path, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
 import { router } from 'kea-router'
 import api from 'lib/api'
-import { billingLogic } from 'scenes/billing/billingLogic'
 import { featureFlagsLogic } from 'scenes/feature-flags/featureFlagsLogic'
 
 import type { SharedMetric } from './sharedMetricLogic'
@@ -17,7 +16,7 @@ export enum SharedMetricsTabs {
 export const sharedMetricsLogic = kea<sharedMetricsLogicType>([
     path(['scenes', 'experiments', 'sharedMetricsLogic']),
     connect(() => ({
-        values: [featureFlagsLogic, ['featureFlags'], billingLogic, ['billing']],
+        values: [featureFlagsLogic, ['featureFlags']],
     })),
     actions({
         setSharedMetricsTab: (tabKey: SharedMetricsTabs) => ({ tabKey }),

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.tsx
@@ -1,4 +1,4 @@
-import { actions, connect, events, kea, listeners, path, reducers, selectors } from 'kea'
+import { actions, connect, events, kea, listeners, path, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
 import { router } from 'kea-router'
 import api from 'lib/api'
@@ -52,13 +52,5 @@ export const sharedMetricsLogic = kea<sharedMetricsLogicType>([
         afterMount: () => {
             actions.loadSharedMetrics()
         },
-    })),
-    selectors(() => ({
-        showLegacyBadge: [
-            () => [],
-            (): boolean => {
-                return true
-            },
-        ],
     })),
 ])

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.tsx
@@ -2,13 +2,9 @@ import { actions, connect, events, kea, listeners, path, reducers, selectors } f
 import { loaders } from 'kea-loaders'
 import { router } from 'kea-router'
 import api from 'lib/api'
-import type { FeatureFlagsSet } from 'lib/logic/featureFlagLogic'
 import { billingLogic } from 'scenes/billing/billingLogic'
 import { featureFlagsLogic } from 'scenes/feature-flags/featureFlagsLogic'
 
-import { BillingType } from '~/types'
-
-import { isLegacySharedMetric, shouldUseNewQueryRunnerForNewObjects } from '../utils'
 import type { SharedMetric } from './sharedMetricLogic'
 import type { sharedMetricsLogicType } from './sharedMetricsLogicType'
 
@@ -59,26 +55,9 @@ export const sharedMetricsLogic = kea<sharedMetricsLogicType>([
     })),
     selectors(() => ({
         showLegacyBadge: [
-            (s) => [featureFlagsLogic.selectors.featureFlags, s.sharedMetrics, billingLogic.selectors.billing],
-            (featureFlags: FeatureFlagsSet, sharedMetrics: SharedMetric[], billing: BillingType): boolean => {
-                /**
-                 * If the new query runner is enabled, we want to always show the legacy badge,
-                 * even if all existing shared metrics are using the legacy metric format.
-                 *
-                 * Not ideal to use feature flags at this level, but this is how things are and
-                 * it'll take a while to change.
-                 */
-                if (shouldUseNewQueryRunnerForNewObjects(featureFlags, billing)) {
-                    return true
-                }
-
-                /**
-                 * If the new query runner is not enabled, we'll set this boolean selector
-                 * so the components can show the legacy badge only if there are experiments
-                 * that use the NEW query runner.
-                 * This covers the case when the feature was disabled after creating new experiments.
-                 */
-                return sharedMetrics.some((sharedMetric) => !isLegacySharedMetric(sharedMetric))
+            () => [],
+            (): boolean => {
+                return true
             },
         ],
     })),

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -7,7 +7,7 @@ import { openSaveToModal } from 'lib/components/FileSystem/SaveTo/saveToLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
-import { featureFlagLogic, FeatureFlagsSet } from 'lib/logic/featureFlagLogic'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { hasFormErrors, toParams } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { ProductIntentContext } from 'lib/utils/product-intents'
@@ -51,7 +51,6 @@ import {
 } from '~/queries/schema/schema-general'
 import { setLatestVersionsOnQuery } from '~/queries/utils'
 import {
-    BillingType,
     Breadcrumb,
     BreakdownAttributionType,
     BreakdownType,
@@ -93,7 +92,6 @@ import {
     featureFlagEligibleForExperiment,
     isLegacyExperiment,
     percentageDistribution,
-    shouldUseNewQueryRunnerForNewObjects,
     toInsightVizNode,
     transformFiltersForWinningVariant,
 } from './utils'
@@ -1845,8 +1843,8 @@ export const experimentLogic = kea<experimentLogicType>([
             },
         ],
         usesNewQueryRunner: [
-            (s) => [s.experiment, s.featureFlags, s.billing],
-            (experiment: Experiment, featureFlags: FeatureFlagsSet, billing: BillingType): boolean => {
+            (s) => [s.experiment],
+            (experiment: Experiment): boolean => {
                 const hasLegacyMetrics = isLegacyExperiment(experiment)
 
                 const allMetrics = [...experiment.metrics, ...experiment.metrics_secondary, ...experiment.saved_metrics]
@@ -1860,8 +1858,8 @@ export const experimentLogic = kea<experimentLogicType>([
                     return false
                 }
 
-                // If the experiment has no experiment metrics, we use the new query runner if the feature is enabled
-                return shouldUseNewQueryRunnerForNewObjects(featureFlags, billing)
+                // If the experiment has no experiment metrics, we use the new query runner
+                return true
             },
         ],
         hasMinimumExposureForResults: [

--- a/frontend/src/scenes/experiments/experimentsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.ts
@@ -8,7 +8,6 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { featureFlagLogic, FeatureFlagsSet } from 'lib/logic/featureFlagLogic'
 import { objectsEqual, toParams } from 'lib/utils'
-import { billingLogic } from 'scenes/billing/billingLogic'
 import { featureFlagsLogic, type FeatureFlagsResult } from 'scenes/feature-flags/featureFlagsLogic'
 import { projectLogic } from 'scenes/projectLogic'
 import { urls } from 'scenes/urls'
@@ -74,8 +73,6 @@ export const experimentsLogic = kea<experimentsLogicType>([
             ['featureFlags'],
             router,
             ['location'],
-            billingLogic,
-            ['billing'],
         ],
     })),
     actions({

--- a/frontend/src/scenes/experiments/experimentsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.ts
@@ -14,10 +14,9 @@ import { projectLogic } from 'scenes/projectLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
-import { BillingType, Experiment, ExperimentsTabs, ProgressStatus } from '~/types'
+import { Experiment, ExperimentsTabs, ProgressStatus } from '~/types'
 
 import type { experimentsLogicType } from './experimentsLogicType'
-import { isLegacyExperiment, shouldUseNewQueryRunnerForNewObjects } from './utils'
 
 export const EXPERIMENTS_PER_PAGE = 100
 
@@ -197,26 +196,9 @@ export const experimentsLogic = kea<experimentsLogicType>([
             },
         ],
         showLegacyBadge: [
-            (s) => [featureFlagsLogic.selectors.featureFlags, s.experiments, s.billing],
-            (featureFlags: FeatureFlagsSet, experiments: ExperimentsResult, billing: BillingType): boolean => {
-                /**
-                 * If the new query runner is enabled, we want to always show the legacy badge,
-                 * even if all existing experiments are legacy experiments.
-                 *
-                 * Not ideal to use feature flags at this level, but this is how things are and
-                 * it'll take a while to change.
-                 */
-                if (shouldUseNewQueryRunnerForNewObjects(featureFlags, billing)) {
-                    return true
-                }
-
-                /**
-                 * If the new query runner is not enabled, we'll set this boolean selector
-                 * so the components can show the legacy badge only if there are experiments
-                 * that use the NEW query runner.
-                 * This covers the case when the feature was disabled after creating new experiments.
-                 */
-                return experiments.results.some((experiment) => !isLegacyExperiment(experiment))
+            () => [],
+            (): boolean => {
+                return true
             },
         ],
     })),

--- a/frontend/src/scenes/experiments/experimentsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.ts
@@ -195,12 +195,6 @@ export const experimentsLogic = kea<experimentsLogicType>([
                 ])
             },
         ],
-        showLegacyBadge: [
-            () => [],
-            (): boolean => {
-                return true
-            },
-        ],
     })),
     events(({ actions }) => ({
         afterMount: () => {

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -1,7 +1,7 @@
 import { getSeriesColor } from 'lib/colors'
-import { EXPERIMENT_DEFAULT_DURATION, FEATURE_FLAGS, FunnelLayout } from 'lib/constants'
+import { EXPERIMENT_DEFAULT_DURATION, FunnelLayout } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
-import { FeatureFlagsSet } from 'lib/logic/featureFlagLogic'
+
 import merge from 'lodash.merge'
 import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
 
@@ -31,7 +31,6 @@ import {
 import { isFunnelsQuery, isNodeWithSource, isTrendsQuery, isValidQueryForExperiment } from '~/queries/utils'
 import {
     ActionFilter,
-    BillingType,
     ChartDisplayType,
     Experiment,
     ExperimentMetricMathType,
@@ -914,18 +913,3 @@ export const isLegacyExperiment = ({ metrics, metrics_secondary, saved_metrics }
 }
 
 export const isLegacySharedMetric = ({ query }: SharedMetric): boolean => isLegacyExperimentQuery(query)
-
-/**
- * TODO: remove since rollout is complete.
- */
-export const shouldUseNewQueryRunnerForNewObjects = (featureFlags: FeatureFlagsSet, billing: BillingType): boolean => {
-    // For non-paying users, we use dedicated flag to control the rollout of the new query runner
-    const isOnFreePlan = billing?.subscription_level === 'free'
-    if (isOnFreePlan && !!featureFlags[FEATURE_FLAGS.EXPERIMENTS_NEW_QUERY_RUNNER_FOR_USERS_ON_FREE_PLAN]) {
-        return true
-    }
-
-    // If the users org. is on a paid plan, or the feature flag above is disabled, we use the default
-    // feature flag to control the rollout of the new query runner
-    return !!featureFlags[FEATURE_FLAGS.EXPERIMENTS_NEW_QUERY_RUNNER]
-}


### PR DESCRIPTION
## Problem
Now that the new engine is rolled out 100%, we can remove the logic that checks whether we should use it or not.

## Changes
Remove code no longer needed

## How did you test this code?
- Manually tested
- Tests passes
