### PR TITLE
fix(experiments): don't cut off exposure queries at 100 rows

### DIFF
--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_experiment_exposures_query_runner.ambr
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_experiment_exposures_query_runner.ambr
@@ -21,16 +21,16 @@
   GROUP BY subq.day,
            subq.variant
   ORDER BY subq.day ASC
-  LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
-                     allow_experimental_object_type=1,
-                     format_csv_allow_double_quotes=0,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1
+  LIMIT 5000 SETTINGS readonly=2,
+                      max_execution_time=180,
+                      allow_experimental_object_type=1,
+                      format_csv_allow_double_quotes=0,
+                      max_ast_elements=4000000,
+                      max_expanded_ast_elements=4000000,
+                      max_bytes_before_external_group_by=0,
+                      transform_null_in=1,
+                      optimize_min_equality_disjunction_chain_length=4294967295,
+                      allow_experimental_join_condition=1
   '''
 # ---
 # name: TestExperimentExposuresQueryRunner.test_exposure_query_filters_test_accounts
@@ -65,16 +65,16 @@
   GROUP BY subq.day,
            subq.variant
   ORDER BY subq.day ASC
-  LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
-                     allow_experimental_object_type=1,
-                     format_csv_allow_double_quotes=0,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1
+  LIMIT 5000 SETTINGS readonly=2,
+                      max_execution_time=180,
+                      allow_experimental_object_type=1,
+                      format_csv_allow_double_quotes=0,
+                      max_ast_elements=4000000,
+                      max_expanded_ast_elements=4000000,
+                      max_bytes_before_external_group_by=0,
+                      transform_null_in=1,
+                      optimize_min_equality_disjunction_chain_length=4294967295,
+                      allow_experimental_join_condition=1
   '''
 # ---
 # name: TestExperimentExposuresQueryRunner.test_exposure_query_filters_test_accounts.1
@@ -99,16 +99,16 @@
   GROUP BY subq.day,
            subq.variant
   ORDER BY subq.day ASC
-  LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
-                     allow_experimental_object_type=1,
-                     format_csv_allow_double_quotes=0,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1
+  LIMIT 5000 SETTINGS readonly=2,
+                      max_execution_time=180,
+                      allow_experimental_object_type=1,
+                      format_csv_allow_double_quotes=0,
+                      max_ast_elements=4000000,
+                      max_expanded_ast_elements=4000000,
+                      max_bytes_before_external_group_by=0,
+                      transform_null_in=1,
+                      optimize_min_equality_disjunction_chain_length=4294967295,
+                      allow_experimental_join_condition=1
   '''
 # ---
 # name: TestExperimentExposuresQueryRunner.test_exposure_query_multiple_variant_handling_first_seen
@@ -133,16 +133,16 @@
   GROUP BY subq.day,
            subq.variant
   ORDER BY subq.day ASC
-  LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
-                     allow_experimental_object_type=1,
-                     format_csv_allow_double_quotes=0,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1
+  LIMIT 5000 SETTINGS readonly=2,
+                      max_execution_time=180,
+                      allow_experimental_object_type=1,
+                      format_csv_allow_double_quotes=0,
+                      max_ast_elements=4000000,
+                      max_expanded_ast_elements=4000000,
+                      max_bytes_before_external_group_by=0,
+                      transform_null_in=1,
+                      optimize_min_equality_disjunction_chain_length=4294967295,
+                      allow_experimental_join_condition=1
   '''
 # ---
 # name: TestExperimentExposuresQueryRunner.test_exposure_query_returns_correct_timeseries
@@ -167,16 +167,16 @@
   GROUP BY subq.day,
            subq.variant
   ORDER BY subq.day ASC
