### PR TITLE
fix(cdp): fix oauth scope problems for gcs

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -772,8 +772,15 @@ class GoogleCloudIntegration:
         """
         Refresh the access token for the integration if necessary
         """
+        if self.integration.kind == "google-pubsub":
+            scope = "https://www.googleapis.com/auth/pubsub"
+        elif self.integration.kind == "google-cloud-storage":
+            scope = "https://www.googleapis.com/auth/devstorage.read_write"
+        else:
+            raise NotImplementedError(f"Google Cloud integration kind {self.integration.kind} not implemented")
+
         credentials = service_account.Credentials.from_service_account_info(
-            self.integration.sensitive_config, scopes=["https://www.googleapis.com/auth/pubsub"]
+            self.integration.sensitive_config, scopes=[scope]
         )
 
         try:


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Customers are experiencing 403 errors after setting up gcs after a while (after token refresh). 
 The Problem:
```
  credentials = service_account.Credentials.from_service_account_info(
      self.integration.sensitive_config, scopes=["https://www.googleapis.com/auth/pubsub"]
  )
```

  What was happening:
  1. Customer creates GCS integration with service account key
  2. Token expires after ~1 hour
  3. Auto-refresh tries to refresh token but uses wrong scope (pubsub instead of devstorage.read_write)
  4. Google returns token with wrong permissions
  5. Subsequent GCS requests fail with 403 Forbidden

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

 The fix:
  - Now correctly uses https://www.googleapis.com/auth/devstorage.read_write for GCS integrations
  - Maintains existing https://www.googleapis.com/auth/pubsub for PubSub integrations
  - Throws proper error for unsupported integration types

 This will resolve the intermittent 403 errors customers are experiencing after their initial setup
  works.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
