### PR TITLE
fix(devex): Remove folder icon from project dropdown

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectDropdownMenu.tsx
+++ b/frontend/src/layout/panel-layout/ProjectDropdownMenu.tsx
@@ -1,4 +1,4 @@
-import { IconCheck, IconChevronRight, IconFolderOpen, IconGear, IconPlusSmall } from '@posthog/icons'
+import { IconCheck, IconChevronRight, IconGear, IconPlusSmall } from '@posthog/icons'
 import { LemonSnack, Link } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { upgradeModalLogic } from 'lib/components/UpgradeModal/upgradeModalLogic'
@@ -46,7 +46,6 @@ export function ProjectDropdownMenu(): JSX.Element | null {
                     className="flex-1 min-w-0 max-w-fit"
                     size="sm"
                 >
-                    <IconFolderOpen className="text-tertiary" />
                     <span className="truncate font-semibold">{currentTeam.name ?? 'Project'}</span>
                     <IconChevronRight
                         className={`


### PR DESCRIPTION
## Problem
Project dropdown in the panel had this icon and it just seems unnecessary!

|Before|After|
|----|----|
|<img width="458" alt="image" src="https://github.com/user-attachments/assets/8737a864-f614-4d1f-aca4-a417cd2862ad" />  | <img width="456" alt="image" src="https://github.com/user-attachments/assets/5a5a8b2b-0602-4916-825b-0ad678701f07" /> |

## Changes
- Omit folder icon from project dropdown trigger

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Locally
