### PR TITLE
chore: supporting mk-a in team config admin

### DIFF
--- a/posthog/admin/admins/team_admin.py
+++ b/posthog/admin/admins/team_admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.utils.html import format_html
 from posthog.admin.inlines.group_type_mapping_inline import GroupTypeMappingInline
+from posthog.admin.inlines.team_marketing_analytics_config_inline import TeamMarketingAnalyticsConfigInline
 from django.urls import reverse
 
 from posthog.models import Team
@@ -40,7 +41,7 @@ class TeamAdmin(admin.ModelAdmin):
         "updated_at",
     ]
 
-    inlines = [GroupTypeMappingInline]
+    inlines = [GroupTypeMappingInline, TeamMarketingAnalyticsConfigInline]
     fieldsets = [
         (
             None,
@@ -55,6 +56,8 @@ class TeamAdmin(admin.ModelAdmin):
                 "fields": [
                     "api_token",
                     "timezone",
+                    "week_start_day",
+                    "base_currency",
                     "slack_incoming_webhook",
                     "primary_dashboard",
                 ],

--- a/posthog/admin/inlines/team_marketing_analytics_config_inline.py
+++ b/posthog/admin/inlines/team_marketing_analytics_config_inline.py
@@ -1,0 +1,23 @@
+from django.contrib import admin
+
+from posthog.models.team.team_marketing_analytics_config import TeamMarketingAnalyticsConfig
+
+
+class TeamMarketingAnalyticsConfigInline(admin.StackedInline):
+    model = TeamMarketingAnalyticsConfig
+    extra = 0
+    max_num = 1
+    classes = ("collapse",)
+
+    fieldsets = [
+        (
+            "Marketing Analytics Configuration",
+            {
+                "fields": ["_sources_map", "_conversion_goals"],
+                "description": "Configure external data sources and conversion tracking for marketing analytics.",
+            },
+        ),
+    ]
+
+    def has_delete_permission(self, request, obj=None):
+        return False  # Don't allow deletion of the config

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -427,7 +427,7 @@ class Team(UUIDClassicModel):
         config, _ = TeamRevenueAnalyticsConfig.objects.get_or_create(team=self)
         return config
 
-    @cached_property
+    @property
     def marketing_analytics_config(self):
         from .team_marketing_analytics_config import TeamMarketingAnalyticsConfig
 

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -157,7 +157,7 @@ class TestAutoProjectMiddleware(APIBaseTest):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        cls.base_app_num_queries = 50
+        cls.base_app_num_queries = 51
         # Create another team that the user does have access to
         cls.second_team = create_team(organization=cls.organization, name="Second Life")
 
@@ -179,7 +179,7 @@ class TestAutoProjectMiddleware(APIBaseTest):
     def test_project_switched_when_accessing_dashboard_of_another_accessible_team(self):
         dashboard = Dashboard.objects.create(team=self.second_team)
 
-        with self.assertNumQueries(self.base_app_num_queries + 8):  # AutoProjectMiddleware adds 4 queries
+        with self.assertNumQueries(self.base_app_num_queries + 7):  # AutoProjectMiddleware adds 4 queries
             response_app = self.client.get(f"/dashboard/{dashboard.id}")
         response_users_api = self.client.get(f"/api/users/@me/")
         response_users_api_data = response_users_api.json()
@@ -227,7 +227,7 @@ class TestAutoProjectMiddleware(APIBaseTest):
 
     @override_settings(PERSON_ON_EVENTS_V2_OVERRIDE=False)
     def test_project_unchanged_when_accessing_dashboards_list(self):
-        with self.assertNumQueries(self.base_app_num_queries + 4):  # No AutoProjectMiddleware queries
+        with self.assertNumQueries(self.base_app_num_queries + 3):  # No AutoProjectMiddleware queries
             response_app = self.client.get(f"/dashboard")
         response_users_api = self.client.get(f"/api/users/@me/")
         response_users_api_data = response_users_api.json()
@@ -297,7 +297,7 @@ class TestAutoProjectMiddleware(APIBaseTest):
     def test_project_switched_when_accessing_feature_flag_of_another_accessible_team(self):
         feature_flag = FeatureFlag.objects.create(team=self.second_team, created_by=self.user)
 
-        with self.assertNumQueries(self.base_app_num_queries + 8):
+        with self.assertNumQueries(self.base_app_num_queries + 7):
             response_app = self.client.get(f"/feature_flags/{feature_flag.id}")
         response_users_api = self.client.get(f"/api/users/@me/")
         response_users_api_data = response_users_api.json()
@@ -311,7 +311,7 @@ class TestAutoProjectMiddleware(APIBaseTest):
 
     @override_settings(PERSON_ON_EVENTS_V2_OVERRIDE=False)
     def test_project_unchanged_when_creating_feature_flag(self):
-        with self.assertNumQueries(self.base_app_num_queries + 4):
+        with self.assertNumQueries(self.base_app_num_queries + 3):
             response_app = self.client.get(f"/feature_flags/new")
         response_users_api = self.client.get(f"/api/users/@me/")
         response_users_api_data = response_users_api.json()

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -179,7 +179,7 @@ class TestAutoProjectMiddleware(APIBaseTest):
     def test_project_switched_when_accessing_dashboard_of_another_accessible_team(self):
         dashboard = Dashboard.objects.create(team=self.second_team)
 
-        with self.assertNumQueries(self.base_app_num_queries + 7):  # AutoProjectMiddleware adds 4 queries
+        with self.assertNumQueries(self.base_app_num_queries + 8):  # AutoProjectMiddleware adds 4 queries
             response_app = self.client.get(f"/dashboard/{dashboard.id}")
         response_users_api = self.client.get(f"/api/users/@me/")
         response_users_api_data = response_users_api.json()
@@ -227,7 +227,7 @@ class TestAutoProjectMiddleware(APIBaseTest):
 
     @override_settings(PERSON_ON_EVENTS_V2_OVERRIDE=False)
     def test_project_unchanged_when_accessing_dashboards_list(self):
-        with self.assertNumQueries(self.base_app_num_queries + 3):  # No AutoProjectMiddleware queries
+        with self.assertNumQueries(self.base_app_num_queries + 4):  # No AutoProjectMiddleware queries
             response_app = self.client.get(f"/dashboard")
         response_users_api = self.client.get(f"/api/users/@me/")
         response_users_api_data = response_users_api.json()
@@ -297,7 +297,7 @@ class TestAutoProjectMiddleware(APIBaseTest):
     def test_project_switched_when_accessing_feature_flag_of_another_accessible_team(self):
         feature_flag = FeatureFlag.objects.create(team=self.second_team, created_by=self.user)
 
-        with self.assertNumQueries(self.base_app_num_queries + 7):
+        with self.assertNumQueries(self.base_app_num_queries + 8):
             response_app = self.client.get(f"/feature_flags/{feature_flag.id}")
         response_users_api = self.client.get(f"/api/users/@me/")
         response_users_api_data = response_users_api.json()
@@ -311,7 +311,7 @@ class TestAutoProjectMiddleware(APIBaseTest):
 
     @override_settings(PERSON_ON_EVENTS_V2_OVERRIDE=False)
     def test_project_unchanged_when_creating_feature_flag(self):
-        with self.assertNumQueries(self.base_app_num_queries + 3):
+        with self.assertNumQueries(self.base_app_num_queries + 4):
             response_app = self.client.get(f"/feature_flags/new")
         response_users_api = self.client.get(f"/api/users/@me/")
         response_users_api_data = response_users_api.json()


### PR DESCRIPTION
If we have any problem in marketing configuration, now we can fix it from the admin directly.

## Changes

Adding marketing analytics config support into django admin. I also update it to add missing support for base currency and week_start_day 

<img width="521" alt="image" src="https://github.com/user-attachments/assets/f3a2dac3-ea3b-4c02-8181-cdd50d681775" />
<img width="1189" alt="image" src="https://github.com/user-attachments/assets/da1d6f49-45a4-453e-986b-c0e9597c2ab5" />
<img width="1190" alt="image" src="https://github.com/user-attachments/assets/a0d8c933-ec9a-4602-b67e-934feb4a96ce" />
