### PR TITLE
fix(cdp): fix resizing for input fields

### DIFF
--- a/frontend/src/lib/monaco/CodeEditorResizable.tsx
+++ b/frontend/src/lib/monaco/CodeEditorResizable.tsx
@@ -89,7 +89,7 @@ export function CodeEditorResizeable({
 
             {/* Using a standard resize css means we need overflow-hidden which hides parts of the editor unnecessarily */}
             <div
-                className="overflow-hidden absolute right-0 bottom-0 z-10 w-5 h-5 resize-y cursor-s-resize"
+                className="overflow-hidden absolute right-0 bottom-0 z-20 w-5 h-5 resize-y cursor-s-resize"
                 onMouseDown={(e) => {
                     const startY = e.clientY
                     const startHeight = ref.current?.clientHeight ?? 0


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

since introduction of templating button the resizing for input fields does not work anymore


![2025-07-08 12 54 33](https://github.com/user-attachments/assets/002a37c5-9ca1-4187-8690-cf2e61ba0f98)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- fixed it 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

- local dev 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
