### PR TITLE
feat: Add `modifiers` parameter to Revenue Analytics

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -510,7 +510,7 @@ def create_hogql_database(
 
         with timings.measure("for_schema_source"):
             for stripe_source in stripe_sources:
-                revenue_views = RevenueAnalyticsBaseView.for_schema_source(stripe_source)
+                revenue_views = RevenueAnalyticsBaseView.for_schema_source(stripe_source, modifiers)
 
                 # View will have a name similar to stripe.prefix.table_name
                 # We want to create a nested table group where stripe is the parent,
@@ -524,7 +524,7 @@ def create_hogql_database(
         # Similar to the above, these will be in the format revenue_analytics.<event_name>.events_revenue_view
         # so let's make sure we have the proper nested queries
         with timings.measure("for_events"):
-            revenue_views = RevenueAnalyticsBaseView.for_events(team)
+            revenue_views = RevenueAnalyticsBaseView.for_events(team, modifiers)
             for view in revenue_views:
                 views[view.name] = view
                 create_nested_table_group(view.name.split("."), views, view)

--- a/posthog/models/team/team_revenue_analytics_config.py
+++ b/posthog/models/team/team_revenue_analytics_config.py
@@ -18,7 +18,6 @@ class TeamRevenueAnalyticsConfig(models.Model):
     filter_test_accounts = models.BooleanField(default=False)
     notified_first_sync = models.BooleanField(default=False, null=True)
 
-    # Mangled fields incoming:
     # Because we want to validate the schema for these fields, we'll have mangled DB fields/columns
     # that are then wrapped by schema-validation getters/setters
     _events = models.JSONField(default=list, db_column="events")

--- a/products/revenue_analytics/backend/hogql_queries/test/test_views.py
+++ b/products/revenue_analytics/backend/hogql_queries/test/test_views.py
@@ -1,4 +1,4 @@
-from posthog.schema import CurrencyCode
+from posthog.schema import CurrencyCode, HogQLQueryModifiers
 from posthog.warehouse.models import ExternalDataSource, ExternalDataSchema, DataWarehouseTable, DataWarehouseCredential
 from posthog.test.base import BaseTest
 
@@ -19,6 +19,8 @@ from products.revenue_analytics.backend.views import (
 class TestRevenueAnalyticsViews(BaseTest):
     def setUp(self):
         super().setUp()
+        self.modifiers = HogQLQueryModifiers()
+
         self.source = ExternalDataSource.objects.create(
             team=self.team,
             source_id="source_id",
@@ -56,18 +58,18 @@ class TestRevenueAnalyticsViews(BaseTest):
         self.assertNotIn(CurrencyCode.USD, ZERO_DECIMAL_CURRENCIES_IN_STRIPE)
 
     def test_schema_source_views(self):
-        views = RevenueAnalyticsBaseView.for_schema_source(self.source)
+        views = RevenueAnalyticsBaseView.for_schema_source(self.source, self.modifiers)
         self.assertEqual(len(views), 1)
         self.assertEqual(views[0].name, "stripe.charge_revenue_view")
 
-        charge_views = RevenueAnalyticsChargeView.for_schema_source(self.source)
+        charge_views = RevenueAnalyticsChargeView.for_schema_source(self.source, self.modifiers)
         self.assertEqual(len(charge_views), 1)
         self.assertEqual(charge_views[0].name, "stripe.charge_revenue_view")
 
-        customer_views = RevenueAnalyticsCustomerView.for_schema_source(self.source)
+        customer_views = RevenueAnalyticsCustomerView.for_schema_source(self.source, self.modifiers)
         self.assertEqual(len(customer_views), 0)
 
-        subscription_views = RevenueAnalyticsSubscriptionView.for_schema_source(self.source)
+        subscription_views = RevenueAnalyticsSubscriptionView.for_schema_source(self.source, self.modifiers)
         self.assertEqual(len(subscription_views), 0)
 
     def test_revenue_view_non_stripe_source(self):
@@ -75,14 +77,14 @@ class TestRevenueAnalyticsViews(BaseTest):
         self.source.source_type = "Salesforce"
         self.source.save()
 
-        views = RevenueAnalyticsBaseView.for_schema_source(self.source)
+        views = RevenueAnalyticsBaseView.for_schema_source(self.source, self.modifiers)
         self.assertEqual(len(views), 0)
 
     def test_revenue_view_missing_schema(self):
         """Test that RevenueAnalyticsBaseView handles missing schema gracefully"""
         self.schema.delete()
 
-        views = RevenueAnalyticsBaseView.for_schema_source(self.source)
+        views = RevenueAnalyticsBaseView.for_schema_source(self.source, self.modifiers)
         self.assertEqual(len(views), 0)
 
     def test_revenue_view_prefix(self):
@@ -90,7 +92,7 @@ class TestRevenueAnalyticsViews(BaseTest):
         self.source.prefix = "prefix"
         self.source.save()
 
-        views = RevenueAnalyticsBaseView.for_schema_source(self.source)
+        views = RevenueAnalyticsBaseView.for_schema_source(self.source, self.modifiers)
         self.assertEqual(len(views), 1)
         self.assertEqual(views[0].name, "stripe.prefix.charge_revenue_view")
 
@@ -99,7 +101,7 @@ class TestRevenueAnalyticsViews(BaseTest):
         self.source.prefix = None
         self.source.save()
 
-        views = RevenueAnalyticsBaseView.for_schema_source(self.source)
+        views = RevenueAnalyticsBaseView.for_schema_source(self.source, self.modifiers)
         self.assertEqual(len(views), 1)
         self.assertEqual(views[0].name, "stripe.charge_revenue_view")
 
@@ -108,7 +110,7 @@ class TestRevenueAnalyticsViews(BaseTest):
         self.source.prefix = "prefix_with_underscores_"
         self.source.save()
 
-        views = RevenueAnalyticsBaseView.for_schema_source(self.source)
+        views = RevenueAnalyticsBaseView.for_schema_source(self.source, self.modifiers)
         self.assertEqual(len(views), 1)
         self.assertEqual(views[0].name, "stripe.prefix_with_underscores.charge_revenue_view")
 
@@ -117,7 +119,7 @@ class TestRevenueAnalyticsViews(BaseTest):
         self.source.prefix = ""
         self.source.save()
 
-        views = RevenueAnalyticsBaseView.for_schema_source(self.source)
+        views = RevenueAnalyticsBaseView.for_schema_source(self.source, self.modifiers)
         self.assertEqual(len(views), 1)
         self.assertEqual(views[0].name, "stripe.charge_revenue_view")
 
@@ -199,7 +201,7 @@ class TestRevenueAnalyticsViews(BaseTest):
             last_synced_at="2024-01-01",
         )
 
-        views = RevenueAnalyticsBaseView.for_schema_source(self.source)
+        views = RevenueAnalyticsBaseView.for_schema_source(self.source, self.modifiers)
         self.assertEqual(len(views), 5)
 
         names = [view.name for view in views]
@@ -210,22 +212,22 @@ class TestRevenueAnalyticsViews(BaseTest):
         self.assertIn("stripe.subscription_revenue_view", names)
 
         # Test individual views
-        charge_views = RevenueAnalyticsChargeView.for_schema_source(self.source)
+        charge_views = RevenueAnalyticsChargeView.for_schema_source(self.source, self.modifiers)
         self.assertEqual(len(charge_views), 1)
         self.assertEqual(charge_views[0].name, "stripe.charge_revenue_view")
 
-        customer_views = RevenueAnalyticsCustomerView.for_schema_source(self.source)
+        customer_views = RevenueAnalyticsCustomerView.for_schema_source(self.source, self.modifiers)
         self.assertEqual(len(customer_views), 1)
         self.assertEqual(customer_views[0].name, "stripe.customer_revenue_view")
 
-        product_views = RevenueAnalyticsProductView.for_schema_source(self.source)
+        product_views = RevenueAnalyticsProductView.for_schema_source(self.source, self.modifiers)
         self.assertEqual(len(product_views), 1)
         self.assertEqual(product_views[0].name, "stripe.product_revenue_view")
 
-        invoice_item_views = RevenueAnalyticsInvoiceItemView.for_schema_source(self.source)
+        invoice_item_views = RevenueAnalyticsInvoiceItemView.for_schema_source(self.source, self.modifiers)
         self.assertEqual(len(invoice_item_views), 1)
         self.assertEqual(invoice_item_views[0].name, "stripe.invoice_item_revenue_view")
 
-        subscription_views = RevenueAnalyticsSubscriptionView.for_schema_source(self.source)
+        subscription_views = RevenueAnalyticsSubscriptionView.for_schema_source(self.source, self.modifiers)
         self.assertEqual(len(subscription_views), 1)
         self.assertEqual(subscription_views[0].name, "stripe.subscription_revenue_view")

--- a/products/revenue_analytics/backend/views/revenue_analytics_base_view.py
+++ b/products/revenue_analytics/backend/views/revenue_analytics_base_view.py
@@ -2,7 +2,10 @@ from typing import Optional
 from posthog.models.team.team import Team
 from posthog.hogql import ast
 from posthog.hogql.database.models import SavedQuery
-from posthog.schema import DatabaseSchemaManagedViewTableKind
+from posthog.schema import (
+    DatabaseSchemaManagedViewTableKind,
+    HogQLQueryModifiers,
+)
 from posthog.warehouse.models.external_data_source import ExternalDataSource
 import re
 
@@ -12,7 +15,9 @@ class RevenueAnalyticsBaseView(SavedQuery):
     prefix: str
 
     @classmethod
-    def for_events(cls, team: "Team") -> list["RevenueAnalyticsBaseView"]:
+    def for_events(
+        cls, team: "Team", modifiers: Optional[HogQLQueryModifiers] = None
+    ) -> list["RevenueAnalyticsBaseView"]:
         from .revenue_analytics_charge_view import RevenueAnalyticsChargeView
         from .revenue_analytics_customer_view import RevenueAnalyticsCustomerView
         from .revenue_analytics_invoice_item_view import RevenueAnalyticsInvoiceItemView
@@ -20,15 +25,17 @@ class RevenueAnalyticsBaseView(SavedQuery):
         from .revenue_analytics_subscription_view import RevenueAnalyticsSubscriptionView
 
         return [
-            *RevenueAnalyticsChargeView.for_events(team),
-            *RevenueAnalyticsCustomerView.for_events(team),
-            *RevenueAnalyticsInvoiceItemView.for_events(team),
-            *RevenueAnalyticsProductView.for_events(team),
-            *RevenueAnalyticsSubscriptionView.for_events(team),
+            *RevenueAnalyticsChargeView.for_events(team, modifiers),
+            *RevenueAnalyticsCustomerView.for_events(team, modifiers),
+            *RevenueAnalyticsInvoiceItemView.for_events(team, modifiers),
+            *RevenueAnalyticsProductView.for_events(team, modifiers),
+            *RevenueAnalyticsSubscriptionView.for_events(team, modifiers),
         ]
 
     @classmethod
-    def for_schema_source(cls, source: ExternalDataSource) -> list["RevenueAnalyticsBaseView"]:
+    def for_schema_source(
+        cls, source: ExternalDataSource, modifiers: Optional[HogQLQueryModifiers] = None
+    ) -> list["RevenueAnalyticsBaseView"]:
         from .revenue_analytics_charge_view import RevenueAnalyticsChargeView
         from .revenue_analytics_customer_view import RevenueAnalyticsCustomerView
         from .revenue_analytics_invoice_item_view import RevenueAnalyticsInvoiceItemView
@@ -36,11 +43,11 @@ class RevenueAnalyticsBaseView(SavedQuery):
         from .revenue_analytics_subscription_view import RevenueAnalyticsSubscriptionView
 
         return [
-            *RevenueAnalyticsChargeView.for_schema_source(source),
-            *RevenueAnalyticsCustomerView.for_schema_source(source),
-            *RevenueAnalyticsInvoiceItemView.for_schema_source(source),
-            *RevenueAnalyticsProductView.for_schema_source(source),
-            *RevenueAnalyticsSubscriptionView.for_schema_source(source),
+            *RevenueAnalyticsChargeView.for_schema_source(source, modifiers),
+            *RevenueAnalyticsCustomerView.for_schema_source(source, modifiers),
+            *RevenueAnalyticsInvoiceItemView.for_schema_source(source, modifiers),
+            *RevenueAnalyticsProductView.for_schema_source(source, modifiers),
+            *RevenueAnalyticsSubscriptionView.for_schema_source(source, modifiers),
         ]
 
     # Used in child classes to generate view names

--- a/products/revenue_analytics/backend/views/revenue_analytics_base_view.py
+++ b/products/revenue_analytics/backend/views/revenue_analytics_base_view.py
@@ -15,9 +15,7 @@ class RevenueAnalyticsBaseView(SavedQuery):
     prefix: str
 
     @classmethod
-    def for_events(
-        cls, team: "Team", modifiers: Optional[HogQLQueryModifiers] = None
-    ) -> list["RevenueAnalyticsBaseView"]:
+    def for_events(cls, team: "Team", modifiers: HogQLQueryModifiers) -> list["RevenueAnalyticsBaseView"]:
         from .revenue_analytics_charge_view import RevenueAnalyticsChargeView
         from .revenue_analytics_customer_view import RevenueAnalyticsCustomerView
         from .revenue_analytics_invoice_item_view import RevenueAnalyticsInvoiceItemView
@@ -34,7 +32,7 @@ class RevenueAnalyticsBaseView(SavedQuery):
 
     @classmethod
     def for_schema_source(
-        cls, source: ExternalDataSource, modifiers: Optional[HogQLQueryModifiers] = None
+        cls, source: ExternalDataSource, modifiers: HogQLQueryModifiers
     ) -> list["RevenueAnalyticsBaseView"]:
         from .revenue_analytics_charge_view import RevenueAnalyticsChargeView
         from .revenue_analytics_customer_view import RevenueAnalyticsCustomerView

--- a/products/revenue_analytics/backend/views/revenue_analytics_charge_view.py
+++ b/products/revenue_analytics/backend/views/revenue_analytics_charge_view.py
@@ -2,7 +2,10 @@ from typing import cast
 
 from posthog.hogql import ast
 from posthog.models.team.team import Team
-from posthog.schema import DatabaseSchemaManagedViewTableKind
+from posthog.schema import (
+    DatabaseSchemaManagedViewTableKind,
+    HogQLQueryModifiers,
+)
 from posthog.warehouse.models.external_data_source import ExternalDataSource
 from posthog.warehouse.models.table import DataWarehouseTable
 from posthog.warehouse.models.external_data_schema import ExternalDataSchema
@@ -53,7 +56,7 @@ class RevenueAnalyticsChargeView(RevenueAnalyticsBaseView):
         return DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_CHARGE
 
     @classmethod
-    def for_events(cls, team: "Team") -> list["RevenueAnalyticsBaseView"]:
+    def for_events(cls, team: "Team", _modifiers: HogQLQueryModifiers) -> list["RevenueAnalyticsBaseView"]:
         if len(team.revenue_analytics_config.events) == 0:
             return []
 
@@ -131,7 +134,9 @@ class RevenueAnalyticsChargeView(RevenueAnalyticsBaseView):
         ]
 
     @classmethod
-    def for_schema_source(cls, source: ExternalDataSource) -> list["RevenueAnalyticsBaseView"]:
+    def for_schema_source(
+        cls, source: ExternalDataSource, _modifiers: HogQLQueryModifiers
+    ) -> list["RevenueAnalyticsBaseView"]:
         # Currently only works for stripe sources
         if not source.source_type == ExternalDataSource.Type.STRIPE:
             return []

--- a/products/revenue_analytics/backend/views/revenue_analytics_customer_view.py
+++ b/products/revenue_analytics/backend/views/revenue_analytics_customer_view.py
@@ -3,7 +3,10 @@ from typing import cast
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_expr
 from posthog.models.team.team import Team
-from posthog.schema import DatabaseSchemaManagedViewTableKind
+from posthog.schema import (
+    DatabaseSchemaManagedViewTableKind,
+    HogQLQueryModifiers,
+)
 from posthog.warehouse.models.external_data_source import ExternalDataSource
 from posthog.warehouse.models.table import DataWarehouseTable
 from posthog.warehouse.models.external_data_schema import ExternalDataSchema
@@ -49,7 +52,7 @@ class RevenueAnalyticsCustomerView(RevenueAnalyticsBaseView):
         return DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_CUSTOMER
 
     @classmethod
-    def for_events(cls, team: "Team") -> list["RevenueAnalyticsBaseView"]:
+    def for_events(cls, team: "Team", _modifiers: HogQLQueryModifiers) -> list["RevenueAnalyticsBaseView"]:
         if len(team.revenue_analytics_config.events) == 0:
             return []
 
@@ -115,7 +118,9 @@ class RevenueAnalyticsCustomerView(RevenueAnalyticsBaseView):
         ]
 
     @classmethod
-    def for_schema_source(cls, source: ExternalDataSource) -> list["RevenueAnalyticsBaseView"]:
+    def for_schema_source(
+        cls, source: ExternalDataSource, _modifiers: HogQLQueryModifiers
+    ) -> list["RevenueAnalyticsBaseView"]:
         # Currently only works for stripe sources
         if not source.source_type == ExternalDataSource.Type.STRIPE:
             return []

--- a/products/revenue_analytics/backend/views/revenue_analytics_invoice_item_view.py
+++ b/products/revenue_analytics/backend/views/revenue_analytics_invoice_item_view.py
@@ -2,7 +2,10 @@ from typing import cast
 
 from posthog.hogql import ast
 from posthog.models.team.team import Team
-from posthog.schema import DatabaseSchemaManagedViewTableKind
+from posthog.schema import (
+    DatabaseSchemaManagedViewTableKind,
+    HogQLQueryModifiers,
+)
 from posthog.warehouse.models.external_data_source import ExternalDataSource
 from posthog.warehouse.models.table import DataWarehouseTable
 from posthog.warehouse.models.external_data_schema import ExternalDataSchema
@@ -158,7 +161,7 @@ class RevenueAnalyticsInvoiceItemView(RevenueAnalyticsBaseView):
 
     # NOTE: Very similar to charge views, but for individual invoice items
     @classmethod
-    def for_events(cls, team: "Team") -> list["RevenueAnalyticsBaseView"]:
+    def for_events(cls, team: "Team", _modifiers: HogQLQueryModifiers) -> list["RevenueAnalyticsBaseView"]:
         if len(team.revenue_analytics_config.events) == 0:
             return []
 
@@ -245,7 +248,9 @@ class RevenueAnalyticsInvoiceItemView(RevenueAnalyticsBaseView):
         ]
 
     @classmethod
