### PR TITLE
chore(persons): Refactor apply properties update

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
@@ -27,7 +27,8 @@ export async function processPersonsStep(
         runner.hub.db.kafkaProducer,
         personStoreBatch,
         runner.hub.PERSON_JSONB_SIZE_ESTIMATE_ENABLE,
-        runner.hub.PERSON_PROPERTY_JSONB_UPDATE_OPTIMIZATION
+        runner.hub.PERSON_PROPERTY_JSONB_UPDATE_OPTIMIZATION,
+        runner.hub.PERSON_BATCH_WRITING_MODE
     )
 
     const processor = new PersonEventProcessor(

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -32,12 +32,7 @@ import {
     personWriteMethodAttemptCounter,
     totalPersonUpdateLatencyPerBatchHistogram,
 } from './metrics'
-import {
-    fromInternalPerson,
-    mergePersonPropertiesWithChangeset,
-    PersonUpdate,
-    toInternalPerson,
-} from './person-update-batch'
+import { fromInternalPerson, PersonUpdate, toInternalPerson } from './person-update-batch'
 import { PersonsStore } from './persons-store'
 import { PersonsStoreForBatch } from './persons-store-for-batch'
 
@@ -600,7 +595,8 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
                       properties_last_operation: result.properties_last_operation
                           ? { ...result.properties_last_operation }
                           : {},
-                      property_changeset: { ...result.property_changeset },
+                      properties_to_set: { ...result.properties_to_set },
+                      properties_to_unset: [...result.properties_to_unset],
                   }
         } else {
             this.cacheMetrics.updateCacheMisses++
@@ -641,11 +637,14 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
                 is_identified: person.is_identified,
             } as Partial<InternalPerson>)
 
