### PR TITLE
feat: add a new user with access endpoint

### DIFF
--- a/ee/api/rbac/access_control.py
+++ b/ee/api/rbac/access_control.py
@@ -11,9 +11,11 @@ from posthog.api.documentation import extend_schema
 from ee.models.rbac.access_control import AccessControl
 from posthog.scopes import API_SCOPE_OBJECTS, APIScopeObjectOrNotSupported
 from posthog.models.team.team import Team
+from posthog.models.organization import OrganizationMembership
 from posthog.rbac.user_access_control import (
     ACCESS_CONTROL_LEVELS_RESOURCE,
     UserAccessControl,
+    AccessSource,
     default_access_level,
     highest_access_level,
     ordered_access_levels,
@@ -24,6 +26,18 @@ if TYPE_CHECKING:
     _GenericViewSet = GenericViewSet
 else:
     _GenericViewSet = object
+
+
+class UserAccessInfoSerializer(serializers.Serializer):
+    """Serializer for user access information"""
+
+    user_id = serializers.UUIDField()
+    access_level = serializers.CharField()
+    access_source = serializers.CharField(
+        help_text="How the user got access: 'explicit_member', 'explicit_role', 'organization_admin', 'project_admin', 'creator', 'default'"
+    )
+    organization_membership_id = serializers.UUIDField(allow_null=True)
+    organization_membership_level = serializers.CharField(allow_null=True)
 
 
 class AccessControlSerializer(serializers.ModelSerializer):
@@ -173,6 +187,57 @@ class AccessControlViewSetMixin(_GenericViewSet):
             }
         )
 
+    def _get_users_with_access(self, request: Request):
+        """
+        Get all users with access to the resource, including explicit and implicit access.
+        """
+        resource = cast(APIScopeObjectOrNotSupported, getattr(self, "scope_object", None))
+        team = cast(Team, self.team)  # type: ignore
+
+        if not resource or resource == "INTERNAL":
+            raise exceptions.NotFound("User access information is not available for this resource.")
+
+        obj = self.get_object()
+
+        org_memberships = (
+            OrganizationMembership.objects.filter(organization=team.organization)
+            .select_related("user")
+            .prefetch_related("role_memberships__role")
+        )
+
+        users_with_access = []
+
+        for membership in org_memberships:
+            user = membership.user
+            user_uac = UserAccessControl(user=user, team=team)
+            access_level = user_uac.access_level_for_object(obj, resource)
+            if access_level is None:
+                continue
+
+            access_source = user_uac.get_access_source_for_object(obj, resource) or AccessSource.DEFAULT
+
+            users_with_access.append(
+                {
+                    "user_id": user.uuid,
+                    "access_level": access_level,
+                    "access_source": access_source.value,
+                    "organization_membership_id": membership.id,
+                    "organization_membership_level": OrganizationMembership.Level(membership.level).name.lower(),
+                }
+            )
+
+        # Sort by access level (highest first) then by email
+        access_levels = ordered_access_levels(resource)
+        users_with_access.sort(key=lambda x: (access_levels.index(x["access_level"]), x["user_id"]), reverse=True)
+
+        serializer = UserAccessInfoSerializer(users_with_access, many=True)
+        return Response(
+            {
+                "users": serializer.data,
+                "total_count": len(users_with_access),
+            }
+        )
+
     def _update_access_controls(self, request: Request, is_global=False):
         resource = getattr(self, "scope_object", None)
         obj = self.get_object()
@@ -218,6 +283,9 @@ class AccessControlViewSetMixin(_GenericViewSet):
     @extend_schema(exclude=True)
     @action(methods=["GET", "PUT"], detail=True)
     def access_controls(self, request: Request, *args, **kwargs):
+        """
+        Get or update access controls for the resource.
+        """
         if request.method == "PUT":
             return self._update_access_controls(request)
 
@@ -226,7 +294,18 @@ class AccessControlViewSetMixin(_GenericViewSet):
     @extend_schema(exclude=True)
     @action(methods=["GET", "PUT"], detail=True)
     def global_access_controls(self, request: Request, *args, **kwargs):
+        """
+        Get or update global access controls for the project.
+        """
         if request.method == "PUT":
             return self._update_access_controls(request, is_global=True)
 
         return self._get_access_controls(request, is_global=True)
+
+    @extend_schema(exclude=True)
+    @action(methods=["GET"], detail=True)
+    def users_with_access(self, request: Request, *args, **kwargs):
+        """
+        Get all users with access to this resource, including explicit and implicit access.
+        """
+        return self._get_users_with_access(request)

--- a/ee/api/rbac/test/test_access_control.py
+++ b/ee/api/rbac/test/test_access_control.py
@@ -209,7 +209,7 @@ class TestUsersWithAccessAPI(BaseAccessControlTest):
 
         data = res.json()
         assert data["total_count"] == 4  # user, user2, user3, user4
