### PR TITLE
chore(dev): Separate migrations from backend in bin/start

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -1,18 +1,18 @@
 procs:
     backend:
-        shell: 'uv sync --active && bin/check_kafka_clickhouse_up && python manage.py migrate && ./bin/start-backend'
+        shell: 'uv sync --active && bin/check_postgres_up && bin/check_kafka_clickhouse_up && ./bin/start-backend'
 
     celery-worker:
-        shell: 'uv sync --active && bin/check_kafka_clickhouse_up && ./bin/start-celery worker'
+        shell: 'uv sync --active && bin/check_postgres_up && bin/check_kafka_clickhouse_up && ./bin/start-celery worker'
 
     celery-beat:
-        shell: 'uv sync --active && bin/check_kafka_clickhouse_up && ./bin/start-celery beat'
+        shell: 'uv sync --active && bin/check_postgres_up && bin/check_kafka_clickhouse_up && ./bin/start-celery beat'
 
     plugin-server:
-        shell: 'bin/check_kafka_clickhouse_up && ./bin/plugin-server'
+        shell: 'bin/check_postgres_up && bin/check_kafka_clickhouse_up && ./bin/plugin-server'
 
     frontend:
-        shell: 'bin/check_kafka_clickhouse_up && ./bin/start-frontend'
+        shell: './bin/start-frontend'
 
     temporal-worker-general-purpose:
         shell: 'bin/check_kafka_clickhouse_up && bin/check_temporal_up && python manage.py start_temporal_worker --task-queue general-purpose-task-queue'
@@ -69,10 +69,11 @@ procs:
             bin/check_kafka_clickhouse_up && \
             bin/start-rust-service capture-replay
 
+    migrate-postgres:
+        shell: 'bin/check_postgres_up && python manage.py migrate' # This takes ~10 s
+
     migrate-clickhouse:
-        # These migrations are not in the `backend` service, because they typically aren't blocking for backend startup,
-        # but unfortunately they DO take 10-30 s just to check if there's any migration to run (haven't profiled why)
-        shell: 'bin/check_kafka_clickhouse_up && python manage.py migrate_clickhouse'
+        shell: 'bin/check_kafka_clickhouse_up && python manage.py migrate_clickhouse' # This takes ~10 s too
 
     storybook:
         shell: 'pnpm --filter=@posthog/storybook install && pnpm run storybook'


### PR DESCRIPTION
## Problem

In #29359 we made `manage.py migrate` part of the `backend` service in mprocs. However, that takes around 10 seconds currently when there are _no_ migrations to run! – that means the vast majority of `bin/start`s take extra 10s for a marginal benefit.

## Changes

Let's move `migrate-postgres` out of `backend`. This means in _some_ cases of new migrations, you have to restart the backend after the migrations finish – but this is rare, as few migrations actually block the backend from starting, and collectively this outweighs the negatives of waiting on migrations _every time_.