### PR TITLE
refactor(insights): rename isDataWarehouseSeries selector

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/Breakdown.tsx
+++ b/frontend/src/queries/nodes/InsightViz/Breakdown.tsx
@@ -5,7 +5,7 @@ import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { EditorFilterProps } from '~/types'
 
 export function Breakdown({ insightProps }: EditorFilterProps): JSX.Element {
-    const { breakdownFilter, display, isTrends, isSingleSeries, isDataWarehouseSeries } = useValues(
+    const { breakdownFilter, display, isTrends, isSingleSeries, hasDataWarehouseSeries } = useValues(
         insightVizDataLogic(insightProps)
     )
     const { updateBreakdownFilter, updateDisplay } = useActions(insightVizDataLogic(insightProps))
@@ -20,7 +20,7 @@ export function Breakdown({ insightProps }: EditorFilterProps): JSX.Element {
                 updateBreakdownFilter={updateBreakdownFilter}
                 updateDisplay={updateDisplay}
                 disabledReason={
-                    !isSingleSeries && isDataWarehouseSeries
+                    !isSingleSeries && hasDataWarehouseSeries
                         ? 'Breakdowns are not allowed for multiple series types'
                         : undefined
                 }

--- a/frontend/src/queries/nodes/InsightViz/GlobalAndOrFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/GlobalAndOrFilters.tsx
@@ -14,7 +14,7 @@ import { getAllEventNames } from './utils'
 export function GlobalAndOrFilters({ insightProps }: EditorFilterProps): JSX.Element {
     const { actions: allActions } = useValues(actionsModel)
     const { groupsTaxonomicTypes } = useValues(groupsModel)
-    const { querySource, isDataWarehouseSeries } = useValues(insightVizDataLogic(insightProps))
+    const { querySource, hasDataWarehouseSeries } = useValues(insightVizDataLogic(insightProps))
     const { updateQuerySource } = useActions(insightVizDataLogic(insightProps))
 
     const taxonomicGroupTypes = [
@@ -37,7 +37,7 @@ export function GlobalAndOrFilters({ insightProps }: EditorFilterProps): JSX.Ele
             setQuery={updateQuerySource}
             eventNames={getAllEventNames(querySource as TrendsQuery | StickinessQuery, allActions)}
             taxonomicGroupTypes={taxonomicGroupTypes}
-            isDataWarehouseSeries={isDataWarehouseSeries}
+            hasDataWarehouseSeries={hasDataWarehouseSeries}
         />
     )
 }

--- a/frontend/src/queries/nodes/InsightViz/PropertyGroupFilters/PropertyGroupFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/PropertyGroupFilters/PropertyGroupFilters.tsx
@@ -24,7 +24,7 @@ type PropertyGroupFiltersProps = {
     pageKey: string
     eventNames?: string[]
     taxonomicGroupTypes?: TaxonomicFilterGroupType[]
-    isDataWarehouseSeries?: boolean
+    hasDataWarehouseSeries?: boolean
 }
 
 export function PropertyGroupFilters({
@@ -34,7 +34,7 @@ export function PropertyGroupFilters({
     pageKey,
     eventNames = [],
     taxonomicGroupTypes,
-    isDataWarehouseSeries,
+    hasDataWarehouseSeries,
 }: PropertyGroupFiltersProps): JSX.Element {
     const logicProps = { query, setQuery, pageKey }
     const { propertyGroupFilter } = useValues(propertyGroupFilterLogic(logicProps))
@@ -48,7 +48,7 @@ export function PropertyGroupFilters({
     } = useActions(propertyGroupFilterLogic(logicProps))
 
     const showHeader = propertyGroupFilter.type && propertyGroupFilter.values.length > 1
-    const disabledReason = isDataWarehouseSeries
+    const disabledReason = hasDataWarehouseSeries
         ? 'Cannot add filter groups to data warehouse series. Use individual series filters'
         : undefined
     return (

--- a/frontend/src/scenes/insights/EditorFilters/SamplingFilter.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/SamplingFilter.tsx
@@ -16,7 +16,7 @@ interface SamplingFilterProps {
 }
 
 export function SamplingFilter({ insightProps, infoTooltipContent }: SamplingFilterProps): JSX.Element {
-    const { isDataWarehouseSeries } = useValues(insightVizDataLogic(insightProps))
+    const { hasDataWarehouseSeries } = useValues(insightVizDataLogic(insightProps))
     const { samplingPercentage } = useValues(samplingFilterLogic(insightProps))
     const { setSamplingPercentage } = useActions(samplingFilterLogic(insightProps))
 
@@ -42,7 +42,7 @@ export function SamplingFilter({ insightProps, infoTooltipContent }: SamplingFil
                     }}
                     checked={!!samplingPercentage}
                     disabledReason={
-                        isDataWarehouseSeries ? 'Sampling is not available for data warehouse series' : undefined
+                        hasDataWarehouseSeries ? 'Sampling is not available for data warehouse series' : undefined
                     }
                 />
             </div>

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
@@ -40,7 +40,7 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
     connect((props: TaxonomicBreakdownFilterLogicProps) => ({
         values: [
             insightVizDataLogic(props.insightProps),
-            ['currentDataWarehouseSchemaColumns', 'isDataWarehouseSeries'],
+            ['currentDataWarehouseSchemaColumns', 'hasDataWarehouseSeries'],
             propertyDefinitionsModel,
             ['getPropertyDefinition'],
             featureFlagLogic,
@@ -136,12 +136,12 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
         breakdownFilter: [(_, p) => [p.breakdownFilter], (breakdownFilter) => breakdownFilter],
         includeSessions: [(_, p) => [p.isTrends], (isTrends) => isTrends],
         isAddBreakdownDisabled: [
-            (s) => [s.breakdownFilter, s.isMultipleBreakdownsEnabled, s.isDataWarehouseSeries],
-            ({ breakdown, breakdowns, breakdown_type }, isMultipleBreakdownsEnabled, isDataWarehouseSeries) => {
+            (s) => [s.breakdownFilter, s.isMultipleBreakdownsEnabled, s.hasDataWarehouseSeries],
+            ({ breakdown, breakdowns, breakdown_type }, isMultipleBreakdownsEnabled, hasDataWarehouseSeries) => {
                 // Multiple breakdowns don't yet support the data warehouse, so it fallbacks to a single breakdown.
                 if (
                     isMultipleBreakdownsEnabled &&
-                    !isDataWarehouseSeries &&
+                    !hasDataWarehouseSeries &&
                     (!breakdown_type || isMultipleBreakdownType(breakdown_type))
                 ) {
                     return !!breakdowns && breakdowns.length >= 3

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -292,7 +292,7 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
             },
         ],
 
-        isDataWarehouseSeries: [
+        hasDataWarehouseSeries: [
             (s) => [s.isTrends, s.series],
             (isTrends, series): boolean => {
                 return isTrends && (series || []).length > 0 && !!series?.some((node) => isDataWarehouseNode(node))
@@ -300,11 +300,17 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
         ],
 
         currentDataWarehouseSchemaColumns: [
-            (s) => [s.series, s.isSingleSeries, s.isDataWarehouseSeries, s.isBreakdownSeries, s.dataWarehouseTablesMap],
+            (s) => [
+                s.series,
+                s.isSingleSeries,
+                s.hasDataWarehouseSeries,
+                s.isBreakdownSeries,
+                s.dataWarehouseTablesMap,
+            ],
             (
                 series,
                 isSingleSeries,
-                isDataWarehouseSeries,
+                hasDataWarehouseSeries,
                 isBreakdownSeries,
                 dataWarehouseTablesMap
             ): DatabaseSchemaField[] => {
@@ -312,7 +318,7 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
                     !series ||
                     series.length === 0 ||
                     (!isSingleSeries && !isBreakdownSeries) ||
-                    !isDataWarehouseSeries
+                    !hasDataWarehouseSeries
                 ) {
                     return []
                 }

--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -88,7 +88,7 @@ function useBoldNumberTooltip({
 
 export function BoldNumber({ showPersonsModal = true, context }: ChartParams): JSX.Element {
     const { insightProps } = useValues(insightLogic)
-    const { insightData, trendsFilter, compareFilter, querySource, isDataWarehouseSeries } = useValues(
+    const { insightData, trendsFilter, compareFilter, querySource, hasDataWarehouseSeries } = useValues(
         insightVizDataLogic(insightProps)
     )
 
@@ -105,7 +105,7 @@ export function BoldNumber({ showPersonsModal = true, context }: ChartParams): J
                 onClick={
                     context?.onDataPointClick
                         ? () => context?.onDataPointClick?.({ compare: 'current' }, resultSeries)
-                        : showPersonsModal && resultSeries.aggregated_value != null && !isDataWarehouseSeries // != is intentional to catch undefined too
+                        : showPersonsModal && resultSeries.aggregated_value != null && !hasDataWarehouseSeries // != is intentional to catch undefined too
                         ? () => {
                               openPersonsModal({
                                   title: resultSeries.label,

--- a/frontend/src/scenes/trends/trendsDataLogic.ts
+++ b/frontend/src/scenes/trends/trendsDataLogic.ts
@@ -75,7 +75,7 @@ export const trendsDataLogic = kea<trendsDataLogicType>([
                 'lifecycleFilter',
                 'stickinessFilter',
                 'isTrends',
-                'isDataWarehouseSeries',
+                'hasDataWarehouseSeries',
                 'isLifecycle',
                 'isStickiness',
                 'isNonTimeSeriesDisplay',

--- a/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
@@ -29,7 +29,7 @@ export function ActionsHorizontalBar({ showPersonsModal = true, context }: Chart
         trendsFilter,
         formula,
         showValuesOnSeries,
-        isDataWarehouseSeries,
+        hasDataWarehouseSeries,
         querySource,
         breakdownFilter,
         hiddenLegendIndexes,
@@ -91,7 +91,7 @@ export function ActionsHorizontalBar({ showPersonsModal = true, context }: Chart
             formula={formula}
             showValuesOnSeries={showValuesOnSeries}
             onClick={
-                context?.onDataPointClick || (showPersonsModal && !trendsFilter?.formula && !isDataWarehouseSeries)
+                context?.onDataPointClick || (showPersonsModal && !trendsFilter?.formula && !hasDataWarehouseSeries)
                     ? (point) => {
                           const { index, points } = point
 

--- a/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
@@ -35,7 +35,7 @@ export function ActionsLineGraph({
         trendsFilter,
         isLifecycle,
         isStickiness,
-        isDataWarehouseSeries,
+        hasDataWarehouseSeries,
         showLegend,
         hiddenLegendIndexes,
         querySource,
@@ -121,7 +121,7 @@ export function ActionsLineGraph({
             goalLines={[...alertThresholdLines, ...(goalLines || [])]}
             onClick={
                 context?.onDataPointClick ||
-                (showPersonsModal && !isMultiSeriesFormula(formula) && !isDataWarehouseSeries)
+                (showPersonsModal && !isMultiSeriesFormula(formula) && !hasDataWarehouseSeries)
                     ? (payload) => {
                           const { index, points } = payload
 

--- a/frontend/src/scenes/trends/viz/ActionsPie.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsPie.tsx
@@ -33,7 +33,7 @@ export function ActionsPie({ inSharedMode, showPersonsModal = true, context }: C
         supportsPercentStackView,
         showPercentStackView,
         pieChartVizOptions,
-        isDataWarehouseSeries,
+        hasDataWarehouseSeries,
         querySource,
         breakdownFilter,
         hiddenLegendIndexes,
@@ -135,7 +135,7 @@ export function ActionsPie({ inSharedMode, showPersonsModal = true, context }: C
                             showLabelOnSeries={showLabelOnSeries}
                             supportsPercentStackView={supportsPercentStackView}
                             showPercentStackView={showPercentStackView}
-                            onClick={isDataWarehouseSeries ? undefined : onClick}
+                            onClick={hasDataWarehouseSeries ? undefined : onClick}
                             disableHoverOffset={pieChartVizOptions?.disableHoverOffset}
                         />
                     </div>


### PR DESCRIPTION
## Problem

I tripped over the `isDataWarehouseSeries` name a few times, so I'd like to rename it to `hasDataWarehouseSeries`. This makes more sense to me for a selector of `series?.some((node) => isDataWarehouseNode(node))`.

## Changes

Renames the `isDataWarehouseSeries` selector to `hasDataWarehouseSeries`.

## How did you test this code?

n/a