### PR TITLE
fix(experiments): metric query preview execution context.

### DIFF
--- a/frontend/src/scenes/experiments/metricQueryUtils.test.ts
+++ b/frontend/src/scenes/experiments/metricQueryUtils.test.ts
@@ -9,7 +9,13 @@ import type {
 } from '~/queries/schema/schema-general'
 import { ExperimentMetricType, NodeKind } from '~/queries/schema/schema-general'
 import { setLatestVersionsOnQuery } from '~/queries/utils'
-import { ChartDisplayType, ExperimentMetricMathType, PropertyMathType } from '~/types'
+import {
+    ChartDisplayType,
+    ExperimentMetricMathType,
+    PropertyFilterType,
+    PropertyMathType,
+    PropertyOperator,
+} from '~/types'
 
 import { getFilter, getQuery } from './metricQueryUtils'
 
@@ -271,7 +277,14 @@ describe('getQuery', () => {
                 event: '$pageview',
                 name: '$pageview',
                 math: ExperimentMetricMathType.TotalCount,
-                properties: [{ key: '$browser', value: ['Chrome'], operator: 'exact', type: 'event' }],
+                properties: [
+                    {
+                        key: '$browser',
+                        value: ['Chrome'],
+                        operator: PropertyOperator.Exact,
+                        type: PropertyFilterType.Event,
+                    },
+                ],
             },
         }
 
@@ -298,7 +311,14 @@ describe('getQuery', () => {
                         name: '$pageview',
                         event: '$pageview',
                         math: ExperimentMetricMathType.TotalCount,
-                        properties: [{ key: '$browser', value: ['Chrome'], operator: 'exact', type: 'event' }],
+                        properties: [
+                            {
+                                key: '$browser',
+                                value: ['Chrome'],
+                                operator: PropertyOperator.Exact,
+                                type: PropertyFilterType.Event,
+                            },
+                        ],
                     },
                 ],
             })
@@ -362,7 +382,14 @@ describe('Data Warehouse Support', () => {
                     data_warehouse_join_key: 'user_id',
                     name: 'user_events',
                     math: 'total',
-                    properties: [{ key: 'event_type', value: ['purchase'], operator: 'exact', type: 'event' }],
+                    properties: [
+                        {
+                            key: 'event_type',
+                            value: ['purchase'],
+                            operator: PropertyOperator.Exact,
+                            type: PropertyFilterType.Event,
+                        },
+                    ],
                 } as ExperimentDataWarehouseNode,
             }
             const filter = getFilter(metric)
@@ -379,7 +406,14 @@ describe('Data Warehouse Support', () => {
                         events_join_key: 'user_id',
                         data_warehouse_join_key: 'user_id',
                         math: 'total',
-                        properties: [{ key: 'event_type', value: ['purchase'], operator: 'exact', type: 'event' }],
+                        properties: [
+                            {
+                                key: 'event_type',
+                                value: ['purchase'],
+                                operator: PropertyOperator.Exact,
+                                type: PropertyFilterType.Event,
+                            },
+                        ],
                         kind: NodeKind.ExperimentDataWarehouseNode,
                     },
                 ],
