### PR TITLE
fix(batch-exports): Fix "Integer exceeds 64-bit range" error

### DIFF
--- a/products/batch_exports/backend/temporal/temporary_file.py
+++ b/products/batch_exports/backend/temporal/temporary_file.py
@@ -39,7 +39,11 @@ def replace_broken_unicode(obj):
 def json_dumps_bytes(d) -> bytes:
     try:
         return orjson.dumps(d, default=str)
-    except orjson.JSONEncodeError:
+    except orjson.JSONEncodeError as e:
+        if str(e) == "Integer exceeds 64-bit range":
+            # orjson doesn't support integers exceeding 64-bit range, so we fall back to json.dumps
+            # see https://github.com/ijl/orjson/issues/301
+            return json.dumps(d, default=str).encode("utf-8")
         # orjson is very strict about invalid unicode. This slow path protects us against
         # things we've observed in practice, like single surrogate codes, e.g. "\ud83d"
         logger.exception("Failed to encode with orjson: %s", d)

--- a/products/batch_exports/backend/temporal/temporary_file.py
+++ b/products/batch_exports/backend/temporal/temporary_file.py
@@ -41,6 +41,7 @@ def json_dumps_bytes(d) -> bytes:
         return orjson.dumps(d, default=str)
     except orjson.JSONEncodeError as e:
         if str(e) == "Integer exceeds 64-bit range":
+            logger.warning("Failed to encode with orjson: Integer exceeds 64-bit range: %s", d)
             # orjson doesn't support integers exceeding 64-bit range, so we fall back to json.dumps
             # see https://github.com/ijl/orjson/issues/301
             return json.dumps(d, default=str).encode("utf-8")

--- a/products/batch_exports/backend/temporal/transformer.py
+++ b/products/batch_exports/backend/temporal/transformer.py
@@ -317,6 +317,7 @@ def dump_dict(d: dict[str, typing.Any]) -> bytes:
                 logger.exception("Orjson detected a deeply nested dict: %s", d)
                 dumped = json.dumps(d, default=str).encode("utf-8") + b"\n"
         elif str(err) == "Integer exceeds 64-bit range":
+            logger.warning("Failed to encode with orjson: Integer exceeds 64-bit range: %s", d)
             # Orjson doesn't support integers exceeding 64-bit range, so we fall back to json.dumps
             # see https://github.com/ijl/orjson/issues/301
             dumped = json.dumps(d, default=str).encode("utf-8") + b"\n"

--- a/products/batch_exports/backend/temporal/transformer.py
+++ b/products/batch_exports/backend/temporal/transformer.py
@@ -327,7 +327,7 @@ def dump_dict(d: dict[str, typing.Any]) -> bytes:
             # "\ud83d"
             logger.exception("Failed to encode with orjson: %s", d)
             cleaned_content = replace_broken_unicode(d)
-            dumped = dump_dict(cleaned_content)  # type: ignore
+            dumped = dump_dict(cleaned_content)
 
     return dumped
 

--- a/products/batch_exports/backend/temporal/transformer.py
+++ b/products/batch_exports/backend/temporal/transformer.py
@@ -309,20 +309,24 @@ def dump_dict(d: dict[str, typing.Any]) -> bytes:
                     logger.exception("PostHog $web_vitals event didn't match expected structure")
                     dumped = json.dumps(d, default=str).encode("utf-8") + b"\n"
                 else:
-                    dumped = orjson.dumps(d, default=str) + b"\n"
+                    dumped = dump_dict(d)
 
             else:
                 # In this case, we fallback to the slower but more permissive stdlib
                 # json.
                 logger.exception("Orjson detected a deeply nested dict: %s", d)
                 dumped = json.dumps(d, default=str).encode("utf-8") + b"\n"
+        elif str(err) == "Integer exceeds 64-bit range":
+            # Orjson doesn't support integers exceeding 64-bit range, so we fall back to json.dumps
+            # see https://github.com/ijl/orjson/issues/301
+            dumped = json.dumps(d, default=str).encode("utf-8") + b"\n"
         else:
             # Orjson is very strict about invalid unicode. This slow path protects us
             # against things we've observed in practice, like single surrogate codes, e.g.
             # "\ud83d"
             logger.exception("Failed to encode with orjson: %s", d)
             cleaned_content = replace_broken_unicode(d)
-            dumped = orjson.dumps(cleaned_content, default=str) + b"\n"
+            dumped = dump_dict(cleaned_content)  # type: ignore
 
     return dumped
 
@@ -336,17 +340,6 @@ def replace_broken_unicode(obj):
         return {replace_broken_unicode(key): replace_broken_unicode(value) for key, value in obj.items()}
     else:
         return obj
