### PR TITLE
fix: set is_calculating to true for static cohort created by query

### DIFF
--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -292,8 +292,9 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
                             {cohort.is_calculating ? (
                                 <div className="cohort-recalculating flex items-center">
                                     <Spinner className="mr-4" />
-                                    We're recalculating who belongs to this cohort. This could take up to a couple of
-                                    minutes.
+                                    {cohort.is_static
+                                        ? 'We are creating this cohort. This could take up to a couple of minutes.'
+                                        : "We're recalculating who belongs to this cohort. This could take up to a couple of minutes."}
                                 </div>
                             ) : (
                                 <Query

--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -293,7 +293,7 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
                                 <div className="cohort-recalculating flex items-center">
                                     <Spinner className="mr-4" />
                                     {cohort.is_static
-                                        ? 'We are creating this cohort. This could take up to a couple of minutes.'
+                                        ? "We're creating this cohort. This could take up to a couple of minutes."
                                         : "We're recalculating who belongs to this cohort. This could take up to a couple of minutes."}
                                 </div>
                             ) : (

--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -293,7 +293,7 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
                                 <div className="cohort-recalculating flex items-center">
                                     <Spinner className="mr-4" />
                                     {cohort.is_static
-                                        ? 'We are creating this cohort. This could take up to a couple of minutes.'
+                                        ? "We are creating this cohort. This could take up to a couple of minutes."
                                         : "We're recalculating who belongs to this cohort. This could take up to a couple of minutes."}
                                 </div>
                             ) : (

--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -293,7 +293,7 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
                                 <div className="cohort-recalculating flex items-center">
                                     <Spinner className="mr-4" />
                                     {cohort.is_static
-                                        ? "We are creating this cohort. This could take up to a couple of minutes."
+                                        ? 'We are creating this cohort. This could take up to a couple of minutes.'
                                         : "We're recalculating who belongs to this cohort. This could take up to a couple of minutes."}
                                 </div>
                             ) : (

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -313,6 +313,10 @@ def insert_cohort_from_query(cohort_id: int, team_id: Optional[int] = None) -> N
         team_id = cohort.team_id
     team = Team.objects.get(pk=team_id)
     try:
+        cohort.is_calculating = True
+        cohort.save(update_fields=["is_calculating"])
+        cohort.refresh_from_db()
+
         insert_cohort_query_actors_into_ch(cohort, team=team)
         insert_cohort_people_into_pg(cohort, team_id=team_id)
         cohort.count = get_static_cohort_size(cohort_id=cohort.id, team_id=cohort.team_id)


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

A customer noticed (https://posthoghelp.zendesk.com/agent/tickets/33042 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/35585)) that when a large cohort created from a query (e.g. from product analytics) the cohort is empty until the background job is completed and populates the tables with persons. We should show a spinner while the background job is running.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Show a spinner when a static cohort is getting created.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [x] No docs needed for this change

## How did you test this code?
- tested locally by 
	- generate a bunch of persons `DEBUG=1 ./manage.py generate_persons --count 60000`
	- create a static cohort from insight with some filters
	- go to cohort and see spinner

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
