### PR TITLE
fix(experiments): multiple variant handling in exposure query

### DIFF
--- a/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
@@ -44,6 +44,8 @@ class ExperimentExposuresQueryRunner(QueryRunner):
 
         self.experiment = Experiment.objects.get(id=self.query.experiment_id)
         self.feature_flag_key = self.query.feature_flag.get("key")
+        if not self.feature_flag_key:
+            raise ValidationError("feature_flag key is required")
         self.group_type_index = self.query.feature_flag.get("filters", {}).get("aggregation_group_type_index")
 
         # Determine how to handle entities exposed to multiple variants
@@ -90,6 +92,8 @@ class ExperimentExposuresQueryRunner(QueryRunner):
 
     def _get_exposure_query(self) -> ast.SelectQuery:
         # Get the exposure event and feature flag variant property
+        if not self.feature_flag_key:
+            raise ValidationError("feature_flag key is required")
         event, feature_flag_variant_property = get_exposure_event_and_property(
             self.feature_flag_key, self.experiment.exposure_criteria
         )

--- a/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
@@ -43,7 +43,6 @@ class ExperimentExposuresQueryRunner(QueryRunner):
             raise ValidationError("experiment_id is required")
 
         self.experiment = Experiment.objects.get(id=self.query.experiment_id)
-        self.exposure_criteria = self.query.exposure_criteria
         self.feature_flag_key = self.query.feature_flag.get("key")
         self.group_type_index = self.query.feature_flag.get("filters", {}).get("aggregation_group_type_index")
 
@@ -92,7 +91,7 @@ class ExperimentExposuresQueryRunner(QueryRunner):
     def _get_exposure_query(self) -> ast.SelectQuery:
         # Get the exposure event and feature flag variant property
         event, feature_flag_variant_property = get_exposure_event_and_property(
-            self.feature_flag_key, self.exposure_criteria
+            self.feature_flag_key, self.experiment.exposure_criteria
         )
 
         # Build common exposure conditions using shared logic
@@ -102,7 +101,7 @@ class ExperimentExposuresQueryRunner(QueryRunner):
             variants=self.variants,
             date_range_query=self.date_range_query,
             team=self.team,
-            exposure_criteria=self.exposure_criteria,
+            exposure_criteria=self.experiment.exposure_criteria,
             feature_flag_key=self.feature_flag_key,
         )
 

--- a/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
@@ -44,7 +44,7 @@ class ExperimentExposuresQueryRunner(QueryRunner):
         self.exposure_criteria = self.query.exposure_criteria
         self.feature_flag_key = self.query.feature_flag.get("key")
         self.group_type_index = self.query.feature_flag.get("filters", {}).get("aggregation_group_type_index")
-        
+
         # Determine how to handle entities exposed to multiple variants
         self.multiple_variant_handling = get_multiple_variant_handling_from_experiment(self.experiment)
 
@@ -181,7 +181,9 @@ class ExperimentExposuresQueryRunner(QueryRunner):
                         ast.Alias(alias="entity_id", expr=ast.Field(chain=[entity])),
                         ast.Alias(
                             alias="variant",
-                            expr=get_variant_selection_expr(feature_flag_variant_property, self.multiple_variant_handling),
+                            expr=get_variant_selection_expr(
+                                feature_flag_variant_property, self.multiple_variant_handling
+                            ),
                         ),
                         parse_expr("toDate(toString(min(timestamp))) as day"),
                     ],

