### PR TITLE
refactor: Remove Rev Analytics person mode hogql modifier

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -12575,12 +12575,6 @@
                     "enum": ["enabled", "disabled", "optimized"],
                     "type": "string"
                 },
-                "revenueAnalyticsPersonsJoinMode": {
-                    "$ref": "#/definitions/RevenueAnalyticsPersonsJoinModeModifier"
-                },
-                "revenueAnalyticsPersonsJoinModeCustom": {
-                    "type": ["string", "null"]
-                },
                 "s3TableUseInvalidColumns": {
                     "type": "boolean"
                 },
@@ -19812,10 +19806,6 @@
             },
             "required": ["results"],
             "type": "object"
-        },
-        "RevenueAnalyticsPersonsJoinModeModifier": {
-            "enum": ["id", "email", "custom"],
-            "type": "string"
         },
         "RevenueAnalyticsPropertyFilter": {
             "additionalProperties": false,

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -329,8 +329,6 @@ export interface HogQLQueryModifiers {
     personsJoinMode?: 'inner' | 'left'
     bounceRatePageViewMode?: 'count_pageviews' | 'uniq_urls' | 'uniq_page_screen_autocaptures'
     bounceRateDurationSeconds?: number
-    revenueAnalyticsPersonsJoinMode?: RevenueAnalyticsPersonsJoinModeModifier
-    revenueAnalyticsPersonsJoinModeCustom?: string | null
     sessionTableVersion?: 'auto' | 'v1' | 'v2'
     sessionsV2JoinMode?: 'string' | 'uuid'
     propertyGroupsMode?: 'enabled' | 'disabled' | 'optimized'
@@ -347,12 +345,6 @@ export interface DataWarehouseEventsModifier {
     timestamp_field: string
     distinct_id_field: string
     id_field: string
-}
-
-export enum RevenueAnalyticsPersonsJoinModeModifier {
-    ID = 'id',
-    EMAIL = 'email',
-    CUSTOM = 'custom',
 }
 
 export interface HogQLQueryResponse<T = any[]> extends AnalyticsQueryResponseBase<T> {

--- a/posthog/hogql/modifiers.py
+++ b/posthog/hogql/modifiers.py
@@ -14,7 +14,6 @@ from posthog.schema import (
     SessionTableVersion,
     CustomChannelRule,
     SessionsV2JoinMode,
-    RevenueAnalyticsPersonsJoinModeModifier,
 )
 
 if TYPE_CHECKING:
@@ -109,9 +108,6 @@ def set_default_modifier_values(modifiers: HogQLQueryModifiers, team: "Team"):
 
     if modifiers.convertToProjectTimezone is None:
         modifiers.convertToProjectTimezone = True
-
-    if modifiers.revenueAnalyticsPersonsJoinMode is None:
-        modifiers.revenueAnalyticsPersonsJoinMode = RevenueAnalyticsPersonsJoinModeModifier.ID
 
 
 def set_default_in_cohort_via(modifiers: HogQLQueryModifiers) -> HogQLQueryModifiers:

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -22,7 +22,6 @@ from posthog.schema import (
     PersonsOnEventsMode,
     SessionsV2JoinMode,
     SessionTableVersion,
-    RevenueAnalyticsPersonsJoinModeModifier,
     TestBasicQueryResponse,
     TestCachedBasicQueryResponse,
     IntervalType,
@@ -109,7 +108,6 @@ class TestQueryRunner(BaseTest):
                 "optimizeJoinedFilters": False,
                 "personsArgMaxVersion": PersonsArgMaxVersion.AUTO,
                 "personsOnEventsMode": PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED,
-                "revenueAnalyticsPersonsJoinMode": RevenueAnalyticsPersonsJoinModeModifier.ID,
                 "sessionTableVersion": SessionTableVersion.AUTO,
                 "sessionsV2JoinMode": SessionsV2JoinMode.STRING,
                 "useMaterializedViews": True,
@@ -144,7 +142,7 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        assert cache_key == "cache_67429a7b0c61b8501e8a94ce1ff98263"
+        assert cache_key == "cache_7583c7c9c2ab66ba5ff7f55ccb617c9a"
 
     def test_cache_key_runner_subclass(self):
         TestQueryRunner = self.setup_test_query_runner_class()
@@ -158,7 +156,7 @@ class TestQueryRunner(BaseTest):
         runner = TestSubclassQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        assert cache_key == "cache_b1f3e920d3349bb9cd9debe535b38e61"
+        assert cache_key == "cache_c2e0cd9925f875dba6539dc1b82078bf"
 
     def test_cache_key_different_timezone(self):
         TestQueryRunner = self.setup_test_query_runner_class()
@@ -169,7 +167,7 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        assert cache_key == "cache_4c137679d6e1f4c56dbe8fafd11ed075"
+        assert cache_key == "cache_af770db18dddd01c5c5d6b8f37a36006"
 
     @mock.patch("django.db.transaction.on_commit")
     def test_cache_response(self, mock_on_commit):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -2017,12 +2017,6 @@ class RevenueAnalyticsOverviewItemKey(StrEnum):
     AVG_REVENUE_PER_CUSTOMER = "avg_revenue_per_customer"
 
 
-class RevenueAnalyticsPersonsJoinModeModifier(StrEnum):
-    ID = "id"
-    EMAIL = "email"
-    CUSTOM = "custom"
-
-
 class RevenueAnalyticsPropertyFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -3369,8 +3363,6 @@ class HogQLQueryModifiers(BaseModel):
     personsJoinMode: Optional[PersonsJoinMode] = None
     personsOnEventsMode: Optional[PersonsOnEventsMode] = None
     propertyGroupsMode: Optional[PropertyGroupsMode] = None
-    revenueAnalyticsPersonsJoinMode: Optional[RevenueAnalyticsPersonsJoinModeModifier] = None
-    revenueAnalyticsPersonsJoinModeCustom: Optional[str] = None
     s3TableUseInvalidColumns: Optional[bool] = None
     sessionTableVersion: Optional[SessionTableVersion] = None
     sessionsV2JoinMode: Optional[SessionsV2JoinMode] = None


### PR DESCRIPTION
> [!WARNING]
> Don't merge before July 12th

These won't be used anymore. We've chosen a different approach where we'll use custom data warehouse joins to support this feature. This should not be deployed immediately because it'll invalidate all queries. We should wait and run this on a weekend.

Towards #33505