### PR TITLE
chore(persons): Ignore sequential fetchForUpdates if another pod has changed values

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/person-store-manager.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-store-manager.test.ts
@@ -779,6 +779,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
                     type: 'addDistinctId',
                     timestamp: expect.any(Number),
                     distinctId: distinctId,
+                    version: existingPerson.version,
                 },
             ])
 
@@ -869,6 +870,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
                     type: 'moveDistinctIds',
                     timestamp: expect.any(Number),
                     distinctId: distinctId,
+                    version: targetPerson.version,
                 },
             ])
 

--- a/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
@@ -100,7 +100,8 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
         personUuid: string,
         person: InternalPerson | null,
         versionDisparity: boolean,
-        operationType: string
+        operationType: string,
+        version?: number
     ): void {
         const key = this.getPersonKey(teamId, personUuid)
         const existing = this.finalStates.get(key)
@@ -109,6 +110,7 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
             type: operationType,
             timestamp: Date.now(),
             distinctId,
+            version,
         }
 
         if (person) {
@@ -137,6 +139,8 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
         // Check if batch store already has cached data for this person
         const existingCached = this.secondaryStore.getCachedPersonForUpdate(teamId, distinctId)
 
+        let versionDisparity = false
+
         if (mainResult && existingCached === undefined) {
             // No existing cache, set the fresh data
             this.secondaryStore.setCachedPersonForUpdate(teamId, distinctId, fromInternalPerson(mainResult, distinctId))
@@ -144,6 +148,11 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
             // Cache was explicitly set to null, but now we have data - update it
             this.secondaryStore.setCachedPersonForUpdate(teamId, distinctId, fromInternalPerson(mainResult, distinctId))
         } else if (mainResult && existingCached) {
+            // Check for version disparity - if the fetched version differs from cached, another pod updated it
+            if (mainResult.version !== existingCached.version) {
+                versionDisparity = true
+            }
+
             // We have both fresh data and existing cache - merge them properly
             const freshPersonUpdate = fromInternalPerson(mainResult, distinctId)
             // Preserve the existing changeset
@@ -159,7 +168,15 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
         }
 
         if (mainResult) {
-            this.updateFinalState(teamId, distinctId, mainResult.uuid, mainResult, false, 'fetchForUpdate')
+            this.updateFinalState(
+                teamId,
+                distinctId,
+                mainResult.uuid,
+                mainResult,
+                versionDisparity,
+                'fetchForUpdate',
+                mainResult.version
+            )
         }
 
         return mainResult
@@ -204,7 +221,8 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
             mainResult[0].uuid,
             mainResult[0],
             false,
-            'createPerson'
+            'createPerson',
+            mainResult[0].version
         )
 
         return mainResult
@@ -238,7 +256,8 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
             mainPersonResult.uuid,
             mainPersonResult,
             mainVersionDisparity,
-            'updatePersonForUpdate'
+            'updatePersonForUpdate',
+            mainPersonResult.version
         )
         return [mainPersonResult, mainKafkaMessages, mainVersionDisparity]
     }
@@ -271,7 +290,8 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
             mainPersonResult.uuid,
             mainPersonResult,
             mainVersionDisparity,
-            'updatePersonForMerge'
+            'updatePersonForMerge',
+            mainPersonResult.version
         )
         return [mainPersonResult, mainKafkaMessages, mainVersionDisparity]
     }
@@ -298,7 +318,7 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
         this.secondaryStore.setCachedPersonForUpdate(person.team_id, distinctId, fromInternalPerson(person, distinctId))
 
         // Track that this distinct ID now points to the person
-        this.updateFinalState(person.team_id, distinctId, person.uuid, person, false, 'addDistinctId')
+        this.updateFinalState(person.team_id, distinctId, person.uuid, person, false, 'addDistinctId', person.version)
 
         return mainResult
     }
@@ -317,8 +337,8 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
         // Update cache for the target person for the current distinct ID
         this.secondaryStore.setCachedPersonForUpdate(target.team_id, distinctId, fromInternalPerson(target, distinctId))
 
-        this.updateFinalState(source.team_id, distinctId, source.uuid, null, false, 'moveDistinctIds')
-        this.updateFinalState(target.team_id, distinctId, target.uuid, target, false, 'moveDistinctIds')
+        this.updateFinalState(source.team_id, distinctId, source.uuid, null, false, 'moveDistinctIds', source.version)
+        this.updateFinalState(target.team_id, distinctId, target.uuid, target, false, 'moveDistinctIds', target.version)
 
         return mainResult
     }


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Chances for this happening are slim, but we see multiple sequential fetchForUpdate that produce unexpected results, this PR tracks if there was a change to the person in between fetches, meaning another pod changed the person data

## Changes

- Add version to operation logs
- Add logic in `fetchForUpdate` to evaluate versionDisparity

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