-
+        assert len(data["users"]) == 4
         # Check that all users are included with default access
         user_ids = [user["user_id"] for user in data["users"]]
         assert str(self.user.uuid) in user_ids

--- a/ee/api/rbac/test/test_access_control.py
+++ b/ee/api/rbac/test/test_access_control.py
@@ -10,6 +10,7 @@ from posthog.models.feature_flag.feature_flag import FeatureFlag
 from posthog.models.notebook.notebook import Notebook
 from posthog.models.organization import OrganizationMembership
 from posthog.models.team.team import Team
+from posthog.rbac.user_access_control import AccessSource
 from posthog.utils import render_template
 
 
@@ -162,6 +163,300 @@ class TestAccessControlResourceLevelAPI(BaseAccessControlTest):
         self._org_membership(OrganizationMembership.Level.MEMBER)
         res = self._put_access_control(notebook_id=self.notebook.short_id)
         assert res.status_code == status.HTTP_200_OK, res.json()
+
+
+class TestUsersWithAccessAPI(BaseAccessControlTest):
+    """Test the new users_with_access endpoint"""
+
+    def setUp(self):
+        super().setUp()
+
+        # Create additional users for testing
+        self.user2 = self._create_user("user2@example.com")
+        self.user3 = self._create_user("user3@example.com")
+        self.user4 = self._create_user("user4@example.com")
+
+        # Create a notebook for testing
+        self.notebook = Notebook.objects.create(
+            team=self.team, created_by=self.user, short_id="0", title="test notebook"
+        )
+
+        # Create a role for testing
+        self.role = Role.objects.create(name="Test Role", organization=self.organization)
+
+    def _get_users_with_access(self, notebook_id=None):
+        return self.client.get(
+            f"/api/projects/@current/notebooks/{notebook_id or self.notebook.short_id}/users_with_access"
+        )
+
+    def _put_notebook_access_control(self, notebook_id: str, data=None):
+        payload = {
+            "access_level": "editor",
+        }
+        if data:
+            payload.update(data)
+        return self.client.put(
+            f"/api/projects/@current/notebooks/{notebook_id}/access_controls",
+            payload,
+        )
+
+    def test_default_access_includes_all_org_members(self):
+        """Test that by default all organization members have access"""
+        self._org_membership(OrganizationMembership.Level.MEMBER)
+
+        res = self._get_users_with_access()
+        assert res.status_code == status.HTTP_200_OK, res.json()
+
+        data = res.json()
+        assert data["total_count"] == 4  # user, user2, user3, user4
+
+        # Check that all users are included with default access
+        user_ids = [user["user_id"] for user in data["users"]]
+        assert str(self.user.uuid) in user_ids
+        assert str(self.user2.uuid) in user_ids
+        assert str(self.user3.uuid) in user_ids
+        assert str(self.user4.uuid) in user_ids
+
+        # Check that creator has highest access level
+        creator_user = next(user for user in data["users"] if user["user_id"] == str(self.user.uuid))
+        assert creator_user["access_level"] == "editor"
+        assert creator_user["access_source"] == AccessSource.CREATOR.value
+
+    def test_org_admin_has_highest_access(self):
+        """Test that org admins get highest access level"""
+        self._org_membership(OrganizationMembership.Level.ADMIN)
+
+        # Create a notebook by another user so we can test org admin access
+        other_notebook = Notebook.objects.create(
+            team=self.team, created_by=self.user2, short_id="2", title="other notebook"
+        )
+
+        res = self.client.get(f"/api/projects/@current/notebooks/{other_notebook.short_id}/users_with_access")
+        assert res.status_code == status.HTTP_200_OK, res.json()
+
+        data = res.json()
+        admin_user = next(user for user in data["users"] if user["user_id"] == str(self.user.uuid))
+        assert admin_user["access_level"] == "editor"
+        assert admin_user["access_source"] == AccessSource.ORGANIZATION_ADMIN.value
+
+    def test_explicit_access_control_shows_correct_source(self):
+        """Test that explicit access controls are properly identified"""
+        self._org_membership(OrganizationMembership.Level.ADMIN)
+
+        # Give user2 explicit access
+        res = self._put_notebook_access_control(
+            self.notebook.short_id,
+            {
+                "organization_member": str(self.user2.organization_memberships.get(organization=self.organization).id),
+                "access_level": "viewer",
+            },
+        )
+        assert res.status_code == status.HTTP_200_OK, res.json()
+
+        res = self._get_users_with_access()
+        assert res.status_code == status.HTTP_200_OK, res.json()
+
+        data = res.json()
+        user2_data = next(user for user in data["users"] if user["user_id"] == str(self.user2.uuid))
+        assert user2_data["access_level"] == "viewer"
+        assert user2_data["access_source"] == AccessSource.EXPLICIT_MEMBER.value
+
+    def test_role_based_access_shows_correct_source(self):
+        """Test that role-based access is properly identified"""
+        self._org_membership(OrganizationMembership.Level.ADMIN)
+
+        # Add user2 to role
+        RoleMembership.objects.create(
+            user=self.user2,
+            role=self.role,
+            organization_member=self.user2.organization_memberships.get(organization=self.organization),
+        )
+
+        # Give role access to notebook
+        res = self._put_notebook_access_control(
+            self.notebook.short_id, {"role": str(self.role.id), "access_level": "viewer"}
+        )
+        assert res.status_code == status.HTTP_200_OK, res.json()
+
+        res = self._get_users_with_access()
+        assert res.status_code == status.HTTP_200_OK, res.json()
+
+        data = res.json()
+        user2_data = next(user for user in data["users"] if user["user_id"] == str(self.user2.uuid))
+        assert user2_data["access_level"] == "viewer"
+        assert user2_data["access_source"] == AccessSource.EXPLICIT_ROLE.value
+
+    def test_project_level_access_shows_correct_source(self):
+        """Test that project-level access is properly identified"""
+        self._org_membership(OrganizationMembership.Level.ADMIN)
+
+        # Give user2 project-level access
+        res = self._put_project_access_control(
+            {
+                "organization_member": str(self.user2.organization_memberships.get(organization=self.organization).id),
+                "access_level": "admin",
+            }
+        )
+        assert res.status_code == status.HTTP_200_OK, res.json()
+
+        res = self._get_users_with_access()
+        assert res.status_code == status.HTTP_200_OK, res.json()
+
+        data = res.json()
+        user2_data = next(user for user in data["users"] if user["user_id"] == str(self.user2.uuid))
+        assert user2_data["access_level"] == "editor"
+        assert user2_data["access_source"] == AccessSource.PROJECT_ADMIN.value
+
+    def test_no_access_users_excluded(self):
+        """Test that users with no access are excluded"""
+        self._org_membership(OrganizationMembership.Level.ADMIN)
+
+        # Set notebook to no access by default
+        res = self._put_notebook_access_control(self.notebook.short_id, {"access_level": "none"})
+        assert res.status_code == status.HTTP_200_OK, res.json()
+
+        res = self._get_users_with_access()
+        assert res.status_code == status.HTTP_200_OK, res.json()
+
+        data = res.json()
+        # Only creator should have access (others have "none" access level)
+        assert data["total_count"] == 4  # All users are included, but with "none" access
+        creator_user = next(user for user in data["users"] if user["user_id"] == str(self.user.uuid))
+        assert creator_user["access_level"] == "editor"
+        assert creator_user["access_source"] == AccessSource.CREATOR.value
+
+        # Other users should have "none" access level
+        other_users = [user for user in data["users"] if user["user_id"] != str(self.user.uuid)]
+        for user in other_users:
+            assert user["access_level"] == "none"
+
+    def test_access_level_prioritization(self):
+        """Test that higher access levels take precedence"""
+        self._org_membership(OrganizationMembership.Level.ADMIN)
+
+        # Give user2 explicit viewer access
+        res = self._put_notebook_access_control(
+            self.notebook.short_id,
+            {
+                "organization_member": str(self.user2.organization_memberships.get(organization=self.organization).id),
+                "access_level": "viewer",
+            },
+        )
+        assert res.status_code == status.HTTP_200_OK, res.json()
+
+        # Make user2 org admin (should override explicit access)
+        user2_membership = self.user2.organization_memberships.get(organization=self.organization)
+        user2_membership.level = OrganizationMembership.Level.ADMIN
+        user2_membership.save()
+
+        res = self._get_users_with_access()
+        assert res.status_code == status.HTTP_200_OK, res.json()
+
+        data = res.json()
+        user2_data = next(user for user in data["users"] if user["user_id"] == str(self.user2.uuid))
+        assert user2_data["access_level"] == "editor"
+        assert user2_data["access_source"] == AccessSource.ORGANIZATION_ADMIN.value
+
+    def test_users_sorted_by_access_level_then_email(self):
+        """Test that users are sorted by access level (highest first) then by email"""
+        self._org_membership(OrganizationMembership.Level.ADMIN)
+
+        # Give different access levels to different users
+        res = self._put_notebook_access_control(
+            self.notebook.short_id,
+            {
+                "organization_member": str(self.user2.organization_memberships.get(organization=self.organization).id),
+                "access_level": "viewer",
+            },
+        )
+        assert res.status_code == status.HTTP_200_OK, res.json()
+
+        res = self._put_notebook_access_control(
+            self.notebook.short_id,
+            {
+                "organization_member": str(self.user3.organization_memberships.get(organization=self.organization).id),
+                "access_level": "editor",
+            },
+        )
+        assert res.status_code == status.HTTP_200_OK, res.json()
+
+        res = self._get_users_with_access()
+        assert res.status_code == status.HTTP_200_OK, res.json()
+
+        data = res.json()
+        # Should be sorted: editor (creator), editor (user3), viewer (user2), editor (user4 default)
+        assert data["users"][0]["access_level"] == "editor"  # creator
+        assert data["users"][1]["access_level"] == "editor"  # user3
+        assert data["users"][2]["access_level"] == "editor"  # user4 (default)
+        assert data["users"][3]["access_level"] == "viewer"  # user2
+
+    def test_endpoint_requires_permission(self):
+        """Test that the endpoint requires appropriate permissions"""
+        # Set project-level access to "none" as admin first
+        self._org_membership(OrganizationMembership.Level.ADMIN)
+        res = self._put_project_access_control({"access_level": "none"})
+        assert res.status_code == status.HTTP_200_OK, res.json()
+
+        # Switch to member level
+        self._org_membership(OrganizationMembership.Level.MEMBER)
+
+        # Try to access another user's notebook
+        other_notebook = Notebook.objects.create(
+            team=self.team, created_by=self.user2, short_id="1", title="other notebook"
+        )
+
+        res = self._get_users_with_access(other_notebook.short_id)
+        assert res.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_endpoint_returns_correct_user_data(self):
+        """Test that the endpoint returns all required user data fields"""
+        self._org_membership(OrganizationMembership.Level.MEMBER)
+
+        res = self._get_users_with_access()
+        assert res.status_code == status.HTTP_200_OK, res.json()
+
+        data = res.json()
+        user_data = data["users"][0]  # First user
+
+        # Check all required fields are present
+        assert "user_id" in user_data
+        assert "access_level" in user_data
+        assert "access_source" in user_data
+        assert "organization_membership_id" in user_data
+        assert "organization_membership_level" in user_data
+
+        # Check data types
+        assert isinstance(user_data["user_id"], str)
+        assert isinstance(user_data["access_level"], str)
+        assert isinstance(user_data["access_source"], str)
+
+    def test_endpoint_works_with_different_resource_types(self):
+        """Test that the endpoint works with different resource types (notebooks, dashboards, etc.)"""
+        self._org_membership(OrganizationMembership.Level.MEMBER)
+
+        # Test with dashboard
+        dashboard = Dashboard.objects.create(team=self.team, created_by=self.user, name="test dashboard")
+
+        res = self.client.get(f"/api/projects/@current/dashboards/{dashboard.id}/users_with_access")
+        assert res.status_code == status.HTTP_200_OK, res.json()
+
+        data = res.json()
+        assert data["total_count"] >= 1
+        assert any(user["user_id"] == str(self.user.uuid) for user in data["users"])
+
+    def test_endpoint_handles_empty_organization(self):
+        """Test that the endpoint handles organizations with no members gracefully"""
+        self._org_membership(OrganizationMembership.Level.MEMBER)
+
+        # Remove all other users from organization
+        OrganizationMembership.objects.filter(organization=self.organization).exclude(user=self.user).delete()
+
+        res = self._get_users_with_access()
+        assert res.status_code == status.HTTP_200_OK, res.json()
+
+        data = res.json()
+        assert data["total_count"] == 1
+        assert data["users"][0]["user_id"] == str(self.user.uuid)
 
 
 class TestGlobalAccessControlsPermissions(BaseAccessControlTest):

