### PR TITLE
fix: loading empty checkpoint if needed

### DIFF
--- a/ee/hogai/django_checkpoint/checkpointer.py
+++ b/ee/hogai/django_checkpoint/checkpointer.py
@@ -15,6 +15,7 @@ from langgraph.checkpoint.base import (
     CheckpointMetadata,
     CheckpointTuple,
     PendingWrite,
+    empty_checkpoint,
     get_checkpoint_id,
 )
 from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
@@ -136,7 +137,9 @@ class DjangoCheckpointer(BaseCheckpointSaver[str]):
 
         async for checkpoint in qs:
             channel_values = self._get_checkpoint_channel_values(checkpoint)
-            loaded_checkpoint: Checkpoint = self._load_json(checkpoint.checkpoint)
+            loaded_checkpoint: Checkpoint = (
+                self._load_json(checkpoint.checkpoint) if checkpoint.checkpoint else empty_checkpoint()
+            )
 
             pending_sends = (
                 [
@@ -175,7 +178,7 @@ class DjangoCheckpointer(BaseCheckpointSaver[str]):
                     }
                 },
                 checkpoint_dict,
-                self._load_json(checkpoint.metadata),
+                self._load_json(checkpoint.metadata) if checkpoint.metadata else {},
                 (
                     {
                         "configurable": {


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Encountering the following error:
```python
    checkpoint_dict: Checkpoint = {
                                  ^
TypeError: 'NoneType' object is not a mapping
``` 

The issue seems to be that the checkpointer was trying to create a `Checkpoint` dict by unpacking None (when loaded_checkpoint was None), which caused the "NoneType object is not a mapping" error.

So the checkpointer should now handle cases where the database contains None values for both checkpoint data and metadata gracefully.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
* `empty_checkpoint()` creates a proper Checkpoint object with all required fields.
* using an empty dictionary {} as fallback metadata instead of trying to load None

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [x] No docs needed for this change

## How did you test this code?

Launched a few chats.
