### PR TITLE
feat: show view recording button when displaying a recording annotation

### DIFF
--- a/frontend/src/lib/components/AnnotationsOverlay/AnnotationsOverlay.tsx
+++ b/frontend/src/lib/components/AnnotationsOverlay/AnnotationsOverlay.tsx
@@ -16,7 +16,7 @@ import { annotationModalLogic, annotationScopeToName } from 'scenes/annotations/
 import { insightLogic } from 'scenes/insights/insightLogic'
 
 import { annotationsModel } from '~/models/annotationsModel'
-import { AnnotationType, IntervalType } from '~/types'
+import { AnnotationScope, AnnotationType, IntervalType } from '~/types'
 
 import {
     annotationsOverlayLogic,
@@ -24,6 +24,7 @@ import {
     determineAnnotationsDateGroup,
 } from './annotationsOverlayLogic'
 import { useAnnotationsPositioning } from './useAnnotationsPositioning'
+import ViewRecordingButton from 'lib/components/ViewRecordingButton/ViewRecordingButton'
 
 /** User-facing format for annotation groups. */
 const INTERVAL_UNIT_TO_HUMAN_DAYJS_FORMAT: Record<IntervalType, string> = {
@@ -250,7 +251,7 @@ function AnnotationCard({ annotation }: { annotation: AnnotationType }): JSX.Ele
                 <h5 className="grow m-0 text-secondary">
                     {annotation.date_marker?.format('MMM DD, YYYY h:mm A')} ({shortTimeZone(timezone)}) –{' '}
                     {annotationScopeToName[annotation.scope]}
-                    -level
+                    {annotation.scope === AnnotationScope.Recording ? ' comment' : '-level'}
                 </h5>
                 <LemonButton
                     size="small"
@@ -270,16 +271,29 @@ function AnnotationCard({ annotation }: { annotation: AnnotationType }): JSX.Ele
                 />
             </div>
             <div className="mt-1">{annotation.content}</div>
-            <div className="leading-6 mt-2">
-                <ProfilePicture
-                    user={
-                        annotation.creation_type === 'GIT' ? { first_name: 'GitHub automation' } : annotation.created_by
-                    }
-                    showName
-                    size="md"
-                    type={annotation.creation_type === 'GIT' ? 'bot' : 'person'}
-                />{' '}
-                • {humanFriendlyDetailedTime(annotation.created_at, 'MMMM DD, YYYY', 'h:mm A')}
+            <div className="leading-6 mt-2 flex flex-row items-center justify-between">
+                <div>
+                    <ProfilePicture
+                        user={
+                            annotation.creation_type === 'GIT'
+                                ? { first_name: 'GitHub automation' }
+                                : annotation.created_by
+                        }
+                        showName
+                        size="md"
+                        type={annotation.creation_type === 'GIT' ? 'bot' : 'person'}
+                    />{' '}
+                    • {humanFriendlyDetailedTime(annotation.created_at, 'MMMM DD, YYYY', 'h:mm A')}
+                </div>
+                {annotation.scope === AnnotationScope.Recording &&
+                !!annotation.recording_id &&
+                !!annotation.date_marker ? (
+                    <ViewRecordingButton
+                        sessionId={annotation.recording_id}
+                        timestamp={annotation.date_marker}
+                        inModal={true}
+                    />
+                ) : null}
             </div>
         </li>
     )

--- a/frontend/src/scenes/annotations/AnnotationModal.tsx
+++ b/frontend/src/scenes/annotations/AnnotationModal.tsx
@@ -18,6 +18,7 @@ import { urls } from 'scenes/urls'
 import { AnnotationScope, AnnotationType } from '~/types'
 
 import { annotationModalLogic, annotationScopeToName } from './annotationModalLogic'
+import ViewRecordingButton from 'lib/components/ViewRecordingButton/ViewRecordingButton'
 
 export function NewAnnotationButton(): JSX.Element {
     const { openModalToCreateAnnotation } = useActions(annotationModalLogic)
@@ -110,7 +111,7 @@ export function AnnotationModal({
             isOpen={isModalOpen}
             onClose={closeModal}
             title={existingModalAnnotation ? 'Edit annotation' : 'New annotation'}
-            description="Use annotations to add context to insights and dashboards."
+            description="Use annotations to comment on insights, dashboards, and recordings."
             footer={
                 <div className="flex-1 flex items-center justify-between">
                     <div className="flex items-center gap-2">
@@ -182,6 +183,19 @@ export function AnnotationModal({
                         maxLength={400}
                     />
                 </LemonField>
+                {!!existingModalAnnotation &&
+                existingModalAnnotation.scope === AnnotationScope.Recording &&
+                !!existingModalAnnotation.recording_id &&
+                !!existingModalAnnotation.date_marker ? (
+                    <div className="flex flex-row justify-end">
+                        <ViewRecordingButton
+                            sessionId={existingModalAnnotation.recording_id}
+                            timestamp={existingModalAnnotation.date_marker}
+                            inModal={true}
+                            type="secondary"
+                        />
+                    </div>
+                ) : null}
             </Form>
         </LemonModal>
     )


### PR DESCRIPTION
see https://x.com/iamsaura_/status/1939984555034701982

when showing a recording comment as an annotation _outside of the replay context_ show a view recording button

<img width="587" alt="Screenshot 2025-07-01 at 13 51 27" src="https://github.com/user-attachments/assets/c9d525cf-da6f-4aa9-819b-040bc9d6d494" />
<img width="594" alt="Screenshot 2025-07-01 at 13 49 56" src="https://github.com/user-attachments/assets/381eb527-c8f1-4797-a3f8-908bc6808665" />
