### PR TITLE
fix: dont persist database tree unless it was open beforehand

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/editorSceneLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/editorSceneLogic.tsx
@@ -107,6 +107,8 @@ export const editorSceneLogic = kea<editorSceneLogicType>([
         reportAIQueryAccepted: true,
         reportAIQueryRejected: true,
         reportAIQueryPromptOpen: true,
+        setWasPanelActive: (wasPanelActive: boolean) => ({ wasPanelActive }),
+        setPreviousUrl: (previousUrl: string) => ({ previousUrl }),
     }),
     reducers({
         sidebarOverlayOpen: [
@@ -114,6 +116,18 @@ export const editorSceneLogic = kea<editorSceneLogicType>([
             {
                 setSidebarOverlayOpen: (_, { isOpen }) => isOpen,
                 selectSchema: (_, { schema }) => schema !== null,
+            },
+        ],
+        wasPanelActive: [
+            false,
+            {
+                setWasPanelActive: (_, { wasPanelActive }) => wasPanelActive,
+            },
+        ],
+        previousUrl: [
+            '',
+            {
+                setPreviousUrl: (_, { previousUrl }) => previousUrl,
             },
         ],
     }),
@@ -507,13 +521,31 @@ export const editorSceneLogic = kea<editorSceneLogicType>([
             },
         ],
     })),
-    urlToAction(({ values }) => ({
+    urlToAction(({ values, actions }) => ({
         [urls.sqlEditor()]: () => {
-            if (values.featureFlags[FEATURE_FLAGS.SQL_EDITOR_TREE_VIEW]) {
+            if (values.featureFlags[FEATURE_FLAGS.SQL_EDITOR_TREE_VIEW] && values.previousUrl !== urls.sqlEditor()) {
+                if (panelLayoutLogic.values.activePanelIdentifier === 'Database') {
+                    actions.setWasPanelActive(true)
+                } else {
+                    actions.setWasPanelActive(false)
+                }
                 panelLayoutLogic.actions.showLayoutPanel(true)
                 panelLayoutLogic.actions.setActivePanelIdentifier('Database')
                 panelLayoutLogic.actions.toggleLayoutPanelPinned(true)
             }
+            actions.setPreviousUrl(urls.sqlEditor())
+        },
+        '*': () => {
+            if (
+                values.featureFlags[FEATURE_FLAGS.SQL_EDITOR_TREE_VIEW] &&
+                router.values.location.pathname !== urls.sqlEditor()
+            ) {
+                if (!values.wasPanelActive) {
+                    panelLayoutLogic.actions.toggleLayoutPanelPinned(false)
+                    panelLayoutLogic.actions.showLayoutPanel(false)
+                }
+            }
+            actions.setPreviousUrl(router.values.location.pathname)
         },
     })),
     subscriptions({


### PR DESCRIPTION
## Problem

- the tree sidebar sticks after navigating to sql editor and navigating away. This is disruptive as you always have a database tree open

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- check when incoming to editor if the sidebar was open or not

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
