### PR TITLE
chore: Set basicLogging level to TEMPORAL_LOG_LEVEL

### DIFF
--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -2,6 +2,7 @@ import asyncio
 import datetime as dt
 import faulthandler
 import functools
+import logging
 import signal
 
 import structlog
@@ -173,17 +174,17 @@ class Command(BaseCommand):
             options["client_key"] = "--SECRET--"
 
         structlog.reset_defaults()
+        logging.basicConfig(level=settings.TEMPORAL_LOG_LEVEL)
 
         # enable faulthandler to print stack traces on segfaults
         faulthandler.enable()
 
         initialize_otel()
-
         metrics_port = int(options["metrics_port"])
 
-        shutdown_task = None
-
         tag_queries(kind="temporal")
+
+        shutdown_task = None
 
         def shutdown_worker_on_signal(worker: Worker, sig: signal.Signals, loop: asyncio.AbstractEventLoop):
             """Shutdown Temporal worker on receiving signal."""

--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -174,7 +174,7 @@ class Command(BaseCommand):
             options["client_key"] = "--SECRET--"
 
         structlog.reset_defaults()
-        logging.basicConfig(level=settings.TEMPORAL_LOG_LEVEL)
+        logging.disable(level=max(logging.getLevelNamesMapping()[settings.TEMPORAL_LOG_LEVEL] - 1, 0))
 
         # enable faulthandler to print stack traces on segfaults
         faulthandler.enable()
@@ -248,3 +248,4 @@ class Command(BaseCommand):
                 logger.info("Waiting on shutdown_task")
                 _ = runner.run(asyncio.wait([shutdown_task]))
                 logger.info("Finished Temporal worker shutdown")
+                logging.flush()


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

All logs should be at least level `TEMPORAL_LOG_LEVEL` on starting a worker.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

~Use `logging.basicConfig` with the level set by `TEMPORAL_LOG_LEVEL` (defaults to info). This clears any debug logs when working locally with a worker, unless requested via `TEMPORAL_LOG_LEVEL="DEBUG"`.~

Change of plans: Using `basicConfig` only configures the root logger, not any loggers in libraries.

Instead, use `logging.disable` to disable all logs right below `TEMPORAL_LOG_LEVEL`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