-  LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
-                     allow_experimental_object_type=1,
-                     format_csv_allow_double_quotes=0,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1
+  LIMIT 5000 SETTINGS readonly=2,
+                      max_execution_time=180,
+                      allow_experimental_object_type=1,
+                      format_csv_allow_double_quotes=0,
+                      max_ast_elements=4000000,
+                      max_expanded_ast_elements=4000000,
+                      max_bytes_before_external_group_by=0,
+                      transform_null_in=1,
+                      optimize_min_equality_disjunction_chain_length=4294967295,
+                      allow_experimental_join_condition=1
   '''
 # ---
 # name: TestExperimentExposuresQueryRunner.test_exposure_query_using_group_aggregation
@@ -194,16 +194,16 @@
   GROUP BY subq.day,
            subq.variant
   ORDER BY subq.day ASC
-  LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
-                     allow_experimental_object_type=1,
-                     format_csv_allow_double_quotes=0,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1
+  LIMIT 5000 SETTINGS readonly=2,
+                      max_execution_time=180,
+                      allow_experimental_object_type=1,
+                      format_csv_allow_double_quotes=0,
+                      max_ast_elements=4000000,
+                      max_expanded_ast_elements=4000000,
+                      max_bytes_before_external_group_by=0,
+                      transform_null_in=1,
+                      optimize_min_equality_disjunction_chain_length=4294967295,
+                      allow_experimental_join_condition=1
   '''
 # ---
 # name: TestExperimentExposuresQueryRunner.test_exposure_query_with_custom_exposure_0__pageview
@@ -228,16 +228,16 @@
   GROUP BY subq.day,
            subq.variant
   ORDER BY subq.day ASC
-  LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
-                     allow_experimental_object_type=1,
-                     format_csv_allow_double_quotes=0,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1
+  LIMIT 5000 SETTINGS readonly=2,
+                      max_execution_time=180,
+                      allow_experimental_object_type=1,
+                      format_csv_allow_double_quotes=0,
+                      max_ast_elements=4000000,
+                      max_expanded_ast_elements=4000000,
+                      max_bytes_before_external_group_by=0,
+                      transform_null_in=1,
+                      optimize_min_equality_disjunction_chain_length=4294967295,
+                      allow_experimental_join_condition=1
   '''
 # ---
 # name: TestExperimentExposuresQueryRunner.test_exposure_query_with_custom_exposure_1__feature_flag_called
@@ -262,16 +262,16 @@
   GROUP BY subq.day,
            subq.variant
   ORDER BY subq.day ASC
-  LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
-                     allow_experimental_object_type=1,
-                     format_csv_allow_double_quotes=0,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1
+  LIMIT 5000 SETTINGS readonly=2,
+                      max_execution_time=180,
+                      allow_experimental_object_type=1,
+                      format_csv_allow_double_quotes=0,
+                      max_ast_elements=4000000,
+                      max_expanded_ast_elements=4000000,
+                      max_bytes_before_external_group_by=0,
+                      transform_null_in=1,
+                      optimize_min_equality_disjunction_chain_length=4294967295,
+                      allow_experimental_join_condition=1
   '''
 # ---
 # name: TestExperimentExposuresQueryRunner.test_exposure_query_with_multiple_variant_exposures
@@ -296,16 +296,16 @@
   GROUP BY subq.day,
            subq.variant
   ORDER BY subq.day ASC
-  LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
-                     allow_experimental_object_type=1,
-                     format_csv_allow_double_quotes=0,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1
+  LIMIT 5000 SETTINGS readonly=2,
+                      max_execution_time=180,
+                      allow_experimental_object_type=1,
+                      format_csv_allow_double_quotes=0,
+                      max_ast_elements=4000000,
+                      max_expanded_ast_elements=4000000,
+                      max_bytes_before_external_group_by=0,
+                      transform_null_in=1,
+                      optimize_min_equality_disjunction_chain_length=4294967295,
+                      allow_experimental_join_condition=1
   '''
 # ---
 # name: TestExperimentExposuresQueryRunner.test_exposure_query_without_feature_flag_property
@@ -330,15 +330,15 @@
   GROUP BY subq.day,
            subq.variant
   ORDER BY subq.day ASC
-  LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
-                     allow_experimental_object_type=1,
-                     format_csv_allow_double_quotes=0,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1
+  LIMIT 5000 SETTINGS readonly=2,
+                      max_execution_time=180,
+                      allow_experimental_object_type=1,
+                      format_csv_allow_double_quotes=0,
+                      max_ast_elements=4000000,
+                      max_expanded_ast_elements=4000000,
+                      max_bytes_before_external_group_by=0,
+                      transform_null_in=1,
+                      optimize_min_equality_disjunction_chain_length=4294967295,
+                      allow_experimental_join_condition=1
   '''
 # ---


### PR DESCRIPTION
## Problem
For long running experiments, the exposure query can hit the default HogQL row limit at 100 rows and cut off the results.

## Changes
Set limit on exposure queries to 5000. This should be more than sufficient for all experiments.

## How did you test this code?
- Tests passes
- Query snapshots looks good