### PR TITLE
chore: Enable external logger in batch exports local worker

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -20,6 +20,8 @@ procs:
     temporal-worker-batch-exports:
         # added a sleep to give the docker stuff time to start
         shell: 'bin/check_kafka_clickhouse_up && bin/check_temporal_up && python manage.py start_temporal_worker --task-queue batch-exports-task-queue --metrics-port 8002'
+        env:
+            TEMPORAL_USE_EXTERNAL_LOGGER: 'true'
 
     temporal-worker-data-warehouse:
         shell: 'bin/check_kafka_clickhouse_up && bin/check_temporal_up && python manage.py start_temporal_worker --task-queue data-warehouse-task-queue --metrics-port 8003'


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We need logs to be correctly configured for batch exports worker in local development, otherwise the metrics logger fails.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Set `TEMPORAL_USE_EXTERNAL_LOGGER` to true for batch exports local worker.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
