### PR TITLE
fix(persons): Minor drifts

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -556,10 +556,6 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
                 : {
                       ...result,
                       properties: { ...result.properties },
-                      properties_last_updated_at: { ...result.properties_last_updated_at },
-                      properties_last_operation: result.properties_last_operation
-                          ? { ...result.properties_last_operation }
-                          : {},
                       created_at: result.created_at,
                   }
         } else {
@@ -583,10 +579,6 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
                 : {
                       ...result,
                       properties: { ...result.properties },
-                      properties_last_updated_at: { ...result.properties_last_updated_at },
-                      properties_last_operation: result.properties_last_operation
-                          ? { ...result.properties_last_operation }
-                          : {},
                       properties_to_set: { ...result.properties_to_set },
                       properties_to_unset: [...result.properties_to_unset],
                   }
@@ -737,7 +729,7 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         }
 
         // Apply other updates (excluding properties which we handled above)
-        const { properties, is_identified, ...otherUpdates } = update
+        const { properties, is_identified, created_at, ...otherUpdates } = update
         Object.assign(personUpdate, otherUpdates)
 
         // Handle is_identified specially with || operator
@@ -866,8 +858,6 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
 
             // Update the PersonUpdate with latest data and merged properties
             personUpdate.properties = mergedProperties
-            personUpdate.properties_last_updated_at = latestPerson.properties_last_updated_at || {}
-            personUpdate.properties_last_operation = latestPerson.properties_last_operation || {}
             personUpdate.version = latestPerson.version
         }
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We have some minor drifts in two points:

- created_at is being updated for some persons
- "properties_last_operation: null !== {}" the measuring store does not consider this variable, so we shouldn't either

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
