### PR TITLE
fix: chevron to the left; adding index to event properties

### DIFF
--- a/frontend/src/layout/navigation/PosthogStories/PosthogStoriesContainer.tsx
+++ b/frontend/src/layout/navigation/PosthogStories/PosthogStoriesContainer.tsx
@@ -35,10 +35,10 @@ export const PosthogStoriesContainer = (): JSX.Element => {
                     className="flex items-center gap-2 hover:opacity-70 transition-opacity cursor-pointer"
                     title={storiesCollapsed ? 'Show stories' : 'Hide stories'}
                 >
-                    <span className="text-sm font-medium text-text-3000">Stories</span>
                     <IconChevronRight
                         className={`w-3 h-3 opacity-80 transition-transform ${storiesCollapsed ? '' : 'rotate-90'}`}
                     />
+                    <span className="text-sm font-medium text-text-3000">Stories</span>
                 </button>
             </div>
             {!storiesCollapsed && (
@@ -64,6 +64,7 @@ export const PosthogStoriesContainer = (): JSX.Element => {
                                         story_group_id: storyGroup.id,
                                         group_title: storyGroup.title,
                                         group_thumbnail_url: nextStory.thumbnailUrl,
+                                        group_index: originalIndex,
                                     })
                                     setActiveStoryIndex(nextStoryIndex)
                                     setActiveGroupIndex(originalIndex)

--- a/frontend/src/layout/navigation/PosthogStories/StoriesModal.tsx
+++ b/frontend/src/layout/navigation/PosthogStories/StoriesModal.tsx
@@ -31,6 +31,8 @@ interface StoryEndEventProps extends StoryEndEventPropsExtraProps {
     time_spent_seconds: number
     story_group_id: string
     story_group_title: string
+    story_index: number
+    group_length: number
     story_watched_percentage?: number
 }
 
@@ -112,6 +114,8 @@ export const StoriesModal = (): JSX.Element | null => {
                 story_type: activeGroup?.stories[activeStoryIndex].type,
                 story_group_id: activeGroup?.id,
                 story_group_title: activeGroup?.title,
+                story_index: activeStoryIndex,
+                group_length: activeGroup?.stories.length || 0,
                 time_spent_ms: timeSpentMs,
                 time_spent_seconds: Math.round(timeSpentMs / 1000),
                 story_watched_percentage:
@@ -139,6 +143,8 @@ export const StoriesModal = (): JSX.Element | null => {
                 story_type: activeGroup?.stories[activeStoryIndex].type,
                 story_group_id: activeGroup?.id,
                 story_group_title: activeGroup?.title,
+                story_index: activeStoryIndex,
+                group_length: activeGroup?.stories.length || 0,
                 time_spent_ms: timeSpentMs,
                 time_spent_seconds: Math.round(timeSpentMs / 1000),
             })
@@ -173,6 +179,8 @@ export const StoriesModal = (): JSX.Element | null => {
                 story_type: activeGroup?.stories[index].type,
                 story_group_id: activeGroup?.id,
                 story_group_title: activeGroup?.title,
+                story_index: index,
+                group_length: activeGroup?.stories.length || 0,
             })
             setActiveStoryIndex(index)
 


### PR DESCRIPTION
## Changes

- Moved chevron to the left of label
- Added index to PostHog event properties


![image](https://github.com/user-attachments/assets/37d10fef-8cf9-441c-81ef-16615fa830d6)
