### PR TITLE
chore(web-analytics): always use UTC for data accuracy checks

### DIFF
--- a/dags/web_preaggregated_asset_checks.py
+++ b/dags/web_preaggregated_asset_checks.py
@@ -279,7 +279,9 @@ def compare_web_overview_metrics(
     runner_pre_agg = WebOverviewQueryRunner(query=query_pre_agg, team=team, modifiers=modifiers_pre_agg)
 
     # Query without pre-aggregated tables
-    modifiers_regular = HogQLQueryModifiers(useWebAnalyticsPreAggregatedTables=False)
+    # We have an known issue that the buckets are always in UTC, so we need to query in UTC to make sure we're comparing apples to apples
+    # This can be improved if we change to hourly buckets but right now this fits our scope
+    modifiers_regular = HogQLQueryModifiers(useWebAnalyticsPreAggregatedTables=False, convertToProjectTimezone=False)
 
     runner_regular = WebOverviewQueryRunner(query=query_pre_agg, team=team, modifiers=modifiers_regular)
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

At times, we observed a drop in accuracy because pre-aggregated queries always use UTC, and the regular `WebOverviewQueryRunner` converts to the team's project, which is usually fine, but not for this asset check purpose.

## Changes

- Do not convert to the project's timezone.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Manually locally