@@ -573,8 +607,18 @@ describe('Data Warehouse Support', () => {
                     name: 'analytics_events',
                     custom_name: 'Custom Analytics Event',
                     properties: [
-                        { key: 'category', value: ['conversion'], operator: 'exact', type: 'event' },
-                        { key: 'value', value: [100], operator: 'gte', type: 'event' },
+                        {
+                            key: 'category',
+                            value: ['conversion'],
+                            operator: PropertyOperator.Exact,
+                            type: PropertyFilterType.Event,
+                        },
+                        {
+                            key: 'value',
+                            value: [100],
+                            operator: PropertyOperator.GreaterThanOrEqual,
+                            type: PropertyFilterType.Event,
+                        },
                     ],
                     math: 'total',
                     math_property: 'conversion_value',
@@ -592,8 +636,18 @@ describe('Data Warehouse Support', () => {
                 data_warehouse_join_key: 'user_external_id',
                 custom_name: 'Custom Analytics Event',
                 properties: [
-                    { key: 'category', value: ['conversion'], operator: 'exact', type: 'event' },
-                    { key: 'value', value: [100], operator: 'gte', type: 'event' },
+                    {
+                        key: 'category',
+                        value: ['conversion'],
+                        operator: PropertyOperator.Exact,
+                        type: PropertyFilterType.Event,
+                    },
+                    {
+                        key: 'value',
+                        value: [100],
+                        operator: PropertyOperator.GreaterThanOrEqual,
+                        type: PropertyFilterType.Event,
+                    },
                 ],
                 math: 'total',
                 math_property: 'conversion_value',

--- a/frontend/src/scenes/experiments/metricQueryUtils.ts
+++ b/frontend/src/scenes/experiments/metricQueryUtils.ts
@@ -3,7 +3,10 @@ import { EXPERIMENT_DEFAULT_DURATION, FunnelLayout } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
 import { match } from 'ts-pattern'
-import { actionsAndEventsToSeries } from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
+import {
+    actionsAndEventsToSeries,
+    FilterTypeActionsAndEvents,
+} from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
 import type {
     ActionsNode,
     BreakdownFilter,
@@ -219,7 +222,7 @@ const getFunnelSeries = (funnelMetric: ExperimentFunnelMetric): (EventsNode | Ac
             actions,
             events,
             data_warehouse: [], // Data warehouse not supported in funnels
-        } as any,
+        } as FilterTypeActionsAndEvents,
         true, // includeProperties
         MathAvailability.None // No math for funnels
     ).filter((series) => series.kind === NodeKind.EventsNode || series.kind === NodeKind.ActionsNode) as (

--- a/frontend/src/scenes/experiments/metricQueryUtils.ts
+++ b/frontend/src/scenes/experiments/metricQueryUtils.ts
@@ -1,15 +1,19 @@
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { EXPERIMENT_DEFAULT_DURATION, FunnelLayout } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
+import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
 import { match } from 'ts-pattern'
+import { actionsAndEventsToSeries } from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
 import type {
     ActionsNode,
     BreakdownFilter,
+    DataWarehouseNode,
     DateRange,
     EntityNode,
     EventsNode,
     ExperimentDataWarehouseNode,
     ExperimentEventExposureConfig,
+    ExperimentFunnelMetric,
     ExperimentFunnelMetricStep,
     ExperimentMetric,
     FunnelsFilter,
@@ -145,24 +149,38 @@ export const getQuery =
                     trendsFilter,
                     series: [
                         {
-                            kind: source.kind,
                             ...match(source)
-                                .with({ kind: NodeKind.EventsNode }, (event) => ({
-                                    event: event.event,
-                                    name: event.name,
-                                }))
-                                .with({ kind: NodeKind.ActionsNode }, (action) => ({
-                                    id: action.id,
-                                    name: action.name,
-                                }))
-                                .with({ kind: NodeKind.ExperimentDataWarehouseNode }, (dataWarehouse) => ({
-                                    table_name: dataWarehouse.table_name,
-                                    timestamp_field: dataWarehouse.timestamp_field,
-                                    events_join_key: dataWarehouse.events_join_key,
-                                    data_warehouse_join_key: dataWarehouse.data_warehouse_join_key,
-                                    name: dataWarehouse.name,
-                                }))
-                                .otherwise(() => {}),
+                                .with(
+                                    { kind: NodeKind.EventsNode },
+                                    (event): EventsNode => ({
+                                        kind: NodeKind.EventsNode,
+                                        event: event.event,
+                                        name: event.name,
+                                        properties: event.properties,
+                                    })
+                                )
+                                .with(
+                                    { kind: NodeKind.ActionsNode },
+                                    (action): ActionsNode => ({
+                                        kind: NodeKind.ActionsNode,
+                                        id: action.id,
+                                        name: action.name,
+                                        properties: action.properties,
+                                    })
+                                )
+                                .with(
+                                    { kind: NodeKind.ExperimentDataWarehouseNode },
+                                    (dataWarehouse): DataWarehouseNode => ({
+                                        kind: NodeKind.DataWarehouseNode,
+                                        id: dataWarehouse.table_name,
+                                        name: dataWarehouse.name,
+                                        table_name: dataWarehouse.table_name,
+                                        timestamp_field: dataWarehouse.timestamp_field,
+                                        distinct_id_field: dataWarehouse.events_join_key,
+                                        id_field: dataWarehouse.data_warehouse_join_key,
+                                    })
+                                )
+                                .exhaustive(),
                             ...getMathProperties(source),
                         },
                     ],
@@ -180,47 +198,35 @@ export const getQuery =
                     dateRange,
                     funnelsFilter,
                     interval: funnelsInterval,
-                    series: funnelMetric.series,
+                    series: getFunnelSeries(funnelMetric), // Use proper conversion pipeline
                 }) as FunnelsQuery
             })
             .otherwise(() => undefined)
     }
 
 /**
- * Enhanced version of ExperimentMetricSource with legacy filter properties
- * This type represents what createSourceNode actually returns - a node with additional
- * filter-compatible properties needed for the legacy filter system
+ * converts a funnel metric to a series of events and actions
+ * this is part of the conversion pipeline for funnel metrics.
+ *
+ * Funnel series are validated with:
+ * Metric Series -> Filter -> Query Series
  */
