### PR TITLE
refactor(flags): Move PostgresReader types to common_database

### DIFF
--- a/rust/common/database/src/lib.rs
+++ b/rust/common/database/src/lib.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -20,6 +20,9 @@ pub enum CustomDatabaseError {
     #[error("Timeout error")]
     Timeout(#[from] tokio::time::error::Elapsed),
 }
+
+pub type PostgresReader = Arc<dyn Client + Send + Sync>;
+pub type PostgresWriter = Arc<dyn Client + Send + Sync>;
 
 /// A simple db wrapper
 /// Supports running any arbitrary query with a timeout.

--- a/rust/feature-flags/src/cohorts/cohort_cache_manager.rs
+++ b/rust/feature-flags/src/cohorts/cohort_cache_manager.rs
@@ -1,10 +1,10 @@
 use crate::api::errors::FlagError;
 use crate::cohorts::cohort_models::Cohort;
-use crate::flags::flag_matching::PostgresReader;
 use crate::metrics::consts::{
     COHORT_CACHE_HIT_COUNTER, COHORT_CACHE_MISS_COUNTER, DB_COHORT_ERRORS_COUNTER,
     DB_COHORT_READS_COUNTER,
 };
+use common_database::PostgresReader;
 use common_types::ProjectId;
 use moka::future::Cache;
 use std::sync::Arc;

--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -1,7 +1,6 @@
 use serde_json::Value;
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::sync::Arc;
 
 use super::cohort_models::CohortPropertyType;
 use super::cohort_models::CohortValues;
@@ -10,12 +9,12 @@ use crate::properties::property_matching::match_property;
 use crate::properties::property_models::OperatorType;
 use crate::utils::graph_utils::{DependencyGraph, DependencyProvider, DependencyType};
 use crate::{api::errors::FlagError, properties::property_models::PropertyFilter};
-use common_database::Client as DatabaseClient;
+use common_database::PostgresReader;
 
 impl Cohort {
     /// Returns all cohorts for a given team
     pub async fn list_from_pg(
-        client: Arc<dyn DatabaseClient + Send + Sync>,
+        client: PostgresReader,
         project_id: i64,
     ) -> Result<Vec<Cohort>, FlagError> {
         let mut conn = client.get_connection().await.map_err(|e| {

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -5,7 +5,7 @@ use crate::api::errors::FlagError;
 use crate::flags::flag_models::{
     FeatureFlag, FeatureFlagList, FeatureFlagRow, TEAM_FLAGS_CACHE_PREFIX,
 };
-use common_database::Client as DatabaseClient;
+use common_database::PostgresReader;
 use common_redis::Client as RedisClient;
 
 impl FeatureFlagList {
@@ -50,7 +50,7 @@ impl FeatureFlagList {
 
     /// Returns feature flags from postgres given a project_id
     pub async fn from_pg(
-        client: Arc<dyn DatabaseClient + Send + Sync>,
+        client: PostgresReader,
         project_id: i64,
     ) -> Result<FeatureFlagList, FlagError> {
         let mut conn = client.get_connection().await.map_err(|e| {

--- a/rust/feature-flags/src/flags/flag_group_type_mapping.rs
+++ b/rust/feature-flags/src/flags/flag_group_type_mapping.rs
@@ -1,13 +1,12 @@
 use std::collections::HashMap;
 
+use common_database::PostgresReader;
 use common_metrics::inc;
 use common_types::ProjectId;
 use sqlx::FromRow;
 use tracing::error;
 
 use crate::{api::errors::FlagError, metrics::consts::FLAG_EVALUATION_ERROR_COUNTER};
-
-use super::flag_matching::PostgresReader;
 
 pub type GroupTypeIndex = i32;
 

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -25,7 +25,7 @@ use crate::metrics::utils::parse_exception_for_prometheus_label;
 use crate::properties::property_models::PropertyFilter;
 use crate::utils::graph_utils::DependencyGraph;
 use anyhow::Result;
-use common_database::Client as DatabaseClient;
+use common_database::{PostgresReader, PostgresWriter};
 use common_metrics::{inc, timing_guard};
 use common_types::{PersonId, ProjectId, TeamId};
 use rayon::prelude::*;
@@ -35,9 +35,6 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tracing::{error, warn};
 use uuid::Uuid;
-
-pub type PostgresReader = Arc<dyn DatabaseClient + Send + Sync>;
-pub type PostgresWriter = Arc<dyn DatabaseClient + Send + Sync>;
 
 #[derive(Debug)]
 struct SuperConditionEvaluation {

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -1,10 +1,14 @@
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+    time::Instant,
+};
 
+use common_database::{PostgresReader, PostgresWriter};
 use common_types::{PersonId, ProjectId, TeamId};
 use serde_json::Value;
 use sha1::{Digest, Sha1};
 use sqlx::{postgres::PgQueryResult, Acquire, Row};
-use std::time::{Duration, Instant};
 use tokio::time::{sleep, timeout};
 use tracing::{info, warn};
 
@@ -27,10 +31,7 @@ use crate::{
     },
 };
 
-use super::{
-    flag_group_type_mapping::GroupTypeIndex,
-    flag_matching::{FlagEvaluationState, PostgresReader, PostgresWriter},
-};
+use super::{flag_group_type_mapping::GroupTypeIndex, flag_matching::FlagEvaluationState};
 
 const LONG_SCALE: u64 = 0xfffffffffffffff;
 

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     team::team_models::Team,
 };
-use common_database::Client as DatabaseClient;
+use common_database::PostgresReader;
 use common_metrics::inc;
 use common_redis::Client as RedisClient;
 use std::sync::Arc;
@@ -17,14 +17,14 @@ use std::sync::Arc;
 pub struct FlagService {
     redis_reader: Arc<dyn RedisClient + Send + Sync>,
     redis_writer: Arc<dyn RedisClient + Send + Sync>,
-    pg_client: Arc<dyn DatabaseClient + Send + Sync>,
+    pg_client: PostgresReader,
 }
 
 impl FlagService {
     pub fn new(
         redis_reader: Arc<dyn RedisClient + Send + Sync>,
         redis_writer: Arc<dyn RedisClient + Send + Sync>,
-        pg_client: Arc<dyn DatabaseClient + Send + Sync>,
+        pg_client: PostgresReader,
     ) -> Self {
         Self {
             redis_reader,

--- a/rust/feature-flags/src/handler/error_tracking.rs
+++ b/rust/feature-flags/src/handler/error_tracking.rs
@@ -1,7 +1,6 @@
 use crate::{api::errors::FlagError, team::team_models::Team};
-use common_database::Client as DatabaseClient;
+use common_database::PostgresReader;
 use serde_json::Value;
-use std::sync::Arc;
 
 #[derive(sqlx::FromRow)]
 struct SuppressionRuleRow {
@@ -11,7 +10,7 @@ struct SuppressionRuleRow {
 /// Get suppression rules for error tracking from the database
 /// Equivalent to Django's get_suppression_rules function
 pub async fn get_suppression_rules(
-    client: Arc<dyn DatabaseClient + Send + Sync>,
+    client: PostgresReader,
     team: &Team,
 ) -> Result<Vec<Value>, FlagError> {
     let mut conn = client.get_connection().await?;

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -7,7 +7,7 @@ use axum::{
     Router,
 };
 use common_cookieless::CookielessManager;
-use common_database::Client as DatabaseClient;
+use common_database::{Client as DatabaseClient, PostgresReader, PostgresWriter};
 use common_geoip::GeoIpClient;
 use common_metrics::{setup_metrics_recorder, track_metrics};
 use common_redis::Client as RedisClient;
@@ -29,8 +29,8 @@ use crate::{
 pub struct State {
     pub redis_reader: Arc<dyn RedisClient + Send + Sync>,
     pub redis_writer: Arc<dyn RedisClient + Send + Sync>,
-    pub reader: Arc<dyn DatabaseClient + Send + Sync>,
-    pub writer: Arc<dyn DatabaseClient + Send + Sync>,
+    pub reader: PostgresReader,
+    pub writer: PostgresWriter,
     pub cohort_cache_manager: Arc<CohortCacheManager>,
     pub geoip: Arc<GeoIpClient>,
     pub team_ids_to_track: TeamIdCollection,

--- a/rust/feature-flags/src/site_apps/mod.rs
+++ b/rust/feature-flags/src/site_apps/mod.rs
@@ -1,9 +1,9 @@
 use crate::api::errors::FlagError;
 use chrono::{DateTime, Utc};
-use common_database::Client as DatabaseClient;
+use common_database::PostgresReader;
 use md5;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WebJsSource {
@@ -46,7 +46,7 @@ struct SiteAppRow {
 /// # Returns
 /// Vector of WebJsUrl for enabled site apps
 pub async fn get_decide_site_apps(
-    db: Arc<dyn DatabaseClient + Send + Sync>,
+    db: PostgresReader,
     team_id: i32,
 ) -> Result<Vec<WebJsUrl>, FlagError> {
     let mut conn = db.get_connection().await?;
@@ -89,11 +89,13 @@ pub async fn get_decide_site_apps(
 
 #[cfg(test)]
 mod tests {
+    use common_database::PostgresWriter;
+
     use super::*;
     use crate::utils::test_utils::{insert_new_team_in_pg, setup_pg_reader_client};
 
     async fn insert_plugin_in_pg(
-        client: Arc<dyn DatabaseClient + Send + Sync>,
+        client: PostgresWriter,
         organization_id: &str,
         name: &str,
     ) -> Result<i32, sqlx::Error> {
@@ -119,7 +121,7 @@ mod tests {
     }
 
     async fn insert_plugin_source_file_in_pg(
-        client: Arc<dyn DatabaseClient + Send + Sync>,
+        client: PostgresWriter,
         plugin_id: i32,
         filename: &str,
         status: &str,
@@ -141,7 +143,7 @@ mod tests {
     }
 
     async fn insert_posthog_pluginconfig_in_pg(
-        client: Arc<dyn DatabaseClient + Send + Sync>,
+        client: PostgresWriter,
         plugin_id: i32,
         team_id: i32,
         enabled: bool,

--- a/rust/feature-flags/src/team/team_operations.rs
+++ b/rust/feature-flags/src/team/team_operations.rs
@@ -2,7 +2,7 @@ use crate::{
     api::errors::FlagError,
     team::team_models::{Team, TEAM_TOKEN_CACHE_PREFIX},
 };
-use common_database::Client as DatabaseClient;
+use common_database::PostgresReader;
 use common_redis::Client as RedisClient;
 use std::sync::Arc;
 
@@ -83,10 +83,7 @@ impl Team {
         Ok(())
     }
 
-    pub async fn from_pg(
-        client: Arc<dyn DatabaseClient + Send + Sync>,
-        token: &str,
-    ) -> Result<Team, FlagError> {
+    pub async fn from_pg(client: PostgresReader, token: &str) -> Result<Team, FlagError> {
         let mut conn = client.get_connection().await?;
 
         let query = "SELECT 


### PR DESCRIPTION
And make use of it within feature flags.

> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

I noticed 8 months ago, @dmarticus added [these nice type aliases](4ce7e9c7814f5b61961cfae8b985846fd4105bf8).

```rust
pub type PostgresReader = Arc<dyn Client + Send + Sync>;
pub type PostgresWriter = Arc<dyn Client + Send + Sync>;
```

But we're not using them everywhere we could. They help make the code a bit cleaner and more readable.

## Changes

1. Moved these type aliases to the `common_database` crate.
2. Updated feature flags to use them.

No functional changes.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Unit test
Quick test in Postman