### PR TITLE
chore(experiments): set up AA tests for the new Bayesian module

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -284,6 +284,8 @@ export const FEATURE_FLAGS = {
     REPLAY_EXPORT_RAW_RECORDING: 'replay-export-raw-recording', // owner: @veryayskiy #team-replay
     GOOGLE_SHEETS_DWH: 'google-shets-dwh', // owner: @Gilbert09 #team-data-warehouse
     NEW_BAYESIAN_STATS_METHOD: 'new-bayesian-stats-method', // owner: @andehen #team-experiments
+    AA_TEST_BAYESIAN_LEGACY: 'aa-test-bayesian-legacy', // owner: #team-experiments
+    AA_TEST_BAYESIAN_NEW: 'aa-test-bayesian-new', // owner: #team-experiments
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
+++ b/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
@@ -34,6 +34,11 @@ export function ProjectHomepage(): JSX.Element {
         sceneDashboardChoiceModalLogic({ scene: Scene.ProjectHomepage })
     )
 
+    // TODO: Remove this after AA test is over
+    const { featureFlags } = useValues(featureFlagLogic)
+    const aaTestBayesianLegacy = featureFlags[FEATURE_FLAGS.AA_TEST_BAYESIAN_LEGACY]
+    const aaTestBayesianNew = featureFlags[FEATURE_FLAGS.AA_TEST_BAYESIAN_NEW]
+
     const headerButtons = (
         <>
             <LemonButton
@@ -58,6 +63,10 @@ export function ProjectHomepage(): JSX.Element {
 
     return (
         <div className="ProjectHomepage">
+            {/* TODO: Remove this after AA test is over. Just a hidden element. */}
+            <span className="hidden" data-attr="aa-test-flag-result">
+                AA test flag result: {String(aaTestBayesianLegacy)} {String(aaTestBayesianNew)}
+            </span>
             <PageHeader buttons={headerButtons} />
             {dashboardLogicProps ? (
                 <HomeDashboard dashboardLogicProps={dashboardLogicProps} />


### PR DESCRIPTION
## Changes
Set up two additional AA tests to compare the old and new Bayesian modules.
https://us.posthog.com/project/2/experiments/134996
https://us.posthog.com/project/2/experiments/134997

The differences from the previous test:
- Running two tests side by side makes it easier to compare results
- Added more metrics, including some that use winsorization
- Put flag evaluation to the homepage to collect data faster