### PR TITLE
feat: tag cache warmup with a feature

### DIFF
--- a/posthog/caching/warming.py
+++ b/posthog/caching/warming.py
@@ -13,7 +13,7 @@ from posthog.exceptions_capture import capture_exception
 
 from posthog.api.services.query import process_query_dict
 from posthog.caching.utils import largest_teams
-from posthog.clickhouse.query_tagging import tag_queries
+from posthog.clickhouse.query_tagging import tag_queries, Feature
 from posthog.errors import CHQueryErrorTooManySimultaneousQueries
 from posthog.hogql.constants import LimitContext
 from posthog.hogql_queries.query_cache import QueryCacheManager
@@ -204,7 +204,7 @@ def warm_insight_cache_task(insight_id: int, dashboard_id: Optional[int]):
 
     dashboard = None
 
-    tag_queries(team_id=insight.team_id, insight_id=insight.pk, trigger="warmingV2")
+    tag_queries(team_id=insight.team_id, insight_id=insight.pk, trigger="warmingV2", feature=Feature.CACHE_WARMUP)
     if dashboard_id:
         tag_queries(dashboard_id=dashboard_id)
         dashboard = insight.dashboards.filter(pk=dashboard_id).first()

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -20,7 +20,7 @@ from posthog.clickhouse.client.connection import (
     ClickHouseUser,
 )
 from posthog.clickhouse.client.escape import substitute_params
-from posthog.clickhouse.query_tagging import get_query_tag_value, get_query_tags, QueryTags, AccessMethod
+from posthog.clickhouse.query_tagging import get_query_tag_value, get_query_tags, QueryTags, AccessMethod, Feature
 from posthog.cloud_utils import is_cloud
 from posthog.errors import wrap_query_error, ch_error_type
 from posthog.exceptions import ClickhouseAtCapacity
@@ -179,6 +179,8 @@ def sync_execute(
         elif tags.kind == "request" and "api/" in tags_id and "capture" not in tags_id:
             # process requests made to API from the PH app
             ch_user = ClickHouseUser.APP
+        elif tags.feature == Feature.CACHE_WARMUP:
+            ch_user = ClickHouseUser.CACHE_WARMUP
 
     # update tags if inside temporal (should not)
     update_query_tags_with_temporal_info()

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -35,6 +35,7 @@ class Feature(StrEnum):
     QUERY = "query"
     INSIGHT = "insight"
     DASHBOARD = "dashboard"
+    CACHE_WARMUP = "cache_warmup"
 
 
 class TemporalTags(BaseModel):


### PR DESCRIPTION
## Problem

cache warmup queries use a proper CH user

## Changes

if a query is tagged as cache warmup, use separate user

## Did you write or update any docs for this change?

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [X] No docs needed for this change