-type ExperimentMetricSourceWithType =
-    | (EventsNode & { type: 'events'; id: string; name: string })
-    | (ActionsNode & { type: 'actions'; id: number; name: string })
-    | (ExperimentDataWarehouseNode & { type: 'data_warehouse'; id: string; name: string })
+const getFunnelSeries = (funnelMetric: ExperimentFunnelMetric): (EventsNode | ActionsNode)[] => {
+    const { events, actions } = getFilter(funnelMetric)
 
-/**
- * this is a type adapter between metrics and filters.
- * takes an experiment mean metric source or funnel metric step and returns a source node that can be used in a filter
- */
-const createSourceNode = (step: ExperimentFunnelMetricStep | ExperimentMetricSource): ExperimentMetricSourceWithType =>
-    match(step)
-        .with({ kind: NodeKind.EventsNode }, (eventStep) => ({
-            ...eventStep,
-            type: 'events' as const,
-            id: eventStep.event || '',
-            name: eventStep.name || eventStep.event || '',
-        }))
-        .with({ kind: NodeKind.ActionsNode }, (actionStep) => ({
-            ...actionStep,
-            type: 'actions' as const,
-            id: actionStep.id,
-            name: actionStep.name || '',
-        }))
-        .with({ kind: NodeKind.ExperimentDataWarehouseNode }, (dwStep) => ({
-            ...dwStep,
-            type: 'data_warehouse' as const,
-            id: dwStep.table_name,
-            name: dwStep.name || dwStep.table_name,
-        }))
-        .exhaustive()
+    return actionsAndEventsToSeries(
+        {
+            actions,
+            events,
+            data_warehouse: [], // Data warehouse not supported in funnels
+        } as any,
+        true, // includeProperties
+        MathAvailability.None // No math for funnels
+    ).filter((series) => series.kind === NodeKind.EventsNode || series.kind === NodeKind.ActionsNode) as (
+        | EventsNode
+        | ActionsNode
+    )[]
+}
 
 /**
  * takes a metric and returns a filter that can be used as part of a query.
@@ -281,6 +287,45 @@ export const getFilter = (metric: ExperimentMetric): FilterType => {
         }))
 }
 
+/**
+ * Enhanced version of ExperimentMetricSource with legacy filter properties
+ * This type represents what createSourceNode actually returns - a node with additional
+ * filter-compatible properties needed for the legacy filter system
+ */
+type ExperimentMetricSourceWithType =
+    | (EventsNode & { type: 'events'; id: string; name: string })
+    | (ActionsNode & { type: 'actions'; id: number; name: string })
+    | (ExperimentDataWarehouseNode & { type: 'data_warehouse'; id: string; name: string })
+
+/**
+ * this is a type adapter between metrics and filters.
+ * takes an experiment mean metric source or funnel metric step and returns a source node that can be used in a filter
+ */
+const createSourceNode = (step: ExperimentFunnelMetricStep | ExperimentMetricSource): ExperimentMetricSourceWithType =>
+    match(step)
+        .with({ kind: NodeKind.EventsNode }, (eventStep) => ({
+            ...eventStep,
+            type: 'events' as const,
+            id: eventStep.event || '',
+            name: eventStep.name || eventStep.event || '',
+        }))
+        .with({ kind: NodeKind.ActionsNode }, (actionStep) => ({
+            ...actionStep,
+            type: 'actions' as const,
+            id: actionStep.id,
+            name: actionStep.name || '',
+        }))
+        .with({ kind: NodeKind.ExperimentDataWarehouseNode }, (dwStep) => ({
+            ...dwStep,
+            type: 'data_warehouse' as const,
+            id: dwStep.table_name,
+            name: dwStep.name || dwStep.table_name,
+        }))
+        .exhaustive()
+
+/**
+ * this is used on the running time calculator to create a node that can be used in a filter
+ */
 export const getEventNode = (
     event: EventConfig,
     options?: { mathProps?: MathProperties }
@@ -307,6 +352,9 @@ export const getEventNode = (
         .exhaustive()
 }
 
+/**
+ * converts the experiment exposure config in to an events node
+ */
 export const getExposureConfigEventsNode = (
     exposureConfig: ExperimentEventExposureConfig,
     options: { featureFlagKey: string; featureFlagVariants: MultivariateFlagVariant[] }
@@ -372,10 +420,12 @@ export const addExposureToQuery =
     (exposureEvent: EventsNode | ActionsNode) =>
     (query: FunnelsQuery | TrendsQuery | undefined): FunnelsQuery | TrendsQuery | undefined =>
         query
-            ? {
-                  ...query,
-                  series: [exposureEvent, ...query.series],
-              }
+            ? query.kind === NodeKind.FunnelsQuery
+                ? {
+                      ...query,
+                      series: [exposureEvent, ...query.series],
+                  }
+                : query // Don't add exposure to TrendsQuery
             : undefined
 
 type InsightVizNodeOptions = {


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

>[!NOTE]
> Follow-up to #34550
> Related to Zendesk ticket [33513](https://posthoghelp.zendesk.com/agent/tickets/33513).

## Problem

The Experiment Metric From uses a `Query` component to preview the results of the metric. Initially, we had some type guards that created a new execution context, forcing the component to unmount when the metric type changed.

```ts
{/* :KLUDGE: Query chart type is inferred from the initial state, so need to render Trends and Funnels separately */}
{isExperimentMeanMetric(metric) && metric.source.kind !== NodeKind.ExperimentDataWarehouseNode && (
    <Query query={queryConfig} readOnly />
)}
{isExperimentFunnelMetric(metric) && <Query query={queryConfig} readOnly />}
```

When fixing a different bug, that code was changed to a single line, causing the component instance to be reused. Because `Query` is not reactive to prop changes, it always keeps the initial query type. So changing types caused an error.

| Query component won't change metric type | DW metric preview won't load |
| - | - |
| <img width="801" alt="image" src="https://github.com/user-attachments/assets/f61c6b36-53f0-400b-97b5-b982e9b8968e" /> | <img width="801" alt="image" src="https://github.com/user-attachments/assets/ecd0f54f-ca55-4a9b-89fc-cf0e18cf6db2" /> |

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

To fix this using idiomatic React, we just added a `key` to the `Query` component linked to the metric type. If that changes, a new instance of the element is mounted.

We are also including some changes to the metric conversion functions to send the correct properties for the query preview (`DataWarehouseNode` instead of `ExperimentDataWarehouseNode`).

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

```bash
pnpm --filter=@posthog/frontend jest src/scenes/experiments/metricQueryUtils.test.ts
```

![cat-type-small](https://github.com/user-attachments/assets/a067055d-9905-426f-9789-7b2a06515766)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
