### PR TITLE
feat(capture): set up mirror deploy to observe /i/v0 events w/legacy handling

### DIFF
--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -93,10 +93,7 @@ pub struct Config {
     #[envconfig(default = "info")]
     pub log_level: Level,
 
-<<<<<<< HEAD
-=======
-    // generic env injection to sample behavior of interest for verbose logging
->>>>>>> a7e70d3a1b (remove temporarily verbose log sampling but leave the stub for later)
+    // deploy var [0.0..100.0] to sample behavior of interest for verbose logging
     #[envconfig(default = "0.0")]
     pub verbose_sample_percent: f32,
 }

--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -93,6 +93,10 @@ pub struct Config {
     #[envconfig(default = "info")]
     pub log_level: Level,
 
+<<<<<<< HEAD
+=======
+    // generic env injection to sample behavior of interest for verbose logging
+>>>>>>> a7e70d3a1b (remove temporarily verbose log sampling but leave the stub for later)
     #[envconfig(default = "0.0")]
     pub verbose_sample_percent: f32,
 }

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -31,22 +31,9 @@ use crate::{
     v0_request::{EventFormData, EventQuery},
 };
 
-<<<<<<< HEAD
 // EXAMPLE: use verbose_sample_percent env var to capture extra logging/metric details of interest
 // let roll = thread_rng().with_borrow_mut(|rng| rng.gen_range(0.0..100.0));
 // if roll < verbose_sample_percent { ... }
-=======
-// Create a thread-local RNG that we can use with sample_verbose_percent
-// env var to cheaply decide if we want to log behavior of interest. example:
-// ```
-//  let roll = RNG.with_borrow_mut(|rng| rng.gen_range(0.0..100.0));
-//  if roll < verbose_sample_percent { ... }
-// ```
-//
-// thread_local! {
-//    static RNG: RefCell<rand::rngs::ThreadRng> = std::cell::RefCell::new(rand::thread_rng());
-// }
->>>>>>> a7e70d3a1b (remove temporarily verbose log sampling but leave the stub for later)
 
 /// handle_legacy owns the /e, /capture, /track, and /engage capture endpoints
 #[instrument(

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -31,9 +31,22 @@ use crate::{
     v0_request::{EventFormData, EventQuery},
 };
 
+<<<<<<< HEAD
 // EXAMPLE: use verbose_sample_percent env var to capture extra logging/metric details of interest
 // let roll = thread_rng().with_borrow_mut(|rng| rng.gen_range(0.0..100.0));
 // if roll < verbose_sample_percent { ... }
+=======
+// Create a thread-local RNG that we can use with sample_verbose_percent
+// env var to cheaply decide if we want to log behavior of interest. example:
+// ```
+//  let roll = RNG.with_borrow_mut(|rng| rng.gen_range(0.0..100.0));
+//  if roll < verbose_sample_percent { ... }
+// ```
+//
+// thread_local! {
+//    static RNG: RefCell<rand::rngs::ThreadRng> = std::cell::RefCell::new(rand::thread_rng());
+// }
+>>>>>>> a7e70d3a1b (remove temporarily verbose log sampling but leave the stub for later)
 
 /// handle_legacy owns the /e, /capture, /track, and /engage capture endpoints
 #[instrument(


### PR DESCRIPTION
## Problem
We'd like to explore the possibility of uniting the current `/i/v0/e` and "legacy" event handling code as we refactor `capture-rs`. But we don't want to break production

## Changes
* Wire up `/i/v0/e/` endpoints to route to legacy event handlers in _mirror deploy only_
* Bonus: remove conditional logging of targeted tokens; keep the plumbing for later

## Did you write or update any docs for this change?

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Locally and in CI; next up, in mirror deploy 🚀 