-
-
-def json_dumps_bytes(d) -> bytes:
-    try:
-        return orjson.dumps(d, default=str)
-    except orjson.JSONEncodeError:
-        # orjson is very strict about invalid unicode. This slow path protects us against
-        # things we've observed in practice, like single surrogate codes, e.g. "\ud83d"
-        logger.exception("Failed to encode with orjson: %s", d)
-        cleaned_d = replace_broken_unicode(d)
-        return orjson.dumps(cleaned_d, default=str)
 
 
 class ParquetStreamTransformer:

--- a/products/batch_exports/backend/tests/temporal/test_temporary_file.py
+++ b/products/batch_exports/backend/tests/temporal/test_temporary_file.py
@@ -536,3 +536,30 @@ async def test_jsonl_writer_deals_with_nested_user_events():
     assert date_ranges_seen == [
         (record_batch.column("_inserted_at")[0].as_py(), record_batch.column("_inserted_at")[-1].as_py())
     ]
+
+
+@pytest.mark.parametrize(
+    "input_dict, expected_output",
+    [
+        ({"large_integer": 12345678901234567890987654321}, b'{"large_integer": 12345678901234567890987654321}'),
+        (
+            {"large_integer_nested": {"large_integer": 12345678901234567890987654321}},
+            b'{"large_integer_nested": {"large_integer": 12345678901234567890987654321}}',
+        ),
+        (
+            {"large_integer_array": [12345678901234567890987654321]},
+            b'{"large_integer_array": [12345678901234567890987654321]}',
+        ),
+        (
+            {"large_integer_nested": [{"large_integer_array": [12345678901234567890987654321]}]},
+            b'{"large_integer_nested": [{"large_integer_array": [12345678901234567890987654321]}]}',
+        ),
+    ],
+)
+def test_json_dumps_bytes_handles_integers_exceeding_64_bit_range(input_dict, expected_output):
+    """Test json_dumps_bytes handles integers exceeding 64-bit range."""
+    result = json_dumps_bytes(input_dict)
+    assert result == expected_output
+    assert isinstance(result, bytes)
+    # check the reverse direction
+    assert json.loads(result) == input_dict

--- a/products/batch_exports/backend/tests/temporal/test_transformer.py
+++ b/products/batch_exports/backend/tests/temporal/test_transformer.py
@@ -1,0 +1,55 @@
+import json
+import typing
+
+import pytest
+
+from products.batch_exports.backend.temporal.transformer import dump_dict
+
+
+def create_deeply_nested_dict(depth: int, value: str = "test") -> typing.Any:
+    """Create a dict with specified nesting depth."""
+    result = value
+    for _ in range(depth):
+        result = {"nested": result}
+    return result
+
+
+@pytest.mark.parametrize(
+    "input_dict, expected_output",
+    [
+        # orjson doesn't support integers exceeding 64-bit range, so ensure we fall back to json.dumps correctly
+        ({"large_integer": 12345678901234567890987654321}, b'{"large_integer": 12345678901234567890987654321}\n'),
+        # Complex nested case with datetime and various types
+        (
+            {
+                "timestamp": "2023-01-01T12:00:00Z",
+                "nested": {
+                    "array": [1, 2, 3],
+                    "big_num": 12345678901234567890987654321,
+                    "null_value": None,
+                    "bool_value": True,
+                    "unicode": "Hello 👋 世界",
+                },
+                "list_of_objects": [{"id": 1, "value": "first"}, {"id": 2, "value": "second"}],
+            },
+            b'{"timestamp": "2023-01-01T12:00:00Z", "nested": {"array": [1, 2, 3], "big_num": 12345678901234567890987654321, "null_value": null, "bool_value": true, "unicode": "Hello \\ud83d\\udc4b \\u4e16\\u754c"}, "list_of_objects": [{"id": 1, "value": "first"}, {"id": 2, "value": "second"}]}\n',
+        ),
+    ],
+)
+def test_dump_dict(input_dict, expected_output):
+    """Test json_dumps_bytes handles integers exceeding 64-bit range."""
+    result = dump_dict(input_dict)
+    assert result == expected_output
+    assert isinstance(result, bytes)
+    # check the reverse direction
+    assert json.loads(result) == input_dict
+
+
+def test_dump_dict_with_deeply_nested_dict():
+    """Test dump_dict with a deeply nested dict."""
+    deeply_nested_dict = create_deeply_nested_dict(300)
+    result = dump_dict(deeply_nested_dict)
+    assert result == json.dumps(deeply_nested_dict, default=str).encode("utf-8") + b"\n"
+    assert isinstance(result, bytes)
+    # check the reverse direction
+    assert json.loads(result) == deeply_nested_dict


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

When exporting JSON, we run into errors if any integers exceed the 64-bit range

## Changes

- Update JSON dumping in `products/batch_exports/backend/temporal/temporary_file.py` which is where the error in question is happening
- Apply same fix in `products/batch_exports/backend/temporal/transformer.py` (also make the `dump_dict` function recursive since we could run into multiple issues within the same JSON object)

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Added tests
