### PR TITLE
feat(cdp): add maxai to input schema generation

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -830,8 +830,8 @@
                 "analyze_user_interviews",
                 "create_and_query_insight",
                 "create_hog_transformation_function",
-                "create_hog_function_inputs",
                 "create_hog_function_filters",
+                "create_hog_function_inputs",
                 "navigate"
             ],
             "type": "string"

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -830,6 +830,7 @@
                 "analyze_user_interviews",
                 "create_and_query_insight",
                 "create_hog_transformation_function",
+                "create_hog_function_inputs",
                 "create_hog_function_filters",
                 "navigate"
             ],

--- a/frontend/src/queries/schema/schema-assistant-messages.ts
+++ b/frontend/src/queries/schema/schema-assistant-messages.ts
@@ -120,6 +120,7 @@ export type AssistantContextualTool =
     | 'create_and_query_insight'
     | 'create_hog_transformation_function'
     | 'create_hog_function_filters'
+    | 'create_hog_function_inputs'
     | 'navigate'
 
 /** Exact possible `urls` keys for the `navigate` tool. */
@@ -166,4 +167,3 @@ export type AssistantNavigateUrls =
     | 'notebooks'
     | 'persons'
     | 'toolbarLaunch'
-    | 'create_hog_function_inputs'

--- a/frontend/src/queries/schema/schema-assistant-messages.ts
+++ b/frontend/src/queries/schema/schema-assistant-messages.ts
@@ -166,3 +166,4 @@ export type AssistantNavigateUrls =
     | 'notebooks'
     | 'persons'
     | 'toolbarLaunch'
+    | 'create_hog_function_inputs'

