### PR TITLE
chore(flags): Support specifying keys for flags with dependencies

### DIFF
--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -23,7 +23,10 @@ use crate::metrics::consts::{
 };
 use crate::metrics::utils::parse_exception_for_prometheus_label;
 use crate::properties::property_models::PropertyFilter;
-use crate::utils::graph_utils::DependencyGraph;
+use crate::utils::graph_utils::{
+    build_dependency_graph, filter_graph_by_keys, log_dependency_graph_construction_errors,
+    log_dependency_graph_operation_error, DependencyGraph,
+};
 use anyhow::Result;
 use common_database::{PostgresReader, PostgresWriter};
 use common_metrics::{inc, timing_guard};
@@ -221,6 +224,7 @@ impl FeatureFlagMatcher {
         group_property_overrides: Option<HashMap<String, HashMap<String, Value>>>,
         hash_key_override: Option<String>,
         request_id: Uuid,
+        flag_keys: Option<Vec<String>>,
     ) -> FlagsResponse {
         let eval_timer = common_metrics::timing_guard(FLAG_EVALUATION_TIME, &[]);
         let flags_have_experience_continuity_enabled = feature_flags
@@ -243,6 +247,7 @@ impl FeatureFlagMatcher {
                 group_property_overrides,
                 hash_key_overrides,
                 request_id,
+                flag_keys,
             )
             .await;
 
@@ -422,6 +427,7 @@ impl FeatureFlagMatcher {
         group_property_overrides: Option<HashMap<String, HashMap<String, Value>>>,
         hash_key_overrides: Option<HashMap<String, String>>,
         request_id: Uuid,
+        flag_keys: Option<Vec<String>>,
     ) -> FlagsResponse {
         let mut errors_while_computing_flags = false;
         let mut evaluated_flags_map = HashMap::new();
@@ -441,10 +447,48 @@ impl FeatureFlagMatcher {
             .await;
         errors_while_computing_flags |= db_prep_errors;
 
-        // Step 3: Build dependency graph and evaluate flags in stages
+        // Step 3: Build dependency graph
+        let (global_dependency_graph, graph_errors) =
+            match build_dependency_graph(&feature_flags, self.team_id) {
+                Some((graph, errors)) => (graph, errors),
+                None => {
+                    return FlagsResponse {
+                        errors_while_computing_flags: true,
+                        flags: evaluated_flags_map,
+                        quota_limited: None,
+                        request_id,
+                        config: ConfigResponse::default(),
+                    }
+                }
+            };
+
+        // Step 4: Filter graph by flag keys if specified
+        let dependency_graph = if let Some(keys) = flag_keys {
+            match filter_graph_by_keys(&global_dependency_graph, &keys) {
+                Some(filtered_graph) => filtered_graph,
+                None => {
+                    return FlagsResponse {
+                        errors_while_computing_flags: true,
+                        flags: evaluated_flags_map,
+                        quota_limited: None,
+                        request_id,
+                        config: ConfigResponse::default(),
+                    }
+                }
+            }
+        } else {
+            global_dependency_graph
+        };
+
+        if !graph_errors.is_empty() {
+            errors_while_computing_flags = true;
+            log_dependency_graph_construction_errors(&graph_errors, self.team_id);
+        }
+
+        // Step 5: Evaluate flags using the dependency graph
         let graph_evaluation_errors = self
             .evaluate_flags_with_dependency_graph(
-                &feature_flags,
+                dependency_graph,
                 &person_property_overrides,
                 &group_property_overrides,
                 &hash_key_overrides,
@@ -460,6 +504,44 @@ impl FeatureFlagMatcher {
             request_id,
             config: ConfigResponse::default(),
         }
+    }
+
+    /// Evaluates flags using the provided dependency graph.
+    /// Returns true if there were errors during evaluation.
+    async fn evaluate_flags_with_dependency_graph(
+        &mut self,
+        flag_dependency_graph: DependencyGraph<FeatureFlag>,
+        person_property_overrides: &Option<HashMap<String, Value>>,
+        group_property_overrides: &Option<HashMap<String, HashMap<String, Value>>>,
+        hash_key_overrides: &Option<HashMap<String, String>>,
+        evaluated_flags_map: &mut HashMap<String, FlagDetails>,
+    ) -> bool {
+        // Get evaluation stages for the dependency graph
+        let evaluation_stages = match flag_dependency_graph.evaluation_stages() {
+            Ok(stages) => stages,
+            Err(e) => {
+                log_dependency_graph_operation_error("get evaluation stages", &e, self.team_id);
+                return true;
+            }
+        };
+
+        // Evaluate flags in dependency order
+        let mut errors_while_computing_flags = false;
+        for stage in evaluation_stages {
+            let (level_evaluated_flags_map, level_errors) = self
+                .evaluate_flags_in_level(
+                    stage.as_slice(),
+                    evaluated_flags_map,
+                    person_property_overrides,
+                    group_property_overrides,
+                    hash_key_overrides,
+                )
+                .await;
+            errors_while_computing_flags |= level_errors;
+            evaluated_flags_map.extend(level_evaluated_flags_map);
+        }
+
+        errors_while_computing_flags
     }
 
     /// Prepares evaluation state for flags that require database properties.
@@ -524,102 +606,13 @@ impl FeatureFlagMatcher {
         );
     }
 
-    /// Evaluates flags using dependency graph to handle flag dependencies correctly.
-    /// Returns true if there were errors during evaluation.
-    async fn evaluate_flags_with_dependency_graph(
-        &mut self,
-        feature_flags: &FeatureFlagList,
-        person_property_overrides: &Option<HashMap<String, Value>>,
-        group_property_overrides: &Option<HashMap<String, HashMap<String, Value>>>,
-        hash_key_overrides: &Option<HashMap<String, String>>,
-        evaluated_flags_map: &mut HashMap<String, FlagDetails>,
-    ) -> bool {
-        let (flag_dependency_graph, errors) =
-            match DependencyGraph::from_nodes(&feature_flags.flags) {
-                Ok((graph, errors)) => (graph, errors),
-                Err(e) => {
-                    self.handle_dependency_graph_error("build feature flag dependency graph", &e);
-                    return true;
-                }
-            };
-
-        let mut errors_while_computing_flags = !errors.is_empty();
-        if errors_while_computing_flags {
-            self.handle_dependency_graph_errors(&errors);
-        }
-
-        let evaluation_stages = match flag_dependency_graph.evaluation_stages() {
-            Ok(stages) => stages,
-            Err(e) => {
-                self.handle_dependency_graph_error("get evaluation stages", &e);
-                // This path should never happen. Normally I'd call unreachable here but if I'm wrong,
-                // I want the prod service to fail gracefully. But not while we're developing.
-                debug_assert!(
-                    false,
-                    "evaluation_stages() failed after dependency graph construction: {e:?}"
-                );
-                return true;
-            }
-        };
-
-        // Evaluate flags in dependency order
-        for stage in evaluation_stages {
-            let stage_flags: Vec<FeatureFlag> = stage.iter().map(|&flag| flag.clone()).collect();
-            let (level_evaluated_flags_map, level_errors) = self
-                .evaluate_flags_in_level(
-                    &stage_flags,
-                    evaluated_flags_map,
-                    person_property_overrides,
-                    group_property_overrides,
-                    hash_key_overrides,
-                )
-                .await;
-            errors_while_computing_flags |= level_errors;
-            evaluated_flags_map.extend(level_evaluated_flags_map);
-        }
-
-        errors_while_computing_flags
-    }
-
-    /// Handles errors during dependency graph operations.
-    fn handle_dependency_graph_error(&self, error_type: &str, error: &dyn std::fmt::Debug) {
-        error!(
-            "Failed to {} for team {}: {:?}",
-            error_type, self.team_id, error
-        );
-        inc(
-            FLAG_EVALUATION_ERROR_COUNTER,
-            &[(
-                "reason".to_string(),
-                format!("{}_error", error_type.replace(" ", "_")),
-            )],
-            1,
-        );
-    }
-
-    /// Handles errors found during dependency graph construction.
-    fn handle_dependency_graph_errors(
-        &self,
-        errors: &[crate::utils::graph_utils::GraphError<i32>],
-    ) {
-        inc(
-            FLAG_EVALUATION_ERROR_COUNTER,
-            &[("reason".to_string(), "dependency_graph_error".to_string())],
-            1,
-        );
-        error!(
-            "There were errors building the feature flag dependency graph for team {}. Will attempt to evaluate the rest of the flags: {:?}",
-            self.team_id, errors
-        );
-    }
-
     /// Evaluates a set of flags with a combination of property overrides and DB properties
     ///
     /// This function is designed to be used as part of a level-based evaluation strategy
     /// (e.g., Kahn's algorithm) for handling flag dependencies.
     async fn evaluate_flags_in_level(
         &mut self,
-        flags: &[FeatureFlag],
+        flags: &[&FeatureFlag],
         evaluated_flags_map: &mut HashMap<String, FlagDetails>,
         person_property_overrides: &Option<HashMap<String, Value>>,
         group_property_overrides: &Option<HashMap<String, HashMap<String, Value>>>,
@@ -636,6 +629,7 @@ impl FeatureFlagMatcher {
             .filter(|flag| {
                 !flag.deleted && !evaluated_flags_map.contains_key(&flag.key) && flag.active
             })
+            .copied()
             .collect::<Vec<&FeatureFlag>>();
 
         // Pre-compute property overrides for all flags upfront

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -196,7 +196,7 @@ mod tests {
             flags: vec![flag.clone()],
         };
         let result = matcher
-            .evaluate_all_feature_flags(flags, Some(overrides), None, None, Uuid::new_v4())
+            .evaluate_all_feature_flags(flags, Some(overrides), None, None, Uuid::new_v4(), None)
             .await;
         assert!(!result.errors_while_computing_flags);
         assert_eq!(
@@ -273,7 +273,14 @@ mod tests {
             flags: vec![flag.clone()],
         };
         let result = matcher
-            .evaluate_all_feature_flags(flags, None, Some(group_overrides), None, Uuid::new_v4())
+            .evaluate_all_feature_flags(
+                flags,
+                None,
+                Some(group_overrides),
+                None,
+                Uuid::new_v4(),
+                None,
+            )
             .await;
 
         let legacy_response = LegacyFlagsResponse::from_response(result);
@@ -284,65 +291,11 @@ mod tests {
         );
     }
 
-    pub fn create_test_flag_with_properties(
-        id: i32,
-        team_id: TeamId,
-        key: &str,
-        filters: Vec<PropertyFilter>,
-    ) -> FeatureFlag {
-        create_test_flag(
-            Some(id),
-            Some(team_id),
-            None,
-            Some(key.to_string()),
-            Some(FlagFilters {
-                groups: vec![FlagPropertyGroup {
-                    properties: Some(filters),
-                    rollout_percentage: Some(100.0),
-                    variant: None,
-                }],
-                multivariate: None,
-                aggregation_group_type_index: None,
-                payloads: None,
-                super_groups: None,
-                holdout_groups: None,
-            }),
-            None,
-            None,
-            None,
-        )
-    }
-
-    pub fn create_test_flag_with_property(
-        id: i32,
-        team_id: TeamId,
-        key: &str,
-        filter: PropertyFilter,
-    ) -> FeatureFlag {
-        create_test_flag_with_properties(id, team_id, key, vec![filter])
-    }
-
-    pub fn create_test_flag_that_depends_on_flag(
-        id: i32,
-        team_id: TeamId,
-        key: &str,
-        depends_on_flag_id: i32,
-        depends_on_flag_value: FlagValue,
-    ) -> FeatureFlag {
-        create_test_flag_with_property(
-            id,
-            team_id,
-            key,
-            PropertyFilter {
-                key: depends_on_flag_id.to_string(),
-                value: Some(json!(depends_on_flag_value)),
-                operator: Some(OperatorType::Exact),
-                prop_type: PropertyType::Flag,
-                group_type_index: None,
-                negation: None,
-            },
-        )
-    }
+    // Use the shared test utility functions from test_utils.rs
+    use crate::utils::test_utils::{
+        create_test_flag_that_depends_on_flag, create_test_flag_with_properties,
+        create_test_flag_with_property,
+    };
 
     #[tokio::test]
     async fn test_flags_that_depends_on_other_boolean_flag() {
@@ -413,6 +366,7 @@ mod tests {
                     None,
                     None,
                     Uuid::new_v4(),
+                    None,
                 )
                 .await;
             assert!(!result.errors_while_computing_flags);
@@ -436,7 +390,7 @@ mod tests {
         {
             // Leaf flag evaluates to false
             let result = matcher
-                .evaluate_all_feature_flags(flags.clone(), None, None, None, Uuid::new_v4())
+                .evaluate_all_feature_flags(flags.clone(), None, None, None, Uuid::new_v4(), None)
                 .await;
             assert!(!result.errors_while_computing_flags);
             assert_eq!(
@@ -562,6 +516,7 @@ mod tests {
                     None,
                     None,
                     Uuid::new_v4(),
+                    None,
                 )
                 .await;
             assert!(!result.errors_while_computing_flags);
@@ -583,6 +538,7 @@ mod tests {
                     None,
                     None,
                     Uuid::new_v4(),
+                    None,
                 )
                 .await;
             assert!(!result.errors_while_computing_flags);
@@ -604,6 +560,7 @@ mod tests {
                     None,
                     None,
                     Uuid::new_v4(),
+                    None,
                 )
                 .await;
             assert!(!result.errors_while_computing_flags);
@@ -713,7 +670,7 @@ mod tests {
         reset_fetch_calls_count();
 
         let result = matcher
-            .evaluate_all_feature_flags(flags.clone(), None, None, None, Uuid::new_v4())
+            .evaluate_all_feature_flags(flags.clone(), None, None, None, Uuid::new_v4(), None)
             .await;
         // Add this assertion to check the call count
         let fetch_calls = get_fetch_calls_count();
@@ -844,6 +801,7 @@ mod tests {
                     None,
                     None,
                     Uuid::new_v4(),
+                    None,
                 )
                 .await;
             assert!(result.errors_while_computing_flags);
@@ -867,7 +825,7 @@ mod tests {
         {
             // Leaf flag evaluates to false
             let result = matcher
-                .evaluate_all_feature_flags(flags.clone(), None, None, None, Uuid::new_v4())
+                .evaluate_all_feature_flags(flags.clone(), None, None, None, Uuid::new_v4(), None)
                 .await;
             assert!(result.errors_while_computing_flags);
             assert_eq!(
@@ -984,6 +942,7 @@ mod tests {
                     None,
                     None,
                     Uuid::new_v4(),
+                    None,
                 )
                 .await;
             assert!(!result.errors_while_computing_flags);
@@ -1006,6 +965,7 @@ mod tests {
                     None,
                     None,
                     Uuid::new_v4(),
+                    None,
                 )
                 .await;
             assert!(!result.errors_while_computing_flags);
@@ -1021,7 +981,7 @@ mod tests {
         {
             // Leaf flag evaluates to false
             let result = matcher
-                .evaluate_all_feature_flags(flags.clone(), None, None, None, Uuid::new_v4())
+                .evaluate_all_feature_flags(flags.clone(), None, None, None, Uuid::new_v4(), None)
                 .await;
             assert!(!result.errors_while_computing_flags);
             assert_eq!(
@@ -1307,6 +1267,7 @@ mod tests {
                 None,
                 None,
                 Uuid::new_v4(),
+                None,
             )
             .await;
 
@@ -3414,6 +3375,7 @@ mod tests {
             None,
             Some("hash_key_continuity".to_string()),
             Uuid::new_v4(),
+            None,
         )
         .await;
 
@@ -3493,7 +3455,7 @@ mod tests {
             Some(group_type_mapping_cache),
             None,
         )
-        .evaluate_all_feature_flags(flags, None, None, None, Uuid::new_v4())
+        .evaluate_all_feature_flags(flags, None, None, None, Uuid::new_v4(), None)
         .await;
 
         assert!(result.flags.get("flag_continuity_missing").unwrap().enabled);
@@ -3621,6 +3583,7 @@ mod tests {
             None,
             Some("hash_key_mixed".to_string()),
             Uuid::new_v4(),
+            None,
         )
         .await;
 
@@ -4284,6 +4247,7 @@ mod tests {
                 None,
                 None,
                 Uuid::new_v4(),
+                None,
             )
             .await;
 
@@ -4799,6 +4763,7 @@ mod tests {
                 None,
                 None,
                 Uuid::new_v4(),
+                None,
             )
             .await;
 
@@ -4839,6 +4804,7 @@ mod tests {
                 None,
                 None,
                 Uuid::new_v4(),
+                None,
             )
             .await;
 
@@ -4872,6 +4838,7 @@ mod tests {
                 None,
                 None,
                 Uuid::new_v4(),
+                None,
             )
             .await;
 
@@ -4907,6 +4874,7 @@ mod tests {
                 None,
                 None,
                 Uuid::new_v4(),
+                None,
             )
             .await;
 
@@ -5048,6 +5016,7 @@ mod tests {
                 Some(partial_group_overrides),
                 None,
                 Uuid::new_v4(),
+                None,
             )
             .await;
 
@@ -5087,6 +5056,7 @@ mod tests {
                 Some(complete_group_overrides_match),
                 None,
                 Uuid::new_v4(),
+                None,
             )
             .await;
 
@@ -5126,6 +5096,7 @@ mod tests {
                 Some(complete_group_overrides_no_match),
                 None,
                 Uuid::new_v4(),
+                None,
             )
             .await;
 
@@ -5161,6 +5132,7 @@ mod tests {
                 Some(complete_group_overrides_condition1),
                 None,
                 Uuid::new_v4(),
+                None,
             )
             .await;
 
@@ -5200,6 +5172,7 @@ mod tests {
                 Some(mixed_group_overrides),
                 None,
                 Uuid::new_v4(),
+                None,
             )
             .await;
 

--- a/rust/feature-flags/src/handler/evaluation.rs
+++ b/rust/feature-flags/src/handler/evaluation.rs
@@ -31,6 +31,7 @@ pub async fn evaluate_feature_flags(
             context.group_property_overrides,
             context.hash_key_override,
             request_id,
+            context.flag_keys,
         )
         .await
 }

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -70,8 +70,7 @@ pub async fn process_request(context: RequestContext) -> Result<FlagsResponse, F
             tracing::debug!("Distinct ID resolved: {}", distinct_id);
 
             let filtered_flags =
-                flags::fetch_and_filter(&flag_service, team.project_id, &request, &context.meta)
-                    .await?;
+                flags::fetch_and_filter(&flag_service, team.project_id, &context.meta).await?;
 
             tracing::debug!("Flags filtered: {} flags found", filtered_flags.flags.len());
 
@@ -90,6 +89,7 @@ pub async fn process_request(context: RequestContext) -> Result<FlagsResponse, F
                 property_overrides.hash_key,
                 context.request_id,
                 request.is_flags_disabled(),
+                request.flag_keys.clone(),
             )
             .await;
 

--- a/rust/feature-flags/src/handler/types.rs
+++ b/rust/feature-flags/src/handler/types.rs
@@ -52,4 +52,6 @@ pub struct FeatureFlagEvaluationContext {
     pub group_property_overrides: Option<HashMap<String, HashMap<String, Value>>>,
     pub groups: Option<HashMap<String, Value>>,
     pub hash_key_override: Option<String>,
+    /// Contains explicitly requested flag keys and their dependencies. If empty, all flags will be evaluated.
+    pub flag_keys: Option<Vec<String>>,
 }

--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -374,7 +374,9 @@ pub fn build_dependency_graph(
 }
 
 /// Filters a dependency graph to include only the requested flags and their dependencies.
-/// Returns None if there were errors during filtering.
+/// Returns None if:
+/// - There were errors during filtering
+/// - The global_graph's internal state is corrupted
 pub fn filter_graph_by_keys(
     global_graph: &DependencyGraph<FeatureFlag>,
     requested_keys: &[String],

--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -382,16 +382,16 @@ pub fn filter_graph_by_keys(
     let mut nodes_to_include = HashSet::new();
 
     // Build an index from flag keys to node indices for O(1) lookups
-    let key_to_node: HashMap<&String, petgraph::graph::NodeIndex> = global_graph
+    let key_to_node: HashMap<&str, petgraph::graph::NodeIndex> = global_graph
         .graph
         .node_indices()
-        .map(|idx| (&global_graph.graph[idx].key, idx))
+        .map(|idx| (global_graph.graph[idx].key.as_str(), idx))
         .collect();
 
     // For each requested flag, traverse the global graph to collect dependencies
     for key in requested_keys {
         // Find the flag in the global graph using the index
-        let node_idx = key_to_node.get(key);
+        let node_idx = key_to_node.get(key.as_str());
 
         if let Some(&start_idx) = node_idx {
             // Use BFS to collect all reachable nodes (dependencies) from this flag

--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -3,9 +3,14 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use petgraph::{
     algo::toposort,
     graph::{DiGraph, NodeIndex},
+    visit::EdgeRef,
 };
 
 use crate::api::errors::FlagError;
+use crate::flags::flag_models::FeatureFlag;
+use crate::metrics::consts::FLAG_EVALUATION_ERROR_COUNTER;
+use common_metrics::inc;
+use tracing::warn;
 
 #[derive(Debug, Clone)]
 pub enum GraphError<Id> {
@@ -333,4 +338,155 @@ where
             .node_indices()
             .any(|idx| self.graph[idx].get_id() == id)
     }
+
+    #[cfg(test)]
+    pub(crate) fn get_all_nodes(&self) -> Vec<&T> {
+        self.graph
+            .node_indices()
+            .map(|idx| &self.graph[idx])
+            .collect()
+    }
+}
+
+/// Builds a dependency graph for flag evaluation.
+/// Returns None only if there were fatal errors during graph construction.
+/// Partial errors (cycles, missing dependencies) are returned in the errors vector
+/// and the graph contains only the valid nodes.
+pub fn build_dependency_graph(
+    feature_flags: &crate::flags::flag_models::FeatureFlagList,
+    team_id: common_types::TeamId,
+) -> Option<(DependencyGraph<FeatureFlag>, Vec<GraphError<i32>>)> {
+    // Build the global dependency graph once, handling partial errors gracefully
+    let (global_graph, errors) = match DependencyGraph::from_nodes(&feature_flags.flags) {
+        Ok((graph, graph_errors)) => (graph, graph_errors),
+        Err(e) => {
+            log_dependency_graph_operation_error("build global dependency graph", &e, team_id);
+            return None; // Only return None for fatal errors
+        }
+    };
+
+    // Log any dependency errors but continue with the valid graph
+    if !errors.is_empty() {
+        log_dependency_graph_construction_errors(&errors, team_id);
+    }
+
+    Some((global_graph, errors))
+}
+
+/// Filters a dependency graph to include only the requested flags and their dependencies.
+/// Returns None if there were errors during filtering.
+pub fn filter_graph_by_keys(
+    global_graph: &DependencyGraph<FeatureFlag>,
+    requested_keys: &[String],
+) -> Option<DependencyGraph<FeatureFlag>> {
+    let mut nodes_to_include = HashSet::new();
+
+    // Build an index from flag keys to node indices for O(1) lookups
+    let key_to_node: HashMap<&String, petgraph::graph::NodeIndex> = global_graph
+        .graph
+        .node_indices()
+        .map(|idx| (&global_graph.graph[idx].key, idx))
+        .collect();
+
+    // For each requested flag, traverse the global graph to collect dependencies
+    for key in requested_keys {
+        // Find the flag in the global graph using the index
+        let node_idx = key_to_node.get(key);
+
+        if let Some(&start_idx) = node_idx {
+            // Use BFS to collect all reachable nodes (dependencies) from this flag
+            let mut visited = HashSet::new();
+            let mut queue = std::collections::VecDeque::new();
+            queue.push_back(start_idx);
+            visited.insert(start_idx);
+
+            while let Some(current_idx) = queue.pop_front() {
+                nodes_to_include.insert(current_idx);
+
+                // Add all dependencies (outgoing edges) to the queue
+                for neighbor_idx in global_graph
+                    .graph
+                    .neighbors_directed(current_idx, petgraph::Direction::Outgoing)
+                {
+                    if visited.insert(neighbor_idx) {
+                        queue.push_back(neighbor_idx);
+                    }
+                }
+            }
+        } else {
+            // Log warning for missing flag key
+            warn!("Requested flag key not found: {}", key);
+            inc(
+                FLAG_EVALUATION_ERROR_COUNTER,
+                &[(
+                    "reason".to_string(),
+                    "missing_requested_flag_key".to_string(),
+                )],
+                1,
+            );
+        }
+    }
+
+    // Create a new graph with only the filtered nodes
+    let mut filtered_graph = DiGraph::new();
+    let mut node_mapping = HashMap::new();
+
+    // Add all the nodes we want to include
+    for &node_idx in &nodes_to_include {
+        let flag = global_graph.graph[node_idx].clone();
+        let new_idx = filtered_graph.add_node(flag);
+        node_mapping.insert(node_idx, new_idx);
+    }
+
+    // Add all the edges between the included nodes
+    for &node_idx in &nodes_to_include {
+        if let Some(&new_source_idx) = node_mapping.get(&node_idx) {
+            for edge in global_graph
+                .graph
+                .edges_directed(node_idx, petgraph::Direction::Outgoing)
+            {
+                let target_idx = edge.target();
+                if let Some(&new_target_idx) = node_mapping.get(&target_idx) {
+                    filtered_graph.add_edge(new_source_idx, new_target_idx, ());
+                }
+            }
+        }
+    }
+
+    Some(DependencyGraph {
+        graph: filtered_graph,
+    })
+}
+
+/// Handles errors during dependency graph operations.
+pub fn log_dependency_graph_operation_error(
+    error_type: &str,
+    error: &dyn std::fmt::Debug,
+    team_id: common_types::TeamId,
+) {
+    tracing::error!("Failed to {} for team {}: {:?}", error_type, team_id, error);
+    inc(
+        FLAG_EVALUATION_ERROR_COUNTER,
+        &[(
+            "reason".to_string(),
+            format!("{}_error", error_type.replace(" ", "_")),
+        )],
+        1,
+    );
+}
+
+/// Handles errors found during dependency graph construction.
+pub fn log_dependency_graph_construction_errors(
+    errors: &[GraphError<i32>],
+    team_id: common_types::TeamId,
+) {
+    inc(
+        FLAG_EVALUATION_ERROR_COUNTER,
+        &[("reason".to_string(), "dependency_graph_error".to_string())],
+        1,
+    );
+    tracing::error!(
+        "There were errors building the feature flag dependency graph for team {}. Will attempt to evaluate the rest of the flags: {:?}",
+        team_id, errors
+    );
 }

--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -467,10 +467,13 @@ pub fn log_dependency_graph_operation_error(
     tracing::error!("Failed to {} for team {}: {:?}", error_type, team_id, error);
     inc(
         FLAG_EVALUATION_ERROR_COUNTER,
-        &[(
-            "reason".to_string(),
-            format!("{}_error", error_type.replace(" ", "_")),
-        )],
+        &[
+            (
+                "reason".to_string(),
+                format!("{}_error", error_type.replace(" ", "_")),
+            ),
+            ("team_id".to_string(), team_id.to_string()),
+        ],
         1,
     );
 }
@@ -482,7 +485,10 @@ pub fn log_dependency_graph_construction_errors(
 ) {
     inc(
         FLAG_EVALUATION_ERROR_COUNTER,
-        &[("reason".to_string(), "dependency_graph_error".to_string())],
+        &[
+            ("reason".to_string(), "dependency_graph_error".to_string()),
+            ("team_id".to_string(), team_id.to_string()),
+        ],
         1,
     );
     tracing::error!(

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -580,3 +580,66 @@ pub async fn update_team_autocapture_exceptions(
         .await?;
     Ok(())
 }
+
+/// Create a test flag with multiple property filters
+pub fn create_test_flag_with_properties(
+    id: i32,
+    team_id: TeamId,
+    key: &str,
+    filters: Vec<crate::properties::property_models::PropertyFilter>,
+) -> FeatureFlag {
+    create_test_flag(
+        Some(id),
+        Some(team_id),
+        None,
+        Some(key.to_string()),
+        Some(FlagFilters {
+            groups: vec![FlagPropertyGroup {
+                properties: Some(filters),
+                rollout_percentage: Some(100.0),
+                variant: None,
+            }],
+            multivariate: None,
+            aggregation_group_type_index: None,
+            payloads: None,
+            super_groups: None,
+            holdout_groups: None,
+        }),
+        None,
+        None,
+        None,
+    )
+}
+
+/// Create a test flag with a single property filter
+pub fn create_test_flag_with_property(
+    id: i32,
+    team_id: TeamId,
+    key: &str,
+    filter: crate::properties::property_models::PropertyFilter,
+) -> FeatureFlag {
+    create_test_flag_with_properties(id, team_id, key, vec![filter])
+}
+
+/// Create a test flag that depends on another flag
+pub fn create_test_flag_that_depends_on_flag(
+    id: i32,
+    team_id: TeamId,
+    key: &str,
+    depends_on_flag_id: i32,
+    depends_on_flag_value: crate::api::types::FlagValue,
+) -> FeatureFlag {
+    create_test_flag_with_property(
+        id,
+        team_id,
+        key,
+        crate::properties::property_models::PropertyFilter {
+            key: depends_on_flag_id.to_string(),
+            value: Some(serde_json::json!(depends_on_flag_value)),
+            operator: Some(crate::properties::property_models::OperatorType::Exact),
+            prop_type: crate::properties::property_models::PropertyType::Flag,
+            group_type_index: None,
+            negation: None,
+        },
+    )
+}

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -1,10 +1,7 @@
 use crate::{
-    cohorts::cohort_models::{Cohort, CohortId},
-    config::{Config, DEFAULT_TEST_CONFIG},
-    flags::flag_models::{
+    cohorts::cohort_models::{Cohort, CohortId}, config::{Config, DEFAULT_TEST_CONFIG}, flags::flag_models::{
         FeatureFlag, FeatureFlagRow, FlagFilters, FlagPropertyGroup, TEAM_FLAGS_CACHE_PREFIX,
-    },
-    team::team_models::{Team, TEAM_TOKEN_CACHE_PREFIX},
+    }, properties::property_models::PropertyFilter, team::team_models::{Team, TEAM_TOKEN_CACHE_PREFIX}
 };
 use anyhow::Error;
 use axum::async_trait;
@@ -586,7 +583,7 @@ pub fn create_test_flag_with_properties(
     id: i32,
     team_id: TeamId,
     key: &str,
-    filters: Vec<crate::properties::property_models::PropertyFilter>,
+    filters: Vec<PropertyFilter>,
 ) -> FeatureFlag {
     create_test_flag(
         Some(id),

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -1,7 +1,12 @@
 use crate::{
-    cohorts::cohort_models::{Cohort, CohortId}, config::{Config, DEFAULT_TEST_CONFIG}, flags::flag_models::{
+    api::types::FlagValue,
+    cohorts::cohort_models::{Cohort, CohortId},
+    config::{Config, DEFAULT_TEST_CONFIG},
+    flags::flag_models::{
         FeatureFlag, FeatureFlagRow, FlagFilters, FlagPropertyGroup, TEAM_FLAGS_CACHE_PREFIX,
-    }, properties::property_models::PropertyFilter, team::team_models::{Team, TEAM_TOKEN_CACHE_PREFIX}
+    },
+    properties::property_models::{OperatorType, PropertyFilter, PropertyType},
+    team::team_models::{Team, TEAM_TOKEN_CACHE_PREFIX},
 };
 use anyhow::Error;
 use axum::async_trait;
@@ -613,7 +618,7 @@ pub fn create_test_flag_with_property(
     id: i32,
     team_id: TeamId,
     key: &str,
-    filter: crate::properties::property_models::PropertyFilter,
+    filter: PropertyFilter,
 ) -> FeatureFlag {
     create_test_flag_with_properties(id, team_id, key, vec![filter])
 }
@@ -624,17 +629,17 @@ pub fn create_test_flag_that_depends_on_flag(
     team_id: TeamId,
     key: &str,
     depends_on_flag_id: i32,
-    depends_on_flag_value: crate::api::types::FlagValue,
+    depends_on_flag_value: FlagValue,
 ) -> FeatureFlag {
     create_test_flag_with_property(
         id,
         team_id,
         key,
-        crate::properties::property_models::PropertyFilter {
+        PropertyFilter {
             key: depends_on_flag_id.to_string(),
-            value: Some(serde_json::json!(depends_on_flag_value)),
-            operator: Some(crate::properties::property_models::OperatorType::Exact),
-            prop_type: crate::properties::property_models::PropertyType::Flag,
+            value: Some(json!(depends_on_flag_value)),
+            operator: Some(OperatorType::Exact),
+            prop_type: PropertyType::Flag,
             group_type_index: None,
             negation: None,
         },

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -4672,3 +4672,229 @@ async fn test_cohort_filter_with_regex_and_negation() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_flag_keys_should_include_dependency_graph() -> Result<()> {
+    // This test is to ensure that when flag_keys is specified, the dependency graph is included in the response
+    // For example, if parent_flag -> intermediate_flag -> leaf_flag, and we only request parent_flag,
+    // we should get the response for parent_flag, intermediate_flag, and leaf_flag otherwise parent_flag can't be evaluated.
+
+    let config = DEFAULT_TEST_CONFIG.clone();
+    let distinct_id = "user_distinct_id".to_string();
+
+    let client = setup_redis_client(Some(config.redis_url.clone())).await;
+    let pg_client = setup_pg_reader_client(None).await;
+    let team = insert_new_team_in_redis(client.clone()).await.unwrap();
+    let token = team.api_token;
+
+    insert_new_team_in_pg(pg_client.clone(), Some(team.id))
+        .await
+        .unwrap();
+
+    insert_person_for_team_in_pg(pg_client.clone(), team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
+
+    // Create a dependency chain: parent_flag -> intermediate_flag -> leaf_flag
+    // parent_flag depends on intermediate_flag being true
+    // intermediate_flag depends on leaf_flag being true
+    let flag_json = json!([
+        {
+            "id": 1,
+            "key": "leaf_flag",
+            "name": "Leaf Flag",
+            "active": true,
+            "deleted": false,
+            "team_id": team.id,
+            "filters": {
+                "groups": [
+                    {
+                        "properties": [
+                            {
+                                "key": "email",
+                                "value": "test@example.com",
+                                "operator": "exact",
+                                "type": "person"
+                            }
+                        ],
+                        "rollout_percentage": 100
+                    }
+                ]
+            }
+        },
+        {
+            "id": 2,
+            "key": "intermediate_flag",
+            "name": "Intermediate Flag",
+            "active": true,
+            "deleted": false,
+            "team_id": team.id,
+            "filters": {
+                "groups": [
+                    {
+                        "properties": [
+                            {
+                                "key": "1", // This references leaf_flag's ID
+                                "value": true,
+                                "operator": "exact",
+                                "type": "flag"
+                            }
+                        ],
+                        "rollout_percentage": 100
+                    }
+                ]
+            }
+        },
+        {
+            "id": 3,
+            "key": "parent_flag",
+            "name": "Parent Flag",
+            "active": true,
+            "deleted": false,
+            "team_id": team.id,
+            "filters": {
+                "groups": [
+                    {
+                        "properties": [
+                            {
+                                "key": "2", // This references intermediate_flag's ID
+                                "value": true,
+                                "operator": "exact",
+                                "type": "flag"
+                            }
+                        ],
+                        "rollout_percentage": 100
+                    }
+                ]
+            }
+        },
+        {
+            "id": 4,
+            "key": "independent_flag",
+            "name": "Independent Flag",
+            "active": true,
+            "deleted": false,
+            "team_id": team.id,
+            "filters": {
+                "groups": [
+                    {
+                        "properties": [],
+                        "rollout_percentage": 50
+                    }
+                ]
+            }
+        }
+    ]);
+
+    insert_flags_for_team_in_redis(
+        client,
+        team.id,
+        team.project_id,
+        Some(flag_json.to_string()),
+    )
+    .await?;
+
+    let server = ServerHandle::for_config(config).await;
+
+    // Test 1: Request only parent_flag with flag_keys where the whole chain evaluates to true because the leaf_flag is true
+    {
+        let payload = json!({
+            "token": token,
+            "distinct_id": distinct_id,
+            "flag_keys": ["parent_flag"],
+            "person_properties": {
+                "email": "test@example.com"
+            }
+        });
+        let res = server
+            .send_flags_request(payload.to_string(), Some("2"), None)
+            .await;
+        assert_eq!(StatusCode::OK, res.status());
+        let json_data = res.json::<Value>().await?;
+        println!("Test 1 - Actual response: {}", serde_json::to_string_pretty(&json_data).unwrap());
+        assert_json_include!(
+            actual: json_data,
+            expected: json!({
+                "errorsWhileComputingFlags": false,
+                "flags": {
+                    "parent_flag": {
+                        "key": "parent_flag",
+                        "enabled": true,
+                        "reason": {
+                            "code": "condition_match",
+                            "condition_index": 0
+                        }
+                    },
+                    "intermediate_flag": {
+                        "key": "intermediate_flag",
+                        "enabled": true,
+                        "reason": {
+                            "code": "condition_match",
+                            "condition_index": 0
+                        }
+                    },
+                    "leaf_flag": {
+                        "key": "leaf_flag",
+                        "enabled": true,
+                        "reason": {
+                            "code": "condition_match",
+                            "condition_index": 0
+                        }
+                    }
+                }
+            })
+        );
+    }
+
+    // Test 1: Request only parent_flag with flag_keys where the whole chain evaluates to false because the leaf_flag is false
+    {
+        let payload = json!({
+            "token": token,
+            "distinct_id": distinct_id,
+            "flag_keys": ["parent_flag"],
+            "person_properties": {
+                "email": "not-test@example.com"
+            }
+        });
+        let res = server
+            .send_flags_request(payload.to_string(), Some("2"), None)
+            .await;
+        assert_eq!(StatusCode::OK, res.status());
+        let json_data = res.json::<Value>().await?;
+        println!("Test 1 - Actual response: {}", serde_json::to_string_pretty(&json_data).unwrap());
+        assert_json_include!(
+            actual: json_data,
+            expected: json!({
+                "errorsWhileComputingFlags": false,
+                "flags": {
+                    "parent_flag": {
+                        "key": "parent_flag",
+                        "enabled": false,
+                        "reason": {
+                            "code": "condition_match",
+                            "condition_index": 0
+                        }
+                    },
+                    "intermediate_flag": {
+                        "key": "intermediate_flag",
+                        "enabled": false,
+                        "reason": {
+                            "code": "condition_match",
+                            "condition_index": 0
+                        }
+                    },
+                    "leaf_flag": {
+                        "key": "leaf_flag",
+                        "enabled": false,
+                        "reason": {
+                            "code": "condition_match",
+                            "condition_index": 0
+                        }
+                    }
+                }
+            })
+        );
+    }
+
+    Ok(())
+}

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -4811,7 +4811,10 @@ async fn test_flag_keys_should_include_dependency_graph() -> Result<()> {
             .await;
         assert_eq!(StatusCode::OK, res.status());
         let json_data = res.json::<Value>().await?;
-        println!("Test 1 - Actual response: {}", serde_json::to_string_pretty(&json_data).unwrap());
+        println!(
+            "Test 1 - Actual response: {}",
+            serde_json::to_string_pretty(&json_data).unwrap()
+        );
         assert_json_include!(
             actual: json_data,
             expected: json!({
@@ -4846,7 +4849,7 @@ async fn test_flag_keys_should_include_dependency_graph() -> Result<()> {
         );
     }
 
-    // Test 1: Request only parent_flag with flag_keys where the whole chain evaluates to false because the leaf_flag is false
+    // Test 2: Request only parent_flag with flag_keys where the whole chain evaluates to false because the leaf_flag is false
     {
         let payload = json!({
             "token": token,
@@ -4861,7 +4864,10 @@ async fn test_flag_keys_should_include_dependency_graph() -> Result<()> {
             .await;
         assert_eq!(StatusCode::OK, res.status());
         let json_data = res.json::<Value>().await?;
-        println!("Test 1 - Actual response: {}", serde_json::to_string_pretty(&json_data).unwrap());
+        println!(
+            "Test 2 - Actual response: {}",
+            serde_json::to_string_pretty(&json_data).unwrap()
+        );
         assert_json_include!(
             actual: json_data,
             expected: json!({
@@ -4871,7 +4877,7 @@ async fn test_flag_keys_should_include_dependency_graph() -> Result<()> {
                         "key": "parent_flag",
                         "enabled": false,
                         "reason": {
-                            "code": "condition_match",
+                            "code": "no_condition_match",
                             "condition_index": 0
                         }
                     },
@@ -4879,7 +4885,7 @@ async fn test_flag_keys_should_include_dependency_graph() -> Result<()> {
                         "key": "intermediate_flag",
                         "enabled": false,
                         "reason": {
-                            "code": "condition_match",
+                            "code": "no_condition_match",
                             "condition_index": 0
                         }
                     },
@@ -4887,7 +4893,7 @@ async fn test_flag_keys_should_include_dependency_graph() -> Result<()> {
                         "key": "leaf_flag",
                         "enabled": false,
                         "reason": {
-                            "code": "condition_match",
+                            "code": "no_condition_match",
                             "condition_index": 0
                         }
                     }

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -4695,12 +4695,17 @@ async fn test_flag_keys_should_include_dependency_graph() -> Result<()> {
         .await
         .unwrap();
 
+    const LEAF_FLAG_ID: i32 = 1;
+    const INTERMEDIATE_FLAG_ID: i32 = 2;
+    const PARENT_FLAG_ID: i32 = 3;
+    const INDEPENDENT_FLAG_ID: i32 = 4;
+
     // Create a dependency chain: parent_flag -> intermediate_flag -> leaf_flag
     // parent_flag depends on intermediate_flag being true
     // intermediate_flag depends on leaf_flag being true
     let flag_json = json!([
         {
-            "id": 1,
+            "id": LEAF_FLAG_ID,
             "key": "leaf_flag",
             "name": "Leaf Flag",
             "active": true,
@@ -4723,7 +4728,7 @@ async fn test_flag_keys_should_include_dependency_graph() -> Result<()> {
             }
         },
         {
-            "id": 2,
+            "id": INTERMEDIATE_FLAG_ID,
             "key": "intermediate_flag",
             "name": "Intermediate Flag",
             "active": true,
@@ -4734,7 +4739,7 @@ async fn test_flag_keys_should_include_dependency_graph() -> Result<()> {
                     {
                         "properties": [
                             {
-                                "key": "1", // This references leaf_flag's ID
+                                "key": LEAF_FLAG_ID.to_string(),
                                 "value": true,
                                 "operator": "exact",
                                 "type": "flag"
@@ -4746,7 +4751,7 @@ async fn test_flag_keys_should_include_dependency_graph() -> Result<()> {
             }
         },
         {
-            "id": 3,
+            "id": PARENT_FLAG_ID,
             "key": "parent_flag",
             "name": "Parent Flag",
             "active": true,
@@ -4757,7 +4762,7 @@ async fn test_flag_keys_should_include_dependency_graph() -> Result<()> {
                     {
                         "properties": [
                             {
-                                "key": "2", // This references intermediate_flag's ID
+                                "key": INTERMEDIATE_FLAG_ID.to_string(),
                                 "value": true,
                                 "operator": "exact",
                                 "type": "flag"
@@ -4769,7 +4774,7 @@ async fn test_flag_keys_should_include_dependency_graph() -> Result<()> {
             }
         },
         {
-            "id": 4,
+            "id": INDEPENDENT_FLAG_ID,
             "key": "independent_flag",
             "name": "Independent Flag",
             "active": true,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Our backend now supports flags that depend on other flags. However, that poses a problem when requesting a subset of flags using `flag_keys`. For example, suppose we have the following dependency graph:

`drinks-flag` -> `ice-flag` -> `freezer-flag`.

If a request comes with: `flag_keys: ["drinks-flag"]`, we can't evaluate the flag because the flags `drinks-flag` depends on is not in the set of evaluated flags.

## Changes

1. Move filtering based on keys to _after_ we build the dependency graph.
2. Include dependents when `flag_keys` requested.

So in the above scenario, even though only `drinks-flag` was requested, the `/flags` response will include the entire dependency tree so that `drinks-flag` can be evaluated: `["drinks-flag", "ice-flag", "freezer-flag"]`

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Unit tests
Manual testing