### PR TITLE
chore(mm): increase request timeouts against amplitude endpoint

### DIFF
--- a/posthog/models/batch_imports.py
+++ b/posthog/models/batch_imports.py
@@ -137,7 +137,7 @@ class BatchImportConfigBuilder:
                     "date_format": "%Y%m%dT%H",
                     # The smallest duration we can request from amplitude is 1 hour at a time
                     "interval_duration": 3600,
-                    "timeout_seconds": 60,
+                    "timeout_seconds": 180,
                 }
             case DateRangeExportSource.MIXPANEL:
                 base_url = "https://data.mixpanel.com/api/2.0/export"


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

The amplitude export endpoint has variable latency associated with it due to different amounts of data being exported from it and the endpoint being flakey. Folks with larger migrations will experience lots of timeouts when trying to migrate with a request timeout of 60 seconds.

## Changes

Up the timeout from 60 seconds to 180 for amplitude exports.

## Did you write or update any docs for this change?

## How did you test this code?

Unit tests cover the ability to create record with this new value
