### PR TITLE
fix: dont hard error create_hogql_query

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -726,7 +726,12 @@ def create_hogql_database(
                 elif isinstance(field, ast.Call) and isinstance(field.args[0], ast.Field):
                     from_field = field.args[0].chain
                 else:
-                    raise ResolutionError("Data Warehouse Join HogQL expression should be a Field or Call node")
+                    capture_exception(
+                        Exception(
+                            f"Data Warehouse Join HogQL expression should be a Field or Call node: {join.source_table_key}"
+                        )
+                    )
+                    continue
 
                 field = parse_expr(join.joining_table_key)
                 if isinstance(field, ast.Field):
@@ -740,7 +745,12 @@ def create_hogql_database(
                 elif isinstance(field, ast.Call) and isinstance(field.args[0], ast.Field):
                     to_field = field.args[0].chain
                 else:
-                    raise ResolutionError("Data Warehouse Join HogQL expression should be a Field or Call node")
+                    capture_exception(
+                        Exception(
+                            f"Data Warehouse Join HogQL expression should be a Field or Call node: {join.joining_table_key}"
+                        )
+                    )
+                    continue
 
                 source_table.fields[join.field_name] = LazyJoin(
                     from_field=from_field,


### PR DESCRIPTION
## Problem

- if a join is bad, create_hogql_fails and the entire hogql virtual db is broken

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- don't hard error

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