-            // Handle fields that are specific to PersonUpdate
-            mergedPersonUpdate.property_changeset = {
-                ...existingPersonUpdate.property_changeset,
-                ...person.property_changeset,
+            // Handle fields that are specific to PersonUpdate - merge properties_to_set and properties_to_unset
+            mergedPersonUpdate.properties_to_set = {
+                ...existingPersonUpdate.properties_to_set,
+                ...person.properties_to_set,
             }
+            mergedPersonUpdate.properties_to_unset = [
+                ...new Set([...existingPersonUpdate.properties_to_unset, ...person.properties_to_unset]),
+            ]
 
             this.personUpdateCache.set(this.getPersonIdCacheKey(teamId, person.id), mergedPersonUpdate)
         } else {
@@ -729,13 +728,20 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
 
     /**
      * Helper method to merge an update into a PersonUpdate
-     * Handles properties, changeset, and is_identified merging with proper logic
+     * Handles properties and is_identified merging with proper logic
      */
     private mergeUpdateIntoPersonUpdate(personUpdate: PersonUpdate, update: Partial<InternalPerson>): PersonUpdate {
-        // Track property changes in changeset and merge into full properties
+        // For properties, we track them in the fine-grained properties_to_set/unset
         if (update.properties) {
-            personUpdate.property_changeset = { ...personUpdate.property_changeset, ...update.properties }
-            personUpdate.properties = { ...personUpdate.properties, ...update.properties }
+            // Add all properties from the update to properties_to_set
+            Object.entries(update.properties).forEach(([key, value]) => {
+                personUpdate.properties_to_set[key] = value
+                // Remove from unset list if it was there
+                const unsetIndex = personUpdate.properties_to_unset.indexOf(key)
+                if (unsetIndex !== -1) {
+                    personUpdate.properties_to_unset.splice(unsetIndex, 1)
+                }
+            })
         }
 
         // Apply other updates (excluding properties which we handled above)
@@ -753,13 +759,54 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
     }
 
     private addPersonPropertiesUpdateToBatch(
-        _person: InternalPerson,
-        _propertiesToSet: Properties,
-        _propertiesToUnset: string[],
-        _otherUpdates: Partial<InternalPerson>,
-        _distinctId: string
+        person: InternalPerson,
+        propertiesToSet: Properties,
+        propertiesToUnset: string[],
+        otherUpdates: Partial<InternalPerson>,
+        distinctId: string
     ): [InternalPerson, TopicMessage[]] {
-        throw new Error('Not implemented')
+        const existingUpdate = this.getCachedPersonForUpdate(person.team_id, distinctId)
+
+        let personUpdate: PersonUpdate
+        if (!existingUpdate) {
+            // Create new PersonUpdate from the person
+            personUpdate = fromInternalPerson(person, distinctId)
+        } else {
+            // Use existing cached PersonUpdate
+            personUpdate = { ...existingUpdate }
+        }
+
+        // Add properties to set (merge with existing properties_to_set)
+        Object.entries(propertiesToSet).forEach(([key, value]) => {
+            personUpdate.properties_to_set[key] = value
+            // Remove from unset list if it was there
+            const unsetIndex = personUpdate.properties_to_unset.indexOf(key)
+            if (unsetIndex !== -1) {
+                personUpdate.properties_to_unset.splice(unsetIndex, 1)
+            }
+        })
+
+        // Add properties to unset (merge with existing properties_to_unset)
+        propertiesToUnset.forEach((key) => {
+            if (!personUpdate.properties_to_unset.includes(key)) {
+                personUpdate.properties_to_unset.push(key)
+            }
+            // Remove from set list if it was there
+            delete personUpdate.properties_to_set[key]
+        })
+
+        // Apply other updates
+        Object.assign(personUpdate, otherUpdates)
+
+        // Handle is_identified specially with || operator
+        if (otherUpdates.is_identified !== undefined) {
+            personUpdate.is_identified = personUpdate.is_identified || otherUpdates.is_identified
+        }
+
+        personUpdate.needs_write = true
+
+        this.setCachedPersonForUpdate(person.team_id, distinctId, personUpdate)
+        return [toInternalPerson(personUpdate), []]
     }
 
     private async updatePersonNoAssert(
@@ -815,8 +862,18 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         const latestPerson = await this.db.fetchPerson(personUpdate.team_id, personUpdate.distinct_id)
 
         if (latestPerson) {
-            // Use changeset-based merge: start with latest properties from DB and apply only our changes
-            const mergedProperties = mergePersonPropertiesWithChangeset(latestPerson.properties, personUpdate)
+            // Use fine-grained merge: start with latest properties from DB and apply our specific changes
+            const mergedProperties = { ...latestPerson.properties }
+
+            // Apply our properties_to_set
+            Object.entries(personUpdate.properties_to_set).forEach(([key, value]) => {
+                mergedProperties[key] = value
+            })
+
+            // Apply our properties_to_unset
+            personUpdate.properties_to_unset.forEach((key) => {
+                delete mergedProperties[key]
+            })
 
             // Update the PersonUpdate with latest data and merged properties
             personUpdate.properties = mergedProperties

--- a/plugin-server/src/worker/ingestion/persons/measuring-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/measuring-person-store.ts
@@ -248,6 +248,17 @@ export class MeasuringPersonsStoreForBatch implements PersonsStoreForBatch {
         return this.updatePerson(person, update, tx, 'updatePersonForMerge', 'forMerge', distinctId)
     }
 
+    updatePersonWithPropertiesDiffForUpdate(
+        _person: InternalPerson,
+        _propertiesToSet: Properties,
+        _propertiesToUnset: string[],
+        _otherUpdates: Partial<InternalPerson>,
+        _distinctId: string,
+        _tx?: TransactionClient
+    ): Promise<[InternalPerson, TopicMessage[]]> {
+        throw new Error('updatePersonWithPropertiesDiffForUpdate not implemented for MeasuringPersonsStoreForBatch')
+    }
+
     private async updatePerson(
         person: InternalPerson,
         update: Partial<InternalPerson>,

--- a/plugin-server/src/worker/ingestion/persons/person-context.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-context.ts
@@ -22,7 +22,8 @@ export class PersonContext {
         public readonly kafkaProducer: KafkaProducerWrapper,
         public readonly personStore: PersonsStoreForBatch,
         public readonly measurePersonJsonbSize: number = 0,
-        public readonly useOptimizedJSONBUpdates: number = 0.0
+        public readonly useOptimizedJSONBUpdates: number = 0.0,
+        public readonly personBatchWritingMode: string = 'NONE'
     ) {
         this.eventProperties = event.properties!
     }

--- a/plugin-server/src/worker/ingestion/persons/person-merge-service.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-merge-service.ts
@@ -11,7 +11,7 @@ import { promiseRetry } from '../../../utils/retries'
 import { captureIngestionWarning } from '../utils'
 import { PersonContext } from './person-context'
 import { PersonCreateService } from './person-create-service'
-import { applyEventPropertyUpdates } from './person-update'
+import { applyEventPropertyUpdates, computeEventPropertyUpdates } from './person-update'
 
 export const mergeFinalFailuresCounter = new Counter({
     name: 'person_merge_final_failure_total',
@@ -377,7 +377,8 @@ export class PersonMergeService {
         //   we're calling aliasDeprecated as we need to refresh the persons info completely first
 
         const properties: Properties = { ...otherPerson.properties, ...mergeInto.properties }
-        applyEventPropertyUpdates(this.context.event, properties)
+        const propertyUpdates = computeEventPropertyUpdates(this.context.event, properties)
+        applyEventPropertyUpdates(propertyUpdates, properties)
 
         const [mergedPerson, kafkaAcks] = await this.handleMergeTransaction(
             mergeInto,

--- a/plugin-server/src/worker/ingestion/persons/person-property-service.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-property-service.ts
@@ -86,37 +86,39 @@ export class PersonPropertyService {
         }
 
         // Check if we have any changes to make
-        if (propertyUpdates.hasChanges || Object.keys(otherUpdates).length > 0) {
-            // For batch stores, use the new method that handles properties to set and unset explicitly
-            if (this.context.personBatchWritingMode === 'BATCH' || this.context.personBatchWritingMode === 'SHADOW') {
-                const [updatedPerson, kafkaMessages] =
-                    await this.context.personStore.updatePersonWithPropertiesDiffForUpdate(
-                        person,
-                        propertyUpdates.toSet,
-                        propertyUpdates.toUnset,
-                        otherUpdates,
-                        this.context.distinctId
-                    )
-                const kafkaAck = this.context.kafkaProducer.queueMessages(kafkaMessages)
-                return [updatedPerson, kafkaAck]
-            } else {
-                // For regular stores, apply the updates to person.properties and use the regular method
-                const update: Partial<InternalPerson> = { ...otherUpdates }
-                if (applyEventPropertyUpdates(propertyUpdates, person.properties)) {
-                    update.properties = person.properties
-                }
-
-                const [updatedPerson, kafkaMessages] = await this.context.personStore.updatePersonForUpdate(
-                    person,
-                    update,
-                    this.context.distinctId
-                )
-                const kafkaAck = this.context.kafkaProducer.queueMessages(kafkaMessages)
-                return [updatedPerson, kafkaAck]
-            }
+        const hasChanges = propertyUpdates.hasChanges || Object.keys(otherUpdates).length > 0
+        if (!hasChanges) {
+            applyEventPropertyUpdates(propertyUpdates, person.properties)
+            return [person, Promise.resolve()]
         }
 
-        return [person, Promise.resolve()]
+        // For batch stores, use the new method that handles properties to set and unset explicitly
+        if (this.context.personBatchWritingMode === 'BATCH' || this.context.personBatchWritingMode === 'SHADOW') {
+            const [updatedPerson, kafkaMessages] =
+                await this.context.personStore.updatePersonWithPropertiesDiffForUpdate(
+                    person,
+                    propertyUpdates.toSet,
+                    propertyUpdates.toUnset,
+                    otherUpdates,
+                    this.context.distinctId
+                )
+            const kafkaAck = this.context.kafkaProducer.queueMessages(kafkaMessages)
+            return [updatedPerson, kafkaAck]
+        } else {
+            // For regular stores, apply the updates to person.properties and use the regular method
+            const update: Partial<InternalPerson> = { ...otherUpdates }
+            if (applyEventPropertyUpdates(propertyUpdates, person.properties)) {
+                update.properties = person.properties
+            }
+
+            const [updatedPerson, kafkaMessages] = await this.context.personStore.updatePersonForUpdate(
+                person,
+                update,
+                this.context.distinctId
+            )
+            const kafkaAck = this.context.kafkaProducer.queueMessages(kafkaMessages)
+            return [updatedPerson, kafkaAck]
+        }
     }
 
     private async capturePersonPropertiesSizeEstimate(at: string): Promise<void> {

--- a/plugin-server/src/worker/ingestion/persons/person-property-service.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-property-service.ts
@@ -5,7 +5,7 @@ import { logger } from '../../../utils/logger'
 import { promiseRetry } from '../../../utils/retries'
 import { PersonContext } from './person-context'
 import { PersonCreateService } from './person-create-service'
-import { applyEventPropertyUpdates } from './person-update'
+import { applyEventPropertyUpdates, computeEventPropertyUpdates } from './person-update'
 
 // temporary: for fetchPerson properties JSONB size observation
 const ONE_MEGABYTE_PROPS_BLOB = 1048576
@@ -77,22 +77,43 @@ export class PersonPropertyService {
     async updatePersonProperties(person: InternalPerson): Promise<[InternalPerson, Promise<void>]> {
         person.properties ||= {}
 
-        const update: Partial<InternalPerson> = {}
-        if (applyEventPropertyUpdates(this.context.event, person.properties)) {
-            update.properties = person.properties
-        }
+        // Compute property changes
+        const propertyUpdates = computeEventPropertyUpdates(this.context.event, person.properties)
+
+        const otherUpdates: Partial<InternalPerson> = {}
         if (this.context.updateIsIdentified && !person.is_identified) {
-            update.is_identified = true
+            otherUpdates.is_identified = true
         }
 
-        if (Object.keys(update).length > 0) {
-            const [updatedPerson, kafkaMessages] = await this.context.personStore.updatePersonForUpdate(
-                person,
-                update,
-                this.context.distinctId
-            )
-            const kafkaAck = this.context.kafkaProducer.queueMessages(kafkaMessages)
-            return [updatedPerson, kafkaAck]
+        // Check if we have any changes to make
+        if (propertyUpdates.hasChanges || Object.keys(otherUpdates).length > 0) {
+            // For batch stores, use the new method that handles properties to set and unset explicitly
+            if (this.context.personBatchWritingMode === 'BATCH' || this.context.personBatchWritingMode === 'SHADOW') {
+                const [updatedPerson, kafkaMessages] =
+                    await this.context.personStore.updatePersonWithPropertiesDiffForUpdate(
+                        person,
+                        propertyUpdates.toSet,
+                        propertyUpdates.toUnset,
+                        otherUpdates,
+                        this.context.distinctId
+                    )
+                const kafkaAck = this.context.kafkaProducer.queueMessages(kafkaMessages)
+                return [updatedPerson, kafkaAck]
+            } else {
+                // For regular stores, apply the updates to person.properties and use the regular method
+                const update: Partial<InternalPerson> = { ...otherUpdates }
+                if (applyEventPropertyUpdates(propertyUpdates, person.properties)) {
+                    update.properties = person.properties
+                }
+
+                const [updatedPerson, kafkaMessages] = await this.context.personStore.updatePersonForUpdate(
+                    person,
+                    update,
+                    this.context.distinctId
+                )
+                const kafkaAck = this.context.kafkaProducer.queueMessages(kafkaMessages)
+                return [updatedPerson, kafkaAck]
+            }
         }
 
         return [person, Promise.resolve()]

--- a/plugin-server/src/worker/ingestion/persons/person-store-manager.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-store-manager.test.ts
@@ -283,7 +283,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
         it('should overwrite existing cache in batch store, but keep changeset', async () => {
             // Pre-populate batch store cache
             const existingUpdate = fromInternalPerson(person, 'test-distinct')
-            existingUpdate.property_changeset = { pre_existing: 'value' }
+            existingUpdate.properties_to_set = { pre_existing: 'value' }
             batchStoreForBatch.setCachedPersonForUpdate(teamId, 'test-distinct', existingUpdate)
 
             const result = await shadowManager.fetchForUpdate(teamId, 'test-distinct')
@@ -296,7 +296,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
             const updateCache = batchStoreForBatch.getUpdateCache()
             const cachedUpdate = updateCache.get(`${teamId}:${person.id}`)
             expect(cachedUpdate!.properties).toEqual(person.properties)
-            expect(cachedUpdate!.property_changeset).toEqual(existingUpdate.property_changeset)
+            expect(cachedUpdate!.properties_to_set).toEqual(existingUpdate.properties_to_set)
         })
     })
 

--- a/plugin-server/src/worker/ingestion/persons/person-update.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-update.ts
@@ -84,10 +84,6 @@ export function computeEventPropertyUpdates(event: PluginEvent, personProperties
  * @returns true if the properties were changed, false if they were not
  */
 export function applyEventPropertyUpdates(propertyUpdates: PropertyUpdates, personProperties: Properties): boolean {
-    if (!propertyUpdates.hasChanges) {
-        return false
-    }
-
     let updated = false
     const metricsKeys = new Set<string>()
 

--- a/plugin-server/src/worker/ingestion/persons/person-update.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-update.ts
@@ -31,15 +31,14 @@ function getMetricKey(key: string): string {
 }
 
 /**
- * @param personProperties Properties of the person to be updated, these are updated in place.
- * @returns true if the properties were changed, false if they were not
+ * Computes property changes from an event without modifying personProperties
+ * @param event The event to extract property changes from
+ * @param personProperties Current person properties (not modified)
+ * @returns Object with properties to set, unset, and whether there are changes
  */
-export function applyEventPropertyUpdates(event: PluginEvent, personProperties: Properties): boolean {
-    // this relies on making changes to the object instance, so...
-    // if we should not update the person,
-    // we return early before changing any values
+export function computeEventPropertyUpdates(event: PluginEvent, personProperties: Properties): PropertyUpdates {
     if (NO_PERSON_UPDATE_EVENTS.has(event.event)) {
-        return false
+        return { hasChanges: false, toSet: {}, toUnset: [] }
     }
 
     const properties: Properties = event.properties!['$set'] || {}
@@ -47,34 +46,65 @@ export function applyEventPropertyUpdates(event: PluginEvent, personProperties: 
     const unsetProps = event.properties!['$unset']
     const unsetProperties: Array<string> = Array.isArray(unsetProps) ? unsetProps : Object.keys(unsetProps || {}) || []
 
-    let updated = false
-    // tracking as set because we only care about if other or geoip was the cause of the update, not how many properties got updated
-    const metricsKeys = new Set<string>()
+    let hasChanges = false
+    const toSet: Properties = {}
+    const toUnset: string[] = []
+
     Object.entries(propertiesOnce).forEach(([key, value]) => {
         if (typeof personProperties[key] === 'undefined') {
-            updated = true
-            metricsKeys.add(getMetricKey(key))
-            personProperties[key] = value
+            hasChanges = true
+            toSet[key] = value
         }
     })
 
     Object.entries(properties).forEach(([key, value]) => {
-        // note: due to the type of equality check here
-        // if there is an array or object nested as a $set property
-        // we'll always return true even if those objects/arrays contain the same values
-        // This results in a shallow merge of the properties from event into the person properties
         if (personProperties[key] !== value) {
             if (typeof personProperties[key] === 'undefined' || shouldUpdatePersonIfOnlyChange(event, key)) {
-                updated = true
+                hasChanges = true
             }
-            metricsKeys.add(getMetricKey(key))
-            personProperties[key] = value
+            toSet[key] = value
         }
     })
+
     unsetProperties.forEach((propertyKey) => {
         if (propertyKey in personProperties) {
+            if (typeof propertyKey === 'string') {
+                hasChanges = true
+                toUnset.push(propertyKey)
+            }
+        }
+    })
+
+    return { hasChanges, toSet, toUnset }
+}
+
+/**
+ * @param propertyUpdates The computed property updates to apply
+ * @param personProperties Properties of the person to be updated, these are updated in place.
+ * @returns true if the properties were changed, false if they were not
+ */
+export function applyEventPropertyUpdates(propertyUpdates: PropertyUpdates, personProperties: Properties): boolean {
+    if (!propertyUpdates.hasChanges) {
+        return false
+    }
+
+    let updated = false
+    const metricsKeys = new Set<string>()
+
+    // Apply properties to set
+    Object.entries(propertyUpdates.toSet).forEach(([key, value]) => {
+        if (personProperties[key] !== value) {
+            updated = true
+        }
+        metricsKeys.add(getMetricKey(key))
+        personProperties[key] = value
+    })
+
+    // Apply properties to unset
+    propertyUpdates.toUnset.forEach((propertyKey) => {
+        if (propertyKey in personProperties) {
             if (typeof propertyKey !== 'string') {
-                logger.warn('🔔', 'unset_property_key_not_string', { propertyKey, unsetProperties })
+                logger.warn('🔔', 'unset_property_key_not_string', { propertyKey, toUnset: propertyUpdates.toUnset })
                 return
             }
             updated = true
@@ -82,6 +112,7 @@ export function applyEventPropertyUpdates(event: PluginEvent, personProperties: 
             delete personProperties[propertyKey]
         }
     })
+
     metricsKeys.forEach((key) => personPropertyKeyUpdateCounter.labels({ key: key }).inc())
     return updated
 }

--- a/plugin-server/src/worker/ingestion/persons/persons-store-for-batch.ts
+++ b/plugin-server/src/worker/ingestion/persons/persons-store-for-batch.ts
@@ -63,6 +63,18 @@ export interface PersonsStoreForBatch extends BatchWritingStore {
     ): Promise<[InternalPerson, TopicMessage[], boolean]>
 
     /**
+     * Updates person with specific properties to set and unset
+     */
+    updatePersonWithPropertiesDiffForUpdate(
+        person: InternalPerson,
+        propertiesToSet: Properties,
+        propertiesToUnset: string[],
+        otherUpdates: Partial<InternalPerson>,
+        distinctId: string,
+        tx?: TransactionClient
+    ): Promise<[InternalPerson, TopicMessage[]]>
+
+    /**
      * Deletes a person
      */
     deletePerson(person: InternalPerson, distinctId: string, tx?: TransactionClient): Promise<TopicMessage[]>


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We had an outstanding error that I caused while trying to fix the behaviour of moveDistinctIds, this error caused `$unset` to not work as intended when computed within a batch. Basically the previous approach maintained a set of properties and a change set for each person in the cache, the issue was the reconciliation of the values when we wanted to delete some of the values, this became even harder when we merged two people as their properties and change sets merged making it virtually impossible to discern if a field had been `unset`

## Changes

- Change the personPropertyUpdate evaluation to generate a list of fields to add or unset.
- Pass this information to the batch and shadow stores
- Change the cached person data to store a group of set and unset operations instead of a change set

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
