### PR TITLE
chore(persons): change person cache to use id

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -432,7 +432,17 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         this.clearCacheByPersonId(source.team_id, source.id)
 
         // Update cache for the target person for the current distinct ID
-        this.setCachedPersonForUpdate(target.team_id, distinctId, fromInternalPerson(target, distinctId))
+        // Check if we already have cached data for the target person that includes merged properties
+        const existingTargetCache = this.getCachedPersonForUpdateByPersonId(target.team_id, target.id)
+        if (existingTargetCache) {
+            // We have existing cached data with merged properties - preserve it
+            // Create a new PersonUpdate for this distinctId that preserves the merged data
+            const mergedPersonUpdate = { ...existingTargetCache, distinct_id: distinctId }
+            this.setCachedPersonForUpdate(target.team_id, distinctId, mergedPersonUpdate)
+        } else {
+            // No existing cache, create fresh cache from target person
+            this.setCachedPersonForUpdate(target.team_id, distinctId, fromInternalPerson(target, distinctId))
+        }
 
         return response
     }

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -103,7 +103,7 @@ export class BatchWritingPersonsStore implements PersonsStore {
  */
 export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, BatchWritingStore {
     private personCheckCache: Map<string, InternalPerson | null>
-    private distinctIdToPersonUuid: Map<string, string>
+    private distinctIdToPersonId: Map<string, string>
     private personUpdateCache: Map<string, PersonUpdate | null>
     private fetchPromisesForUpdate: Map<string, Promise<InternalPerson | null>>
     private fetchPromisesForChecking: Map<string, Promise<InternalPerson | null>>
@@ -115,7 +115,7 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
 
     constructor(private db: DB, options?: Partial<BatchWritingPersonsStoreOptions>) {
         this.options = { ...DEFAULT_OPTIONS, ...options }
-        this.distinctIdToPersonUuid = new Map()
+        this.distinctIdToPersonId = new Map()
         this.personUpdateCache = new Map()
         this.personCheckCache = new Map()
         this.fetchPromisesForUpdate = new Map()
@@ -201,7 +201,7 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
                                     update.team_id,
                                     'person_upsert_message_size_too_large',
                                     {
-                                        personUuid: update.uuid,
+                                        personId: update.id,
                                         distinctId: update.distinct_id,
                                     }
                                 )
@@ -215,7 +215,7 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
 
                             logger.warn('⚠️', 'Falling back to direct update after max retries', {
                                 teamId: update.team_id,
-                                personUuid: update.uuid,
+                                personId: update.id,
                                 distinctId: update.distinct_id,
                             })
 
@@ -239,7 +239,7 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
                             error,
                             cacheKey,
                             teamId: update.team_id,
-                            personUuid: update.uuid,
+                            personId: update.id,
                             distinctId: update.distinct_id,
                             errorMessage: error instanceof Error ? error.message : String(error),
                             errorStack: error instanceof Error ? error.stack : undefined,
@@ -390,13 +390,13 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         this.incrementCount('deletePerson', distinctId)
         this.incrementDatabaseOperation('deletePerson', distinctId)
         const start = performance.now()
-        const personToDelete = this.getCachedPersonForUpdateByUuid(person.team_id, person.uuid) || person
+        const personToDelete = this.getCachedPersonForUpdateByPersonId(person.team_id, person.id) || person
 
         const response = await this.db.deletePerson(personToDelete, tx)
         observeLatencyByVersion(person, start, 'deletePerson')
 
-        // Clear ALL caches related to this person UUID
-        this.clearAllCachesForPersonUuid(person.team_id, person.uuid)
+        // Clear ALL caches related to this person id
+        this.clearAllCachesForPersonId(person.team_id, person.id)
 
         return response
     }
@@ -412,7 +412,7 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         const start = performance.now()
         const response = await this.db.addDistinctId(person, distinctId, version, tx)
         observeLatencyByVersion(person, start, 'addDistinctId')
-        this.setDistinctIdToPersonUuid(person.team_id, distinctId, person.uuid)
+        this.setDistinctIdToPersonId(person.team_id, distinctId, person.id)
         return response
     }
 
@@ -428,8 +428,8 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         const response = await this.db.moveDistinctIds(source, target, tx)
         observeLatencyByVersion(target, start, 'moveDistinctIds')
 
-        // Clear the cache for the source person UUID to ensure deleted person isn't cached
-        this.clearCacheByUuid(source.team_id, source.uuid)
+        // Clear the cache for the source person id to ensure deleted person isn't cached
+        this.clearCacheByPersonId(source.team_id, source.id)
 
         // Update cache for the target person for the current distinct ID
         this.setCachedPersonForUpdate(target.team_id, distinctId, fromInternalPerson(target, distinctId))
