### PR TITLE
fix(experiments): break down funnel results by first step value

### DIFF
--- a/frontend/src/scenes/experiments/components/ResultsBreakdown/resultsBreakdownLogic.ts
+++ b/frontend/src/scenes/experiments/components/ResultsBreakdown/resultsBreakdownLogic.ts
@@ -106,7 +106,10 @@ export const resultsBreakdownLogic = kea<resultsBreakdownLogicType>([
                         },
                         funnelsFilter: {
                             layout: FunnelLayout.vertical,
-                            breakdownAttributionType: BreakdownAttributionType.FirstTouch,
+                            /* We want to break down results by the flag value from the _first_ step
+                            which is the expsoure criteria */
+                            breakdownAttributionType: BreakdownAttributionType.Step,
+                            breakdownAttributionValue: 0,
                             funnelOrderType:
                                 (isExperimentFunnelMetric(metric) && metric.funnel_order_type) ||
                                 StepOrderValue.ORDERED,


### PR DESCRIPTION
## Problem
We are not consistent when breaking down funnel results as we break down by "First touch" there, but in the experiment query runner, we always break down by the "First step" (the exposure criteria).

## Changes
Change the funnel query filters such that we also break down by the first step there. This should solve a few more cases where numbers are inconsistent.

## How did you test this code?
- I tested this locally, and everything worked fine
- Also clicked the "Explore results" button and the query there had "Step 1" correctly set.
