### PR TITLE
fix(b2b2c): rely on IAM access for s3 table functions

### DIFF
--- a/posthog/hogql/database/schema/web_analytics_s3.py
+++ b/posthog/hogql/database/schema/web_analytics_s3.py
@@ -51,7 +51,7 @@ def get_s3_web_bounces_structure() -> str:
         sessions_uniq_state AggregateFunction(uniq, String),
         pageviews_count_state AggregateFunction(sum, UInt64),
         bounces_count_state AggregateFunction(sum, UInt64),
-        total_session_duration_state AggregateFunction(sum, Int64)
+        total_session_duration_state AggregateFunction(sum, UInt64)
     """
 
 
@@ -75,29 +75,42 @@ WEB_BOUNCES_S3_FIELDS: dict[str, FieldOrTable] = {
 }
 
 
-def create_s3_web_stats_table(team_id: int) -> S3Table:
-    url = get_s3_url(table_name="web_stats_daily_export", team_id=team_id)
+def _get_s3_credentials() -> tuple[str | None, str | None]:
+    if DEBUG:
+        return OBJECT_STORAGE_ACCESS_KEY_ID, OBJECT_STORAGE_SECRET_ACCESS_KEY
+    return None, None
+
+
+def _create_s3_web_table(team_id: int, table_name: str, s3_name: str, structure_func, fields: dict) -> S3Table:
+    url = get_s3_url(table_name=table_name, team_id=team_id)
+    access_key, access_secret = _get_s3_credentials()
 
     return S3Table(
-        name="web_stats_daily_s3",
+        name=s3_name,
         url=url,
         format="Native",
-        access_key=OBJECT_STORAGE_ACCESS_KEY_ID,
-        access_secret=OBJECT_STORAGE_SECRET_ACCESS_KEY,
-        structure=get_s3_web_stats_structure(),
+        access_key=access_key,
+        access_secret=access_secret,
+        structure=structure_func(),
+        fields=fields,
+    )
+
+
+def create_s3_web_stats_table(team_id: int) -> S3Table:
+    return _create_s3_web_table(
+        team_id=team_id,
+        table_name="web_stats_daily_export",
+        s3_name="web_stats_daily_s3",
+        structure_func=get_s3_web_stats_structure,
         fields=WEB_STATS_S3_FIELDS,
     )
 
 
 def create_s3_web_bounces_table(team_id: int) -> S3Table:
-    url = get_s3_url(table_name="web_bounces_daily_export", team_id=team_id)
-
-    return S3Table(
-        name="web_bounces_daily_s3",
-        url=url,
-        format="Native",
-        access_key=OBJECT_STORAGE_ACCESS_KEY_ID,
-        access_secret=OBJECT_STORAGE_SECRET_ACCESS_KEY,
-        structure=get_s3_web_bounces_structure(),
+    return _create_s3_web_table(
+        team_id=team_id,
+        table_name="web_bounces_daily_export",
+        s3_name="web_bounces_daily_s3",
+        structure_func=get_s3_web_bounces_structure,
         fields=WEB_BOUNCES_S3_FIELDS,
     )

--- a/posthog/hogql_queries/web_analytics/external/test/test_summary_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/external/test/test_summary_query_runner.py
@@ -9,6 +9,7 @@ from posthog.schema import (
     DateRange,
 )
 from posthog.test.base import APIBaseTest
+from posthog.hogql.database.s3_table import S3Table
 
 
 class TestWebAnalyticsExternalSummaryQueryRunner(APIBaseTest):
@@ -148,3 +149,78 @@ class TestWebAnalyticsExternalSummaryQueryRunner(APIBaseTest):
         assert results["total_sessions"] == 0
         assert results["total_pageviews"] == 0
         assert results["bounce_rate"] == 0.0
+
+    def test_build_correct_paths_and_structures_production(self):
+        """Test that correct paths and structures are built for chdb queries in production environment"""
+        with patch("posthog.hogql.database.schema.web_analytics_s3.DEBUG", False):
+            runner = WebAnalyticsExternalSummaryQueryRunner(query=self.query, team=self.team)
+
+            # Test stats table function - should use IAM role (no credentials) in production
+            stats_func = runner._build_s3_stats_table_func()
+
+            # Should include the basic S3 function structure
+            assert stats_func.startswith("s3('https://")
+            assert "'Native'" in stats_func
+            assert "period_bucket DateTime" in stats_func
+            assert "persons_uniq_state AggregateFunction(uniq, UUID)" in stats_func
+
+            # Should NOT include any credentials (access keys/secrets)
+            # In production, the pattern should be: s3('url', 'format', 'structure')
+            # If credentials were included, they would appear between URL and format
+            url_end = stats_func.find("data.native'")
+            format_start = stats_func.find("'Native'")
+            between_url_and_format = stats_func[url_end + len("data.native'") : format_start]
+            assert (
+                between_url_and_format.strip() == ","
+            ), f"Expected only comma between URL and format, found: {between_url_and_format}"
+
+            # Test bounces table function - should use IAM role (no credentials) in production
+            bounces_func = runner._build_s3_bounces_table_func()
+            assert bounces_func.startswith("s3('https://")
+            assert "'Native'" in bounces_func
+            assert "bounces_count_state AggregateFunction(sum, UInt64)" in bounces_func
+
+            # Should NOT include any credentials for bounces either
+            url_end = bounces_func.find("data.native'")
+            format_start = bounces_func.find("'Native'")
+            between_url_and_format = bounces_func[url_end + len("data.native'") : format_start]
+            assert (
+                between_url_and_format.strip() == ","
+            ), f"Expected only comma between URL and format, found: {between_url_and_format}"
+
+    @patch("posthog.hogql.database.schema.web_analytics_s3.DEBUG", True)
+    @patch("posthog.hogql_queries.web_analytics.external.summary_query_runner.create_s3_web_stats_table")
+    @patch("posthog.hogql_queries.web_analytics.external.summary_query_runner.create_s3_web_bounces_table")
+    def test_build_correct_paths_and_structures_debug(self, mock_create_bounces_table, mock_create_stats_table):
+        mock_stats_table = S3Table(
+            name="web_stats_daily_s3",
+            url=f"http://objectstorage:19000/posthog/web_stats_daily_export/{self.team.pk}/data.native",
+            format="Native",
+            access_key="test_key",
+            access_secret="test_secret",
+            structure="period_bucket DateTime, team_id UInt64, persons_uniq_state AggregateFunction(uniq, UUID), sessions_uniq_state AggregateFunction(uniq, String), pageviews_count_state AggregateFunction(sum, UInt64)",
+            fields={},
+        )
+
+        mock_bounces_table = S3Table(
+            name="web_bounces_daily_s3",
+            url=f"http://objectstorage:19000/posthog/web_bounces_daily_export/{self.team.pk}/data.native",
+            format="Native",
+            access_key="test_key",
+            access_secret="test_secret",
+            structure="period_bucket DateTime, team_id UInt64, persons_uniq_state AggregateFunction(uniq, UUID), sessions_uniq_state AggregateFunction(uniq, String), pageviews_count_state AggregateFunction(sum, UInt64), bounces_count_state AggregateFunction(sum, UInt64), total_session_duration_state AggregateFunction(sum, UInt64)",
+            fields={},
+        )
+
+        mock_create_stats_table.return_value = mock_stats_table
+        mock_create_bounces_table.return_value = mock_bounces_table
+
+        runner = WebAnalyticsExternalSummaryQueryRunner(query=self.query, team=self.team)
+
+        stats_func = runner._build_s3_stats_table_func()
+        expected_stats = f"s3('http://objectstorage:19000/posthog/web_stats_daily_export/{self.team.pk}/data.native', 'test_key', 'test_secret', 'Native', 'period_bucket DateTime, team_id UInt64, persons_uniq_state AggregateFunction(uniq, UUID), sessions_uniq_state AggregateFunction(uniq, String), pageviews_count_state AggregateFunction(sum, UInt64)')"
+        assert stats_func == expected_stats
+
+        bounces_func = runner._build_s3_bounces_table_func()
+        expected_bounces = f"s3('http://objectstorage:19000/posthog/web_bounces_daily_export/{self.team.pk}/data.native', 'test_key', 'test_secret', 'Native', 'period_bucket DateTime, team_id UInt64, persons_uniq_state AggregateFunction(uniq, UUID), sessions_uniq_state AggregateFunction(uniq, String), pageviews_count_state AggregateFunction(sum, UInt64), bounces_count_state AggregateFunction(sum, UInt64), total_session_duration_state AggregateFunction(sum, UInt64)')"
+        assert bounces_func == expected_bounces


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

The Dagster jobs are now able to query the exports again but the new endpoints were having the same access control issue (403) because they were always providing the S3 table format with key/id instead of relying on IAM: [Check the logs](https://grafana.prod-us.posthog.dev/explore?schemaVersion=1&panes=%7B%22r3l%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bservice_name%3D%5C%22posthog-web-django%5C%22%7D%20%7C%3D%20%60web%20analytics%60%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22builder%22,%22hide%22:false%7D%5D,%22range%22:%7B%22from%22:%221751403600000%22,%22to%22:%221751410799000%22%7D%7D%7D&orgId=1
)


## Changes

- Apply the same logic to S3Table constructs (on web analytics contexts) to build the correct `s3 table function` calls.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Manually and with unit tests