-    def for_schema_source(cls, source: ExternalDataSource) -> list["RevenueAnalyticsBaseView"]:
+    def for_schema_source(
+        cls, source: ExternalDataSource, _modifiers: HogQLQueryModifiers
+    ) -> list["RevenueAnalyticsBaseView"]:
         # Currently only works for stripe sources
         if not source.source_type == ExternalDataSource.Type.STRIPE:
             return []

--- a/products/revenue_analytics/backend/views/revenue_analytics_product_view.py
+++ b/products/revenue_analytics/backend/views/revenue_analytics_product_view.py
@@ -2,7 +2,10 @@ from typing import cast
 
 from posthog.hogql import ast
 from posthog.models.team.team import Team
-from posthog.schema import DatabaseSchemaManagedViewTableKind
+from posthog.schema import (
+    DatabaseSchemaManagedViewTableKind,
+    HogQLQueryModifiers,
+)
 from posthog.warehouse.models.external_data_source import ExternalDataSource
 from posthog.warehouse.models.table import DataWarehouseTable
 from posthog.warehouse.models.external_data_schema import ExternalDataSchema
@@ -31,11 +34,13 @@ class RevenueAnalyticsProductView(RevenueAnalyticsBaseView):
 
     # NOTE: Products are not supported for events
     @classmethod
