### PR TITLE
chore(cdp): cleanup db flag for templates

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2373,7 +2373,6 @@ const api = {
         },
         async listTemplates(params: {
             types: HogFunctionTypeType[]
-            db_templates?: boolean
         }): Promise<PaginatedResponse<HogFunctionTemplateType>> {
             const finalParams = {
                 ...params,
@@ -2383,8 +2382,8 @@ const api = {
 
             return new ApiRequest().hogFunctionTemplates().withQueryString(finalParams).get()
         },
-        async getTemplate(id: HogFunctionTemplateType['id'], db_templates?: boolean): Promise<HogFunctionTemplateType> {
-            return await new ApiRequest().hogFunctionTemplate(id).withQueryString({ db_templates }).get()
+        async getTemplate(id: HogFunctionTemplateType['id']): Promise<HogFunctionTemplateType> {
+            return await new ApiRequest().hogFunctionTemplate(id).get()
         },
 
         async listIcons(params: { query?: string } = {}): Promise<HogFunctionIconResponse[]> {

--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
@@ -7,7 +7,6 @@ import { beforeUnload, router } from 'kea-router'
 import { CombinedLocation } from 'kea-router/lib/utils'
 import { subscriptions } from 'kea-subscriptions'
 import api from 'lib/api'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { uuid } from 'lib/utils'
@@ -427,8 +426,7 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                         }
                     }
 
-                    const dbTemplates = !!values.featureFlags[FEATURE_FLAGS.GET_HOG_TEMPLATES_FROM_DB]
-                    const res = await api.hogFunctions.getTemplate(props.templateId, dbTemplates)
+                    const res = await api.hogFunctions.getTemplate(props.templateId)
 
                     if (!res) {
                         throw new Error('Template not found')

--- a/frontend/src/scenes/hog-functions/list/hogFunctionTemplateListLogic.tsx
+++ b/frontend/src/scenes/hog-functions/list/hogFunctionTemplateListLogic.tsx
@@ -92,16 +92,14 @@ export const hogFunctionTemplateListLogic = kea<hogFunctionTemplateListLogicType
             },
         ],
     })),
-    loaders(({ props, values }) => ({
+    loaders(({ props }) => ({
         rawTemplates: [
             [] as HogFunctionTemplateType[],
             {
                 loadHogFunctionTemplates: async () => {
-                    const dbTemplates = !!values.featureFlags[FEATURE_FLAGS.GET_HOG_TEMPLATES_FROM_DB]
                     return (
                         await api.hogFunctions.listTemplates({
                             types: [props.type, ...(props.additionalTypes || [])],
-                            db_templates: dbTemplates,
                         })
                     ).results
                 },

--- a/frontend/src/scenes/pipeline/destinations/newDestinationsLogic.tsx
+++ b/frontend/src/scenes/pipeline/destinations/newDestinationsLogic.tsx
@@ -53,10 +53,8 @@ export const newDestinationsLogic = kea<newDestinationsLogicType>([
                     const destinationTypes = siteDesinationsEnabled
                         ? props.types
                         : props.types.filter((type) => type !== 'site_destination')
-                    const dbTemplates = !!values.featureFlags[FEATURE_FLAGS.GET_HOG_TEMPLATES_FROM_DB]
                     const templates = await api.hogFunctions.listTemplates({
                         types: destinationTypes,
-                        db_templates: dbTemplates,
                     })
                     return templates.results.reduce((acc, template) => {
                         acc[template.id] = template

--- a/posthog/api/hog_function_template.py
+++ b/posthog/api/hog_function_template.py
@@ -123,20 +123,16 @@ class PublicHogFunctionTemplateViewSet(viewsets.GenericViewSet):
     permission_classes = [permissions.AllowAny]
     serializer_class = HogFunctionTemplateSerializer
 
-    def list(self, request: Request, *args, **kwargs):
+    def list(self, request: Request, **kwargs):
         types = ["destination"]
         sub_template_id = request.GET.get("sub_template_id")
-        use_db_templates = request.GET.get("db_templates") == "true"
 
         if "type" in request.GET:
             types = [self.request.GET.get("type", "destination")]
         elif "types" in request.GET:
             types = self.request.GET.get("types", "destination").split(",")
 
-        if use_db_templates:
-            templates_list = HogFunctionTemplates.templates_from_db()
-        else:
-            templates_list = HogFunctionTemplates.templates()
+        templates_list = HogFunctionTemplates.templates_from_db()
 
         matching_templates = []
 
@@ -182,14 +178,10 @@ class PublicHogFunctionTemplateViewSet(viewsets.GenericViewSet):
         serializer = self.get_serializer(page, many=True)
         return self.get_paginated_response(serializer.data)
 
-    def retrieve(self, request: Request, *args, **kwargs):
-        use_db_templates = request.GET.get("db_templates") == "true"
+    def retrieve(self, request: Request, **kwargs):
         template_id = kwargs["pk"]
 
-        if use_db_templates:
-            item = HogFunctionTemplates.template_from_db(template_id)
-        else:
-            item = HogFunctionTemplates.template(template_id)
+        item = HogFunctionTemplates.template_from_db(template_id)
 
         if not item:
             raise NotFound(f"Template with id {template_id} not found.")


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Currently still the flag for loading templates is in our code. we need to clean it up as we are - for a while now - loading the templates from the db with no issues.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- remove unneeded code 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

- adjust tests / existing tests still pass

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
