### PR TITLE
chore(data-warehouse): Track everytime someone gets a failure when trying to create a new so…

### DIFF
--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -1489,11 +1489,13 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                 actions.setDatabaseSchemas(schemas)
                 actions.onNext()
             } catch (e: any) {
-                lemonToast.error(e.data?.message ?? e.message)
+                const errorMessage = e.data?.message ?? e.message
+                lemonToast.error(errorMessage)
 
-                if (((e.data?.message as string | undefined) ?? '').indexOf('Invalid credentials') != -1) {
-                    posthog.capture('warehouse credentials invalid', { sourceType: values.selectedConnector.name })
-                }
+                posthog.capture('warehouse credentials invalid', {
+                    sourceType: values.selectedConnector.name,
+                    errorMessage,
+                })
             }
 
             actions.setIsLoading(false)


### PR DESCRIPTION
## Changes
- Better tracking of failed source creations by source type and error mesage
- Had someone in a call today say that they kept getting "invalid credentials" for vitally (btw, we only have 1 vitally source, team 2..... so something is likely broken there - will fix next). 
- We've been tracking this a bit, but only reporting a handful of the errors