### PR TITLE
fix: dont render sidebar items until loading done

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
@@ -453,6 +453,7 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
                 s.searchTreeData,
                 s.databaseLoading,
                 s.dataWarehouseSavedQueriesLoading,
+                s.joinsLoading,
             ],
             (
                 posthogTables: DatabaseSchemaTable[],
@@ -462,7 +463,8 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
                 searchTerm: string,
                 searchTreeData: TreeDataItem[],
                 databaseLoading: boolean,
-                dataWarehouseSavedQueriesLoading: boolean
+                dataWarehouseSavedQueriesLoading: boolean,
+                joinsLoading: boolean
             ): TreeDataItem[] => {
                 if (searchTerm) {
                     return searchTreeData
@@ -471,7 +473,10 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
                 const sourcesChildren: TreeDataItem[] = []
 
                 // Add loading indicator for sources if still loading
-                if (databaseLoading && posthogTables.length === 0 && dataWarehouseTables.length === 0) {
+                if (
+                    (databaseLoading && posthogTables.length === 0 && dataWarehouseTables.length === 0) ||
+                    joinsLoading
+                ) {
                     sourcesChildren.push({
                         id: 'sources-loading/',
                         name: 'Loading...',
@@ -510,9 +515,10 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
 
                 // Add loading indicator for views if still loading
                 if (
-                    dataWarehouseSavedQueriesLoading &&
-                    dataWarehouseSavedQueries.length === 0 &&
-                    managedViews.length === 0
+                    (dataWarehouseSavedQueriesLoading &&
+                        dataWarehouseSavedQueries.length === 0 &&
+                        managedViews.length === 0) ||
+                    joinsLoading
                 ) {
                     viewsChildren.push({
                         id: 'views-loading/',


### PR DESCRIPTION
## Problem

- new tree view of data items requires joins but there's a race condition

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- wait on joins to load

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
