### PR TITLE
feat(batch-exports): Support additional compression for S3 Parquet

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -637,9 +637,9 @@ jobs:
 
             # Uncomment this code to create an ssh-able console so you can debug issues with github actions
             # (Consider changing the timeout in ci-backend.yml to have more time)
-            # - name: Setup tmate session
-            #   if: failure()
-            #   uses: mxschmitt/action-tmate@v3
+            - name: Setup tmate session
+              if: failure()
+              uses: mxschmitt/action-tmate@v3
 
             - name: Run /decide read replica tests
               id: run-decide-read-replica-tests

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -637,9 +637,9 @@ jobs:
 
             # Uncomment this code to create an ssh-able console so you can debug issues with github actions
             # (Consider changing the timeout in ci-backend.yml to have more time)
-            - name: Setup tmate session
-              if: failure()
-              uses: mxschmitt/action-tmate@v3
+            # - name: Setup tmate session
+            #   if: failure()
+            #   uses: mxschmitt/action-tmate@v3
 
             - name: Run /decide read replica tests
               id: run-decide-read-replica-tests

--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
@@ -10,6 +10,7 @@ import {
     Tooltip,
 } from '@posthog/lemon-ui'
 import { LemonField } from 'lib/lemon-ui/LemonField'
+import React from 'react'
 
 import { BatchExportConfigurationForm } from './types'
 
