### PR TITLE
chore: Move metrics logging to new loggers

### DIFF
--- a/products/batch_exports/backend/temporal/metrics.py
+++ b/products/batch_exports/backend/temporal/metrics.py
@@ -6,7 +6,9 @@ import structlog
 from temporalio import activity, workflow
 from temporalio.common import MetricCounter
 
-from posthog.temporal.common.logger import get_internal_logger
+from posthog.temporal.common.logger import get_logger
+
+LOGGER = get_logger(__name__)
 
 
 def get_rows_exported_metric() -> MetricCounter:
@@ -109,8 +111,7 @@ class ExecutionTimeRecorder:
         try:
             hist.record(value=delta)
         except Exception:
-            logger = get_internal_logger()
-            logger.exception("Failed to record execution time to histogram '%s'", self.histogram_name)
+            LOGGER.exception("Failed to record execution time to histogram '%s'", self.histogram_name)
 
         if self.log:
             log_execution_time(
@@ -201,8 +202,6 @@ def log_execution_time(
     extra_arguments: Attributes | None = None,
 ):
     """Log execution time."""
-    logger = get_internal_logger()
-
     duration_seconds = delta.total_seconds()
 
     if bytes_processed is not None:
@@ -232,9 +231,9 @@ def log_execution_time(
         arguments = {**arguments, **extra_arguments}
 
     try:
-        logger.info(log_message, arguments)
+        LOGGER.info(log_message, arguments)
     except:
-        logger.exception(
+        LOGGER.exception(
             "Failed to log execution time with attributes '%s' and configuration '%s'",
             arguments,
             structlog.get_config(),


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

New loggers should be used by metrics, they are not.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Use new logger in metrics.py.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