--- a/frontend/src/scenes/hog-functions/configuration/HogFunctionConfiguration.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/HogFunctionConfiguration.tsx
@@ -1,4 +1,4 @@
-import { IconPlus } from '@posthog/icons'
+import { IconCheck, IconPlus, IconX } from '@posthog/icons'
 import {
     LemonBanner,
     LemonButton,
@@ -31,7 +31,7 @@ import { HogFunctionMappings } from 'scenes/hog-functions/mapping/HogFunctionMap
 import { HogFunctionEventEstimates } from 'scenes/hog-functions/metrics/HogFunctionEventEstimates'
 import MaxTool from 'scenes/max/MaxTool'
 
-import { AvailableFeature } from '~/types'
+import { AvailableFeature, CyclotronJobInputSchemaType } from '~/types'
 
 import { HogFunctionStatusIndicator } from '../misc/HogFunctionStatusIndicator'
 import { HogFunctionStatusTag } from '../misc/HogFunctionStatusTag'
@@ -89,7 +89,6 @@ export function HogFunctionConfiguration({
         newHogCode,
         oldInputs,
         newInputs,
-        inputsDiff,
         featureFlags,
     } = useValues(logic)
 
@@ -397,78 +396,93 @@ export function HogFunctionConfiguration({
                                     </LemonBanner>
                                 </div>
                             )}
-                            <div
-                                className={clsx(
-                                    'p-3 deprecated-space-y-2 bg-surface-primary',
-                                    !embedded && 'border rounded'
-                                )}
-                            >
-                                <div className="deprecated-space-y-2">
-                                    {usesGroups && !hasGroupsAddon ? (
-                                        <LemonBanner type="warning">
-                                            <span className="flex gap-2 items-center">
-                                                This function appears to use Groups but you do not have the Groups
-                                                Analytics addon. Without it, you may see empty values where you use
-                                                templates like {'"{groups.kind.properties}"'}
-                                                <PayGateButton
-                                                    feature={AvailableFeature.GROUP_ANALYTICS}
-                                                    type="secondary"
-                                                />
-                                            </span>
-                                        </LemonBanner>
-                                    ) : null}
+                            {aiHogFunctionCreation ? (
+                                <MaxTool
+                                    name="create_hog_function_inputs"
+                                    displayName="Generate and manage input variables"
+                                    description="Max can generate and manage input variables for your function"
+                                    context={{
+                                        current_inputs_schema: configuration.inputs_schema ?? [],
+                                        hog_code: configuration.hog ?? '',
+                                    }}
+                                    callback={(toolOutput: CyclotronJobInputSchemaType[]) => {
+                                        // Store the old inputs before changing
+                                        setOldInputs(configuration.inputs_schema ?? [])
+                                        // Store the new inputs from Max Tool
+                                        setNewInputs(toolOutput)
+                                        // Report that AI was prompted
+                                        reportAIHogFunctionInputsPrompted()
+                                        // Don't immediately update the form - let user accept/reject
+                                    }}
+                                    onMaxOpen={() => {
+                                        reportAIHogFunctionInputsPromptOpen()
+                                    }}
+                                    suggestions={[]}
+                                    introOverride={{
+                                        headline: 'What input variables do you need?',
+                                        description:
+                                            'Let me help you generate the input variables for your function based on your code and requirements.',
+                                    }}
+                                >
+                                    <div
+                                        className={clsx(
+                                            'p-3 deprecated-space-y-2 bg-surface-primary',
+                                            !embedded && 'border rounded'
+                                        )}
+                                    >
+                                        <div className="deprecated-space-y-2">
+                                            {usesGroups && !hasGroupsAddon ? (
+                                                <LemonBanner type="warning">
+                                                    <span className="flex gap-2 items-center">
+                                                        This function appears to use Groups but you do not have the
+                                                        Groups Analytics addon. Without it, you may see empty values
+                                                        where you use templates like {'"{groups.kind.properties}"'}
+                                                        <PayGateButton
+                                                            feature={AvailableFeature.GROUP_ANALYTICS}
+                                                            type="secondary"
+                                                        />
+                                                    </span>
+                                                </LemonBanner>
+                                            ) : null}
 
-                                    {aiHogFunctionCreation ? (
-                                        <MaxTool
-                                            name="create_hog_function_inputs"
-                                            displayName="Generate and manage input variables"
-                                            context={{
-                                                current_inputs_schema: configuration.inputs_schema ?? [],
-                                                hog_code: configuration.hog ?? '',
-                                                function_type: configuration.type ?? 'destination',
-                                            }}
-                                            callback={(toolOutput: any) => {
-                                                // Store the old inputs before changing
-                                                setOldInputs(configuration.inputs_schema ?? [])
-                                                // Store the new inputs from Max Tool
-                                                setNewInputs(toolOutput)
-                                                // Report that AI was prompted
-                                                reportAIHogFunctionInputsPrompted()
-                                                // Don't immediately update the form - let user accept/reject
-                                            }}
-                                            onMaxOpen={() => {
-                                                reportAIHogFunctionInputsPromptOpen()
-                                            }}
-                                            suggestions={[]}
-                                            introOverride={{
-                                                headline: 'What input variables do you need?',
-                                                description:
-                                                    'Let me help you generate the input variables for your function based on your code and requirements.',
-                                            }}
-                                        >
-                                            <div>
-                                                <CyclotronJobInputs
-                                                    configuration={{
-                                                        inputs_schema: newInputs ?? configuration.inputs_schema ?? [],
-                                                        inputs: configuration.inputs ?? {},
-                                                    }}
-                                                    onInputSchemaChange={(schema) => {
-                                                        // If user manually edits while diff is showing, clear the diff
-                                                        if (oldInputs && newInputs) {
-                                                            clearInputsDiff()
-                                                        }
-                                                        setConfigurationValue('inputs_schema', schema)
-                                                    }}
-                                                    onInputChange={(key, input) => {
-                                                        setConfigurationValue(`inputs.${key}`, input)
-                                                    }}
-                                                    showSource={showSource}
-                                                />
-                                                {inputsDiff && (
-                                                    <div className="flex gap-2 mt-2">
+                                            <CyclotronJobInputs
+                                                configuration={{
+                                                    inputs_schema: newInputs ?? configuration.inputs_schema ?? [],
+                                                    inputs: configuration.inputs ?? {},
+                                                }}
+                                                onInputSchemaChange={(schema) => {
+                                                    // If user manually edits while diff is showing, clear the diff
+                                                    if (oldInputs && newInputs) {
+                                                        clearInputsDiff()
+                                                    }
+                                                    setConfigurationValue('inputs_schema', schema)
+                                                }}
+                                                onInputChange={(key, input) => {
+                                                    setConfigurationValue(`inputs.${key}`, input)
+                                                }}
+                                                showSource={showSource}
+                                            />
+                                            {oldInputs && newInputs && (
+                                                <div className="flex gap-2 items-center mt-4 p-2 bg-surface-secondary rounded border border-dashed">
+                                                    <div className="flex-1 text-center">
+                                                        <span className="text-sm font-medium">Suggested by Max</span>
+                                                    </div>
+                                                    <div className="flex gap-2">
                                                         <LemonButton
-                                                            type="primary"
+                                                            status="danger"
+                                                            icon={<IconX />}
+                                                            onClick={() => {
+                                                                reportAIHogFunctionInputsRejected()
+                                                                clearInputsDiff()
+                                                            }}
+                                                            tooltipPlacement="top"
                                                             size="small"
+                                                        >
+                                                            Reject
+                                                        </LemonButton>
+                                                        <LemonButton
+                                                            type="tertiary"
+                                                            icon={<IconCheck color="var(--success)" />}
                                                             onClick={() => {
                                                                 if (newInputs) {
                                                                     setConfigurationValue('inputs_schema', newInputs)
@@ -476,24 +490,62 @@ export function HogFunctionConfiguration({
                                                                 reportAIHogFunctionInputsAccepted()
                                                                 clearInputsDiff()
                                                             }}
-                                                        >
-                                                            Accept changes
-                                                        </LemonButton>
-                                                        <LemonButton
-                                                            type="secondary"
+                                                            tooltipPlacement="top"
                                                             size="small"
-                                                            onClick={() => {
-                                                                reportAIHogFunctionInputsRejected()
-                                                                clearInputsDiff()
-                                                            }}
                                                         >
-                                                            Reject changes
+                                                            Accept
                                                         </LemonButton>
                                                     </div>
-                                                )}
-                                            </div>
-                                        </MaxTool>
-                                    ) : (
+                                                </div>
+                                            )}
+                                            {showSource && canEditSource ? (
+                                                <LemonButton
+                                                    icon={<IconPlus />}
+                                                    size="small"
+                                                    type="secondary"
+                                                    className="my-4"
+                                                    onClick={() => {
+                                                        setConfigurationValue('inputs_schema', [
+                                                            ...(configuration.inputs_schema ?? []),
+                                                            {
+                                                                type: 'string',
+                                                                key: `input_${
+                                                                    (configuration.inputs_schema?.length ?? 0) + 1
+                                                                }`,
+                                                                label: '',
+                                                                required: false,
+                                                            },
+                                                        ])
+                                                    }}
+                                                >
+                                                    Add input variable
+                                                </LemonButton>
+                                            ) : null}
+                                        </div>
+                                    </div>
+                                </MaxTool>
+                            ) : (
+                                <div
+                                    className={clsx(
+                                        'p-3 deprecated-space-y-2 bg-surface-primary',
+                                        !embedded && 'border rounded'
+                                    )}
+                                >
+                                    <div className="deprecated-space-y-2">
+                                        {usesGroups && !hasGroupsAddon ? (
+                                            <LemonBanner type="warning">
+                                                <span className="flex gap-2 items-center">
+                                                    This function appears to use Groups but you do not have the Groups
+                                                    Analytics addon. Without it, you may see empty values where you use
+                                                    templates like {'"{groups.kind.properties}"'}
+                                                    <PayGateButton
+                                                        feature={AvailableFeature.GROUP_ANALYTICS}
+                                                        type="secondary"
+                                                    />
+                                                </span>
+                                            </LemonBanner>
+                                        ) : null}
+
                                         <CyclotronJobInputs
                                             configuration={{
                                                 inputs_schema: configuration.inputs_schema ?? [],
@@ -507,30 +559,32 @@ export function HogFunctionConfiguration({
                                             }}
                                             showSource={showSource}
                                         />
-                                    )}
-                                    {showSource && canEditSource ? (
-                                        <LemonButton
-                                            icon={<IconPlus />}
-                                            size="small"
-                                            type="secondary"
-                                            className="my-4"
-                                            onClick={() => {
-                                                setConfigurationValue('inputs_schema', [
-                                                    ...(configuration.inputs_schema ?? []),
-                                                    {
-                                                        type: 'string',
-                                                        key: `input_${(configuration.inputs_schema?.length ?? 0) + 1}`,
-                                                        label: '',
-                                                        required: false,
-                                                    },
-                                                ])
-                                            }}
-                                        >
-                                            Add input variable
-                                        </LemonButton>
-                                    ) : null}
+                                        {showSource && canEditSource ? (
+                                            <LemonButton
+                                                icon={<IconPlus />}
+                                                size="small"
+                                                type="secondary"
+                                                className="my-4"
+                                                onClick={() => {
+                                                    setConfigurationValue('inputs_schema', [
+                                                        ...(configuration.inputs_schema ?? []),
+                                                        {
+                                                            type: 'string',
+                                                            key: `input_${
+                                                                (configuration.inputs_schema?.length ?? 0) + 1
+                                                            }`,
+                                                            label: '',
+                                                            required: false,
+                                                        },
+                                                    ])
+                                                }}
+                                            >
+                                                Add input variable
+                                            </LemonButton>
+                                        ) : null}
+                                    </div>
                                 </div>
-                            </div>
+                            )}
 
                             <HogFunctionMappings />
 

--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
@@ -317,6 +317,13 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
         reportAIFiltersAccepted: true,
         reportAIFiltersRejected: true,
         reportAIFiltersPromptOpen: true,
+        setOldInputs: (oldInputs: any) => ({ oldInputs }),
+        setNewInputs: (newInputs: any) => ({ newInputs }),
+        clearInputsDiff: true,
+        reportAIHogFunctionInputsPrompted: true,
+        reportAIHogFunctionInputsAccepted: true,
+        reportAIHogFunctionInputsRejected: true,
+        reportAIHogFunctionInputsPromptOpen: true,
     }),
     reducers(({ props }) => ({
         sampleGlobals: [
@@ -388,6 +395,20 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
             {
                 setNewFilters: (_, { newFilters }) => newFilters,
                 clearFiltersDiff: () => null,
+            },
+        ],
+        oldInputs: [
+            null as any,
+            {
+                setOldInputs: (_, { oldInputs }) => oldInputs,
+                clearInputsDiff: () => null,
+            },
+        ],
+        newInputs: [
+            null as any,
+            {
+                setNewInputs: (_, { newInputs }) => newInputs,
+                clearInputsDiff: () => null,
             },
         ],
     })),
@@ -1141,6 +1162,23 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
             },
         ],
 
+        currentInputs: [
+            (s) => [s.newInputs, s.configuration],
+            (newInputs: any, configuration: HogFunctionConfigurationType) => {
+                return newInputs ?? configuration.inputs_schema ?? []
+            },
+        ],
+
+        inputsDiff: [
+            (s) => [s.oldInputs, s.newInputs],
+            (oldInputs: any, newInputs: any) => {
+                if (!oldInputs || !newInputs) {
+                    return null
+                }
+                return { oldInputs, newInputs }
+            },
+        ],
+
         canLoadSampleGlobals: [
             (s) => [s.lastEventQuery],
             (lastEventQuery) => {
@@ -1173,6 +1211,18 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
         },
         reportAIFiltersPromptOpen: () => {
             posthog.capture('ai_hog_function_filters_prompt_open', { type: values.type })
+        },
+        reportAIHogFunctionInputsPrompted: () => {
+            posthog.capture('ai_hog_function_inputs_prompted', { type: values.type })
+        },
+        reportAIHogFunctionInputsAccepted: () => {
+            posthog.capture('ai_hog_function_inputs_accepted', { type: values.type })
+        },
+        reportAIHogFunctionInputsRejected: () => {
+            posthog.capture('ai_hog_function_inputs_rejected', { type: values.type })
+        },
+        reportAIHogFunctionInputsPromptOpen: () => {
+            posthog.capture('ai_hog_function_inputs_prompt_open', { type: values.type })
         },
         loadTemplateSuccess: () => actions.resetForm(),
         loadHogFunctionSuccess: () => {

--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
@@ -317,8 +317,8 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
         reportAIFiltersAccepted: true,
         reportAIFiltersRejected: true,
         reportAIFiltersPromptOpen: true,
-        setOldInputs: (oldInputs: any) => ({ oldInputs }),
-        setNewInputs: (newInputs: any) => ({ newInputs }),
+        setOldInputs: (oldInputs: CyclotronJobInputSchemaType[]) => ({ oldInputs }),
+        setNewInputs: (newInputs: CyclotronJobInputSchemaType[]) => ({ newInputs }),
         clearInputsDiff: true,
         reportAIHogFunctionInputsPrompted: true,
         reportAIHogFunctionInputsAccepted: true,
@@ -398,14 +398,14 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
             },
         ],
         oldInputs: [
-            null as any,
+            null as CyclotronJobInputSchemaType[] | null,
             {
                 setOldInputs: (_, { oldInputs }) => oldInputs,
                 clearInputsDiff: () => null,
             },
         ],
         newInputs: [
-            null as any,
+            null as CyclotronJobInputSchemaType[] | null,
             {
                 setNewInputs: (_, { newInputs }) => newInputs,
                 clearInputsDiff: () => null,
@@ -1164,14 +1164,14 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
 
         currentInputs: [
             (s) => [s.newInputs, s.configuration],
-            (newInputs: any, configuration: HogFunctionConfigurationType) => {
+            (newInputs: CyclotronJobInputSchemaType[] | null, configuration: HogFunctionConfigurationType) => {
                 return newInputs ?? configuration.inputs_schema ?? []
             },
         ],
 
         inputsDiff: [
             (s) => [s.oldInputs, s.newInputs],
-            (oldInputs: any, newInputs: any) => {
+            (oldInputs: CyclotronJobInputSchemaType[] | null, newInputs: CyclotronJobInputSchemaType[] | null) => {
                 if (!oldInputs || !newInputs) {
                     return null
                 }

--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFilters.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFilters.tsx
@@ -395,7 +395,7 @@ export function HogFunctionFilters({ embedded = false }: { embedded?: boolean })
             <MaxTool
                 name="create_hog_function_filters"
                 displayName="Set up filters with AI"
-                description="Max can set up filters for your Hog function"
+                description="Max can set up filters for your function"
                 context={{
                     current_filters: JSON.stringify(configuration?.filters ?? {}),
                     function_type: type,
@@ -411,7 +411,7 @@ export function HogFunctionFilters({ embedded = false }: { embedded?: boolean })
                 }}
                 introOverride={{
                     headline: 'What events and properties should trigger this function?',
-                    description: 'Let me help you set up the right filters for your hog function.',
+                    description: 'Let me help you set up the right filters for your function.',
                 }}
             >
                 {mainContent}

--- a/posthog/hogql/ai.py
+++ b/posthog/hogql/ai.py
@@ -2834,4 +2834,110 @@ export type CyclotronJobInputSchemaType = {
     integration_field?: string
     requires_field?: string
     requiredScopes?: string
-}"""
+}
+
+Here are some example input schemas to help you understand the format:
+
+Example 1 - Bot Detection Function:
+[
+    {
+        "key": "userAgent",
+        "type": "string",
+        "label": "User Agent Property",
+        "description": "The property that contains the user agent string (e.g. $raw_user_agent, $useragent)",
+        "default": "$raw_user_agent",
+        "secret": false,
+        "required": true
+    },
+    {
+        "key": "customBotPatterns",
+        "type": "string",
+        "label": "Custom Bot Patterns",
+        "description": "Additional bot patterns to detect, separated by commas (e.g. mybot,customcrawler)",
+        "default": "",
+        "secret": false,
+        "required": false
+    },
+    {
+        "key": "customIpPrefixes",
+        "type": "string",
+        "label": "Custom IP Prefixes",
+        "description": "Additional IPv4 or IPv6 prefixes in CIDR notation to block, separated by commas (e.g. 198.51.100.14/24,2001:db8::/48)",
+        "default": "",
+        "secret": false,
+        "required": false
+    }
+]
+
+Example 2 - Property Filter Function:
+[
+    {
+        "key": "propertiesToFilter",
+        "type": "string",
+        "label": "Properties to filter",
+        "description": "Comma-separated list of properties to filter (e.g. \"$set.email, $set.name, custom_prop\")",
+        "required": true
+    }
+]
+
+Example 3 - PII Hashing Function:
+[
+    {
+        "key": "salt",
+        "type": "string",
+        "label": "Salt",
+        "description": "A secret salt used for hashing. This should be kept secure and consistent.",
+        "default": "",
+        "secret": true,
+        "required": true
+    },
+    {
+        "key": "privateFields",
+        "type": "string",
+        "label": "Fields to hash",
+        "description": "Comma-separated list of field names to hash. Can include both event properties and top-level event fields like distinct_id.",
+        "default": "distinct_id,name,userid,email",
+        "secret": false,
+        "required": true
+    },
+    {
+        "key": "includeSetProperties",
+        "type": "boolean",
+        "label": "Also hash $set and $set_once properties",
+        "description": "Whether to also hash $set and $set_once properties that are used to update Person properties.",
+        "default": true,
+        "secret": false,
+        "required": false
+    }
+]
+
+Example 4 - Property Hashing Function:
+[
+    {
+        "key": "propertiesToHash",
+        "type": "string",
+        "label": "Properties to Hash",
+        "description": "Comma-separated list of property paths to hash (e.g. \"$ip,$email,$set.$phone\")",
+        "default": "$ip",
+        "secret": false,
+        "required": true
+    },
+    {
+        "key": "hashDistinctId",
+        "type": "boolean",
+        "label": "Hash Distinct ID",
+        "description": "Whether to hash the distinct_id field",
+        "default": false,
+        "secret": false,
+        "required": false
+    },
+    {
+        "key": "salt",
+        "type": "string",
+        "label": "Salt",
+        "description": "Optional salt to add to the hashed values for additional security",
+        "default": "",
+        "secret": true,
+        "required": false
+    }
+]"""

--- a/posthog/hogql/ai.py
+++ b/posthog/hogql/ai.py
@@ -2777,3 +2777,61 @@ Common operators:
 - "gt", "lt", "gte", "lte" for numeric comparisons
 
 Return ONLY the JSON object inside <filters> tags. Do not add any other text or explanation."""
+
+HOG_FUNCTION_INPUTS_SYSTEM_PROMPT = """You are an expert at creating input variable schemas for PostHog hog functions.
+
+Your task is to analyze the hog code and create appropriate input variable schemas based on the instructions.
+CRITICAL: You must extract the EXACT variable names used in the hog code. Look for patterns like:
+- inputs.variableName
+- inputs['variableName']
+- inputs["variableName"]
+The "key" field in the schema MUST match exactly what is used in the hog code after "inputs.". For example:
+- If code uses inputs.propertiesToRedact, the key must be "propertiesToRedact" (NOT "properties_to_redact")
+- If code uses inputs.webhookUrl, the key must be "webhookUrl" (NOT "webhook_url")
+- If code uses inputs.api_key, the key must be "api_key" (NOT "apiKey")
+
+Return ONLY a valid JSON array of input schema objects inside <inputs_schema> tags."""
+
+INPUT_SCHEMA_TYPES_MESSAGE = """Input schema format should be a list of objects with these fields:
+- key: string (EXACT variable name as used in hog code, preserve camelCase/snake_case)
+- type: string (one of: string, number, boolean, dictionary, choice, json, integration, integration_field, email)
+- label: string (human readable label)
+- description: string (description of what this input is for)
+- required: boolean (whether this input is required)
+- default: any (default value, optional)
+- choices: list (for choice type, list of {label, value} objects)
+- templating: boolean (whether templating is enabled, defaults to true)
+- secret: boolean (whether this is a secret value, defaults to false)
+- hidden: boolean (whether this input is hidden from users, defaults to false)
+- integration: string (for integration type, the integration name)
+- integration_key: string (for integration_field type, the integration key)
+- integration_field: string (for integration_field type, the field name)
+- requires_field: string (for conditional fields)
+- requiredScopes: string (for integrations, required OAuth scopes)
+
+export type CyclotronJobInputSchemaType = {
+    type:
+        | 'string'
+        | 'number'
+        | 'boolean'
+        | 'dictionary'
+        | 'choice'
+        | 'json'
+        | 'integration'
+        | 'integration_field'
+        | 'email'
+    key: string
+    label: string
+    choices?: { value: string; label: string }[]
+    required?: boolean
+    default?: any
+    secret?: boolean
+    hidden?: boolean
+    templating?: boolean
+    description?: string
+    integration?: string
+    integration_key?: string
+    integration_field?: string
+    requires_field?: string
+    requiredScopes?: string
+}"""

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -78,6 +78,7 @@ class AssistantContextualTool(StrEnum):
     CREATE_HOG_TRANSFORMATION_FUNCTION = "create_hog_transformation_function"
     CREATE_HOG_FUNCTION_FILTERS = "create_hog_function_filters"
     NAVIGATE = "navigate"
+    CREATE_HOG_FUNCTION_INPUTS = "create_hog_function_inputs"
 
 
 class AssistantDateRange(BaseModel):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -77,8 +77,8 @@ class AssistantContextualTool(StrEnum):
     CREATE_AND_QUERY_INSIGHT = "create_and_query_insight"
     CREATE_HOG_TRANSFORMATION_FUNCTION = "create_hog_transformation_function"
     CREATE_HOG_FUNCTION_FILTERS = "create_hog_function_filters"
-    NAVIGATE = "navigate"
     CREATE_HOG_FUNCTION_INPUTS = "create_hog_function_inputs"
+    NAVIGATE = "navigate"
 
 
 class AssistantDateRange(BaseModel):

--- a/products/cdp/backend/prompts.py
+++ b/products/cdp/backend/prompts.py
@@ -10,6 +10,18 @@ NOTE: When calling the `create_hog_transformation_function` tool, do not provide
 After the tool completes, do NOT repeat the code, as the user can see it. Only summarize the changes, comprehensively, but in only one brief sentence.
 """
 
+HOG_FUNCTION_INPUTS_ASSISTANT_ROOT_SYSTEM_PROMPT = """
+The user is currently editing or creating input variables for a Hog function. They expect your help with generating and managing input schemas.
+
+IMPORTANT: This is currently your primary task. Therefore `create_hog_function_inputs` is currently your primary tool.
+Use `create_hog_function_inputs` when answering ANY requests remotely related to creating, modifying, or managing input variables for hog functions.
+It's very important to disregard other tools for these purposes - the user expects `create_hog_function_inputs`.
+
+NOTE: When calling the `create_hog_function_inputs` tool, do not provide any response other than the tool call.
+
+After the tool completes, do NOT repeat the schema, as the user can see it. Only summarize the changes, comprehensively, but in only one brief sentence.
+"""
+
 HOG_FUNCTION_FILTERS_ASSISTANT_ROOT_SYSTEM_PROMPT = """
 The user is currently setting up filters for a Hog function. They expect your help with configuring which events and properties should trigger the function.
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._


## Demo (end to end creation of hog function)

![2025-07-04 11 13 17](https://github.com/user-attachments/assets/4f0b3a37-49a8-4e09-9544-8fce5f7f7343)

## Problem

We need an AI automated way to create inputs for the hog functions

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

 - analyzes existing hog code to identify required input variables
 - Generates appropriate input schemas with correct types 
 - Shows before/after comparison of input schemas
 - Accept/reject changes with visual diff display
 - Manual editing clears AI suggestions automatically
 - Tracks AI usage with events

## How did you test this code?

- tested on local dev

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
