### PR TITLE
fix(flags): TypeError when groups is null

### DIFF
--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
@@ -31,7 +31,7 @@ import {
     UserBlastRadiusType,
 } from '~/types'
 
-import type { featureFlagReleaseConditionsLogicType } from './FeatureFlagReleaseConditionsLogicType'
+import type { featureFlagReleaseConditionsLogicType } from './featureFlagReleaseConditionsLogicType'
 
 // Helper function to move a condition set to a new index
 function moveConditionSet<T>(groups: T[], index: number, newIndex: number): T[] {

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
@@ -31,7 +31,7 @@ import {
     UserBlastRadiusType,
 } from '~/types'
 
-import type { featureFlagReleaseConditionsLogicType } from './featureFlagReleaseConditionsLogicType'
+import type { featureFlagReleaseConditionsLogicType } from './FeatureFlagReleaseConditionsLogicType'
 
 // Helper function to move a condition set to a new index
 function moveConditionSet<T>(groups: T[], index: number, newIndex: number): T[] {
@@ -55,7 +55,7 @@ export interface FeatureFlagReleaseConditionsLogicProps {
 function ensureSortKeys(filters: FeatureFlagFilters): FeatureFlagFilters {
     return {
         ...filters,
-        groups: filters.groups.map((group: FeatureFlagGroupType) => ({
+        groups: (filters.groups || []).map((group: FeatureFlagGroupType) => ({
             ...group,
             sort_key: group.sort_key ?? uuidv4(),
         })),
@@ -102,7 +102,7 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
         filters: {
             setFilters: (_, { filters }) => {
                 // Only assign sort_keys to groups that don't have one
-                const groupsWithKeys = filters.groups.map((group: FeatureFlagGroupType) => {
+                const groupsWithKeys = (filters.groups || []).map((group: FeatureFlagGroupType) => {
                     if (group.sort_key) {
                         return group
                     }


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
This specific flag doesn't load on the frontend: https://us.posthog.com/project/2/feature_flags/73259. There appears to be nothing wrong with the flag when I inspect it in [metabase](https://metabase.prod-us.posthog.dev/question/1436-73259) and refreshing the page seems to make the flag load sometimes. 

I wasn't able to reproduce the error locally, but in prod I can see this error in the console

```
TypeError: Cannot read properties of null (reading 'map')
    at Sr (https://app-static-prod.posthog.com/static/chunk-WKAUQGH4.js:1:7514)
    at Pe (https://app-static-prod.posthog.com/static/chunk-WKAUQGH4.js:1:7446)
    at Object.loadFeatureFlagSuccess (https://app-static-prod.posthog.com/static/chunk-WKAUQGH4.js:1:11622)
    at Object.keys.length.t.reducers.<computed> (https://app-static-prod.posthog.com/static/chunk-6S6VVGPR.js:2:20372)
    at https://app-static-prod.posthog.com/static/chunk-6S6VVGPR.js:2:3566
    at e.reducer (https://app-static-prod.posthog.com/static/chunk-6S6VVGPR.js:2:18553)
    at https://app-static-prod.posthog.com/static/chunk-6S6VVGPR.js:2:3566
    at https://app-static-prod.posthog.com/static/chunk-6S6VVGPR.js:2:3566
    at https://app-static-prod.posthog.com/static/chunk-6S6VVGPR.js:2:3566
    at Object.combined (https://app-static-prod.posthog.com/static/chunk-6S6VVGPR.js:2:3566)
```

I think it's possible that `filters.groups` is null 
## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->
- [x] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
