### PR TITLE
fix: Update types for BigQuery batch export in UI

### DIFF
--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigurationLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigurationLogic.tsx
@@ -254,7 +254,7 @@ const sessionsTable: DatabaseSchemaBatchExportTable = {
         },
         urls: {
             name: 'urls',
-            type: service == 'BigQuery' ? 'ARRAY<STRING>' : 'array',
+            type: 'array',
             hogql_value: 'urls',
             schema_valid: true,
         },

--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigurationLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigurationLogic.tsx
@@ -62,7 +62,7 @@ function getEventTable(service: BatchExportService['type']): DatabaseSchemaBatch
             timestamp: {
                 name: 'timestamp',
                 hogql_value: 'timestamp',
-                type: 'datetime',
+                type: service == 'BigQuery' ? 'timestamp' : 'datetime',
                 schema_valid: true,
             },
             event: {
@@ -145,7 +145,7 @@ function getEventTable(service: BatchExportService['type']): DatabaseSchemaBatch
                 bq_ingested_timestamp: {
                     name: 'bq_ingested_timestamp',
                     hogql_value: 'NOW64()',
-                    type: 'datetime',
+                    type: 'timestamp',
                     schema_valid: true,
                 },
             }),
@@ -199,7 +199,7 @@ const personsTable: DatabaseSchemaBatchExportTable = {
         created_at: {
             name: 'created_at',
             hogql_value: 'created_at',
-            type: 'datetime',
+            type: service == 'BigQuery' ? 'timestamp' : 'datetime',
             schema_valid: true,
         },
         is_deleted: {
@@ -242,19 +242,19 @@ const sessionsTable: DatabaseSchemaBatchExportTable = {
         },
         start_timestamp: {
             name: 'start_timestamp',
-            type: 'datetime',
+            type: service == 'BigQuery' ? 'timestamp' : 'datetime',
             hogql_value: 'start_timestamp',
             schema_valid: true,
         },
         end_timestamp: {
             name: 'end_timestamp',
-            type: 'datetime',
+            type: service == 'BigQuery' ? 'timestamp' : 'datetime',
             hogql_value: 'end_timestamp',
             schema_valid: true,
         },
         urls: {
             name: 'urls',
-            type: 'array',
+            type: service == 'BigQuery' ? 'ARRAY<STRING>' : 'array',
             hogql_value: 'urls',
             schema_valid: true,
         },


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Some types in the UI should more closely match the real BigQuery types when creating a BigQuery batch export.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Update `datetime` to `timestamp` in schemas of tables when creating a BigQuery batch export.
~Update `array` to `ARRAY<STRING>` in schemas of tables when creating a BigQuery batch export.~ Nevermind, not doing this one as it breaks stuff.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
