### PR TITLE
feat: add log_comment to exchange rates dagster queries

### DIFF
--- a/dags/common.py
+++ b/dags/common.py
@@ -32,8 +32,7 @@ class ClickhouseClusterResource(dagster.ConfigurableResource):
         "max_execution_time": "0",
         "max_memory_usage": "0",
         "mutations_sync": "0",
-        "receive_timeout": f"{15 * 60}",
-        # some synchronous queries like dictionary checksumming can be very slow to return
+        "receive_timeout": f"{15 * 60}",  # some synchronous queries like dictionary checksumming can be very slow to return
     }
 
     def create_resource(self, context: dagster.InitResourceContext) -> ClickhouseCluster:
@@ -48,14 +47,12 @@ class ClickhouseClusterResource(dagster.ConfigurableResource):
                     and (
                         (
                             e.code
-                            in (
-                                # these are typically transient errors and unrelated to the query being executed
+                            in (  # these are typically transient errors and unrelated to the query being executed
                                 ErrorCodes.NETWORK_ERROR,
                                 ErrorCodes.TOO_MANY_SIMULTANEOUS_QUERIES,
                                 ErrorCodes.NOT_ENOUGH_SPACE,
                                 ErrorCodes.SOCKET_TIMEOUT,
-                                439,
-                                # CANNOT_SCHEDULE_TASK: "Cannot schedule a task: cannot allocate thread"
+                                439,  # CANNOT_SCHEDULE_TASK: "Cannot schedule a task: cannot allocate thread"
                             )
                         )
                         # queries that exceed memory limits can be retried if they were killed due to total server

--- a/dags/common.py
+++ b/dags/common.py
@@ -92,7 +92,7 @@ job_status_metrics_sensors = [
 ]
 
 
-def dagster_tags(context: dagster.AbstractComputeExecutionContext) -> DagsterTags:
+def dagster_tags(context: dagster.OpExecutionContext) -> DagsterTags:
     r = context.run
     return DagsterTags(
         job_name=r.job_name,
@@ -105,7 +105,7 @@ def dagster_tags(context: dagster.AbstractComputeExecutionContext) -> DagsterTag
     )
 
 
-def settings_with_log_comment(context: dagster.AbstractComputeExecutionContext) -> dict[str, str]:
+def settings_with_log_comment(context: dagster.OpExecutionContext) -> dict[str, str]:
     qt = query_tagging.get_query_tags()
     qt.with_dagster(dagster_tags(context))
     return {"log_comment": qt.to_json()}

--- a/dags/exchange_rate.py
+++ b/dags/exchange_rate.py
@@ -36,8 +36,7 @@ HOURLY_PARTITION_DEFINITION = dagster.HourlyPartitionsDefinition(
         2025, 3, 10
     ),  # Start in March 2025 because that's when we started using hourly updates
     minute_offset=45,  # Run at XX:45 to avoid peak load at the top of the hour
-    end_offset=12,
-    # Generate 12 partitions after the current hour to be safe (1 should be enough, 0 breaks our workflow)
+    end_offset=12,  # Generate 12 partitions after the current hour to be safe (1 should be enough, 0 breaks our workflow)
 )
 
 
@@ -180,7 +179,8 @@ def store_exchange_rates_in_clickhouse(
         def insert(client: Client) -> bool:
             try:
                 client.execute(
-                    EXCHANGE_RATE_DATA_BACKFILL_SQL(exchange_rates=values), settings=settings_with_log_comment(context)
+                    EXCHANGE_RATE_DATA_BACKFILL_SQL(exchange_rates=values),
+                    settings=settings_with_log_comment(context),
                 )
                 context.log.info("Successfully inserted exchange rates")
                 return True

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -158,6 +158,7 @@ class QueryTags(BaseModel):
         self.temporal = temporal_tags
 
     def with_dagster(self, dagster_tags: DagsterTags):
+        """Tags for dagster runs and activities."""
         self.kind = "dagster"
         self.dagster = dagster_tags
 

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -54,6 +54,22 @@ class TemporalTags(BaseModel):
     model_config = ConfigDict(validate_assignment=True, use_enum_values=True)
 
 
+class DagsterTags(BaseModel):
+    """
+    Tags for Dagster runs
+
+    Check: https://docs.dagster.io/api/dagster/internals#dagster.DagsterRun
+    """
+
+    job_name: str
+    run_id: str
+    tags: Optional[dict[str, str]]
+    root_run_id: Optional[str]
+    parent_run_id: Optional[str]
+    job_snapshot_id: Optional[str]
+    execution_plan_snapshot_id: Optional[str]
+
+
 class QueryTags(BaseModel):
     team_id: Optional[int] = None
     user_id: Optional[int] = None
@@ -66,6 +82,8 @@ class QueryTags(BaseModel):
 
     # temporalio tags
     temporal: Optional[TemporalTags] = None
+    # dagster specific tags
+    dagster: Optional[DagsterTags] = None
 
     query: Optional[object] = None
     query_settings: Optional[object] = None
@@ -138,6 +156,10 @@ class QueryTags(BaseModel):
     def with_temporal(self, temporal_tags: TemporalTags):
         self.kind = "temporal"
         self.temporal = temporal_tags
+
+    def with_dagster(self, dagster_tags: DagsterTags):
+        self.kind = "dagster"
+        self.dagster = dagster_tags
 
     def to_json(self) -> str:
         return self.model_dump_json(exclude_none=True)


### PR DESCRIPTION
## Problem

let make the query_log useful for dagster

## Changes

add basic log_comment in dagster currency exchange jobs
cannot add it easily and globally, as the cluster resource is shared among many assets and reused
