### PR TITLE
chore: Update external logs when finishing batch export

### DIFF
--- a/products/batch_exports/backend/temporal/batch_exports.py
+++ b/products/batch_exports/backend/temporal/batch_exports.py
@@ -27,7 +27,11 @@ from posthog.settings.base_variables import TEST
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.clickhouse import ClickHouseClient
 from posthog.temporal.common.client import connect
-from posthog.temporal.common.logger import bind_contextvars, get_logger
+from posthog.temporal.common.logger import (
+    bind_contextvars,
+    get_external_logger,
+    get_logger,
+)
 from products.batch_exports.backend.temporal.metrics import (
     get_export_finished_metric,
     get_export_started_metric,
@@ -43,7 +47,8 @@ from products.batch_exports.backend.temporal.sql import (
     SELECT_FROM_EVENTS_VIEW_UNBOUNDED,
 )
 
-LOGGER = get_logger()
+LOGGER = get_logger(__name__)
+EXTERNAL_LOGGER = get_external_logger()
 
 BytesGenerator = collections.abc.Generator[bytes, None, None]
 RecordsGenerator = collections.abc.Generator[pa.RecordBatch, None, None]
@@ -419,6 +424,7 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
     """
     bind_contextvars(team_id=inputs.team_id, batch_export_id=inputs.batch_export_id, status=inputs.status)
     logger = LOGGER.bind()
+    external_logger = EXTERNAL_LOGGER.bind()
 
     not_model_params = ("id", "team_id", "batch_export_id", "failure_threshold", "failure_check_window")
     update_params = {
@@ -441,10 +447,23 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
     )
 
     if batch_export_run.status == BatchExportRun.Status.FAILED_RETRYABLE:
-        logger.error("Batch export failed with error: %s", batch_export_run.latest_error)
+        # We should never get here as we do not have a retry limit.
+        # So, users should never be asked to retry for things we can retry ourselves.
+        # However, I am covering my bases if something like that indeed happens.
+        external_logger.error(
+            "Batch export for range %s - %s failed with an error that can be retried: %s",
+            batch_export_run.data_interval_start or "START",
+            batch_export_run.data_interval_end or "END",
+            batch_export_run.latest_error,
+        )
 
     elif batch_export_run.status == BatchExportRun.Status.FAILED:
-        logger.error("Batch export failed with non-recoverable error: %s", batch_export_run.latest_error)
+        external_logger.error(
+            "Batch export for range %s - %s failed with a non-recoverable error: %s",
+            batch_export_run.data_interval_start or "START",
+            batch_export_run.data_interval_end or "END",
+            batch_export_run.latest_error,
+        )
 
         from posthog.tasks.email import send_batch_export_run_failure
 
@@ -453,7 +472,7 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
         except Exception:
             logger.exception("Failure email notification could not be sent")
         else:
-            logger.info("Failure notification email for run %s has been sent", inputs.id)
+            external_logger.info("Failure notification email for run '%s' has been sent", inputs.id)
 
         is_over_failure_threshold = await check_if_over_failure_threshold(
             inputs.batch_export_id,
@@ -473,7 +492,7 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
             logger.exception("Batch export could not be automatically paused")
         else:
             if was_paused:
-                logger.warning(
+                external_logger.warning(
                     "Batch export was automatically paused due to exceeding failure threshold and exhausting "
                     "all automated retries."
                     "The batch export can be unpaused after addressing any errors."
@@ -484,10 +503,10 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
                 inputs.batch_export_id,
             )
         except Exception:
-            logger.aexception("Ongoing backfills could not be automatically cancelled")
+            logger.exception("Ongoing backfills could not be automatically cancelled")
         else:
             if total_cancelled > 0:
-                logger.warning(
+                external_logger.warning(
                     f"{total_cancelled} ongoing batch export backfill{'s' if total_cancelled > 1 else ''} "
                     f"{'were' if total_cancelled > 1 else 'was'} cancelled due to exceeding failure threshold "
                     " and exhausting all automated retries."
@@ -495,13 +514,18 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
                 )
 
     elif batch_export_run.status == BatchExportRun.Status.CANCELLED:
-        logger.warning("Batch export was cancelled")
+        external_logger.warning(
+            "Batch export for range %s - %s was cancelled",
+            batch_export_run.data_interval_start or "START",
+            batch_export_run.data_interval_end or "END",
+        )
 
     else:
-        logger.info(
-            "Successfully finished exporting batch %s - %s",
-            batch_export_run.data_interval_start,
-            batch_export_run.data_interval_end,
+        external_logger.info(
+            "Batch export for range %s - %s finished successfully with %d records exported",
+            batch_export_run.data_interval_start or "START",
+            batch_export_run.data_interval_end or "END",
+            inputs.records_completed,
         )
 
 

--- a/products/batch_exports/backend/temporal/batch_exports.py
+++ b/products/batch_exports/backend/temporal/batch_exports.py
@@ -522,10 +522,10 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
 
     else:
         external_logger.info(
-            "Batch export for range %s - %s finished successfully with %d records exported",
+            "Batch export for range %s - %s finished successfully with %s records exported",
             batch_export_run.data_interval_start or "START",
             batch_export_run.data_interval_end or "END",
-            inputs.records_completed,
+            inputs.records_completed if inputs.records_completed is not None else "no",
         )
 
 

--- a/products/batch_exports/backend/temporal/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/bigquery_batch_export.py
@@ -712,7 +712,7 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
         record_batch_schema = await wait_for_schema_or_producer(queue, producer_task)
         if record_batch_schema is None:
             external_logger.info(
-                "Batch export finished as there is no data in range %s - %s matching specified filters",
+                "Batch export will finish early as there is no data matching specified filters in range %s - %s",
                 inputs.data_interval_start or "START",
                 inputs.data_interval_end or "END",
             )
@@ -855,13 +855,6 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
                                 update_key=update_key,
                                 stage_fields_cast_to_json=json_columns,
                             )
-
-        external_logger.info(
-            "Batch export for range %s - %s finished with %d records exported",
-            inputs.data_interval_start or "START",
-            inputs.data_interval_end or "END",
-            details.records_completed,
-        )
 
         return details.records_completed
 

--- a/products/batch_exports/backend/temporal/postgres_batch_export.py
+++ b/products/batch_exports/backend/temporal/postgres_batch_export.py
@@ -658,7 +658,7 @@ async def insert_into_postgres_activity(inputs: PostgresInsertInputs) -> Records
         record_batch_schema = await wait_for_schema_or_producer(queue, producer_task)
         if record_batch_schema is None:
             external_logger.info(
-                "Batch export finished as there is no data in range %s - %s matching specified filters",
+                "Batch export will finish early as there is no data matching specified filters in range %s - %s",
                 inputs.data_interval_start or "START",
                 inputs.data_interval_end or "END",
             )
@@ -798,13 +798,6 @@ async def insert_into_postgres_activity(inputs: PostgresInsertInputs) -> Records
                             merge_key=merge_key,
                             update_key=update_key,
                         )
-
-                external_logger.info(
-                    "Batch export for range %s - %s finished with %d records exported",
-                    inputs.data_interval_start or "START",
-                    inputs.data_interval_end or "END",
-                    details.records_completed,
-                )
 
                 return details.records_completed
 

--- a/products/batch_exports/backend/temporal/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/redshift_batch_export.py
@@ -419,7 +419,7 @@ async def insert_into_redshift_activity(inputs: RedshiftInsertInputs) -> Records
         record_batch_schema = await wait_for_schema_or_producer(queue, producer_task)
         if record_batch_schema is None:
             external_logger.info(
-                "Batch export finished as there is no data in range %s - %s matching specified filters",
+                "Batch export will finish early as there is no data matching specified filters in range %s - %s",
                 inputs.data_interval_start or "START",
                 inputs.data_interval_end or "END",
             )
@@ -549,13 +549,6 @@ async def insert_into_redshift_activity(inputs: RedshiftInsertInputs) -> Records
                             merge_key=merge_key,
                             update_key=update_key,
                         )
-
-                external_logger.info(
-                    "Batch export for range %s - %s finished with %d records exported",
-                    inputs.data_interval_start or "START",
-                    inputs.data_interval_end or "END",
-                    details.records_completed,
-                )
 
                 return details.records_completed
 

--- a/products/batch_exports/backend/temporal/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/s3_batch_export.py
@@ -1004,7 +1004,7 @@ async def insert_into_s3_activity_from_stage(inputs: S3InsertInputs) -> RecordsC
         record_batch_schema = await wait_for_schema_or_producer(queue, producer_task)
         if record_batch_schema is None:
             external_logger.info(
-                "Batch export finished as there is no data in range %s - %s matching specified filters",
+                "Batch export will finish early as there is no data matching specified filters in range %s - %s",
                 inputs.data_interval_start or "START",
                 inputs.data_interval_end or "END",
             )
@@ -1038,13 +1038,6 @@ async def insert_into_s3_activity_from_stage(inputs: S3InsertInputs) -> RecordsC
             include_inserted_at=True,
             max_file_size_bytes=inputs.max_file_size_mb * 1024 * 1024 if inputs.max_file_size_mb else 0,
             json_columns=("properties", "person_properties", "set", "set_once"),
-        )
-
-        external_logger.info(
-            "Batch export for range %s - %s finished with %d records exported",
-            inputs.data_interval_start or "START",
-            inputs.data_interval_end or "END",
-            records_completed,
         )
 
         return records_completed

--- a/products/batch_exports/backend/temporal/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/snowflake_batch_export.py
@@ -848,7 +848,7 @@ async def insert_into_snowflake_activity(inputs: SnowflakeInsertInputs) -> Recor
         record_batch_schema = await wait_for_schema_or_producer(queue, producer_task)
         if record_batch_schema is None:
             external_logger.info(
-                "Batch export finished as there is no data in range %s - %s matching specified filters",
+                "Batch export will finish early as there is no data matching specified filters in range %s - %s",
                 inputs.data_interval_start or "START",
                 inputs.data_interval_end or "END",
             )
@@ -958,13 +958,6 @@ async def insert_into_snowflake_activity(inputs: SnowflakeInsertInputs) -> Recor
                             merge_key=merge_key,
                             update_key=update_key,
                         )
-
-        external_logger.info(
-            "Batch export for range %s - %s finished with %d records exported",
-            inputs.data_interval_start or "START",
-            inputs.data_interval_end or "END",
-            details.records_completed,
-        )
 
         return details.records_completed
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

A couple things being tackled here:
* We have redundant logs: Both the `insert_into_*` activities and the `finish_batch_export_run` activity log the end of a batch export.
* Some logs in `finish_batch_export_run` should be external.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

* Removed end log from `insert_into_*` activities and left it up to `finish_batch_export_run` to report.
* Made some logs in that activity external.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
