### PR TITLE
fix(cdp): fixes token refresh logic for salesforce integration

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -434,7 +434,6 @@ class OauthIntegration:
         expires_in = self.integration.config.get("expires_in")
         refreshed_at = self.integration.config.get("refreshed_at")
 
-        # For Salesforce, if we don't have expires_in info, assume 2 hour expiry (default Salesforce behavior)
         if not refresh_token:
             return False
 

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -403,6 +403,11 @@ class OauthIntegration:
             "id_token": config.pop("id_token", None),
         }
 
+        # Handle case where Salesforce doesn't provide expires_in in initial response
+        if not config.get("expires_in") and kind == "salesforce":
+            # Default to 1 hour for Salesforce if not provided (conservative)
+            config["expires_in"] = 3600
+
         config["refreshed_at"] = int(time.time())
 
         integration, created = Integration.objects.update_or_create(
@@ -428,7 +433,16 @@ class OauthIntegration:
         refresh_token = self.integration.sensitive_config.get("refresh_token")
         expires_in = self.integration.config.get("expires_in")
         refreshed_at = self.integration.config.get("refreshed_at")
-        if not refresh_token or not expires_in or not refreshed_at:
+
+        # For Salesforce, if we don't have expires_in info, assume 2 hour expiry (default Salesforce behavior)
+        if not refresh_token:
+            return False
+
+        if not expires_in and self.integration.kind == "salesforce":
+            # Salesforce tokens typically last 2-4 hours, we'll assume 1 hour (3600 seconds) to be conservative
+            expires_in = 3600
+
+        if not expires_in or not refreshed_at:
             return False
 
         # To be really safe we refresh if its half way through the expiry
@@ -462,7 +476,14 @@ class OauthIntegration:
         else:
             logger.info(f"Refreshed access token for {self}")
             self.integration.sensitive_config["access_token"] = config["access_token"]
-            self.integration.config["expires_in"] = config.get("expires_in")
+
+            # Handle case where Salesforce doesn't provide expires_in in refresh response
+            expires_in = config.get("expires_in")
+            if not expires_in and self.integration.kind == "salesforce":
+                # Default to 1 hour for Salesforce if not provided (conservative)
+                expires_in = 3600
+
+            self.integration.config["expires_in"] = expires_in
             self.integration.config["refreshed_at"] = int(time.time())
             reload_integrations_on_workers(self.integration.team_id, [self.integration.id])
             oauth_refresh_counter.labels(self.integration.kind, "success").inc()


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Based on customer feedback, Salesforce destinations were becoming unusable due to expired access tokens. Users reported that while Salesforce integrations worked fine during initial testing, they would fail hours later with "Salesforce access token has expired" errors. 

According to the referenced blog post (https://dev.to/xkit/when-do-salesforce-access-tokens-expire-1ih9), Salesforce access tokens typically expire after 2-4 hours. Salesforce OAuth responses don't always include an `expires_in` field, which causes our token expiry detection to fail and never trigger automatic refresh.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

The fix adds special handling for Salesforce integrations in three key areas: 
- (1) initial OAuth token creation now defaults to 1-hour expiry when expires_in is missing,
- (2) token expiry detection logic assumes 1-hour expiry for Salesforce tokens without expiry info, and 
- (3) token refresh process applies the same 1-hour default. With our existing halfway-point refresh strategy, this ensures Salesforce tokens are automatically refreshed every 30 minutes, providing a conservative safety margin.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
