### PR TITLE
chore(flags): update outdated reference to `getDecryptedFeatureFlagPayload` (even though I think it's a better name)

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -1154,7 +1154,7 @@ function FeatureFlagRollout({ readOnly }: { readOnly?: boolean }): JSX.Element {
                                         Note: remote config flags must be accessed through payloads, e.g.{' '}
                                         <span className="font-mono font-bold">
                                             {featureFlag.has_encrypted_payloads
-                                                ? 'getDecryptedFeatureFlagPayload'
+                                                ? 'getRemoteConfigPayload'
                                                 : 'getFeatureFlagPayload'}
                                         </span>
                                         . Using standard SDK methods such as{' '}


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

I think `getDecryptedFeatureFlagPayload` is a decent name for this operation, but everywhere else (including, critically, the SDK method) calls it `getRemoteConfigPayload`.
 
I agree with Phil that we should probably call it AppConfig too.  Maybe we'll do that all in one fell swoop.