@@ -156,11 +157,16 @@ export function BatchExportsEditFields({
                         </LemonField>
 
                         <div className="flex gap-4">
-                            <LemonField name="file_format" label="Format" className="flex-1">
+                            <LemonField
+                                name="file_format"
+                                label="Format"
+                                className="flex-1"
+                                info="Parquet with zstd compression has shown to offer the best performance"
+                            >
                                 <LemonSelect
                                     options={[
-                                        { value: 'JSONLines', label: 'JSON lines' },
                                         { value: 'Parquet', label: 'Apache Parquet' },
+                                        { value: 'JSONLines', label: 'JSON lines' },
                                     ]}
                                 />
                             </LemonField>
@@ -183,13 +189,61 @@ export function BatchExportsEditFields({
 
                         <div className="flex gap-4">
                             <LemonField name="compression" label="Compression" className="flex-1">
-                                <LemonSelect
-                                    options={[
+                                {({ value, onChange }) => {
+                                    const parquetCompressionOptions = [
+                                        { value: 'zstd', label: 'zstd' },
+                                        { value: 'lz4', label: 'lz4' },
+                                        { value: 'snappy', label: 'snappy' },
                                         { value: 'gzip', label: 'gzip' },
                                         { value: 'brotli', label: 'brotli' },
                                         { value: null, label: 'No compression' },
-                                    ]}
-                                />
+                                    ]
+                                    const jsonLinesCompressionOptions = [
+                                        { value: 'gzip', label: 'gzip' },
+                                        { value: 'brotli', label: 'brotli' },
+                                        { value: null, label: 'No compression' },
+                                    ]
+                                    const compressionOptions =
+                                        batchExportConfigForm.file_format === 'Parquet'
+                                            ? parquetCompressionOptions
+                                            : batchExportConfigForm.file_format === 'JSONLines'
+                                            ? jsonLinesCompressionOptions
+                                            : []
+
+                                    const isSelectedCompressionOptionValid = (value: string | null): boolean => {
+                                        if (batchExportConfigForm.file_format === 'Parquet') {
+                                            return parquetCompressionOptions.some((option) => option.value === value)
+                                        } else if (batchExportConfigForm.file_format === 'JSONLines') {
+                                            return jsonLinesCompressionOptions.some((option) => option.value === value)
+                                        }
+                                        return false
+                                    }
+
+                                    // Set defaults when file format changes for new destinations
+                                    React.useEffect(() => {
+                                        if (isNew && batchExportConfigForm.file_format === 'JSONLines') {
+                                            onChange(null)
+                                        } else if (isNew && batchExportConfigForm.file_format === 'Parquet') {
+                                            onChange('zstd')
+                                        } else if (!isSelectedCompressionOptionValid(value)) {
+                                            // if file format is changed but existing compression is not valid, set to null
+                                            onChange(null)
+                                        }
+                                    }, [batchExportConfigForm.file_format, isNew])
+
+                                    return (
+                                        <LemonSelect
+                                            options={compressionOptions}
+                                            value={value}
+                                            onChange={onChange}
+                                            placeholder={
+                                                !batchExportConfigForm.file_format
+                                                    ? 'Select file format first'
+                                                    : undefined
+                                            }
+                                        />
+                                    )
+                                }}
                             </LemonField>
 
                             <LemonField name="encryption" label="Encryption" className="flex-1">

--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
@@ -161,7 +161,7 @@ export function BatchExportsEditFields({
                                 name="file_format"
                                 label="Format"
                                 className="flex-1"
-                                info="Parquet with zstd compression has shown to offer the best performance"
+                                info="We recommend Parquet with zstd compression for the best performance"
                             >
                                 <LemonSelect
                                     options={[

--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigurationLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigurationLogic.tsx
@@ -44,6 +44,10 @@ export function getDefaultConfiguration(service: string): Record<string, any> {
         ...(service === 'Snowflake' && {
             authentication_type: 'password',
         }),
+        ...(service === 'S3' && {
+            file_format: 'Parquet',
+            compression: 'zstd',
+        }),
     }
 }
 

--- a/posthog/api/test/batch_exports/conftest.py
+++ b/posthog/api/test/batch_exports/conftest.py
@@ -41,7 +41,7 @@ class ThreadedWorker(Worker):
         finally:
             self._shutdown_event.set()
             # Give the worker a chance to shut down before exiting
-            max_wait = 10
+            max_wait = 10.0
             while t.is_alive() and max_wait > 0:
                 time.sleep(0.1)
                 max_wait -= 0.1

--- a/posthog/api/test/batch_exports/conftest.py
+++ b/posthog/api/test/batch_exports/conftest.py
@@ -10,11 +10,10 @@ import temporalio.worker
 from asgiref.sync import async_to_sync
 from temporalio.client import Client as TemporalClient
 from temporalio.service import RPCError
-from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+from temporalio.worker import Worker
 
 from posthog import constants
 from posthog.batch_exports.models import BatchExport
-from posthog.constants import BATCH_EXPORTS_TASK_QUEUE
 from posthog.temporal.batch_exports import ACTIVITIES, WORKFLOWS
 from posthog.temporal.common.client import sync_connect
 
@@ -41,6 +40,11 @@ class ThreadedWorker(Worker):
             yield
         finally:
             self._shutdown_event.set()
+            # Give the worker a chance to shut down before exiting
+            max_wait = 10
+            while t.is_alive() and max_wait > 0:
+                time.sleep(0.1)
+                max_wait -= 0.1
 
     def run_using_loop(self, loop):
         """Setup an event loop to run the Worker.
@@ -97,19 +101,6 @@ def start_test_worker(temporal: TemporalClient):
         workflows=WORKFLOWS,
         activities=ACTIVITIES,  # type: ignore
         workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
-        graceful_shutdown_timeout=dt.timedelta(seconds=5),
-    ).run_in_thread():
-        yield
-
-
-@contextmanager
-def start_test_worker_async(temporal: TemporalClient):
-    with ThreadedWorker(
-        client=temporal,
-        task_queue=BATCH_EXPORTS_TASK_QUEUE,
-        workflows=WORKFLOWS,
-        activities=ACTIVITIES,  # type: ignore
-        workflow_runner=UnsandboxedWorkflowRunner(),
         graceful_shutdown_timeout=dt.timedelta(seconds=5),
     ).run_in_thread():
         yield

--- a/posthog/api/test/batch_exports/test_create.py
+++ b/posthog/api/test/batch_exports/test_create.py
@@ -490,7 +490,7 @@ def test_create_snowflake_batch_export_validates_credentials(
         (
             "JSONLines",
             "zstd",
-            "Compression zstd is not supported for file format JSONLines",
+            "Compression zstd is not supported for file format JSONLines. Supported compressions are ['gzip', 'brotli']",
         ),
         (
             "Parquet",
@@ -515,7 +515,12 @@ def test_create_snowflake_batch_export_validates_credentials(
         (
             "Parquet",
             "unknown",
-            "Compression unknown is not supported for file format Parquet",
+            "Compression unknown is not supported for file format Parquet. Supported compressions are ['zstd', 'lz4', 'snappy', 'gzip', 'brotli']",
+        ),
+        (
+            "unknown",
+            "gzip",
+            "File format unknown is not supported. Supported file formats are ['Parquet', 'JSONLines']",
         ),
     ],
 )
@@ -559,4 +564,4 @@ def test_create_s3_batch_export_validates_file_format_and_compression(
             assert response.status_code == status.HTTP_201_CREATED
         else:
             assert response.status_code == status.HTTP_400_BAD_REQUEST
-            assert expected_error_message in response.json()["detail"]
+            assert response.json()["detail"] == expected_error_message

--- a/posthog/api/test/batch_exports/test_create.py
+++ b/posthog/api/test/batch_exports/test_create.py
@@ -472,3 +472,91 @@ def test_create_snowflake_batch_export_validates_credentials(
                 assert "Password is required if authentication type is password" in response.json()["detail"]
             else:
                 assert "Private key is required if authentication type is key pair" in response.json()["detail"]
+
+
+@pytest.mark.parametrize(
+    "file_format,compression,expected_error_message",
+    [
+        (
+            "JSONLines",
+            None,
+            None,
+        ),
+        (
+            "JSONLines",
+            "gzip",
+            None,
+        ),
+        (
+            "JSONLines",
+            "zstd",
+            "Compression zstd is not supported for file format JSONLines",
+        ),
+        (
+            "Parquet",
+            None,
+            None,
+        ),
+        (
+            "Parquet",
+            "gzip",
+            None,
+        ),
+        (
+            "Parquet",
+            "brotli",
+            None,
+        ),
+        (
+            "Parquet",
+            "zstd",
+            None,
+        ),
+        (
+            "Parquet",
+            "unknown",
+            "Compression unknown is not supported for file format Parquet",
+        ),
+    ],
+)
+def test_create_s3_batch_export_validates_file_format_and_compression(
+    client: HttpClient, file_format, compression, expected_error_message, temporal
+):
+    """Test creating a BatchExport with S3 destination validates file format and compression."""
+
+    destination_data = {
+        "type": "S3",
+        "config": {
+            "bucket_name": "my-s3-bucket",
+            "region": "us-east-1",
+            "prefix": "posthog-events/",
+            "aws_access_key_id": "abc123",
+            "aws_secret_access_key": "secret",
+            "file_format": file_format,
+            "compression": compression,
+        },
+    }
+
+    batch_export_data = {
+        "name": "my-s3-bucket",
+        "destination": destination_data,
+        "interval": "hour",
+    }
+
+    organization = create_organization("Test Org")
+    team = create_team(organization)
+    user = create_user("test@user.com", "Test User", organization)
+    client.force_login(user)
+
+    with start_test_worker(temporal):
+        response = create_batch_export(
+            client,
+            team.pk,
+            batch_export_data,
+        )
+
+        if expected_error_message is None:
+            assert response.status_code == status.HTTP_201_CREATED
+        else:
+            assert response.status_code == status.HTTP_400_BAD_REQUEST
+            assert expected_error_message in response.json()["detail"]

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -7,7 +7,15 @@ import structlog
 from django.db import transaction
 from django.utils.timezone import now
 from loginas.utils import is_impersonated_session
-from rest_framework import filters, mixins, request, response, serializers, status, viewsets
+from rest_framework import (
+    filters,
+    mixins,
+    request,
+    response,
+    serializers,
+    status,
+    viewsets,
+)
 from rest_framework.exceptions import (
     NotAuthenticated,
     NotFound,
@@ -50,6 +58,7 @@ from posthog.models import (
 )
 from posthog.schema import HogQLQueryModifiers, PersonsOnEventsMode
 from posthog.temporal.batch_exports.destination_tests import get_destination_test
+from posthog.temporal.batch_exports.s3_batch_export import SUPPORTED_COMPRESSIONS
 from posthog.temporal.common.client import sync_connect
 from posthog.utils import relative_date_parse
 
@@ -305,6 +314,15 @@ class BatchExportSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError("Password is required if authentication type is password")
             if config.get("authentication_type") == "keypair" and merged_config.get("private_key") is None:
                 raise serializers.ValidationError("Private key is required if authentication type is key pair")
+        if destination_attrs["type"] == BatchExportDestination.Destination.S3:
+            config = destination_attrs["config"]
+            # TODO: should file format be required?
+            file_format = config.get("file_format")
+            compression = config.get("compression")
+            if compression and file_format and compression not in SUPPORTED_COMPRESSIONS[file_format]:
+                raise serializers.ValidationError(
+                    f"Compression {compression} is not supported for file format {file_format}"
+                )
         return destination_attrs
 
     def create(self, validated_data: dict) -> BatchExport:

--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -103,7 +103,7 @@ COMPRESSION_EXTENSIONS = {
     "gzip": "gz",
     "snappy": "sz",
     "brotli": "br",
-    "ztsd": "zst",
+    "zstd": "zst",
     "lz4": "lz4",
 }
 

--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -107,6 +107,11 @@ COMPRESSION_EXTENSIONS = {
     "lz4": "lz4",
 }
 
+SUPPORTED_COMPRESSIONS = {
+    "Parquet": ["gzip", "snappy", "brotli", "zstd", "lz4"],
+    "JSONLines": ["gzip", "brotli"],
+}
+
 
 @dataclasses.dataclass(kw_only=True)
 class S3InsertInputs(BatchExportInsertInputs):

--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -108,7 +108,7 @@ COMPRESSION_EXTENSIONS = {
 }
 
 SUPPORTED_COMPRESSIONS = {
-    "Parquet": ["gzip", "snappy", "brotli", "zstd", "lz4"],
+    "Parquet": ["zstd", "lz4", "snappy", "gzip", "brotli"],
     "JSONLines": ["gzip", "brotli"],
 }
 

--- a/posthog/temporal/batch_exports/transformer.py
+++ b/posthog/temporal/batch_exports/transformer.py
@@ -411,7 +411,6 @@ class ParquetStreamTransformer:
                 schema=self.schema,
                 compression="none" if self.compression is None else self.compression,  # type: ignore
                 compression_level=self.compression_level,
-                write_statistics=False,  # Disable statistics to improve performance
             )
         assert self._parquet_writer is not None
         return self._parquet_writer

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -13,7 +13,6 @@ from collections.abc import Collection
 from dataclasses import asdict
 from unittest import mock
 from unittest.mock import patch
-from flaky import flaky
 
 import aioboto3
 import botocore.exceptions
@@ -22,6 +21,7 @@ import pytest
 import pytest_asyncio
 from django.conf import settings
 from django.test import override_settings
+from flaky import flaky
 from temporalio import activity
 from temporalio.client import WorkflowFailureError
 from temporalio.common import RetryPolicy
@@ -47,6 +47,7 @@ from posthog.temporal.batch_exports.pre_export_stage import (
 from posthog.temporal.batch_exports.s3_batch_export import (
     COMPRESSION_EXTENSIONS,
     FILE_FORMAT_EXTENSIONS,
+    SUPPORTED_COMPRESSIONS,
     IntermittentUploadPartTimeoutError,
     InvalidS3EndpointError,
     S3BatchExportInputs,
@@ -472,7 +473,7 @@ class TestInsertIntoS3Activity:
 
         return records_exported
 
-    @pytest.mark.parametrize("compression", [None, "gzip", "brotli"], indirect=True)
+    @pytest.mark.parametrize("compression", COMPRESSION_EXTENSIONS.keys(), indirect=True)
     @pytest.mark.parametrize("exclude_events", [None, ["test-exclude"]], indirect=True)
     @pytest.mark.parametrize("model", TEST_S3_MODELS)
     @pytest.mark.parametrize("file_format", FILE_FORMAT_EXTENSIONS.keys())
@@ -514,6 +515,9 @@ class TestInsertIntoS3Activity:
 
         if use_internal_s3_stage and isinstance(model, BatchExportModel) and model.name == "sessions":
             pytest.skip("Sessions batch export is not supported with internal S3 stage at this time")
+
+        if compression and compression not in SUPPORTED_COMPRESSIONS[file_format]:
+            pytest.skip(f"Compression {compression} is not supported for file format {file_format}")
 
         prefix = str(uuid.uuid4())
 
@@ -578,7 +582,7 @@ class TestInsertIntoS3Activity:
             sort_key=sort_key,
         )
 
-    @pytest.mark.parametrize("compression", [None, "gzip", "brotli"], indirect=True)
+    @pytest.mark.parametrize("compression", COMPRESSION_EXTENSIONS.keys(), indirect=True)
     @pytest.mark.parametrize("model", [BatchExportModel(name="events", schema=None)])
     @pytest.mark.parametrize("file_format", FILE_FORMAT_EXTENSIONS.keys())
     # Use 0 to test that the file is not split up and 6MB since this is slightly
@@ -610,6 +614,9 @@ class TestInsertIntoS3Activity:
 
         if file_format == "JSONLines" and compression is not None:
             pytest.skip("Compressing large JSONLines files takes too long to run; skipping for now")
+
+        if compression and compression not in SUPPORTED_COMPRESSIONS[file_format]:
+            pytest.skip(f"Compression {compression} is not supported for file format {file_format}")
 
         prefix = str(uuid.uuid4())
 
@@ -981,7 +988,7 @@ async def test_s3_export_workflow_with_minio_bucket_with_various_intervals_and_m
 @pytest.mark.parametrize("interval", ["hour"], indirect=True)
 @pytest.mark.parametrize("model", [BatchExportModel(name="events", schema=None)])
 @pytest.mark.parametrize("exclude_events", [None], indirect=True)
-@pytest.mark.parametrize("compression", [None, "gzip", "brotli"], indirect=True)
+@pytest.mark.parametrize("compression", COMPRESSION_EXTENSIONS.keys(), indirect=True)
 @pytest.mark.parametrize("file_format", FILE_FORMAT_EXTENSIONS.keys(), indirect=True)
 @pytest.mark.parametrize("use_internal_s3_stage", [True, False])
 async def test_s3_export_workflow_with_minio_bucket_with_various_compression_and_file_formats(
@@ -1002,6 +1009,9 @@ async def test_s3_export_workflow_with_minio_bucket_with_various_compression_and
     use_internal_s3_stage: bool,
 ):
     """Test S3BatchExport Workflow end-to-end by using a local MinIO bucket and various compression and file formats."""
+
+    if compression and compression not in SUPPORTED_COMPRESSIONS[file_format]:
+        pytest.skip(f"Compression {compression} is not supported for file format {file_format}")
 
     with override_settings(
         BATCH_EXPORT_USE_INTERNAL_S3_STAGE_TEAM_IDS=[str(ateam.pk)] if use_internal_s3_stage else []
@@ -1263,7 +1273,7 @@ async def test_s3_export_workflow_with_s3_bucket_with_various_intervals_and_mode
 @pytest.mark.parametrize("use_internal_s3_stage", [True, False])
 @pytest.mark.parametrize("file_format", FILE_FORMAT_EXTENSIONS.keys(), indirect=True)
 @pytest.mark.parametrize("encryption", [None, "AES256", "aws:kms"], indirect=True)
-@pytest.mark.parametrize("compression", [None, "gzip", "brotli"], indirect=True)
+@pytest.mark.parametrize("compression", COMPRESSION_EXTENSIONS.keys(), indirect=True)
 @pytest.mark.parametrize("model", [BatchExportModel(name="events", schema=None)])
 @pytest.mark.parametrize("interval", ["hour"], indirect=True)
 @pytest.mark.parametrize("exclude_events", [None], indirect=True)
@@ -1289,6 +1299,9 @@ async def test_s3_export_workflow_with_s3_bucket_with_various_file_formats(
     """Test S3 Export Workflow end-to-end by using an S3 bucket with various file formats, compression, and
     encryption.
     """
+
+    if compression and compression not in SUPPORTED_COMPRESSIONS[file_format]:
+        pytest.skip(f"Compression {compression} is not supported for file format {file_format}")
 
     destination_config = s3_batch_export.destination.config | {
         "endpoint_url": None,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

For S3 batch exports, we only support gzip and brotli compression for Parquet file formats. These are very slow compared to alternatives.

## Changes

Support additional compression formats, such as `zstd`, `lz4` & `snappy` which have been shown to be much more performant.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

Run frontend locally to test form.

Ran a batch export locally using Parquet with zstd.

Using existing tests, plus added new ones for new formats.
