### PR TITLE
fix(person): View recording button resets person exceptions filter

### DIFF
--- a/frontend/src/scenes/persons/PersonScene.tsx
+++ b/frontend/src/scenes/persons/PersonScene.tsx
@@ -7,7 +7,7 @@ import { NotFound } from 'lib/components/NotFound'
 import { PageHeader } from 'lib/components/PageHeader'
 import { PropertiesTable } from 'lib/components/PropertiesTable'
 import { TZLabel } from 'lib/components/TZLabel'
-import { FEATURE_FLAGS, PERSON_DISPLAY_NAME_COLUMN_NAME } from 'lib/constants'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
@@ -25,9 +25,8 @@ import { SessionRecordingsPlaylist } from 'scenes/session-recordings/playlist/Se
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
-import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
 import { Query } from '~/queries/Query/Query'
-import { NodeKind } from '~/queries/schema/schema-general'
+
 import {
     ActivityScope,
     NotebookNodeType,
@@ -116,6 +115,7 @@ export function PersonScene(): JSX.Element | null {
         distinctId,
         primaryDistinctId,
         eventsQuery,
+        exceptionsQuery,
     } = useValues(personsLogic)
     const { loadPersons, editProperty, deleteProperty, navigateToTab, setSplitMergeModalShown, setDistinctId } =
         useActions(personsLogic)
@@ -257,23 +257,7 @@ export function PersonScene(): JSX.Element | null {
                     {
                         key: PersonsTabType.EXCEPTIONS,
                         label: <span data-attr="persons-exceptions-tab">Exceptions</span>,
-                        content: (
-                            <Query
-                                query={{
-                                    kind: NodeKind.DataTableNode,
-                                    full: true,
-                                    showEventFilter: false,
-                                    hiddenColumns: [PERSON_DISPLAY_NAME_COLUMN_NAME],
-                                    source: {
-                                        kind: NodeKind.EventsQuery,
-                                        select: defaultDataTableColumns(NodeKind.EventsQuery),
-                                        personId: person.id,
-                                        event: '$exception',
-                                        after: '-24h',
-                                    },
-                                }}
-                            />
-                        ),
+                        content: <Query query={exceptionsQuery} />,
                     },
                     {
                         key: PersonsTabType.COHORTS,

--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -281,9 +281,7 @@ export const personsLogic = kea<personsLogicType>([
         exceptionsQuery: [
             null as DataTableNode | null,
             {
-                setExceptionsQuery: (_, { exceptionsQuery }) => {
-                    return exceptionsQuery
-                },
+                setExceptionsQuery: (_, { exceptionsQuery }) => exceptionsQuery,
             },
         ],
     })),

--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -55,6 +55,22 @@ function createInitialEventsPayload(personId: string): DataTableNode {
     }
 }
 
+function createInitialExceptionsPayload(personId: string): DataTableNode {
+    return {
+        kind: NodeKind.DataTableNode,
+        full: true,
+        showEventFilter: false,
+        hiddenColumns: [PERSON_DISPLAY_NAME_COLUMN_NAME],
+        source: {
+            kind: NodeKind.EventsQuery,
+            select: defaultDataTableColumns(NodeKind.EventsQuery),
+            personId: personId,
+            event: '$exception',
+            after: '-24h',
+        },
+    }
+}
+
 export const personsLogic = kea<personsLogicType>([
     props({} as PersonsLogicProps),
     key((props) => {
@@ -85,6 +101,7 @@ export const personsLogic = kea<personsLogicType>([
         setSplitMergeModalShown: (shown: boolean) => ({ shown }),
         setDistinctId: (distinctId: string) => ({ distinctId }),
         setEventsQuery: (eventsQuery: DataTableNode | null) => ({ eventsQuery }),
+        setExceptionsQuery: (exceptionsQuery: DataTableNode | null) => ({ exceptionsQuery }),
     }),
     loaders(({ values, actions, props }) => ({
         persons: [
@@ -130,6 +147,8 @@ export const personsLogic = kea<personsLogicType>([
                         if (person.id != null) {
                             const eventsQuery = createInitialEventsPayload(person.id)
                             actions.setEventsQuery(eventsQuery)
+                            const exceptionsQuery = createInitialExceptionsPayload(person.id)
+                            actions.setExceptionsQuery(exceptionsQuery)
                         }
                     }
 
@@ -155,6 +174,8 @@ export const personsLogic = kea<personsLogicType>([
                         if (person.id != null) {
                             const eventsQuery = createInitialEventsPayload(person.id)
                             actions.setEventsQuery(eventsQuery)
+                            const exceptionsQuery = createInitialExceptionsPayload(person.id)
+                            actions.setExceptionsQuery(exceptionsQuery)
                         }
                         return person
                     }
@@ -254,6 +275,14 @@ export const personsLogic = kea<personsLogicType>([
             {
                 setEventsQuery: (_, { eventsQuery }) => {
                     return eventsQuery
+                },
+            },
+        ],
+        exceptionsQuery: [
+            null as DataTableNode | null,
+            {
+                setExceptionsQuery: (_, { exceptionsQuery }) => {
+                    return exceptionsQuery
                 },
             },
         ],


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Similar to https://github.com/PostHog/posthog/issues/30732

## Changes

Solution is the same as https://github.com/PostHog/posthog/pull/34596:


https://github.com/user-attachments/assets/ad0710f7-b652-4a13-b801-99813fe7447a


## Did you write or update any docs for this change?
- [x] No docs needed for this change

## How did you test this code?
Locally!

1) Go to persons screen
2) Click on a person
3) Switch to `Exceptions` tab
4) Update filter
5) Click on the view recording button on one of the exception
6) Filter should still be the same.