@@ -505,43 +505,43 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         return `${teamId}:${distinctId}`
     }
 
-    private getPersonUuidCacheKey(teamId: number, personUuid: string): string {
-        return `${teamId}:${personUuid}`
+    private getPersonIdCacheKey(teamId: number, personId: string): string {
+        return `${teamId}:${personId}`
     }
 
-    clearCacheByUuid(teamId: number, personUuid: string): void {
-        this.personUpdateCache.delete(this.getPersonUuidCacheKey(teamId, personUuid))
+    clearCacheByPersonId(teamId: number, personId: string): void {
+        this.personUpdateCache.delete(this.getPersonIdCacheKey(teamId, personId))
     }
 
-    clearAllCachesForPersonUuid(teamId: number, personUuid: string): void {
-        // Clear the person UUID cache
-        this.clearCacheByUuid(teamId, personUuid)
+    clearAllCachesForPersonId(teamId: number, personId: string): void {
+        // Clear the person id cache
+        this.clearCacheByPersonId(teamId, personId)
 
-        // Find and clear all distinct ID mappings that point to this person UUID
+        // Find and clear all distinct ID mappings that point to this person id
         const distinctIdsToRemove: string[] = []
-        for (const [distinctCacheKey, mappedPersonUuid] of this.distinctIdToPersonUuid.entries()) {
-            if (mappedPersonUuid === personUuid && distinctCacheKey.startsWith(`${teamId}:`)) {
+        for (const [distinctCacheKey, mappedPersonId] of this.distinctIdToPersonId.entries()) {
+            if (mappedPersonId === personId && distinctCacheKey.startsWith(`${teamId}:`)) {
                 distinctIdsToRemove.push(distinctCacheKey)
             }
         }
 
         // Remove all distinct ID mappings and their check cache entries
         for (const distinctCacheKey of distinctIdsToRemove) {
-            this.distinctIdToPersonUuid.delete(distinctCacheKey)
+            this.distinctIdToPersonId.delete(distinctCacheKey)
             this.personCheckCache.delete(distinctCacheKey)
         }
     }
 
     clearCache(teamId: number, distinctId: string): void {
         const cacheKey = this.getDistinctCacheKey(teamId, distinctId)
-        const personUuid = this.distinctIdToPersonUuid.get(cacheKey)
+        const personId = this.distinctIdToPersonId.get(cacheKey)
 
         // Clear the distinct ID mapping
-        this.distinctIdToPersonUuid.delete(cacheKey)
+        this.distinctIdToPersonId.delete(cacheKey)
 
-        // Clear the person data if we have the UUID
-        if (personUuid) {
-            this.clearCacheByUuid(teamId, personUuid)
+        // Clear the person data if we have the id
+        if (personId) {
+            this.clearCacheByPersonId(teamId, personId)
         }
 
         // Clear the check cache
@@ -571,13 +571,13 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         return result
     }
 
-    getCachedPersonForUpdateByUuid(teamId: number, personUuid: string | undefined): PersonUpdate | null | undefined {
-        if (personUuid === undefined) {
+    getCachedPersonForUpdateByPersonId(teamId: number, personId: string | undefined): PersonUpdate | null | undefined {
+        if (personId === undefined) {
             this.cacheMetrics.updateCacheMisses++
             return undefined
         }
 
-        const result = this.personUpdateCache.get(this.getPersonUuidCacheKey(teamId, personUuid))
+        const result = this.personUpdateCache.get(this.getPersonIdCacheKey(teamId, personId))
         if (result !== undefined) {
             this.cacheMetrics.updateCacheHits++
             // Return a deep copy to prevent modifications from affecting the cached object
@@ -600,9 +600,9 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
 
     getCachedPersonForUpdate(teamId: number, distinctId: string): PersonUpdate | null | undefined {
         const cacheKey = this.getDistinctCacheKey(teamId, distinctId)
-        const personUuid = this.distinctIdToPersonUuid.get(cacheKey)
+        const personId = this.distinctIdToPersonId.get(cacheKey)
 
-        return this.getCachedPersonForUpdateByUuid(teamId, personUuid)
+        return this.getCachedPersonForUpdateByPersonId(teamId, personId)
     }
 
     setCachedPersonForUpdate(teamId: number, distinctId: string, person: PersonUpdate | null): void {
@@ -610,19 +610,19 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
 
         if (person === null) {
             // Remove mappings when person is null
-            const existingPersonUuid = this.distinctIdToPersonUuid.get(cacheKey)
-            this.distinctIdToPersonUuid.delete(cacheKey)
-            if (existingPersonUuid) {
-                this.personUpdateCache.set(this.getPersonUuidCacheKey(teamId, existingPersonUuid), null)
+            const existingPersonId = this.distinctIdToPersonId.get(cacheKey)
+            this.distinctIdToPersonId.delete(cacheKey)
+            if (existingPersonId) {
+                this.personUpdateCache.set(this.getPersonIdCacheKey(teamId, existingPersonId), null)
             }
             return
         }
 
-        // Set the distinct ID -> person UUID mapping
-        this.distinctIdToPersonUuid.set(cacheKey, person.uuid)
+        // Set the distinct ID -> person id mapping
+        this.distinctIdToPersonId.set(cacheKey, person.id)
 
-        // Check if we already have cached data for this person UUID
-        const existingPersonUpdate = this.personUpdateCache.get(this.getPersonUuidCacheKey(teamId, person.uuid))
+        // Check if we already have cached data for this person id
+        const existingPersonUpdate = this.personUpdateCache.get(this.getPersonIdCacheKey(teamId, person.id))
 
         if (existingPersonUpdate) {
             // Merge the properties and changesets from both updates
@@ -637,10 +637,10 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
                 ...person.property_changeset,
             }
 
-            this.personUpdateCache.set(this.getPersonUuidCacheKey(teamId, person.uuid), mergedPersonUpdate)
+            this.personUpdateCache.set(this.getPersonIdCacheKey(teamId, person.id), mergedPersonUpdate)
         } else {
-            // First time we're caching this person UUID
-            this.personUpdateCache.set(this.getPersonUuidCacheKey(teamId, person.uuid), person)
+            // First time we're caching this person id
+            this.personUpdateCache.set(this.getPersonIdCacheKey(teamId, person.id), person)
         }
     }
 
@@ -649,9 +649,9 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         this.personCheckCache.set(cacheKey, person)
     }
 
-    setDistinctIdToPersonUuid(teamId: number, distinctId: string, personUuid: string): void {
+    setDistinctIdToPersonId(teamId: number, distinctId: string, personId: string): void {
         const cacheKey = this.getDistinctCacheKey(teamId, distinctId)
-        this.distinctIdToPersonUuid.set(cacheKey, personUuid)
+        this.distinctIdToPersonId.set(cacheKey, personId)
     }
 
     async createPerson(

--- a/plugin-server/src/worker/ingestion/persons/person-store-manager.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-store-manager.test.ts
@@ -57,14 +57,14 @@ describe('PersonStoreManager', () => {
                         _teamId,
                         _isUserId,
                         _isIdentified,
-                        uuid,
+                        id,
                         _distinctIds
                     ) => {
                         dbCounter++
                         latestPerson = {
                             ...latestPerson,
                             version: dbCounter,
-                            uuid: latestPerson.uuid || uuid,
+                            id: latestPerson.id || id,
                             properties: latestPerson.properties || properties,
                         }
                         return Promise.resolve([latestPerson, []])
@@ -198,14 +198,14 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
                         _teamId,
                         _isUserId,
                         _isIdentified,
-                        uuid,
+                        id,
                         _distinctIds
                     ) => {
                         dbCounter++
                         latestPerson = {
                             ...latestPerson,
                             version: dbCounter,
-                            uuid: uuid || latestPerson.uuid,
+                            id: id || latestPerson.id,
                             properties: properties || latestPerson.properties,
                         }
                         return Promise.resolve([latestPerson, []])
@@ -275,7 +275,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
 
             // Check that batch store update cache was set
             const updateCache = batchStoreForBatch.getUpdateCache()
-            const cachedUpdate = updateCache.get(`${teamId}:${person.uuid}`)
+            const cachedUpdate = updateCache.get(`${teamId}:${person.id}`)
             expect(cachedUpdate).toBeDefined()
             expect(cachedUpdate!.distinct_id).toBe('test-distinct')
         })
@@ -294,7 +294,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
 
             // Cache should override properties, but keep changeset
             const updateCache = batchStoreForBatch.getUpdateCache()
-            const cachedUpdate = updateCache.get(`${teamId}:${person.uuid}`)
+            const cachedUpdate = updateCache.get(`${teamId}:${person.id}`)
             expect(cachedUpdate!.properties).toEqual(person.properties)
             expect(cachedUpdate!.property_changeset).toEqual(existingUpdate.property_changeset)
         })
@@ -310,18 +310,18 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
                 teamId,
                 null,
                 false,
-                'new-uuid',
+                'new-id',
                 [{ distinctId: 'test-distinct', version: 0 }]
             )
             expect(result).toBeDefined()
-            expect(result[0].uuid).toBe('new-uuid')
+            expect(result[0].id).toBe('new-id')
 
             await shadowManager.flush()
             expect(db.createPerson).toHaveBeenCalledTimes(1)
 
             // Check that batch store cache was set
             const updateCache = batchStoreForBatch.getUpdateCache()
-            const cachedUpdate = updateCache.get(`${teamId}:${result[0].uuid}`)
+            const cachedUpdate = updateCache.get(`${teamId}:${result[0].id}`)
             expect(cachedUpdate).toBeDefined()
         })
     })
@@ -342,7 +342,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
 
             // Check that final state was tracked
             const finalStates = shadowManager.getFinalStates()
-            const finalState = finalStates.get(`${teamId}:${person.uuid}`)
+            const finalState = finalStates.get(`${teamId}:${person.id}`)
             expect(finalState).toBeDefined()
             expect(finalState?.person.properties).toEqual({ test: 'test', new_prop: 'new_value' })
             expect(finalState?.versionDisparity).toBe(false)
@@ -366,7 +366,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
 
             // Check that final state was tracked
             const finalStates = shadowManager.getFinalStates()
-            const finalState = finalStates.get(`${teamId}:${person.uuid}`)
+            const finalState = finalStates.get(`${teamId}:${person.id}`)
             expect(finalState).toBeDefined()
             expect(finalState?.person.properties).toEqual({ test: 'test', merge_prop: 'merge_value' })
             expect(finalState?.versionDisparity).toBe(false)
@@ -388,7 +388,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
 
             // Check that final state was set to null
             const finalStates = shadowManager.getFinalStates()
-            const finalState = finalStates.get(`${teamId}:${person.uuid}`)
+            const finalState = finalStates.get(`${teamId}:${person.id}`)
             expect(finalState).toBeNull()
 
             // Check that batch store cache was cleared
@@ -477,7 +477,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
             expect(metricsData!.differentOutcomeDifferentBatch).toBe(0)
             expect(metricsData!.sameOutcomeDifferentBatch).toBe(0)
             expect(metricsData!.logicErrors).toHaveLength(1)
-            expect(metricsData!.logicErrors[0].key).toBe(`${teamId}:${person.uuid}`)
+            expect(metricsData!.logicErrors[0].key).toBe(`${teamId}:${person.id}`)
             expect(metricsData!.logicErrors[0].differences.length).toBeGreaterThan(0)
             expect(metricsData!.concurrentModifications).toHaveLength(0)
 
@@ -524,7 +524,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
             expect(metricsData!.logicErrors).toHaveLength(0)
             expect(metricsData!.concurrentModifications).toHaveLength(1)
             expect(metricsData!.concurrentModifications[0].type).toBe('different_outcome')
-            expect(metricsData!.concurrentModifications[0].key).toBe(`${teamId}:${person.uuid}`)
+            expect(metricsData!.concurrentModifications[0].key).toBe(`${teamId}:${person.id}`)
 
             // Test that reportBatch logs the concurrent modifications
             shadowManager.reportBatch()
@@ -598,7 +598,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
                 person.team_id,
                 person.is_user_id,
                 person.is_identified,
-                person.uuid,
+                person.id,
                 [{ distinctId: 'test-distinct', version: 0 }]
             )
             const [personUpdateResult] = await shadowManager.updatePersonForUpdate(
@@ -628,14 +628,14 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
             const update3 = { properties: { prop3: 'value3' } }
 
             // Person 1: Same outcome, same batch (ideal case)
-            const person1 = { ...person, uuid: 'person1-uuid' }
+            const person1 = { ...person, id: 'person1-id' }
             await shadowManager.updatePersonForUpdate(person1, update1, 'person1-distinct')
             const expectedPerson1 = { ...person1, properties: { test: 'test', prop1: 'value1' }, version: 2 }
             const personUpdate1 = fromInternalPerson(expectedPerson1, 'person1-distinct')
             batchStoreForBatch.setCachedPersonForUpdate(teamId, 'person1-distinct', personUpdate1)
 
             // Person 2: Different outcome, same batch (logic error)
-            const person2 = { ...person, uuid: 'person2-uuid' }
+            const person2 = { ...person, id: 'person2-id' }
             await shadowManager.updatePersonForUpdate(person2, update2, 'person2-distinct')
             const differentPerson2 = { ...person2, properties: { test: 'test', wrong_prop: 'wrong_value' }, version: 3 }
             const personUpdate2 = fromInternalPerson(differentPerson2, 'person2-distinct')
@@ -651,7 +651,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
                         ...personInput,
                         ...update,
                         version: personInput.version + 1,
-                        uuid: 'person3-uuid',
+                        id: 'person3-id',
                     }
                     return Promise.resolve([personCopy, [], true]) // version disparity = true
                 } else {
@@ -659,7 +659,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
                 }
             })
 
