### PR TITLE
fix(flags): handle negation in dynamic cohort property filters

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -52,6 +52,11 @@ procs:
             bin/check_kafka_clickhouse_up && \
             bin/start-rust-service cymbal
 
+    feature-flags:
+        shell: |-
+            bin/check_postgres_up posthog && \
+            bin/start-rust-service feature-flags
+
     property-defs-rs:
         shell: |-
             bin/check_postgres_up && \

--- a/bin/start-rust-service
+++ b/bin/start-rust-service
@@ -106,7 +106,7 @@ case "$RS_SVC" in
     # Download MaxMind DB if it doesn't exist
     ./bin/download-mmdb
     
-    export RUST_LOG=debug
+    export RUST_LOG=debug,tower=warn,maxminddb=warn
     export RUST_BACKTRACE=1
     export WRITE_DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog
     export READ_DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog

--- a/bin/start-rust-service
+++ b/bin/start-rust-service
@@ -102,6 +102,21 @@ case "$RS_SVC" in
     export ALLOW_INTERNAL_IPS=${ALLOW_INTERNAL_IPS:-true}
     ;;
 
+  feature-flags)
+    # Download MaxMind DB if it doesn't exist
+    ./bin/download-mmdb
+    
+    export RUST_LOG=debug
+    export RUST_BACKTRACE=1
+    export WRITE_DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog
+    export READ_DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog
+    export MAXMIND_DB_PATH=../share/GeoLite2-City.mmdb
+    export REDIS_URL=redis://localhost:6379/
+    export ADDRESS=0.0.0.0:3001
+    export DEBUG=1
+    export ALLOW_INTERNAL_IPS=${ALLOW_INTERNAL_IPS:-true}
+    ;;
+
   *)
     echo "ERROR unknown posthog/rust service '$RS_SVC' please register in: $0" >&2
     exit 1

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -47,7 +47,7 @@ services:
                     }
 
                     handle @flags {
-                        reverse_proxy feature-flags:3001
+                        reverse_proxy host.docker.internal:3001
                     }
 
                     handle @webhooks {
@@ -245,8 +245,6 @@ services:
             # REDIS_TIMEOUT_MS: 200
             ADDRESS: '0.0.0.0:3001'
             RUST_LOG: 'info'
-            SKIP_WRITES: 'false'
-            SKIP_READS: 'false'
 
     plugins:
         command: ./bin/plugin-server --no-restart-loop

--- a/docker-compose.dev-coordinator.yml
+++ b/docker-compose.dev-coordinator.yml
@@ -17,7 +17,6 @@ services:
         depends_on:
             - replay-capture
             - capture
-            - feature-flags
         extra_hosts:
             - 'web:host-gateway'
     db:
@@ -171,14 +170,6 @@ services:
             service: property-defs-rs
         depends_on:
             - kafka
-
-    feature-flags:
-        extends:
-            file: docker-compose.base.yml
-            service: feature-flags
-        depends_on:
-            - redis
-            - db
 
     livestream:
         extends:

--- a/docker-compose.dev-full.yml
+++ b/docker-compose.dev-full.yml
@@ -18,7 +18,6 @@ services:
         depends_on:
             - replay-capture
             - capture
-            - feature-flags
             - web
     db:
         extends:
@@ -152,14 +151,6 @@ services:
             service: property-defs-rs
         depends_on:
             - kafka
-
-    feature-flags:
-        extends:
-            file: docker-compose.base.yml
-            service: feature-flags
-        depends_on:
-            - redis
-            - db
 
     plugins:
         extends:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,13 +14,13 @@ services:
             service: proxy
         ports:
             - 8010:8000
-        depends_on:
-            - feature-flags
         extra_hosts:
             - 'web:host-gateway'
             - 'plugins:host-gateway'
             - 'capture:host-gateway'
             - 'replay-capture:host-gateway'
+            - 'feature-flags:host-gateway'
+            - 'host.docker.internal:host-gateway'
         environment:
             CADDYFILE: |
                 http://localhost:8000 {
@@ -177,14 +177,6 @@ services:
             - '2080:2080'
         environment:
             - LISTEN_PORT=2080
-
-    feature-flags:
-        extends:
-            file: docker-compose.base.yml
-            service: feature-flags
-        depends_on:
-            - redis
-            - db
 
     livestream:
         extends:

--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -234,7 +234,15 @@ fn evaluate_cohort_values(
                     }
                 } else {
                     // Handle regular property check
-                    if match_property(filter, target_properties, false).unwrap_or(false) {
+                    let property_result =
+                        match_property(filter, target_properties, false).unwrap_or(false);
+                    // handle any property negation
+                    let final_result = if filter.negation.unwrap_or(false) {
+                        !property_result
+                    } else {
+                        property_result
+                    };
+                    if final_result {
                         return Ok(true);
                     }
                 }
@@ -250,7 +258,15 @@ fn evaluate_cohort_values(
                     }
                 } else {
                     // Handle regular property check
-                    if !match_property(filter, target_properties, false).unwrap_or(false) {
+                    let property_result =
+                        match_property(filter, target_properties, false).unwrap_or(false);
+                    // handle any property negation
+                    let final_result = if filter.negation.unwrap_or(false) {
+                        !property_result
+                    } else {
+                        property_result
+                    };
+                    if !final_result {
                         return Ok(false);
                     }
                 }

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -4460,3 +4460,215 @@ async fn test_group_key_property_matching() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_cohort_filter_with_regex_and_negation() -> Result<()> {
+    let config = DEFAULT_TEST_CONFIG.clone();
+    let distinct_id = "test.user".to_string();
+
+    let client = setup_redis_client(Some(config.redis_url.clone())).await;
+    let pg_client = setup_pg_reader_client(None).await;
+    let team = insert_new_team_in_redis(client.clone()).await.unwrap();
+    let token = team.api_token;
+
+    insert_new_team_in_pg(pg_client.clone(), Some(team.id))
+        .await
+        .unwrap();
+
+    // Insert person with the target email that should match the cohort
+    insert_person_for_team_in_pg(
+        pg_client.clone(),
+        team.id,
+        distinct_id.clone(),
+        Some(json!({"email": "test.user@example.com"})),
+    )
+    .await
+    .unwrap();
+
+    // Create the cohort with the specified filters:
+    // OR condition with AND group that checks:
+    // - email matches regex ^.*@example.com$ (ends with @example.com)
+    // - email does NOT contain "excluded.user@example.com" (negation: true)
+    let cohort_filters = json!({
+        "properties": {
+            "type": "OR",
+            "values": [{
+                "type": "AND",
+                "values": [
+                    {
+                        "key": "email",
+                        "type": "person",
+                        "value": "^.*@example.com$",
+                        "negation": false,
+                        "operator": "regex"
+                    },
+                    {
+                        "key": "email",
+                        "type": "person",
+                        "value": "excluded.user@example.com",
+                        "negation": true,
+                        "operator": "icontains"
+                    }
+                ]
+            }]
+        }
+    });
+
+    // Create the cohort in the database
+    let mut conn = pg_client.get_connection().await.unwrap();
+    let cohort_id: i32 = sqlx::query_scalar(
+        r#"INSERT INTO posthog_cohort 
+           (name, description, team_id, deleted, filters, is_calculating, created_by_id, created_at, is_static, last_calculation, errors_calculating, groups, version)
+           VALUES ($1, $2, $3, false, $4, false, NULL, NOW(), false, NOW(), 0, '[]', NULL)
+           RETURNING id"#,
+    )
+    .bind("Example Domain (excluding specific user)")
+    .bind("Test cohort for regex and negation conditions")
+    .bind(team.id)
+    .bind(cohort_filters)
+    .fetch_one(&mut *conn)
+    .await
+    .unwrap();
+
+    // Create flag with cohort filter exactly as specified
+    let flag_json = json!([{
+        "id": 1,
+        "key": "example-cohort-flag",
+        "name": "Example Cohort Flag",
+        "active": true,
+        "deleted": false,
+        "team_id": team.id,
+        "filters": {
+            "groups": [{
+                "variant": null,
+                "properties": [{
+                    "key": "id",
+                    "type": "cohort",
+                    "value": cohort_id,
+                    "operator": "in",
+                    "cohort_name": "Example Domain (excluding specific user)"
+                }],
+                "rollout_percentage": 100
+            }],
+            "payloads": {},
+            "multivariate": null
+        }
+    }]);
+
+    insert_flags_for_team_in_redis(
+        client,
+        team.id,
+        team.project_id,
+        Some(flag_json.to_string()),
+    )
+    .await?;
+
+    let server = ServerHandle::for_config(config).await;
+
+    // Test with test.user@example.com - should match cohort and return true
+    let payload = json!({
+        "token": token,
+        "distinct_id": distinct_id,
+    });
+
+    let res = server
+        .send_flags_request(payload.to_string(), Some("2"), None)
+        .await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    let json_data = res.json::<Value>().await?;
+    assert_json_include!(
+        actual: json_data,
+        expected: json!({
+            "errorsWhileComputingFlags": false,
+            "flags": {
+                "example-cohort-flag": {
+                    "key": "example-cohort-flag",
+                    "enabled": true,
+                    "reason": {
+                        "code": "condition_match",
+                        "condition_index": 0
+                    }
+                }
+            }
+        })
+    );
+
+    // Test with excluded.user@example.com - should NOT match cohort due to negation condition
+    let excluded_distinct_id = "excluded.user".to_string();
+    insert_person_for_team_in_pg(
+        pg_client.clone(),
+        team.id,
+        excluded_distinct_id.clone(),
+        Some(json!({"email": "excluded.user@example.com"})),
+    )
+    .await
+    .unwrap();
+
+    let payload_excluded = json!({
+        "token": token,
+        "distinct_id": excluded_distinct_id,
+    });
+
+    let res_excluded = server
+        .send_flags_request(payload_excluded.to_string(), Some("2"), None)
+        .await;
+    assert_eq!(StatusCode::OK, res_excluded.status());
+
+    let json_excluded = res_excluded.json::<Value>().await?;
+    assert_json_include!(
+        actual: json_excluded,
+        expected: json!({
+            "errorsWhileComputingFlags": false,
+            "flags": {
+                "example-cohort-flag": {
+                    "key": "example-cohort-flag",
+                    "enabled": false,
+                    "reason": {
+                        "code": "no_condition_match"
+                    }
+                }
+            }
+        })
+    );
+
+    // Test with non-example.com email - should NOT match cohort due to regex condition
+    let non_example_distinct_id = "other.user".to_string();
+    insert_person_for_team_in_pg(
+        pg_client.clone(),
+        team.id,
+        non_example_distinct_id.clone(),
+        Some(json!({"email": "other.user@other.com"})),
+    )
+    .await
+    .unwrap();
+
+    let payload_non_example = json!({
+        "token": token,
+        "distinct_id": non_example_distinct_id,
+    });
+
+    let res_non_example = server
+        .send_flags_request(payload_non_example.to_string(), Some("2"), None)
+        .await;
+    assert_eq!(StatusCode::OK, res_non_example.status());
+
+    let json_non_example = res_non_example.json::<Value>().await?;
+    assert_json_include!(
+        actual: json_non_example,
+        expected: json!({
+            "errorsWhileComputingFlags": false,
+            "flags": {
+                "example-cohort-flag": {
+                    "key": "example-cohort-flag",
+                    "enabled": false,
+                    "reason": {
+                        "code": "no_condition_match"
+                    }
+                }
+            }
+        })
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Filters derived from dynamic cohorts and feature flag filters have different semantics for handling for handling the concept of "not contains" – flags use the `NotIContains` operation, but cohorts uses `IContains` with the `negation` field.  Turns out we weren't handling these negation fields in cohort filters.  The fix is to have the `evaluate_cohort_values` method account for this field.

`/decide` handled this behavior, `/flags` did not.

## Changes

- handle `negation` in `evaluate_cohort_values`

## Did you write or update any docs for this change?

- [x] No docs needed for this change

## How did you test this code?

Added a new integration test and some new unit tests 
