### PR TITLE
fix: canvas plugin fix

### DIFF
--- a/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
+++ b/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
@@ -215,7 +215,8 @@ export const CanvasReplayerPlugin = (events: eventWithTime[]): ReplayPlugin => {
 
             if (node.nodeName === 'CANVAS' && node.nodeType === 1) {
                 const el = containers.get(id) || document.createElement('img')
-                ;(node as HTMLCanvasElement).appendChild(el)
+                const parent = node.parentNode as Node
+                parent?.replaceChild?.(el, node as Node)
                 containers.set(id, el)
             }
         },


### PR DESCRIPTION
When we work around a canvas we replace it with an image. 

However, we were appending img to canvas, which is not correct, as canvas elements cannot have child elements. They're "replaced content" elements in HTML - any content inside them is only fallback text for browsers that don't support canvas.

Let's fix it and replace canvas with image.