### PR TITLE
feat(activity): use inserted_at for ordering in recent events table

### DIFF
--- a/frontend/src/scenes/activity/explore/defaults.ts
+++ b/frontend/src/scenes/activity/explore/defaults.ts
@@ -8,7 +8,7 @@ export const getDefaultEventsSceneQuery = (properties?: AnyPropertyFilter[]): Da
     source: {
         kind: NodeKind.EventsQuery,
         select: defaultDataTableColumns(NodeKind.EventsQuery),
-        orderBy: ['timestamp DESC'],
+        orderBy: ['inserted_at DESC'],
         after: '-24h',
         useRecentEventsTable: true,
         ...(properties ? { properties } : {}),


### PR DESCRIPTION
## Summary
Updates the activity page to order events by `inserted_at` instead of `timestamp` when querying the `events_recent` table.

## Changes
- Modified `frontend/src/scenes/activity/explore/defaults.ts` to use `inserted_at DESC` ordering
- This ensures events are shown in the order they were received by the system rather than when they originally occurred

## Test plan
- [x] Verified `inserted_at` field exists in `RecentEventsTable` schema
- [x] Code compiles successfully
- [ ] Manual testing on activity page with recent events table enabled

🤖 Generated with [Claude Code](https://claude.ai/code)