-            const person3 = { ...person, uuid: 'person3-uuid' }
+            const person3 = { ...person, id: 'person3-id' }
             await shadowManager.updatePersonForUpdate(person3, update3, 'person3-distinct')
             const concurrentPerson3 = {
                 ...person3,
@@ -707,10 +707,10 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
                     errorRate: '33.33%',
                     sampleErrors: expect.arrayContaining([
                         expect.objectContaining({
-                            key: `${teamId}:${person2.uuid}`,
+                            key: `${teamId}:${person2.id}`,
                             differences: expect.any(Array),
-                            mainPersonUuid: expect.any(String),
-                            secondaryPersonUuid: expect.any(String),
+                            mainPersonId: expect.any(String),
+                            secondaryPersonId: expect.any(String),
                         }),
                     ]),
                 })
@@ -726,10 +726,10 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
                     concurrentModificationRate: '33.33%',
                     sampleModifications: expect.arrayContaining([
                         expect.objectContaining({
-                            key: `${teamId}:${person3.uuid}`,
+                            key: `${teamId}:${person3.id}`,
                             type: 'different_outcome',
-                            mainPersonUuid: expect.any(String),
-                            secondaryPersonUuid: expect.any(String),
+                            mainPersonId: expect.any(String),
+                            secondaryPersonId: expect.any(String),
                         }),
                     ]),
                 })
