### PR TITLE
fix: email renders in CI

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -725,9 +725,9 @@ jobs:
               uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
               if: needs.changes.outputs.backend == 'true' && matrix.segment == 'Core' && !matrix.person-on-events
               with:
-                  name: email_renders-${{ matrix.segment }}-${{ matrix.person-on-events }}
+                  name: email_renders-${{ github.sha }}-${{ github.run_attempt }}-${{ matrix.segment }}-${{ matrix.person-on-events }}-${{ matrix.group }}
                   path: posthog/tasks/test/__emails__
-                  retention-days: 5
+                  retention-days: 1
 
     async-migrations:
         name: Async migrations tests -  ${{ matrix.clickhouse-server-image }}


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We get conflict errors on this, let's scope it and reduce the retention period since these are rarely used.

## Changes

- Scope the archive to the commit + run attempt + group + segment + poe
