### PR TITLE
fix(web-analytics): export files s3 path are failing

### DIFF
--- a/dags/web_preaggregated_asset_checks.py
+++ b/dags/web_preaggregated_asset_checks.py
@@ -110,7 +110,7 @@ def stats_hourly_has_data() -> AssetCheckResult:
 
 def check_export_chdb_queryable(export_type: str, log_event_name: str) -> AssetCheckResult:
     try:
-        export_filename = f"{export_type}_export.native"
+        export_filename = f"{export_type}_export"
         export_path = get_s3_url(table_name=export_filename, team_id=2)
 
         if export_type == "web_stats_daily":

--- a/posthog/hogql/database/schema/test/test_web_analytics_s3.py
+++ b/posthog/hogql/database/schema/test/test_web_analytics_s3.py
@@ -25,7 +25,7 @@ class TestWebAnalyticsS3(BaseTest):
         # Verify URL components
         assert ".s3.us-east-1.amazonaws.com" in url  # Region is included
         assert f"/{table_name}/{team_id}/data.native" in url  # Path is correct
-        assert ".native/" not in url  # No extra .native/ in path from
+        assert ".native/" not in url  # No extra .native/ in path
 
     @override_settings(DEBUG=False)
     @patch("posthog.settings.object_storage.OBJECT_STORAGE_EXTERNAL_WEB_ANALYTICS_BUCKET", "test-bucket-name")

--- a/posthog/hogql/database/schema/test/test_web_analytics_s3.py
+++ b/posthog/hogql/database/schema/test/test_web_analytics_s3.py
@@ -1,0 +1,96 @@
+from unittest.mock import patch
+from django.test import override_settings
+
+from posthog.test.base import BaseTest
+from posthog.hogql.database.schema.web_analytics_s3 import get_s3_url, get_s3_function_args
+
+
+class TestWebAnalyticsS3(BaseTest):
+    @override_settings(DEBUG=False)
+    @patch(
+        "posthog.settings.object_storage.OBJECT_STORAGE_EXTERNAL_WEB_ANALYTICS_BUCKET",
+        "external-web-analytics-854902948032-us-east-1",
+    )
+    @patch("posthog.settings.object_storage.OBJECT_STORAGE_REGION", "us-east-1")
+    def test_get_s3_url_production_format(self):
+        table_name = "web_stats_daily_export"
+        team_id = 2
+
+        url = get_s3_url(table_name=table_name, team_id=team_id)
+
+        expected_url = "https://external-web-analytics-854902948032-us-east-1.s3.us-east-1.amazonaws.com/web_stats_daily_export/2/data.native"
+
+        assert url == expected_url
+
+        # Verify URL components
+        assert ".s3.us-east-1.amazonaws.com" in url  # Region is included
+        assert f"/{table_name}/{team_id}/data.native" in url  # Path is correct
+        assert ".native/" not in url  # No extra .native/ in path from
+
+    @override_settings(DEBUG=False)
+    @patch("posthog.settings.object_storage.OBJECT_STORAGE_EXTERNAL_WEB_ANALYTICS_BUCKET", "test-bucket-name")
+    @patch("posthog.settings.object_storage.OBJECT_STORAGE_REGION", "eu-west-1")
+    def test_get_s3_url_production_different_region(self):
+        table_name = "web_bounces_daily_export"
+        team_id = 123
+
+        url = get_s3_url(table_name=table_name, team_id=team_id)
+
+        expected_url = "https://test-bucket-name.s3.eu-west-1.amazonaws.com/web_bounces_daily_export/123/data.native"
+
+        assert url == expected_url
+        assert ".s3.eu-west-1.amazonaws.com" in url
+
+    @override_settings(DEBUG=True)
+    def test_get_s3_url_debug_format(self):
+        table_name = "web_stats_daily_export"
+        team_id = 2
+
+        url = get_s3_url(table_name=table_name, team_id=team_id)
+
+        expected_url = "http://objectstorage:19000/posthog/web_stats_daily_export/2/data.native"
+
+        assert url == expected_url
+        assert url.startswith("http://")  # HTTP protocol for local
+        assert "objectstorage:19000" in url  # Local MinIO endpoint
+        assert "/posthog/" in url  # Local bucket name
+
+    def test_get_s3_url_path_validation(self):
+        test_cases = [
+            ("web_stats_daily_export", 1),
+            ("web_bounces_daily_export", 999),
+            ("test_export", 42),
+        ]
+
+        with (
+            override_settings(DEBUG=False),
+            patch("posthog.settings.object_storage.OBJECT_STORAGE_EXTERNAL_WEB_ANALYTICS_BUCKET", "test-bucket"),
+            patch("posthog.settings.object_storage.OBJECT_STORAGE_REGION", "us-east-1"),
+        ):
+            for table_name, team_id in test_cases:
+                url = get_s3_url(table_name=table_name, team_id=team_id)
+
+                expected_path = f"/{table_name}/{team_id}/data.native"
+                assert url.endswith(expected_path), f"Path structure incorrect for {table_name}"
+
+    @override_settings(DEBUG=False)
+    @patch("posthog.settings.object_storage.OBJECT_STORAGE_ACCESS_KEY_ID", "test-key")
+    @patch("posthog.settings.object_storage.OBJECT_STORAGE_SECRET_ACCESS_KEY", "test-secret")
+    def test_get_s3_function_args_production_should_not_include_credentials(self):
+        s3_path = "https://test-bucket.s3.us-east-1.amazonaws.com/path/to/file.native"
+
+        args = get_s3_function_args(s3_path)
+
+        expected_args = "'https://test-bucket.s3.us-east-1.amazonaws.com/path/to/file.native', 'Native'"
+        assert args == expected_args
+
+    @override_settings(DEBUG=True)
+    @patch("posthog.settings.object_storage.OBJECT_STORAGE_ACCESS_KEY_ID", "test-key")
+    @patch("posthog.settings.object_storage.OBJECT_STORAGE_SECRET_ACCESS_KEY", "test-secret")
+    def test_get_s3_function_args_debug(self):
+        s3_path = "http://objectstorage:19000/posthog/path/to/file.native"
+
+        args = get_s3_function_args(s3_path)
+
+        expected_args = "'http://objectstorage:19000/posthog/path/to/file.native', 'test-key', 'test-secret', 'Native'"
+        assert args == expected_args

