### PR TITLE
fix: Configure internal logger to treat dict arguments like stdlib

### DIFF
--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -26,6 +26,21 @@ def get_internal_logger():
     We attach the temporal context to the logger for easier debugging (for
     example, we can track things like the workflow id across log entries).
     """
+    if not structlog.is_configured():
+        base_processors: list[structlog.types.Processor] = [
+            structlog.processors.add_log_level,
+            structlog.processors.format_exc_info,
+            structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S.%f", utc=True),
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            EventRenamer("msg"),
+            structlog.processors.JSONRenderer(),
+        ]
+        structlog.configure(
+            processors=base_processors,
+            logger_factory=structlog.PrintLoggerFactory(),
+            cache_logger_on_first_use=True,
+        )
+
     logger = structlog.get_logger()
     temporal_context = get_temporal_context()
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Internal logger is not configured to process dictionaries like Stalin.


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
