### PR TITLE
fix(persons): Fix updatePersonNoAssert Retries

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
@@ -593,7 +593,7 @@ describe('BatchWritingPersonStore', () => {
                 )
 
                 await expect(personStoreForBatch.flush()).rejects.toThrow('Database error')
-                expect(db.updatePerson).toHaveBeenCalledTimes(2) // 1 for update, 1 for fallback
+                expect(db.updatePerson).toHaveBeenCalledTimes(6) // 5 for update, 1 for fallback
                 expect(db.updatePersonAssertVersion).not.toHaveBeenCalled()
             })
         })

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -159,7 +159,14 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
                             let kafkaMessages: TopicMessage[] = []
                             switch (this.options.dbWriteMode) {
                                 case 'NO_ASSERT': {
-                                    const [_, messages] = await this.updatePersonNoAssert(update, 'batch')
+                                    const [_, messages] = await promiseRetry(
+                                        () => this.updatePersonNoAssert(update, 'batch'),
+                                        'updatePersonNoAssert',
+                                        this.options.maxOptimisticUpdateRetries,
+                                        this.options.optimisticUpdateRetryInterval,
+                                        undefined,
+                                        [MessageSizeTooLarge]
+                                    )
                                     kafkaMessages = messages
                                     break
                                 }


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

updatePersonNoAssert was missing proper retry logic, unlike other methods

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
