### PR TITLE
fix(cdp): make hogwatcher state in capture human readable

### DIFF
--- a/plugin-server/src/cdp/services/monitoring/hog-watcher.service.test.ts
+++ b/plugin-server/src/cdp/services/monitoring/hog-watcher.service.test.ts
@@ -333,7 +333,7 @@ describe('HogWatcher', () => {
                 hog_function_type: hogFunction.type,
                 hog_function_name: hogFunction.name,
                 hog_function_template_id: hogFunction.template_id,
-                state: HogWatcherState.healthy,
+                state: HogWatcherState[HogWatcherState.healthy],
             })
         })
         it('should force degraded', async () => {
@@ -351,7 +351,7 @@ describe('HogWatcher', () => {
                 hog_function_type: hogFunction.type,
                 hog_function_name: hogFunction.name,
                 hog_function_template_id: hogFunction.template_id,
-                state: HogWatcherState.degraded,
+                state: HogWatcherState[HogWatcherState.degraded],
             })
         })
         it('should force disabledForPeriod', async () => {
@@ -372,7 +372,7 @@ describe('HogWatcher', () => {
                 hog_function_type: hogFunction.type,
                 hog_function_name: hogFunction.name,
                 hog_function_template_id: hogFunction.template_id,
-                state: HogWatcherState.disabledForPeriod,
+                state: HogWatcherState[HogWatcherState.disabledForPeriod],
             })
         })
         it('should force disabledIndefinitely', async () => {
@@ -393,7 +393,7 @@ describe('HogWatcher', () => {
                 hog_function_type: hogFunction.type,
                 hog_function_name: hogFunction.name,
                 hog_function_template_id: hogFunction.template_id,
-                state: HogWatcherState.disabledIndefinitely,
+                state: HogWatcherState[HogWatcherState.disabledIndefinitely],
             })
         })
     })

--- a/plugin-server/src/cdp/services/monitoring/hog-watcher.service.ts
+++ b/plugin-server/src/cdp/services/monitoring/hog-watcher.service.ts
@@ -96,7 +96,7 @@ export class HogWatcherService {
                 hog_function_type: hogFunction.type,
                 hog_function_name: hogFunction.name,
                 hog_function_template_id: hogFunction.template_id,
-                state,
+                state: HogWatcherState[state], // Convert numeric state to readable string
             })
         }
         await this.hub.celery.applyAsync(CELERY_TASK_ID, [hogFunction.id, state])


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We (for now) want a slack msg indicating that a hog-function changed state since otherwise we do not have any other indication for now. In order to know what state the hog function is now in we make the state human readable instead of an integer

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- changed state to be human readable

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

- adjusted tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