@@ -738,17 +738,16 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
 
         it('should handle addDistinctId ', async () => {
             const teamId = 126617
-            const personUuid = '483a46b9-aea8-5205-828e-85a6f77ad6b0'
+            const personId = '483a46b9-aea8-5205-828e-85a6f77ad6b0'
             const distinctId = '0197a209-f567-7daa-8810-900f7c7f7b5d'
 
             const existingPerson: InternalPerson = {
-                id: '11212424398',
-                uuid: personUuid,
+                id: personId,
+                uuid: 'existing-person-uuid',
                 created_at: DateTime.fromISO('2025-04-11T00:22:49.998Z'),
                 team_id: teamId,
                 properties: {
                     $os: 'Android',
-                    $app_name: 'Skorlife',
                     $creator_event_uuid: '0196223a-5299-72a2-b7cd-3c9cc03d6869',
                 },
                 properties_last_updated_at: {
@@ -770,7 +769,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
 
             const metrics = shadowManager.getShadowMetrics()
             const finalStates = shadowManager.getFinalStates()
-            const finalState = finalStates.get(`${teamId}:${existingPerson.uuid}`)
+            const finalState = finalStates.get(`${teamId}:${existingPerson.id}`)
 
             // Verify the final state is tracked correctly
             expect(finalState?.person).toEqual(existingPerson)
@@ -791,11 +790,11 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
 
         it('should handle createPerson followed by moveDistinctIds', async () => {
             const teamId = 61953
-            const personUuid = 'person-uuid'
+            const personId = 'person-id'
 
             // Mock the main store to successfully create a person
             const createdPerson: InternalPerson = {
-                id: '13219553701',
+                id: personId,
                 created_at: DateTime.fromISO('2025-06-23T13:05:07.461Z'),
                 properties: {
                     $creator_event_uuid: '01979ce4-7561-7b81-b188-4d2a6e9bbae3',
@@ -803,7 +802,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
                 team_id: teamId,
                 is_user_id: null,
                 is_identified: false,
-                uuid: personUuid,
+                uuid: 'created-person-uuid',
                 properties_last_updated_at: {},
                 properties_last_operation: {},
                 version: 1,
@@ -812,7 +811,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
             // Create another person that will be the merge target
             const targetPerson: InternalPerson = {
                 ...createdPerson,
-                id: '13219553702',
+                id: 'target-person-id',
                 uuid: 'target-person-uuid',
                 version: 2,
             }
@@ -839,31 +838,31 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
                 teamId,
                 null,
                 false,
-                personUuid,
+                personId,
                 [{ distinctId: distinctId, version: 0 }]
             )
 
             // Verify batch cache was set after create
             const batchUpdateCache = batchStoreForBatch.getUpdateCache()
-            expect(batchUpdateCache.get(`${teamId}:${createdPerson.uuid}`)).toBeDefined()
+            expect(batchUpdateCache.get(`${teamId}:${createdPerson.id}`)).toBeDefined()
 
             // Step 2: Move distinct IDs (simulate merge)
             await shadowManager.moveDistinctIds(createdPerson, targetPerson, distinctId)
 
             // Verify batch cache is populated after moveDistinctIds
-            expect(batchUpdateCache.get(`${teamId}:${createdPerson.uuid}`)).toBeUndefined()
-            expect(batchUpdateCache.get(`${teamId}:${targetPerson.uuid}`)).toBeDefined()
+            expect(batchUpdateCache.get(`${teamId}:${createdPerson.id}`)).toBeUndefined()
+            expect(batchUpdateCache.get(`${teamId}:${targetPerson.id}`)).toBeDefined()
 
             // Step 3: Flush and compare final states
             await shadowManager.flush()
 
             const metrics = shadowManager.getShadowMetrics()
             const finalStates = shadowManager.getFinalStates()
-            const finalStateSource = finalStates.get(`${teamId}:${createdPerson.uuid}`)
+            const finalStateSource = finalStates.get(`${teamId}:${createdPerson.id}`)
 
             expect(finalStateSource).toBeNull()
 
-            const finalStateTarget = finalStates.get(`${teamId}:${targetPerson.uuid}`)
+            const finalStateTarget = finalStates.get(`${teamId}:${targetPerson.id}`)
             expect(finalStateTarget?.person).toEqual(targetPerson)
             expect(finalStateTarget?.operations).toEqual([
                 {
@@ -878,6 +877,90 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
             expect(metrics.differentOutcomeSameBatch).toBe(0)
             expect(metrics.logicErrors).toHaveLength(0)
             expect(metrics.sameOutcomeSameBatch).toBe(2)
+        })
+
+        it('should handle fetchForUpdate → updatePersonForMerge → moveDistinctIds sequence', async () => {
+            // Create a person with some properties
+            const sourcePerson: InternalPerson = {
+                ...person,
+                id: 'source-id',
+                properties: {
+                    test: 'test',
+                    existing_prop: 'existing_value',
+                },
+                version: 4,
+            }
+
+            const targetPerson: InternalPerson = {
+                ...person,
+                id: 'target-id',
+                properties: {
+                    target_prop: 'target_value',
+                },
+                version: 5,
+                is_identified: true,
+            }
+
+            // Mock DB to return the source person for fetchForUpdate
+            db.fetchPerson = jest.fn().mockResolvedValue(sourcePerson)
+
+            // Mock updatePerson to simulate merge operation
+            db.updatePerson = jest.fn().mockImplementation((person, update) => {
+                const updatedPerson = {
+                    ...person,
+                    ...update,
+                    properties: { ...person.properties, ...update.properties },
+                    version: person.version + 1,
+                }
+                return Promise.resolve([updatedPerson, [], false])
+            })
+
+            // Step 1: fetchForUpdate
+            const fetchedPerson = await shadowManager.fetchForUpdate(teamId, 'test-distinct')
+            expect(fetchedPerson).toEqual(sourcePerson)
+
+            // Step 2: updatePersonForMerge - merge additional properties
+            const mergeUpdate = {
+                properties: {
+                    merged_prop: 'merged_value',
+                },
+                is_identified: true,
+            }
+            const [mergedPerson] = await shadowManager.updatePersonForMerge(sourcePerson, mergeUpdate, 'test-distinct')
+
+            // Verify the merge worked
+            expect(mergedPerson.properties.merged_prop).toBe('merged_value')
+            expect(mergedPerson.properties.existing_prop).toBe('existing_value')
+            expect(mergedPerson.is_identified).toBe(true)
+
+            // Step 3: moveDistinctIds - simulate moving distinct IDs to target person
+            await shadowManager.moveDistinctIds(sourcePerson, targetPerson, 'test-distinct')
+
+            // Step 4: Flush and check final states
+            await shadowManager.flush()
+
+            const metrics = shadowManager.getShadowMetrics()
+            const finalStates = shadowManager.getFinalStates()
+
+            // Verify final state tracking
+            const sourceState = finalStates.get(`${teamId}:${sourcePerson.id}`)
+            const targetState = finalStates.get(`${teamId}:${targetPerson.id}`)
+
+            // After moveDistinctIds, source should be null, target should have the data
+            expect(sourceState).toBeNull()
+            expect(targetState?.person).toEqual(targetPerson)
+            expect(targetState?.operations).toContainEqual(
+                expect.objectContaining({
+                    type: 'moveDistinctIds',
+                    distinctId: 'test-distinct',
+                })
+            )
+
+            // Check for any logic errors that might indicate the bug
+            if (metrics.logicErrors.length > 0) {
+                const logicError = metrics.logicErrors[0]
+                console.log('Detected logic error:', logicError.differences)
+            }
         })
     })
 
@@ -943,13 +1026,13 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
             expect(logger.info).toHaveBeenCalledWith(
                 'updatePersonForUpdate returned inconsistent results between stores',
                 expect.objectContaining({
-                    key: `${teamId}:${person.uuid}`,
+                    key: `${teamId}:${person.id}`,
                     teamId: 1,
                     methodName: 'updatePersonForUpdate',
                     samePersonResult: false,
                     differences: expect.arrayContaining([expect.stringContaining('person.properties')]),
-                    mainPersonUuid: mainPerson.uuid,
-                    secondaryPersonUuid: secondaryPerson.uuid,
+                    mainPersonId: mainPerson.id,
+                    secondaryPersonId: secondaryPerson.id,
                     mainVersionDisparity: false,
                 })
             )
@@ -982,13 +1065,13 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
             expect(logger.info).toHaveBeenCalledWith(
                 'updatePersonForMerge returned inconsistent results between stores',
                 expect.objectContaining({
-                    key: `${teamId}:${person.uuid}`,
+                    key: `${teamId}:${person.id}`,
                     teamId: 1,
                     methodName: 'updatePersonForMerge',
                     samePersonResult: false,
                     differences: expect.arrayContaining([expect.stringContaining('person.properties')]),
-                    mainPersonUuid: mainPerson.uuid,
-                    secondaryPersonUuid: secondaryPerson.uuid,
+                    mainPersonId: mainPerson.id,
+                    secondaryPersonId: secondaryPerson.id,
                 })
             )
         })
@@ -1020,8 +1103,8 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
                 'updatePersonForUpdate returned inconsistent results between stores',
                 expect.objectContaining({
                     samePersonResult: false,
-                    mainPersonUuid: mainPerson.uuid,
-                    secondaryPersonUuid: undefined,
+                    mainPersonId: mainPerson.id,
+                    secondaryPersonId: undefined,
                 })
             )
         })

--- a/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
@@ -90,20 +90,20 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
         }
     }
 
