### PR TITLE
fix(experiments): prevent secondary metrics showing Error when no primary metrics

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRow.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRow.tsx
@@ -90,7 +90,9 @@ export function MetricRow({
                     // eslint-disable-next-line react/forbid-dom-props
                     style={{ height: `${panelHeight}px` }}
                 >
-                    {result && hasMinimumExposureForResults ? (
+                    {resultsLoading ? (
+                        <ChartLoadingState height={panelHeight} />
+                    ) : result && hasMinimumExposureForResults ? (
                         <div className="relative">
                             <Chart
                                 chartSvgRef={chartSvgRef}
@@ -116,8 +118,6 @@ export function MetricRow({
                                 isSecondary={isSecondary}
                             />
                         </div>
-                    ) : resultsLoading ? (
-                        <ChartLoadingState height={panelHeight} />
                     ) : (
                         <ChartEmptyState
                             height={panelHeight}


### PR DESCRIPTION
## Problem
When only secondary metrics are added to an experiment, they just display "Error" even though queries run fine.

## Changes
Reordered the conditions to check `resultsLoading` first, ensuring the loading state is shown while results are being fetched, preventing premature error display.

## How did you test this code?
- Manually verified that an experiment with only secondary metrics loads fine.
- Verified that experiments with primary metrics also loads fine