### PR TITLE
fix(experiments): fix experiment form button padding

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm.tsx
@@ -316,7 +316,7 @@ const ExperimentFormFields = (): JSX.Element => {
                                 </div>
                             </div>
                         </div>
-                        <div className="mt-10 max-w-150">
+                        <div className="mt-10 pb-6 max-w-150">
                             <LemonField name="parameters.ensure_experience_continuity">
                                 {({ value, onChange }) => (
                                     <div className="border rounded p-4">


### PR DESCRIPTION
## Changes
Add padding before the "Save as draft" button to maintain consistent vertical spacing between form elements.

## How did you test this code?
|Before|After|
|----|----|
|<img width="626" alt="image" src="https://github.com/user-attachments/assets/93ed5f92-5017-4599-b6ee-9fe4f8fd0f4a" />|<img width="627" alt="image" src="https://github.com/user-attachments/assets/2818790f-4ea9-4c28-bcc6-5456adacbb3d" />|