### PR TITLE
fix: backward compatibility for surveys in old SDKs

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -116,7 +116,16 @@ def get_base_config(token: str, team: Team, request: HttpRequest, skip_db: bool 
             response["isAuthenticated"] = False
             response["toolbarParams"] = {}
             response["config"] = {"enable_collect_everything": True}
-            response["surveys"] = surveys_opt_in
+
+            # FIX: Maintain backward compatibility by checking if RemoteConfig actually has survey data
+            # Older SDKs expect surveys=true only when surveys exist, not just when surveys_opt_in=true
+            has_actual_surveys = (
+                surveys_opt_in
+                and "surveys" in response
+                and response["surveys"]
+                and (isinstance(response["surveys"], list) and len(response["surveys"]) > 0)
+            )
+            response["surveys"] = has_actual_surveys
 
             # Remove some stuff that is specific to the new RemoteConfig
             del response["hasFeatureFlags"]


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

Surveys are broken in all SDKs prior to 1.255.3, this tries to add some back compat checks to decide that will hopefully fix it.
