### PR TITLE
feat: add week_start_day to cache payload for weekly intervals

### DIFF
--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -985,7 +985,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         query = to_dict(self.query)
         query.pop("tags", None)
 
-        return {
+        payload = {
             "query_runner": self.__class__.__name__,
             "query": query,
             "team_id": self.team.pk,
@@ -994,6 +994,13 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             "timezone": self.team.timezone,
             "version": 2,
         }
+
+        # add week_start_day to the payload for queries with weekly intervals
+        query_date_range = getattr(self, "query_date_range", None)
+        if query_date_range and query_date_range.interval_name == "week":
+            payload["week_start_day"] = self.team.week_start_day
+
+        return payload
 
     def get_cache_key(self) -> str:
         return generate_cache_key(f"query_{bytes.decode(to_json(self.get_cache_payload()))}")

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -985,22 +985,16 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         query = to_dict(self.query)
         query.pop("tags", None)
 
-        payload = {
+        return {
             "query_runner": self.__class__.__name__,
             "query": query,
             "team_id": self.team.pk,
             "hogql_modifiers": to_dict(self.modifiers),
             "limit_context": self._limit_context_aliased_for_cache,
             "timezone": self.team.timezone,
+            "week_start_day": self.team.week_start_day,
             "version": 2,
         }
-
-        # add week_start_day to the payload for queries with weekly intervals
-        query_date_range = getattr(self, "query_date_range", None)
-        if query_date_range and query_date_range.interval_name == "week":
-            payload["week_start_day"] = self.team.week_start_day
-
-        return payload
 
     def get_cache_key(self) -> str:
         return generate_cache_key(f"query_{bytes.decode(to_json(self.get_cache_payload()))}")

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -31,6 +31,7 @@ from posthog.hogql.timings import HogQLTimings
 from posthog.hogql_queries.query_cache import QueryCacheManager
 from posthog.metrics import LABEL_TEAM_ID
 from posthog.models import Team, User
+from posthog.models.team import WeekStartDay
 from posthog.schema import (
     ActorsPropertyTaxonomyQuery,
     ActorsQuery,
@@ -992,7 +993,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             "hogql_modifiers": to_dict(self.modifiers),
             "limit_context": self._limit_context_aliased_for_cache,
             "timezone": self.team.timezone,
-            "week_start_day": self.team.week_start_day,
+            "week_start_day": self.team.week_start_day or WeekStartDay.SUNDAY,
             "version": 2,
         }
 

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -112,6 +112,7 @@ class TestQueryRunner(BaseTest):
             "query_runner": "TestQueryRunner",
             "team_id": 42,
             "timezone": "UTC",
+            "week_start_day": WeekStartDay.SUNDAY,
             "version": 2,
         }
 

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -8,7 +8,8 @@ from freezegun import freeze_time
 from pydantic import BaseModel
 
 from posthog.hogql_queries.query_runner import ExecutionMode, QueryRunner
-from posthog.models.team.team import Team
+from posthog.hogql_queries.utils.query_date_range import QueryDateRange
+from posthog.models.team.team import Team, WeekStartDay
 from posthog.schema import (
     CacheMissResponse,
     HogQLQuery,
@@ -17,6 +18,7 @@ from posthog.schema import (
     PersonsOnEventsMode,
     TestBasicQueryResponse,
     TestCachedBasicQueryResponse,
+    IntervalType,
 )
 from posthog.test.base import BaseTest
 
@@ -112,6 +114,18 @@ class TestQueryRunner(BaseTest):
             "timezone": "UTC",
             "version": 2,
         }
+
+    def test_cache_payload_week_interval(self):
+        TestQueryRunner = self.setup_test_query_runner_class()
+        # set the pk directly as it affects the hash in the _cache_key call
+        team = Team.objects.create(pk=42, organization=self.organization, week_start_day=WeekStartDay.MONDAY)
+        runner = TestQueryRunner(query={"some_attr": "bla", "tags": {"scene": "foo", "productKey": "bar"}}, team=team)
+        runner.query_date_range = QueryDateRange(
+            team=team, date_range=None, interval=IntervalType.WEEK, now=datetime.now()
+        )
+
+        cache_payload = runner.get_cache_payload()
+        assert cache_payload["week_start_day"] == WeekStartDay.MONDAY
 
     def test_cache_key(self):
         TestQueryRunner = self.setup_test_query_runner_class()

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -136,7 +136,7 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        assert cache_key == "cache_81cddfbbf27c8656cc0c71e17917c8bd"
+        assert cache_key == "cache_7583c7c9c2ab66ba5ff7f55ccb617c9a"
 
     def test_cache_key_runner_subclass(self):
         TestQueryRunner = self.setup_test_query_runner_class()
@@ -150,7 +150,7 @@ class TestQueryRunner(BaseTest):
         runner = TestSubclassQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        assert cache_key == "cache_ac85f6f0bfcc738665881287b9d86890"
+        assert cache_key == "cache_c2e0cd9925f875dba6539dc1b82078bf"
 
     def test_cache_key_different_timezone(self):
         TestQueryRunner = self.setup_test_query_runner_class()
@@ -161,7 +161,7 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        assert cache_key == "cache_2c629e23e4015d311ade6565dcdf0387"
+        assert cache_key == "cache_af770db18dddd01c5c5d6b8f37a36006"
 
     @mock.patch("django.db.transaction.on_commit")
     def test_cache_response(self, mock_on_commit):


### PR DESCRIPTION

> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

When you update the "Week starts on" setting, there is an alert indicating that the queries grouped by week need to be recalculated but we do not do this automatically. I think it makes sense to ensure the cache gets recalculated when that value changes so the users won't see out of date data. We already do this with the timezone setting.

<img width="437" alt="image" src="https://github.com/user-attachments/assets/25f840bc-a0ca-4348-add7-52314c64885d" />
<img width="476" alt="image" src="https://github.com/user-attachments/assets/b12b6305-508b-4bed-9086-545ec3ab6be0" />



## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->


This PR adds the week_start_day setting to the cache key _ONLY_ if the query's interval is set to `week`. This ensures that the cache depends on the week_start_day setting for those queries.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

- Create an insight and set it to week interval
- Change the week starts on setting and refresh the page
- The chart should now reflect the new week start day on both labels and tooltip

<img width="1129" alt="image" src="https://github.com/user-attachments/assets/48bf9239-78b4-4385-80ac-76552da02d91" />

<img width="966" alt="image" src="https://github.com/user-attachments/assets/e5191e3d-c8e3-4cc6-ab6d-8c80cacfeea7" />


<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