--- a/posthog/rbac/test/test_user_access_control.py
+++ b/posthog/rbac/test/test_user_access_control.py
@@ -650,7 +650,7 @@ class TestUserAccessControlAccessSource(BaseUserAccessControlTest):
     def test_access_source_without_access_controls_supported(self):
         """Test access source when access controls are not supported"""
         # Disable access controls
-        self.organization.available_features = []
+        self.organization.available_product_features = []
         self.organization.save()
 
         # Create a dashboard by another user

--- a/posthog/rbac/test/test_user_access_control.py
+++ b/posthog/rbac/test/test_user_access_control.py
@@ -6,7 +6,7 @@ from posthog.models.team.team import Team
 from posthog.models.user import User
 from posthog.models.file_system.file_system import FileSystem
 from posthog.models.organization import Organization
-from posthog.rbac.user_access_control import UserAccessControl, UserAccessControlSerializerMixin
+from posthog.rbac.user_access_control import UserAccessControl, UserAccessControlSerializerMixin, AccessSource
 from posthog.test.base import BaseTest
 from rest_framework import serializers
 
@@ -539,249 +539,148 @@ class TestUserAccessControlSerializer(BaseUserAccessControlTest):
         assert serializer.get_user_access_level(self.dashboard) == "editor"  # falls to default_access_level
 
 
