### PR TITLE
chore: make sensors track all code locations

### DIFF
--- a/dags/locations/clickhouse.py
+++ b/dags/locations/clickhouse.py
@@ -1,9 +1,7 @@
 import dagster
 
-from django.conf import settings
 from . import resources
 
-from dags.common import job_status_metrics_sensors
 from dags import (
     backups,
     ch_examples,
@@ -13,7 +11,6 @@ from dags import (
     orm_examples,
     person_overrides,
     property_definitions,
-    slack_alerts,
 )
 
 defs = dagster.Definitions(
@@ -44,13 +41,6 @@ defs = dagster.Definitions(
     ],
     sensors=[
         deletes.run_deletes_after_squash,
-        slack_alerts.notify_slack_on_failure,
-        *job_status_metrics_sensors,
     ],
     resources=resources,
 )
-
-if settings.DEBUG:
-    from dags import testing
-
-    defs.jobs.append(testing.error)

--- a/dags/locations/error_tracking.py
+++ b/dags/locations/error_tracking.py
@@ -3,9 +3,7 @@ import dagster
 from django.conf import settings
 from . import resources
 
-from dags.common import job_status_metrics_sensors
 from dags import (
-    slack_alerts,
     symbol_set_cleanup,
 )
 
@@ -20,10 +18,6 @@ defs = dagster.Definitions(
     ],
     schedules=[
         symbol_set_cleanup.daily_symbol_set_cleanup_schedule,
-    ],
-    sensors=[
-        slack_alerts.notify_slack_on_failure,
-        *job_status_metrics_sensors,
     ],
     resources=resources,
 )

--- a/dags/locations/error_tracking.py
+++ b/dags/locations/error_tracking.py
@@ -1,6 +1,5 @@
 import dagster
 
-from django.conf import settings
 from . import resources
 
 from dags import (
@@ -21,8 +20,3 @@ defs = dagster.Definitions(
     ],
     resources=resources,
 )
-
-if settings.DEBUG:
-    from dags import testing
-
-    defs.jobs.append(testing.error)

--- a/dags/locations/growth.py
+++ b/dags/locations/growth.py
@@ -1,6 +1,5 @@
 import dagster
 
-from django.conf import settings
 from . import resources
 
 from dags import (
@@ -17,8 +16,3 @@ defs = dagster.Definitions(
     ],
     resources=resources,
 )
-
-if settings.DEBUG:
-    from dags import testing
-
-    defs.jobs.append(testing.error)

--- a/dags/locations/revenue_analytics.py
+++ b/dags/locations/revenue_analytics.py
@@ -3,10 +3,8 @@ import dagster
 from django.conf import settings
 from . import resources
 
-from dags.common import job_status_metrics_sensors
 from dags import (
     exchange_rate,
-    slack_alerts,
 )
 
 defs = dagster.Definitions(
@@ -23,10 +21,6 @@ defs = dagster.Definitions(
     schedules=[
         exchange_rate.daily_exchange_rates_schedule,
         exchange_rate.hourly_exchange_rates_schedule,
-    ],
-    sensors=[
-        slack_alerts.notify_slack_on_failure,
-        *job_status_metrics_sensors,
     ],
     resources=resources,
 )

--- a/dags/locations/revenue_analytics.py
+++ b/dags/locations/revenue_analytics.py
@@ -1,6 +1,5 @@
 import dagster
 
-from django.conf import settings
 from . import resources
 
 from dags import (
@@ -24,8 +23,3 @@ defs = dagster.Definitions(
     ],
     resources=resources,
 )
-
-if settings.DEBUG:
-    from dags import testing
-
-    defs.jobs.append(testing.error)

--- a/dags/locations/shared.py
+++ b/dags/locations/shared.py
@@ -3,17 +3,17 @@ import dagster
 from django.conf import settings
 from . import resources
 
+from dags.common import job_status_metrics_sensors
 from dags import (
-    oauth,
+    slack_alerts,
 )
 
-
+# Used for definitions that are shared between locations.
+# Mainly sensors
 defs = dagster.Definitions(
-    jobs=[
-        oauth.oauth_clear_expired_oauth_tokens_job,
-    ],
-    schedules=[
-        oauth.oauth_clear_expired_oauth_tokens_schedule,
+    sensors=[
+        slack_alerts.notify_slack_on_failure,
+        *job_status_metrics_sensors,
     ],
     resources=resources,
 )

--- a/dags/locations/web_analytics.py
+++ b/dags/locations/web_analytics.py
@@ -1,6 +1,5 @@
 import dagster
 
-from django.conf import settings
 from . import resources
 
 from dags.common import job_status_metrics_sensors
@@ -56,8 +55,3 @@ defs = dagster.Definitions(
     ],
     resources=resources,
 )
-
-if settings.DEBUG:
-    from dags import testing
-
-    defs.jobs.append(testing.error)

--- a/dags/slack_alerts.py
+++ b/dags/slack_alerts.py
@@ -36,7 +36,7 @@ def get_job_owner_for_alert(failed_run: dagster.DagsterRun, error_message: str) 
     return job_owner
 
 
-@dagster.run_failure_sensor(default_status=dagster.DefaultSensorStatus.RUNNING)
+@dagster.run_failure_sensor(default_status=dagster.DefaultSensorStatus.RUNNING, monitor_all_code_locations=True)
 def notify_slack_on_failure(context: dagster.RunFailureSensorContext, slack: dagster_slack.SlackResource):
     """Send a notification to Slack when any job fails."""
     # Get the failed run


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We define the same sensors in all code locations to track job metrics and send Slack notifications.

Dagster allows to make sensors track all code locations, so define a shared one that contains these shared sensors.


## Changes

Define sensors that track all locations in a specific, shared location.

