### PR TITLE
feat(mm): allow user to configure eu endpoint

### DIFF
--- a/posthog/api/batch_imports.py
+++ b/posthog/api/batch_imports.py
@@ -156,6 +156,7 @@ class BatchImportDateRangeSourceCreateSerializer(BatchImportSerializer):
     )
     access_key = serializers.CharField(write_only=True, required=True)
     secret_key = serializers.CharField(write_only=True, required=True)
+    is_eu_region = serializers.BooleanField(write_only=True, required=False, default=False)
 
     class Meta:
         model = BatchImport
@@ -174,6 +175,7 @@ class BatchImportDateRangeSourceCreateSerializer(BatchImportSerializer):
             "content_type",
             "access_key",
             "secret_key",
+            "is_eu_region",
         ]
         read_only_fields = [
             "id",
@@ -222,6 +224,7 @@ class BatchImportDateRangeSourceCreateSerializer(BatchImportSerializer):
                 access_key=validated_data["access_key"],
                 secret_key=validated_data["secret_key"],
                 export_source=DateRangeExportSource(source_type),
+                is_eu_region=validated_data.get("is_eu_region", False),
             ).to_kafka(
                 topic=KAFKA_EVENTS_PLUGIN_INGESTION_HISTORICAL,
                 send_rate=1000,

--- a/posthog/models/batch_imports.py
+++ b/posthog/models/batch_imports.py
@@ -118,12 +118,16 @@ class BatchImportConfigBuilder:
         export_source: DateRangeExportSource,
         access_key_key: str = "api_key",
         secret_key_key: str = "secret_key",
+        is_eu_region: bool = False,
     ) -> Self:
         # there is a bunch of annoying business logic around how each endpoint behaves (what requests an endpoint expects, what it responds with, etc.)
         # jam a bunch of that messy configuration here to keep it off the batch-import-worker and out of the client
         match export_source:
             case DateRangeExportSource.AMPLITUDE:
-                base_url = "https://amplitude.com/api/2/export"
+                if is_eu_region:
+                    base_url = "https://analytics.eu.amplitude.com/api/2/export"
+                else:
+                    base_url = "https://amplitude.com/api/2/export"
                 auth_config = {
                     "type": "basic_auth",
                     "username_secret": access_key_key,
@@ -140,7 +144,11 @@ class BatchImportConfigBuilder:
                     "timeout_seconds": 180,
                 }
             case DateRangeExportSource.MIXPANEL:
-                base_url = "https://data.mixpanel.com/api/2.0/export"
+                if is_eu_region:
+                    # TODO: Confirm the correct EU endpoint for Mixpanel
+                    base_url = "https://data.eu.mixpanel.com/api/2.0/export"
+                else:
+                    base_url = "https://data.mixpanel.com/api/2.0/export"
                 auth_config = {
                     "type": "mixpanel_auth",
                     "secret_key_secret": secret_key_key,

--- a/posthog/models/batch_imports.py
+++ b/posthog/models/batch_imports.py
@@ -145,8 +145,7 @@ class BatchImportConfigBuilder:
                 }
             case DateRangeExportSource.MIXPANEL:
                 if is_eu_region:
-                    # TODO: Confirm the correct EU endpoint for Mixpanel
-                    base_url = "https://data.eu.mixpanel.com/api/2.0/export"
+                    base_url = "https://data-eu.mixpanel.com/api/2.0/export"
                 else:
                     base_url = "https://data.mixpanel.com/api/2.0/export"
                 auth_config = {

--- a/products/managed_migrations/frontend/ManagedMigration.tsx
+++ b/products/managed_migrations/frontend/ManagedMigration.tsx
@@ -6,6 +6,7 @@ import { PageHeader } from 'lib/components/PageHeader'
 import { TZLabel } from 'lib/components/TZLabel'
 import { dayjs } from 'lib/dayjs'
 import { LemonCalendarSelectInput } from 'lib/lemon-ui/LemonCalendar/LemonCalendarSelect'
+import { LemonCheckbox } from 'lib/lemon-ui/LemonCheckbox'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
@@ -127,6 +128,14 @@ export function ManagedMigration(): JSX.Element {
                             />
                         </LemonField>
                     </div>
+
+                    <LemonField name="is_eu_region">
+                        <LemonCheckbox
+                            checked={managedMigration.is_eu_region || false}
+                            onChange={(checked) => setManagedMigrationValue('is_eu_region', checked)}
+                            label="Use EU region endpoint"
+                        />
+                    </LemonField>
                 </>
             )}
 

--- a/products/managed_migrations/frontend/managedMigrationLogic.ts
+++ b/products/managed_migrations/frontend/managedMigrationLogic.ts
@@ -24,6 +24,8 @@ export interface ManagedMigrationForm {
     // date range specific fields
     start_date?: string
     end_date?: string
+    // EU region support for amplitude/mixpanel
+    is_eu_region?: boolean
 }
 
 const NEW_MANAGED_MIGRATION: ManagedMigrationForm = {
@@ -36,6 +38,7 @@ const NEW_MANAGED_MIGRATION: ManagedMigrationForm = {
     content_type: 'captured',
     start_date: '',
     end_date: '',
+    is_eu_region: false,
 }
 
 export const managedMigrationLogic = kea<managedMigrationLogicType>([
@@ -122,6 +125,7 @@ export const managedMigrationLogic = kea<managedMigrationLogicType>([
                         ...payload,
                         start_date: values.start_date,
                         end_date: values.end_date,
+                        is_eu_region: values.is_eu_region,
                     }
                 }
                 try {


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Mixpanel and Amplitude have separate residency endpoints for EU region. Allow users to configure their import to request from the EU residency servers

## Changes

A boolean value checkbox that a user can select that tells the api to export from the EU endpoint.

Logic in API to configure the correct endpoint if user has selected the EU residency box.

## Did you write or update any docs for this change?

## How did you test this code?

Tested locally
