### PR TITLE
chore: insight cache metrics

### DIFF
--- a/posthog/caching/warming.py
+++ b/posthog/caching/warming.py
@@ -40,7 +40,7 @@ PRIORITY_INSIGHTS_COUNTER = Counter(
 WARM_INSIGHTS_CACHE_TASK_COUNTER = Counter(
     name="posthog_warm_insight_cache_task",
     documentation="tracks the warm_insight_cache_task task",
-    labelnames=["started", "swallowed_error", "error"],
+    labelnames=["started", "finished", "swallowed_error", "error"],
 )
 
 LAST_VIEWED_THRESHOLD = timedelta(days=7)
@@ -255,6 +255,7 @@ def warm_insight_cache_task(insight_id: int, dashboard_id: Optional[int]):
                     },
                 )
 
+            WARM_INSIGHTS_CACHE_TASK_COUNTER.labels("finished").inc()
         except CHQueryErrorTooManySimultaneousQueries:
             WARM_INSIGHTS_CACHE_TASK_COUNTER.labels("swallowed_error").inc()
             raise

--- a/posthog/caching/warming.py
+++ b/posthog/caching/warming.py
@@ -37,6 +37,12 @@ PRIORITY_INSIGHTS_COUNTER = Counter(
     ["team_id", "dashboard", "is_cached"],
 )
 
+WARM_INSIGHTS_CACHE_TASK_COUNTER = Counter(
+    name="posthog_warm_insight_cache_task",
+    documentation="tracks the warm_insight_cache_task task",
+    labelnames=["started", "swallowed_error", "error"],
+)
+
 LAST_VIEWED_THRESHOLD = timedelta(days=7)
 SHARED_INSIGHTS_LAST_VIEWED_THRESHOLD = timedelta(days=3)
 
@@ -196,6 +202,8 @@ def schedule_warming_for_teams_task():
     max_retries=3,
 )
 def warm_insight_cache_task(insight_id: int, dashboard_id: Optional[int]):
+    WARM_INSIGHTS_CACHE_TASK_COUNTER.labels("started").inc()
+
     try:
         insight = Insight.objects.get(pk=insight_id)
     except Insight.DoesNotExist:
@@ -248,6 +256,8 @@ def warm_insight_cache_task(insight_id: int, dashboard_id: Optional[int]):
                 )
 
         except CHQueryErrorTooManySimultaneousQueries:
+            WARM_INSIGHTS_CACHE_TASK_COUNTER.labels("swallowed_error").inc()
             raise
         except Exception as e:
-            capture_exception(e)
+            WARM_INSIGHTS_CACHE_TASK_COUNTER.labels("error").inc()
+            capture_exception(e, {"$exception_fingerprint": f"warm_insight_cache_task_{e.__class__.__name__}"})


### PR DESCRIPTION
redis is alerting that this task isn't running

but it's so hard to find out what celery is doing

other metrics suggest that it is running...

be it or not it be?

* adds counters to started, errored, finished
* finger print errors captured from this task