### PR TITLE
fix(tracing): revert - enable tracing for temporal jobs

### DIFF
--- a/posthog/otel_instrumentation.py
+++ b/posthog/otel_instrumentation.py
@@ -32,7 +32,7 @@ def _otel_django_response_hook(span, request, response):
         span.set_attribute("http.status_code", response.status_code)
 
 
-def initialize_otel(sample_rate_override=None):
+def initialize_otel():
     # --- BEGIN FORCED OTEL DEBUG LOGGING ---
     otel_python_log_level_env = os.environ.get("OTEL_PYTHON_LOG_LEVEL", "info").lower()
     effective_log_level = logging.DEBUG if otel_python_log_level_env == "debug" else logging.INFO
@@ -65,7 +65,7 @@ def initialize_otel(sample_rate_override=None):
         # Let OpenTelemetry SDK handle sampling configuration via OTEL_TRACES_SAMPLER and OTEL_TRACES_SAMPLER_ARG
         # This allows parentbased_traceidratio and other standard sampler types
         sampler_type = os.environ.get("OTEL_TRACES_SAMPLER", "parentbased_traceidratio")  # Respect parent decisions
-        sampler_arg = sample_rate_override or os.environ.get("OTEL_TRACES_SAMPLER_ARG", "0")
+        sampler_arg = os.environ.get("OTEL_TRACES_SAMPLER_ARG", "0")
 
         logger.info(
             "otel_sampler_configured",

--- a/posthog/temporal/common/client.py
+++ b/posthog/temporal/common/client.py
@@ -2,7 +2,6 @@ import dataclasses
 from typing import Any
 
 import temporalio.converter
-import temporalio.contrib.opentelemetry
 from asgiref.sync import async_to_sync
 from django.conf import settings as django_settings
 from temporalio.client import Client, TLSConfig
@@ -28,13 +27,11 @@ async def connect(
             client_cert=bytes(client_cert, "utf-8"),
             client_private_key=bytes(client_key, "utf-8"),
         )
-
     client = await Client.connect(
         f"{host}:{port}",
         namespace=namespace,
         tls=tls,
         runtime=runtime,
-        interceptors=[temporalio.contrib.opentelemetry.TracingInterceptor()],
         data_converter=dataclasses.replace(
             temporalio.converter.default(),
             payload_codec=EncryptionCodec(settings=settings),

--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -6,7 +6,6 @@ import structlog
 from temporalio.runtime import PrometheusConfig, Runtime, TelemetryConfig
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
-from posthog.otel_instrumentation import initialize_otel
 from posthog.temporal.common.client import connect
 from posthog.temporal.common.posthog_client import PostHogClientInterceptor
 
@@ -49,8 +48,6 @@ async def create_worker(
         max_concurrent_activities: Maximum number of concurrent activity tasks the
             worker can handle. Defaults to 50.
     """
-    initialize_otel(sample_rate_override="1")
-
     runtime = Runtime(telemetry=TelemetryConfig(metrics=PrometheusConfig(bind_address=f"0.0.0.0:{metrics_port:d}")))
     client = await connect(
         host,


### PR DESCRIPTION
This reverts commit 81177adfaab02d518b269def285b1c298aff26b2.

> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We're seeing errors with Postgres batch exports - [example](https://cloud.temporal.io/namespaces/posthog-prod-us.usz2o/workflows/01958651-6728-0001-4dc8-c465cee758e4-2025-07-07T10%3A00%3A00Z/0197e460-965e-729f-939f-a0c0324a21ac/history)

## Changes

Revert the previous PR

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
