### PR TITLE
feat: position max tool

### DIFF
--- a/frontend/src/scenes/max/MaxTool.tsx
+++ b/frontend/src/scenes/max/MaxTool.tsx
@@ -20,6 +20,7 @@ interface MaxToolProps extends ToolDefinition {
     initialMaxPrompt?: string
     onMaxOpen?: () => void
     className?: string
+    position?: 'top-right' | 'bottom-right' | 'top-left' | 'bottom-left'
 }
 
 export function MaxTool({
@@ -32,6 +33,7 @@ export function MaxTool({
     initialMaxPrompt,
     onMaxOpen,
     className,
+    position = 'top-right',
 }: MaxToolProps): JSX.Element {
     const { registerTool, deregisterTool } = useActions(maxGlobalLogic)
     const { user } = useValues(userLogic)
@@ -74,7 +76,13 @@ export function MaxTool({
                     delayMs={0}
                 >
                     <button
-                        className="absolute -top-2 -right-2 z-10 transition duration-50 cursor-pointer -scale-x-100 hover:scale-y-110 hover:-scale-x-110"
+                        className={clsx(
+                            'absolute z-10 transition duration-50 cursor-pointer -scale-x-100 hover:scale-y-110 hover:-scale-x-110',
+                            position === 'top-right' && '-top-2 -right-2',
+                            position === 'bottom-right' && '-bottom-2 -right-2',
+                            position === 'top-left' && '-top-2 -left-2',
+                            position === 'bottom-left' && '-bottom-2 -left-2'
+                        )}
                         type="button"
                         onClick={() => {
                             openSidePanel(SidePanelTab.Max, initialMaxPrompt)


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
We want to be able to edit the position of the small Max from MaxTool. This PR lets you specify a positioning.

## Changes
- Add a `position` parameter to `MaxTool`

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [X] No docs needed for this change

## How did you test this code?
Locally