### PR TITLE
refactor: use env var for import historical topic

### DIFF
--- a/posthog/api/batch_imports.py
+++ b/posthog/api/batch_imports.py
@@ -223,7 +223,7 @@ class BatchImportDateRangeSourceCreateSerializer(BatchImportSerializer):
                 secret_key=validated_data["secret_key"],
                 export_source=DateRangeExportSource(source_type),
             ).to_kafka(
-                topic=f"events_plugin_ingestion_historical",
+                topic=KAFKA_EVENTS_PLUGIN_INGESTION_HISTORICAL,
                 send_rate=1000,
                 transaction_timeout_seconds=60,
             )


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We have one hardcoded historical batch import topic name.

## Changes

Changes the code to use the env var for topic configuration.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [X] No docs needed for this change

## How did you test this code?