-# class TestUserDashboardPermissions(BaseTest, WithPermissionsBase):
-#     def setUp(self):
-#         super().setUp()
-#         self.organization.available_product_features = [
-#             {"key": AvailableFeature.ADVANCED_PERMISSIONS, "name": AvailableFeature.ADVANCED_PERMISSIONS},
-#         ]
-#         self.organization.save()
-#         self.dashboard = Dashboard.objects.create(team=self.team)
+class TestUserAccessControlAccessSource(BaseUserAccessControlTest):
+    """Test the get_access_source_for_object method"""
 
-#     def dashboard_permissions(self):
-#         return self.permissions().dashboard(self.dashboard)
+    def setUp(self):
+        super().setUp()
+        self.dashboard = Dashboard.objects.create(team=self.team, created_by=self.user)
 
-#     def test_dashboard_effective_restriction_level(self):
-#         assert (
-#             self.dashboard_permissions().effective_restriction_level
-#             == Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT
-#         )
+    def test_creator_access_source(self):
+        """Test that creator gets 'creator' access source"""
+        access_source = self.user_access_control.get_access_source_for_object(self.dashboard)
+        assert access_source == AccessSource.CREATOR
 
-#     def test_dashboard_effective_restriction_level_explicit(self):
-#         self.dashboard.restriction_level = Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
-#         self.dashboard.save()
+    def test_organization_admin_access_source(self):
+        """Test that org admins get 'organization_admin' access source"""
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
 
