### PR TITLE
chore(ingestion): Make pipeline Stall a metric, clear up log

### DIFF
--- a/plugin-server/src/utils/db/utils.ts
+++ b/plugin-server/src/utils/db/utils.ts
@@ -44,13 +44,17 @@ export function timeoutGuard(
     message: string,
     context?: Record<string, any> | (() => Record<string, any>),
     timeout = defaultConfig.TASK_TIMEOUT * 1000,
-    sendException = true
+    sendException = true,
+    reportMetric?: () => void
 ): NodeJS.Timeout {
     return setTimeout(() => {
         const ctx = typeof context === 'function' ? context() : context
         logger.warn('⌛', message, ctx)
         if (sendException) {
             captureException(message, ctx ? { extra: ctx } : undefined)
+        }
+        if (reportMetric) {
+            reportMetric()
         }
     }, timeout)
 }

--- a/plugin-server/src/worker/ingestion/event-pipeline/metrics.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/metrics.ts
@@ -10,6 +10,11 @@ export const pipelineStepErrorCounter = new Counter({
     help: 'Number of events that have errored in the step',
     labelNames: ['step_name'],
 })
+export const pipelineStepStalledCounter = new Counter({
+    name: 'events_pipeline_step_stalled_total',
+    help: 'Number of events that have stalled in the step',
+    labelNames: ['step_name'],
+})
 export const pipelineStepMsSummary = new Summary({
     name: 'events_pipeline_step_ms',
     help: 'Duration spent in each step',

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -318,7 +318,7 @@ export class EventPipelineRunner {
         }
     }
 
-    reportStalled(stepName: string) {
+    private reportStalled(stepName: string) {
         pipelineStepStalledCounter.labels(stepName).inc()
     }
 

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -335,6 +335,7 @@ export class EventPipelineRunner {
             () => ({
                 step: step.name,
                 teamId: teamId,
+                event_name: this.originalEvent.event,
                 distinctId: this.originalEvent.distinct_id,
             }),
             this.hub.PIPELINE_STEP_STALLED_LOG_TIMEOUT * 1000,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Currently we have a massive warning log for pipeline step stalling.

## Changes

- Adds a metric for pipeline step stall
- Remove logging the whole object in the warn log for the step stall

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
