### PR TITLE
fix(flags): handle negation in dynamic cohort property filters

### DIFF
--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -233,16 +233,8 @@ fn evaluate_cohort_values(
                         return Ok(true);
                     }
                 } else {
-                    // Handle regular property check
-                    let property_result =
-                        match_property(filter, target_properties, false).unwrap_or(false);
-                    // handle any property negation; cohort filters use negation (as compared to flag filters, which use NotIContains)
-                    let final_result = if filter.negation.unwrap_or(false) {
-                        !property_result
-                    } else {
-                        property_result
-                    };
-                    if final_result {
+                    // Handle regular property check with negation
+                    if evaluate_property_with_negation(filter, target_properties) {
                         return Ok(true);
                     }
                 }
@@ -257,16 +249,8 @@ fn evaluate_cohort_values(
                         return Ok(false);
                     }
                 } else {
-                    // Handle regular property check
-                    let property_result =
-                        match_property(filter, target_properties, false).unwrap_or(false);
-                    // handle any property negation; cohort filters use negation (as compared to flag filters, which use NotIContains)
-                    let final_result = if filter.negation.unwrap_or(false) {
-                        !property_result
-                    } else {
-                        property_result
-                    };
-                    if !final_result {
+                    // Handle regular property check with negation
+                    if !evaluate_property_with_negation(filter, target_properties) {
                         return Ok(false);
                     }
                 }
@@ -274,6 +258,24 @@ fn evaluate_cohort_values(
             Ok(true)
         }
         _ => Err(FlagError::CohortFiltersParsingError),
+    }
+}
+
+/// Evaluates a property filter against target properties, applying negation if specified.
+///
+/// Cohort filters use the `negation` field to invert results, unlike flag filters
+/// which use specific operators like `NotIContains`.
+fn evaluate_property_with_negation(
+    filter: &PropertyFilter,
+    target_properties: &HashMap<String, Value>,
+) -> bool {
+    let property_result = match_property(filter, target_properties, false).unwrap_or(false);
+
+    // Apply negation if specified
+    if filter.negation.unwrap_or(false) {
+        !property_result
+    } else {
+        property_result
     }
 }
 

