### PR TITLE
fix(persons): Produce to kafka during flush

### DIFF
--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -298,7 +298,7 @@ export class IngestionConsumer {
 
         const [_, personsStoreMessages] = await Promise.all([groupStoreForBatch.flush(), personsStoreForBatch.flush()])
 
-        if (this.kafkaProducer && personsStoreMessages.length > 0) {
+        if (personsStoreMessages.length > 0 && this.kafkaProducer) {
             await Promise.all([this.kafkaProducer.queueMessages(personsStoreMessages)])
 
             await this.kafkaProducer.flush()

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -301,8 +301,11 @@ export class IngestionConsumer {
             personsStoreForBatch.flush(),
         ])
 
-        await this.kafkaProducer?.queueMessages(groupStoreMessages)
-        await this.kafkaProducer?.queueMessages(personsStoreMessages)
+        await Promise.all([
+            this.kafkaProducer?.queueMessages(groupStoreMessages),
+            this.kafkaProducer?.queueMessages(personsStoreMessages),
+        ])
+
         await this.kafkaProducer?.flush()
 
         personsStoreForBatch.reportBatch()

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -296,16 +296,10 @@ export class IngestionConsumer {
             )
         })
 
-        const [groupStoreMessages, personsStoreMessages] = await Promise.all([
-            groupStoreForBatch.flush(),
-            personsStoreForBatch.flush(),
-        ])
+        const [_, personsStoreMessages] = await Promise.all([groupStoreForBatch.flush(), personsStoreForBatch.flush()])
 
-        if (this.kafkaProducer) {
-            await Promise.all([
-                this.kafkaProducer.queueMessages(groupStoreMessages),
-                this.kafkaProducer.queueMessages(personsStoreMessages),
-            ])
+        if (this.kafkaProducer && personsStoreMessages.length > 0) {
+            await Promise.all([this.kafkaProducer.queueMessages(personsStoreMessages)])
 
             await this.kafkaProducer.flush()
         }

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -301,12 +301,14 @@ export class IngestionConsumer {
             personsStoreForBatch.flush(),
         ])
 
-        await Promise.all([
-            this.kafkaProducer?.queueMessages(groupStoreMessages),
-            this.kafkaProducer?.queueMessages(personsStoreMessages),
-        ])
+        if (this.kafkaProducer) {
+            await Promise.all([
+                this.kafkaProducer.queueMessages(groupStoreMessages),
+                this.kafkaProducer.queueMessages(personsStoreMessages),
+            ])
 
-        await this.kafkaProducer?.flush()
+            await this.kafkaProducer.flush()
+        }
 
         personsStoreForBatch.reportBatch()
         groupStoreForBatch.reportBatch()

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -296,7 +296,15 @@ export class IngestionConsumer {
             )
         })
 
-        await Promise.all([groupStoreForBatch.flush(), personsStoreForBatch.flush()])
+        const [groupStoreMessages, personsStoreMessages] = await Promise.all([
+            groupStoreForBatch.flush(),
+            personsStoreForBatch.flush(),
+        ])
+
+        await this.kafkaProducer?.queueMessages(groupStoreMessages)
+        await this.kafkaProducer?.queueMessages(personsStoreMessages)
+        await this.kafkaProducer?.flush()
+
         personsStoreForBatch.reportBatch()
         groupStoreForBatch.reportBatch()
 

