### PR TITLE
fix: make exception result unpacking safe

### DIFF
--- a/posthog/exceptions_capture.py
+++ b/posthog/exceptions_capture.py
@@ -16,11 +16,14 @@ def capture_exception(error=None, additional_properties=None):
 
         # Only log if captured
         if result is not None:
-            _, msg = result
-
             log_kwargs = {}
-            if isinstance(msg, dict):
-                log_kwargs["event_id"] = msg.get("uuid")
+
+            if isinstance(result, tuple) and len(result) == 2:
+                _, msg = result
+                if isinstance(msg, dict):
+                    log_kwargs["event_id"] = msg.get("uuid")
+            elif isinstance(result, str):
+                log_kwargs["event_id"] = result
 
             logger.exception(error, **log_kwargs)
     else:

--- a/posthog/exceptions_capture.py
+++ b/posthog/exceptions_capture.py
@@ -12,19 +12,10 @@ def capture_exception(error=None, additional_properties=None):
         properties.update(additional_properties)
 
     if api_key:
-        result = posthog_capture_exception(error, properties=properties)
+        uuid = posthog_capture_exception(error, properties=properties)
 
         # Only log if captured
-        if result is not None:
-            log_kwargs = {}
-
-            if isinstance(result, tuple) and len(result) == 2:
-                _, msg = result
-                if isinstance(msg, dict):
-                    log_kwargs["event_id"] = msg.get("uuid")
-            elif isinstance(result, str):
-                log_kwargs["event_id"] = result
-
-            logger.exception(error, **log_kwargs)
+        if uuid is not None:
+            logger.exception(error, event_id=uuid)
     else:
         logger.exception(error)


### PR DESCRIPTION
## Problem

- [error](https://us.posthog.com/project/2/error_tracking/0197d1db-772f-73f1-972a-dbe0c7ea4b55) emitting that says this is unpacking into a single string

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- safe unpack by checking if it's a single string

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