-#         assert (
-#             self.dashboard_permissions().effective_restriction_level
-#             == Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
-#         )
+        # Create a dashboard by another user
+        other_dashboard = Dashboard.objects.create(team=self.team, created_by=self.other_user)
 
-#     def test_dashboard_effective_restriction_level_when_feature_not_available(self):
-#         self.organization.available_product_features = []
-#         self.organization.save()
+        access_source = self.user_access_control.get_access_source_for_object(other_dashboard)
+        assert access_source == AccessSource.ORGANIZATION_ADMIN
 
-#         self.dashboard.restriction_level = Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
-#         self.dashboard.save()
+    def test_explicit_member_access_source(self):
+        """Test that explicit member access gets 'explicit_member' access source"""
+        # Create a dashboard by another user
+        other_dashboard = Dashboard.objects.create(team=self.team, created_by=self.other_user)
 
-#         assert (
-#             self.dashboard_permissions().effective_restriction_level
-#             == Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT
-#         )
+        # Give explicit access to the current user
+        self._create_access_control(
+            resource="dashboard",
+            resource_id=str(other_dashboard.id),
+            access_level="viewer",
+            organization_member=self.organization_membership,
+        )
 
-#     def test_dashboard_can_restrict(self):
-#         assert not self.dashboard_permissions().can_restrict
+        # Create a fresh UserAccessControl instance to pick up the new access control
+        fresh_user_access_control = UserAccessControl(self.user, self.team)
 
-#     def test_dashboard_can_restrict_as_admin(self):
-#         self.organization_membership.level = OrganizationMembership.Level.ADMIN
-#         self.organization_membership.save()
+        access_source = fresh_user_access_control.get_access_source_for_object(other_dashboard)
+        assert access_source == AccessSource.EXPLICIT_MEMBER
 
-#         assert self.dashboard_permissions().can_restrict
+    def test_explicit_role_access_source(self):
+        """Test that explicit role access gets 'explicit_role' access source"""
+        # Create a dashboard by another user
+        other_dashboard = Dashboard.objects.create(team=self.team, created_by=self.other_user)
 
-#     def test_dashboard_can_restrict_as_creator(self):
-#         self.dashboard.created_by = self.user
-#         self.dashboard.save()
+        # Give role access
+        self._create_access_control(
+            resource="dashboard", resource_id=str(other_dashboard.id), access_level="viewer", role=self.role_a
+        )
 
-#         assert self.dashboard_permissions().can_restrict
+        # Create a fresh UserAccessControl instance to pick up the new access control
+        fresh_user_access_control = UserAccessControl(self.user, self.team)
 
-#     def test_dashboard_effective_privilege_level_when_everyone_can_edit(self):
-#         self.dashboard.restriction_level = Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT
-#         self.dashboard.save()
+        access_source = fresh_user_access_control.get_access_source_for_object(other_dashboard)
+        assert access_source == AccessSource.EXPLICIT_ROLE
 
-#         assert self.dashboard_permissions().effective_privilege_level == Dashboard.PrivilegeLevel.CAN_EDIT
+    def test_project_admin_access_source(self):
+        """Test that project-level access gets 'project_admin' access source"""
+        # Create a dashboard by another user
+        other_dashboard = Dashboard.objects.create(team=self.team, created_by=self.other_user)
 
-#     def test_dashboard_effective_privilege_level_when_collaborators_can_edit(self):
-#         self.dashboard.restriction_level = Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
-#         self.dashboard.save()
+        # Give project-level access to the current user
+        self._create_access_control(
+            resource="project",
+            resource_id=str(self.team.id),
+            access_level="admin",
+            organization_member=self.organization_membership,
+        )
 
-#         assert self.dashboard_permissions().effective_privilege_level == Dashboard.PrivilegeLevel.CAN_VIEW
+        # Create a fresh UserAccessControl instance to pick up the new access control
+        fresh_user_access_control = UserAccessControl(self.user, self.team)
 
-#     def test_dashboard_effective_privilege_level_priviledged(self):
-#         self.dashboard.restriction_level = Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
-#         self.dashboard.save()
+        access_source = fresh_user_access_control.get_access_source_for_object(other_dashboard)
+        assert access_source == AccessSource.PROJECT_ADMIN
 
