### PR TITLE
fix: default icons for database tree

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTreeUtils.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTreeUtils.tsx
@@ -93,8 +93,8 @@ export const TreeNodeDisplayIcon = ({
     const isFile = item.record?.type === 'file'
     let iconElement: React.ReactNode = item.icon || defaultNodeIcon || <div />
 
-    // use provided icon as the default icon for folder nodes
-    if (isFolder) {
+    // use provided icon as the default icon for source folder nodes
+    if (isFolder && item.record?.type !== 'source-folder') {
         iconElement = defaultFolderIcon ? defaultFolderIcon : isOpen ? <IconFolderOpenFilled /> : <IconFolder />
     }
 

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTreeUtils.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTreeUtils.tsx
@@ -86,15 +86,13 @@ export const TreeNodeDisplayIcon = ({
     size = 'default',
 }: TreeNodeDisplayIconProps): JSX.Element => {
     const isOpen = expandedItemIds.includes(item.id)
-    const isFolder =
-        (item.record?.type === 'folder' || (item.children && item.children.length > 0)) &&
-        item.record?.type !== 'sources'
+    const isFolder = item.record?.type === 'folder' || (item.children && item.children.length > 0)
     const isEmptyFolder = item.type === 'empty-folder'
     const isFile = item.record?.type === 'file'
     let iconElement: React.ReactNode = item.icon || defaultNodeIcon || <div />
 
     // use provided icon as the default icon for source folder nodes
-    if (isFolder && item.record?.type !== 'source-folder') {
+    if (isFolder && !['sources', 'source-folder', 'table', 'view'].includes(item.record?.type)) {
         iconElement = defaultFolderIcon ? defaultFolderIcon : isOpen ? <IconFolderOpenFilled /> : <IconFolder />
     }
 


### PR DESCRIPTION
## Problem

- #34745 reverted database tree icons

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- database tree icons should be visible but on hover folder dropdown icons should be used

<!-- If there are frontend changes, please include screenshots. -->


https://github.com/user-attachments/assets/943afd5e-3fe1-4838-9e1d-883669c140b9




<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
