### PR TITLE
fix(cdp): increase payload size to be 200kb for json 

### DIFF
--- a/plugin-server/src/server.ts
+++ b/plugin-server/src/server.ts
@@ -72,7 +72,7 @@ export class PluginServer {
         }
 
         this.expressApp = express()
-        this.expressApp.use(express.json())
+        this.expressApp.use(express.json({ limit: '200kb' }))
         this.nodeInstrumentation = new NodeInstrumentation(this.config)
     }
 


### PR DESCRIPTION
## Problem

<img width="599" alt="Screenshot 2025-07-07 at 14 18 15" src="https://github.com/user-attachments/assets/a8fdfc33-2429-4e15-8bd0-7ddd45c32a5b" />

When hitting the invocation api for cdp (whilst testing your hog-functions) we run into content too large responses sinze the payload is too big as our events get bigger. 

in express you can control that on api level through the limit param.. here are the docs:

>  * Controls the maximum request body size. If this is a number,
>   * then the value specifies the number of bytes; if it is a string,
>   * the value is passed to the bytes library for parsing. Defaults to '100kb'.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- gradual increase of the payload to fit 200kb

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- local dev

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
