### PR TITLE
fix(user): Avoid useless UPDATEs in `team` property

### DIFF
--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -672,12 +672,6 @@ class TestUserAPI(APIBaseTest):
             email="newuser@posthog.com", password="testpass123", first_name="New", last_name="User"
         )
 
-        # First, trigger the organization property to set up the state
-        # This will call save once to set current_organization to None
-        with mock.patch.object(new_user, "save") as mock_save:
-            new_user.organization  # noqa: B018 - property access, but it can actually perform a save
-            mock_save.assert_called_once_with(update_fields=["current_organization"])
-
         # Clear the cached properties to force re-evaluation
         if hasattr(new_user, "_cached_team"):
             delattr(new_user, "_cached_team")
@@ -686,7 +680,7 @@ class TestUserAPI(APIBaseTest):
 
         # Now test the team property - this should not trigger a save since no teams exist
         with mock.patch.object(new_user, "save") as mock_save:
-            team = new_user.team
+            team = new_user.team  # Property access, but it can actually perform a save
 
             # Verify no save was called for the team property
             mock_save.assert_not_called()
@@ -694,6 +688,30 @@ class TestUserAPI(APIBaseTest):
             # Verify team is None
             self.assertIsNone(team)
             self.assertIsNone(new_user.current_team)
+
+    def test_team_property_saves_when_team_found(self):
+        """
+        Test that the team property does trigger a save when a team is found
+        """
+        # Set current organization but no current team
+        self.user.current_team = None
+        self.user.save()
+
+        # Clear the cached property to force re-evaluation
+        if hasattr(self.user, "_cached_team"):
+            delattr(self.user, "_cached_team")
+
+        # Mock the save method to track if it's called
+        with mock.patch.object(self.user, "save") as mock_save:
+            # Access the team property - this should trigger a save since a team exists
+            result_team = self.user.team
+
+            # Verify save was called with correct parameters
+            mock_save.assert_called_once_with(update_fields=["current_team"])
+
+            # Verify team is set correctly
+            self.assertEqual(result_team, self.team)
+            self.assertEqual(self.user.current_team, self.team)
 
     def test_organization_property_does_not_save_when_no_organizations_found(self):
         """
@@ -743,30 +761,6 @@ class TestUserAPI(APIBaseTest):
             self.assertIsNotNone(result_organization)
             self.assertIn(result_organization, [self.organization, new_org])
             self.assertEqual(self.user.current_organization, result_organization)
-
-    def test_team_property_saves_when_team_found(self):
-        """
-        Test that the team property does trigger a save when a team is found
-        """
-        # Set current organization but no current team
-        self.user.current_team = None
-        self.user.save()
-
-        # Clear the cached property to force re-evaluation
-        if hasattr(self.user, "_cached_team"):
-            delattr(self.user, "_cached_team")
-
-        # Mock the save method to track if it's called
-        with mock.patch.object(self.user, "save") as mock_save:
-            # Access the team property - this should trigger a save since a team exists
-            result_team = self.user.team
-
-            # Verify save was called with correct parameters
-            mock_save.assert_called_once_with(update_fields=["current_team"])
-
-            # Verify team is set correctly
-            self.assertEqual(result_team, self.team)
-            self.assertEqual(self.user.current_team, self.team)
 
     @patch("posthog.tasks.user_identify.identify_task")
     @patch("posthoganalytics.capture")

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -237,14 +237,15 @@ class User(AbstractUser, UUIDClassicModel):
             if self.current_team is not None:
                 self.current_organization_id = self.current_team.organization_id
             self.current_organization = self.organizations.first()
-            self.save()
+            self.save(update_fields=["current_organization"])
         return self.current_organization
 
     @cached_property
     def team(self) -> Optional[Team]:
         if self.current_team is None and self.organization is not None:
             self.current_team = self.teams.filter(organization=self.current_organization).first()
-            self.save()
+            if self.current_team:
+                self.save(update_fields=["current_team"])
         return self.current_team
 
     def join(

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -237,7 +237,8 @@ class User(AbstractUser, UUIDClassicModel):
             if self.current_team is not None:
                 self.current_organization_id = self.current_team.organization_id
             self.current_organization = self.organizations.first()
-            self.save(update_fields=["current_organization"])
+            if self.current_organization is not None:
+                self.save(update_fields=["current_organization"])
         return self.current_organization
 
     @cached_property


### PR DESCRIPTION
## Problem

@MichaelKutsch-ph noticed we're running unexpected UPDATE statements in a read-only endpoint. ([Slack thread](https://posthog.slack.com/archives/C0185UNBSJZ/p1752145540119459)). We do expect an `UPDATE` in the `def team()` method of the `User` model – but only once, because then the `current_team` field should actually be set.

However if a user doesn't have access to _any_ teams, we run the `UPDATE` setting a null `current_team` value, which is pointless. And then we keep doing that over and over again with no effect.

## Changes

No longer doing the `.save()` if there's no point.

## How did you test this code?

Added a couple tests.