### PR TITLE
refactor(experiments): create dashboard query builder

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -47,7 +47,10 @@ import {
     ExperimentMetric,
     ExperimentMetricType,
     ExperimentTrendsQuery,
+    FunnelsQuery,
+    InsightVizNode,
     NodeKind,
+    TrendsQuery,
 } from '~/queries/schema/schema-general'
 import { setLatestVersionsOnQuery } from '~/queries/utils'
 import {
@@ -84,6 +87,7 @@ import {
 import type { experimentLogicType } from './experimentLogicType'
 import { experimentsLogic } from './experimentsLogic'
 import { holdoutsLogic } from './holdoutsLogic'
+import { addExposureToMetric, compose, getInsight, getQuery } from './metricQueryUtils'
 import { getDefaultMetricTitle } from './MetricsView/shared/utils'
 import { modalsLogic } from './modalsLogic'
 import { SharedMetric } from './SharedMetrics/sharedMetricLogic'
@@ -92,7 +96,6 @@ import {
     featureFlagEligibleForExperiment,
     isLegacyExperiment,
     percentageDistribution,
-    toInsightVizNode,
     transformFiltersForWinningVariant,
 } from './utils'
 
@@ -1137,13 +1140,37 @@ export const experimentLogic = kea<experimentLogicType>([
         },
         createExperimentDashboard: async () => {
             actions.setIsCreatingExperimentDashboard(true)
-            try {
-                // 1. Create the dashboard
-                // 2. Create secondary metric insights in reverse order
-                // 3. Create primary metric insights in reverse order
 
+            /**
+             * create a query builder to transform the experiment metric into a query
+             * that can be used to create an insight
+             */
+            const queryBuilder = compose<
+                ExperimentMetric,
+                ExperimentMetric,
+                FunnelsQuery | TrendsQuery | undefined,
+                InsightVizNode | undefined
+            >(
+                addExposureToMetric({
+                    kind: NodeKind.EventsNode,
+                    event: '$pageview',
+                    custom_name: 'Placeholder for experiment exposure',
+                    properties: [],
+                }),
+                getQuery(),
+                getInsight()
+            )
+
+            try {
+                /**
+                 * get the experiment url for the dashbaord description
+                 */
                 const experimentUrl =
                     window.location.origin + addProjectIdIfMissing(urls.experiment(values.experimentId))
+
+                /**
+                 * create a new dashboard
+                 */
                 const dashboard: DashboardType = await api.create(
                     `api/environments/${teamLogic.values.currentTeamId}/dashboards/`,
                     {
@@ -1161,8 +1188,11 @@ export const experimentLogic = kea<experimentLogicType>([
                     } as Partial<DashboardType>
                 )
 
-                // Reverse order because adding an insight to the dashboard
-                // places it at the beginning of the list
+                /**
+                 * create a new insight for each metric, either primary or secondary
+                 * reverse the order of the metric because adding an insight to the dashboard
+                 * places it at the beginning of the list
+                 */
                 for (const type of ['secondary', 'primary']) {
                     const singleMetrics =
                         type === 'secondary' ? values.experiment.metrics_secondary : values.experiment.metrics
@@ -1174,11 +1204,8 @@ export const experimentLogic = kea<experimentLogicType>([
                         ...sharedMetrics.map((m) => ({ name: m.name, ...m.query })),
                     ].reverse()
 
-                    /**
-                     * TODO: replace with a queryBuilder composed from getQuery
-                     */
                     for (const query of metrics) {
-                        const insightQuery = toInsightVizNode(query)
+                        const insightQuery = queryBuilder(query)
 
                         await api.create(`api/projects/${projectLogic.values.currentProjectId}/insights`, {
                             name: query.name || undefined,

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1163,7 +1163,7 @@ export const experimentLogic = kea<experimentLogicType>([
 
             try {
                 /**
-                 * get the experiment url for the dashbaord description
+                 * get the experiment url for the dashboard description
                  */
                 const experimentUrl =
                     window.location.origin + addProjectIdIfMissing(urls.experiment(values.experimentId))

--- a/frontend/src/scenes/experiments/metricQueryUtils.ts
+++ b/frontend/src/scenes/experiments/metricQueryUtils.ts
@@ -399,7 +399,7 @@ type InsightVizNodeOptions = {
  * this is the format that the Query component expects
  */
 export const getInsight =
-    (options: Partial<InsightVizNodeOptions>) =>
+    (options?: Partial<InsightVizNodeOptions>) =>
     (query: FunnelsQuery | TrendsQuery | undefined): InsightVizNode | undefined => {
         if (!query) {
             return undefined


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

The _Create Dashboard_ action was not using the new composable query functions from `metricQueryUtils`.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We are removing the old `metricToQuery` for the new composable query builder. There are no functional changes in the code.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/e4aa320c-99bb-4596-b13d-f1be28a56fe8)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