-    private getPersonKey(teamId: number, personUuid: string): string {
-        return `${teamId}:${personUuid}`
+    private getPersonKey(teamId: number, personId: string): string {
+        return `${teamId}:${personId}`
     }
 
     private updateFinalState(
         teamId: number,
         distinctId: string,
-        personUuid: string,
+        personId: string,
         person: InternalPerson | null,
         versionDisparity: boolean,
         operationType: string,
         version?: number
     ): void {
-        const key = this.getPersonKey(teamId, personUuid)
+        const key = this.getPersonKey(teamId, personId)
         const existing = this.finalStates.get(key)
 
         const operation = {
@@ -171,7 +171,7 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
             this.updateFinalState(
                 teamId,
                 distinctId,
-                mainResult.uuid,
+                mainResult.id,
                 mainResult,
                 versionDisparity,
                 'fetchForUpdate',
@@ -218,7 +218,7 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
         this.updateFinalState(
             teamId,
             distinctIds![0].distinctId,
-            mainResult[0].uuid,
+            mainResult[0].id,
             mainResult[0],
             false,
             'createPerson',
@@ -244,7 +244,7 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
         this.compareUpdateResults(
             'updatePersonForUpdate',
             person.team_id,
-            person.uuid,
+            person.id,
             mainPersonResult,
             secondaryPersonResult,
             mainVersionDisparity
@@ -253,7 +253,7 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
         this.updateFinalState(
             person.team_id,
             distinctId,
-            mainPersonResult.uuid,
+            mainPersonResult.id,
             mainPersonResult,
             mainVersionDisparity,
             'updatePersonForUpdate',
@@ -278,7 +278,7 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
         this.compareUpdateResults(
             'updatePersonForMerge',
             person.team_id,
-            person.uuid,
+            person.id,
             mainPersonResult,
             secondaryPersonResult,
             mainVersionDisparity
@@ -287,7 +287,7 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
         this.updateFinalState(
             person.team_id,
             distinctId,
-            mainPersonResult.uuid,
+            mainPersonResult.id,
             mainPersonResult,
             mainVersionDisparity,
             'updatePersonForMerge',
@@ -299,9 +299,9 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
     async deletePerson(person: InternalPerson, distinctId: string, tx?: TransactionClient): Promise<TopicMessage[]> {
         const kafkaMessages = await this.mainStore.deletePerson(person, distinctId, tx)
 
-        // Clear ALL caches related to this person UUID
-        this.secondaryStore.clearAllCachesForPersonUuid(person.team_id, person.uuid)
-        this.updateFinalState(person.team_id, distinctId, person.uuid, null, false, 'deletePerson')
+        // Clear ALL caches related to this person id
+        this.secondaryStore.clearAllCachesForPersonId(person.team_id, person.id)
+        this.updateFinalState(person.team_id, distinctId, person.id, null, false, 'deletePerson')
 
         return kafkaMessages
     }
@@ -318,7 +318,7 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
         this.secondaryStore.setCachedPersonForUpdate(person.team_id, distinctId, fromInternalPerson(person, distinctId))
 
         // Track that this distinct ID now points to the person
-        this.updateFinalState(person.team_id, distinctId, person.uuid, person, false, 'addDistinctId', person.version)
+        this.updateFinalState(person.team_id, distinctId, person.id, person, false, 'addDistinctId', person.version)
 
         return mainResult
     }
@@ -331,14 +331,14 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
     ): Promise<TopicMessage[]> {
         const mainResult = await this.mainStore.moveDistinctIds(source, target, distinctId, tx)
 
-        // Clear the cache for the source person UUID to ensure deleted person isn't cached
-        this.secondaryStore.clearCacheByUuid(source.team_id, source.uuid)
+        // Clear the cache for the source person id to ensure deleted person isn't cached
+        this.secondaryStore.clearCacheByPersonId(source.team_id, source.id)
 
         // Update cache for the target person for the current distinct ID
         this.secondaryStore.setCachedPersonForUpdate(target.team_id, distinctId, fromInternalPerson(target, distinctId))
 
-        this.updateFinalState(source.team_id, distinctId, source.uuid, null, false, 'moveDistinctIds', source.version)
-        this.updateFinalState(target.team_id, distinctId, target.uuid, target, false, 'moveDistinctIds', target.version)
+        this.updateFinalState(source.team_id, distinctId, source.id, null, false, 'moveDistinctIds', source.version)
+        this.updateFinalState(target.team_id, distinctId, target.id, target, false, 'moveDistinctIds', target.version)
 
         return mainResult
     }
@@ -422,8 +422,8 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
                     sampleErrors: this.shadowMetrics.logicErrors.slice(0, 5).map((error) => ({
                         key: error.key,
                         differences: error.differences,
-                        mainPersonUuid: error.mainPerson?.uuid,
-                        secondaryPersonUuid: error.secondaryPerson?.uuid,
+                        mainPersonId: error.mainPerson?.id,
+                        secondaryPersonId: error.secondaryPerson?.id,
                         operations: error.operations,
                     })),
                 })
@@ -442,8 +442,8 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
                     sampleModifications: this.shadowMetrics.concurrentModifications.slice(0, 3).map((mod) => ({
                         key: mod.key,
                         type: mod.type,
-                        mainPersonUuid: mod.mainPerson?.uuid,
-                        secondaryPersonUuid: mod.secondaryPerson?.uuid,
+                        mainPersonId: mod.mainPerson?.id,
+                        secondaryPersonId: mod.secondaryPerson?.id,
                     })),
                 })
             }
@@ -476,11 +476,11 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
                 }
             }
 
