### PR TITLE
fix: fix toUTC logging

### DIFF
--- a/plugin-server/src/utils/utils.ts
+++ b/plugin-server/src/utils/utils.ts
@@ -341,7 +341,6 @@ export function castTimestampToClickhouseFormat(
         logger.error('🔴', 'Timestamp is missing toUTC method', {
             timestamp,
             type: typeof timestamp,
-            toUTC: timestamp.toUTC.toString(),
         })
     }
     timestamp = timestamp.toUTC()


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We're calling toString on an undefined field.

## Changes

Removes the toString call from the toUTC log.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [X] No docs needed for this change

## How did you test this code?

