### PR TITLE
fix: filter for only active users

### DIFF
--- a/ee/api/rbac/access_control.py
+++ b/ee/api/rbac/access_control.py
@@ -215,7 +215,7 @@ class AccessControlViewSetMixin(_GenericViewSet):
         obj = self.get_object()
 
         org_memberships = (
-            OrganizationMembership.objects.filter(organization=team.organization)
+            OrganizationMembership.objects.filter(organization=team.organization, user__is_active=True)
             .select_related("user")
             .prefetch_related("role_memberships__role")
         )

--- a/ee/api/rbac/test/test_access_control.py
+++ b/ee/api/rbac/test/test_access_control.py
@@ -460,6 +460,35 @@ class TestUsersWithAccessAPI(BaseAccessControlTest):
         assert data["total_count"] == 1
         assert data["users"][0]["user_id"] == str(self.user.uuid)
 
+    def test_only_active_users_included(self):
+        """Test that only active users are included in the users_with_access endpoint"""
+        self._org_membership(OrganizationMembership.Level.ADMIN)
+
+        # Create an inactive user and add them to the organization
+        inactive_user = self._create_user("inactive_user@example.com")
+        inactive_user.is_active = False
+        inactive_user.save()
+
+        OrganizationMembership.objects.create(
+            organization=self.organization, user=inactive_user, level=OrganizationMembership.Level.MEMBER
+        )
+
+        # Get users with access
+        res = self._get_users_with_access()
+        assert res.status_code == status.HTTP_200_OK, res.json()
+
+        data = res.json()
+        user_ids = [user["user_id"] for user in data["users"]]
+
+        # Verify inactive user is not included
+        assert str(inactive_user.uuid) not in user_ids
+
+        # Verify active users are still included
+        assert str(self.user.uuid) in user_ids
+        assert str(self.user2.uuid) in user_ids
+        assert str(self.user3.uuid) in user_ids
+        assert str(self.user4.uuid) in user_ids
+
 
 class TestGlobalAccessControlsPermissions(BaseAccessControlTest):
     def setUp(self):

--- a/ee/api/rbac/test/test_access_control.py
+++ b/ee/api/rbac/test/test_access_control.py
@@ -469,10 +469,6 @@ class TestUsersWithAccessAPI(BaseAccessControlTest):
         inactive_user.is_active = False
         inactive_user.save()
 
-        OrganizationMembership.objects.create(
-            organization=self.organization, user=inactive_user, level=OrganizationMembership.Level.MEMBER
-        )
-
         # Get users with access
         res = self._get_users_with_access()
         assert res.status_code == status.HTTP_200_OK, res.json()


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changes

We want to make sure only active members are included in the user with access endpoint. 

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

Added a test 
