### PR TITLE
fix(hogql): Query breaks when there is orderby `display_person_name`

### DIFF
--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -199,7 +199,7 @@ class EventsQueryRunner(QueryRunner):
                                 else:
                                     props.append(f"toString(person.properties.`{key}`)")
                             expr = f"(coalesce({', '.join([*props, 'distinct_id'])}), toString(person.id))"
-                            newCol = re.sub(r"person_display_name", expr, col)
+                            newCol = re.sub(r"person_display_name -- Person ", expr, col)
                             columns.append(newCol)
                         else:
                             columns.append(col)

--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -186,7 +186,23 @@ class EventsQueryRunner(QueryRunner):
             # order by
             with self.timings.measure("order"):
                 if self.query.orderBy is not None:
-                    order_by = [parse_order_expr(column, timings=self.timings) for column in self.query.orderBy]
+                    columns: list[str] = []
+                    for _, col in enumerate(self.query.orderBy):
+                        if col.split("--")[0].strip() == "person_display_name":
+                            property_keys = (
+                                self.team.person_display_name_properties or PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES
+                            )
+                            props = []
+                            for key in property_keys:
+                                if re.match(r"^[A-Za-z_$][A-Za-z0-9_$]*$", key):
+                                    props.append(f"toString(person.properties.{key})")
+                                else:
+                                    props.append(f"toString(person.properties.`{key}`)")
+                            expr = f"(coalesce({', '.join([*props, 'distinct_id'])}), toString(person.id))"
+                            columns.append(expr)
+                        else:
+                            columns.append(col)
+                    order_by = [parse_order_expr(column, timings=self.timings) for column in columns]
                 elif "count()" in select_input:
                     order_by = [ast.OrderExpr(expr=parse_expr("count()"), order="DESC")]
                 elif len(aggregations) > 0:

--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -199,7 +199,8 @@ class EventsQueryRunner(QueryRunner):
                                 else:
                                     props.append(f"toString(person.properties.`{key}`)")
                             expr = f"(coalesce({', '.join([*props, 'distinct_id'])}), toString(person.id))"
-                            columns.append(expr)
+                            newCol = re.sub(r"person_display_name", expr, col)
+                            columns.append(newCol)
                         else:
                             columns.append(col)
                     order_by = [parse_order_expr(column, timings=self.timings) for column in columns]

--- a/posthog/hogql_queries/test/test_events_query_runner.py
+++ b/posthog/hogql_queries/test/test_events_query_runner.py
@@ -674,11 +674,6 @@ class TestEventsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                 "$initial_utm_source": "facebook",
             },
         )
-        _create_person(
-            team_id=self.team.pk,
-            distinct_ids=["id_email_2", "id_anon_2"],
-            properties={"email": "user2@email.com", "name": "Test User 2"},
-        )
         _create_event(
             team=self.team,
             event="$pageview",

--- a/posthog/hogql_queries/test/test_events_query_runner.py
+++ b/posthog/hogql_queries/test/test_events_query_runner.py
@@ -701,3 +701,53 @@ class TestEventsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         response = runner.run()
         assert isinstance(response, CachedEventsQueryResponse)
         assert response.results[0][2] == "Organic Social"
+
+    def test_orderby_person_display_name_field(self):
+        _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["id_email", "id_anon"],
+            properties={"email": "user@email.com", "name": "Test User"},
+        )
+        _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["id_email_2", "id_anon_2"],
+            properties={"email": "user2@email.com", "name": "Test User 2"},
+        )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="id_email",
+            properties={},
+        )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="id_email_2",
+            properties={},
+        )
+
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="id_email_2",
+            properties={},
+        )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="id_anon",
+            properties={},
+        )
+        flush_persons_and_events()
+
+        query = EventsQuery(
+            kind="EventsQuery",
+            select=["event", "person_display_name -- Person"],
+            orderBy=["person_display_name -- Person  DESC"],
+        )
+        runner = EventsQueryRunner(query=query, team=self.team)
+        response = runner.run()
+        assert isinstance(response, CachedEventsQueryResponse)
+        # Should use default display name property (email)
+        display_names = [row[1]["display_name"] for row in response.results]
+        assert display_names[0] == "user@email.com"

--- a/posthog/hogql_queries/test/test_events_query_runner.py
+++ b/posthog/hogql_queries/test/test_events_query_runner.py
@@ -674,6 +674,11 @@ class TestEventsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                 "$initial_utm_source": "facebook",
             },
         )
+        _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["id_email_2", "id_anon_2"],
+            properties={"email": "user2@email.com", "name": "Test User 2"},
+        )
         _create_event(
             team=self.team,
             event="$pageview",


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

I believe https://github.com/PostHog/posthog/issues/32726 is not fixed yet as I can still reproduce it in production:


https://github.com/user-attachments/assets/c1dc2626-4cfa-498c-a6bd-5b360fae5660



## Changes

I referenced the way https://github.com/PostHog/posthog/pull/31704 was handling the `select` and apply it to `orderby`.


https://github.com/user-attachments/assets/d34a2458-f3f0-46be-a837-aef29df34f7a



## Did you write or update any docs for this change?
- [x] No docs needed for this change

## How did you test this code?

Locally!
