### PR TITLE
feat: Merge changes affecting `cache_key`

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -12571,6 +12571,12 @@
                     "enum": ["enabled", "disabled", "optimized"],
                     "type": "string"
                 },
+                "revenueAnalyticsPersonsJoinMode": {
+                    "$ref": "#/definitions/RevenueAnalyticsPersonsJoinModeModifier"
+                },
+                "revenueAnalyticsPersonsJoinModeCustom": {
+                    "type": ["string", "null"]
+                },
                 "s3TableUseInvalidColumns": {
                     "type": "boolean"
                 },
@@ -19802,6 +19808,10 @@
             },
             "required": ["results"],
             "type": "object"
+        },
+        "RevenueAnalyticsPersonsJoinModeModifier": {
+            "enum": ["id", "email", "custom"],
+            "type": "string"
         },
         "RevenueAnalyticsPropertyFilter": {
             "additionalProperties": false,

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -329,6 +329,8 @@ export interface HogQLQueryModifiers {
     personsJoinMode?: 'inner' | 'left'
     bounceRatePageViewMode?: 'count_pageviews' | 'uniq_urls' | 'uniq_page_screen_autocaptures'
     bounceRateDurationSeconds?: number
+    revenueAnalyticsPersonsJoinMode?: RevenueAnalyticsPersonsJoinModeModifier
+    revenueAnalyticsPersonsJoinModeCustom?: string | null
     sessionTableVersion?: 'auto' | 'v1' | 'v2'
     sessionsV2JoinMode?: 'string' | 'uuid'
     propertyGroupsMode?: 'enabled' | 'disabled' | 'optimized'
@@ -345,6 +347,12 @@ export interface DataWarehouseEventsModifier {
     timestamp_field: string
     distinct_id_field: string
     id_field: string
+}
+
+export enum RevenueAnalyticsPersonsJoinModeModifier {
+    ID = 'id',
+    EMAIL = 'email',
+    CUSTOM = 'custom',
 }
 
 export interface HogQLQueryResponse<T = any[]> extends AnalyticsQueryResponseBase<T> {

--- a/posthog/hogql/modifiers.py
+++ b/posthog/hogql/modifiers.py
@@ -14,6 +14,7 @@ from posthog.schema import (
     SessionTableVersion,
     CustomChannelRule,
     SessionsV2JoinMode,
+    RevenueAnalyticsPersonsJoinModeModifier,
 )
 
 if TYPE_CHECKING:
@@ -108,6 +109,9 @@ def set_default_modifier_values(modifiers: HogQLQueryModifiers, team: "Team"):
 
     if modifiers.convertToProjectTimezone is None:
         modifiers.convertToProjectTimezone = True
+
+    if modifiers.revenueAnalyticsPersonsJoinMode is None:
+        modifiers.revenueAnalyticsPersonsJoinMode = RevenueAnalyticsPersonsJoinModeModifier.ID
 
 
 def set_default_in_cohort_via(modifiers: HogQLQueryModifiers) -> HogQLQueryModifiers:

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -31,6 +31,7 @@ from posthog.hogql.timings import HogQLTimings
 from posthog.hogql_queries.query_cache import QueryCacheManager
 from posthog.metrics import LABEL_TEAM_ID
 from posthog.models import Team, User
+from posthog.models.team import WeekStartDay
 from posthog.schema import (
     ActorsPropertyTaxonomyQuery,
     ActorsQuery,
@@ -1006,6 +1007,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             "hogql_modifiers": to_dict(self.modifiers),
             "limit_context": self._limit_context_aliased_for_cache,
             "timezone": self.team.timezone,
+            "week_start_day": self.team.week_start_day or WeekStartDay.SUNDAY,
             "version": 2,
         }
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -2017,6 +2017,12 @@ class RevenueAnalyticsOverviewItemKey(StrEnum):
     AVG_REVENUE_PER_CUSTOMER = "avg_revenue_per_customer"
 
 
+class RevenueAnalyticsPersonsJoinModeModifier(StrEnum):
+    ID = "id"
+    EMAIL = "email"
+    CUSTOM = "custom"
+
+
 class RevenueAnalyticsPropertyFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -3363,6 +3369,8 @@ class HogQLQueryModifiers(BaseModel):
     personsJoinMode: Optional[PersonsJoinMode] = None
     personsOnEventsMode: Optional[PersonsOnEventsMode] = None
     propertyGroupsMode: Optional[PropertyGroupsMode] = None
+    revenueAnalyticsPersonsJoinMode: Optional[RevenueAnalyticsPersonsJoinModeModifier] = None
+    revenueAnalyticsPersonsJoinModeCustom: Optional[str] = None
     s3TableUseInvalidColumns: Optional[bool] = None
     sessionTableVersion: Optional[SessionTableVersion] = None
     sessionsV2JoinMode: Optional[SessionsV2JoinMode] = None


### PR DESCRIPTION
PRs have been previously approved, we're waiting until Saturday to merge this to invalidate the least amount of queries