### PR TITLE
fix(experiments): truncate metric titles

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/shared/MetricTitle.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/MetricTitle.tsx
@@ -1,4 +1,5 @@
 import { IconArrowRight, IconFunnels } from '@posthog/icons'
+import { Tooltip } from '@posthog/lemon-ui'
 
 import { NodeKind } from '~/queries/schema/schema-general'
 import { InsightType } from '~/types'
@@ -6,16 +7,38 @@ import { InsightType } from '~/types'
 import { getDefaultMetricTitle } from './utils'
 
 export const MetricTitle = ({ metric, metricType }: { metric: any; metricType?: InsightType }): JSX.Element => {
+    const getTextClassName = (text: string): string => {
+        // If text contains spaces, allow word breaks; otherwise truncate
+        return text.includes(' ') ? 'break-words' : 'truncate'
+    }
+
+    const shouldShowTooltip = (text: string): boolean => {
+        // Only show tooltip when we're truncating (single long words without spaces)
+        return !text.includes(' ') && text.length > 15
+    }
+
+    const wrapWithTooltip = (text: string, element: JSX.Element): JSX.Element => {
+        if (shouldShowTooltip(text)) {
+            return <Tooltip title={text}>{element}</Tooltip>
+        }
+        return element
+    }
+
     if (metric.name) {
-        return <span className="break-words">{metric.name}</span>
+        const element = <span className={getTextClassName(metric.name)}>{metric.name}</span>
+        return wrapWithTooltip(metric.name, element)
     }
 
     if (metric.kind === NodeKind.ExperimentMetric) {
-        return <span className="break-words">{getDefaultMetricTitle(metric)}</span>
+        const title = getDefaultMetricTitle(metric)
+        const element = <span className={getTextClassName(title)}>{title}</span>
+        return wrapWithTooltip(title, element)
     }
 
     if (metricType === InsightType.TRENDS && metric.count_query?.series?.[0]?.name) {
-        return <span className="break-words">{metric.count_query.series[0].name}</span>
+        const name = metric.count_query.series[0].name
+        const element = <span className={getTextClassName(name)}>{name}</span>
+        return wrapWithTooltip(name, element)
     }
 
     if (metricType === InsightType.FUNNELS && metric.funnels_query?.series) {
@@ -28,11 +51,11 @@ export const MetricTitle = ({ metric, metricType }: { metric: any; metricType?: 
                 <div className="inline-flex flex-wrap items-center gap-1 min-w-0">
                     <div className="inline-flex items-center gap-1 min-w-0">
                         <IconFunnels className="text-secondary flex-shrink-0" fontSize="14" />
-                        <span className="break-words">{firstStep}</span>
+                        {wrapWithTooltip(firstStep, <span className={getTextClassName(firstStep)}>{firstStep}</span>)}
                     </div>
                     <div className="inline-flex items-center gap-1 min-w-0 @max-[200px]:ml-5">
                         <IconArrowRight className="text-secondary flex-shrink-0" fontSize="14" />
-                        <span className="break-words">{lastStep}</span>
+                        {wrapWithTooltip(lastStep, <span className={getTextClassName(lastStep)}>{lastStep}</span>)}
                     </div>
                 </div>
             )


### PR DESCRIPTION
## Changes
The current way we break metric titles doesn't work well when users include underscores in the name (which happens quite often).

I went with a _good enough_ solution that detects when truncation is needed and, if so, adds a tooltip to show the full name.

|Before|After|
|----|----|
|![image](https://github.com/user-attachments/assets/2e73c59e-32bb-4593-a49b-a97c4997d231)|![image](https://github.com/user-attachments/assets/b0919f3a-4735-4e46-a69a-c274976b5365)|

## How did you test this code?
👀 