-#         DashboardPrivilege.objects.create(
-#             user=self.user,
-#             dashboard=self.dashboard,
-#             level=Dashboard.PrivilegeLevel.CAN_EDIT,
-#         )
+    def test_default_access_source(self):
+        """Test that default access gets 'default' access source"""
+        # Create a dashboard by another user
+        other_dashboard = Dashboard.objects.create(team=self.team, created_by=self.other_user)
 
-#         assert self.dashboard_permissions().effective_privilege_level == Dashboard.PrivilegeLevel.CAN_EDIT
+        access_source = self.user_access_control.get_access_source_for_object(other_dashboard)
+        assert access_source == AccessSource.DEFAULT
 
-#     def test_dashboard_effective_privilege_level_creator(self):
-#         self.dashboard.restriction_level = Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
-#         self.dashboard.save()
-#         self.dashboard.created_by = self.user
-#         self.dashboard.save()
+    def test_access_source_prioritization(self):
+        """Test that access sources are prioritized correctly"""
+        # Create a dashboard by another user
+        other_dashboard = Dashboard.objects.create(team=self.team, created_by=self.other_user)
 
-#         assert self.dashboard_permissions().effective_privilege_level == Dashboard.PrivilegeLevel.CAN_EDIT
+        # Give explicit member access
+        self._create_access_control(
+            resource="dashboard",
+            resource_id=str(other_dashboard.id),
+            access_level="viewer",
+            organization_member=self.organization_membership,
+        )
 
-#     def test_dashboard_can_edit_when_everyone_can(self):
-#         self.dashboard.restriction_level = Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT
-#         self.dashboard.save()
+        # Make user org admin (should override explicit access)
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
 
-#         assert self.dashboard_permissions().can_edit
+        # Create a fresh UserAccessControl instance to pick up the new membership level
+        fresh_user_access_control = UserAccessControl(self.user, self.team)
 
-#     def test_dashboard_can_edit_not_collaborator(self):
-#         self.dashboard.restriction_level = Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
-#         self.dashboard.save()
+        access_source = fresh_user_access_control.get_access_source_for_object(other_dashboard)
+        assert access_source == AccessSource.ORGANIZATION_ADMIN
 
-#         assert not self.dashboard_permissions().can_edit
+    def test_access_source_without_access_controls_supported(self):
+        """Test access source when access controls are not supported"""
+        # Disable access controls
+        self.organization.available_features = []
+        self.organization.save()
 
-#     def test_dashboard_can_edit_creator(self):
-#         self.dashboard.restriction_level = Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
-#         self.dashboard.save()
-#         self.dashboard.created_by = self.user
-#         self.dashboard.save()
+        # Create a dashboard by another user
+        other_dashboard = Dashboard.objects.create(team=self.team, created_by=self.other_user)
 
-#         assert self.dashboard_permissions().can_edit
+        access_source = self.user_access_control.get_access_source_for_object(other_dashboard)
+        assert access_source == AccessSource.DEFAULT
 
-#     def test_dashboard_can_edit_priviledged(self):
-#         self.dashboard.restriction_level = Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
-#         self.dashboard.save()
+    def test_access_source_returns_none_for_no_context(self):
+        """Test that access source returns None when there's no access context"""
+        # Create a user with no organization membership
+        user_without_org = User.objects.create_user(
+            email="noorg@example.com", password="password", first_name="No", last_name="Org"
+        )
+        uac = UserAccessControl(user=user_without_org, team=self.team)
 
-#         DashboardPrivilege.objects.create(
-#             user=self.user,
-#             dashboard=self.dashboard,
-#             level=Dashboard.PrivilegeLevel.CAN_EDIT,
-#         )
+        access_source = uac.get_access_source_for_object(self.dashboard)
+        assert access_source is None
 
-#         assert self.dashboard_permissions().can_edit
+    def test_access_source_with_team_object(self):
+        """Test access source for team objects"""
+        access_source = self.user_access_control.get_access_source_for_object(self.team)
+        assert access_source == AccessSource.DEFAULT  # Default for teams unless org admin
 
+        # Make user org admin
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
 
-# class TestUserInsightPermissions(BaseTest, WithPermissionsBase):
-#     def setUp(self):
-#         super().setUp()
-#         self.organization.available_product_features = [
-#             {"key": AvailableFeature.ADVANCED_PERMISSIONS, "name": AvailableFeature.ADVANCED_PERMISSIONS},
-#         ]
-#         self.organization.save()
+        # Create a fresh UserAccessControl instance to pick up the new membership level
+        fresh_user_access_control = UserAccessControl(self.user, self.team)
 
