### PR TITLE
feat(query): add query_date_range to some query responses

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -3407,6 +3407,10 @@
                     "format": "date-time",
                     "type": "string"
                 },
+                "query_date_range": {
+                    "$ref": "#/definitions/QueryDateRangeResponse",
+                    "description": "The date range used for the query"
+                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
@@ -3935,6 +3939,10 @@
                     "format": "date-time",
                     "type": "string"
                 },
+                "query_date_range": {
+                    "$ref": "#/definitions/QueryDateRangeResponse",
+                    "description": "The date range used for the query"
+                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
@@ -4372,6 +4380,10 @@
                     "format": "date-time",
                     "type": "string"
                 },
+                "query_date_range": {
+                    "$ref": "#/definitions/QueryDateRangeResponse",
+                    "description": "The date range used for the query"
+                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
@@ -4434,6 +4446,10 @@
                 "next_allowed_client_refresh": {
                     "format": "date-time",
                     "type": "string"
+                },
+                "query_date_range": {
+                    "$ref": "#/definitions/QueryDateRangeResponse",
+                    "description": "The date range used for the query"
                 },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
@@ -4509,6 +4525,10 @@
                     "format": "date-time",
                     "type": "string"
                 },
+                "query_date_range": {
+                    "$ref": "#/definitions/QueryDateRangeResponse",
+                    "description": "The date range used for the query"
+                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
@@ -4579,6 +4599,10 @@
                 "next_allowed_client_refresh": {
                     "format": "date-time",
                     "type": "string"
+                },
+                "query_date_range": {
+                    "$ref": "#/definitions/QueryDateRangeResponse",
+                    "description": "The date range used for the query"
                 },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
@@ -5222,6 +5246,10 @@
                 "next_allowed_client_refresh": {
                     "format": "date-time",
                     "type": "string"
+                },
+                "query_date_range": {
+                    "$ref": "#/definitions/QueryDateRangeResponse",
+                    "description": "The date range used for the query"
                 },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
@@ -7446,6 +7474,10 @@
                                     "$ref": "#/definitions/HogQLQueryModifiers",
                                     "description": "Modifiers used when performing the query"
                                 },
+                                "query_date_range": {
+                                    "$ref": "#/definitions/QueryDateRangeResponse",
+                                    "description": "The date range used for the query"
+                                },
                                 "query_status": {
                                     "$ref": "#/definitions/QueryStatus",
                                     "description": "Query status indicates whether next to the provided data, a query is still running."
@@ -7476,6 +7508,10 @@
                                 "modifiers": {
                                     "$ref": "#/definitions/HogQLQueryModifiers",
                                     "description": "Modifiers used when performing the query"
+                                },
+                                "query_date_range": {
+                                    "$ref": "#/definitions/QueryDateRangeResponse",
+                                    "description": "The date range used for the query"
                                 },
                                 "query_status": {
                                     "$ref": "#/definitions/QueryStatus",
@@ -7519,6 +7555,10 @@
                                     "$ref": "#/definitions/HogQLQueryModifiers",
                                     "description": "Modifiers used when performing the query"
                                 },
+                                "query_date_range": {
+                                    "$ref": "#/definitions/QueryDateRangeResponse",
+                                    "description": "The date range used for the query"
+                                },
                                 "query_status": {
                                     "$ref": "#/definitions/QueryStatus",
                                     "description": "Query status indicates whether next to the provided data, a query is still running."
@@ -7557,6 +7597,10 @@
                                 "modifiers": {
                                     "$ref": "#/definitions/HogQLQueryModifiers",
                                     "description": "Modifiers used when performing the query"
+                                },
+                                "query_date_range": {
+                                    "$ref": "#/definitions/QueryDateRangeResponse",
+                                    "description": "The date range used for the query"
                                 },
                                 "query_status": {
                                     "$ref": "#/definitions/QueryStatus",
@@ -11651,6 +11695,10 @@
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
                 },
+                "query_date_range": {
+                    "$ref": "#/definitions/QueryDateRangeResponse",
+                    "description": "The date range used for the query"
+                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
@@ -13639,6 +13687,10 @@
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
                 },
+                "query_date_range": {
+                    "$ref": "#/definitions/QueryDateRangeResponse",
+                    "description": "The date range used for the query"
+                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
@@ -14991,6 +15043,23 @@
             ],
             "type": "string"
         },
+        "QueryDateRangeResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "date_from": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "date_to": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "interval": {
+                    "$ref": "#/definitions/IntervalType"
+                }
+            },
+            "type": "object"
+        },
         "QueryIndexUsage": {
             "enum": ["undecisive", "no", "partial", "yes"],
             "type": "string"
@@ -16294,6 +16363,10 @@
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
                         },
+                        "query_date_range": {
+                            "$ref": "#/definitions/QueryDateRangeResponse",
+                            "description": "The date range used for the query"
+                        },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
                             "description": "Query status indicates whether next to the provided data, a query is still running."
@@ -16324,6 +16397,10 @@
                         "modifiers": {
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
+                        },
+                        "query_date_range": {
+                            "$ref": "#/definitions/QueryDateRangeResponse",
+                            "description": "The date range used for the query"
                         },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
@@ -16367,6 +16444,10 @@
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
                         },
+                        "query_date_range": {
+                            "$ref": "#/definitions/QueryDateRangeResponse",
+                            "description": "The date range used for the query"
+                        },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
                             "description": "Query status indicates whether next to the provided data, a query is still running."
@@ -16405,6 +16486,10 @@
                         "modifiers": {
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
+                        },
+                        "query_date_range": {
+                            "$ref": "#/definitions/QueryDateRangeResponse",
+                            "description": "The date range used for the query"
                         },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
@@ -17050,6 +17135,10 @@
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
                         },
+                        "query_date_range": {
+                            "$ref": "#/definitions/QueryDateRangeResponse",
+                            "description": "The date range used for the query"
+                        },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
                             "description": "Query status indicates whether next to the provided data, a query is still running."
@@ -17080,6 +17169,10 @@
                         "modifiers": {
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
+                        },
+                        "query_date_range": {
+                            "$ref": "#/definitions/QueryDateRangeResponse",
+                            "description": "The date range used for the query"
                         },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
@@ -17123,6 +17216,10 @@
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
                         },
+                        "query_date_range": {
+                            "$ref": "#/definitions/QueryDateRangeResponse",
+                            "description": "The date range used for the query"
+                        },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
                             "description": "Query status indicates whether next to the provided data, a query is still running."
@@ -17161,6 +17258,10 @@
                         "modifiers": {
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
+                        },
+                        "query_date_range": {
+                            "$ref": "#/definitions/QueryDateRangeResponse",
+                            "description": "The date range used for the query"
                         },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
@@ -17583,6 +17684,10 @@
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
                         },
+                        "query_date_range": {
+                            "$ref": "#/definitions/QueryDateRangeResponse",
+                            "description": "The date range used for the query"
+                        },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
                             "description": "Query status indicates whether next to the provided data, a query is still running."
@@ -17658,6 +17763,10 @@
                         "modifiers": {
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
+                        },
+                        "query_date_range": {
+                            "$ref": "#/definitions/QueryDateRangeResponse",
+                            "description": "The date range used for the query"
                         },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
