### PR TITLE
fix(plugin-server): log liveness fail per service

### DIFF
--- a/plugin-server/src/router.ts
+++ b/plugin-server/src/router.ts
@@ -71,7 +71,7 @@ const buildGetHealth =
         if (statusCode === 200) {
             logger.info('💚', 'Server liveness check succeeded')
         } else {
-            logger.info('💔', 'Server liveness check failed', checkResultsMapping)
+            logger.info('💔', 'Server liveness check failed', { checkResults: checkResultsMapping })
         }
 
         return res.status(statusCode).json({ status: statusCode === 200 ? 'ok' : 'error', checks: checkResultsMapping })

--- a/plugin-server/src/router.ts
+++ b/plugin-server/src/router.ts
@@ -68,8 +68,7 @@ const buildGetHealth =
 
         const checkResultsMapping = Object.fromEntries(checkResults.map((result) => [result.service, result.status]))
 
-        // Fail on purpose 10% of the time (for testing)
-        if (statusCode === 200 && Math.random() > 0.1) {
+        if (statusCode === 200) {
             logger.info('💚', 'Server liveness check succeeded')
         } else {
             logger.info('💔', 'Server liveness check failed', { checkResults: checkResultsMapping })

--- a/plugin-server/src/router.ts
+++ b/plugin-server/src/router.ts
@@ -68,7 +68,8 @@ const buildGetHealth =
 
         const checkResultsMapping = Object.fromEntries(checkResults.map((result) => [result.service, result.status]))
 
-        if (statusCode === 200) {
+        // Fail on purpose 10% of the time (for testing)
+        if (statusCode === 200 && Math.random() > 0.1) {
             logger.info('💚', 'Server liveness check succeeded')
         } else {
             logger.info('💔', 'Server liveness check failed', { checkResults: checkResultsMapping })


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We don't see liveness checks fail status per service in logs, this may be because of a parsing error in Loki

## Changes

Force a specific key for the checkResults. 

<img width="1243" alt="Screenshot 2025-07-01 at 15 44 17" src="https://github.com/user-attachments/assets/5985ed02-2356-4371-af8a-b5c6b1f91654" />

I forced the health check to fail 10% of the time to test this (hence why the services say "ok"

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