--- a/posthog/hogql/database/schema/test/test_web_analytics_s3.py
+++ b/posthog/hogql/database/schema/test/test_web_analytics_s3.py
@@ -1,41 +1,40 @@
 from unittest.mock import patch
 from django.test import override_settings
-
 from posthog.test.base import BaseTest
 from posthog.hogql.database.schema.web_analytics_s3 import get_s3_url, get_s3_function_args
+from posthog.settings.object_storage import (
+    OBJECT_STORAGE_ACCESS_KEY_ID,
+    OBJECT_STORAGE_SECRET_ACCESS_KEY,
+    OBJECT_STORAGE_REGION,
+    OBJECT_STORAGE_EXTERNAL_WEB_ANALYTICS_BUCKET,
+)
 
 
 class TestWebAnalyticsS3(BaseTest):
-    @override_settings(DEBUG=False)
-    @patch(
-        "posthog.settings.object_storage.OBJECT_STORAGE_EXTERNAL_WEB_ANALYTICS_BUCKET",
-        "external-web-analytics-854902948032-us-east-1",
-    )
-    @patch("posthog.settings.object_storage.OBJECT_STORAGE_REGION", "us-east-1")
+    @patch("posthog.hogql.database.schema.web_analytics_s3.DEBUG", False)
     def test_get_s3_url_production_format(self):
         table_name = "web_stats_daily_export"
         team_id = 2
 
         url = get_s3_url(table_name=table_name, team_id=team_id)
 
-        expected_url = "https://external-web-analytics-854902948032-us-east-1.s3.us-east-1.amazonaws.com/web_stats_daily_export/2/data.native"
+        # Use actual environment values for the expected URL
+        expected_url = f"https://{OBJECT_STORAGE_EXTERNAL_WEB_ANALYTICS_BUCKET}.s3.{OBJECT_STORAGE_REGION}.amazonaws.com/web_stats_daily_export/2/data.native"
 
         assert url == expected_url
 
