### PR TITLE
chore(sql-editor): Tweaks to the sql editor data grid

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/DataGrid.scss
+++ b/frontend/src/scenes/data-warehouse/editor/DataGrid.scss
@@ -1,7 +1,6 @@
 .rdg-cell {
     font-size: 0.75rem;
     border-block-end: 1px solid var(--border);
-    border-right: 0;
 }
 
 .rdg-header-row .rdg-cell:focus,

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -327,7 +327,7 @@ export function OutputPane(): JSX.Element {
                 const isLongContent = maxContentLength > 100
                 const finalWidth = isLongContent ? 600 : undefined
 
-                const baseColumn = {
+                const baseColumn: DataGridProps<Record<string, any>>['columns'][0] = {
                     key: column,
                     name: (
                         <>
@@ -342,9 +342,9 @@ export function OutputPane(): JSX.Element {
                     width: finalWidth,
                     headerCellClass: 'cursor-pointer',
                     renderHeaderCell: ({ column: col, sortDirection }: RenderHeaderCellProps<any>) => (
-                        <div className="flex items-center justify-between px-3 py-2">
+                        <div className="flex items-center justify-between py-2">
                             <span>{col.name}</span>
-                            <div className="flex flex-col">
+                            <div className="flex flex-col ml-1">
                                 <span
                                     className={`text-[7px] leading-none ${
                                         sortDirection === 'ASC' ? 'text-black-600' : 'text-gray-400'


### PR DESCRIPTION
## Changes
Some minor styling tweaks to the results table of the sql editor
- Added column borders back in
- Removed horizontal spacing on the headers
- Added a margin to the sort icon