### PR TITLE
fix: updating validation after renaming schema into schema_map

### DIFF
--- a/posthog/models/team/team_marketing_analytics_config.py
+++ b/posthog/models/team/team_marketing_analytics_config.py
@@ -46,8 +46,8 @@ def validate_conversion_goals(conversion_goals: list) -> None:
             raise ValidationError(f"Conversion goal name must be a string, got {type(goal.get('name'))}")
         if goal.get("id") and not isinstance(goal.get("id"), str) and not isinstance(goal.get("id"), int):
             raise ValidationError(f"Conversion goal id must be a string or integer, got {type(goal.get('id'))}")
-        if not isinstance(goal.get("schema"), dict):
-            raise ValidationError(f"Conversion goal schema must be a dictionary, got {type(goal.get('schema'))}")
+        if not isinstance(goal.get("schema_map"), dict):
+            raise ValidationError(f"Conversion goal schema_map must be a string, got {type(goal.get('schema_map'))}")
         if goal.get("kind") is None:
             raise ValidationError("Conversion goal must have a 'kind' field")
         if goal.get("kind") == NodeKind.EVENTS_NODE:
@@ -141,7 +141,7 @@ class TeamMarketingAnalyticsConfig(models.Model):
             validate_conversion_goals(value)
             self._conversion_goals = value
         except ValidationError as e:
-            raise ValidationError(f"Invalid conversion goals schema: {str(e)}")
+            raise ValidationError(f"Invalid conversion goals: {str(e)}")
 
 
 # This is best effort, we always attempt to create the config manually

--- a/posthog/models/team/team_marketing_analytics_config.py
+++ b/posthog/models/team/team_marketing_analytics_config.py
@@ -47,7 +47,9 @@ def validate_conversion_goals(conversion_goals: list) -> None:
         if goal.get("id") and not isinstance(goal.get("id"), str) and not isinstance(goal.get("id"), int):
             raise ValidationError(f"Conversion goal id must be a string or integer, got {type(goal.get('id'))}")
         if not isinstance(goal.get("schema_map"), dict):
-            raise ValidationError(f"Conversion goal schema_map must be a string, got {type(goal.get('schema_map'))}")
+            raise ValidationError(
+                f"Conversion goal schema_map must be a dictionary, got {type(goal.get('schema_map'))}"
+            )
         if goal.get("kind") is None:
             raise ValidationError("Conversion goal must have a 'kind' field")
         if goal.get("kind") == NodeKind.EVENTS_NODE:


### PR DESCRIPTION
## Problem

Without this change it would always fail on creating new conversionGoals. This happened because of a breaking change ranaming because schema.py transformed `schema` from `schema-general` into `schema_` (probably a reserved word) and that caused many issues. So I renamed into `schema_map` in another PR that was already merged


## Changes

Updated the validation with the last name.
