### PR TITLE
fix(dashboards): duplicating insight does not copy dashboard filters

### DIFF
--- a/frontend/src/models/insightsModel.tsx
+++ b/frontend/src/models/insightsModel.tsx
@@ -15,7 +15,7 @@ export const insightsModel = kea<insightsModelType>([
     actions(() => ({
         renameInsight: (item: QueryBasedInsightModel) => ({ item }),
         renameInsightSuccess: (item: QueryBasedInsightModel) => ({ item }),
-        //TODO this duplicates the insight but not the dashboard tile (e.g. if duplicated from dashboard you lose tile color
+        // TODO: this duplicates the insight but not the dashboard tile (e.g. if duplicated from dashboard you lose tile color
         duplicateInsight: (item: QueryBasedInsightModel) => ({ item }),
         duplicateInsightSuccess: (item: QueryBasedInsightModel) => ({ item }),
         insightsAddedToDashboard: ({ dashboardId, insightIds }: { dashboardId: number; insightIds: number[] }) => ({
@@ -48,7 +48,10 @@ export const insightsModel = kea<insightsModelType>([
             })
         },
         duplicateInsight: async ({ item }) => {
-            const addedItem = await insightsApi.duplicate(item)
+            // get the insight, to ensure we duplicate it without any changes that might have been made to it
+            // e.g. any dashboard filters that were applied to it
+            const insight = await insightsApi.getByNumericId(item.id)
+            const addedItem = await insightsApi.duplicate(insight!)
 
             actions.duplicateInsightSuccess(addedItem)
             lemonToast.success('Insight duplicated')

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -230,7 +230,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
             null as DashboardType<QueryBasedInsightModel> | null,
             {
                 /**
-                 * TRICKY:Load dashboard only gets the dashboard meta + cached insights (as we pass `force_cache`)
+                 * TRICKY: Load dashboard only gets the dashboard meta + cached insights (as we pass `force_cache`)
                  * if manualDashboardRefresh is passed then in loadDashboardSuccess we trigger
                  * updateDashboardItems to refresh all insights with `force_blocking`
                  */


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/issues/33471

## Changes

The dashboard api returns insights, where the query is adapted based on the dashboard. Most notably dashboard filters are applied to the query.

This PR fetches the insight for duplication, instead of using the insight obtained from the dashboard tile.

## How did you test this code?

Tried locally