-            // Parse the key to extract teamId and personUuid
-            const [teamIdStr, personUuid] = key.split(':')
+            // Parse the key to extract teamId and personId
+            const [teamIdStr, personId] = key.split(':')
             const teamId = parseInt(teamIdStr, 10)
 
-            const secondaryPersonUpdate = this.secondaryStore.getCachedPersonForUpdateByUuid(teamId, personUuid)
+            const secondaryPersonUpdate = this.secondaryStore.getCachedPersonForUpdateByPersonId(teamId, personId)
             const secondaryPerson = secondaryPersonUpdate ? toInternalPerson(secondaryPersonUpdate) : null
             const mainPerson = mainUpdate?.person || null
             const versionDisparity = mainUpdate?.versionDisparity || false
@@ -534,12 +534,12 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
     private compareUpdateResults(
         methodName: string,
         teamId: number,
-        personUuid: string,
+        personId: string,
         mainPerson: InternalPerson,
         secondaryPerson: InternalPerson,
         mainVersionDisparity: boolean
     ): void {
-        const key = this.getPersonKey(teamId, personUuid)
+        const key = this.getPersonKey(teamId, personId)
 
         // Compare the person results (excluding version for primary comparison)
         const mainComparable = this.getComparablePerson(mainPerson)
@@ -555,12 +555,12 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
             logger.info(`${methodName} returned inconsistent results between stores`, {
                 key,
                 teamId,
-                personUuid,
+                personId,
                 methodName,
                 samePersonResult,
                 differences,
-                mainPersonUuid: mainPerson?.uuid,
-                secondaryPersonUuid: secondaryPerson?.uuid,
+                mainPersonId: mainPerson?.id,
+                secondaryPersonId: secondaryPerson?.id,
                 mainVersionDisparity,
             })
         } else {


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

For debugging purposes id is much more helpful as we can easily query it from both clickhouse and Postgres

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