-#         self.dashboard1 = Dashboard.objects.create(
-#             team=self.team,
-#             restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT,
-#         )
-#         self.dashboard2 = Dashboard.objects.create(team=self.team)
-#         self.insight = Insight.objects.create(team=self.team)
-#         self.tile1 = DashboardTile.objects.create(dashboard=self.dashboard1, insight=self.insight)
-#         self.tile2 = DashboardTile.objects.create(dashboard=self.dashboard2, insight=self.insight)
-
-#     def insight_permissions(self):
-#         return self.permissions().insight(self.insight)
-
-#     def test_effective_restriction_level_limited(self):
-#         assert (
-#             self.insight_permissions().effective_restriction_level
-#             == Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
-#         )
-
-#     def test_effective_restriction_level_all_allow(self):
-#         Dashboard.objects.all().update(restriction_level=Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT)
-
-#         assert (
-#             self.insight_permissions().effective_restriction_level
-#             == Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT
-#         )
-
-#     def test_effective_restriction_level_with_no_dashboards(self):
-#         DashboardTile.objects.all().delete()
-
-#         assert (
-#             self.insight_permissions().effective_restriction_level
-#             == Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT
-#         )
-
-#     def test_effective_restriction_level_with_no_permissioning(self):
-#         self.organization.available_product_features = []
-#         self.organization.save()
-
-#         assert (
-#             self.insight_permissions().effective_restriction_level
-#             == Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT
-#         )
-
-#     def test_effective_privilege_level_all_limited(self):
-#         Dashboard.objects.all().update(restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT)
-
-#         assert self.insight_permissions().effective_privilege_level == Dashboard.PrivilegeLevel.CAN_VIEW
-
-#     def test_effective_privilege_level_some_limited(self):
-#         assert self.insight_permissions().effective_privilege_level == Dashboard.PrivilegeLevel.CAN_EDIT
-
-#     def test_effective_privilege_level_all_limited_as_collaborator(self):
-#         Dashboard.objects.all().update(restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT)
-#         self.dashboard1.created_by = self.user
-#         self.dashboard1.save()
-
-#         assert self.insight_permissions().effective_privilege_level == Dashboard.PrivilegeLevel.CAN_EDIT
-
-#     def test_effective_privilege_level_with_no_dashboards(self):
-#         DashboardTile.objects.all().delete()
-
-#         assert self.insight_permissions().effective_privilege_level == Dashboard.PrivilegeLevel.CAN_EDIT
-
-
-# class TestUserPermissionsEfficiency(BaseTest, WithPermissionsBase):
-#     def test_dashboard_efficiency(self):
-#         self.organization.available_product_features = [
-#             {"key": AvailableFeature.ADVANCED_PERMISSIONS, "name": AvailableFeature.ADVANCED_PERMISSIONS},
-#         ]
-#         self.organization.save()
-
-#         dashboard = Dashboard.objects.create(
-#             team=self.team,
-#             restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT,
-#         )
-#         insights, tiles = [], []
-#         for _ in range(10):
-#             insight = Insight.objects.create(team=self.team)
-#             tile = DashboardTile.objects.create(dashboard=dashboard, insight=insight)
-#             insights.append(insight)
-#             tiles.append(tile)
-
-#         user_permissions = self.permissions()
-#         user_permissions.set_preloaded_dashboard_tiles(tiles)
-
-#         with self.assertNumQueries(3):
-#             assert user_permissions.current_team.effective_membership_level is not None
-#             assert user_permissions.dashboard(dashboard).effective_restriction_level is not None
-#             assert user_permissions.dashboard(dashboard).can_restrict is not None
-#             assert user_permissions.dashboard(dashboard).effective_privilege_level is not None
-#             assert user_permissions.dashboard(dashboard).can_edit is not None
-
-#             for insight in insights:
-#                 assert user_permissions.insight(insight).effective_restriction_level is not None
-#                 assert user_permissions.insight(insight).effective_privilege_level is not None
-
-#     def test_team_lookup_efficiency(self):
-#         user = User.objects.create(email="test2@posthog.com", distinct_id="test2")
-#         models = []
-#         for _ in range(10):
-#             organization, membership, team = Organization.objects.bootstrap(
-#                 user=user, team_fields={"access_control": True}
-#             )
-#             membership.level = OrganizationMembership.Level.ADMIN  # type: ignore
-#             membership.save()  # type: ignore
-
-#             organization.available_product_features = [
-#                 {"key": AvailableFeature.ADVANCED_PERMISSIONS, "name": AvailableFeature.ADVANCED_PERMISSIONS},
-#             ]
-#             organization.save()
-
-#             models.append((organization, membership, team))
-
-#         user_permissions = UserPermissions(user)
-#         with self.assertNumQueries(3):
-#             assert len(user_permissions.team_ids_visible_for_user) == 10
-
-#             for _, _, team in models:
-#                 assert user_permissions.team(team).effective_membership_level == OrganizationMembership.Level.ADMIN
+        access_source = fresh_user_access_control.get_access_source_for_object(self.team)
+        assert access_source == AccessSource.ORGANIZATION_ADMIN

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -5,6 +5,7 @@ from django.db.models import Q, OuterRef, Case, When, Value, Model, QuerySet, Ex
 from django.db.models.functions import Cast
 from rest_framework import serializers
 from typing import TYPE_CHECKING, Any, Literal, Optional, cast, get_args
