### PR TITLE
fix: don't show recording annotations on insights

### DIFF
--- a/frontend/src/lib/components/AnnotationsOverlay/annotationsOverlayLogic.ts
+++ b/frontend/src/lib/components/AnnotationsOverlay/annotationsOverlayLogic.ts
@@ -152,6 +152,7 @@ export const annotationsOverlayLogic = kea<annotationsOverlayLogicType>([
                     dateRange
                         ? annotations.filter(
                               (annotation) =>
+                                  annotation.scope !== AnnotationScope.Recording &&
                                   (annotation.scope !== AnnotationScope.Insight ||
                                       annotation.dashboard_item === insightNumericId) &&
                                   (annotation.scope !== AnnotationScope.Dashboard ||


### PR DESCRIPTION
we should only show recording annotations if the sessions are in the result set maybe...
but for now let's remove the recording annotations from insights