### PR TITLE
feat(experiments): "persist flag" option in experiment form

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -274,10 +274,9 @@ class ExperimentSerializer(serializers.ModelSerializer):
             }
 
             # Pass ensure_experience_continuity from experiment parameters
-            if validated_data.get("parameters", {}).get("ensure_experience_continuity") is not None:
-                feature_flag_data["ensure_experience_continuity"] = validated_data["parameters"][
-                    "ensure_experience_continuity"
-                ]
+            parameters = validated_data.get("parameters") or {}
+            if parameters.get("ensure_experience_continuity") is not None:
+                feature_flag_data["ensure_experience_continuity"] = parameters["ensure_experience_continuity"]
             if validated_data.get("_create_in_folder") is not None:
                 feature_flag_data["_create_in_folder"] = validated_data["_create_in_folder"]
             feature_flag_serializer = FeatureFlagSerializer(

--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -272,6 +272,12 @@ class ExperimentSerializer(serializers.ModelSerializer):
                 "active": not is_draft,
                 "creation_context": "experiments",
             }
+
+            # Pass ensure_experience_continuity from experiment parameters
+            if validated_data.get("parameters", {}).get("ensure_experience_continuity") is not None:
+                feature_flag_data["ensure_experience_continuity"] = validated_data["parameters"][
+                    "ensure_experience_continuity"
+                ]
             if validated_data.get("_create_in_folder") is not None:
                 feature_flag_data["_create_in_folder"] = validated_data["_create_in_folder"]
             feature_flag_serializer = FeatureFlagSerializer(

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -128,6 +128,76 @@ class TestExperimentCRUD(APILicensedTest):
         self.assertEqual(experiment.description, "Bazinga")
         self.assertEqual(experiment.end_date.strftime("%Y-%m-%dT%H:%M"), end_date)
 
+    def test_creating_experiment_with_ensure_experience_continuity(self):
+        ff_key = "test-continuity-flag"
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Test Experiment with Continuity",
+                "description": "",
+                "start_date": None,  # Draft experiment
+                "end_date": None,
+                "feature_flag_key": ff_key,
+                "parameters": {"ensure_experience_continuity": True},
+                "filters": {
+                    "events": [{"order": 0, "id": "$pageview"}],
+                    "properties": [],
+                },
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.json()["name"], "Test Experiment with Continuity")
+        self.assertEqual(response.json()["feature_flag_key"], ff_key)
+
+        # Check that the feature flag was created with ensure_experience_continuity
+        created_ff = FeatureFlag.objects.get(key=ff_key)
+        self.assertEqual(created_ff.ensure_experience_continuity, True)
+
+        # Test with ensure_experience_continuity set to False
+        ff_key_false = "test-no-continuity-flag"
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Test Experiment without Continuity",
+                "description": "",
+                "start_date": None,
+                "end_date": None,
+                "feature_flag_key": ff_key_false,
+                "parameters": {"ensure_experience_continuity": False},
+                "filters": {
+                    "events": [{"order": 0, "id": "$pageview"}],
+                    "properties": [],
+                },
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        created_ff_false = FeatureFlag.objects.get(key=ff_key_false)
+        self.assertEqual(created_ff_false.ensure_experience_continuity, False)
+
+        # Test without specifying ensure_experience_continuity (should default to False)
+        ff_key_default = "test-default-continuity-flag"
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Test Experiment with Default Continuity",
+                "description": "",
+                "start_date": None,
+                "end_date": None,
+                "feature_flag_key": ff_key_default,
+                "parameters": {},
+                "filters": {
+                    "events": [{"order": 0, "id": "$pageview"}],
+                    "properties": [],
+                },
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        created_ff_default = FeatureFlag.objects.get(key=ff_key_default)
+        self.assertEqual(created_ff_default.ensure_experience_continuity, False)
+
     def test_creating_updating_web_experiment(self):
         ff_key = "a-b-tests"
         response = self.client.post(

--- a/frontend/src/scenes/experiments/ExperimentForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm.tsx
@@ -168,11 +168,11 @@ const ExperimentFormFields = (): JSX.Element => {
                     </div>
                 )}
                 {groupsAccessStatus === GroupsAccessStatus.AlreadyUsing && (
-                    <div>
-                        <h3 className="mt-10">Participant type</h3>
-                        <div className="text-xs text-secondary">
-                            The type on which to aggregate metrics. You can change this at any time during the
-                            experiment.
+                    <div className="mt-10">
+                        <h3>Participant type</h3>
+                        <div className="text-xs text-secondary  max-w-150">
+                            Determines on what level you want to aggregate metrics. You can change this later, but flag
+                            values for users will change so you need to reset the experiment for accurate results.
                         </div>
                         <LemonDivider />
                         <LemonRadio

--- a/frontend/src/scenes/experiments/ExperimentForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm.tsx
@@ -316,9 +316,7 @@ const ExperimentFormFields = (): JSX.Element => {
                                 </div>
                             </div>
                         </div>
-                        <div className="mt-10">
-                            <h3 className="mb-1">Advanced settings</h3>
-                            <LemonDivider />
+                        <div className="mt-10 max-w-150">
                             <LemonField name="parameters.ensure_experience_continuity">
                                 {({ value, onChange }) => (
                                     <div className="border rounded p-4">
@@ -330,10 +328,10 @@ const ExperimentFormFields = (): JSX.Element => {
                                             checked={value}
                                         />
                                         <div className="text-secondary text-sm pl-7">
-                                            If your feature flag is applied before identifying the user, use this to
-                                            ensure that the flag value remains consistent for the same user. Depending
-                                            on your setup, this option might not always be suitable. This feature
-                                            requires creating profiles for anonymous users.{' '}
+                                            If your feature flag is evaluated on anonymous users, use this to ensure
+                                            that the flag value remains consistent when the user logs in. Depending on
+                                            your setup, this option might not always be suitable. This feature requires
+                                            creating profiles for anonymous users.{' '}
                                             <Link
                                                 to="https://posthog.com/docs/feature-flags/creating-feature-flags#persisting-feature-flags-across-authentication-steps"
                                                 target="_blank"

--- a/frontend/src/scenes/experiments/ExperimentForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm.tsx
@@ -328,10 +328,10 @@ const ExperimentFormFields = (): JSX.Element => {
                                             checked={value}
                                         />
                                         <div className="text-secondary text-sm pl-7">
-                                            If your feature flag is evaluated on anonymous users, use this to ensure
-                                            that the flag value remains consistent when the user logs in. Depending on
-                                            your setup, this option might not always be suitable. This feature requires
-                                            creating profiles for anonymous users.{' '}
+                                            If your feature flag is evaluated for anonymous users, use this option to
+                                            ensure the flag value remains consistent after the user logs in. Depending
+                                            on your setup, this option may not always be appropriate. Note that this
+                                            feature requires creating profiles for anonymous users.{' '}
                                             <Link
                                                 to="https://posthog.com/docs/feature-flags/creating-feature-flags#persisting-feature-flags-across-authentication-steps"
                                                 target="_blank"

--- a/frontend/src/scenes/experiments/ExperimentForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm.tsx
@@ -1,6 +1,7 @@
 import { IconPlusSmall, IconToggle, IconTrash } from '@posthog/icons'
 import {
     LemonBanner,
+    LemonCheckbox,
     LemonDivider,
     LemonInput,
     LemonModal,
@@ -314,6 +315,35 @@ const ExperimentFormFields = (): JSX.Element => {
                                     )}
                                 </div>
                             </div>
+                        </div>
+                        <div className="mt-10">
+                            <h3 className="mb-1">Advanced settings</h3>
+                            <LemonDivider />
+                            <LemonField name="parameters.ensure_experience_continuity">
+                                {({ value, onChange }) => (
+                                    <div className="border rounded p-4">
+                                        <LemonCheckbox
+                                            id="continuity-checkbox"
+                                            label="Persist flag across authentication steps"
+                                            onChange={() => onChange(!value)}
+                                            fullWidth
+                                            checked={value}
+                                        />
+                                        <div className="text-secondary text-sm pl-7">
+                                            If your feature flag is applied before identifying the user, use this to
+                                            ensure that the flag value remains consistent for the same user. Depending
+                                            on your setup, this option might not always be suitable. This feature
+                                            requires creating profiles for anonymous users.{' '}
+                                            <Link
+                                                to="https://posthog.com/docs/feature-flags/creating-feature-flags#persisting-feature-flags-across-authentication-steps"
+                                                target="_blank"
+                                            >
+                                                Learn more
+                                            </Link>
+                                        </div>
+                                    </div>
+                                )}
+                            </LemonField>
                         </div>
                     </>
                 )}


### PR DESCRIPTION
## Problem
When creating an experiment with a new flag, we default to _not_ persisting flag values when users logs in. This is causing users to see a lot of `$multiple` values in experiments, as flag values can change on log in.

## Changes
Let the user decide whether or not to persist flag values across login when creating an experiment.

![Screenshot 2025-07-02 at 12 03 04](https://github.com/user-attachments/assets/ece711c9-bea7-4c7c-a482-a953d89e6dc5)

## Did you write or update any docs for this change?
I will add docs. This is a frequent support issue so we need to document this.

## How did you test this code?
- Unit test added
- Manually created an experiment and verified that both enabled/disabled passed on to the feature flag
