### PR TITLE
fix(plugin-server): Gracefully shutdown logger transport thread

### DIFF
--- a/plugin-server/jest.setup.js
+++ b/plugin-server/jest.setup.js
@@ -4,7 +4,7 @@ const { join } = require('path')
 
 import fetch from 'node-fetch'
 
-import { logger } from './src/utils/logger'
+import { logger, shutdownLogger } from './src/utils/logger'
 
 // Setup spies on the logger for all tests to use
 
@@ -98,4 +98,9 @@ beforeAll(() => {
     jest.spyOn(process, 'exit').mockImplementation((number) => {
         throw new Error('process.exit: ' + number)
     })
+})
+
+afterAll(async () => {
+    // Shutdown logger to prevent Jest from hanging on open handles
+    await shutdownLogger()
 })

--- a/plugin-server/src/utils/logger.ts
+++ b/plugin-server/src/utils/logger.ts
@@ -7,6 +7,7 @@ import { isProdEnv } from './env-utils'
 export class Logger {
     private pino: ReturnType<typeof pino>
     private prefix: string
+    private transport?: ReturnType<typeof pino.transport>
 
     constructor(name: string) {
         this.prefix = `[${name.toUpperCase()}]`
@@ -33,14 +34,14 @@ export class Logger {
             //
             // NOTE: we keep a reference to the transport such that we can call
             // end on it, otherwise Jest will hang on open handles.
-            const transport = pino.transport({
+            this.transport = pino.transport({
                 target: 'pino-pretty',
                 options: {
                     sync: true,
                     level: logLevel,
                 },
             })
-            this.pino = pino({ level: logLevel }, transport)
+            this.pino = pino({ level: logLevel }, this.transport)
         }
     }
 
@@ -78,6 +79,16 @@ export class Logger {
     error(...args: any[]) {
         this._log(LogLevel.Error, ...args)
     }
+
+    async shutdown(): Promise<void> {
+        if (this.transport) {
+            await this.transport.end()
+        }
+    }
 }
 
 export const logger = new Logger(defaultConfig.PLUGIN_SERVER_MODE ?? 'MAIN')
+
+export async function shutdownLogger(): Promise<void> {
+    await logger.shutdown()
+}


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

pino.transport creates a child process that doesn't get properly closed, causing Jest to hang. 

## Changes

- Adds shutdown method to the logger
- Add Shutdown to jest setup

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
