### PR TITLE
chore(editor-sidebar): track if initial load

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/editorSceneLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/editorSceneLogic.tsx
@@ -523,7 +523,11 @@ export const editorSceneLogic = kea<editorSceneLogicType>([
     })),
     urlToAction(({ values, actions }) => ({
         [urls.sqlEditor()]: () => {
-            if (values.featureFlags[FEATURE_FLAGS.SQL_EDITOR_TREE_VIEW] && values.previousUrl !== urls.sqlEditor()) {
+            if (
+                values.featureFlags[FEATURE_FLAGS.SQL_EDITOR_TREE_VIEW] &&
+                values.previousUrl && // otherwise it means we're on the first page load
+                values.previousUrl !== urls.sqlEditor()
+            ) {
                 if (panelLayoutLogic.values.activePanelIdentifier === 'Database') {
                     actions.setWasPanelActive(true)
                 } else {


### PR DESCRIPTION
## Problem

- sidebar isn't tracking initial load so it's persisting across scene changes

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- track it

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