-    @override_settings(DEBUG=False)
-    @patch("posthog.settings.object_storage.OBJECT_STORAGE_EXTERNAL_WEB_ANALYTICS_BUCKET", "test-bucket-name")
-    @patch("posthog.settings.object_storage.OBJECT_STORAGE_REGION", "eu-west-1")
+    @patch("posthog.hogql.database.schema.web_analytics_s3.DEBUG", False)
     def test_get_s3_url_production_different_region(self):
         table_name = "web_bounces_daily_export"
         team_id = 123
 
         url = get_s3_url(table_name=table_name, team_id=team_id)
-
-        expected_url = "https://test-bucket-name.s3.eu-west-1.amazonaws.com/web_bounces_daily_export/123/data.native"
+        expected_url = f"https://{OBJECT_STORAGE_EXTERNAL_WEB_ANALYTICS_BUCKET}.s3.{OBJECT_STORAGE_REGION}.amazonaws.com/web_bounces_daily_export/123/data.native"
 
         assert url == expected_url
 
     @override_settings(DEBUG=True)
+    @patch("posthog.hogql.database.schema.web_analytics_s3.DEBUG", True)
     def test_get_s3_url_debug_format(self):
         table_name = "web_stats_daily_export"
         team_id = 2
@@ -45,10 +44,8 @@ class TestWebAnalyticsS3(BaseTest):
         expected_url = "http://objectstorage:19000/posthog/web_stats_daily_export/2/data.native"
 
         assert url == expected_url
-        assert url.startswith("http://")  # HTTP protocol for local
-        assert "objectstorage:19000" in url  # Local MinIO endpoint
-        assert "/posthog/" in url  # Local bucket name
 
+    @patch("posthog.hogql.database.schema.web_analytics_s3.DEBUG", False)
     def test_get_s3_url_path_validation(self):
         test_cases = [
             ("web_stats_daily_export", 1),
@@ -56,20 +53,13 @@ class TestWebAnalyticsS3(BaseTest):
             ("test_export", 42),
         ]
 
-        with (
-            override_settings(DEBUG=False),
-            patch("posthog.settings.object_storage.OBJECT_STORAGE_EXTERNAL_WEB_ANALYTICS_BUCKET", "test-bucket"),
-            patch("posthog.settings.object_storage.OBJECT_STORAGE_REGION", "us-east-1"),
-        ):
-            for table_name, team_id in test_cases:
-                url = get_s3_url(table_name=table_name, team_id=team_id)
+        for table_name, team_id in test_cases:
+            url = get_s3_url(table_name=table_name, team_id=team_id)
 
-                expected_path = f"/{table_name}/{team_id}/data.native"
-                assert url.endswith(expected_path), f"Path structure incorrect for {table_name}"
+            expected_path = f"/{table_name}/{team_id}/data.native"
+            assert url.endswith(expected_path), f"Path structure incorrect for {table_name}"
 
-    @override_settings(DEBUG=False)
-    @patch("posthog.settings.object_storage.OBJECT_STORAGE_ACCESS_KEY_ID", "test-key")
-    @patch("posthog.settings.object_storage.OBJECT_STORAGE_SECRET_ACCESS_KEY", "test-secret")
+    @patch("posthog.hogql.database.schema.web_analytics_s3.DEBUG", False)
     def test_get_s3_function_args_production_should_not_include_credentials(self):
         s3_path = "https://test-bucket.s3.us-east-1.amazonaws.com/path/to/file.native"
 
@@ -78,13 +68,12 @@ class TestWebAnalyticsS3(BaseTest):
         expected_args = "'https://test-bucket.s3.us-east-1.amazonaws.com/path/to/file.native', 'Native'"
         assert args == expected_args
 
-    @override_settings(DEBUG=True)
-    @patch("posthog.settings.object_storage.OBJECT_STORAGE_ACCESS_KEY_ID", "test-key")
-    @patch("posthog.settings.object_storage.OBJECT_STORAGE_SECRET_ACCESS_KEY", "test-secret")
+    @patch("posthog.hogql.database.schema.web_analytics_s3.DEBUG", True)
     def test_get_s3_function_args_debug(self):
         s3_path = "http://objectstorage:19000/posthog/path/to/file.native"
 
         args = get_s3_function_args(s3_path)
 