--- a/plugin-server/src/ingestion/ingestion-e2e.test.ts
+++ b/plugin-server/src/ingestion/ingestion-e2e.test.ts
@@ -820,6 +820,8 @@ describe('Event Pipeline E2E tests', () => {
 
         await ingester.handleKafkaBatch(createKafkaMessages(events))
 
+        await waitForKafkaMessages(hub)
+
         await waitForExpect(async () => {
             const persons = await fetchPersons(hub, team.id)
             expect(persons.length).toEqual(2)
@@ -880,6 +882,8 @@ describe('Event Pipeline E2E tests', () => {
         const event2 = new EventBuilder(team, secondDistinctId).withEvent('custom event 2').withProperties({}).build()
 
         await ingester.handleKafkaBatch(createKafkaMessages([event1, event2]))
+
+        await waitForKafkaMessages(hub)
 
         await waitForExpect(async () => {
             const persons = await fetchPersons(hub, team.id)

--- a/plugin-server/src/ingestion/ingestion-e2e.test.ts
+++ b/plugin-server/src/ingestion/ingestion-e2e.test.ts
@@ -1213,7 +1213,18 @@ describe('Event Pipeline E2E tests', () => {
         await waitForExpect(async () => {
             const persons = await fetchPostgresPersons(hub.db, team.id)
             expect(persons.length).toBe(1)
+            const personsClickhouse = await fetchPersons(hub, team.id)
+            expect(personsClickhouse.length).toBe(1)
             expect(persons[0].properties).toMatchObject(
+                expect.objectContaining({
+                    name: 'User 1',
+                    new_name: 'User 1 - Updated',
+                    email: `user1-${user1DistinctId}@example.com`,
+                    age: 30,
+                    test_name: testName,
+                })
+            )
+            expect(personsClickhouse[0].properties).toMatchObject(
                 expect.objectContaining({
                     name: 'User 1',
                     new_name: 'User 1 - Updated',
@@ -1317,7 +1328,18 @@ describe('Event Pipeline E2E tests', () => {
         await waitForExpect(async () => {
             const persons = await fetchPostgresPersons(hub.db, team.id)
             expect(persons.length).toBe(1)
+            const personsClickhouse = await fetchPersons(hub, team.id)
+            expect(personsClickhouse.length).toBe(1)
             expect(persons[0].properties).toMatchObject(
+                expect.objectContaining({
+                    name: 'User 1',
+                    new_name: 'User 1 - Updated',
+                    email: `user1-${user1DistinctId}@example.com`,
+                    age: 30,
+                    test_name: testName,
+                })
+            )
+            expect(personsClickhouse[0].properties).toMatchObject(
                 expect.objectContaining({
                     name: 'User 1',
                     new_name: 'User 1 - Updated',
@@ -1422,7 +1444,18 @@ describe('Event Pipeline E2E tests', () => {
         await waitForExpect(async () => {
             const persons = await fetchPostgresPersons(hub.db, team.id)
             expect(persons.length).toBe(1)
+            const personsClickhouse = await fetchPersons(hub, team.id)
+            expect(personsClickhouse.length).toBe(1)
             expect(persons[0].properties).toMatchObject(
+                expect.objectContaining({
+                    name: 'User 1',
+                    new_name: 'User 1 - Updated',
+                    email: `user1-${user1DistinctId}@example.com`,
+                    age: 30,
+                    test_name: testName,
+                })
+            )
+            expect(personsClickhouse[0].properties).toMatchObject(
                 expect.objectContaining({
                     name: 'User 1',
                     new_name: 'User 1 - Updated',
@@ -1534,7 +1567,27 @@ describe('Event Pipeline E2E tests', () => {
             await waitForExpect(async () => {
                 const persons = await fetchPostgresPersons(hub.db, team.id)
                 expect(persons.length).toBe(2)
+                const personsClickhouse = await fetchPersons(hub, team.id)
+                expect(personsClickhouse.length).toBe(2)
                 expect(persons.map((person) => person.properties)).toEqual(
+                    expect.arrayContaining([
+                        expect.objectContaining({
+                            name: 'User 1',
+                            new_name: 'User 1 - Updated',
+                            email: `user1-${user1DistinctId}@example.com`,
+                            age: 30,
+                            test_name: testName,
+                        }),
+                        expect.objectContaining({
+                            name: 'User 2',
+                            new_name: 'User 2 - Updated',
+                            email: `user2-${user2DistinctId}@example.com`,
+                            age: 30,
+                            test_name: testName,
+                        }),
+                    ])
+                )
+                expect(personsClickhouse.map((person) => person.properties)).toEqual(
                     expect.arrayContaining([
                         expect.objectContaining({
                             name: 'User 1',
@@ -1597,7 +1650,15 @@ describe('Event Pipeline E2E tests', () => {
         await waitForExpect(async () => {
             const persons = await fetchPostgresPersons(hub.db, team.id)
             expect(persons.length).toBe(1)
+            const personsClickhouse = await fetchPersons(hub, team.id)
+            expect(personsClickhouse.length).toBe(1)
             expect(persons[0].properties).toMatchObject(
+                expect.objectContaining({
+                    name: 'User 1',
+                    property_to_unset: 'value',
+                })
+            )
+            expect(personsClickhouse[0].properties).toMatchObject(
                 expect.objectContaining({
                     name: 'User 1',
                     property_to_unset: 'value',
@@ -1620,12 +1681,20 @@ describe('Event Pipeline E2E tests', () => {
         await waitForExpect(async () => {
             const persons = await fetchPostgresPersons(hub.db, team.id)
             expect(persons.length).toBe(1)
+            const personsClickhouse = await fetchPersons(hub, team.id)
+            expect(personsClickhouse.length).toBe(1)
             expect(persons[0].properties).toMatchObject(
                 expect.objectContaining({
                     name: 'User 1',
                 })
             )
             expect(persons[0].properties).not.toHaveProperty('property_to_unset')
+            expect(personsClickhouse[0].properties).toMatchObject(
+                expect.objectContaining({
+                    name: 'User 1',
+                })
+            )
+            expect(personsClickhouse[0].properties).not.toHaveProperty('property_to_unset')
         })
     })
 
@@ -1656,12 +1725,20 @@ describe('Event Pipeline E2E tests', () => {
         await waitForExpect(async () => {
             const persons = await fetchPostgresPersons(hub.db, team.id)
             expect(persons.length).toBe(1)
+            const personsClickhouse = await fetchPersons(hub, team.id)
+            expect(personsClickhouse.length).toBe(1)
             expect(persons[0].properties).toMatchObject(
                 expect.objectContaining({
                     name: 'User 1',
                 })
             )
             expect(persons[0].properties).not.toHaveProperty('property_to_unset')
+            expect(personsClickhouse[0].properties).toMatchObject(
+                expect.objectContaining({
+                    name: 'User 1',
+                })
+            )
+            expect(personsClickhouse[0].properties).not.toHaveProperty('property_to_unset')
         })
     })
 })

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -698,10 +698,11 @@ export class DB {
             'updatePersonAssertVersion'
         )
 
-        const updatedPerson = this.toPerson(rows[0])
         if (rows.length === 0) {
             return [undefined, []]
         }
+
+        const updatedPerson = this.toPerson(rows[0])
 
         const kafkaMessage = generateKafkaPersonUpdateMessage(updatedPerson)
 

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -673,8 +673,8 @@ export class DB {
         return [person, kafkaMessages]
     }
 
-    public async updatePersonAssertVersion(personUpdate: PersonUpdate): Promise<number | undefined> {
-        const result = await this.postgres.query<{ version: string }>(
+    public async updatePersonAssertVersion(personUpdate: PersonUpdate): Promise<[number | undefined, TopicMessage[]]> {
+        const { rows } = await this.postgres.query<RawPerson>(
             PostgresUse.PERSONS_WRITE,
             `
             UPDATE posthog_person SET
@@ -684,7 +684,7 @@ export class DB {
                 is_identified = $4,
                 version = COALESCE(version, 0)::numeric + 1
             WHERE team_id = $5 AND uuid = $6 AND version = $7
-            RETURNING version
+            RETURNING *
             `,
             [
                 JSON.stringify(personUpdate.properties),
@@ -698,11 +698,14 @@ export class DB {
             'updatePersonAssertVersion'
         )
 
-        if (result.rows.length === 0) {
-            return undefined
+        const updatedPerson = this.toPerson(rows[0])
+        if (rows.length === 0) {
+            return [undefined, []]
         }
 
-        return Number(result.rows[0].version || 0)
+        const kafkaMessage = generateKafkaPersonUpdateMessage(updatedPerson)
+
+        return [updatedPerson.version, [kafkaMessage]]
     }
 
     // Currently in use, but there are various problems with this function

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
@@ -222,7 +222,7 @@ describe('BatchWritingPersonStore', () => {
         const personStoreForBatch = assertVersionStore.forBatch()
 
         // Mock optimistic update to fail (version mismatch)
-        db.updatePersonAssertVersion = jest.fn().mockResolvedValue(undefined)
+        db.updatePersonAssertVersion = jest.fn().mockResolvedValue([undefined, []])
 
         // Add a person update to cache
         await personStoreForBatch.updatePersonWithPropertiesDiffForUpdate(
@@ -345,9 +345,9 @@ describe('BatchWritingPersonStore', () => {
         db.updatePersonAssertVersion = jest.fn().mockImplementation(() => {
             callCount++
             if (callCount < 3) {
-                return Promise.resolve(undefined) // version mismatch
+                return Promise.resolve([undefined, []]) // version mismatch
             }
-            return Promise.resolve(5) // success on 3rd try
+            return Promise.resolve([5, []]) // success on 3rd try
         })
 
         await personStoreForBatch.updatePersonWithPropertiesDiffForUpdate(
@@ -370,7 +370,7 @@ describe('BatchWritingPersonStore', () => {
         const personStoreForBatch = assertVersionStore.forBatch()
 
         // Mock to always fail optimistic updates
-        db.updatePersonAssertVersion = jest.fn().mockResolvedValue(undefined)
+        db.updatePersonAssertVersion = jest.fn().mockResolvedValue([undefined, []])
 
         await personStoreForBatch.updatePersonWithPropertiesDiffForUpdate(
             person,
@@ -396,7 +396,7 @@ describe('BatchWritingPersonStore', () => {
             properties: { existing_prop: 'existing_value', shared_prop: 'old_value' },
         }
 
-        db.updatePersonAssertVersion = jest.fn().mockResolvedValue(undefined) // Always fail
+        db.updatePersonAssertVersion = jest.fn().mockResolvedValue([undefined, []]) // Always fail, but we don't care about the version
         db.fetchPerson = jest.fn().mockResolvedValue(latestPerson)
 
         // Update with new properties
@@ -603,7 +603,7 @@ describe('BatchWritingPersonStore', () => {
                 const personStore = new BatchWritingPersonsStore(db, { dbWriteMode: 'ASSERT_VERSION' })
                 const personStoreForBatch = personStore.forBatch()
 
-                db.updatePersonAssertVersion = jest.fn().mockResolvedValue(5) // success
+                db.updatePersonAssertVersion = jest.fn().mockResolvedValue([5, []]) // success
 
                 await personStoreForBatch.updatePersonWithPropertiesDiffForUpdate(
                     person,
@@ -627,7 +627,7 @@ describe('BatchWritingPersonStore', () => {
                 const personStoreForBatch = personStore.forBatch()
 
                 // Mock to always fail optimistic updates
-                db.updatePersonAssertVersion = jest.fn().mockResolvedValue(undefined)
+                db.updatePersonAssertVersion = jest.fn().mockResolvedValue([undefined, []])
 
                 await personStoreForBatch.updatePersonWithPropertiesDiffForUpdate(
                     person,
@@ -791,7 +791,7 @@ describe('BatchWritingPersonStore', () => {
                 const person2 = { ...person, id: '2', uuid: '2' }
 
                 // Mock successful updates
-                db.updatePersonAssertVersion = jest.fn().mockResolvedValue(5)
+                db.updatePersonAssertVersion = jest.fn().mockResolvedValue([5, []])
 
                 await Promise.all([
                     noAssertBatch.updatePersonWithPropertiesDiffForUpdate(
@@ -850,8 +850,8 @@ describe('BatchWritingPersonStore', () => {
         // Completely replace the mock from beforeEach
         db.updatePersonAssertVersion = jest
             .fn()
-            .mockResolvedValueOnce(undefined) // First call fails (version mismatch)
-            .mockResolvedValueOnce(3) // Second call succeeds with new version
+            .mockResolvedValueOnce([undefined, []]) // First call fails (version mismatch)
+            .mockResolvedValueOnce([3, []]) // Second call succeeds with new version
 
         // Mock fetchPerson to return the updated person when called during conflict resolution
         db.fetchPerson = jest.fn().mockResolvedValue(updatedByOtherPod)

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -144,7 +144,6 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         }
 
         const limit = pLimit(this.options.maxConcurrentUpdates)
-        const allKafkaMessages: TopicMessage[] = []
 
         try {
             const results = await Promise.all(
@@ -260,7 +259,7 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
             )
 
             // Flatten all Kafka messages from all operations
-            results.forEach((messages) => allKafkaMessages.push(...messages))
+            const allKafkaMessages = results.flat()
 
             // Record successful flush
             const flushLatency = (performance.now() - flushStartTime) / 1000

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -125,7 +125,7 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         }
     }
 
-    async flush(): Promise<void> {
+    async flush(): Promise<TopicMessage[]> {
         const flushStartTime = performance.now()
         const updateEntries = Array.from(this.personUpdateCache.entries()).filter(
             (entry): entry is [string, PersonUpdate] => {
@@ -140,15 +140,16 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         if (batchSize === 0) {
             personFlushLatencyHistogram.observe({ db_write_mode: this.options.dbWriteMode }, 0)
             personFlushOperationsCounter.inc({ db_write_mode: this.options.dbWriteMode, outcome: 'success' })
-            return
+            return []
         }
 
         const limit = pLimit(this.options.maxConcurrentUpdates)
+        const allKafkaMessages: TopicMessage[] = []
 
         try {
-            await Promise.all(
+            const results = await Promise.all(
                 updateEntries.map(([cacheKey, update]) =>
-                    limit(async () => {
+                    limit(async (): Promise<TopicMessage[]> => {
                         try {
                             personWriteMethodAttemptCounter.inc({
                                 db_write_mode: this.options.dbWriteMode,
@@ -156,9 +157,11 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
                                 outcome: 'attempt',
                             })
 
+                            let kafkaMessages: TopicMessage[] = []
                             switch (this.options.dbWriteMode) {
                                 case 'NO_ASSERT':
-                                    await this.updatePersonNoAssert(update, 'batch')
+                                    const [_, messages] = await this.updatePersonNoAssert(update, 'batch')
+                                    kafkaMessages = messages
                                     break
                                 case 'ASSERT_VERSION':
                                     await promiseRetry(
@@ -169,6 +172,9 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
                                         undefined,
                                         [MessageSizeTooLarge]
                                     )
+                                    // ASSERT_VERSION updates the DB directly via updatePersonAssertVersion
+                                    // which creates Kafka messages internally, so we don't get messages back
+                                    kafkaMessages = []
                                     break
                                 case 'WITH_TRANSACTION':
                                     await promiseRetry(
@@ -179,6 +185,9 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
                                         undefined,
                                         [MessageSizeTooLarge]
                                     )
+                                    // WITH_TRANSACTION updates the DB directly via updatePerson
+                                    // which creates Kafka messages internally, so we don't get messages back
+                                    kafkaMessages = []
                                     break
                             }
 
@@ -187,6 +196,8 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
                                 method: this.options.dbWriteMode,
                                 outcome: 'success',
                             })
+
+                            return kafkaMessages
                         } catch (error) {
                             // If the Kafka message is too large, we can't retry, so we need to capture a warning and stop retrying
                             if (error instanceof MessageSizeTooLarge) {
@@ -204,7 +215,7 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
                                     method: this.options.dbWriteMode,
                                     outcome: 'error',
                                 })
-                                return
+                                return []
                             }
 
                             logger.warn('⚠️', 'Falling back to direct update after max retries', {
@@ -218,13 +229,15 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
                                 fallback_reason: 'max_retries',
                             })
 
-                            await this.updatePersonNoAssert(update, 'conflictRetry')
+                            const [_, fallbackMessages] = await this.updatePersonNoAssert(update, 'conflictRetry')
 
                             personWriteMethodAttemptCounter.inc({
                                 db_write_mode: this.options.dbWriteMode,
                                 method: 'fallback',
                                 outcome: 'success',
                             })
+
+                            return fallbackMessages
                         }
                     }).catch((error) => {
                         logger.error('Failed to update person after max retries and direct update fallback', {
@@ -247,10 +260,15 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
                 )
             )
 
+            // Flatten all Kafka messages from all operations
+            results.forEach((messages) => allKafkaMessages.push(...messages))
+
             // Record successful flush
             const flushLatency = (performance.now() - flushStartTime) / 1000
             personFlushLatencyHistogram.observe({ db_write_mode: this.options.dbWriteMode }, flushLatency)
             personFlushOperationsCounter.inc({ db_write_mode: this.options.dbWriteMode, outcome: 'success' })
+
+            return allKafkaMessages
         } catch (error) {
             // Record failed flush
             const flushLatency = (performance.now() - flushStartTime) / 1000

--- a/plugin-server/src/worker/ingestion/persons/measuring-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/measuring-person-store.ts
@@ -100,8 +100,8 @@ export class MeasuringPersonsStoreForBatch implements PersonsStoreForBatch {
         }
     }
 
-    flush(): Promise<void> {
-        return Promise.resolve()
+    flush(): Promise<TopicMessage[]> {
+        return Promise.resolve([])
     }
 
     reportBatch(): void {

--- a/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
@@ -498,8 +498,9 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
         }
     }
 
-    async flush(): Promise<void> {
+    async flush(): Promise<TopicMessage[]> {
         await Promise.resolve(this.compareFinalStates())
+        return []
     }
 
     compareFinalStates(): void {

--- a/plugin-server/src/worker/ingestion/persons/persons-store-for-batch.ts
+++ b/plugin-server/src/worker/ingestion/persons/persons-store-for-batch.ts
@@ -123,5 +123,5 @@ export interface PersonsStoreForBatch extends BatchWritingStore {
     /**
      * Flushes the batch
      */
-    flush(): Promise<void>
+    flush(): Promise<TopicMessage[]>
 }

--- a/plugin-server/src/worker/ingestion/stores/batch-writing-store.ts
+++ b/plugin-server/src/worker/ingestion/stores/batch-writing-store.ts
@@ -1,6 +1,9 @@
+import { TopicMessage } from '../../../kafka/producer'
+
 export interface BatchWritingStore {
     /*
      * Flushes all batch data that needs to be written
+     * Returns Kafka messages that need to be sent
      */
-    flush(): Promise<void>
+    flush(): Promise<TopicMessage[]>
 }

--- a/plugin-server/tests/helpers/sql.ts
+++ b/plugin-server/tests/helpers/sql.ts
@@ -278,6 +278,7 @@ export async function createUserTeamAndOrganization(
         available_product_features: [],
         domain_whitelist: [],
         is_member_join_email_enabled: false,
+        members_can_use_personal_api_keys: true,
         slug: new UUIDT().toString(),
     } as RawOrganization)
     await updateOrganizationAvailableFeatures(db, organizationId, [{ key: 'data_pipelines', name: 'Data Pipelines' }])
@@ -388,7 +389,7 @@ export const createOrganization = async (pg: PostgresRouter) => {
         setup_section_2_completed: true, // DEPRECATED
         for_internal_metrics: false,
         available_product_features: [],
-        members_can_use_personal_api_keys: false,
+        members_can_use_personal_api_keys: true,
         domain_whitelist: [],
         is_member_join_email_enabled: false,
         slug: new UUIDT().toString(),

--- a/plugin-server/tests/helpers/sql.ts
+++ b/plugin-server/tests/helpers/sql.ts
@@ -388,6 +388,7 @@ export const createOrganization = async (pg: PostgresRouter) => {
         setup_section_2_completed: true, // DEPRECATED
         for_internal_metrics: false,
         available_product_features: [],
+        members_can_use_personal_api_keys: false,
         domain_whitelist: [],
         is_member_join_email_enabled: false,
         slug: new UUIDT().toString(),


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Because the person update method in `db.ts` does not directly produce to kafka, we were not producing personUpdates to kafka on updates when in Batch mode. This PR fixes it

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
