### PR TITLE
fix: Allow log propagation on tests

### DIFF
--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -63,7 +63,9 @@ def get_external_logger():
 
         logger.addHandler(handler)
         logger.setLevel(logging.DEBUG)
-        logger.propagate = False
+
+        if not settings.TEST:
+            logger.propagate = False
 
     return structlog.get_logger(EXTERNAL_LOGGER_NAME)
 
@@ -92,7 +94,9 @@ def configure_stdlib_logger(logger: logging.Logger) -> None:
 
     logger.addHandler(handler)
     logger.setLevel(settings.TEMPORAL_LOG_LEVEL)
-    logger.propagate = False
+
+    if not settings.TEST:
+        logger.propagate = False
 
 
 async def bind_temporal_worker_logger(team_id: int, destination: str | None = None) -> FilteringBoundLogger:


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

In order to capture logs when using `log-cli-level` pytest attaches a handler to the root logger to capture all logs. However, we (on purpose) disable propagation of logs to the root logger with `logger.propagate = False`.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Allow log propagation when running tests.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
