### PR TITLE
fix(persons): Split created_at logic for merge and update

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -707,11 +707,11 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         if (!existingUpdate) {
             // Create new PersonUpdate from the person and apply the update
             personUpdate = fromInternalPerson(person, distinctId)
-            personUpdate = this.mergeUpdateIntoPersonUpdate(personUpdate, update)
+            personUpdate = this.mergeUpdateIntoPersonUpdate(personUpdate, update, true)
             this.setCachedPersonForUpdate(person.team_id, distinctId, personUpdate)
         } else {
             // Merge updates into existing cached PersonUpdate
-            personUpdate = this.mergeUpdateIntoPersonUpdate(existingUpdate, update)
+            personUpdate = this.mergeUpdateIntoPersonUpdate(existingUpdate, update, true)
             this.setCachedPersonForUpdate(person.team_id, distinctId, personUpdate)
         }
         // Return the merged person from the cache
@@ -722,7 +722,11 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
      * Helper method to merge an update into a PersonUpdate
      * Handles properties and is_identified merging with proper logic
      */
-    private mergeUpdateIntoPersonUpdate(personUpdate: PersonUpdate, update: Partial<InternalPerson>): PersonUpdate {
+    private mergeUpdateIntoPersonUpdate(
+        personUpdate: PersonUpdate,
+        update: Partial<InternalPerson>,
+        allowCreatedAtUpdate: boolean = false
+    ): PersonUpdate {
         // For properties, we track them in the fine-grained properties_to_set/unset
         if (update.properties) {
             // Add all properties from the update to properties_to_set
@@ -737,12 +741,19 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         }
 
         // Apply other updates (excluding properties which we handled above)
-        const { properties, is_identified, ...otherUpdates } = update
+        const fieldsToExclude = ['properties', 'is_identified']
+        if (!allowCreatedAtUpdate) {
+            fieldsToExclude.push('created_at')
+        }
+
+        const otherUpdates = Object.fromEntries(
+            Object.entries(update).filter(([key]) => !fieldsToExclude.includes(key))
+        )
         Object.assign(personUpdate, otherUpdates)
 
         // Handle is_identified specially with || operator
-        if (is_identified !== undefined) {
-            personUpdate.is_identified = personUpdate.is_identified || is_identified
+        if (update.is_identified !== undefined) {
+            personUpdate.is_identified = personUpdate.is_identified || update.is_identified
         }
 
         personUpdate.needs_write = true


### PR DESCRIPTION
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Seeing that the update is sometimes updating the  `created_at` field. This field should be updated during merge operations but not for updates, this PR aims to do that.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