--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -236,7 +236,7 @@ fn evaluate_cohort_values(
                     // Handle regular property check
                     let property_result =
                         match_property(filter, target_properties, false).unwrap_or(false);
-                    // handle any property negation
+                    // handle any property negation; cohort filters use negation (as compared to flag filters, which use NotIContains)
                     let final_result = if filter.negation.unwrap_or(false) {
                         !property_result
                     } else {
@@ -260,7 +260,7 @@ fn evaluate_cohort_values(
                     // Handle regular property check
                     let property_result =
                         match_property(filter, target_properties, false).unwrap_or(false);
-                    // handle any property negation
+                    // handle any property negation; cohort filters use negation (as compared to flag filters, which use NotIContains)
                     let final_result = if filter.negation.unwrap_or(false) {
                         !property_result
                     } else {

--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -234,7 +234,15 @@ fn evaluate_cohort_values(
                     }
                 } else {
                     // Handle regular property check
-                    if match_property(filter, target_properties, false).unwrap_or(false) {
+                    let property_result =
+                        match_property(filter, target_properties, false).unwrap_or(false);
+                    // handle any property negation
+                    let final_result = if filter.negation.unwrap_or(false) {
+                        !property_result
+                    } else {
+                        property_result
+                    };
+                    if final_result {
                         return Ok(true);
                     }
                 }
@@ -250,7 +258,15 @@ fn evaluate_cohort_values(
                     }
                 } else {
                     // Handle regular property check
-                    if !match_property(filter, target_properties, false).unwrap_or(false) {
+                    let property_result =
+                        match_property(filter, target_properties, false).unwrap_or(false);
+                    // handle any property negation
+                    let final_result = if filter.negation.unwrap_or(false) {
+                        !property_result
+                    } else {
+                        property_result
+                    };
+                    if !final_result {
                         return Ok(false);
                     }
                 }
@@ -686,6 +702,93 @@ mod tests {
         assert!(
             !result,
             "Static cohorts should return false from evaluate_dynamic_cohorts"
+        );
+    }
+
+    #[test]
+    fn test_evaluate_dynamic_cohorts_with_negation_filters() {
+        // Create a cohort with filters that include negation
+        // This cohort should match people with emails ending in @example.com
+        // BUT exclude those containing "excluded.user"
+        let cohort_with_negation = Cohort {
+            id: 1,
+            name: Some("Cohort with Negation".to_string()),
+            description: None,
+            team_id: 1,
+            deleted: false,
+            filters: Some(json!({
+                "properties": {
+                    "type": "OR",
+                    "values": [{
+                        "type": "AND",
+                        "values": [
+                            {
+                                "key": "email",
+                                "type": "person",
+                                "value": "^.*@example.com$",
+                                "negation": false,
+                                "operator": "regex"
+                            },
+                            {
+                                "key": "email",
+                                "type": "person",
+                                "value": "excluded.user",
+                                "negation": true,  // This should be inverted
+                                "operator": "icontains"
+                            }
+                        ]
+                    }]
+                }
+            })),
+            query: None,
+            version: None,
+            pending_version: None,
+            count: None,
+            is_calculating: false,
+            is_static: false,
+            errors_calculating: 0,
+            groups: json!({}),
+            created_by_id: None,
+        };
+
+        let cohorts = vec![cohort_with_negation];
+
+        // Test case 1: User with @example.com email but NOT excluded
+        // Should match because: regex matches AND (icontains doesn't match -> negated to true)
+        let mut target_properties = HashMap::new();
+        target_properties.insert("email".to_string(), json!("test.user@example.com"));
+
+        let result = evaluate_dynamic_cohorts(1, &target_properties, &cohorts).unwrap();
+        assert!(
+            result,
+            "User with @example.com email should match when not excluded"
+        );
+
+        // Test case 2: User with @example.com email but IS excluded
+        // Should NOT match because: regex matches BUT (icontains matches -> negated to false)
+        target_properties.insert("email".to_string(), json!("excluded.user@example.com"));
+
+        let result = evaluate_dynamic_cohorts(1, &target_properties, &cohorts).unwrap();
+        assert!(
+            !result,
+            "User with @example.com email should NOT match when excluded"
+        );
+
+        // Test case 3: User without @example.com email
+        // Should NOT match because: regex doesn't match (regardless of negation)
+        target_properties.insert("email".to_string(), json!("test.user@other.com"));
+
+        let result = evaluate_dynamic_cohorts(1, &target_properties, &cohorts).unwrap();
+        assert!(!result, "User without @example.com email should NOT match");
+
+        // Test case 4: User with excluded term but wrong domain
+        // Should NOT match because: regex doesn't match (regardless of negation)
+        target_properties.insert("email".to_string(), json!("excluded.user@other.com"));
+
+        let result = evaluate_dynamic_cohorts(1, &target_properties, &cohorts).unwrap();
+        assert!(
+            !result,
+            "User with wrong domain should NOT match regardless of exclusion"
         );
     }
 }

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -4460,3 +4460,215 @@ async fn test_group_key_property_matching() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_cohort_filter_with_regex_and_negation() -> Result<()> {
+    let config = DEFAULT_TEST_CONFIG.clone();
+    let distinct_id = "test.user".to_string();
+
+    let client = setup_redis_client(Some(config.redis_url.clone())).await;
+    let pg_client = setup_pg_reader_client(None).await;
+    let team = insert_new_team_in_redis(client.clone()).await.unwrap();
+    let token = team.api_token;
+
+    insert_new_team_in_pg(pg_client.clone(), Some(team.id))
+        .await
+        .unwrap();
+
+    // Insert person with the target email that should match the cohort
+    insert_person_for_team_in_pg(
+        pg_client.clone(),
+        team.id,
+        distinct_id.clone(),
+        Some(json!({"email": "test.user@example.com"})),
+    )
+    .await
+    .unwrap();
+
+    // Create the cohort with the specified filters:
+    // OR condition with AND group that checks:
+    // - email matches regex ^.*@example.com$ (ends with @example.com)
+    // - email does NOT contain "excluded.user@example.com" (negation: true)
+    let cohort_filters = json!({
+        "properties": {
+            "type": "OR",
+            "values": [{
+                "type": "AND",
+                "values": [
+                    {
+                        "key": "email",
+                        "type": "person",
+                        "value": "^.*@example.com$",
+                        "negation": false,
+                        "operator": "regex"
+                    },
+                    {
+                        "key": "email",
+                        "type": "person",
+                        "value": "excluded.user@example.com",
+                        "negation": true,
+                        "operator": "icontains"
+                    }
+                ]
+            }]
+        }
+    });
+
+    // Create the cohort in the database
+    let mut conn = pg_client.get_connection().await.unwrap();
+    let cohort_id: i32 = sqlx::query_scalar(
+        r#"INSERT INTO posthog_cohort 
+           (name, description, team_id, deleted, filters, is_calculating, created_by_id, created_at, is_static, last_calculation, errors_calculating, groups, version)
+           VALUES ($1, $2, $3, false, $4, false, NULL, NOW(), false, NOW(), 0, '[]', NULL)
+           RETURNING id"#,
+    )
+    .bind("Example Domain (excluding specific user)")
+    .bind("Test cohort for regex and negation conditions")
+    .bind(team.id)
+    .bind(cohort_filters)
+    .fetch_one(&mut *conn)
+    .await
+    .unwrap();
+
+    // Create flag with cohort filter exactly as specified
+    let flag_json = json!([{
+        "id": 1,
+        "key": "example-cohort-flag",
+        "name": "Example Cohort Flag",
+        "active": true,
+        "deleted": false,
+        "team_id": team.id,
+        "filters": {
+            "groups": [{
+                "variant": null,
+                "properties": [{
+                    "key": "id",
+                    "type": "cohort",
+                    "value": cohort_id,
+                    "operator": "in",
+                    "cohort_name": "Example Domain (excluding specific user)"
+                }],
+                "rollout_percentage": 100
+            }],
+            "payloads": {},
+            "multivariate": null
+        }
+    }]);
+
+    insert_flags_for_team_in_redis(
+        client,
+        team.id,
+        team.project_id,
+        Some(flag_json.to_string()),
+    )
+    .await?;
+
+    let server = ServerHandle::for_config(config).await;
+
+    // Test with test.user@example.com - should match cohort and return true
+    let payload = json!({
+        "token": token,
+        "distinct_id": distinct_id,
+    });
+
+    let res = server
+        .send_flags_request(payload.to_string(), Some("2"), None)
+        .await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    let json_data = res.json::<Value>().await?;
+    assert_json_include!(
+        actual: json_data,
+        expected: json!({
+            "errorsWhileComputingFlags": false,
+            "flags": {
+                "example-cohort-flag": {
+                    "key": "example-cohort-flag",
+                    "enabled": true,
+                    "reason": {
+                        "code": "condition_match",
+                        "condition_index": 0
+                    }
+                }
+            }
+        })
+    );
+
+    // Test with excluded.user@example.com - should NOT match cohort due to negation condition
+    let excluded_distinct_id = "excluded.user".to_string();
+    insert_person_for_team_in_pg(
+        pg_client.clone(),
+        team.id,
+        excluded_distinct_id.clone(),
+        Some(json!({"email": "excluded.user@example.com"})),
+    )
+    .await
+    .unwrap();
+
+    let payload_excluded = json!({
+        "token": token,
+        "distinct_id": excluded_distinct_id,
+    });
+
+    let res_excluded = server
+        .send_flags_request(payload_excluded.to_string(), Some("2"), None)
+        .await;
+    assert_eq!(StatusCode::OK, res_excluded.status());
+
+    let json_excluded = res_excluded.json::<Value>().await?;
+    assert_json_include!(
+        actual: json_excluded,
+        expected: json!({
+            "errorsWhileComputingFlags": false,
+            "flags": {
+                "example-cohort-flag": {
+                    "key": "example-cohort-flag",
+                    "enabled": false,
+                    "reason": {
+                        "code": "no_condition_match"
+                    }
+                }
+            }
+        })
+    );
+
+    // Test with non-example.com email - should NOT match cohort due to regex condition
+    let non_example_distinct_id = "other.user".to_string();
+    insert_person_for_team_in_pg(
+        pg_client.clone(),
+        team.id,
+        non_example_distinct_id.clone(),
+        Some(json!({"email": "other.user@other.com"})),
+    )
+    .await
+    .unwrap();
+
+    let payload_non_example = json!({
+        "token": token,
+        "distinct_id": non_example_distinct_id,
+    });
+
+    let res_non_example = server
+        .send_flags_request(payload_non_example.to_string(), Some("2"), None)
+        .await;
+    assert_eq!(StatusCode::OK, res_non_example.status());
+
+    let json_non_example = res_non_example.json::<Value>().await?;
+    assert_json_include!(
+        actual: json_non_example,
+        expected: json!({
+            "errorsWhileComputingFlags": false,
+            "flags": {
+                "example-cohort-flag": {
+                    "key": "example-cohort-flag",
+                    "enabled": false,
+                    "reason": {
+                        "code": "no_condition_match"
+                    }
+                }
+            }
+        })
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Filters derived from dynamic cohorts and feature flag filters have different semantics for handling for handling the concept of "not contains" – flags use the `NotIContains` operation, but cohorts uses `IContains` with the `negation` field.  Turns out we weren't handling these negation fields in cohort filters.  The fix is to have the `evaluate_cohort_values` method account for this field.

`/decide` handled this behavior, `/flags` did not.

## Changes

- handle `negation` in `evaluate_cohort_values`

## Did you write or update any docs for this change?

- [x] No docs needed for this change

## How did you test this code?

Added a new integration test and some new unit tests 
