### PR TITLE
fix(cdp): use icon url for template sha

### DIFF
--- a/posthog/models/hog_function_template.py
+++ b/posthog/models/hog_function_template.py
@@ -247,6 +247,7 @@ class HogFunctionTemplate(UUIDModel):
             if dataclass_template.mapping_templates
             else None,
             "filters": dataclass_template.filters,
+            "icon_url": dataclass_template.icon_url
         }
         content_for_hash = json.dumps(template_dict, sort_keys=True)
         sha = cls.generate_sha_from_content(content_for_hash)

--- a/posthog/models/hog_function_template.py
+++ b/posthog/models/hog_function_template.py
@@ -247,7 +247,7 @@ class HogFunctionTemplate(UUIDModel):
             if dataclass_template.mapping_templates
             else None,
             "filters": dataclass_template.filters,
-            "icon_url": dataclass_template.icon_url
+            "icon_url": dataclass_template.icon_url,
         }
         content_for_hash = json.dumps(template_dict, sort_keys=True)
         sha = cls.generate_sha_from_content(content_for_hash)


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

I've changed the `icon_url` of the segment destinations. [PR for more context](https://github.com/PostHog/posthog/pull/34404), but these changes aren't being reflected in production because the `icon_url` isn't part of the `sha`.

## Changes

- add `icon_url` as a part of the `sha`

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