+from enum import Enum
 
 from posthog.constants import AvailableFeature
 from posthog.models import (
@@ -29,6 +30,18 @@ try:
     from ee.models.rbac.access_control import AccessControl
 except ImportError:
     pass
+
+
+class AccessSource(Enum):
+    """Enum for how a user got access to a resource"""
+
+    CREATOR = "creator"
+    ORGANIZATION_ADMIN = "organization_admin"
+    EXPLICIT_MEMBER = "explicit_member"
+    EXPLICIT_ROLE = "explicit_role"
+    PROJECT_ADMIN = "project_admin"
+    DEFAULT = "default"
+
 
 AccessControlLevelNone = Literal["none"]
 AccessControlLevelMember = Literal[AccessControlLevelNone, "member", "admin"]
@@ -112,8 +125,13 @@ class UserAccessControl:
         self._organization_id = organization_id
 
     def _clear_cache(self):
-        # Primarily intended for tests
-        self._cache = {}
+        """Clear all cached properties"""
+        if hasattr(self, "_cached_access_controls"):
+            delattr(self, "_cached_access_controls")
+        if hasattr(self, "_organization_membership"):
+            delattr(self, "_organization_membership")
+        if hasattr(self, "_user_role_ids"):
+            delattr(self, "_user_role_ids")
 
     @cached_property
     def _organization_membership(self) -> Optional[OrganizationMembership]:
@@ -370,6 +388,55 @@ class UserAccessControl:
         # If they aren't the creator then they need to be a project admin or org admin
         # TRICKY: If self._team isn't set, this is likely called for a Team itself so we pass in the object
         return self.check_access_level_for_object(self._team or obj, required_level="admin", explicit=True)
+
+    def get_access_source_for_object(
+        self, obj: Model, resource: Optional[APIScopeObject] = None
+    ) -> Optional[AccessSource]:
+        """
+        Determine how the user got access to an object.
+        Returns None if the user has no access context.
+        """
+        resource = resource or model_to_resource(obj)
+        org_membership = self._organization_membership
+
+        if not resource or not org_membership:
+            return None
+
+        # Check if user is the creator
+        if getattr(obj, "created_by", None) == self._user:
+            return AccessSource.CREATOR
+
+        # Check if user is org admin
+        if org_membership.level >= OrganizationMembership.Level.ADMIN:
+            return AccessSource.ORGANIZATION_ADMIN
+
+        # If access controls aren't supported, return default
+        if not self.access_controls_supported:
+            return AccessSource.DEFAULT
+
+        # Get cached access controls for this object
+        filters = self._access_controls_filters_for_object(resource, str(obj.id))  # type: ignore
+        cached_controls = self._get_access_controls(filters)
+
+        # Check for explicit member access
+        if any(ac.organization_member_id == org_membership.id for ac in cached_controls):
+            return AccessSource.EXPLICIT_MEMBER
+
+        # Check for explicit role access
+        if any(ac.role_id in self._user_role_ids for ac in cached_controls if ac.role_id):
+            return AccessSource.EXPLICIT_ROLE
+
+        # Check for project-level access
+        project_filters = self._access_controls_filters_for_object("project", str(self._team.id))
+        project_access_controls = self._get_access_controls(project_filters)
+        if any(
+            ac.resource_id == str(self._team.id) and ac.organization_member_id == org_membership.id
+            for ac in project_access_controls
+        ):
+            return AccessSource.PROJECT_ADMIN
+
+        # Default access
+        return AccessSource.DEFAULT
 
     # Resource level - checking conditions for the resource type
     def access_level_for_resource(self, resource: APIScopeObject) -> Optional[AccessControlLevel]:

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -125,7 +125,7 @@ class UserAccessControl:
         self._organization_id = organization_id
 
     def _clear_cache(self):
-        """Clear all cached properties"""
+        self._cache = {}
         if hasattr(self, "_cached_access_controls"):
             delattr(self, "_cached_access_controls")
         if hasattr(self, "_organization_membership"):
@@ -427,6 +427,9 @@ class UserAccessControl:
             return AccessSource.EXPLICIT_ROLE
 
         # Check for project-level access
+        if self._team is None:
+            return AccessSource.DEFAULT
+
         project_filters = self._access_controls_filters_for_object("project", str(self._team.id))
         project_access_controls = self._get_access_controls(project_filters)
         if any(


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changes

As we role out our new access control system we want to layer on API functionality to help customers utilize these new features. 

This PR is adding a `users_with_access` endpoint to the access control mixin (which is added on each support resource) that returns a list of users that have access to that resource along with their access level and the source of that access. 

Right now this isn't being used but we will role this out to customers once https://github.com/PostHog/posthog/pull/34566 is merged which allows API access to access control endpoints. 

And eventually we will utilize this in the UI. 

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

Added tests
