### PR TITLE
fix(max): checkpointer race conditions

### DIFF
--- a/ee/hogai/django_checkpoint/checkpointer.py
+++ b/ee/hogai/django_checkpoint/checkpointer.py
@@ -62,7 +62,7 @@ class DjangoCheckpointer(BaseCheckpointSaver[str]):
         filter: Optional[dict[str, Any]],
         before: Optional[RunnableConfig],
     ):
-        query = Q()
+        query = Q(checkpoint__isnull=False)
 
         # construct predicate for config filter
         if config and "configurable" in config:


### PR DESCRIPTION
## Problem

Since LangGraph can save checkpoints and checkpoint writes/blobs without a guaranteed order, the list query may return a checkpoint without checkpoint data, which can sometimes break the execution. Additionally, the order might actually be correct, but another pod handles a request where a lock doesn't apply (separate pods).

[Related exception](https://us.posthog.com/project/2/error_tracking/01979e9f-79d7-7331-b051-42b6db4c7a90).

## Changes

- Handle gracefully checkpoints where writes save before the checkpoint data arrives.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Unit tests, manual testing
