### PR TITLE
fix: API QUERIES legacy team list must be parsed as JSON

### DIFF
--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -226,7 +226,7 @@ except Exception:
 # Set of teams querying the data before we switched to new limits
 API_QUERIES_LEGACY_TEAM_LIST: Optional[set[int]] = None
 with suppress(Exception):
-    as_json = get_from_env("API_QUERIES_LEGACY_TEAM_LIST")
+    as_json = json.loads(get_from_env("API_QUERIES_LEGACY_TEAM_LIST"))
     API_QUERIES_LEGACY_TEAM_LIST = {int(v) for v in as_json}
 
 # Per-team API /query concurrent limits, e.g. {"2": 7}


### PR DESCRIPTION
## Problem

env var was treated as string, should be parsed as JSON value

## Changes

properly parse the value

## How did you test this code?

locally run