-        expected_args = "'http://objectstorage:19000/posthog/path/to/file.native', 'test-key', 'test-secret', 'Native'"
+        # Use actual environment values for expected args
+        expected_args = f"'{s3_path}', '{OBJECT_STORAGE_ACCESS_KEY_ID}', '{OBJECT_STORAGE_SECRET_ACCESS_KEY}', 'Native'"
         assert args == expected_args

--- a/posthog/hogql/database/schema/test/test_web_analytics_s3.py
+++ b/posthog/hogql/database/schema/test/test_web_analytics_s3.py
@@ -22,11 +22,6 @@ class TestWebAnalyticsS3(BaseTest):
 
         assert url == expected_url
 
-        # Verify URL components
-        assert ".s3.us-east-1.amazonaws.com" in url  # Region is included
-        assert f"/{table_name}/{team_id}/data.native" in url  # Path is correct
-        assert ".native/" not in url  # No extra .native/ in path
-
     @override_settings(DEBUG=False)
     @patch("posthog.settings.object_storage.OBJECT_STORAGE_EXTERNAL_WEB_ANALYTICS_BUCKET", "test-bucket-name")
     @patch("posthog.settings.object_storage.OBJECT_STORAGE_REGION", "eu-west-1")
@@ -39,7 +34,6 @@ class TestWebAnalyticsS3(BaseTest):
         expected_url = "https://test-bucket-name.s3.eu-west-1.amazonaws.com/web_bounces_daily_export/123/data.native"
 
         assert url == expected_url
-        assert ".s3.eu-west-1.amazonaws.com" in url
 
     @override_settings(DEBUG=True)
     def test_get_s3_url_debug_format(self):

--- a/posthog/hogql/database/schema/web_analytics_s3.py
+++ b/posthog/hogql/database/schema/web_analytics_s3.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from posthog.settings.base_variables import DEBUG
 from posthog.settings.object_storage import (
     OBJECT_STORAGE_ACCESS_KEY_ID,
+    OBJECT_STORAGE_REGION,
     OBJECT_STORAGE_SECRET_ACCESS_KEY,
     OBJECT_STORAGE_EXTERNAL_WEB_ANALYTICS_BUCKET,
 )
@@ -28,7 +29,7 @@ def get_s3_url(table_name: str, team_id: int) -> str:
         key = f"{table_name}/{team_id}/data.native"
         return f"{s3_endpoint}/{bucket}/{key}"
 
-    base_url = f"https://{OBJECT_STORAGE_EXTERNAL_WEB_ANALYTICS_BUCKET}.s3.amazonaws.com"
+    base_url = f"https://{OBJECT_STORAGE_EXTERNAL_WEB_ANALYTICS_BUCKET}.s3.{OBJECT_STORAGE_REGION}.amazonaws.com"
 
     return f"{base_url}/{table_name}/{team_id}/data.native"
 

--- a/posthog/hogql/database/schema/web_analytics_s3.py
+++ b/posthog/hogql/database/schema/web_analytics_s3.py
@@ -5,7 +5,6 @@ from posthog.hogql.database.schema.web_analytics_preaggregated import (
     web_preaggregated_base_aggregation_fields,
     WEB_BOUNCES_SPECIFIC_FIELDS,
 )
-from django.conf import settings
 from posthog.settings.base_variables import DEBUG
 from posthog.settings.object_storage import (
     OBJECT_STORAGE_ACCESS_KEY_ID,
@@ -23,7 +22,7 @@ def get_s3_function_args(s3_path: str) -> str:
 
 
 def get_s3_url(table_name: str, team_id: int) -> str:
-    if settings.DEBUG:
+    if DEBUG:
         s3_endpoint = "http://objectstorage:19000"
         bucket = "posthog"
         key = f"{table_name}/{team_id}/data.native"


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

There were two problems on the URL format:
- We were using the `s3://` format for the files; we must include the region on the `https://` references. 
- It had an extra `.native/` from the previous split method, which now fails since we're prefixing with the `team_id` and all files are stored as `<export_name>/<team_id>/data.native`.

## Changes

- Include the region in the URL.
- Remove the extra `.native` while building the URL to query.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [x] No docs needed for this change

## How did you test this code?

Unit test and running Dagster locally