### PR TITLE
fix(sql-editor): Fix being able to edit joins with the same name

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -206,8 +206,9 @@ export const QueryDatabaseTreeView = (): JSX.Element => {
                 if (item.record?.type === 'column') {
                     if (
                         isJoined(item.record.field) &&
-                        joinsByFieldName[item.record.columnName] &&
-                        joinsByFieldName[item.record.columnName].source_table_name === item.record.table
+                        joinsByFieldName[`${item.record.table}.${item.record.columnName}`] &&
+                        joinsByFieldName[`${item.record.table}.${item.record.columnName}`].source_table_name ===
+                            item.record.table
                     ) {
                         return (
                             <DropdownMenuGroup>
@@ -216,7 +217,9 @@ export const QueryDatabaseTreeView = (): JSX.Element => {
                                     onClick={(e) => {
                                         e.stopPropagation()
                                         if (item.record?.columnName) {
-                                            toggleEditJoinModal(joinsByFieldName[item.record.columnName])
+                                            toggleEditJoinModal(
+                                                joinsByFieldName[`${item.record.table}.${item.record.columnName}`]
+                                            )
                                         }
                                     }}
                                 >
@@ -227,7 +230,8 @@ export const QueryDatabaseTreeView = (): JSX.Element => {
                                     onClick={(e) => {
                                         e.stopPropagation()
                                         if (item.record?.columnName) {
-                                            const join = joinsByFieldName[item.record.columnName]
+                                            const join =
+                                                joinsByFieldName[`${item.record.table}.${item.record.columnName}`]
                                             void deleteWithUndo({
                                                 endpoint: api.dataWarehouseViewLinks.determineDeleteEndpoint(),
                                                 object: {

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
@@ -638,7 +638,7 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
                     return Object.values(table.fields).map((field) => ({
                         name: field.name,
                         type: field.type,
-                        menuItems: menuItems(field, table.name),
+                        menuItems: menuItems(field, table?.name ?? ''), // table cant be null, but the typechecker is confused
                     }))
                 }
 
@@ -646,7 +646,7 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
                     return Object.values(table.columns).map((column) => ({
                         name: column.name,
                         type: column.type,
-                        menuItems: menuItems(column, table.name),
+                        menuItems: menuItems(column, table?.name ?? ''), // table cant be null, but the typechecker is confused
                     }))
                 }
                 return []

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
@@ -634,7 +634,7 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
                         : []
                 }
 
-                if ('fields' in table) {
+                if ('fields' in table && table !== null) {
                     return Object.values(table.fields).map((field) => ({
                         name: field.name,
                         type: field.type,
@@ -642,7 +642,7 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
                     }))
                 }
 
-                if ('columns' in table) {
+                if ('columns' in table && table !== null) {
                     return Object.values(table.columns).map((column) => ({
                         name: column.name,
                         type: column.type,


### PR DESCRIPTION
## Problem
- Its not possible to delete a joined table if there is another table with a join using the same field name
- This is cause `joinsByFieldName` is keyed by field name and doesnt take into account multiple tables having the same join name

## Changes
- Make `joinsByFieldName` take into account the source table name 

## How did you test this code?
Tested locally