### PR TITLE
chore: add required scopes for GET and PUT to access_controls

### DIFF
--- a/ee/api/rbac/access_control.py
+++ b/ee/api/rbac/access_control.py
@@ -216,7 +216,14 @@ class AccessControlViewSetMixin(_GenericViewSet):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     @extend_schema(exclude=True)
-    @action(methods=["GET", "PUT"], detail=True)
+    @action(
+        methods=["GET", "PUT"],
+        detail=True,
+        required_scopes={
+            "GET": ["project:read"],
+            "PUT": ["project:write"],
+        },
+    )
     def access_controls(self, request: Request, *args, **kwargs):
         if request.method == "PUT":
             return self._update_access_controls(request)
@@ -224,7 +231,14 @@ class AccessControlViewSetMixin(_GenericViewSet):
         return self._get_access_controls(request)
 
     @extend_schema(exclude=True)
-    @action(methods=["GET", "PUT"], detail=True)
+    @action(
+        methods=["GET", "PUT"],
+        detail=True,
+        required_scopes={
+            "GET": ["project:read"],
+            "PUT": ["project:write"],
+        },
+    )
     def global_access_controls(self, request: Request, *args, **kwargs):
         if request.method == "PUT":
             return self._update_access_controls(request, is_global=True)


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Users can't query the access_controls API currently

## Changes

Added required scopes to GET and PUT to access_controls

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
