### PR TITLE
add required_scopes for duplicate_as_static_cohort method

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -514,6 +514,7 @@ class CohortViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
     @action(
         methods=["GET"],
         detail=True,
+        required_scopes=["cohort:write"],
     )
     def duplicate_as_static_cohort(self, request: Request, **kwargs) -> Response:
         cohort: Cohort = self.get_object()


### PR DESCRIPTION

## Problem

It is impossible to use the duplicate_as_static_cohort method via the API with a Personal API Key, as stated in the documentation:

https://posthog.com/docs/api/cohorts#get-api-projects-project_id-cohorts-id-duplicate_as_static_cohort

It returns a 403 error with the message:
"This action does not support Personal API Key access."

## Changes

add required_scopes for duplicate_as_static_cohort method

## Did you write or update any docs for this change?
- No docs needed for this change