--- a/posthog/hogql_queries/experiments/exposure_query_logic.py
+++ b/posthog/hogql_queries/experiments/exposure_query_logic.py
@@ -70,12 +70,8 @@ def get_test_accounts_filter(team: Team, exposure_criteria: Optional[dict] = Non
     """
     filter_test_accounts = False
 
-    if exposure_criteria:
-        # Handle both dict and object-like access patterns
-        if hasattr(exposure_criteria, "filterTestAccounts"):
-            filter_test_accounts = bool(exposure_criteria.filterTestAccounts)
-        elif isinstance(exposure_criteria, dict) and exposure_criteria.get("filterTestAccounts"):
-            filter_test_accounts = True
+    if exposure_criteria and exposure_criteria.get("filterTestAccounts"):
+        filter_test_accounts = True
 
     if filter_test_accounts and isinstance(team.test_account_filters, list) and len(team.test_account_filters) > 0:
         return [property_to_expr(property, team) for property in team.test_account_filters]
@@ -93,23 +89,11 @@ def get_exposure_event_and_property(feature_flag_key: str, exposure_criteria: Op
     Returns:
         Tuple of (event_name, feature_flag_variant_property)
     """
-    exposure_config = None
-    if exposure_criteria:
-        # Handle both dict and object-like access patterns
-        if hasattr(exposure_criteria, "exposure_config"):
-            exposure_config = exposure_criteria.exposure_config
-        elif isinstance(exposure_criteria, dict):
-            exposure_config = exposure_criteria.get("exposure_config")
+    exposure_config = exposure_criteria.get("exposure_config") if exposure_criteria else None
 
-    if exposure_config and hasattr(exposure_config, "event") and exposure_config.event != "$feature_flag_called":
+    if exposure_config and exposure_config.get("event") != "$feature_flag_called":
         # For custom exposure events, we extract the event name from the exposure config
         # and get the variant from the $feature/<key> property
-        feature_flag_variant_property = f"$feature/{feature_flag_key}"
-        event = exposure_config.event
-    elif (
-        exposure_config and isinstance(exposure_config, dict) and exposure_config.get("event") != "$feature_flag_called"
-    ):
-        # Handle dict-based exposure config
         feature_flag_variant_property = f"$feature/{feature_flag_key}"
         event = exposure_config.get("event")
     else:
@@ -166,35 +150,15 @@ def build_common_exposure_conditions(
     ]
 
     # Add custom exposure property filters if present
-    exposure_config = None
-    if exposure_criteria:
-        # Handle both dict and object-like access patterns
-        if hasattr(exposure_criteria, "exposure_config"):
-            exposure_config = exposure_criteria.exposure_config
-        elif isinstance(exposure_criteria, dict):
-            exposure_config = exposure_criteria.get("exposure_config")
+    exposure_config = exposure_criteria.get("exposure_config") if exposure_criteria else None
+    if exposure_config and exposure_config.get("kind") == "ExperimentEventExposureConfig":
+        exposure_property_filters: list[ast.Expr] = []
 
-    if exposure_config:
-        # Check if this is an ExperimentEventExposureConfig
-        is_event_exposure_config = (
-            hasattr(exposure_config, "kind") and exposure_config.kind == "ExperimentEventExposureConfig"
-        ) or (isinstance(exposure_config, dict) and exposure_config.get("kind") == "ExperimentEventExposureConfig")
-
-        if is_event_exposure_config:
-            exposure_property_filters: list[ast.Expr] = []
-
-            # Get properties from either object or dict
-            properties = None
-            if hasattr(exposure_config, "properties"):
-                properties = exposure_config.properties
-            elif isinstance(exposure_config, dict):
-                properties = exposure_config.get("properties")
-
-            if properties:
-                for property in properties:
-                    exposure_property_filters.append(property_to_expr(property, team))
-            if exposure_property_filters:
-                exposure_conditions.append(ast.And(exprs=exposure_property_filters))
+        if exposure_config.get("properties"):
+            for property in exposure_config.get("properties"):
+                exposure_property_filters.append(property_to_expr(property, team))
+        if exposure_property_filters:
+            exposure_conditions.append(ast.And(exprs=exposure_property_filters))
 
     # For the $feature_flag_called events, we need an additional filter to ensure the event is for the correct feature flag
     if event == "$feature_flag_called" and feature_flag_key:

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_experiment_exposures_query_runner.ambr
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_experiment_exposures_query_runner.ambr
@@ -52,7 +52,7 @@
         HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      LEFT JOIN
        (SELECT person.id AS id,
-               nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
         FROM person
         WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
                                                       (SELECT person.id AS id, max(person.version) AS version

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_experiment_exposures_query_runner.ambr
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_experiment_exposures_query_runner.ambr
@@ -52,7 +52,7 @@
         HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      LEFT JOIN
        (SELECT person.id AS id,
-               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+               nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
         FROM person
         WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
                                                       (SELECT person.id AS id, max(person.version) AS version
@@ -85,6 +85,40 @@
   FROM
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             if(ifNull(greater(count(DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+            toDateOrNull(toString(min(toTimeZone(events.timestamp, 'UTC')))) AS day
+     FROM events
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), equals(events.event, '$feature_flag_called'), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0))
+     GROUP BY entity_id) AS subq
+  GROUP BY subq.day,
+           subq.variant
+  ORDER BY subq.day ASC
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=180,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestExperimentExposuresQueryRunner.test_exposure_query_multiple_variant_handling_first_seen
+  '''
+  SELECT subq.day AS day,
+         subq.variant AS variant,
+         count(subq.entity_id) AS exposed_count
+  FROM
+    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+            argMin(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), toTimeZone(events.timestamp, 'UTC')) AS variant,
             toDateOrNull(toString(min(toTimeZone(events.timestamp, 'UTC')))) AS day
      FROM events
      LEFT OUTER JOIN

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_experiment_exposures_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_experiment_exposures_query_runner.py
@@ -933,3 +933,111 @@ class TestExperimentExposuresQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(response.total_exposures["control"], 2)
         self.assertEqual(response.total_exposures["test"], 3)
+
+    @freeze_time("2024-01-07T12:00:00Z")
+    @snapshot_clickhouse_queries
+    def test_exposure_query_multiple_variant_handling_first_seen(self):
+        ff_property = f"$feature/{self.feature_flag.key}"
+
+        # Set the experiment to use first_seen handling for multiple variants
+        self.experiment.exposure_criteria = {"multiple_variant_handling": "first_seen"}
+        self.experiment.save()
+
+        journeys_for(
+            {
+                "user_control_only": [
+                    {
+                        "event": "$feature_flag_called",
+                        "timestamp": "2024-01-02",
+                        "properties": {
+                            "$feature_flag_response": "control",
+                            ff_property: "control",
+                            "$feature_flag": self.feature_flag.key,
+                        },
+                    },
+                ],
+                "user_test_only": [
+                    {
+                        "event": "$feature_flag_called",
+                        "timestamp": "2024-01-02",
+                        "properties": {
+                            "$feature_flag_response": "test",
+                            ff_property: "test",
+                            "$feature_flag": self.feature_flag.key,
+                        },
+                    },
+                ],
+                # User who sees control first, then test (should be counted as control)
+                "user_multiple_control_first": [
+                    {
+                        "event": "$feature_flag_called",
+                        "timestamp": "2024-01-02",
+                        "properties": {
+                            "$feature_flag_response": "control",
+                            ff_property: "control",
+                            "$feature_flag": self.feature_flag.key,
+                        },
+                    },
+                    {
+                        "event": "$feature_flag_called",
+                        "timestamp": "2024-01-03",
+                        "properties": {
+                            "$feature_flag_response": "test",
+                            ff_property: "test",
+                            "$feature_flag": self.feature_flag.key,
+                        },
+                    },
+                ],
+                # User who sees test first, then control (should be counted as test)
+                "user_multiple_test_first": [
+                    {
+                        "event": "$feature_flag_called",
+                        "timestamp": "2024-01-02",
+                        "properties": {
+                            "$feature_flag_response": "test",
+                            ff_property: "test",
+                            "$feature_flag": self.feature_flag.key,
+                        },
+                    },
+                    {
+                        "event": "$feature_flag_called",
+                        "timestamp": "2024-01-04",
+                        "properties": {
+                            "$feature_flag_response": "control",
+                            ff_property: "control",
+                            "$feature_flag": self.feature_flag.key,
+                        },
+                    },
+                ],
+            },
+            self.team,
+        )
+
+        flush_persons_and_events()
+
+        query = ExperimentExposureQuery(
+            kind="ExperimentExposureQuery",
+            experiment_id=self.experiment.id,
+            experiment_name=self.experiment.name,
+            feature_flag=model_to_dict(self.feature_flag),
+            holdout=model_to_dict(self.experiment.holdout) if self.experiment.holdout else None,
+            start_date=self.experiment.start_date.isoformat() if self.experiment.start_date else None,
+            end_date=self.experiment.end_date.isoformat() if self.experiment.end_date else None,
+            exposure_criteria=self.experiment.exposure_criteria,
+        )
+        query_runner = ExperimentExposuresQueryRunner(
+            team=self.team,
+            query=query,
+        )
+        response = query_runner.calculate()
+
+        # With first_seen handling:
+        # - user_control_only: counted in control
+        # - user_test_only: counted in test
+        # - user_multiple_control_first: counted in control (first seen variant)
+        # - user_multiple_test_first: counted in test (first seen variant)
+        self.assertEqual(response.total_exposures["control"], 2)  # user_control_only + user_multiple_control_first
+        self.assertEqual(response.total_exposures["test"], 2)  # user_test_only + user_multiple_test_first
+
+        # Verify no MULTIPLE_VARIANT_KEY appears in total_exposures for first_seen handling
+        self.assertNotIn(MULTIPLE_VARIANT_KEY, response.total_exposures)


### PR DESCRIPTION
## Problem
Exposure query was missing multiple variant handling and defaulting to `exclude`. Thought I added it, but I just consolidated the logic to a shared module and forgot to update the exposure query runner with it, so here it comes.

## Changes
- Use the shared exposure query logic that's already being used in the experiment query runner
- Use the same access pattern in the exposure query runner for the exposure criteria as experiment query runner does.

## How did you test this code?
- Tests added
- Existing tests passes