### PR TITLE
refactor(flags): Organize the code a bit.

### DIFF
--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -1,0 +1,330 @@
+use std::sync::Arc;
+use tracing;
+
+use crate::api::errors::FlagError;
+use crate::flags::flag_models::{
+    FeatureFlag, FeatureFlagList, FeatureFlagRow, TEAM_FLAGS_CACHE_PREFIX,
+};
+use common_database::Client as DatabaseClient;
+use common_redis::Client as RedisClient;
+
+impl FeatureFlagList {
+    pub fn new(flags: Vec<FeatureFlag>) -> Self {
+        Self { flags }
+    }
+
+    /// Returns feature flags from redis given a project_id
+    pub async fn from_redis(
+        client: Arc<dyn RedisClient + Send + Sync>,
+        project_id: i64,
+    ) -> Result<FeatureFlagList, FlagError> {
+        tracing::debug!(
+            "Attempting to read flags from Redis at key '{}{}'",
+            TEAM_FLAGS_CACHE_PREFIX,
+            project_id
+        );
+
+        let serialized_flags = client
+            .get(format!("{TEAM_FLAGS_CACHE_PREFIX}{}", project_id))
+            .await?;
+
+        let flags_list: Vec<FeatureFlag> =
+            serde_json::from_str(&serialized_flags).map_err(|e| {
+                tracing::error!(
+                    "failed to parse data to flags list for project {}: {}",
+                    project_id,
+                    e
+                );
+                FlagError::RedisDataParsingError
+            })?;
+
+        tracing::debug!(
+            "Successfully read {} flags from Redis at key '{}{}'",
+            flags_list.len(),
+            TEAM_FLAGS_CACHE_PREFIX,
+            project_id
+        );
+
+        Ok(FeatureFlagList { flags: flags_list })
+    }
+
+    /// Returns feature flags from postgres given a project_id
+    pub async fn from_pg(
+        client: Arc<dyn DatabaseClient + Send + Sync>,
+        project_id: i64,
+    ) -> Result<FeatureFlagList, FlagError> {
+        let mut conn = client.get_connection().await.map_err(|e| {
+            tracing::error!(
+                "Failed to get database connection for project {}: {}",
+                project_id,
+                e
+            );
+            FlagError::DatabaseUnavailable
+        })?;
+
+        let query = r#"
+            SELECT f.id,
+                  f.team_id,
+                  f.name,
+                  f.key,
+                  f.filters,
+                  f.deleted,
+                  f.active,
+                  f.ensure_experience_continuity,
+                  f.version
+              FROM posthog_featureflag AS f
+              JOIN posthog_team AS t ON (f.team_id = t.id)
+            WHERE t.project_id = $1
+              AND f.deleted = false
+              AND f.active = true
+        "#;
+        let flags_row = sqlx::query_as::<_, FeatureFlagRow>(query)
+            .bind(project_id)
+            .fetch_all(&mut *conn)
+            .await
+            .map_err(|e| {
+                tracing::error!(
+                    "Failed to fetch feature flags from database for project {}: {}",
+                    project_id,
+                    e
+                );
+                FlagError::Internal(format!("Database query error: {}", e))
+            })?;
+
+        let flags_list = flags_row
+            .into_iter()
+            .map(|row| {
+                let filters = serde_json::from_value(row.filters).map_err(|e| {
+                    tracing::error!(
+                        "Failed to deserialize filters for flag {} in project {} (team {}): {}",
+                        row.key,
+                        project_id,
+                        row.team_id,
+                        e
+                    );
+                    FlagError::DeserializeFiltersError
+                })?;
+
+                Ok(FeatureFlag {
+                    id: row.id,
+                    team_id: row.team_id,
+                    name: row.name,
+                    key: row.key,
+                    filters,
+                    deleted: row.deleted,
+                    active: row.active,
+                    ensure_experience_continuity: row.ensure_experience_continuity,
+                    version: row.version,
+                })
+            })
+            .collect::<Result<Vec<FeatureFlag>, FlagError>>()?;
+
+        Ok(FeatureFlagList { flags: flags_list })
+    }
+
+    pub async fn update_flags_in_redis(
+        client: Arc<dyn RedisClient + Send + Sync>,
+        project_id: i64,
+        flags: &FeatureFlagList,
+    ) -> Result<(), FlagError> {
+        let payload = serde_json::to_string(&flags.flags).map_err(|e| {
+            tracing::error!(
+                "Failed to serialize {} flags for project {}: {}",
+                flags.flags.len(),
+                project_id,
+                e
+            );
+            FlagError::RedisDataParsingError
+        })?;
+
+        tracing::info!(
+            "Writing flags to Redis at key '{}{}': {} flags",
+            TEAM_FLAGS_CACHE_PREFIX,
+            project_id,
+            flags.flags.len()
+        );
+
+        client
+            .set(format!("{TEAM_FLAGS_CACHE_PREFIX}{}", project_id), payload)
+            .await
+            .map_err(|e| {
+                tracing::error!(
+                    "Failed to update Redis cache for project {}: {}",
+                    project_id,
+                    e
+                );
+                FlagError::CacheUpdateError
+            })?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::test_utils::{
+        insert_flag_for_team_in_pg, insert_flags_for_team_in_redis, insert_new_team_in_pg,
+        insert_new_team_in_redis, setup_invalid_pg_client, setup_pg_reader_client,
+        setup_redis_client,
+    };
+    use rand::Rng;
+
+    #[tokio::test]
+    async fn test_fetch_flags_from_redis() {
+        let redis_client = setup_redis_client(None).await;
+
+        let team = insert_new_team_in_redis(redis_client.clone())
+            .await
+            .expect("Failed to insert team");
+
+        // TODO HANDLE THIS
+        insert_flags_for_team_in_redis(redis_client.clone(), team.id, team.project_id, None)
+            .await
+            .expect("Failed to insert flags");
+
+        let flags_from_redis = FeatureFlagList::from_redis(redis_client.clone(), team.project_id)
+            .await
+            .expect("Failed to fetch flags from redis");
+        assert_eq!(flags_from_redis.flags.len(), 1);
+        let flag = flags_from_redis
+            .flags
+            .first()
+            .expect("Empty flags in redis");
+        assert_eq!(flag.key, "flag1");
+        assert_eq!(flag.team_id, team.id);
+        assert_eq!(flag.filters.groups.len(), 1);
+        assert_eq!(flag.filters.groups[0].properties.as_ref().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_invalid_team_from_redis() {
+        let redis_client = setup_redis_client(None).await;
+
+        match FeatureFlagList::from_redis(redis_client.clone(), 1234).await {
+            Err(FlagError::TokenValidationError) => {
+                // Expected error
+            }
+            _ => panic!("Expected TokenValidationError"),
+        }
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "Failed to create redis client")]
+    async fn test_cant_connect_to_redis_error_is_not_token_validation_error() {
+        // Test that client creation fails when Redis is unavailable
+        setup_redis_client(Some("redis://localhost:1111/".to_string())).await;
+    }
+
+    #[tokio::test]
+    async fn test_fetch_flags_from_pg() {
+        let reader = setup_pg_reader_client(None).await;
+
+        let team = insert_new_team_in_pg(reader.clone(), None)
+            .await
+            .expect("Failed to insert team");
+
+        insert_flag_for_team_in_pg(reader.clone(), team.id, None)
+            .await
+            .expect("Failed to insert flag");
+
+        let flags_from_pg = FeatureFlagList::from_pg(reader.clone(), team.project_id)
+            .await
+            .expect("Failed to fetch flags from pg");
+
+        assert_eq!(flags_from_pg.flags.len(), 1);
+        let flag = flags_from_pg.flags.first().expect("Flags should be in pg");
+        assert_eq!(flag.key, "flag1");
+        assert_eq!(flag.team_id, team.id);
+        assert_eq!(flag.filters.groups.len(), 1);
+        assert_eq!(flag.filters.groups[0].properties.as_ref().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_empty_team_from_pg() {
+        let reader = setup_pg_reader_client(None).await;
+
+        let FeatureFlagList { flags } = FeatureFlagList::from_pg(reader.clone(), 1234)
+            .await
+            .expect("Failed to fetch flags from pg");
+
+        assert_eq!(flags.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_nonexistent_team_from_pg() {
+        let reader = setup_pg_reader_client(None).await;
+
+        match FeatureFlagList::from_pg(reader.clone(), -1).await {
+            Ok(flags) => assert_eq!(flags.flags.len(), 0),
+            Err(err) => panic!("Expected empty result, got error: {:?}", err),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_fetch_flags_db_connection_failure() {
+        let invalid_client = setup_invalid_pg_client().await;
+
+        match FeatureFlagList::from_pg(invalid_client, 1).await {
+            Ok(_) => panic!("Expected error for invalid database connection"),
+            Err(FlagError::DatabaseUnavailable) => {
+                // Expected error
+            }
+            Err(e) => panic!("Unexpected error: {:?}", e),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_fetch_multiple_flags_from_pg() {
+        let reader = setup_pg_reader_client(None).await;
+
+        let team = insert_new_team_in_pg(reader.clone(), None)
+            .await
+            .expect("Failed to insert team");
+
+        let random_id_1 = rand::thread_rng().gen_range(0..10_000_000);
+        let random_id_2 = rand::thread_rng().gen_range(0..10_000_000);
+
+        let flag1 = FeatureFlagRow {
+            id: random_id_1,
+            team_id: team.id,
+            name: Some("Test Flag".to_string()),
+            key: "test_flag".to_string(),
+            filters: serde_json::json!({"groups": [{"properties": [], "rollout_percentage": 100}]}),
+            deleted: false,
+            active: true,
+            ensure_experience_continuity: false,
+            version: Some(1),
+        };
+
+        let flag2 = FeatureFlagRow {
+            id: random_id_2,
+            team_id: team.id,
+            name: Some("Test Flag 2".to_string()),
+            key: "test_flag_2".to_string(),
+            filters: serde_json::json!({"groups": [{"properties": [], "rollout_percentage": 100}]}),
+            deleted: false,
+            active: true,
+            ensure_experience_continuity: false,
+            version: Some(1),
+        };
+
+        // Insert multiple flags for the team
+        insert_flag_for_team_in_pg(reader.clone(), team.id, Some(flag1))
+            .await
+            .expect("Failed to insert flags");
+
+        insert_flag_for_team_in_pg(reader.clone(), team.id, Some(flag2))
+            .await
+            .expect("Failed to insert flags");
+
+        let flags_from_pg = FeatureFlagList::from_pg(reader.clone(), team.project_id)
+            .await
+            .expect("Failed to fetch flags from pg");
+
+        assert_eq!(flags_from_pg.flags.len(), 2);
+        for flag in &flags_from_pg.flags {
+            assert_eq!(flag.team_id, team.id);
+        }
+    }
+}

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -178,7 +178,6 @@ mod tests {
             .await
             .expect("Failed to insert team");
 
-        // TODO HANDLE THIS
         insert_flags_for_team_in_redis(redis_client.clone(), team.id, team.project_id, None)
             .await
             .expect("Failed to insert flags");

--- a/rust/feature-flags/src/flags/flag_models.rs
+++ b/rust/feature-flags/src/flags/flag_models.rs
@@ -115,9 +115,3 @@ pub struct FeatureFlagRow {
 pub struct FeatureFlagList {
     pub flags: Vec<FeatureFlag>,
 }
-
-impl FeatureFlagList {
-    pub fn new(flags: Vec<FeatureFlag>) -> Self {
-        Self { flags }
-    }
-}

--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -2,11 +2,8 @@ use crate::api::errors::FlagError;
 use crate::flags::flag_models::*;
 use crate::properties::property_models::PropertyFilter;
 use crate::utils::graph_utils::{DependencyProvider, DependencyType};
-use common_database::Client as DatabaseClient;
-use common_redis::Client as RedisClient;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
 
 impl FeatureFlag {
     /// Returns the group type index for the flag, or None if it's not set.
@@ -100,154 +97,6 @@ impl DependencyProvider for FeatureFlag {
     }
 }
 
-impl FeatureFlagList {
-    /// Returns feature flags from redis given a project_id
-    pub async fn from_redis(
-        client: Arc<dyn RedisClient + Send + Sync>,
-        project_id: i64,
-    ) -> Result<FeatureFlagList, FlagError> {
-        tracing::debug!(
-            "Attempting to read flags from Redis at key '{}{}'",
-            TEAM_FLAGS_CACHE_PREFIX,
-            project_id
-        );
-
-        let serialized_flags = client
-            .get(format!("{TEAM_FLAGS_CACHE_PREFIX}{}", project_id))
-            .await?;
-
-        let flags_list: Vec<FeatureFlag> =
-            serde_json::from_str(&serialized_flags).map_err(|e| {
-                tracing::error!(
-                    "failed to parse data to flags list for project {}: {}",
-                    project_id,
-                    e
-                );
-                FlagError::RedisDataParsingError
-            })?;
-
-        tracing::debug!(
-            "Successfully read {} flags from Redis at key '{}{}'",
-            flags_list.len(),
-            TEAM_FLAGS_CACHE_PREFIX,
-            project_id
-        );
-
-        Ok(FeatureFlagList { flags: flags_list })
-    }
-
-    /// Returns feature flags from postgres given a project_id
-    pub async fn from_pg(
-        client: Arc<dyn DatabaseClient + Send + Sync>,
-        project_id: i64,
-    ) -> Result<FeatureFlagList, FlagError> {
-        let mut conn = client.get_connection().await.map_err(|e| {
-            tracing::error!(
-                "Failed to get database connection for project {}: {}",
-                project_id,
-                e
-            );
-            FlagError::DatabaseUnavailable
-        })?;
-
-        let query = r#"
-            SELECT f.id,
-                  f.team_id,
-                  f.name,
-                  f.key,
-                  f.filters,
-                  f.deleted,
-                  f.active,
-                  f.ensure_experience_continuity,
-                  f.version
-              FROM posthog_featureflag AS f
-              JOIN posthog_team AS t ON (f.team_id = t.id)
-            WHERE t.project_id = $1
-              AND f.deleted = false
-              AND f.active = true
-        "#;
-        let flags_row = sqlx::query_as::<_, FeatureFlagRow>(query)
-            .bind(project_id)
-            .fetch_all(&mut *conn)
-            .await
-            .map_err(|e| {
-                tracing::error!(
-                    "Failed to fetch feature flags from database for project {}: {}",
-                    project_id,
-                    e
-                );
-                FlagError::Internal(format!("Database query error: {}", e))
-            })?;
-
-        let flags_list = flags_row
-            .into_iter()
-            .map(|row| {
-                let filters = serde_json::from_value(row.filters).map_err(|e| {
-                    tracing::error!(
-                        "Failed to deserialize filters for flag {} in project {} (team {}): {}",
-                        row.key,
-                        project_id,
-                        row.team_id,
-                        e
-                    );
-                    FlagError::DeserializeFiltersError
-                })?;
-
-                Ok(FeatureFlag {
-                    id: row.id,
-                    team_id: row.team_id,
-                    name: row.name,
-                    key: row.key,
-                    filters,
-                    deleted: row.deleted,
-                    active: row.active,
-                    ensure_experience_continuity: row.ensure_experience_continuity,
-                    version: row.version,
-                })
-            })
-            .collect::<Result<Vec<FeatureFlag>, FlagError>>()?;
-
-        Ok(FeatureFlagList { flags: flags_list })
-    }
-
-    pub async fn update_flags_in_redis(
-        client: Arc<dyn RedisClient + Send + Sync>,
-        project_id: i64,
-        flags: &FeatureFlagList,
-    ) -> Result<(), FlagError> {
-        let payload = serde_json::to_string(&flags.flags).map_err(|e| {
-            tracing::error!(
-                "Failed to serialize {} flags for project {}: {}",
-                flags.flags.len(),
-                project_id,
-                e
-            );
-            FlagError::RedisDataParsingError
-        })?;
-
-        tracing::info!(
-            "Writing flags to Redis at key '{}{}': {} flags",
-            TEAM_FLAGS_CACHE_PREFIX,
-            project_id,
-            flags.flags.len()
-        );
-
-        client
-            .set(format!("{TEAM_FLAGS_CACHE_PREFIX}{}", project_id), payload)
-            .await
-            .map_err(|e| {
-                tracing::error!(
-                    "Failed to update Redis cache for project {}: {}",
-                    project_id,
-                    e
-                );
-                FlagError::CacheUpdateError
-            })?;
-
-        Ok(())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::{
@@ -257,7 +106,6 @@ mod tests {
         },
         properties::property_models::{OperatorType, PropertyType},
     };
-    use rand::Rng;
     use serde_json::{json, Value};
     use std::time::Instant;
     use tokio::task;
@@ -265,103 +113,8 @@ mod tests {
     use super::*;
     use crate::utils::test_utils::{
         insert_flag_for_team_in_pg, insert_flags_for_team_in_redis, insert_new_team_in_pg,
-        insert_new_team_in_redis, setup_invalid_pg_client, setup_pg_reader_client,
-        setup_redis_client,
+        setup_pg_reader_client, setup_redis_client,
     };
-
-    #[tokio::test]
-    async fn test_fetch_flags_from_redis() {
-        let redis_client = setup_redis_client(None).await;
-
-        let team = insert_new_team_in_redis(redis_client.clone())
-            .await
-            .expect("Failed to insert team");
-
-        // TODO HANDLE THIS
-        insert_flags_for_team_in_redis(redis_client.clone(), team.id, team.project_id, None)
-            .await
-            .expect("Failed to insert flags");
-
-        let flags_from_redis = FeatureFlagList::from_redis(redis_client.clone(), team.project_id)
-            .await
-            .expect("Failed to fetch flags from redis");
-        assert_eq!(flags_from_redis.flags.len(), 1);
-        let flag = flags_from_redis
-            .flags
-            .first()
-            .expect("Empty flags in redis");
-        assert_eq!(flag.key, "flag1");
-        assert_eq!(flag.team_id, team.id);
-        assert_eq!(flag.filters.groups.len(), 1);
-        assert_eq!(
-            flag.filters.groups[0]
-                .properties
-                .as_ref()
-                .expect("Properties don't exist on flag")
-                .len(),
-            1
-        );
-    }
-
-    #[tokio::test]
-    async fn test_fetch_invalid_team_from_redis() {
-        let redis_client = setup_redis_client(None).await;
-
-        match FeatureFlagList::from_redis(redis_client.clone(), 1234).await {
-            Err(FlagError::TokenValidationError) => (),
-            _ => panic!("Expected TokenValidationError"),
-        };
-    }
-
-    #[tokio::test]
-    #[should_panic(expected = "Failed to create redis client")]
-    async fn test_cant_connect_to_redis_error_is_not_token_validation_error() {
-        // Test that client creation fails when Redis is unavailable
-        setup_redis_client(Some("redis://localhost:1111/".to_string())).await;
-    }
-
-    #[tokio::test]
-    async fn test_fetch_flags_from_pg() {
-        let reader = setup_pg_reader_client(None).await;
-
-        let team = insert_new_team_in_pg(reader.clone(), None)
-            .await
-            .expect("Failed to insert team in pg");
-
-        insert_flag_for_team_in_pg(reader.clone(), team.id, None)
-            .await
-            .expect("Failed to insert flags");
-
-        let flags_from_pg = FeatureFlagList::from_pg(reader.clone(), team.project_id)
-            .await
-            .expect("Failed to fetch flags from pg");
-
-        assert_eq!(flags_from_pg.flags.len(), 1);
-        let flag = flags_from_pg.flags.first().expect("Flags should be in pg");
-
-        assert_eq!(flag.key, "flag1");
-        assert_eq!(flag.team_id, team.id);
-        assert_eq!(flag.filters.groups.len(), 1);
-        assert_eq!(
-            flag.filters.groups[0]
-                .properties
-                .as_ref()
-                .expect("Properties don't exist on flag")
-                .len(),
-            1
-        );
-        let property_filter = &flag.filters.groups[0]
-            .properties
-            .as_ref()
-            .expect("Properties don't exist on flag")[0];
-
-        assert_eq!(property_filter.key, "email");
-        assert_eq!(property_filter.value, Some(json!("a@b.com")));
-        assert_eq!(property_filter.operator, None);
-        assert_eq!(property_filter.prop_type, PropertyType::Person);
-        assert_eq!(property_filter.group_type_index, None);
-        assert_eq!(flag.filters.groups[0].rollout_percentage, Some(50.0));
-    }
 
     #[test]
     fn test_utf16_property_names_and_values() {
@@ -458,93 +211,6 @@ mod tests {
 
     // TODO: Add more tests to validate deserialization of flags.
     // TODO: Also make sure old flag data is handled, or everything is migrated to new style in production
-
-    #[tokio::test]
-    async fn test_fetch_empty_team_from_pg() {
-        let reader = setup_pg_reader_client(None).await;
-
-        let FeatureFlagList { flags } = FeatureFlagList::from_pg(reader.clone(), 1234)
-            .await
-            .expect("Failed to fetch flags from pg");
-        {
-            assert_eq!(flags.len(), 0);
-        }
-    }
-
-    #[tokio::test]
-    async fn test_fetch_nonexistent_team_from_pg() {
-        let reader = setup_pg_reader_client(None).await;
-
-        match FeatureFlagList::from_pg(reader.clone(), -1).await {
-            Ok(flags) => assert_eq!(flags.flags.len(), 0),
-            Err(err) => panic!("Expected empty result, got error: {:?}", err),
-        }
-    }
-
-    #[tokio::test]
-    async fn test_fetch_flags_db_connection_failure() {
-        // Simulate a database connection failure by using an invalid client setup
-        let invalid_client = setup_invalid_pg_client().await;
-
-        match FeatureFlagList::from_pg(invalid_client, 1).await {
-            Err(FlagError::DatabaseUnavailable) => (),
-            other => panic!("Expected DatabaseUnavailable error, got: {:?}", other),
-        }
-    }
-
-    #[tokio::test]
-    async fn test_fetch_multiple_flags_from_pg() {
-        let reader = setup_pg_reader_client(None).await;
-
-        let team = insert_new_team_in_pg(reader.clone(), None)
-            .await
-            .expect("Failed to insert team in pg");
-
-        let random_id_1 = rand::thread_rng().gen_range(0..10_000_000);
-        let random_id_2 = rand::thread_rng().gen_range(0..10_000_000);
-
-        let flag1 = FeatureFlagRow {
-            id: random_id_1,
-            team_id: team.id,
-            name: Some("Test Flag".to_string()),
-            key: "test_flag".to_string(),
-            filters: serde_json::json!({"groups": [{"properties": [], "rollout_percentage": 100}]}),
-            deleted: false,
-            active: true,
-            ensure_experience_continuity: false,
-            version: Some(1),
-        };
-
-        let flag2 = FeatureFlagRow {
-            id: random_id_2,
-            team_id: team.id,
-            name: Some("Test Flag 2".to_string()),
-            key: "test_flag_2".to_string(),
-            filters: serde_json::json!({"groups": [{"properties": [], "rollout_percentage": 100}]}),
-            deleted: false,
-            active: true,
-            ensure_experience_continuity: false,
-            version: Some(1),
-        };
-
-        // Insert multiple flags for the team
-        insert_flag_for_team_in_pg(reader.clone(), team.id, Some(flag1))
-            .await
-            .expect("Failed to insert flags");
-
-        insert_flag_for_team_in_pg(reader.clone(), team.id, Some(flag2))
-            .await
-            .expect("Failed to insert flags");
-
-        let flags_from_pg = FeatureFlagList::from_pg(reader.clone(), team.project_id)
-            .await
-            .expect("Failed to fetch flags from pg");
-
-        assert_eq!(flags_from_pg.flags.len(), 2);
-        for flag in &flags_from_pg.flags {
-            assert_eq!(flag.team_id, team.id);
-        }
-    }
 
     #[test]
     fn test_operator_type_deserialization() {

--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -8,14 +8,6 @@ use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-fn extract_feature_flag_dependency(filter: &PropertyFilter) -> Option<FeatureFlagId> {
-    if filter.depends_on_feature_flag() {
-        filter.get_feature_flag_id()
-    } else {
-        None
-    }
-}
-
 impl FeatureFlag {
     /// Returns the group type index for the flag, or None if it's not set.
     ///
@@ -53,13 +45,21 @@ impl FeatureFlag {
         for group in &self.filters.groups {
             if let Some(properties) = &group.properties {
                 for filter in properties {
-                    if let Some(feature_flag_id) = extract_feature_flag_dependency(filter) {
+                    if let Some(feature_flag_id) = Self::extract_feature_flag_dependency(filter) {
                         dependencies.insert(feature_flag_id);
                     }
                 }
             }
         }
         Ok(dependencies)
+    }
+
+    fn extract_feature_flag_dependency(filter: &PropertyFilter) -> Option<FeatureFlagId> {
+        if filter.depends_on_feature_flag() {
+            filter.get_feature_flag_id()
+        } else {
+            None
+        }
     }
 
     /// Returns true if the flag requires DB preparation in order to evaluate the flag.

--- a/rust/feature-flags/src/flags/mod.rs
+++ b/rust/feature-flags/src/flags/mod.rs
@@ -9,6 +9,7 @@ pub mod flag_operations;
 pub mod flag_property_group;
 pub mod flag_request;
 pub mod flag_service;
+pub mod property_filter;
 
 #[cfg(test)]
 mod test_flag_matching;

--- a/rust/feature-flags/src/flags/mod.rs
+++ b/rust/feature-flags/src/flags/mod.rs
@@ -1,3 +1,4 @@
+pub mod feature_flag_list;
 pub mod flag_analytics;
 pub mod flag_filters;
 pub mod flag_group_type_mapping;

--- a/rust/feature-flags/src/flags/property_filter.rs
+++ b/rust/feature-flags/src/flags/property_filter.rs
@@ -1,0 +1,152 @@
+use serde_json::Value;
+use std::collections::HashMap;
+
+use crate::cohorts::cohort_models::CohortId;
+use crate::flags::flag_models::FeatureFlagId;
+use crate::properties::property_models::{PropertyFilter, PropertyType};
+
+impl PropertyFilter {
+    /// Checks if the filter is a cohort filter
+    pub fn is_cohort(&self) -> bool {
+        self.prop_type == PropertyType::Cohort
+    }
+
+    /// Returns the cohort id if the filter is a cohort filter, or None if it's not a cohort filter
+    /// or if the value cannot be parsed as a cohort id
+    pub fn get_cohort_id(&self) -> Option<CohortId> {
+        if !self.is_cohort() {
+            return None;
+        }
+        self.value
+            .as_ref()
+            .and_then(|value| value.as_i64())
+            .map(|id| id as CohortId)
+    }
+
+    /// Checks if the filter depends on a feature flag
+    pub fn depends_on_feature_flag(&self) -> bool {
+        self.prop_type == PropertyType::Flag
+    }
+
+    /// Returns the feature flag id if the filter depends on a feature flag, or None if it's not a feature flag filter
+    /// or if the value cannot be parsed as a feature flag id
+    pub fn get_feature_flag_id(&self) -> Option<FeatureFlagId> {
+        if !self.depends_on_feature_flag() {
+            return None;
+        }
+        self.key.parse::<FeatureFlagId>().ok()
+    }
+
+    /// Returns true if the filter requires DB properties to be evaluated.
+    ///
+    /// This is true if the filter key is not in the overrides, but only for non cohort and non flag filters
+    pub fn requires_db_property(&self, overrides: &HashMap<String, Value>) -> bool {
+        if self.is_cohort() || self.depends_on_feature_flag() {
+            return false;
+        }
+        !overrides.contains_key(&self.key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::flags::test_helpers::create_simple_property_filter;
+    use crate::properties::property_models::OperatorType;
+
+    #[test]
+    fn test_filter_requires_db_property_if_override_not_present() {
+        let filter = create_simple_property_filter(
+            "some_property",
+            PropertyType::Person,
+            OperatorType::Exact,
+        );
+
+        {
+            // Wrong override.
+            let overrides =
+                HashMap::from([("not_cohort".to_string(), Value::String("value".to_string()))]);
+
+            assert!(filter.requires_db_property(&overrides));
+        }
+
+        {
+            // Correct override.
+            let overrides = HashMap::from([(
+                "some_property".to_string(),
+                Value::String("value".to_string()),
+            )]);
+
+            assert!(!filter.requires_db_property(&overrides));
+        }
+    }
+
+    #[test]
+    fn test_filter_does_not_require_db_property_if_cohort_or_flag_filter() {
+        // Cohort filter.
+        let filter =
+            create_simple_property_filter("cohort", PropertyType::Cohort, OperatorType::Exact);
+        assert!(!filter.requires_db_property(&HashMap::new()));
+
+        // Flag filter.
+        let filter = create_simple_property_filter("flag", PropertyType::Flag, OperatorType::Exact);
+        assert!(!filter.requires_db_property(&HashMap::new()));
+    }
+
+    #[test]
+    fn test_is_cohort() {
+        let filter =
+            create_simple_property_filter("cohort", PropertyType::Cohort, OperatorType::Exact);
+        assert!(filter.is_cohort());
+
+        let filter =
+            create_simple_property_filter("person", PropertyType::Person, OperatorType::Exact);
+        assert!(!filter.is_cohort());
+    }
+
+    #[test]
+    fn test_get_cohort_id() {
+        let mut filter =
+            create_simple_property_filter("cohort", PropertyType::Cohort, OperatorType::Exact);
+        filter.value = Some(Value::Number(serde_json::Number::from(123)));
+
+        assert_eq!(filter.get_cohort_id(), Some(123));
+
+        // Non-cohort filter should return None
+        let filter =
+            create_simple_property_filter("person", PropertyType::Person, OperatorType::Exact);
+        assert_eq!(filter.get_cohort_id(), None);
+
+        // Cohort filter with non-numeric value should return None
+        let mut filter =
+            create_simple_property_filter("cohort", PropertyType::Cohort, OperatorType::Exact);
+        filter.value = Some(Value::String("not_a_number".to_string()));
+        assert_eq!(filter.get_cohort_id(), None);
+    }
+
+    #[test]
+    fn test_depends_on_feature_flag() {
+        let filter = create_simple_property_filter("flag", PropertyType::Flag, OperatorType::Exact);
+        assert!(filter.depends_on_feature_flag());
+
+        let filter =
+            create_simple_property_filter("person", PropertyType::Person, OperatorType::Exact);
+        assert!(!filter.depends_on_feature_flag());
+    }
+
+    #[test]
+    fn test_get_feature_flag_id() {
+        let filter = create_simple_property_filter("123", PropertyType::Flag, OperatorType::Exact);
+        assert_eq!(filter.get_feature_flag_id(), Some(123));
+
+        // Non-flag filter should return None
+        let filter =
+            create_simple_property_filter("person", PropertyType::Person, OperatorType::Exact);
+        assert_eq!(filter.get_feature_flag_id(), None);
+
+        // Flag filter with non-numeric key should return None
+        let filter =
+            create_simple_property_filter("not_a_number", PropertyType::Flag, OperatorType::Exact);
+        assert_eq!(filter.get_feature_flag_id(), None);
+    }
+}

--- a/rust/feature-flags/src/flags/property_filter.rs
+++ b/rust/feature-flags/src/flags/property_filter.rs
@@ -41,10 +41,7 @@ impl PropertyFilter {
     ///
     /// This is true if the filter key is not in the overrides, but only for non cohort and non flag filters
     pub fn requires_db_property(&self, overrides: &HashMap<String, Value>) -> bool {
-        if self.is_cohort() || self.depends_on_feature_flag() {
-            return false;
-        }
-        !overrides.contains_key(&self.key)
+        !self.is_cohort() && !self.depends_on_feature_flag() && !overrides.contains_key(&self.key)
     }
 }
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

No functional changes. This PR just moves some code around and adds a few tests.

## Problem

The code in the `rust/feature-flags/src/flags` directory was getting a bit unwieldy and hard to navigate. Some files had a lot of different concerns mixed in the same file.

## Changes

This PR only moves code around and adds a few tests. I decided to keep tests together with implementation for now because each file was relatively small. As the combined size gets too large, it's helpful to split the file into two:  implementation and tests.

1. Moved the `PropertyFilter` implementation and tests from `flag_operations.rs` to `property_filter.rs`: _note: I thought about moving the `PropertyFilter` struct in here too. It's currently in `property_models.rs`, but wanted to get feedback from @dmarticus and @andyzzhao first.
2. Moved `FeatureFlagList` and tests from `flag_operations.rs` to `feature_flag_list.rs`.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Unit tests.
Manual test with Postman.