### PR TITLE
chore: log timestamps with no toUTC method

### DIFF
--- a/plugin-server/src/utils/utils.ts
+++ b/plugin-server/src/utils/utils.ts
@@ -337,8 +337,12 @@ export function castTimestampToClickhouseFormat(
     timestamp: DateTime,
     timestampFormat: TimestampFormat = TimestampFormat.ISO
 ): ISOTimestamp | ClickHouseTimestamp | ClickHouseTimestampSecondPrecision {
-    if (!timestamp.toUTC) {
-        logger.error('🔴', 'Timestamp is missing toUTC method', { timestamp, type: typeof timestamp })
+    if (typeof timestamp.toUTC !== 'function') {
+        logger.error('🔴', 'Timestamp is missing toUTC method', {
+            timestamp,
+            type: typeof timestamp,
+            toUTC: timestamp.toUTC.toString(),
+        })
     }
     timestamp = timestamp.toUTC()
     switch (timestampFormat) {

--- a/plugin-server/src/utils/utils.ts
+++ b/plugin-server/src/utils/utils.ts
@@ -337,6 +337,9 @@ export function castTimestampToClickhouseFormat(
     timestamp: DateTime,
     timestampFormat: TimestampFormat = TimestampFormat.ISO
 ): ISOTimestamp | ClickHouseTimestamp | ClickHouseTimestampSecondPrecision {
+    if (!timestamp.toUTC) {
+        logger.error('🔴', 'Timestamp is missing toUTC method', { timestamp, type: typeof timestamp })
+    }
     timestamp = timestamp.toUTC()
     switch (timestampFormat) {
         case TimestampFormat.ClickHouseSecondPrecision:


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We're seeing some events being dropped due to invalid timestamps, but it's not clear why the timestamps are wrong.

## Changes

Adds logging for timestamps that don't have the `toUTC` method.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [X] No docs needed for this change

## How did you test this code?

Just logging.