### PR TITLE
chore: tidy up filters box

### DIFF
--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -428,57 +428,67 @@ export const RecordingsUniversalFiltersEmbed = ({
                             </UniversalFilters>
                         </div>
                     </div>
-                    <div className="flex flex-wrap gap-2 items-center mt-8 justify-end border-t pt-4 mx-2">
-                        <LemonButton
-                            type="tertiary"
-                            size="small"
-                            onClick={handleResetFilters}
-                            icon={<IconRevert />}
-                            tooltip="Reset any changes you've made to the filters"
-                            disabledReason={
-                                !(resetFilters && (totalFiltersCount ?? 0) > 0) ? 'No filters applied' : undefined
-                            }
-                        >
-                            Reset filters
-                        </LemonButton>
-                        {appliedSavedFilter ? (
+                    <div className="flex justify-between gap-2 border-t pt-4 mx-2 mt-8 ">
+                        <div className="flex flex-wrap gap-2 items-center justify-end ">
                             <LemonButton
-                                type="secondary"
+                                type="tertiary"
                                 size="small"
-                                onClick={() => void updateSavedFilter()}
-                                tooltip="Update saved filter"
+                                onClick={handleResetFilters}
+                                icon={<IconRevert />}
+                                tooltip="Reset any changes you've made to the filters"
                                 disabledReason={
-                                    equal(appliedSavedFilter.filters, filters) ? 'No changes to update' : undefined
+                                    !(resetFilters && (totalFiltersCount ?? 0) > 0) ? 'No filters applied' : undefined
                                 }
-                                sideAction={{
-                                    dropdown: {
-                                        placement: 'bottom-end',
-                                        overlay: (
-                                            <LemonMenuOverlay
-                                                items={[
-                                                    {
-                                                        label: 'Save as a new filter',
-                                                        onClick: () => setIsSaveFiltersModalOpen(true),
-                                                    },
-                                                ]}
-                                            />
-                                        ),
-                                    },
-                                }}
                             >
-                                Update "{appliedSavedFilter.name || 'Unnamed'}"
+                                Reset filters
                             </LemonButton>
-                        ) : (
-                            <LemonButton
-                                type="primary"
-                                size="small"
-                                onClick={() => setIsSaveFiltersModalOpen(true)}
-                                disabledReason={(totalFiltersCount ?? 0) === 0 ? 'No filters applied' : undefined}
-                                tooltip="Save filters for later"
-                            >
-                                Save filters
-                            </LemonButton>
-                        )}
+                            {appliedSavedFilter ? (
+                                <LemonButton
+                                    type="secondary"
+                                    size="small"
+                                    onClick={() => void updateSavedFilter()}
+                                    tooltip="Update saved filter"
+                                    disabledReason={
+                                        equal(appliedSavedFilter.filters, filters) ? 'No changes to update' : undefined
+                                    }
+                                    sideAction={{
+                                        dropdown: {
+                                            placement: 'bottom-end',
+                                            overlay: (
+                                                <LemonMenuOverlay
+                                                    items={[
+                                                        {
+                                                            label: 'Save as a new filter',
+                                                            onClick: () => setIsSaveFiltersModalOpen(true),
+                                                        },
+                                                    ]}
+                                                />
+                                            ),
+                                        },
+                                    }}
+                                >
+                                    Update "{appliedSavedFilter.name || 'Unnamed'}"
+                                </LemonButton>
+                            ) : (
+                                <LemonButton
+                                    type="secondary"
+                                    size="small"
+                                    onClick={() => setIsSaveFiltersModalOpen(true)}
+                                    disabledReason={(totalFiltersCount ?? 0) === 0 ? 'No filters applied' : undefined}
+                                    tooltip="Save filters for later"
+                                >
+                                    Add to "Saved filters"
+                                </LemonButton>
+                            )}
+                        </div>
+                        <LemonButton
+                            type="primary"
+                            size="small"
+                            onClick={() => setIsFiltersExpanded(false)}
+                            tooltip="Close filters and start watching recordings"
+                        >
+                            {(totalFiltersCount ?? 0) === 0 ? 'Close filters' : 'Start watching'}
+                        </LemonButton>
                     </div>
                     {SaveFiltersModal()}
                 </div>

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -429,7 +429,7 @@ export const RecordingsUniversalFiltersEmbed = ({
                         </div>
                     </div>
                     <div className="flex justify-between gap-2 border-t pt-4 mx-2 mt-8 ">
-                        <div className="flex flex-wrap gap-2 items-center justify-end ">
+                        <div className="flex flex-wrap gap-2 items-center justify-end">
                             <LemonButton
                                 type="tertiary"
                                 size="small"


### PR DESCRIPTION
## Issue
"Save filters" as a primary action can be misleading. Let's fix it:

### Before
<img width="1001" alt="Screenshot 2025-07-08 at 11 14 48" src="https://github.com/user-attachments/assets/8a3cf00e-2d2a-4e59-97f7-835464f8ef75" />


### After
#### No filters applied
<img width="909" alt="Screenshot 2025-07-08 at 11 14 59" src="https://github.com/user-attachments/assets/c75e72be-9be7-4132-b0e6-a675278376a9" />

#### Some filters applies
<img width="900" alt="Screenshot 2025-07-08 at 11 15 04" src="https://github.com/user-attachments/assets/a60ba202-0761-4d28-9618-dc868af21b1c" />

