### PR TITLE
fix: propagate the asset context down the stack

### DIFF
--- a/dags/exchange_rate.py
+++ b/dags/exchange_rate.py
@@ -234,7 +234,7 @@ def daily_exchange_rates_in_clickhouse(
 
     # Store the rates in ClickHouse
     rows, values = store_exchange_rates_in_clickhouse(
-        context=dagster.build_op_context(), date_str=date_str, exchange_rates=exchange_rates, cluster=cluster
+        context=context, date_str=date_str, exchange_rates=exchange_rates, cluster=cluster
     )
 
     # Calculate some statistics for metadata
@@ -275,7 +275,7 @@ def hourly_exchange_rates_in_clickhouse(
 
     # Store the rates in ClickHouse
     rows, values = store_exchange_rates_in_clickhouse(
-        context=dagster.build_op_context(), date_str=date_str, exchange_rates=exchange_rates, cluster=cluster
+        context=context, date_str=date_str, exchange_rates=exchange_rates, cluster=cluster
     )
 
     # Calculate some statistics for metadata

--- a/dags/exchange_rate.py
+++ b/dags/exchange_rate.py
@@ -149,7 +149,6 @@ def hourly_exchange_rates(
     )
 
 
-@dagster.op
 def store_exchange_rates_in_clickhouse(
     context: dagster.OpExecutionContext,
     date_str: str,


### PR DESCRIPTION
## Problem

a dagster.build_op_context creates a context without most necessary fields set

## Changes

propagate the current context