@@ -17812,6 +17921,10 @@
                         "modifiers": {
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
+                        },
+                        "query_date_range": {
+                            "$ref": "#/definitions/QueryDateRangeResponse",
+                            "description": "The date range used for the query"
                         },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
@@ -19230,6 +19343,10 @@
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
                 },
+                "query_date_range": {
+                    "$ref": "#/definitions/QueryDateRangeResponse",
+                    "description": "The date range used for the query"
+                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
@@ -19308,6 +19425,10 @@
                 "modifiers": {
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
+                },
+                "query_date_range": {
+                    "$ref": "#/definitions/QueryDateRangeResponse",
+                    "description": "The date range used for the query"
                 },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
@@ -19420,6 +19541,10 @@
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
                 },
+                "query_date_range": {
+                    "$ref": "#/definitions/QueryDateRangeResponse",
+                    "description": "The date range used for the query"
+                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
@@ -19511,6 +19636,10 @@
                 "modifiers": {
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
+                },
+                "query_date_range": {
+                    "$ref": "#/definitions/QueryDateRangeResponse",
+                    "description": "The date range used for the query"
                 },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
@@ -21268,6 +21397,10 @@
                 "modifiers": {
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
+                },
+                "query_date_range": {
+                    "$ref": "#/definitions/QueryDateRangeResponse",
+                    "description": "The date range used for the query"
                 },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -18764,9 +18764,6 @@
                 "date_to": {
                     "format": "date-time",
                     "type": "string"
-                },
-                "interval": {
-                    "$ref": "#/definitions/IntervalType"
                 }
             },
             "type": "object"

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -3407,13 +3407,13 @@
                     "format": "date-time",
                     "type": "string"
                 },
-                "query_date_range": {
-                    "$ref": "#/definitions/QueryDateRangeResponse",
-                    "description": "The date range used for the query"
-                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "resolved_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The date range used for the query"
                 },
                 "results": {
                     "anyOf": [
@@ -3939,13 +3939,13 @@
                     "format": "date-time",
                     "type": "string"
                 },
-                "query_date_range": {
-                    "$ref": "#/definitions/QueryDateRangeResponse",
-                    "description": "The date range used for the query"
-                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "resolved_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The date range used for the query"
                 },
                 "results": {
                     "items": {
@@ -4380,13 +4380,13 @@
                     "format": "date-time",
                     "type": "string"
                 },
-                "query_date_range": {
-                    "$ref": "#/definitions/QueryDateRangeResponse",
-                    "description": "The date range used for the query"
-                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "resolved_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The date range used for the query"
                 },
                 "results": {},
                 "timezone": {
@@ -4447,13 +4447,13 @@
                     "format": "date-time",
                     "type": "string"
                 },
-                "query_date_range": {
-                    "$ref": "#/definitions/QueryDateRangeResponse",
-                    "description": "The date range used for the query"
-                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "resolved_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The date range used for the query"
                 },
                 "results": {
                     "items": {
@@ -4525,13 +4525,13 @@
                     "format": "date-time",
                     "type": "string"
                 },
-                "query_date_range": {
-                    "$ref": "#/definitions/QueryDateRangeResponse",
-                    "description": "The date range used for the query"
-                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "resolved_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The date range used for the query"
                 },
                 "results": {
                     "$ref": "#/definitions/RevenueAnalyticsRevenueQueryResult"
@@ -4600,13 +4600,13 @@
                     "format": "date-time",
                     "type": "string"
                 },
-                "query_date_range": {
-                    "$ref": "#/definitions/QueryDateRangeResponse",
-                    "description": "The date range used for the query"
-                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "resolved_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The date range used for the query"
                 },
                 "results": {},
                 "timezone": {
@@ -5247,13 +5247,13 @@
                     "format": "date-time",
                     "type": "string"
                 },
-                "query_date_range": {
-                    "$ref": "#/definitions/QueryDateRangeResponse",
-                    "description": "The date range used for the query"
-                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "resolved_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The date range used for the query"
                 },
                 "results": {
                     "items": {
@@ -7474,13 +7474,13 @@
                                     "$ref": "#/definitions/HogQLQueryModifiers",
                                     "description": "Modifiers used when performing the query"
                                 },
-                                "query_date_range": {
-                                    "$ref": "#/definitions/QueryDateRangeResponse",
-                                    "description": "The date range used for the query"
-                                },
                                 "query_status": {
                                     "$ref": "#/definitions/QueryStatus",
                                     "description": "Query status indicates whether next to the provided data, a query is still running."
+                                },
+                                "resolved_date_range": {
+                                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                                    "description": "The date range used for the query"
                                 },
                                 "results": {},
                                 "timings": {
@@ -7509,13 +7509,13 @@
                                     "$ref": "#/definitions/HogQLQueryModifiers",
                                     "description": "Modifiers used when performing the query"
                                 },
-                                "query_date_range": {
-                                    "$ref": "#/definitions/QueryDateRangeResponse",
-                                    "description": "The date range used for the query"
-                                },
                                 "query_status": {
                                     "$ref": "#/definitions/QueryStatus",
                                     "description": "Query status indicates whether next to the provided data, a query is still running."
+                                },
+                                "resolved_date_range": {
+                                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                                    "description": "The date range used for the query"
                                 },
                                 "results": {
                                     "items": {
@@ -7555,13 +7555,13 @@
                                     "$ref": "#/definitions/HogQLQueryModifiers",
                                     "description": "Modifiers used when performing the query"
                                 },
-                                "query_date_range": {
-                                    "$ref": "#/definitions/QueryDateRangeResponse",
-                                    "description": "The date range used for the query"
-                                },
                                 "query_status": {
                                     "$ref": "#/definitions/QueryStatus",
                                     "description": "Query status indicates whether next to the provided data, a query is still running."
+                                },
+                                "resolved_date_range": {
+                                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                                    "description": "The date range used for the query"
                                 },
                                 "results": {
                                     "$ref": "#/definitions/RevenueAnalyticsRevenueQueryResult"
@@ -7598,13 +7598,13 @@
                                     "$ref": "#/definitions/HogQLQueryModifiers",
                                     "description": "Modifiers used when performing the query"
                                 },
-                                "query_date_range": {
-                                    "$ref": "#/definitions/QueryDateRangeResponse",
-                                    "description": "The date range used for the query"
-                                },
                                 "query_status": {
                                     "$ref": "#/definitions/QueryStatus",
                                     "description": "Query status indicates whether next to the provided data, a query is still running."
+                                },
+                                "resolved_date_range": {
+                                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                                    "description": "The date range used for the query"
                                 },
                                 "results": {},
                                 "timings": {
@@ -11695,13 +11695,13 @@
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
                 },
-                "query_date_range": {
-                    "$ref": "#/definitions/QueryDateRangeResponse",
-                    "description": "The date range used for the query"
-                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "resolved_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The date range used for the query"
                 },
                 "results": {
                     "anyOf": [
@@ -13687,13 +13687,13 @@
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
                 },
-                "query_date_range": {
-                    "$ref": "#/definitions/QueryDateRangeResponse",
-                    "description": "The date range used for the query"
-                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "resolved_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The date range used for the query"
                 },
                 "results": {
                     "items": {
@@ -15043,23 +15043,6 @@
             ],
             "type": "string"
         },
-        "QueryDateRangeResponse": {
-            "additionalProperties": false,
-            "properties": {
-                "date_from": {
-                    "format": "date-time",
-                    "type": "string"
-                },
-                "date_to": {
-                    "format": "date-time",
-                    "type": "string"
-                },
-                "interval": {
-                    "$ref": "#/definitions/IntervalType"
-                }
-            },
-            "type": "object"
-        },
         "QueryIndexUsage": {
             "enum": ["undecisive", "no", "partial", "yes"],
             "type": "string"
@@ -16363,13 +16346,13 @@
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
                         },
-                        "query_date_range": {
-                            "$ref": "#/definitions/QueryDateRangeResponse",
-                            "description": "The date range used for the query"
-                        },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
                             "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "resolved_date_range": {
+                            "$ref": "#/definitions/ResolvedDateRangeResponse",
+                            "description": "The date range used for the query"
                         },
                         "results": {},
                         "timings": {
@@ -16398,13 +16381,13 @@
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
                         },
-                        "query_date_range": {
-                            "$ref": "#/definitions/QueryDateRangeResponse",
-                            "description": "The date range used for the query"
-                        },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
                             "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "resolved_date_range": {
+                            "$ref": "#/definitions/ResolvedDateRangeResponse",
+                            "description": "The date range used for the query"
                         },
                         "results": {
                             "items": {
@@ -16444,13 +16427,13 @@
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
                         },
-                        "query_date_range": {
-                            "$ref": "#/definitions/QueryDateRangeResponse",
-                            "description": "The date range used for the query"
-                        },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
                             "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "resolved_date_range": {
+                            "$ref": "#/definitions/ResolvedDateRangeResponse",
+                            "description": "The date range used for the query"
                         },
                         "results": {
                             "$ref": "#/definitions/RevenueAnalyticsRevenueQueryResult"
@@ -16487,13 +16470,13 @@
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
                         },
-                        "query_date_range": {
-                            "$ref": "#/definitions/QueryDateRangeResponse",
-                            "description": "The date range used for the query"
-                        },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
                             "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "resolved_date_range": {
+                            "$ref": "#/definitions/ResolvedDateRangeResponse",
+                            "description": "The date range used for the query"
                         },
                         "results": {},
                         "timings": {
@@ -17135,13 +17118,13 @@
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
                         },
-                        "query_date_range": {
-                            "$ref": "#/definitions/QueryDateRangeResponse",
-                            "description": "The date range used for the query"
-                        },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
                             "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "resolved_date_range": {
+                            "$ref": "#/definitions/ResolvedDateRangeResponse",
+                            "description": "The date range used for the query"
                         },
                         "results": {},
                         "timings": {
@@ -17170,13 +17153,13 @@
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
                         },
-                        "query_date_range": {
-                            "$ref": "#/definitions/QueryDateRangeResponse",
-                            "description": "The date range used for the query"
-                        },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
                             "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "resolved_date_range": {
+                            "$ref": "#/definitions/ResolvedDateRangeResponse",
+                            "description": "The date range used for the query"
                         },
                         "results": {
                             "items": {
@@ -17216,13 +17199,13 @@
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
                         },
-                        "query_date_range": {
-                            "$ref": "#/definitions/QueryDateRangeResponse",
-                            "description": "The date range used for the query"
-                        },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
                             "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "resolved_date_range": {
+                            "$ref": "#/definitions/ResolvedDateRangeResponse",
+                            "description": "The date range used for the query"
                         },
                         "results": {
                             "$ref": "#/definitions/RevenueAnalyticsRevenueQueryResult"
@@ -17259,13 +17242,13 @@
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
                         },
-                        "query_date_range": {
-                            "$ref": "#/definitions/QueryDateRangeResponse",
-                            "description": "The date range used for the query"
-                        },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
                             "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "resolved_date_range": {
+                            "$ref": "#/definitions/ResolvedDateRangeResponse",
+                            "description": "The date range used for the query"
                         },
                         "results": {},
                         "timings": {
@@ -17684,13 +17667,13 @@
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
                         },
