### PR TITLE
fix: Add the membership_level field to the basic org serializer

### DIFF
--- a/frontend/src/lib/utils/permissioning.ts
+++ b/frontend/src/lib/utils/permissioning.ts
@@ -65,7 +65,8 @@ export function hasMembershipLevelOrHigher(org: OrganizationBasicType, role: Org
 }
 
 export function organizationAllowsPersonalApiKeysForMembers(org: OrganizationBasicType): boolean {
-    return !!org.members_can_use_personal_api_keys
+    // undefined means the value is missing from the API response, so we treat it as true as a fallback
+    return [true, undefined].includes(org.members_can_use_personal_api_keys)
 }
 
 export const organizationMembershipLevelIntegers = Object.values(OrganizationMembershipLevel).filter(

--- a/posthog/api/shared.py
+++ b/posthog/api/shared.py
@@ -214,7 +214,7 @@ class OrganizationBasicSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Organization
-        fields = ["id", "name", "slug", "logo_media_id", "membership_level"]
+        fields = ["id", "name", "slug", "logo_media_id", "membership_level", "members_can_use_personal_api_keys"]
 
     def get_membership_level(self, organization: Organization) -> Optional[OrganizationMembership.Level]:
         membership = OrganizationMembership.objects.filter(

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -102,6 +102,7 @@ class TestUserAPI(APIBaseTest):
                     "slug": slugify(self.organization.name),
                     "logo_media_id": None,
                     "membership_level": 1,
+                    "members_can_use_personal_api_keys": True,
                 },
                 {
                     "id": str(self.new_org.id),
@@ -109,6 +110,7 @@ class TestUserAPI(APIBaseTest):
                     "slug": "new-organization",
                     "logo_media_id": None,
                     "membership_level": 1,
+                    "members_can_use_personal_api_keys": True,
                 },
             ],
         )


### PR DESCRIPTION

## Changes

- Adds the field to the basic org serializer + adds a fallback to make sure we dont lock out users from creating API keys if the field is not on the API response for some reason

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