-    def for_events(cls, team: "Team") -> list["RevenueAnalyticsBaseView"]:
+    def for_events(cls, _team: "Team", _modifiers: HogQLQueryModifiers) -> list["RevenueAnalyticsBaseView"]:
         return []
 
     @classmethod
-    def for_schema_source(cls, source: ExternalDataSource) -> list["RevenueAnalyticsBaseView"]:
+    def for_schema_source(
+        cls, source: ExternalDataSource, _modifiers: HogQLQueryModifiers
+    ) -> list["RevenueAnalyticsBaseView"]:
         # Currently only works for stripe sources
         if not source.source_type == ExternalDataSource.Type.STRIPE:
             return []

--- a/products/revenue_analytics/backend/views/revenue_analytics_subscription_view.py
+++ b/products/revenue_analytics/backend/views/revenue_analytics_subscription_view.py
@@ -2,7 +2,10 @@ from .revenue_analytics_base_view import RevenueAnalyticsBaseView
 from typing import cast
 from posthog.hogql import ast
 from posthog.models.team.team import Team
-from posthog.schema import DatabaseSchemaManagedViewTableKind
+from posthog.schema import (
+    DatabaseSchemaManagedViewTableKind,
+    HogQLQueryModifiers,
+)
 from posthog.warehouse.models.external_data_source import ExternalDataSource
 from posthog.warehouse.models.table import DataWarehouseTable
 from posthog.warehouse.models.external_data_schema import ExternalDataSchema
@@ -46,11 +49,13 @@ class RevenueAnalyticsSubscriptionView(RevenueAnalyticsBaseView):
 
     # No subscription views for events, we only have that for schema sources
     @classmethod
-    def for_events(cls, team: "Team") -> list["RevenueAnalyticsBaseView"]:
+    def for_events(cls, _team: "Team", _modifiers: HogQLQueryModifiers) -> list["RevenueAnalyticsBaseView"]:
         return []
 
     @classmethod
-    def for_schema_source(cls, source: ExternalDataSource) -> list["RevenueAnalyticsBaseView"]:
+    def for_schema_source(
+        cls, source: ExternalDataSource, _modifiers: HogQLQueryModifiers
+    ) -> list["RevenueAnalyticsBaseView"]:
         # Currently only works for stripe sources
         if not source.source_type == ExternalDataSource.Type.STRIPE:
             return []


### PR DESCRIPTION
This isnt being used yet, this was extracted from https://github.com/PostHog/posthog/pull/33883. There's a lot of noise in that PR, let's simplify it by removing some of it