-                        "query_date_range": {
-                            "$ref": "#/definitions/QueryDateRangeResponse",
-                            "description": "The date range used for the query"
-                        },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
                             "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "resolved_date_range": {
+                            "$ref": "#/definitions/ResolvedDateRangeResponse",
+                            "description": "The date range used for the query"
                         },
                         "results": {
                             "items": {
@@ -17764,13 +17747,13 @@
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
                         },
-                        "query_date_range": {
-                            "$ref": "#/definitions/QueryDateRangeResponse",
-                            "description": "The date range used for the query"
-                        },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
                             "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "resolved_date_range": {
+                            "$ref": "#/definitions/ResolvedDateRangeResponse",
+                            "description": "The date range used for the query"
                         },
                         "results": {
                             "anyOf": [
@@ -17922,13 +17905,13 @@
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
                         },
-                        "query_date_range": {
-                            "$ref": "#/definitions/QueryDateRangeResponse",
-                            "description": "The date range used for the query"
-                        },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
                             "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "resolved_date_range": {
+                            "$ref": "#/definitions/ResolvedDateRangeResponse",
+                            "description": "The date range used for the query"
                         },
                         "results": {
                             "items": {
@@ -18771,6 +18754,23 @@
             ],
             "type": "string"
         },
+        "ResolvedDateRangeResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "date_from": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "date_to": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "interval": {
+                    "$ref": "#/definitions/IntervalType"
+                }
+            },
+            "type": "object"
+        },
         "ResultCustomization": {
             "anyOf": [
                 {
@@ -19343,13 +19343,13 @@
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
                 },
-                "query_date_range": {
-                    "$ref": "#/definitions/QueryDateRangeResponse",
-                    "description": "The date range used for the query"
-                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "resolved_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The date range used for the query"
                 },
                 "results": {},
                 "timings": {
@@ -19426,13 +19426,13 @@
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
                 },
-                "query_date_range": {
-                    "$ref": "#/definitions/QueryDateRangeResponse",
-                    "description": "The date range used for the query"
-                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "resolved_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The date range used for the query"
                 },
                 "results": {
                     "items": {
@@ -19541,13 +19541,13 @@
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
                 },
-                "query_date_range": {
-                    "$ref": "#/definitions/QueryDateRangeResponse",
-                    "description": "The date range used for the query"
-                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "resolved_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The date range used for the query"
                 },
                 "results": {
                     "$ref": "#/definitions/RevenueAnalyticsRevenueQueryResult"
@@ -19637,13 +19637,13 @@
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
                 },
-                "query_date_range": {
-                    "$ref": "#/definitions/QueryDateRangeResponse",
-                    "description": "The date range used for the query"
-                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "resolved_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The date range used for the query"
                 },
                 "results": {},
                 "timings": {
@@ -21398,13 +21398,13 @@
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
                 },
-                "query_date_range": {
-                    "$ref": "#/definitions/QueryDateRangeResponse",
-                    "description": "The date range used for the query"
-                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "resolved_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The date range used for the query"
                 },
                 "results": {
                     "items": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1084,7 +1084,7 @@ export interface TrendsQueryResponse extends AnalyticsQueryResponseBase<Record<s
     /** Wether more breakdown values are available. */
     hasMore?: boolean
     /** The date range used for the query */
-    query_date_range?: QueryDateRangeResponse
+    resolved_date_range?: ResolvedDateRangeResponse
 }
 
 export type CachedTrendsQueryResponse = CachedQueryResponse<TrendsQueryResponse>
@@ -1237,7 +1237,7 @@ export interface FunnelsQueryResponse
     > {
     isUdf?: boolean
     /** The date range used for the query */
-    query_date_range?: QueryDateRangeResponse
+    resolved_date_range?: ResolvedDateRangeResponse
 }
 
 export type CachedFunnelsQueryResponse = CachedQueryResponse<FunnelsQueryResponse>
@@ -1580,7 +1580,7 @@ export type QueryStatus = {
 
 export interface LifecycleQueryResponse extends AnalyticsQueryResponseBase<Record<string, any>[]> {
     /** The date range used for the query */
-    query_date_range?: QueryDateRangeResponse
+    resolved_date_range?: ResolvedDateRangeResponse
 }
 
 export type CachedLifecycleQueryResponse = CachedQueryResponse<LifecycleQueryResponse>
@@ -1954,7 +1954,7 @@ export interface RevenueAnalyticsRevenueQueryResponse
     extends AnalyticsQueryResponseBase<RevenueAnalyticsRevenueQueryResult> {
     columns?: string[]
     /** The date range used for the query */
-    query_date_range?: QueryDateRangeResponse
+    resolved_date_range?: ResolvedDateRangeResponse
 }
 export type CachedRevenueAnalyticsRevenueQueryResponse = CachedQueryResponse<RevenueAnalyticsRevenueQueryResponse>
 
@@ -1972,7 +1972,7 @@ export interface RevenueAnalyticsOverviewItem {
 export interface RevenueAnalyticsOverviewQueryResponse
     extends AnalyticsQueryResponseBase<RevenueAnalyticsOverviewItem[]> {
     /** The date range used for the query */
-    query_date_range?: QueryDateRangeResponse
+    resolved_date_range?: ResolvedDateRangeResponse
 }
 export type CachedRevenueAnalyticsOverviewQueryResponse = CachedQueryResponse<RevenueAnalyticsOverviewQueryResponse>
 
@@ -1984,7 +1984,7 @@ export interface RevenueAnalyticsGrowthRateQuery
 export interface RevenueAnalyticsGrowthRateQueryResponse extends AnalyticsQueryResponseBase<unknown> {
     columns?: string[]
     /** The date range used for the query */
-    query_date_range?: QueryDateRangeResponse
+    resolved_date_range?: ResolvedDateRangeResponse
 }
 export type CachedRevenueAnalyticsGrowthRateQueryResponse = CachedQueryResponse<RevenueAnalyticsGrowthRateQueryResponse>
 
@@ -1998,7 +1998,7 @@ export interface RevenueAnalyticsTopCustomersQuery
 export interface RevenueAnalyticsTopCustomersQueryResponse extends AnalyticsQueryResponseBase<unknown> {
     columns?: string[]
     /** The date range used for the query */
-    query_date_range?: QueryDateRangeResponse
+    resolved_date_range?: ResolvedDateRangeResponse
 }
 export type CachedRevenueAnalyticsTopCustomersQueryResponse =
     CachedQueryResponse<RevenueAnalyticsTopCustomersQueryResponse>
@@ -2726,7 +2726,7 @@ export interface DateRange {
     explicitDate?: boolean | null
 }
 
-export interface QueryDateRangeResponse {
+export interface ResolvedDateRangeResponse {
     /**  @format date-time */
     date_from?: string
     /**  @format date-time */

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2731,7 +2731,6 @@ export interface ResolvedDateRangeResponse {
     date_from?: string
     /**  @format date-time */
     date_to?: string
-    interval?: IntervalType
 }
 
 export type MultipleBreakdownType = Extract<

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1083,6 +1083,8 @@ export const TRENDS_FILTER_PROPERTIES = new Set<keyof TrendsFilter>([
 export interface TrendsQueryResponse extends AnalyticsQueryResponseBase<Record<string, any>[]> {
     /** Wether more breakdown values are available. */
     hasMore?: boolean
+    /** The date range used for the query */
+    query_date_range?: QueryDateRangeResponse
 }
 
 export type CachedTrendsQueryResponse = CachedQueryResponse<TrendsQueryResponse>
@@ -1234,6 +1236,8 @@ export interface FunnelsQueryResponse
         FunnelStepsResults | FunnelStepsBreakdownResults | FunnelTimeToConvertResults | FunnelTrendsResults
     > {
     isUdf?: boolean
+    /** The date range used for the query */
+    query_date_range?: QueryDateRangeResponse
 }
 
 export type CachedFunnelsQueryResponse = CachedQueryResponse<FunnelsQueryResponse>
@@ -1574,7 +1578,10 @@ export type QueryStatus = {
     labels?: string[]
 }
 
-export interface LifecycleQueryResponse extends AnalyticsQueryResponseBase<Record<string, any>[]> {}
+export interface LifecycleQueryResponse extends AnalyticsQueryResponseBase<Record<string, any>[]> {
+    /** The date range used for the query */
+    query_date_range?: QueryDateRangeResponse
+}
 
 export type CachedLifecycleQueryResponse = CachedQueryResponse<LifecycleQueryResponse>
 
@@ -1946,6 +1953,8 @@ export interface RevenueAnalyticsRevenueQueryResult {
 export interface RevenueAnalyticsRevenueQueryResponse
     extends AnalyticsQueryResponseBase<RevenueAnalyticsRevenueQueryResult> {
     columns?: string[]
+    /** The date range used for the query */
+    query_date_range?: QueryDateRangeResponse
 }
 export type CachedRevenueAnalyticsRevenueQueryResponse = CachedQueryResponse<RevenueAnalyticsRevenueQueryResponse>
 
@@ -1961,7 +1970,10 @@ export interface RevenueAnalyticsOverviewItem {
 }
 
 export interface RevenueAnalyticsOverviewQueryResponse
-    extends AnalyticsQueryResponseBase<RevenueAnalyticsOverviewItem[]> {}
+    extends AnalyticsQueryResponseBase<RevenueAnalyticsOverviewItem[]> {
+    /** The date range used for the query */
+    query_date_range?: QueryDateRangeResponse
+}
 export type CachedRevenueAnalyticsOverviewQueryResponse = CachedQueryResponse<RevenueAnalyticsOverviewQueryResponse>
 
 export interface RevenueAnalyticsGrowthRateQuery
@@ -1971,6 +1983,8 @@ export interface RevenueAnalyticsGrowthRateQuery
 
 export interface RevenueAnalyticsGrowthRateQueryResponse extends AnalyticsQueryResponseBase<unknown> {
     columns?: string[]
+    /** The date range used for the query */
+    query_date_range?: QueryDateRangeResponse
 }
 export type CachedRevenueAnalyticsGrowthRateQueryResponse = CachedQueryResponse<RevenueAnalyticsGrowthRateQueryResponse>
 
@@ -1983,6 +1997,8 @@ export interface RevenueAnalyticsTopCustomersQuery
 
 export interface RevenueAnalyticsTopCustomersQueryResponse extends AnalyticsQueryResponseBase<unknown> {
     columns?: string[]
+    /** The date range used for the query */
+    query_date_range?: QueryDateRangeResponse
 }
 export type CachedRevenueAnalyticsTopCustomersQueryResponse =
     CachedQueryResponse<RevenueAnalyticsTopCustomersQueryResponse>
@@ -2708,6 +2724,14 @@ export interface DateRange {
      * @default false
      * */
     explicitDate?: boolean | null
+}
+
+export interface QueryDateRangeResponse {
+    /**  @format date-time */
+    date_from?: string
+    /**  @format date-time */
+    date_to?: string
+    interval?: IntervalType
 }
 
 export type MultipleBreakdownType = Extract<

--- a/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
@@ -30,6 +30,7 @@ from posthog.schema import (
     FunnelsQuery,
     FunnelsQueryResponse,
     HogQLQueryModifiers,
+    QueryDateRangeResponse,
 )
 
 
@@ -105,7 +106,16 @@ class FunnelsQueryRunner(QueryRunner):
             timings.extend(response.timings)
 
         return FunnelsQueryResponse(
-            isUdf=self._use_udf, results=results, timings=timings, hogql=hogql, modifiers=self.modifiers
+            isUdf=self._use_udf,
+            results=results,
+            timings=timings,
+            hogql=hogql,
+            modifiers=self.modifiers,
+            query_date_range=QueryDateRangeResponse(
+                date_from=self.query_date_range.date_from(),
+                date_to=self.query_date_range.date_to(),
+                interval=self.query_date_range.interval_type,
+            ),
         )
 
     @cached_property

--- a/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
@@ -30,7 +30,7 @@ from posthog.schema import (
     FunnelsQuery,
     FunnelsQueryResponse,
     HogQLQueryModifiers,
-    QueryDateRangeResponse,
+    ResolvedDateRangeResponse,
 )
 
 
@@ -111,7 +111,7 @@ class FunnelsQueryRunner(QueryRunner):
             timings=timings,
             hogql=hogql,
             modifiers=self.modifiers,
-            query_date_range=QueryDateRangeResponse(
+            resolved_date_range=ResolvedDateRangeResponse(
                 date_from=self.query_date_range.date_from(),
                 date_to=self.query_date_range.date_to(),
                 interval=self.query_date_range.interval_type,

--- a/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
@@ -114,7 +114,6 @@ class FunnelsQueryRunner(QueryRunner):
             resolved_date_range=ResolvedDateRangeResponse(
                 date_from=self.query_date_range.date_from(),
                 date_to=self.query_date_range.date_to(),
-                interval=self.query_date_range.interval_type,
             ),
         )
 

--- a/posthog/hogql_queries/insights/lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle_query_runner.py
@@ -26,7 +26,7 @@ from posthog.schema import (
     IntervalType,
     StatusItem,
     DayItem,
-    QueryDateRangeResponse,
+    ResolvedDateRangeResponse,
 )
 from posthog.utils import format_label_date
 
@@ -209,7 +209,7 @@ class LifecycleQueryRunner(QueryRunner):
             timings=response.timings,
             hogql=hogql,
             modifiers=self.modifiers,
-            query_date_range=QueryDateRangeResponse(
+            resolved_date_range=ResolvedDateRangeResponse(
                 date_from=self.query_date_range.date_from(),
                 date_to=self.query_date_range.date_to(),
                 interval=self.query_date_range.interval_type,

--- a/posthog/hogql_queries/insights/lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle_query_runner.py
@@ -26,6 +26,7 @@ from posthog.schema import (
     IntervalType,
     StatusItem,
     DayItem,
+    QueryDateRangeResponse,
 )
 from posthog.utils import format_label_date
 
@@ -203,7 +204,17 @@ class LifecycleQueryRunner(QueryRunner):
                 }
             )
 
-        return LifecycleQueryResponse(results=res, timings=response.timings, hogql=hogql, modifiers=self.modifiers)
+        return LifecycleQueryResponse(
+            results=res,
+            timings=response.timings,
+            hogql=hogql,
+            modifiers=self.modifiers,
+            query_date_range=QueryDateRangeResponse(
+                date_from=self.query_date_range.date_from(),
+                date_to=self.query_date_range.date_to(),
+                interval=self.query_date_range.interval_type,
+            ),
+        )
 
     @cached_property
     def query_date_range(self):

--- a/posthog/hogql_queries/insights/lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle_query_runner.py
@@ -212,7 +212,6 @@ class LifecycleQueryRunner(QueryRunner):
             resolved_date_range=ResolvedDateRangeResponse(
                 date_from=self.query_date_range.date_from(),
                 date_to=self.query_date_range.date_to(),
-                interval=self.query_date_range.interval_type,
             ),
         )
 

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -72,6 +72,7 @@ from posthog.schema import (
     TrendsQuery,
     TrendsQueryResponse,
     TrendsFormulaNode,
+    QueryDateRangeResponse,
 )
 from posthog.utils import format_label_date, multisort
 from posthog.warehouse.models.util import get_view_or_table_by_name
@@ -486,6 +487,11 @@ class TrendsQueryRunner(QueryRunner):
             hogql=response_hogql,
             modifiers=self.modifiers,
             error=". ".join(debug_errors),
+            query_date_range=QueryDateRangeResponse(
+                date_from=self.query_date_range.date_from(),
+                date_to=self.query_date_range.date_to(),
+                interval=self.query_date_range.interval_type,
+            ),
         )
 
     def build_series_response(self, response: HogQLQueryResponse, series: SeriesWithExtras, series_count: int):

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -72,7 +72,7 @@ from posthog.schema import (
     TrendsQuery,
     TrendsQueryResponse,
     TrendsFormulaNode,
-    QueryDateRangeResponse,
+    ResolvedDateRangeResponse,
 )
 from posthog.utils import format_label_date, multisort
 from posthog.warehouse.models.util import get_view_or_table_by_name
@@ -487,7 +487,7 @@ class TrendsQueryRunner(QueryRunner):
             hogql=response_hogql,
             modifiers=self.modifiers,
             error=". ".join(debug_errors),
-            query_date_range=QueryDateRangeResponse(
+            resolved_date_range=ResolvedDateRangeResponse(
                 date_from=self.query_date_range.date_from(),
                 date_to=self.query_date_range.date_to(),
                 interval=self.query_date_range.interval_type,

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -490,7 +490,6 @@ class TrendsQueryRunner(QueryRunner):
             resolved_date_range=ResolvedDateRangeResponse(
                 date_from=self.query_date_range.date_from(),
                 date_to=self.query_date_range.date_to(),
-                interval=self.query_date_range.interval_type,
             ),
         )
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1738,15 +1738,6 @@ class PropertyOperator(StrEnum):
     IS_CLEANED_PATH_EXACT = "is_cleaned_path_exact"
 
 
-class QueryDateRangeResponse(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    date_from: Optional[datetime] = None
-    date_to: Optional[datetime] = None
-    interval: Optional[IntervalType] = None
-
-
 class QueryIndexUsage(StrEnum):
     UNDECISIVE = "undecisive"
     NO = "no"
@@ -1862,6 +1853,15 @@ class RefreshType(StrEnum):
     FORCE_BLOCKING = "force_blocking"
     FORCE_CACHE = "force_cache"
     LAZY_ASYNC = "lazy_async"
+
+
+class ResolvedDateRangeResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    date_from: Optional[datetime] = None
+    date_to: Optional[datetime] = None
+    interval: Optional[IntervalType] = None
 
 
 class ResultCustomizationBase(BaseModel):
@@ -3525,11 +3525,11 @@ class RevenueAnalyticsGrowthRateQueryResponse(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: Any
     timings: Optional[list[QueryTiming]] = Field(
@@ -3557,11 +3557,11 @@ class RevenueAnalyticsOverviewQueryResponse(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: list[RevenueAnalyticsOverviewItem]
     timings: Optional[list[QueryTiming]] = Field(
@@ -3582,11 +3582,11 @@ class RevenueAnalyticsRevenueQueryResponse(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: RevenueAnalyticsRevenueQueryResult
     timings: Optional[list[QueryTiming]] = Field(
@@ -3607,11 +3607,11 @@ class RevenueAnalyticsTopCustomersQueryResponse(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: Any
     timings: Optional[list[QueryTiming]] = Field(
@@ -4032,11 +4032,11 @@ class TrendsQueryResponse(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: list[dict[str, Any]]
     timings: Optional[list[QueryTiming]] = Field(
@@ -5007,11 +5007,11 @@ class CachedFunnelsQueryResponse(BaseModel):
         default=None, description="Modifiers used when performing the query"
     )
     next_allowed_client_refresh: datetime
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: Union[FunnelTimeToConvertResults, list[dict[str, Any]], list[list[dict[str, Any]]]]
     timezone: str
@@ -5076,11 +5076,11 @@ class CachedLifecycleQueryResponse(BaseModel):
         default=None, description="Modifiers used when performing the query"
     )
     next_allowed_client_refresh: datetime
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: list[dict[str, Any]]
     timezone: str
@@ -5230,11 +5230,11 @@ class CachedRevenueAnalyticsGrowthRateQueryResponse(BaseModel):
         default=None, description="Modifiers used when performing the query"
     )
     next_allowed_client_refresh: datetime
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: Any
     timezone: str
@@ -5263,11 +5263,11 @@ class CachedRevenueAnalyticsOverviewQueryResponse(BaseModel):
         default=None, description="Modifiers used when performing the query"
     )
     next_allowed_client_refresh: datetime
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: list[RevenueAnalyticsOverviewItem]
     timezone: str
@@ -5297,11 +5297,11 @@ class CachedRevenueAnalyticsRevenueQueryResponse(BaseModel):
         default=None, description="Modifiers used when performing the query"
     )
     next_allowed_client_refresh: datetime
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: RevenueAnalyticsRevenueQueryResult
     timezone: str
@@ -5331,11 +5331,11 @@ class CachedRevenueAnalyticsTopCustomersQueryResponse(BaseModel):
         default=None, description="Modifiers used when performing the query"
     )
     next_allowed_client_refresh: datetime
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: Any
     timezone: str
@@ -5614,11 +5614,11 @@ class CachedTrendsQueryResponse(BaseModel):
         default=None, description="Modifiers used when performing the query"
     )
     next_allowed_client_refresh: datetime
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: list[dict[str, Any]]
     timezone: str
@@ -6389,11 +6389,11 @@ class Response10(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: Any
     timings: Optional[list[QueryTiming]] = Field(
@@ -6413,11 +6413,11 @@ class Response11(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: list[RevenueAnalyticsOverviewItem]
     timings: Optional[list[QueryTiming]] = Field(
@@ -6438,11 +6438,11 @@ class Response12(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: RevenueAnalyticsRevenueQueryResult
     timings: Optional[list[QueryTiming]] = Field(
@@ -6463,11 +6463,11 @@ class Response13(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: Any
     timings: Optional[list[QueryTiming]] = Field(
@@ -7263,11 +7263,11 @@ class FunnelsQueryResponse(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: Union[FunnelTimeToConvertResults, list[dict[str, Any]], list[list[dict[str, Any]]]]
     timings: Optional[list[QueryTiming]] = Field(
@@ -7421,11 +7421,11 @@ class LifecycleQueryResponse(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: list[dict[str, Any]]
     timings: Optional[list[QueryTiming]] = Field(
@@ -7952,11 +7952,11 @@ class QueryResponseAlternative25(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: Any
     timings: Optional[list[QueryTiming]] = Field(
@@ -7976,11 +7976,11 @@ class QueryResponseAlternative26(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: list[RevenueAnalyticsOverviewItem]
     timings: Optional[list[QueryTiming]] = Field(
@@ -8001,11 +8001,11 @@ class QueryResponseAlternative27(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: RevenueAnalyticsRevenueQueryResult
     timings: Optional[list[QueryTiming]] = Field(
@@ -8026,11 +8026,11 @@ class QueryResponseAlternative28(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: Any
     timings: Optional[list[QueryTiming]] = Field(
@@ -8315,11 +8315,11 @@ class QueryResponseAlternative40(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: Any
     timings: Optional[list[QueryTiming]] = Field(
@@ -8339,11 +8339,11 @@ class QueryResponseAlternative41(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: list[RevenueAnalyticsOverviewItem]
     timings: Optional[list[QueryTiming]] = Field(
@@ -8364,11 +8364,11 @@ class QueryResponseAlternative42(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: RevenueAnalyticsRevenueQueryResult
     timings: Optional[list[QueryTiming]] = Field(
@@ -8389,11 +8389,11 @@ class QueryResponseAlternative43(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: Any
     timings: Optional[list[QueryTiming]] = Field(
@@ -8517,11 +8517,11 @@ class QueryResponseAlternative51(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: list[dict[str, Any]]
     timings: Optional[list[QueryTiming]] = Field(
@@ -8564,11 +8564,11 @@ class QueryResponseAlternative53(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: Union[FunnelTimeToConvertResults, list[dict[str, Any]], list[list[dict[str, Any]]]]
     timings: Optional[list[QueryTiming]] = Field(
@@ -8630,11 +8630,11 @@ class QueryResponseAlternative57(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    query_date_range: Optional[QueryDateRangeResponse] = Field(
-        default=None, description="The date range used for the query"
-    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     results: list[dict[str, Any]]
     timings: Optional[list[QueryTiming]] = Field(

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1861,7 +1861,6 @@ class ResolvedDateRangeResponse(BaseModel):
     )
     date_from: Optional[datetime] = None
     date_to: Optional[datetime] = None
-    interval: Optional[IntervalType] = None
 
 
 class ResultCustomizationBase(BaseModel):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1738,6 +1738,15 @@ class PropertyOperator(StrEnum):
     IS_CLEANED_PATH_EXACT = "is_cleaned_path_exact"
 
 
+class QueryDateRangeResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    date_from: Optional[datetime] = None
+    date_to: Optional[datetime] = None
+    interval: Optional[IntervalType] = None
+
+
 class QueryIndexUsage(StrEnum):
     UNDECISIVE = "undecisive"
     NO = "no"
@@ -3516,6 +3525,9 @@ class RevenueAnalyticsGrowthRateQueryResponse(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
+    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
@@ -3545,6 +3557,9 @@ class RevenueAnalyticsOverviewQueryResponse(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
+    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
@@ -3567,6 +3582,9 @@ class RevenueAnalyticsRevenueQueryResponse(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
+    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
@@ -3588,6 +3606,9 @@ class RevenueAnalyticsTopCustomersQueryResponse(BaseModel):
     hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
+    )
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -4010,6 +4031,9 @@ class TrendsQueryResponse(BaseModel):
     hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
+    )
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -4983,6 +5007,9 @@ class CachedFunnelsQueryResponse(BaseModel):
         default=None, description="Modifiers used when performing the query"
     )
     next_allowed_client_refresh: datetime
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
+    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
@@ -5049,6 +5076,9 @@ class CachedLifecycleQueryResponse(BaseModel):
         default=None, description="Modifiers used when performing the query"
     )
     next_allowed_client_refresh: datetime
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
+    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
@@ -5200,6 +5230,9 @@ class CachedRevenueAnalyticsGrowthRateQueryResponse(BaseModel):
         default=None, description="Modifiers used when performing the query"
     )
     next_allowed_client_refresh: datetime
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
+    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
@@ -5230,6 +5263,9 @@ class CachedRevenueAnalyticsOverviewQueryResponse(BaseModel):
         default=None, description="Modifiers used when performing the query"
     )
     next_allowed_client_refresh: datetime
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
+    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
@@ -5261,6 +5297,9 @@ class CachedRevenueAnalyticsRevenueQueryResponse(BaseModel):
         default=None, description="Modifiers used when performing the query"
     )
     next_allowed_client_refresh: datetime
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
+    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
@@ -5292,6 +5331,9 @@ class CachedRevenueAnalyticsTopCustomersQueryResponse(BaseModel):
         default=None, description="Modifiers used when performing the query"
     )
     next_allowed_client_refresh: datetime
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
+    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
@@ -5572,6 +5614,9 @@ class CachedTrendsQueryResponse(BaseModel):
         default=None, description="Modifiers used when performing the query"
     )
     next_allowed_client_refresh: datetime
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
+    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
@@ -6344,6 +6389,9 @@ class Response10(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
+    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
@@ -6364,6 +6412,9 @@ class Response11(BaseModel):
     hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
+    )
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -6387,6 +6438,9 @@ class Response12(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
+    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
@@ -6408,6 +6462,9 @@ class Response13(BaseModel):
     hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
+    )
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7206,6 +7263,9 @@ class FunnelsQueryResponse(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
+    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
@@ -7360,6 +7420,9 @@ class LifecycleQueryResponse(BaseModel):
     hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
+    )
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7889,6 +7952,9 @@ class QueryResponseAlternative25(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
+    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
@@ -7909,6 +7975,9 @@ class QueryResponseAlternative26(BaseModel):
     hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
+    )
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7932,6 +8001,9 @@ class QueryResponseAlternative27(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
+    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
@@ -7953,6 +8025,9 @@ class QueryResponseAlternative28(BaseModel):
     hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
+    )
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -8240,6 +8315,9 @@ class QueryResponseAlternative40(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
+    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
@@ -8260,6 +8338,9 @@ class QueryResponseAlternative41(BaseModel):
     hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
+    )
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -8283,6 +8364,9 @@ class QueryResponseAlternative42(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
+    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
@@ -8304,6 +8388,9 @@ class QueryResponseAlternative43(BaseModel):
     hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
+    )
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -8430,6 +8517,9 @@ class QueryResponseAlternative51(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
+    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
@@ -8474,6 +8564,9 @@ class QueryResponseAlternative53(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
+    )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
@@ -8515,6 +8608,30 @@ class QueryResponseAlternative56(BaseModel):
     hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
+    )
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    results: list[dict[str, Any]]
+    timings: Optional[list[QueryTiming]] = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+
+
+class QueryResponseAlternative57(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    error: Optional[str] = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    query_date_range: Optional[QueryDateRangeResponse] = Field(
+        default=None, description="The date range used for the query"
     )
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -11278,6 +11395,7 @@ class QueryResponseAlternative(
             QueryResponseAlternative54,
             QueryResponseAlternative55,
             QueryResponseAlternative56,
+            QueryResponseAlternative57,
             QueryResponseAlternative58,
             QueryResponseAlternative59,
             QueryResponseAlternative60,
@@ -11344,6 +11462,7 @@ class QueryResponseAlternative(
         QueryResponseAlternative54,
         QueryResponseAlternative55,
         QueryResponseAlternative56,
+        QueryResponseAlternative57,
         QueryResponseAlternative58,
         QueryResponseAlternative59,
         QueryResponseAlternative60,

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_growth_rate_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_growth_rate_query_runner.py
@@ -7,6 +7,7 @@ from posthog.schema import (
     CachedRevenueAnalyticsGrowthRateQueryResponse,
     RevenueAnalyticsGrowthRateQueryResponse,
     RevenueAnalyticsGrowthRateQuery,
+    QueryDateRangeResponse,
 )
 
 from .revenue_analytics_query_runner import RevenueAnalyticsQueryRunner
@@ -156,4 +157,9 @@ class RevenueAnalyticsGrowthRateQueryRunner(RevenueAnalyticsQueryRunner):
                 "six_month_growth_rate",
             ],
             modifiers=self.modifiers,
+            query_date_range=QueryDateRangeResponse(
+                date_from=self.query_date_range.date_from(),
+                date_to=self.query_date_range.date_to(),
+                interval=self.query_date_range.interval_type,
+            ),
         )

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_growth_rate_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_growth_rate_query_runner.py
@@ -7,7 +7,7 @@ from posthog.schema import (
     CachedRevenueAnalyticsGrowthRateQueryResponse,
     RevenueAnalyticsGrowthRateQueryResponse,
     RevenueAnalyticsGrowthRateQuery,
-    QueryDateRangeResponse,
+    ResolvedDateRangeResponse,
 )
 
 from .revenue_analytics_query_runner import RevenueAnalyticsQueryRunner
@@ -157,7 +157,7 @@ class RevenueAnalyticsGrowthRateQueryRunner(RevenueAnalyticsQueryRunner):
                 "six_month_growth_rate",
             ],
             modifiers=self.modifiers,
-            query_date_range=QueryDateRangeResponse(
+            resolved_date_range=ResolvedDateRangeResponse(
                 date_from=self.query_date_range.date_from(),
                 date_to=self.query_date_range.date_to(),
                 interval=self.query_date_range.interval_type,

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_growth_rate_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_growth_rate_query_runner.py
@@ -160,6 +160,5 @@ class RevenueAnalyticsGrowthRateQueryRunner(RevenueAnalyticsQueryRunner):
             resolved_date_range=ResolvedDateRangeResponse(
                 date_from=self.query_date_range.date_from(),
                 date_to=self.query_date_range.date_to(),
-                interval=self.query_date_range.interval_type,
             ),
         )

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_overview_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_overview_query_runner.py
@@ -6,6 +6,7 @@ from posthog.schema import (
     CachedRevenueAnalyticsOverviewQueryResponse,
     RevenueAnalyticsOverviewQueryResponse,
     RevenueAnalyticsOverviewQuery,
+    QueryDateRangeResponse,
 )
 
 from .revenue_analytics_query_runner import RevenueAnalyticsQueryRunner
@@ -113,6 +114,11 @@ class RevenueAnalyticsOverviewQueryRunner(RevenueAnalyticsQueryRunner):
         return RevenueAnalyticsOverviewQueryResponse(
             results=results,
             modifiers=self.modifiers,
+            query_date_range=QueryDateRangeResponse(
+                date_from=self.query_date_range.date_from(),
+                date_to=self.query_date_range.date_to(),
+                interval=self.query_date_range.interval_type,
+            ),
         )
 
 

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_overview_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_overview_query_runner.py
@@ -117,7 +117,6 @@ class RevenueAnalyticsOverviewQueryRunner(RevenueAnalyticsQueryRunner):
             resolved_date_range=ResolvedDateRangeResponse(
                 date_from=self.query_date_range.date_from(),
                 date_to=self.query_date_range.date_to(),
-                interval=self.query_date_range.interval_type,
             ),
         )
 

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_overview_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_overview_query_runner.py
@@ -6,7 +6,7 @@ from posthog.schema import (
     CachedRevenueAnalyticsOverviewQueryResponse,
     RevenueAnalyticsOverviewQueryResponse,
     RevenueAnalyticsOverviewQuery,
-    QueryDateRangeResponse,
+    ResolvedDateRangeResponse,
 )
 
 from .revenue_analytics_query_runner import RevenueAnalyticsQueryRunner
@@ -114,7 +114,7 @@ class RevenueAnalyticsOverviewQueryRunner(RevenueAnalyticsQueryRunner):
         return RevenueAnalyticsOverviewQueryResponse(
             results=results,
             modifiers=self.modifiers,
-            query_date_range=QueryDateRangeResponse(
+            resolved_date_range=ResolvedDateRangeResponse(
                 date_from=self.query_date_range.date_from(),
                 date_to=self.query_date_range.date_to(),
                 interval=self.query_date_range.interval_type,

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_revenue_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_revenue_query_runner.py
@@ -10,7 +10,7 @@ from posthog.schema import (
     RevenueAnalyticsRevenueQuery,
     RevenueAnalyticsGroupBy,
     RevenueAnalyticsRevenueQueryResult,
-    QueryDateRangeResponse,
+    ResolvedDateRangeResponse,
 )
 from posthog.utils import format_label_date
 
@@ -312,7 +312,7 @@ class RevenueAnalyticsRevenueQueryRunner(RevenueAnalyticsQueryRunner):
             results=results,
             hogql=response.hogql,
             modifiers=self.modifiers,
-            query_date_range=QueryDateRangeResponse(
+            resolved_date_range=ResolvedDateRangeResponse(
                 date_from=self.query_date_range.date_from(),
                 date_to=self.query_date_range.date_to(),
                 interval=self.query_date_range.interval_type,

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_revenue_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_revenue_query_runner.py
@@ -10,6 +10,7 @@ from posthog.schema import (
     RevenueAnalyticsRevenueQuery,
     RevenueAnalyticsGroupBy,
     RevenueAnalyticsRevenueQueryResult,
+    QueryDateRangeResponse,
 )
 from posthog.utils import format_label_date
 
@@ -311,4 +312,9 @@ class RevenueAnalyticsRevenueQueryRunner(RevenueAnalyticsQueryRunner):
             results=results,
             hogql=response.hogql,
             modifiers=self.modifiers,
+            query_date_range=QueryDateRangeResponse(
+                date_from=self.query_date_range.date_from(),
+                date_to=self.query_date_range.date_to(),
+                interval=self.query_date_range.interval_type,
+            ),
         )

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_revenue_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_revenue_query_runner.py
@@ -315,6 +315,5 @@ class RevenueAnalyticsRevenueQueryRunner(RevenueAnalyticsQueryRunner):
             resolved_date_range=ResolvedDateRangeResponse(
                 date_from=self.query_date_range.date_from(),
                 date_to=self.query_date_range.date_to(),
-                interval=self.query_date_range.interval_type,
             ),
         )

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_top_customers_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_top_customers_query_runner.py
@@ -6,7 +6,7 @@ from posthog.schema import (
     CachedRevenueAnalyticsTopCustomersQueryResponse,
     RevenueAnalyticsTopCustomersQueryResponse,
     RevenueAnalyticsTopCustomersQuery,
-    QueryDateRangeResponse,
+    ResolvedDateRangeResponse,
 )
 
 from .revenue_analytics_query_runner import RevenueAnalyticsQueryRunner
@@ -139,7 +139,7 @@ class RevenueAnalyticsTopCustomersQueryRunner(RevenueAnalyticsQueryRunner):
             results=response.results,
             columns=["name", "customer_id", "amount", "month"],
             modifiers=self.modifiers,
-            query_date_range=QueryDateRangeResponse(
+            resolved_date_range=ResolvedDateRangeResponse(
                 date_from=self.query_date_range.date_from(),
                 date_to=self.query_date_range.date_to(),
                 interval=self.query_date_range.interval_type,

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_top_customers_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_top_customers_query_runner.py
@@ -142,6 +142,5 @@ class RevenueAnalyticsTopCustomersQueryRunner(RevenueAnalyticsQueryRunner):
             resolved_date_range=ResolvedDateRangeResponse(
                 date_from=self.query_date_range.date_from(),
                 date_to=self.query_date_range.date_to(),
-                interval=self.query_date_range.interval_type,
             ),
         )

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_top_customers_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_top_customers_query_runner.py
@@ -6,6 +6,7 @@ from posthog.schema import (
     CachedRevenueAnalyticsTopCustomersQueryResponse,
     RevenueAnalyticsTopCustomersQueryResponse,
     RevenueAnalyticsTopCustomersQuery,
+    QueryDateRangeResponse,
 )
 
 from .revenue_analytics_query_runner import RevenueAnalyticsQueryRunner
@@ -138,4 +139,9 @@ class RevenueAnalyticsTopCustomersQueryRunner(RevenueAnalyticsQueryRunner):
             results=response.results,
             columns=["name", "customer_id", "amount", "month"],
             modifiers=self.modifiers,
+            query_date_range=QueryDateRangeResponse(
+                date_from=self.query_date_range.date_from(),
+                date_to=self.query_date_range.date_to(),
+                interval=self.query_date_range.interval_type,
+            ),
         )


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

This PR is split from and part of https://github.com/PostHog/posthog/pull/34366

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Adds the `query_date_range` to the response returned by:

- Product Analytics (Trends, Funnels, Lifecycle)
- Revenue Analytics

This will be used to format the tooltips/labels for data grouped by week on charts.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

Refresh an insight and Inspect the response of the API request sent to `/api/environments/1/query/` to make sure it includes the query_date_range with the following properties:

```json
{
	"query_date_range": {
		"date_from": "2025-06-11T00:00:00Z",
		"date_to": "2025-06-18T23:59:59.999999Z",
		"interval": "week"
	}
}
```

If you select "All time" or a relative date range like "Last 90 days", the date range returned in response must include the absolute date range.