### PR TITLE
feat(experiments): capture exceptions from query runners

### DIFF
--- a/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta, UTC
 from zoneinfo import ZoneInfo
 
+from posthog.exceptions_capture import capture_exception
 from rest_framework.exceptions import ValidationError
 
 from posthog.clickhouse.query_tagging import tag_queries
@@ -144,69 +145,79 @@ class ExperimentExposuresQueryRunner(QueryRunner):
         return exposure_query
 
     def calculate(self) -> ExperimentExposureQueryResponse:
-        # Adding experiment specific tags to the tag collection
-        # This will be available as labels in Prometheus
-        tag_queries(
-            experiment_id=self.query.experiment_id,
-            experiment_name=self.query.experiment_name,
-            experiment_feature_flag_key=self.feature_flag_key,
-        )
-
-        response = execute_hogql_query(
-            query_type="ExperimentExposuresQuery",
-            query=self._get_exposure_query(),
-            team=self.team,
-            timings=self.timings,
-            modifiers=create_default_modifiers_for_team(self.team),
-            settings=HogQLGlobalSettings(max_execution_time=180),
-        )
-
-        response.results = self._fill_date_gaps(response.results)
-        variant_series: dict[str, ExperimentExposureTimeSeries] = {}
-
-        # Organize results by variant
-        variant_data: dict[str, dict[str, int]] = {}
-        for result in response.results:
-            day, variant, count = result
-            if variant not in variant_data:
-                variant_data[variant] = {}
-            variant_data[variant][day.isoformat()] = count
-
-        # Create cumulative series for each variant
-        for variant, daily_counts in variant_data.items():
-            sorted_days = sorted(daily_counts.keys())
-            cumulative_counts = []
-            running_total = 0
-
-            for day in sorted_days:
-                running_total += daily_counts[day]
-                cumulative_counts.append(int(running_total))
-
-            variant_series[variant] = ExperimentExposureTimeSeries(
-                variant=variant, days=sorted_days, exposure_counts=cumulative_counts
+        try:
+            # Adding experiment specific tags to the tag collection
+            # This will be available as labels in Prometheus
+            tag_queries(
+                experiment_id=self.query.experiment_id,
+                experiment_name=self.query.experiment_name,
+                experiment_feature_flag_key=self.feature_flag_key,
             )
 
-        # Sort timeseries by original variant order, with MULTIPLE_VARIANT_KEY last
-        ordered_timeseries = []
+            response = execute_hogql_query(
+                query_type="ExperimentExposuresQuery",
+                query=self._get_exposure_query(),
+                team=self.team,
+                timings=self.timings,
+                modifiers=create_default_modifiers_for_team(self.team),
+                settings=HogQLGlobalSettings(max_execution_time=180),
+            )
 
-        # Add variants in original order
-        for variant in self.variants:
-            if variant in variant_series:
-                ordered_timeseries.append(variant_series[variant])
+            response.results = self._fill_date_gaps(response.results)
+            variant_series: dict[str, ExperimentExposureTimeSeries] = {}
 
-        if MULTIPLE_VARIANT_KEY in variant_series:
-            ordered_timeseries.append(variant_series[MULTIPLE_VARIANT_KEY])
+            # Organize results by variant
+            variant_data: dict[str, dict[str, int]] = {}
+            for result in response.results:
+                day, variant, count = result
+                if variant not in variant_data:
+                    variant_data[variant] = {}
+                variant_data[variant][day.isoformat()] = count
 
-        # Calculate total exposures, excluding MULTIPLE_VARIANT_KEY for FIRST_SEEN handling
-        total_exposures = {}
-        for variant, series in variant_series.items():
-            total_exposures[variant] = int(series.exposure_counts[-1]) if series.exposure_counts else 0
+            # Create cumulative series for each variant
+            for variant, daily_counts in variant_data.items():
+                sorted_days = sorted(daily_counts.keys())
+                cumulative_counts = []
+                running_total = 0
 
-        return ExperimentExposureQueryResponse(
-            timeseries=ordered_timeseries,
-            total_exposures=total_exposures,
-            date_range=self.date_range,
-        )
+                for day in sorted_days:
+                    running_total += daily_counts[day]
+                    cumulative_counts.append(int(running_total))
+
+                variant_series[variant] = ExperimentExposureTimeSeries(
+                    variant=variant, days=sorted_days, exposure_counts=cumulative_counts
+                )
+
+            # Sort timeseries by original variant order, with MULTIPLE_VARIANT_KEY last
+            ordered_timeseries = []
+
+            # Add variants in original order
+            for variant in self.variants:
+                if variant in variant_series:
+                    ordered_timeseries.append(variant_series[variant])
+
+            if MULTIPLE_VARIANT_KEY in variant_series:
+                ordered_timeseries.append(variant_series[MULTIPLE_VARIANT_KEY])
+
+            # Calculate total exposures, excluding MULTIPLE_VARIANT_KEY for FIRST_SEEN handling
+            total_exposures = {}
+            for variant, series in variant_series.items():
+                total_exposures[variant] = int(series.exposure_counts[-1]) if series.exposure_counts else 0
+
+            return ExperimentExposureQueryResponse(
+                timeseries=ordered_timeseries,
+                total_exposures=total_exposures,
+                date_range=self.date_range,
+            )
+        except Exception as e:
+            capture_exception(
+                e,
+                additional_properties={
+                    "query_runner": "ExperimentExposuresQueryRunner",
+                    "experiment_id": self.query.experiment_id,
+                },
+            )
+            raise
 
     def to_query(self) -> ast.SelectQuery:
         raise ValueError("Cannot convert exposure query to raw query")

--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -601,9 +601,6 @@ class ExperimentQueryRunner(QueryRunner):
 
     def calculate(self) -> ExperimentQueryResponse:
         try:
-            # Mock exception for testing
-            raise Exception("Mocking experiment error")
-
             sorted_results = self._evaluate_experiment_query()
 
             # Check if we should use the new Bayesian method

--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Optional, cast
 from zoneinfo import ZoneInfo
 
+from posthog.exceptions_capture import capture_exception
 from rest_framework.exceptions import ValidationError
 
 from posthog.clickhouse.query_tagging import tag_queries
@@ -599,124 +600,137 @@ class ExperimentQueryRunner(QueryRunner):
         return sorted_results
 
     def calculate(self) -> ExperimentQueryResponse:
-        sorted_results = self._evaluate_experiment_query()
+        try:
+            # Mock exception for testing
+            raise Exception("Mocking experiment error")
 
-        # Check if we should use the new Bayesian method
-        use_new_bayesian_method = self.experiment.stats_config and self.experiment.stats_config.get(
-            "use_new_bayesian_method", False
-        )
-        if self.stats_method == "bayesian" and use_new_bayesian_method:
-            bayesian_variants = get_new_variant_results(sorted_results)
+            sorted_results = self._evaluate_experiment_query()
 
-            self._validate_event_variants(bayesian_variants)
-
-            control_variant, test_variants = split_baseline_and_test_variants(bayesian_variants)
-
-            return get_bayesian_experiment_result_new_format(
-                metric=self.metric,
-                control_variant=control_variant,
-                test_variants=test_variants,
+            # Check if we should use the new Bayesian method
+            use_new_bayesian_method = self.experiment.stats_config and self.experiment.stats_config.get(
+                "use_new_bayesian_method", False
             )
+            if self.stats_method == "bayesian" and use_new_bayesian_method:
+                bayesian_variants = get_new_variant_results(sorted_results)
 
-        elif self.stats_method == "frequentist":
-            frequentist_variants = get_new_variant_results(sorted_results)
+                self._validate_event_variants(bayesian_variants)
 
-            self._validate_event_variants(frequentist_variants)
+                control_variant, test_variants = split_baseline_and_test_variants(bayesian_variants)
 
-            control_variant, test_variants = split_baseline_and_test_variants(frequentist_variants)
+                return get_bayesian_experiment_result_new_format(
+                    metric=self.metric,
+                    control_variant=control_variant,
+                    test_variants=test_variants,
+                )
 
-            return get_frequentist_experiment_result_new_format(
+            elif self.stats_method == "frequentist":
+                frequentist_variants = get_new_variant_results(sorted_results)
+
+                self._validate_event_variants(frequentist_variants)
+
+                control_variant, test_variants = split_baseline_and_test_variants(frequentist_variants)
+
+                return get_frequentist_experiment_result_new_format(
+                    metric=self.metric,
+                    control_variant=control_variant,
+                    test_variants=test_variants,
+                )
+
+            # Legacy stats methods
+            else:
+                variants: list[ExperimentVariantTrendsBaseStats] | list[ExperimentVariantFunnelsBaseStats]
+                match self.metric:
+                    case ExperimentMeanMetric():
+                        trends_variants = get_legacy_trends_variant_results(sorted_results)
+                        self._validate_event_variants(trends_variants)
+                        trends_control_variant, trends_test_variants = split_baseline_and_test_variants(trends_variants)
+                        match is_continuous(self.metric.source.math):
+                            case True:
+                                probabilities = calculate_probabilities_v2_continuous(
+                                    control_variant=trends_control_variant,
+                                    test_variants=trends_test_variants,
+                                )
+                                significance_code, p_value = are_results_significant_v2_continuous(
+                                    control_variant=trends_control_variant,
+                                    test_variants=trends_test_variants,
+                                    probabilities=probabilities,
+                                )
+                                credible_intervals = calculate_credible_intervals_v2_continuous(
+                                    [trends_control_variant, *trends_test_variants]
+                                )
+                            # Otherwise, we default to count
+                            case False:
+                                probabilities = calculate_probabilities_v2_count(
+                                    control_variant=trends_control_variant,
+                                    test_variants=trends_test_variants,
+                                )
+                                significance_code, p_value = are_results_significant_v2_count(
+                                    control_variant=trends_control_variant,
+                                    test_variants=trends_test_variants,
+                                    probabilities=probabilities,
+                                )
+                                credible_intervals = calculate_credible_intervals_v2_count(
+                                    [trends_control_variant, *trends_test_variants]
+                                )
+
+                        probability = {
+                            variant.key: probability
+                            for variant, probability in zip(
+                                [trends_control_variant, *trends_test_variants],
+                                probabilities,
+                            )
+                        }
+                        variants = trends_variants
+
+                    case ExperimentFunnelMetric():
+                        funnel_variants = get_legacy_funnels_variant_results(sorted_results)
+                        self._validate_event_variants(funnel_variants)
+                        funnel_control_variant, funnel_test_variants = split_baseline_and_test_variants(funnel_variants)
+                        probabilities = calculate_probabilities_v2_funnel(
+                            control=funnel_control_variant,
+                            variants=funnel_test_variants,
+                        )
+                        significance_code, p_value = are_results_significant_v2_funnel(
+                            control=funnel_control_variant,
+                            variants=funnel_test_variants,
+                            probabilities=probabilities,
+                        )
+                        credible_intervals = calculate_credible_intervals_v2_funnel(
+                            [funnel_control_variant, *funnel_test_variants]
+                        )
+                        probability = {
+                            variant.key: probability
+                            for variant, probability in zip(
+                                [funnel_control_variant, *funnel_test_variants],
+                                probabilities,
+                            )
+                        }
+                        variants = funnel_variants
+
+                    case _:
+                        raise ValueError(f"Unsupported metric type: {self.metric.metric_type}")
+
+            return ExperimentQueryResponse(
+                kind="ExperimentQuery",
+                insight=[],
                 metric=self.metric,
-                control_variant=control_variant,
-                test_variants=test_variants,
+                variants=variants,
+                probability=probability,
+                significant=significance_code == ExperimentSignificanceCode.SIGNIFICANT,
+                significance_code=significance_code,
+                stats_version=2,
+                p_value=p_value,
+                credible_intervals=credible_intervals,
             )
-
-        # Legacy stats methods
-        else:
-            variants: list[ExperimentVariantTrendsBaseStats] | list[ExperimentVariantFunnelsBaseStats]
-            match self.metric:
-                case ExperimentMeanMetric():
-                    trends_variants = get_legacy_trends_variant_results(sorted_results)
-                    self._validate_event_variants(trends_variants)
-                    trends_control_variant, trends_test_variants = split_baseline_and_test_variants(trends_variants)
-                    match is_continuous(self.metric.source.math):
-                        case True:
-                            probabilities = calculate_probabilities_v2_continuous(
-                                control_variant=trends_control_variant,
-                                test_variants=trends_test_variants,
-                            )
-                            significance_code, p_value = are_results_significant_v2_continuous(
-                                control_variant=trends_control_variant,
-                                test_variants=trends_test_variants,
-                                probabilities=probabilities,
-                            )
-                            credible_intervals = calculate_credible_intervals_v2_continuous(
-                                [trends_control_variant, *trends_test_variants]
-                            )
-                        # Otherwise, we default to count
-                        case False:
-                            probabilities = calculate_probabilities_v2_count(
-                                control_variant=trends_control_variant,
-                                test_variants=trends_test_variants,
-                            )
-                            significance_code, p_value = are_results_significant_v2_count(
-                                control_variant=trends_control_variant,
-                                test_variants=trends_test_variants,
-                                probabilities=probabilities,
-                            )
-                            credible_intervals = calculate_credible_intervals_v2_count(
-                                [trends_control_variant, *trends_test_variants]
-                            )
-
-                    probability = {
-                        variant.key: probability
-                        for variant, probability in zip(
-                            [trends_control_variant, *trends_test_variants],
-                            probabilities,
-                        )
-                    }
-                    variants = trends_variants
-
-                case ExperimentFunnelMetric():
-                    funnel_variants = get_legacy_funnels_variant_results(sorted_results)
-                    self._validate_event_variants(funnel_variants)
-                    funnel_control_variant, funnel_test_variants = split_baseline_and_test_variants(funnel_variants)
-                    probabilities = calculate_probabilities_v2_funnel(
-                        control=funnel_control_variant,
-                        variants=funnel_test_variants,
-                    )
-                    significance_code, p_value = are_results_significant_v2_funnel(
-                        control=funnel_control_variant,
-                        variants=funnel_test_variants,
-                        probabilities=probabilities,
-                    )
-                    credible_intervals = calculate_credible_intervals_v2_funnel(
-                        [funnel_control_variant, *funnel_test_variants]
-                    )
-                    probability = {
-                        variant.key: probability
-                        for variant, probability in zip(
-                            [funnel_control_variant, *funnel_test_variants],
-                            probabilities,
-                        )
-                    }
-                    variants = funnel_variants
-
-                case _:
-                    raise ValueError(f"Unsupported metric type: {self.metric.metric_type}")
-
-        return ExperimentQueryResponse(
-            kind="ExperimentQuery",
-            insight=[],
-            metric=self.metric,
-            variants=variants,
-            probability=probability,
-            significant=significance_code == ExperimentSignificanceCode.SIGNIFICANT,
-            significance_code=significance_code,
-            stats_version=2,
-            p_value=p_value,
-            credible_intervals=credible_intervals,
-        )
+        except Exception as e:
+            capture_exception(
+                e,
+                additional_properties={
+                    "query_runner": "ExperimentQueryRunner",
+                    "experiment_id": self.experiment.id,
+                },
+            )
+            raise
 
     def _validate_event_variants(
         self,


### PR DESCRIPTION
## Problem
It's currently hard to find errors from our query runners. A few show up when searching for experiment_query_runner.py in the stack trace, but the number is suspiciously low and doesn’t include known errors like this one: https://posthoghelp.zendesk.com/agent/tickets/33149 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/36159)

## Changes
- Explicitly catch and capture errors from our query runners.
- Added a `query_runner` property which will be used to route alerts to the alerts-experiments channel.
- Added an `experiment_id` field to make it easy to filter errors by experiment.

## How did you test this code?
Confirmed locally that the exception is being captured:
![image](https://github.com/user-attachments/assets/c1e80256-067d-4f26-b4b4-61b7c48be598)