### PR TITLE
fix(max): add retry efficiency scorer & resolve unsupported sql function

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -193,7 +193,8 @@
             "module": "pytest",
             "args": ["${file}", "-vvv"],
             "console": "integratedTerminal",
-            "justMyCode": true
+            "justMyCode": true,
+            "envFile": "${workspaceFolder}/.env"
         },
         {
             "name": "Frontend: Debug Jest Tests",

--- a/ee/hogai/eval/conftest.py
+++ b/ee/hogai/eval/conftest.py
@@ -91,11 +91,20 @@ def call_root_for_insight_generation(demo_org_team_user):
             initial_state,
             {"configurable": {"thread_id": conversation.id}},
         )
+
         final_state = AssistantState.model_validate(final_state_raw)
 
         if not final_state.messages or not isinstance(final_state.messages[-1], VisualizationMessage):
-            return {"plan": None, "query": None}
-        return {"plan": final_state.messages[-1].plan, "query": final_state.messages[-1].answer}
+            return {
+                "plan": None,
+                "query": None,
+                "query_generation_retry_count": final_state.query_generation_retry_count,
+            }
+        return {
+            "plan": final_state.messages[-1].plan,
+            "query": final_state.messages[-1].answer,
+            "query_generation_retry_count": final_state.query_generation_retry_count,
+        }
 
     return callable
 
@@ -141,7 +150,7 @@ def core_memory(demo_org_team_user, django_db_blocker) -> Generator[CoreMemory, 
 
     Their audience includes professionals and organizations seeking file management and collaboration solutions.
 
-    Hedgebox’s freemium model provides free accounts with limited storage and paid subscription plans for additional features.
+    Hedgebox's freemium model provides free accounts with limited storage and paid subscription plans for additional features.
 
     Core features include file storage, synchronization, sharing, and collaboration tools for seamless file access and sharing.
 

--- a/ee/hogai/eval/scorers.py
+++ b/ee/hogai/eval/scorers.py
@@ -59,6 +59,7 @@ class ToolRelevance(ScorerWithPartial):
 class PlanAndQueryOutput(TypedDict):
     plan: str | None
     query: AssistantTrendsQuery | AssistantFunnelsQuery | AssistantRetentionQuery | AssistantHogQLQuery
+    query_generation_retry_count: int | None
 
 
 def serialize_output(output: PlanAndQueryOutput | dict | None) -> PlanAndQueryOutput | None:

--- a/ee/hogai/graph/schema_generator/nodes.py
+++ b/ee/hogai/graph/schema_generator/nodes.py
@@ -94,11 +94,12 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
                 return PartialAssistantState(
                     messages=[
                         FailureMessage(
-                            content=f"Oops! It looks like I’m having trouble generating this {self.INSIGHT_NAME} insight. Could you please try again?"
+                            content=f"Oops! It looks like I'm having trouble generating this {self.INSIGHT_NAME} insight. Could you please try again?"
                         )
                     ],
                     intermediate_steps=[],
                     plan="",
+                    query_generation_retry_count=len(intermediate_steps) + 1,
                 )
 
             return PartialAssistantState(
@@ -106,6 +107,7 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
                     *intermediate_steps,
                     (AgentAction("handle_incorrect_response", e.llm_output, e.validation_message), None),
                 ],
+                query_generation_retry_count=len(intermediate_steps) + 1,
             )
 
         final_message = VisualizationMessage(
@@ -120,6 +122,7 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
             messages=[final_message],
             intermediate_steps=[],
             plan="",
+            query_generation_retry_count=len(intermediate_steps),
         )
 
     def router(self, state: AssistantState):

--- a/ee/hogai/utils/types.py
+++ b/ee/hogai/utils/types.py
@@ -65,6 +65,19 @@ def add_and_merge_messages(
     return merged
 
 
+def merge_retry_counts(left: int, right: int) -> int:
+    """Merges two retry counts by taking the maximum value.
+
+    Args:
+        left: The base retry count
+        right: The new retry count
+
+    Returns:
+        The maximum of the two counts
+    """
+    return max(left, right)
+
+
 class _SharedAssistantState(BaseModel):
     """
     The state of the root node.
@@ -126,7 +139,7 @@ class _SharedAssistantState(BaseModel):
     """
     The context for taxonomy agent.
     """
-    query_generation_retry_count: int = Field(default=0)
+    query_generation_retry_count: Annotated[int, merge_retry_counts] = Field(default=0)
     """
     Tracks the number of times the query generation has been retried.
     """

--- a/ee/hogai/utils/types.py
+++ b/ee/hogai/utils/types.py
@@ -126,6 +126,10 @@ class _SharedAssistantState(BaseModel):
     """
     The context for taxonomy agent.
     """
+    query_generation_retry_count: int = Field(default=0)
+    """
+    Tracks the number of times the query generation has been retried.
+    """
 
 
 class AssistantState(_SharedAssistantState):
@@ -155,6 +159,7 @@ class PartialAssistantState(_SharedAssistantState):
             root_tool_calls_count=0,
             root_conversation_start_id="",
             rag_context="",
+            query_generation_retry_count=0,
         )
 
 

--- a/posthog/hogql/ai.py
+++ b/posthog/hogql/ai.py
@@ -43,6 +43,8 @@ ORDER BY week_of DESC
 
 Important HogQL differences versus other SQL dialects:
 - JSON properties are accessed like `properties.foo.bar` instead of `properties->foo->bar`
+- toFloat64OrNull() and toFloat64() are NOT SUPPORTED. Use toFloat() instead. If you use them, the query will NOT WORK.
+
 """
 
 SCHEMA_MESSAGE = """


### PR DESCRIPTION

## Problem
While using the HogQL generation functionality we noticed Max was retrying multiple times to generate a query. This was due to Max using unsupported functions such as `toFloat64OrNull()` and `toFloat64()`

## Changes
1. An Eval Scorer was added to test the efficiency of Max's retries when given the error message
2. The issue was mitigated by adding more context to the `HOGQL_EXAMPLE_MESSAGE` about HOGQL not being able to support those functions

## Did you write or update any docs for this change?
- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ x] No docs needed for this change

## How did you test this code?
1. Added two evaluation test cases 
2. Observed the traces in BrainTrust and the retries in order to make sure calculations were correct
