### PR TITLE
fix(persons): Fix merging issues

### DIFF
--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -156,9 +156,8 @@ export type IngestionConsumerConfig = {
  * The mode of db batch writes to use for person batch writing
  * NO_ASSERT: No assertions are made, we write the latest value in memory to the DB (no locks)
  * ASSERT_VERSION: Assert that the current db version is the same as the version in memory (no locks)
- * WITH_TRANSACTION: Use SELECT FOR UPDATE in transaction to get the latest version of the person (locks the row)
  */
-export type PersonBatchWritingDbWriteMode = 'NO_ASSERT' | 'ASSERT_VERSION' | 'WITH_TRANSACTION'
+export type PersonBatchWritingDbWriteMode = 'NO_ASSERT' | 'ASSERT_VERSION'
 export type PersonBatchWritingMode = 'BATCH' | 'SHADOW' | 'NONE'
 
 export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig {

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
@@ -381,8 +381,8 @@ describe('BatchWritingPersonStore', () => {
         )
         await personStoreForBatch.flush()
 
-        // Should try optimistic update multiple times based on config
-        expect(db.updatePersonAssertVersion).toHaveBeenCalledTimes(5) // default max retries
+        // Should try optimistic update multiple times based on config (1 initial + 5 retries = 6 total)
+        expect(db.updatePersonAssertVersion).toHaveBeenCalledTimes(6) // default max retries
         expect(db.updatePerson).toHaveBeenCalledTimes(1) // fallback
     })
 
@@ -578,8 +578,11 @@ describe('BatchWritingPersonStore', () => {
                 expect(db.postgres.transaction).not.toHaveBeenCalled()
             })
 
-            it('should handle errors in NO_ASSERT mode without fallback', async () => {
-                const personStore = new BatchWritingPersonsStore(db, { dbWriteMode: 'NO_ASSERT' })
+            it('should fallback with NO_ASSERT mode', async () => {
+                const personStore = new BatchWritingPersonsStore(db, {
+                    dbWriteMode: 'NO_ASSERT',
+                    maxOptimisticUpdateRetries: 5,
+                })
                 const personStoreForBatch = personStore.forBatch()
 
                 db.updatePerson = jest.fn().mockRejectedValue(new Error('Database error'))
@@ -593,7 +596,7 @@ describe('BatchWritingPersonStore', () => {
                 )
 
                 await expect(personStoreForBatch.flush()).rejects.toThrow('Database error')
-                expect(db.updatePerson).toHaveBeenCalledTimes(6) // 5 for update, 1 for fallback
+                expect(db.updatePerson).toHaveBeenCalledTimes(7) // 6 for update (1 initial + 5 retries), 1 for fallback
                 expect(db.updatePersonAssertVersion).not.toHaveBeenCalled()
             })
         })
@@ -638,7 +641,7 @@ describe('BatchWritingPersonStore', () => {
                 )
                 await personStoreForBatch.flush()
 
-                expect(db.updatePersonAssertVersion).toHaveBeenCalledTimes(2) // retries
+                expect(db.updatePersonAssertVersion).toHaveBeenCalledTimes(3) // 1 initial + 2 retries
                 expect(db.updatePerson).toHaveBeenCalledTimes(1) // fallback
             })
 
@@ -670,113 +673,6 @@ describe('BatchWritingPersonStore', () => {
                     }
                 )
                 expect(db.updatePerson).not.toHaveBeenCalled() // No fallback for MessageSizeTooLarge
-            })
-        })
-
-        describe('flush with WITH_TRANSACTION mode', () => {
-            it('should call updatePersonWithTransaction directly without optimistic updates', async () => {
-                const personStore = new BatchWritingPersonsStore(db, { dbWriteMode: 'WITH_TRANSACTION' })
-                const personStoreForBatch = personStore.forBatch()
-
-                await personStoreForBatch.updatePersonWithPropertiesDiffForUpdate(
-                    person,
-                    { new_value: 'new_value' },
-                    [],
-                    {},
-                    'test'
-                )
-                await personStoreForBatch.flush()
-
-                expect(db.postgres.transaction).toHaveBeenCalledTimes(1)
-                expect(db.updatePersonAssertVersion).not.toHaveBeenCalled()
-                expect(db.updatePerson).toHaveBeenCalledWith(
-                    expect.any(Object),
-                    expect.any(Object),
-                    expect.anything(), // tx
-                    'forUpdate'
-                )
-            })
-
-            it('should retry WITH_TRANSACTION on failures', async () => {
-                const personStore = new BatchWritingPersonsStore(db, {
-                    dbWriteMode: 'WITH_TRANSACTION',
-                    maxOptimisticUpdateRetries: 2,
-                })
-                const personStoreForBatch = personStore.forBatch()
-
-                let callCount = 0
-                db.postgres.transaction = jest.fn().mockImplementation(async (_usage, _tag, transactionCallback) => {
-                    callCount++
-                    if (callCount < 2) {
-                        throw new Error('Transaction failed')
-                    }
-                    return await transactionCallback({}) // success on second try
-                })
-
-                await personStoreForBatch.updatePersonWithPropertiesDiffForUpdate(
-                    person,
-                    { new_value: 'new_value' },
-                    [],
-                    {},
-                    'test'
-                )
-                await personStoreForBatch.flush()
-
-                expect(db.postgres.transaction).toHaveBeenCalledTimes(2)
-                expect(db.updatePersonAssertVersion).not.toHaveBeenCalled()
-            })
-
-            it('should handle MessageSizeTooLarge in WITH_TRANSACTION mode', async () => {
-                const personStore = new BatchWritingPersonsStore(db, { dbWriteMode: 'WITH_TRANSACTION' })
-                const personStoreForBatch = personStore.forBatch()
-
-                db.postgres.transaction = jest
-                    .fn()
-                    .mockRejectedValue(new MessageSizeTooLarge('test', new Error('test')))
-
-                await personStoreForBatch.updatePersonWithPropertiesDiffForUpdate(
-                    person,
-                    { new_value: 'new_value' },
-                    [],
-                    {},
-                    'test'
-                )
-                await personStoreForBatch.flush()
-
-                expect(captureIngestionWarning).toHaveBeenCalledWith(
-                    db.kafkaProducer,
-                    teamId,
-                    'person_upsert_message_size_too_large',
-                    {
-                        personId: person.id,
-                        distinctId: 'test',
-                    }
-                )
-                expect(db.postgres.transaction).toHaveBeenCalled()
-            })
-
-            it('should fallback to updatePersonNoAssert after max retries', async () => {
-                const personStore = new BatchWritingPersonsStore(db, {
-                    dbWriteMode: 'WITH_TRANSACTION',
-                    maxOptimisticUpdateRetries: 2,
-                })
-                const personStoreForBatch = personStore.forBatch()
-
-                // Mock transaction to always fail
-                db.postgres.transaction = jest.fn().mockRejectedValue(new Error('Transaction failed'))
-
-                await personStoreForBatch.updatePersonWithPropertiesDiffForUpdate(
-                    person,
-                    { new_value: 'new_value' },
-                    [],
-                    {},
-                    'test'
-                )
-                await personStoreForBatch.flush()
-
-                expect(db.postgres.transaction).toHaveBeenCalledTimes(2)
-                expect(db.updatePersonAssertVersion).not.toHaveBeenCalled()
-                expect(db.updatePerson).toHaveBeenCalledTimes(1)
             })
         })
 

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
@@ -596,7 +596,7 @@ describe('BatchWritingPersonStore', () => {
                 )
 
                 await expect(personStoreForBatch.flush()).rejects.toThrow('Database error')
-                expect(db.updatePerson).toHaveBeenCalledTimes(7) // 6 for update (1 initial + 5 retries), 1 for fallback
+                expect(db.updatePerson).toHaveBeenCalledTimes(6) // 6 for update (1 fallback + 5 retries)
                 expect(db.updatePersonAssertVersion).not.toHaveBeenCalled()
             })
         })
@@ -777,7 +777,7 @@ describe('BatchWritingPersonStore', () => {
         // Verify the second call to updatePersonAssertVersion had the merged properties
         expect(db.updatePersonAssertVersion).toHaveBeenLastCalledWith(
             expect.objectContaining({
-                version: 3, // Should use the latest version from the database
+                version: 2, // Should use the latest version from the database (updatedByOtherPod has version 2)
                 properties: {
                     existing_prop1: 'updated_by_other_pod', // Preserved from other pod's update
                     existing_prop2: 'updated_by_this_pod', // Updated by this pod

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -2,6 +2,8 @@ import { Properties } from '@posthog/plugin-scaffold'
 import { DateTime } from 'luxon'
 import pLimit from 'p-limit'
 
+import { NoRowsUpdatedError, RaceConditionError } from '~/utils/utils'
+
 import { TopicMessage } from '../../../kafka/producer'
 import {
     InternalPerson,
@@ -14,7 +16,6 @@ import { DB } from '../../../utils/db/db'
 import { MessageSizeTooLarge } from '../../../utils/db/error'
 import { PostgresUse, TransactionClient } from '../../../utils/db/postgres'
 import { logger } from '../../../utils/logger'
-import { promiseRetry } from '../../../utils/retries'
 import { BatchWritingStore } from '../stores/batch-writing-store'
 import { captureIngestionWarning } from '../utils'
 import {
@@ -42,7 +43,6 @@ type MethodName =
     | 'fetchPerson'
     | 'updatePersonAssertVersion'
     | 'updatePersonNoAssert'
-    | 'updatePersonWithTransaction'
     | 'createPerson'
     | 'updatePersonWithPropertiesDiffForUpdate'
     | 'updatePersonForMerge'
@@ -54,7 +54,7 @@ type MethodName =
     | 'addPersonlessDistinctIdForMerge'
     | 'addPersonUpdateToBatch'
 
-type UpdateType = 'updatePersonAssertVersion' | 'updatePersonNoAssert' | 'updatePersonWithTransaction'
+type UpdateType = 'updatePersonAssertVersion' | 'updatePersonNoAssert'
 
 export interface BatchWritingPersonsStoreOptions {
     maxConcurrentUpdates: number
@@ -159,37 +159,28 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
                             let kafkaMessages: TopicMessage[] = []
                             switch (this.options.dbWriteMode) {
                                 case 'NO_ASSERT': {
-                                    const [_, messages] = await promiseRetry(
-                                        () => this.updatePersonNoAssert(update, 'batch'),
+                                    const [_, messages] = await this.withMergeRetry(
+                                        update,
+                                        async (personUpdate) => {
+                                            const [person, messages] = await this.updatePersonNoAssert(personUpdate)
+                                            return [person, messages]
+                                        },
                                         'updatePersonNoAssert',
                                         this.options.maxOptimisticUpdateRetries,
-                                        this.options.optimisticUpdateRetryInterval,
-                                        undefined,
-                                        [MessageSizeTooLarge]
+                                        this.options.optimisticUpdateRetryInterval
                                     )
                                     kafkaMessages = messages
                                     break
                                 }
                                 case 'ASSERT_VERSION': {
-                                    const messages = await promiseRetry(
-                                        () => this.updatePersonAssertVersion(update),
+                                    const [_, messages] = await this.withMergeRetry(
+                                        update,
+                                        async (personUpdate) => {
+                                            return await this.updatePersonAssertVersion(personUpdate)
+                                        },
                                         'updatePersonAssertVersion',
                                         this.options.maxOptimisticUpdateRetries,
-                                        this.options.optimisticUpdateRetryInterval,
-                                        undefined,
-                                        [MessageSizeTooLarge]
-                                    )
-                                    kafkaMessages = messages
-                                    break
-                                }
-                                case 'WITH_TRANSACTION': {
-                                    const messages = await promiseRetry(
-                                        () => this.updatePersonWithTransaction(update, 'batch'),
-                                        'updatePersonWithTransaction',
-                                        this.options.maxOptimisticUpdateRetries,
-                                        this.options.optimisticUpdateRetryInterval,
-                                        undefined,
-                                        [MessageSizeTooLarge]
+                                        this.options.optimisticUpdateRetryInterval
                                     )
                                     kafkaMessages = messages
                                     break
@@ -234,7 +225,7 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
                                 fallback_reason: 'max_retries',
                             })
 
-                            const [_, fallbackMessages] = await this.updatePersonNoAssert(update, 'conflictRetry')
+                            const [_, fallbackMessages] = await this.updatePersonNoAssert(update)
 
                             personWriteMethodAttemptCounter.inc({
                                 db_write_mode: this.options.dbWriteMode,
@@ -579,10 +570,6 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
                 : {
                       ...result,
                       properties: { ...result.properties },
-                      properties_last_updated_at: { ...result.properties_last_updated_at },
-                      properties_last_operation: result.properties_last_operation
-                          ? { ...result.properties_last_operation }
-                          : {},
                       created_at: result.created_at,
                   }
         } else {
@@ -606,10 +593,6 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
                 : {
                       ...result,
                       properties: { ...result.properties },
-                      properties_last_updated_at: { ...result.properties_last_updated_at },
-                      properties_last_operation: result.properties_last_operation
-                          ? { ...result.properties_last_operation }
-                          : {},
                       properties_to_set: { ...result.properties_to_set },
                       properties_to_unset: [...result.properties_to_unset],
                   }
@@ -660,6 +643,8 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
             mergedPersonUpdate.properties_to_unset = [
                 ...new Set([...existingPersonUpdate.properties_to_unset, ...person.properties_to_unset]),
             ]
+
+            mergedPersonUpdate.created_at = DateTime.min(existingPersonUpdate.created_at, person.created_at)
 
             this.personUpdateCache.set(this.getPersonIdCacheKey(teamId, person.id), mergedPersonUpdate)
         } else {
@@ -731,10 +716,12 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
             // Create new PersonUpdate from the person and apply the update
             personUpdate = fromInternalPerson(person, distinctId)
             personUpdate = this.mergeUpdateIntoPersonUpdate(personUpdate, update, true)
+            personUpdate.id = person.id
             this.setCachedPersonForUpdate(person.team_id, distinctId, personUpdate)
         } else {
             // Merge updates into existing cached PersonUpdate
             personUpdate = this.mergeUpdateIntoPersonUpdate(existingUpdate, update, true)
+            personUpdate.id = person.id
             this.setCachedPersonForUpdate(person.team_id, distinctId, personUpdate)
         }
         // Return the merged person from the cache
@@ -772,6 +759,17 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         const otherUpdates = Object.fromEntries(
             Object.entries(update).filter(([key]) => !fieldsToExclude.includes(key))
         )
+        if (allowCreatedAtUpdate) {
+            // Get minimum of existing and new created_at
+            if (update.created_at) {
+                if (personUpdate.created_at) {
+                    otherUpdates.created_at =
+                        personUpdate.created_at < update.created_at ? personUpdate.created_at : update.created_at
+                } else {
+                    otherUpdates.created_at = update.created_at
+                }
+            }
+        }
         Object.assign(personUpdate, otherUpdates)
 
         // Handle is_identified specially with || operator
@@ -832,11 +830,8 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         return [toInternalPerson(personUpdate), []]
     }
 
-    private async updatePersonNoAssert(
-        personUpdate: PersonUpdate,
-        source: string
-    ): Promise<[InternalPerson, TopicMessage[], boolean]> {
-        const operation = 'updatePersonNoAssert' + (source ? `-${source}` : '')
+    private async updatePersonNoAssert(personUpdate: PersonUpdate): Promise<[InternalPerson, TopicMessage[], boolean]> {
+        const operation = 'updatePersonNoAssert'
         this.incrementDatabaseOperation(operation as MethodName, personUpdate.distinct_id)
         // Convert PersonUpdate back to InternalPerson for database call
         const person = toInternalPerson(personUpdate)
@@ -846,6 +841,7 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         this.incrementCount('updatePersonNoAssert', personUpdate.distinct_id)
         this.incrementDatabaseOperation('updatePersonNoAssert', personUpdate.distinct_id)
         const start = performance.now()
+
         const response = await this.db.updatePerson(person, updateFields, undefined, 'updatePersonNoAssert')
         this.recordUpdateLatency('updatePersonNoAssert', (performance.now() - start) / 1000, personUpdate.distinct_id)
         observeLatencyByVersion(person, start, 'updatePersonNoAssert')
@@ -859,10 +855,11 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
      * @param personUpdate the personUpdate to write
      * @returns the actual version of the person after the write
      */
-    private async updatePersonAssertVersion(personUpdate: PersonUpdate): Promise<TopicMessage[]> {
+    private async updatePersonAssertVersion(personUpdate: PersonUpdate): Promise<[InternalPerson, TopicMessage[]]> {
         this.incrementDatabaseOperation('updatePersonAssertVersion', personUpdate.distinct_id)
 
         const start = performance.now()
+
         const [actualVersion, kafkaMessages] = await this.db.updatePersonAssertVersion(personUpdate)
         this.recordUpdateLatency(
             'updatePersonAssertVersion',
@@ -874,7 +871,7 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         if (actualVersion !== undefined) {
             // Success - optimistic update worked, update version in cache
             personUpdate.version = actualVersion
-            return kafkaMessages
+            return [toInternalPerson(personUpdate), kafkaMessages]
         }
 
         // Optimistic update failed due to version mismatch
@@ -900,45 +897,10 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
 
             // Update the PersonUpdate with latest data and merged properties
             personUpdate.properties = mergedProperties
-            personUpdate.properties_last_updated_at = latestPerson.properties_last_updated_at || {}
-            personUpdate.properties_last_operation = latestPerson.properties_last_operation || {}
             personUpdate.version = latestPerson.version
         }
 
-        throw new Error('Assert version update failed, will retry')
-    }
-
-    private async updatePersonWithTransaction(personUpdate: PersonUpdate, source: string): Promise<TopicMessage[]> {
-        const operation = 'updatePersonTransaction' + (source ? `-${source}` : '')
-        this.incrementDatabaseOperation(operation as MethodName, personUpdate.distinct_id)
-
-        // Convert PersonUpdate back to InternalPerson for database call
-        const internalPerson = toInternalPerson(personUpdate)
-        const start = performance.now()
-
-        // Use a transaction to ensure we get the latest version with FOR UPDATE
-        const kafkaMessages = await this.db.postgres.transaction(PostgresUse.PERSONS_WRITE, operation, async (tx) => {
-            // First fetch the person with FOR UPDATE to lock the row
-            const latestPerson = await this.db.fetchPerson(personUpdate.team_id, personUpdate.distinct_id, {
-                forUpdate: true,
-            })
-
-            if (!latestPerson) {
-                throw new Error('Person not found during direct update')
-            }
-
-            // Create update object without version field (updatePerson handles version internally)
-            const { version, ...updateFields } = internalPerson
-            const [_, kafkaMessages] = await this.db.updatePerson(latestPerson, updateFields, tx, 'forUpdate')
-            return kafkaMessages
-        })
-        this.recordUpdateLatency(
-            'updatePersonWithTransaction',
-            (performance.now() - start) / 1000,
-            personUpdate.distinct_id
-        )
-        observeLatencyByVersion(internalPerson, start, operation)
-        return kafkaMessages
+        throw new RaceConditionError('Assert version update failed, will retry')
     }
 
     private incrementCount(method: MethodName, distinctId: string): void {
@@ -960,5 +922,102 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
             (updateLatencyPerDistinctIdSeconds.get(updateType) || 0) + latencySeconds
         )
         this.updateLatencyPerDistinctIdSeconds.set(distinctId, updateLatencyPerDistinctIdSeconds)
+    }
+
+    /**
+     * Retry wrapper that handles both update conflicts and person merges.
+     */
+    private async withMergeRetry(
+        personUpdate: PersonUpdate,
+        updateFn: (personUpdate: PersonUpdate) => Promise<[InternalPerson, TopicMessage[]]>,
+        operation: string,
+        maxRetries: number,
+        retryInterval: number
+    ): Promise<[InternalPerson, TopicMessage[]]> {
+        let attempt = 0
+        while (attempt <= maxRetries) {
+            try {
+                return await updateFn(personUpdate)
+            } catch (error) {
+                attempt++
+
+                if (attempt <= maxRetries) {
+                    // Handle person merge scenarios with special logic
+                    if (error instanceof NoRowsUpdatedError) {
+                        const refreshedPersonUpdate = await this.refreshPersonIdAfterMerge(personUpdate)
+                        if (refreshedPersonUpdate) {
+                            personUpdate = refreshedPersonUpdate
+                            continue
+                        }
+                        // If we can't refresh the person ID, we can't retry, fail gracefully
+                        return [toInternalPerson(personUpdate), []]
+                    }
+
+                    // Handle optimistic update conflicts with special logging
+                    if (error instanceof RaceConditionError) {
+                        logger.warn(`Optimistic update conflict for ${operation}, retrying...`, {
+                            attempt,
+                            maxRetries,
+                            teamId: personUpdate.team_id,
+                            personId: personUpdate.id,
+                            distinctId: personUpdate.distinct_id,
+                        })
+                    } else {
+                        // For any other error type, still retry but with generic logging
+                        logger.warn(`Database error for ${operation}, retrying...`, {
+                            attempt,
+                            maxRetries,
+                            teamId: personUpdate.team_id,
+                            personId: personUpdate.id,
+                            distinctId: personUpdate.distinct_id,
+                            error: error instanceof Error ? error.message : String(error),
+                        })
+                    }
+
+                    await new Promise((resolve) => setTimeout(resolve, retryInterval))
+                    continue
+                }
+
+                throw error
+            }
+        }
+
+        // This should never be reached, but TypeScript requires it
+        throw new Error('Unexpected end of retry loop')
+    }
+
+    /**
+     * Refreshes the person ID for a given distinct ID by fetching from the database.
+     * This handles cases where the person was merged and the ID changed.
+     * @param personUpdate the PersonUpdate that failed to update
+     * @returns updated PersonUpdate with new person ID if found, null if person no longer exists
+     */
+    private async refreshPersonIdAfterMerge(personUpdate: PersonUpdate): Promise<PersonUpdate | null> {
+        const currentPerson = await this.db.fetchPerson(personUpdate.team_id, personUpdate.distinct_id)
+
+        if (!currentPerson) {
+            // Person truly doesn't exist anymore
+            return null
+        }
+
+        // Clear the old person ID from cache since it's been merged
+        this.clearPersonCacheForPersonId(personUpdate.team_id, personUpdate.id)
+
+        // Update our cache mapping to reflect the new person ID
+        this.setDistinctIdToPersonId(personUpdate.team_id, personUpdate.distinct_id, currentPerson.id)
+
+        // Create updated PersonUpdate with the new person ID and version
+        const updatedPersonUpdate = {
+            ...personUpdate,
+            id: currentPerson.id,
+            version: currentPerson.version,
+            // Also update other fields that might have changed due to merge
+            uuid: currentPerson.uuid,
+            created_at: currentPerson.created_at,
+            is_identified: currentPerson.is_identified || personUpdate.is_identified,
+            properties: currentPerson.properties,
+        }
+
+        return updatedPersonUpdate
     }
 }

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -763,8 +763,8 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
             // Get minimum of existing and new created_at
             if (update.created_at) {
                 if (personUpdate.created_at) {
-                    otherUpdates.created_at = 
-                        personUpdate.created_at.isBefore(update.created_at) ? personUpdate.created_at : update.created_at
+                    otherUpdates.created_at =
+                        personUpdate.created_at < update.created_at ? personUpdate.created_at : update.created_at
                 } else {
                     otherUpdates.created_at = update.created_at
                 }

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -763,8 +763,8 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
             // Get minimum of existing and new created_at
             if (update.created_at) {
                 if (personUpdate.created_at) {
-                    otherUpdates.created_at =
-                        personUpdate.created_at < update.created_at ? personUpdate.created_at : update.created_at
+                    otherUpdates.created_at = 
+                        personUpdate.created_at.isBefore(update.created_at) ? personUpdate.created_at : update.created_at
                 } else {
                     otherUpdates.created_at = update.created_at
                 }

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -955,7 +955,7 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
 
                     // Handle optimistic update conflicts with special logging
                     if (error instanceof RaceConditionError) {
-                        logger.warn(`Optimistic update conflict for ${operation}, retrying...`, {
+                        logger.debug(`Optimistic update conflict for ${operation}, retrying...`, {
                             attempt,
                             maxRetries,
                             teamId: personUpdate.team_id,
@@ -1007,15 +1007,21 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         this.setDistinctIdToPersonId(personUpdate.team_id, personUpdate.distinct_id, currentPerson.id)
 
         // Create updated PersonUpdate with the new person ID and version
-        const updatedPersonUpdate = {
-            ...personUpdate,
+        const updatedPersonUpdate: PersonUpdate = {
             id: currentPerson.id,
-            version: currentPerson.version,
-            // Also update other fields that might have changed due to merge
+            team_id: personUpdate.team_id,
             uuid: currentPerson.uuid,
-            created_at: currentPerson.created_at,
-            is_identified: currentPerson.is_identified || personUpdate.is_identified,
+            distinct_id: personUpdate.distinct_id,
             properties: currentPerson.properties,
+            properties_last_updated_at: personUpdate.properties_last_updated_at,
+            properties_last_operation: personUpdate.properties_last_operation,
+            created_at: currentPerson.created_at,
+            version: currentPerson.version,
+            is_identified: currentPerson.is_identified || personUpdate.is_identified,
+            is_user_id: personUpdate.is_user_id,
+            needs_write: personUpdate.needs_write,
+            properties_to_set: personUpdate.properties_to_set,
+            properties_to_unset: personUpdate.properties_to_unset,
         }
 
         return updatedPersonUpdate

--- a/plugin-server/src/worker/ingestion/persons/metrics.ts
+++ b/plugin-server/src/worker/ingestion/persons/metrics.ts
@@ -88,7 +88,7 @@ export const personFlushBatchSizeHistogram = new Histogram({
 export const personWriteMethodAttemptCounter = new Counter({
     name: 'person_write_method_attempt_total',
     help: 'Number of attempts for each write method',
-    labelNames: ['db_write_mode', 'method', 'outcome'], // method: no_assert, assert_version, with_transaction, outcome: success, retry, fallback
+    labelNames: ['db_write_mode', 'method', 'outcome'], // method: no_assert, assert_versionL outcome: success, retry, fallback
 })
 
 export const personFallbackOperationsCounter = new Counter({

--- a/plugin-server/src/worker/ingestion/persons/metrics.ts
+++ b/plugin-server/src/worker/ingestion/persons/metrics.ts
@@ -88,7 +88,7 @@ export const personFlushBatchSizeHistogram = new Histogram({
 export const personWriteMethodAttemptCounter = new Counter({
     name: 'person_write_method_attempt_total',
     help: 'Number of attempts for each write method',
-    labelNames: ['db_write_mode', 'method', 'outcome'], // method: no_assert, assert_versionL outcome: success, retry, fallback
+    labelNames: ['db_write_mode', 'method', 'outcome'], // method: no_assert, assert_version; outcome: success, retry, fallback
 })
 
 export const personFallbackOperationsCounter = new Counter({

--- a/plugin-server/src/worker/ingestion/persons/person-event-processor.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-event-processor.ts
@@ -129,4 +129,8 @@ export class PersonEventProcessor {
         }
         return [fakePerson, Promise.resolve()]
     }
+
+    getContext(): PersonContext {
+        return this.context
+    }
 }

--- a/plugin-server/src/worker/ingestion/persons/person-merge-service.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-merge-service.ts
@@ -511,4 +511,8 @@ export class PersonMergeService {
     public getUpdateIsIdentified(): boolean {
         return this.context.updateIsIdentified
     }
+
+    getContext(): PersonContext {
+        return this.context
+    }
 }

--- a/plugin-server/src/worker/ingestion/persons/person-property-service.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-property-service.ts
@@ -129,4 +129,8 @@ export class PersonPropertyService {
 
         return
     }
+
+    getContext(): PersonContext {
+        return this.context
+    }
 }

--- a/plugin-server/tests/worker/ingestion/person-state-batch.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state-batch.test.ts
@@ -1,0 +1,2504 @@
+import { PluginEvent, Properties } from '@posthog/plugin-scaffold'
+import { DateTime } from 'luxon'
+
+import { TopicMessage } from '../../../src/kafka/producer'
+import {
+    Database,
+    Hub,
+    InternalPerson,
+    PropertiesLastOperation,
+    PropertiesLastUpdatedAt,
+    Team,
+} from '../../../src/types'
+import { DependencyUnavailableError } from '../../../src/utils/db/error'
+import { closeHub, createHub } from '../../../src/utils/db/hub'
+import { PostgresUse, TransactionClient } from '../../../src/utils/db/postgres'
+import { defaultRetryConfig } from '../../../src/utils/retries'
+import { UUIDT } from '../../../src/utils/utils'
+import { uuidFromDistinctId } from '../../../src/worker/ingestion/person-uuid'
+import { BatchWritingPersonsStoreForBatch } from '../../../src/worker/ingestion/persons/batch-writing-person-store'
+import { PersonContext } from '../../../src/worker/ingestion/persons/person-context'
+import { PersonEventProcessor } from '../../../src/worker/ingestion/persons/person-event-processor'
+import { PersonMergeService } from '../../../src/worker/ingestion/persons/person-merge-service'
+import { PersonPropertyService } from '../../../src/worker/ingestion/persons/person-property-service'
+import { PersonsStoreForBatch } from '../../../src/worker/ingestion/persons/persons-store-for-batch'
+import { delayUntilEventIngested } from '../../helpers/clickhouse'
+import { createOrganization, createTeam, fetchPostgresPersons, getTeam, insertRow } from '../../helpers/sql'
+
+jest.setTimeout(30000)
+
+async function createPerson(
+    hub: Hub,
+    createdAt: DateTime,
+    properties: Properties,
+    propertiesLastUpdatedAt: PropertiesLastUpdatedAt,
+    propertiesLastOperation: PropertiesLastOperation,
+    teamId: number,
+    isUserId: number | null,
+    isIdentified: boolean,
+    uuid: string,
+    distinctIds?: { distinctId: string; version?: number }[],
+    tx?: TransactionClient
+): Promise<InternalPerson> {
+    const [person, kafkaMessages] = await hub.db.createPerson(
+        createdAt,
+        properties,
+        propertiesLastUpdatedAt,
+        propertiesLastOperation,
+        teamId,
+        isUserId,
+        isIdentified,
+        uuid,
+        distinctIds,
+        tx
+    )
+    await hub.db.kafkaProducer.queueMessages(kafkaMessages)
+    return person
+}
+
+async function flushPersonStoreToKafka(hub: Hub, personStore: PersonsStoreForBatch, kafkaAcks: Promise<void>) {
+    const kafkaMessages = await (personStore as BatchWritingPersonsStoreForBatch).flush()
+    await hub.db.kafkaProducer.queueMessages(kafkaMessages)
+    await hub.db.kafkaProducer.flush()
+    await kafkaAcks
+    return kafkaMessages
+}
+
+describe('PersonState.processEvent()', () => {
+    let hub: Hub
+
+    let teamId: number
+    let mainTeam: Team
+    let organizationId: string
+
+    // Common Distinct IDs (and their deterministic UUIDs) used in tests below.
+    const newUserDistinctId = 'new-user'
+    let newUserUuid: string
+    const oldUserDistinctId = 'old-user'
+    let oldUserUuid: string
+    const firstUserDistinctId = 'first'
+    let firstUserUuid: string
+    const secondUserDistinctId = 'second'
+    let secondUserUuid: string
+
+    let timestamp: DateTime
+    let timestamp2: DateTime
+    let timestampch: string
+
+    beforeAll(async () => {
+        hub = await createHub({})
+        await hub.db.clickhouseQuery('SYSTEM STOP MERGES')
+
+        organizationId = await createOrganization(hub.db.postgres)
+    })
+
+    beforeEach(async () => {
+        teamId = await createTeam(hub.db.postgres, organizationId)
+        mainTeam = (await getTeam(hub, teamId))!
+        timestamp = DateTime.fromISO('2020-01-01T12:00:05.200Z').toUTC()
+        timestamp2 = DateTime.fromISO('2020-02-02T12:00:05.200Z').toUTC()
+        timestampch = '2020-01-01 12:00:05.000'
+
+        newUserUuid = uuidFromDistinctId(teamId, newUserDistinctId)
+        oldUserUuid = uuidFromDistinctId(teamId, oldUserDistinctId)
+        firstUserUuid = uuidFromDistinctId(teamId, firstUserDistinctId)
+        secondUserUuid = uuidFromDistinctId(teamId, secondUserDistinctId)
+
+        jest.spyOn(hub.db, 'fetchPerson')
+        jest.spyOn(hub.db, 'updatePerson')
+
+        defaultRetryConfig.RETRY_INTERVAL_DEFAULT = 0
+    })
+
+    afterEach(() => {
+        jest.clearAllTimers()
+        jest.useRealTimers()
+        jest.restoreAllMocks()
+    })
+
+    afterAll(async () => {
+        await closeHub(hub)
+        await hub.db.clickhouseQuery('SYSTEM START MERGES')
+    })
+
+    function personProcessor(
+        event: Partial<PluginEvent>,
+        propertyService?: PersonPropertyService,
+        mergeService?: PersonMergeService,
+        customHub?: Hub,
+        processPerson = true,
+        timestampParam = timestamp,
+        team = mainTeam
+    ) {
+        const fullEvent = {
+            team_id: teamId,
+            properties: {},
+            ...event,
+        }
+
+        const personsStore = new BatchWritingPersonsStoreForBatch(customHub ? customHub.db : hub.db)
+
+        const context = new PersonContext(
+            fullEvent as any,
+            team,
+            event.distinct_id!,
+            timestampParam,
+            processPerson,
+            customHub ? customHub.db.kafkaProducer : hub.db.kafkaProducer,
+            personsStore,
+            0
+        )
+        const processor = new PersonEventProcessor(
+            context,
+            propertyService ?? new PersonPropertyService(context),
+            mergeService ?? new PersonMergeService(context)
+        )
+        return processor
+    }
+
+    function personPropertyService(
+        event: Partial<PluginEvent>,
+        customHub?: Hub,
+        processPerson = true,
+        timestampParam = timestamp,
+        team = mainTeam,
+        updateIsIdentified: boolean = false
+    ) {
+        const fullEvent = {
+            team_id: teamId,
+            properties: {},
+            ...event,
+        }
+
+        const personsStore = new BatchWritingPersonsStoreForBatch(customHub ? customHub.db : hub.db)
+
+        const context = new PersonContext(
+            fullEvent as PluginEvent,
+            team,
+            event.distinct_id!,
+            timestampParam,
+            processPerson,
+            customHub ? customHub.db.kafkaProducer : hub.db.kafkaProducer,
+            personsStore,
+            0
+        )
+        context.updateIsIdentified = updateIsIdentified
+        return new PersonPropertyService(context)
+    }
+
+    function personMergeService(
+        event: Partial<PluginEvent>,
+        customHub?: Hub,
+        processPerson = true,
+        timestampParam = timestamp,
+        team = mainTeam
+    ) {
+        const fullEvent = {
+            team_id: teamId,
+            properties: {},
+            ...event,
+        }
+
+        const personsStore = new BatchWritingPersonsStoreForBatch(customHub ? customHub.db : hub.db)
+
+        const context = new PersonContext(
+            fullEvent as any,
+            team,
+            event.distinct_id!,
+            timestampParam,
+            processPerson,
+            customHub ? customHub.db.kafkaProducer : hub.db.kafkaProducer,
+            personsStore,
+            0
+        )
+        return new PersonMergeService(context)
+    }
+
+    const sortPersons = (persons: InternalPerson[]) => persons.sort((a, b) => Number(a.id) - Number(b.id))
+
+    async function fetchPostgresPersonsH() {
+        return await fetchPostgresPersons(hub.db, teamId)
+    }
+
+    async function fetchPersonsRows() {
+        const query = `SELECT * FROM person FINAL WHERE team_id = ${teamId} ORDER BY _offset`
+        return (await hub.db.clickhouseQuery(query)).data
+    }
+
+    async function fetchOverridesForDistinctId(distinctId: string) {
+        const query = `SELECT * FROM person_distinct_id_overrides_mv FINAL WHERE team_id = ${teamId} AND distinct_id = '${distinctId}'`
+        return (await hub.db.clickhouseQuery(query)).data
+    }
+
+    async function fetchPersonsRowsWithVersionHigerEqualThan(version = 1) {
+        const query = `SELECT * FROM person FINAL WHERE team_id = ${teamId} AND version >= ${version}`
+        return (await hub.db.clickhouseQuery(query)).data
+    }
+
+    async function fetchDistinctIdsClickhouse(person: InternalPerson) {
+        return hub.db.fetchDistinctIdValues(person, Database.ClickHouse)
+    }
+
+    async function fetchDistinctIdsClickhouseVersion1() {
+        const query = `SELECT distinct_id FROM person_distinct_id2 FINAL WHERE team_id = ${teamId} AND version = 1`
+        return (await hub.db.clickhouseQuery(query)).data
+    }
+
+    describe('on person creation', () => {
+        it('creates deterministic person uuids that are different between teams', async () => {
+            const event_uuid = new UUIDT().toString()
+            const primaryTeamId = teamId
+            const [personPrimaryTeam, kafkaAcks] = await personPropertyService({
+                event: '$pageview',
+                distinct_id: newUserDistinctId,
+                uuid: event_uuid,
+            }).updateProperties()
+
+            const otherTeamId = await createTeam(hub.db.postgres, organizationId)
+            const otherTeam = (await getTeam(hub, otherTeamId))!
+            teamId = otherTeamId
+            const [personOtherTeam, kafkaAcksOther] = await personPropertyService(
+                {
+                    event: '$pageview',
+                    distinct_id: newUserDistinctId,
+                    uuid: event_uuid,
+                },
+                undefined,
+                true,
+                timestamp,
+                otherTeam
+            ).updateProperties()
+
+            await hub.db.kafkaProducer.flush()
+            await kafkaAcks
+            await kafkaAcksOther
+
+            expect(personPrimaryTeam.uuid).toEqual(uuidFromDistinctId(primaryTeamId, newUserDistinctId))
+            expect(personOtherTeam.uuid).toEqual(uuidFromDistinctId(otherTeamId, newUserDistinctId))
+            expect(personPrimaryTeam.uuid).not.toEqual(personOtherTeam.uuid)
+        })
+
+        it('returns an ephemeral user object when $process_person_profile=false', async () => {
+            const event_uuid = new UUIDT().toString()
+
+            const hubParam = undefined
+            const processPerson = false
+            const [fakePerson, kafkaAcks] = await personProcessor(
+                {
+                    event: '$pageview',
+                    distinct_id: newUserDistinctId,
+                    uuid: event_uuid,
+                    properties: { $set: { should_be_dropped: 100 } },
+                },
+                undefined,
+                undefined,
+                hubParam,
+                processPerson
+            ).processEvent()
+            await hub.db.kafkaProducer.flush()
+            await kafkaAcks
+
+            expect(fakePerson).toEqual(
+                expect.objectContaining({
+                    team_id: teamId,
+                    uuid: newUserUuid, // deterministic even though no user rows were created
+                    properties: {}, // empty even though there was a $set attempted
+                    created_at: DateTime.utc(1970, 1, 1, 0, 0, 5), // fake person created_at
+                })
+            )
+            expect(fakePerson.force_upgrade).toBeUndefined()
+
+            // verify there is no Postgres person
+            const persons = await fetchPostgresPersonsH()
+            expect(persons.length).toEqual(0)
+
+            // verify there are no Postgres distinct_ids
+            const distinctIds = await hub.db.fetchDistinctIdValues(fakePerson as InternalPerson)
+            expect(distinctIds).toEqual(expect.arrayContaining([]))
+        })
+
+        it('overrides are created only when distinct_id is in posthog_personlessdistinctid', async () => {
+            // oldUserDistinctId exists, and 'old2' will merge into it, but not create an override
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, oldUserUuid, [
+                { distinctId: oldUserDistinctId },
+            ])
+
+            // newUserDistinctId exists, and 'new2' will merge into it, and will create an override
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, newUserUuid, [
+                { distinctId: newUserDistinctId },
+            ])
+
+            await hub.db.addPersonlessDistinctId(teamId, 'new2')
+
+            const hubParam = undefined
+            const processPerson = true
+            const [_person, kafkaAcks] = await personProcessor(
+                {
+                    event: '$identify',
+                    distinct_id: oldUserDistinctId,
+                    properties: {
+                        $anon_distinct_id: 'old2',
+                    },
+                },
+                undefined,
+                undefined,
+                hubParam,
+                processPerson
+            ).processEvent()
+
+            const [_person2, kafkaAcks2] = await personProcessor(
+                {
+                    event: '$identify',
+                    distinct_id: newUserDistinctId,
+                    properties: {
+                        $anon_distinct_id: 'new2',
+                    },
+                },
+                undefined,
+                undefined,
+                hubParam,
+                processPerson
+            ).processEvent()
+
+            await hub.db.kafkaProducer.flush()
+            await kafkaAcks
+            await kafkaAcks2
+
+            // new2 has an override, because it was in posthog_personlessdistinctid
+            await delayUntilEventIngested(() => fetchOverridesForDistinctId('new2'))
+            const chOverrides = await fetchOverridesForDistinctId('new2')
+            expect(chOverrides.length).toEqual(1)
+            expect(chOverrides).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        distinct_id: 'new2',
+                        person_id: newUserUuid,
+                        version: 1,
+                    }),
+                ])
+            )
+
+            // old2 has no override, because it wasn't in posthog_personlessdistinctid
+            const chOverridesOld = await fetchOverridesForDistinctId('old2')
+            expect(chOverridesOld.length).toEqual(0)
+        })
+
+        it('force_upgrade works', async () => {
+            const [_, oldPersonKafkaMessages] = await hub.db.createPerson(
+                timestamp,
+                {},
+                {},
+                {},
+                teamId,
+                null,
+                false,
+                oldUserUuid,
+                [{ distinctId: oldUserDistinctId }]
+            )
+            await hub.db.kafkaProducer.queueMessages(oldPersonKafkaMessages)
+
+            const hubParam = undefined
+            let processPerson = true
+            const [_person, kafkaAcks] = await personProcessor(
+                {
+                    event: '$identify',
+                    distinct_id: newUserDistinctId,
+                    properties: {
+                        $anon_distinct_id: oldUserDistinctId,
+                    },
+                },
+                undefined,
+                undefined,
+                hubParam,
+                processPerson
+            ).processEvent()
+            await hub.db.kafkaProducer.flush()
+            await kafkaAcks
+
+            // Using the `distinct_id` again with `processPerson=false` results in
+            // `force_upgrade=true` and real Person `uuid` and `created_at`
+            processPerson = false
+            const event_uuid = new UUIDT().toString()
+            const timestampParam = timestamp.plus({ minutes: 5 }) // Event needs to happen after Person creation
+            const [fakePerson, kafkaAcks2] = await personProcessor(
+                {
+                    event: '$pageview',
+                    distinct_id: newUserDistinctId,
+                    uuid: event_uuid,
+                    properties: { $set: { should_be_dropped: 100 } },
+                },
+                undefined,
+                undefined,
+                hubParam,
+                processPerson,
+                timestampParam
+            ).processEvent()
+            await hub.db.kafkaProducer.flush()
+            await kafkaAcks2
+
+            expect(fakePerson).toEqual(
+                expect.objectContaining({
+                    team_id: teamId,
+                    uuid: oldUserUuid, // *old* user, because it existed before the merge
+                    properties: {}, // empty even though there was a $set attempted
+                    created_at: timestamp, // *not* the fake person created_at
+                    force_upgrade: true,
+                })
+            )
+        })
+
+        it('force_upgrade is ignored if team.person_processing_opt_out is true', async () => {
+            mainTeam.person_processing_opt_out = true
+            const [_, oldPersonKafkaMessages] = await hub.db.createPerson(
+                timestamp,
+                {},
+                {},
+                {},
+                teamId,
+                null,
+                false,
+                oldUserUuid,
+                [{ distinctId: oldUserDistinctId }]
+            )
+            await hub.db.kafkaProducer.queueMessages(oldPersonKafkaMessages)
+
+            const hubParam = undefined
+            let processPerson = true
+            const [_person, kafkaAcks] = await personProcessor(
+                {
+                    event: '$identify',
+                    distinct_id: newUserDistinctId,
+                    properties: {
+                        $anon_distinct_id: oldUserDistinctId,
+                    },
+                },
+                undefined,
+                undefined,
+                hubParam,
+                processPerson
+            ).processEvent()
+            await hub.db.kafkaProducer.flush()
+            await kafkaAcks
+
+            // Using the `distinct_id` again with `processPerson=false` results in
+            // `force_upgrade=true` and real Person `uuid` and `created_at`
+            processPerson = false
+            const event_uuid = new UUIDT().toString()
+            const timestampParam = timestamp.plus({ minutes: 5 }) // Event needs to happen after Person creation
+            const [fakePerson, kafkaAcks2] = await personProcessor(
+                {
+                    event: '$pageview',
+                    distinct_id: newUserDistinctId,
+                    uuid: event_uuid,
+                    properties: { $set: { should_be_dropped: 100 } },
+                },
+                undefined,
+                undefined,
+                hubParam,
+                processPerson,
+                timestampParam
+            ).processEvent()
+            await hub.db.kafkaProducer.flush()
+            await kafkaAcks2
+
+            expect(fakePerson.force_upgrade).toBeUndefined()
+        })
+
+        it('creates person if they are new', async () => {
+            const event_uuid = new UUIDT().toString()
+            const [person, kafkaAcks] = await personPropertyService({
+                event: '$pageview',
+                distinct_id: newUserDistinctId,
+                uuid: event_uuid,
+                // `null_byte` validates that `sanitizeJsonbValue` is working as expected
+                properties: { $set: { null_byte: '\u0000' } },
+            }).updateProperties()
+            await hub.db.kafkaProducer.flush()
+            await kafkaAcks
+
+            expect(person).toEqual(
+                expect.objectContaining({
+                    id: expect.any(String),
+                    uuid: newUserUuid,
+                    properties: { $creator_event_uuid: event_uuid, null_byte: '\uFFFD' },
+                    created_at: timestamp,
+                    version: 0,
+                    is_identified: false,
+                })
+            )
+
+            expect(hub.db.fetchPerson).toHaveBeenCalledTimes(1)
+            expect(hub.db.updatePerson).not.toHaveBeenCalled()
+
+            // verify Postgres persons
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(1)
+            expect(persons[0]).toEqual(person)
+
+            // verify Postgres distinct_ids
+            const distinctIds = await hub.db.fetchDistinctIdValues(persons[0])
+            expect(distinctIds).toEqual(expect.arrayContaining([newUserDistinctId]))
+        })
+
+        it('does not attach existing person properties to $process_person_profile=false events', async () => {
+            const originalEventUuid = new UUIDT().toString()
+            const [person, kafkaAcks] = await personProcessor({
+                event: '$pageview',
+                distinct_id: newUserDistinctId,
+                uuid: originalEventUuid,
+                properties: { $set: { c: 420 } },
+            }).processEvent()
+            await hub.db.kafkaProducer.flush()
+            await kafkaAcks
+
+            expect(person).toEqual(
+                expect.objectContaining({
+                    id: expect.any(String),
+                    uuid: newUserUuid,
+                    properties: { $creator_event_uuid: originalEventUuid, c: 420 },
+                    created_at: timestamp,
+                    version: 0,
+                    is_identified: false,
+                })
+            )
+
+            // verify Postgres persons
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(1)
+            expect(persons[0]).toEqual(person)
+
+            // verify Postgres distinct_ids
+            const distinctIds = await hub.db.fetchDistinctIdValues(persons[0])
+            expect(distinctIds).toEqual(expect.arrayContaining([newUserDistinctId]))
+
+            // OK, a person now exists with { c: 420 }, let's prove the properties come back out
+            // of the DB.
+            const [personVerifyProps] = await personProcessor({
+                event: '$pageview',
+                distinct_id: newUserDistinctId,
+                uuid: new UUIDT().toString(),
+                properties: {},
+            }).processEvent()
+            expect(personVerifyProps.properties).toEqual({ $creator_event_uuid: originalEventUuid, c: 420 })
+
+            // But they don't when $process_person_profile=false
+            const [processPersonFalseResult] = await personProcessor(
+                {
+                    event: '$pageview',
+                    distinct_id: newUserDistinctId,
+                    uuid: new UUIDT().toString(),
+                    properties: {},
+                },
+                undefined,
+                undefined,
+                hub,
+                false
+            ).processEvent()
+            expect(processPersonFalseResult.properties).toEqual({})
+        })
+
+        it('handles person being created in a race condition', async () => {
+            const [_, newPersonKafkaMessages] = await hub.db.createPerson(
+                timestamp,
+                {},
+                {},
+                {},
+                teamId,
+                null,
+                false,
+                newUserUuid,
+                [{ distinctId: newUserDistinctId }]
+            )
+            await hub.db.kafkaProducer.queueMessages(newPersonKafkaMessages)
+
+            jest.spyOn(hub.db, 'fetchPerson').mockImplementationOnce(() => {
+                return Promise.resolve(undefined)
+            })
+
+            const [person, kafkaAcks] = await personPropertyService({
+                event: '$pageview',
+                distinct_id: newUserDistinctId,
+            }).handleUpdate()
+            await hub.db.kafkaProducer.flush()
+            await kafkaAcks
+
+            // if creation fails we should return the person that another thread already created
+            expect(person).toEqual(
+                expect.objectContaining({
+                    id: expect.any(String),
+                    uuid: newUserUuid,
+                    properties: {},
+                    created_at: timestamp,
+                    version: 0,
+                    is_identified: false,
+                })
+            )
+            expect(hub.db.updatePerson).not.toHaveBeenCalled()
+            // verify Postgres persons
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(1)
+            expect(persons[0]).toEqual(person)
+
+            // verify Postgres distinct_ids
+            const distinctIds = await hub.db.fetchDistinctIdValues(person)
+            expect(distinctIds).toEqual(expect.arrayContaining([newUserDistinctId]))
+        })
+
+        it('handles person being created in a race condition updates properties if needed', async () => {
+            const [_, newPersonKafkaMessages] = await hub.db.createPerson(
+                timestamp,
+                { b: 3, c: 4 },
+                {},
+                {},
+                teamId,
+                null,
+                false,
+                newUserUuid,
+                [{ distinctId: newUserDistinctId }]
+            )
+            await hub.db.kafkaProducer.queueMessages(newPersonKafkaMessages)
+
+            const fetchPersonSpy = jest.spyOn(hub.db, 'fetchPerson').mockImplementationOnce(() => {
+                return Promise.resolve(undefined)
+            })
+
+            const propertyService = personPropertyService({
+                event: '$pageview',
+                distinct_id: newUserDistinctId,
+                properties: {
+                    $set_once: { c: 3, e: 4 },
+                    $set: { b: 4 },
+                },
+            })
+            const [person, kafkaAcks] = await propertyService.handleUpdate()
+            const context = propertyService.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+
+            // Explicitly restore the spy to prevent Jest state corruption
+            fetchPersonSpy.mockRestore()
+
+            // if creation fails we should return the person that another thread already created
+            expect(person).toMatchObject({
+                id: expect.any(String),
+                uuid: newUserUuid,
+                properties: { b: 4, c: 4, e: 4 },
+                created_at: timestamp,
+                version: 0,
+                is_identified: false,
+            })
+            expect(hub.db.updatePerson).toHaveBeenCalledTimes(1)
+            // verify Postgres persons
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(1)
+            expect(persons[0]).toMatchObject({
+                id: person.id,
+                uuid: newUserUuid,
+                created_at: timestamp,
+                is_identified: false,
+                properties: { b: 4, c: 4, e: 4 },
+                version: 1,
+            })
+
+            // verify Postgres distinct_ids
+            const distinctIds = await hub.db.fetchDistinctIdValues(person)
+            expect(distinctIds).toEqual(expect.arrayContaining([newUserDistinctId]))
+        })
+
+        it('creates person with properties', async () => {
+            const [person, kafkaAcks] = await personPropertyService({
+                event: '$pageview',
+                distinct_id: newUserDistinctId,
+                properties: {
+                    $set_once: { a: 1, b: 2 },
+                    $set: { b: 3, c: 4 },
+                },
+            }).updateProperties()
+            await hub.db.kafkaProducer.flush()
+            await kafkaAcks
+
+            expect(person).toMatchObject({
+                id: expect.any(String),
+                uuid: newUserUuid,
+                properties: { a: 1, b: 3, c: 4 },
+                created_at: timestamp,
+                version: 0,
+                is_identified: false,
+            })
+
+            expect(hub.db.fetchPerson).toHaveBeenCalledTimes(1)
+            expect(hub.db.updatePerson).not.toHaveBeenCalled()
+
+            // verify Postgres persons
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(1)
+            expect(persons[0]).toEqual(person)
+
+            // verify Postgres distinct_ids
+            const distinctIds = await hub.db.fetchDistinctIdValues(persons[0])
+            expect(distinctIds).toEqual(expect.arrayContaining([newUserDistinctId]))
+        })
+    })
+
+    describe('on person update', () => {
+        it('updates person properties xx', async () => {
+            await createPerson(hub, timestamp, { b: 3, c: 4, toString: {} }, {}, {}, teamId, null, false, newUserUuid, [
+                { distinctId: newUserDistinctId },
+            ])
+            const propertyService = personPropertyService({
+                event: '$pageview',
+                distinct_id: newUserDistinctId,
+                properties: {
+                    $set_once: { c: 3, e: 4 },
+                    $set: { b: 4, toString: 1, null_byte: '\u0000' },
+                },
+            })
+            const [person, kafkaAcks] = await propertyService.updateProperties()
+            const context = propertyService.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+
+            expect(person).toMatchObject({
+                id: expect.any(String),
+                uuid: newUserUuid,
+                properties: { b: 4, c: 4, e: 4, toString: 1, null_byte: '\u0000' },
+                is_identified: false,
+            })
+
+            expect(hub.db.fetchPerson).toHaveBeenCalledTimes(1)
+
+            // verify Postgres persons
+            const postgresPersons = sortPersons(await fetchPostgresPersonsH())
+            expect(postgresPersons.length).toEqual(1)
+            expect(postgresPersons[0]).toMatchObject({
+                id: person.id,
+                uuid: newUserUuid,
+                created_at: timestamp,
+                is_identified: false,
+                // `null_byte` validates that `sanitizeJsonbValue` is working as expected
+                properties: { b: 4, c: 4, e: 4, toString: 1, null_byte: '\uFFFD' },
+                version: 1,
+            })
+        })
+
+        it.each(['$$heatmap', '$exception'])('does not update person properties for %s', async (event: string) => {
+            const originalPersonProperties = { b: 3, c: 4, toString: {} }
+
+            await createPerson(hub, timestamp, originalPersonProperties, {}, {}, teamId, null, false, newUserUuid, [
+                { distinctId: newUserDistinctId },
+            ])
+
+            const [person, kafkaAcks] = await personPropertyService({
+                event: event,
+                distinct_id: newUserDistinctId,
+                properties: {
+                    $set_once: { c: 3, e: 4 },
+                    $set: { b: 4, toString: 1, null_byte: '\u0000' },
+                },
+            }).updateProperties()
+            await hub.db.kafkaProducer.flush()
+            await kafkaAcks
+
+            expect(person).toMatchObject({
+                id: expect.any(String),
+                uuid: newUserUuid,
+                properties: originalPersonProperties,
+                created_at: timestamp,
+                version: 0,
+                is_identified: false,
+            })
+
+            expect(hub.db.fetchPerson).toHaveBeenCalledTimes(1)
+
+            // verify Postgres persons
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(1)
+            expect(persons[0]).toEqual(person)
+        })
+
+        it('updates person properties - no update if not needed', async () => {
+            await createPerson(hub, timestamp, { $current_url: 123 }, {}, {}, teamId, null, false, newUserUuid, [
+                { distinctId: newUserDistinctId },
+            ])
+            const [person, kafkaAcks] = await personPropertyService({
+                event: '$pageview',
+                distinct_id: newUserDistinctId,
+                properties: {
+                    $set: { $current_url: 4 },
+                },
+            }).updateProperties()
+            await hub.db.kafkaProducer.flush()
+            await kafkaAcks
+
+            expect(person).toEqual(
+                expect.objectContaining({
+                    id: expect.any(String),
+                    uuid: newUserUuid,
+                    properties: { $current_url: 4 }, // Here we keep 4 for passing forward to PoE
+                    created_at: timestamp,
+                    version: 0,
+                    is_identified: false,
+                })
+            )
+
+            expect(hub.db.fetchPerson).toHaveBeenCalledTimes(1)
+
+            // verify Postgres persons
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons).toEqual([
+                expect.objectContaining({
+                    id: expect.any(String),
+                    uuid: newUserUuid,
+                    properties: { $current_url: 123 }, // We didn 't update this as it's auto added and it's not a person event
+                    created_at: timestamp,
+                    version: 0,
+                    is_identified: false,
+                }),
+            ])
+        })
+
+        it('updates person properties - always update for person events', async () => {
+            await createPerson(hub, timestamp, { $current_url: 123 }, {}, {}, teamId, null, false, newUserUuid, [
+                { distinctId: newUserDistinctId },
+            ])
+
+            const propertyService = personPropertyService({
+                event: '$set',
+                distinct_id: newUserDistinctId,
+                properties: {
+                    $set: { $current_url: 4 },
+                },
+            })
+            const [person, kafkaAcks] = await propertyService.updateProperties()
+            const context = propertyService.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+
+            expect(person).toEqual(
+                expect.objectContaining({
+                    id: expect.any(String),
+                    uuid: newUserUuid,
+                    properties: { $current_url: 4 }, // Here we keep 4 for passing forward to PoE
+                    created_at: timestamp,
+                    is_identified: false,
+                })
+            )
+
+            expect(hub.db.fetchPerson).toHaveBeenCalledTimes(1)
+
+            // verify Postgres persons
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(1)
+            expect(persons[0]).toEqual(
+                expect.objectContaining({
+                    id: person.id,
+                    uuid: newUserUuid,
+                    created_at: timestamp,
+                    is_identified: false,
+                    properties: { $current_url: 4 },
+                    version: 1,
+                })
+            ) // We updated PG as it's a person event
+        })
+
+        it('updates person properties - always update if undefined before', async () => {
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, newUserUuid, [
+                { distinctId: newUserDistinctId },
+            ])
+
+            const propertyService = personPropertyService({
+                event: '$pageview',
+                distinct_id: newUserDistinctId,
+                properties: {
+                    $set: { $initial_current_url: 4 },
+                },
+            })
+            const [person, kafkaAcks] = await propertyService.updateProperties()
+            const context = propertyService.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+
+            expect(person).toEqual(
+                expect.objectContaining({
+                    id: expect.any(String),
+                    uuid: newUserUuid,
+                    properties: { $initial_current_url: 4 }, // Here we keep 4 for passing forward to PoE
+                    created_at: timestamp,
+                    is_identified: false,
+                })
+            )
+
+            expect(hub.db.fetchPerson).toHaveBeenCalledTimes(1)
+
+            // verify Postgres persons
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(1)
+            expect(persons[0]).toEqual(
+                expect.objectContaining({
+                    id: person.id,
+                    uuid: newUserUuid,
+                    created_at: timestamp,
+                    is_identified: false,
+                    properties: { $initial_current_url: 4 },
+                    version: 1,
+                })
+            ) // We updated PG as it was undefined before
+        })
+
+        it('updates person properties - always update for initial properties', async () => {
+            await createPerson(
+                hub,
+                timestamp,
+                { $initial_current_url: 123 },
+                {},
+                {},
+                teamId,
+                null,
+                false,
+                newUserUuid,
+                [{ distinctId: newUserDistinctId }]
+            )
+
+            const propertyService = personPropertyService({
+                event: '$pageview',
+                distinct_id: newUserDistinctId,
+                properties: {
+                    $set: { $initial_current_url: 4 },
+                },
+            })
+            const [person, kafkaAcks] = await propertyService.updateProperties()
+            const context = propertyService.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+
+            expect(person).toEqual(
+                expect.objectContaining({
+                    id: expect.any(String),
+                    uuid: newUserUuid,
+                    properties: { $initial_current_url: 4 }, // Here we keep 4 for passing forward to PoE
+                    created_at: timestamp,
+                    is_identified: false,
+                })
+            )
+
+            expect(hub.db.fetchPerson).toHaveBeenCalledTimes(1)
+
+            // verify Postgres persons
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(1)
+            expect(persons[0]).toEqual(
+                expect.objectContaining({
+                    id: person.id,
+                    uuid: newUserUuid,
+                    created_at: timestamp,
+                    is_identified: false,
+                    properties: { $initial_current_url: 4 },
+                    version: 1,
+                })
+            ) // We updated PG as it's an initial property
+        })
+
+        it('updating with cached person data shortcuts to update directly', async () => {
+            const personInitial = await createPerson(
+                hub,
+                timestamp,
+                { b: 3, c: 4 },
+                {},
+                {},
+                teamId,
+                null,
+                false,
+                newUserUuid,
+                [{ distinctId: newUserDistinctId }]
+            )
+            const event = {
+                event: '$pageview',
+                distinct_id: newUserDistinctId,
+                properties: {
+                    $set_once: { c: 3, e: 4 },
+                    $set: { b: 4 },
+                },
+            }
+
+            // create mock merge service,
+            const mergeService = personMergeService(event)
+            jest.spyOn(mergeService, 'handleIdentifyOrAlias').mockReturnValue(
+                Promise.resolve([personInitial, Promise.resolve()])
+            )
+
+            const personS = personProcessor(event, undefined, mergeService)
+            const [person, kafkaAcks] = await personS.processEvent()
+            const context = personS.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+
+            expect(person).toEqual(
+                expect.objectContaining({
+                    id: expect.any(String),
+                    uuid: newUserUuid,
+                    properties: { b: 4, c: 4, e: 4 },
+                    created_at: timestamp,
+                    is_identified: false,
+                })
+            )
+
+            expect(hub.db.fetchPerson).toHaveBeenCalledTimes(0)
+
+            // verify Postgres persons
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(1)
+            expect(persons[0]).toMatchObject({
+                id: expect.any(String),
+                uuid: newUserUuid,
+                created_at: timestamp,
+                is_identified: false,
+                properties: { b: 4, c: 4, e: 4 },
+                version: 1,
+            })
+        })
+
+        it('does not update person if not needed', async () => {
+            await createPerson(hub, timestamp, { b: 3, c: 4 }, {}, {}, teamId, null, false, newUserUuid, [
+                { distinctId: newUserDistinctId },
+            ])
+
+            const propertyService = personPropertyService({
+                event: '$pageview',
+                distinct_id: newUserDistinctId,
+                properties: {
+                    $set_once: { c: 3 },
+                    $set: { b: 3 },
+                },
+            })
+            const [person, kafkaAcks] = await propertyService.updateProperties()
+            const context = propertyService.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+
+            expect(person).toEqual(
+                expect.objectContaining({
+                    id: expect.any(String),
+                    uuid: newUserUuid,
+                    properties: { b: 3, c: 4 },
+                    created_at: timestamp,
+                    version: 0,
+                    is_identified: false,
+                })
+            )
+
+            expect(hub.db.fetchPerson).toHaveBeenCalledTimes(1)
+            expect(hub.db.updatePerson).not.toHaveBeenCalled()
+
+            // verify Postgres persons
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(1)
+            expect(persons[0]).toEqual(person)
+        })
+
+        it('marks user as is_identified', async () => {
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, newUserUuid, [
+                { distinctId: newUserDistinctId },
+            ])
+
+            const personS = personPropertyService(
+                {
+                    event: '$pageview',
+                    distinct_id: newUserDistinctId,
+                    properties: {},
+                },
+                undefined,
+                true,
+                timestamp,
+                mainTeam,
+                true
+            )
+
+            const [person, kafkaAcks] = await personS.updateProperties()
+            const context = personS.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+            expect(person).toEqual(
+                expect.objectContaining({
+                    id: expect.any(String),
+                    uuid: newUserUuid,
+                    properties: {},
+                    created_at: timestamp,
+                    is_identified: true,
+                })
+            )
+
+            expect(hub.db.fetchPerson).toHaveBeenCalledTimes(1)
+            expect(hub.db.updatePerson).toHaveBeenCalledTimes(1)
+
+            // verify Postgres persons
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(1)
+            expect(persons[0]).toEqual(
+                expect.objectContaining({
+                    id: person.id,
+                    uuid: newUserUuid,
+                    created_at: timestamp,
+                    is_identified: true,
+                    properties: {},
+                    version: 1,
+                })
+            )
+
+            await personS.updateProperties()
+            expect(hub.db.updatePerson).toHaveBeenCalledTimes(1)
+        })
+
+        it('handles race condition when person provided has been merged', async () => {
+            // TODO: we don't handle this currently person having been changed / updated properties can get overridden
+            // Pass in a person, but another thread merges it - we shouldn't error in this case, but instead if we couldn't update we should retry?
+            const mergeDeletedPerson: InternalPerson = {
+                created_at: timestamp,
+                version: 0,
+                id: '0',
+                team_id: teamId,
+                properties: { a: 5, b: 7 },
+                is_user_id: 0,
+                is_identified: false,
+                uuid: uuidFromDistinctId(teamId, 'deleted-user'),
+                properties_last_updated_at: {},
+                properties_last_operation: null,
+            }
+            await createPerson(hub, timestamp, { a: 6, c: 8 }, {}, {}, teamId, null, true, newUserUuid, [
+                { distinctId: newUserDistinctId },
+                { distinctId: oldUserDistinctId },
+            ]) // the merged Person
+
+            const event = {
+                event: '$pageview',
+                distinct_id: newUserDistinctId,
+                properties: { $set: { a: 7, d: 9 } },
+            }
+            // create mock merge service
+            const mergeService = personMergeService(event)
+            jest.spyOn(mergeService, 'handleIdentifyOrAlias').mockReturnValue(
+                Promise.resolve([mergeDeletedPerson, Promise.resolve()])
+            )
+
+            const personS = personProcessor(event, undefined, mergeService)
+            const context = personS.getContext()
+
+            const [person, kafkaAcks] = await personS.processEvent()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+
+            // Return logic is still unaware that merge happened
+            expect(person).toMatchObject({
+                id: expect.any(String),
+                uuid: mergeDeletedPerson.uuid,
+                properties: { a: 7, b: 7, d: 9 },
+                created_at: timestamp,
+                version: 0,
+                is_identified: false,
+            })
+
+            expect(hub.db.fetchPerson).toHaveBeenCalledTimes(1)
+            expect(hub.db.updatePerson).toHaveBeenCalledTimes(2)
+
+            // verify Postgres persons
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(1)
+            expect(persons[0]).toMatchObject({
+                id: expect.any(String),
+                uuid: newUserUuid,
+                properties: { a: 7, c: 8, d: 9 },
+                created_at: timestamp,
+                version: 1,
+                is_identified: true,
+            })
+        })
+    })
+
+    describe('on $identify event', () => {
+        it(`no-op when $anon_distinct_id not passed`, async () => {
+            const mergeService: PersonMergeService = personMergeService({
+                event: '$identify',
+                distinct_id: newUserDistinctId,
+                properties: {
+                    $set: { foo: 'bar' },
+                },
+            })
+            const [person, kafkaAcks] = await mergeService.handleIdentifyOrAlias()
+            const context = mergeService.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+
+            expect(person).toEqual(undefined)
+            const persons = await fetchPostgresPersonsH()
+            expect(persons.length).toEqual(0)
+        })
+
+        it(`creates person with both distinct_ids and marks user as is_identified when $anon_distinct_id passed`, async () => {
+            const mergeService: PersonMergeService = personMergeService({
+                event: '$identify',
+                distinct_id: newUserDistinctId,
+                properties: {
+                    $set: { foo: 'bar' },
+                    $anon_distinct_id: oldUserDistinctId,
+                },
+            })
+            const [person, kafkaAcks] = await mergeService.handleIdentifyOrAlias()
+            const context = mergeService.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+
+            expect(person).toEqual(
+                expect.objectContaining({
+                    id: expect.any(String),
+                    uuid: newUserUuid,
+                    properties: { foo: 'bar' },
+                    created_at: timestamp,
+                    version: 0,
+                    is_identified: true,
+                })
+            )
+
+            expect(hub.db.updatePerson).not.toHaveBeenCalled()
+
+            // verify Postgres persons
+            const persons = await fetchPostgresPersonsH()
+            expect(persons.length).toEqual(1)
+            expect(persons[0]).toEqual(person)
+
+            // verify Postgres distinct_ids
+            const distinctIds = await hub.db.fetchDistinctIdValues(persons[0])
+            expect(distinctIds).toEqual(expect.arrayContaining([oldUserDistinctId, newUserDistinctId]))
+        })
+
+        it(`marks is_identified to be updated when no changes to distinct_ids but $anon_distinct_id passe`, async () => {
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, newUserUuid, [
+                { distinctId: newUserDistinctId },
+                { distinctId: oldUserDistinctId },
+            ])
+            const mergeService: PersonMergeService = personMergeService({
+                event: '$identify',
+                distinct_id: newUserDistinctId,
+                properties: {
+                    $anon_distinct_id: oldUserDistinctId,
+                },
+            })
+            const [person, kafkaAcks] = await mergeService.handleIdentifyOrAlias()
+            const context = mergeService.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+
+            expect(person).toMatchObject({
+                id: expect.any(String),
+                uuid: newUserUuid,
+                properties: {},
+                created_at: timestamp,
+                version: 0,
+                is_identified: false,
+            })
+            expect(mergeService.getUpdateIsIdentified()).toBeTruthy()
+
+            // verify Postgres persons
+            const persons = await fetchPostgresPersonsH()
+            expect(persons.length).toEqual(1)
+            expect(persons[0]).toMatchObject({
+                id: person!.id,
+                uuid: newUserUuid,
+                created_at: timestamp,
+                is_identified: false,
+                properties: {},
+                version: 1,
+            })
+        })
+
+        it(`add distinct id and marks user is_identified when passed $anon_distinct_id person does not exists and distinct_id does`, async () => {
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, newUserUuid, [
+                { distinctId: newUserDistinctId },
+            ])
+            const mergeService: PersonMergeService = personMergeService({
+                event: '$identify',
+                distinct_id: newUserDistinctId,
+                properties: {
+                    $anon_distinct_id: oldUserDistinctId,
+                },
+            })
+            const [person, kafkaAcks] = await mergeService.handleIdentifyOrAlias()
+            const context = mergeService.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+
+            const persons = await fetchPostgresPersonsH()
+            expect(person).toMatchObject({
+                id: expect.any(String),
+                uuid: newUserUuid,
+                properties: {},
+                created_at: timestamp,
+                version: 0,
+                is_identified: false,
+            })
+            expect(mergeService.getUpdateIsIdentified()).toBeTruthy()
+
+            // verify Postgres persons
+            expect(persons.length).toEqual(1)
+            expect(persons[0]).toMatchObject({
+                id: person!.id,
+                uuid: newUserUuid,
+                created_at: timestamp,
+                is_identified: false,
+                properties: {},
+                version: 0,
+            })
+
+            // verify Postgres distinct_ids
+            const distinctIds = await hub.db.fetchDistinctIdValues(persons[0])
+            expect(distinctIds).toEqual(expect.arrayContaining([oldUserDistinctId, newUserDistinctId]))
+        })
+
+        it(`add distinct id and marks user as is_identified when passed $anon_distinct_id person exists and distinct_id does not`, async () => {
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, oldUserUuid, [
+                { distinctId: oldUserDistinctId },
+            ])
+
+            const mergeService: PersonMergeService = personMergeService({
+                event: '$identify',
+                distinct_id: newUserDistinctId,
+                properties: {
+                    $anon_distinct_id: oldUserDistinctId,
+                },
+            })
+            const [person, kafkaAcks] = await mergeService.handleIdentifyOrAlias()
+            const context = mergeService.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+
+            const persons = await fetchPostgresPersonsH()
+
+            expect(person).toMatchObject({
+                id: expect.any(String),
+                uuid: oldUserUuid,
+                properties: {},
+                created_at: timestamp,
+                version: 0,
+                is_identified: false,
+            })
+            expect(mergeService.getUpdateIsIdentified()).toBeTruthy()
+            expect(hub.db.updatePerson).not.toHaveBeenCalled()
+
+            // verify Postgres persons
+            expect(persons.length).toEqual(1)
+            expect(persons[0]).toMatchObject({
+                id: person!.id,
+                uuid: oldUserUuid,
+                created_at: timestamp,
+                is_identified: false,
+                properties: {},
+                version: 0,
+            })
+
+            // verify Postgres distinct_ids
+            const distinctIds = await hub.db.fetchDistinctIdValues(persons[0])
+            expect(distinctIds).toEqual(expect.arrayContaining([oldUserDistinctId, newUserDistinctId]))
+        })
+
+        it(`merge into distinct_id person and marks user as is_identified when both persons have is_identified false`, async () => {
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, oldUserUuid, [
+                { distinctId: oldUserDistinctId },
+            ])
+            await createPerson(hub, timestamp2, {}, {}, {}, teamId, null, false, newUserUuid, [
+                { distinctId: newUserDistinctId },
+            ])
+
+            const mergeService: PersonMergeService = personMergeService({
+                event: '$identify',
+                distinct_id: newUserDistinctId,
+                properties: {
+                    $anon_distinct_id: oldUserDistinctId,
+                },
+            })
+            const [person, kafkaAcks] = await mergeService.handleIdentifyOrAlias()
+            const context = mergeService.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+
+            expect(person).toMatchObject({
+                id: expect.any(String),
+                uuid: expect.any(String),
+                properties: {},
+                created_at: timestamp,
+                version: 1,
+                is_identified: true,
+            })
+
+            // verify Postgres persons
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(1)
+            expect(persons[0]).toMatchObject({
+                id: person!.id,
+                uuid: newUserUuid,
+                created_at: timestamp,
+                is_identified: true,
+                properties: {},
+                version: 1,
+            })
+            expect([newUserUuid, oldUserUuid]).toContain(persons[0].uuid)
+
+            // verify Postgres distinct_ids
+            const distinctIds = await hub.db.fetchDistinctIdValues(persons[0])
+            expect(distinctIds).toEqual(expect.arrayContaining([oldUserDistinctId, newUserDistinctId]))
+
+            // verify ClickHouse persons
+            await delayUntilEventIngested(() => fetchPersonsRowsWithVersionHigerEqualThan(), 2) // wait until merge and delete processed
+            const clickhousePersons = await fetchPersonsRows() // but verify full state
+            expect(clickhousePersons.length).toEqual(2)
+            expect(clickhousePersons).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        id: expect.any(String),
+                        properties: '{}',
+                        created_at: timestampch,
+                        version: 1,
+                        is_identified: 1,
+                    }),
+                    expect.objectContaining({
+                        id: expect.any(String),
+                        is_deleted: 1,
+                        version: 100,
+                    }),
+                ])
+            )
+            expect(new Set(clickhousePersons.map((p) => p.id))).toEqual(new Set([newUserUuid, oldUserUuid]))
+
+            // verify ClickHouse distinct_ids
+            await delayUntilEventIngested(() => fetchDistinctIdsClickhouseVersion1())
+            const clickHouseDistinctIds = await fetchDistinctIdsClickhouse(persons[0])
+            expect(clickHouseDistinctIds).toEqual(expect.arrayContaining([oldUserDistinctId, newUserDistinctId]))
+        })
+
+        it(`merge into distinct_id person and marks user as is_identified when distinct_id user is identified and $anon_distinct_id user is not`, async () => {
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, oldUserUuid, [
+                { distinctId: oldUserDistinctId },
+            ])
+            await createPerson(hub, timestamp2, {}, {}, {}, teamId, null, true, newUserUuid, [
+                { distinctId: newUserDistinctId },
+            ])
+
+            const mergeService = personMergeService({
+                event: '$identify',
+                distinct_id: newUserDistinctId,
+                properties: {
+                    $anon_distinct_id: oldUserDistinctId,
+                },
+            })
+            const [person, kafkaAcks] = await mergeService.handleIdentifyOrAlias()
+            const context = mergeService.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+
+            expect(person).toEqual(
+                expect.objectContaining({
+                    id: expect.any(String),
+                    uuid: expect.any(String),
+                    properties: {},
+                    created_at: timestamp,
+                    version: 1,
+                    is_identified: true,
+                })
+            )
+
+            // verify Postgres persons
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(1)
+            expect(persons[0]).toMatchObject({
+                id: person!.id,
+                uuid: newUserUuid,
+                created_at: timestamp,
+                is_identified: true,
+                properties: {},
+                version: 1,
+            })
+            expect([newUserUuid, oldUserUuid]).toContain(persons[0].uuid)
+
+            // verify Postgres distinct_ids
+            const distinctIds = await hub.db.fetchDistinctIdValues(persons[0])
+            expect(distinctIds).toEqual(expect.arrayContaining([oldUserDistinctId, newUserDistinctId]))
+
+            // verify ClickHouse persons
+            await delayUntilEventIngested(() => fetchPersonsRowsWithVersionHigerEqualThan(), 2) // wait until merge and delete processed
+            const clickhousePersons = await fetchPersonsRows() // but verify full state
+            expect(clickhousePersons.length).toEqual(2)
+            expect(clickhousePersons).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        id: expect.any(String),
+                        properties: '{}',
+                        created_at: timestampch,
+                        version: 1,
+                        is_identified: 1,
+                    }),
+                    expect.objectContaining({
+                        id: expect.any(String),
+                        is_deleted: 1,
+                        version: 100,
+                    }),
+                ])
+            )
+            expect(new Set(clickhousePersons.map((p) => p.id))).toEqual(new Set([newUserUuid, oldUserUuid]))
+
+            // verify ClickHouse distinct_ids
+            await delayUntilEventIngested(() => fetchDistinctIdsClickhouseVersion1())
+            const clickHouseDistinctIds = await fetchDistinctIdsClickhouse(persons[0])
+            expect(clickHouseDistinctIds).toEqual(expect.arrayContaining([oldUserDistinctId, newUserDistinctId]))
+        })
+
+        it(`does not merge people when distinct_id user is not identified and $anon_distinct_id user is`, async () => {
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, true, oldUserUuid, [
+                { distinctId: oldUserDistinctId },
+            ])
+            await createPerson(hub, timestamp2, {}, {}, {}, teamId, null, false, newUserUuid, [
+                { distinctId: newUserDistinctId },
+            ])
+
+            const personS = personMergeService({
+                event: '$identify',
+                distinct_id: newUserDistinctId,
+                properties: {
+                    $anon_distinct_id: oldUserDistinctId,
+                },
+            })
+            const [person, kafkaAcks] = await personS.handleIdentifyOrAlias()
+            await hub.db.kafkaProducer.flush()
+            await kafkaAcks
+
+            expect(personS.getUpdateIsIdentified()).toBeTruthy()
+            expect(person).toEqual(
+                expect.objectContaining({
+                    id: expect.any(String),
+                    uuid: newUserUuid,
+                    properties: {},
+                    created_at: timestamp2,
+                    version: 0,
+                    is_identified: false,
+                })
+            )
+
+            // verify Postgres persons
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(2)
+            expect(persons[0]).toEqual(
+                expect.objectContaining({
+                    id: expect.any(String),
+                    uuid: oldUserUuid,
+                    properties: {},
+                    created_at: timestamp,
+                    version: 0,
+                    is_identified: true,
+                })
+            )
+            expect(persons[1]).toEqual(person)
+
+            // verify Postgres distinct_ids
+            const distinctIds = await hub.db.fetchDistinctIdValues(persons[0])
+            expect(distinctIds).toEqual(expect.arrayContaining([oldUserDistinctId]))
+            const distinctIds2 = await hub.db.fetchDistinctIdValues(persons[1])
+            expect(distinctIds2).toEqual(expect.arrayContaining([newUserDistinctId]))
+        })
+
+        it(`does not merge people when both users are identified`, async () => {
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, true, oldUserUuid, [
+                { distinctId: oldUserDistinctId },
+            ])
+            await createPerson(hub, timestamp2, {}, {}, {}, teamId, null, true, newUserUuid, [
+                { distinctId: newUserDistinctId },
+            ])
+            const [person, kafkaAcks] = await personMergeService({
+                event: '$identify',
+                distinct_id: newUserDistinctId,
+                properties: {
+                    $anon_distinct_id: oldUserDistinctId,
+                },
+            }).handleIdentifyOrAlias()
+            await hub.db.kafkaProducer.flush()
+            await kafkaAcks
+
+            expect(person).toEqual(
+                expect.objectContaining({
+                    id: expect.any(String),
+                    uuid: newUserUuid,
+                    properties: {},
+                    created_at: timestamp2,
+                    version: 0,
+                    is_identified: true,
+                })
+            )
+
+            // verify Postgres persons
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(2)
+            expect(persons[0]).toMatchObject({
+                id: expect.any(String),
+                uuid: oldUserUuid,
+                properties: {},
+                created_at: timestamp,
+                version: 0,
+                is_identified: true,
+            })
+            expect(persons[1]).toMatchObject({
+                id: person!.id,
+                uuid: newUserUuid,
+                created_at: timestamp2,
+                is_identified: true,
+                properties: {},
+                version: 0,
+            })
+
+            // verify Postgres distinct_ids
+            const distinctIds = await hub.db.fetchDistinctIdValues(persons[0])
+            expect(distinctIds).toEqual(expect.arrayContaining([oldUserDistinctId]))
+            const distinctIds2 = await hub.db.fetchDistinctIdValues(persons[1])
+            expect(distinctIds2).toEqual(expect.arrayContaining([newUserDistinctId]))
+        })
+
+        it(`merge into distinct_id person and updates properties with $set/$set_once`, async () => {
+            await createPerson(hub, timestamp, { a: 1, b: 2 }, {}, {}, teamId, null, false, oldUserUuid, [
+                { distinctId: oldUserDistinctId },
+            ])
+            await createPerson(hub, timestamp2, { b: 3, c: 4, d: 5 }, {}, {}, teamId, null, false, newUserUuid, [
+                { distinctId: newUserDistinctId },
+            ])
+
+            const mergeService = personMergeService({
+                event: '$identify',
+                distinct_id: newUserDistinctId,
+                properties: {
+                    $set: { d: 6, e: 7 },
+                    $set_once: { a: 8, f: 9 },
+                    $anon_distinct_id: oldUserDistinctId,
+                },
+            })
+            const [person, kafkaAcks] = await mergeService.handleIdentifyOrAlias()
+            const context = mergeService.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+
+            expect(person).toMatchObject({
+                id: expect.any(String),
+                uuid: expect.any(String),
+                properties: { a: 1, b: 3, c: 4, d: 6, e: 7, f: 9 },
+                created_at: timestamp,
+                version: 1,
+                is_identified: true,
+            })
+            // verify Postgres persons
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(1)
+            expect(persons[0]).toMatchObject({
+                id: person!.id,
+                uuid: newUserUuid,
+                properties: { a: 1, b: 3, c: 4, d: 6, e: 7, f: 9 },
+                created_at: timestamp,
+                version: 1,
+                is_identified: true,
+            })
+            expect([newUserUuid, oldUserUuid]).toContain(persons[0].uuid)
+
+            // verify Postgres distinct_ids
+            const distinctIds = await hub.db.fetchDistinctIdValues(persons[0])
+            expect(distinctIds).toEqual(expect.arrayContaining([oldUserDistinctId, newUserDistinctId]))
+
+            // verify ClickHouse persons
+            await delayUntilEventIngested(() => fetchPersonsRowsWithVersionHigerEqualThan(), 2) // wait until merge and delete processed
+            const clickhousePersons = await fetchPersonsRows() // but verify full state
+            expect(clickhousePersons.length).toEqual(2)
+            expect(clickhousePersons).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        id: expect.any(String),
+                        properties: JSON.stringify({ a: 1, b: 3, c: 4, d: 6, e: 7, f: 9 }),
+                        created_at: timestampch,
+                        version: 1,
+                        is_identified: 1,
+                    }),
+                    expect.objectContaining({
+                        id: expect.any(String),
+                        is_deleted: 1,
+                        version: 100,
+                    }),
+                ])
+            )
+            expect(new Set(clickhousePersons.map((p) => p.id))).toEqual(new Set([newUserUuid, oldUserUuid]))
+
+            // verify ClickHouse distinct_ids
+            await delayUntilEventIngested(() => fetchDistinctIdsClickhouseVersion1())
+            const clickHouseDistinctIds = await fetchDistinctIdsClickhouse(persons[0])
+            expect(clickHouseDistinctIds).toEqual(expect.arrayContaining([oldUserDistinctId, newUserDistinctId]))
+        })
+
+        it(`handles race condition when other thread creates the user`, async () => {
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, oldUserUuid, [
+                { distinctId: oldUserDistinctId },
+            ])
+
+            // Fake the race by assuming createPerson was called before the addDistinctId creation above
+            jest.spyOn(hub.db, 'addDistinctId').mockImplementation(
+                async (person, distinctId): Promise<TopicMessage[]> => {
+                    await hub.db.createPerson(
+                        timestamp,
+                        {},
+                        {},
+                        {},
+                        teamId,
+                        null,
+                        false,
+                        uuidFromDistinctId(teamId, distinctId),
+                        [{ distinctId }]
+                    )
+
+                    return await hub.db.addDistinctId(person, distinctId, 0) // this throws
+                }
+            )
+
+            const mergeService = personMergeService({
+                event: '$identify',
+                distinct_id: oldUserDistinctId,
+                properties: {
+                    $anon_distinct_id: newUserDistinctId,
+                },
+            })
+            const [person, kafkaAcks] = await mergeService.handleIdentifyOrAlias()
+            const context = mergeService.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+            jest.spyOn(hub.db, 'addDistinctId').mockRestore()
+
+            // if creation fails we should return the person that another thread already created
+            expect(person).toMatchObject({
+                id: expect.any(String),
+                uuid: oldUserUuid,
+                properties: {},
+                created_at: timestamp,
+                version: 1,
+                is_identified: true,
+            })
+
+            // expect(hub.db.updatePerson).not.toHaveBeenCalled()
+            // verify Postgres persons
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(1)
+            expect(persons[0]).toMatchObject({
+                id: expect.any(String),
+                uuid: oldUserUuid,
+                properties: {},
+                created_at: timestamp,
+                version: 1,
+                is_identified: true,
+            })
+
+            // verify Postgres distinct_ids
+            const distinctIds = await hub.db.fetchDistinctIdValues(persons[0])
+            expect(distinctIds).toEqual(expect.arrayContaining([newUserDistinctId]))
+        })
+    })
+
+    describe('on $create_alias events', () => {
+        // All the functionality tests are provided above in $identify tests, here we just make sure the calls are equivalent
+        it('calls merge on $identify as expected', async () => {
+            const state: PersonMergeService = personMergeService(
+                {
+                    event: '$identify',
+                    distinct_id: newUserDistinctId,
+                    properties: { $anon_distinct_id: oldUserDistinctId },
+                },
+                hub
+            )
+            jest.spyOn(state, 'merge').mockImplementation(() => {
+                return Promise.resolve([undefined, Promise.resolve()])
+            })
+            await state.handleIdentifyOrAlias()
+            expect(state.merge).toHaveBeenCalledWith(oldUserDistinctId, newUserDistinctId, teamId, timestamp)
+            jest.spyOn(state, 'merge').mockRestore()
+        })
+
+        it('calls merge on $create_alias as expected', async () => {
+            const state: PersonMergeService = personMergeService(
+                {
+                    event: '$create_alias',
+                    distinct_id: newUserDistinctId,
+                    properties: { alias: oldUserDistinctId },
+                },
+                hub
+            )
+            jest.spyOn(state, 'merge').mockImplementation(() => {
+                return Promise.resolve([undefined, Promise.resolve()])
+            })
+
+            await state.handleIdentifyOrAlias()
+            expect(state.merge).toHaveBeenCalledWith(oldUserDistinctId, newUserDistinctId, teamId, timestamp)
+            jest.spyOn(state, 'merge').mockRestore()
+        })
+
+        it('calls merge on $merge_dangerously as expected', async () => {
+            const state: PersonMergeService = personMergeService(
+                {
+                    event: '$merge_dangerously',
+                    distinct_id: newUserDistinctId,
+                    properties: { alias: oldUserDistinctId },
+                },
+                hub
+            )
+            jest.spyOn(state, 'merge').mockImplementation(() => {
+                return Promise.resolve([undefined, Promise.resolve()])
+            })
+
+            await state.handleIdentifyOrAlias()
+            expect(state.merge).toHaveBeenCalledWith(oldUserDistinctId, newUserDistinctId, teamId, timestamp)
+            jest.spyOn(state, 'merge').mockRestore()
+        })
+    })
+
+    describe('on $merge_dangerously events', () => {
+        // only difference between $merge_dangerously and $identify
+        it(`merge_dangerously can merge people when alias id user is identified`, async () => {
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, true, oldUserUuid, [
+                { distinctId: oldUserDistinctId },
+            ])
+            await createPerson(hub, timestamp2, {}, {}, {}, teamId, null, true, newUserUuid, [
+                { distinctId: newUserDistinctId },
+            ])
+            const mergeService = personMergeService({
+                event: '$merge_dangerously',
+                distinct_id: newUserDistinctId,
+                properties: {
+                    alias: oldUserDistinctId,
+                },
+            })
+            const [person, kafkaAcks] = await mergeService.handleIdentifyOrAlias()
+            const context = mergeService.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+
+            expect(person).toEqual(
+                expect.objectContaining({
+                    id: expect.any(String),
+                    uuid: expect.any(String),
+                    properties: {},
+                    created_at: timestamp,
+                    version: 1,
+                    is_identified: true,
+                })
+            )
+
+            // verify Postgres persons
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(1)
+            expect(persons[0]).toMatchObject({
+                id: person!.id,
+                uuid: newUserUuid,
+                created_at: timestamp,
+                is_identified: true,
+                properties: {},
+                version: 1,
+            })
+            expect([newUserUuid, oldUserUuid]).toContain(persons[0].uuid)
+
+            // verify Postgres distinct_ids
+            const distinctIds = await hub.db.fetchDistinctIdValues(persons[0])
+            expect(distinctIds).toEqual(expect.arrayContaining([oldUserDistinctId, newUserDistinctId]))
+
+            // verify ClickHouse persons
+            await delayUntilEventIngested(() => fetchPersonsRowsWithVersionHigerEqualThan(), 2) // wait until merge and delete processed
+            const clickhousePersons = await fetchPersonsRows() // but verify full state
+            expect(clickhousePersons.length).toEqual(2)
+            expect(clickhousePersons).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        id: expect.any(String),
+                        properties: '{}',
+                        created_at: timestampch,
+                        version: 1,
+                        is_identified: 1,
+                    }),
+                    expect.objectContaining({
+                        id: expect.any(String),
+                        is_deleted: 1,
+                        version: 100,
+                    }),
+                ])
+            )
+            expect(new Set(clickhousePersons.map((p) => p.id))).toEqual(new Set([newUserUuid, oldUserUuid]))
+
+            // verify ClickHouse distinct_ids
+            await delayUntilEventIngested(() => fetchDistinctIdsClickhouseVersion1())
+            const clickHouseDistinctIds = await fetchDistinctIdsClickhouse(persons[0])
+            expect(clickHouseDistinctIds).toEqual(expect.arrayContaining([oldUserDistinctId, newUserDistinctId]))
+        })
+    })
+
+    describe('illegal aliasing', () => {
+        const illegalIds = ['', '   ', 'null', 'undefined', '"undefined"', '[object Object]', '"[object Object]"']
+        it.each(illegalIds)('stops $identify if current distinct_id is illegal: `%s`', async (illegalId: string) => {
+            const mergeService = personMergeService({
+                event: '$identify',
+                distinct_id: illegalId,
+                properties: {
+                    $anon_distinct_id: 'anonymous_id',
+                },
+            })
+            const [person, kafkaAcks] = await mergeService.handleIdentifyOrAlias()
+            const context = mergeService.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+
+            expect(person).toEqual(undefined)
+            const persons = await fetchPostgresPersonsH()
+            expect(persons.length).toEqual(0)
+        })
+
+        it.each(illegalIds)('stops $identify if $anon_distinct_id is illegal: `%s`', async (illegalId: string) => {
+            const mergeService = personMergeService({
+                event: '$identify',
+                distinct_id: 'some_distinct_id',
+                properties: {
+                    $anon_distinct_id: illegalId,
+                },
+            })
+            const [person, kafkaAcks] = await mergeService.handleIdentifyOrAlias()
+            const context = mergeService.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+
+            expect(person).toEqual(undefined)
+            const persons = await fetchPostgresPersonsH()
+            expect(persons.length).toEqual(0)
+        })
+
+        it('stops $create_alias if current distinct_id is illegal', async () => {
+            const mergeService = personMergeService({
+                event: '$create_alias',
+                distinct_id: 'false',
+                properties: {
+                    alias: 'some_distinct_id',
+                },
+            })
+            const [person, kafkaAcks] = await mergeService.handleIdentifyOrAlias()
+            const context = mergeService.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+
+            expect(person).toEqual(undefined)
+            const persons = await fetchPostgresPersonsH()
+            expect(persons.length).toEqual(0)
+        })
+
+        it('stops $create_alias if alias is illegal', async () => {
+            const mergeService = personMergeService({
+                event: '$create_alias',
+                distinct_id: 'some_distinct_id',
+                properties: {
+                    alias: 'null',
+                },
+            })
+            const [person, kafkaAcks] = await mergeService.handleIdentifyOrAlias()
+            const context = mergeService.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+
+            expect(person).toEqual(undefined)
+            const persons = await fetchPostgresPersonsH()
+            expect(persons.length).toEqual(0)
+        })
+    })
+
+    describe('foreign key updates in other tables', () => {
+        it('handles feature flag hash key overrides with no conflicts', async () => {
+            const anonPerson = await createPerson(
+                hub,
+                timestamp.minus({ hours: 1 }),
+                {},
+                {},
+                {},
+                teamId,
+                null,
+                false,
+                uuidFromDistinctId(teamId, 'anonymous_id'),
+                [{ distinctId: 'anonymous_id' }]
+            )
+
+            const identifiedPerson = await createPerson(
+                hub,
+                timestamp,
+                {},
+                {},
+                {},
+                teamId,
+                null,
+                false,
+                uuidFromDistinctId(teamId, 'new_distinct_id'),
+                [{ distinctId: 'new_distinct_id' }]
+            )
+
+            // existing overrides
+            await insertRow(hub.db.postgres, 'posthog_featureflaghashkeyoverride', {
+                team_id: teamId,
+                person_id: anonPerson.id,
+                feature_flag_key: 'beta-feature',
+                hash_key: 'example_id',
+            })
+            await insertRow(hub.db.postgres, 'posthog_featureflaghashkeyoverride', {
+                team_id: teamId,
+                person_id: identifiedPerson.id,
+                feature_flag_key: 'multivariate-flag',
+                hash_key: 'example_id',
+            })
+
+            // this event means the person will be merged
+            // so hashkeyoverride should be updated to the new person id whichever way we merged
+            const mergeService = personMergeService({
+                event: '$identify',
+                distinct_id: 'new_distinct_id',
+                properties: {
+                    $anon_distinct_id: 'anonymous_id',
+                    distinct_id: 'new_distinct_id',
+                },
+            })
+            const [_, kafkaAcks] = await mergeService.handleIdentifyOrAlias()
+            const context = mergeService.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+
+            const [person] = await fetchPostgresPersonsH()
+            expect([identifiedPerson.id, anonPerson.id]).toContain(person.id)
+            expect(await hub.db.fetchDistinctIdValues(person)).toEqual(['anonymous_id', 'new_distinct_id'])
+            expect(person.is_identified).toEqual(true)
+
+            const result = await hub.db.postgres.query(
+                PostgresUse.COMMON_WRITE,
+                `SELECT "feature_flag_key", "person_id", "hash_key" FROM "posthog_featureflaghashkeyoverride" WHERE "team_id" = $1`,
+                [teamId],
+                'testQueryHashKeyOverride'
+            )
+            expect(result.rows).toEqual(
+                expect.arrayContaining([
+                    {
+                        feature_flag_key: 'beta-feature',
+                        person_id: person.id,
+                        hash_key: 'example_id',
+                    },
+                    {
+                        feature_flag_key: 'multivariate-flag',
+                        person_id: person.id,
+                        hash_key: 'example_id',
+                    },
+                ])
+            )
+        })
+
+        it('handles feature flag hash key overrides with some conflicts handled gracefully', async () => {
+            const anonPerson = await createPerson(
+                hub,
+                timestamp.minus({ hours: 1 }),
+                {},
+                {},
+                {},
+                teamId,
+                null,
+                false,
+                uuidFromDistinctId(teamId, 'anonymous_id'),
+                [{ distinctId: 'anonymous_id' }]
+            )
+
+            const identifiedPerson = await createPerson(
+                hub,
+                timestamp,
+                {},
+                {},
+                {},
+                teamId,
+                null,
+                false,
+                uuidFromDistinctId(teamId, 'new_distinct_id'),
+                [{ distinctId: 'new_distinct_id' }]
+            )
+
+            // existing overrides for both anonPerson and identifiedPerson
+            // which implies a clash when they are merged
+            await insertRow(hub.db.postgres, 'posthog_featureflaghashkeyoverride', {
+                team_id: teamId,
+                person_id: anonPerson.id,
+                feature_flag_key: 'beta-feature',
+                hash_key: 'anon_id',
+            })
+            await insertRow(hub.db.postgres, 'posthog_featureflaghashkeyoverride', {
+                team_id: teamId,
+                person_id: identifiedPerson.id,
+                feature_flag_key: 'beta-feature',
+                hash_key: 'identified_id',
+            })
+            await insertRow(hub.db.postgres, 'posthog_featureflaghashkeyoverride', {
+                team_id: teamId,
+                person_id: anonPerson.id,
+                feature_flag_key: 'multivariate-flag',
+                hash_key: 'other_different_id',
+            })
+
+            // this event means the person will be merged
+            // so hashkeyoverride should be updated to be either
+            // we're optimizing on updates to not write on conflict and ordering is not guaranteed
+            const mergeService = personMergeService({
+                event: '$identify',
+                distinct_id: 'new_distinct_id',
+                properties: {
+                    $anon_distinct_id: 'anonymous_id',
+                    distinct_id: 'new_distinct_id',
+                },
+            })
+            const [_, kafkaAcks] = await mergeService.handleIdentifyOrAlias()
+            const context = mergeService.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+
+            const [person] = await fetchPostgresPersonsH()
+            expect([identifiedPerson.id, anonPerson.id]).toContain(person.id)
+            expect(await hub.db.fetchDistinctIdValues(person)).toEqual(['anonymous_id', 'new_distinct_id'])
+            expect(person.is_identified).toEqual(true)
+
+            const result = await hub.db.postgres.query(
+                PostgresUse.COMMON_WRITE,
+                `SELECT "feature_flag_key", "person_id", "hash_key" FROM "posthog_featureflaghashkeyoverride" WHERE "team_id" = $1`,
+                [teamId],
+                'testQueryHashKeyOverride'
+            )
+            expect(result.rows).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        feature_flag_key: 'beta-feature',
+                        person_id: person.id,
+                        hash_key: expect.any(String), // either anon_id or identified_id
+                    }),
+                    {
+                        feature_flag_key: 'multivariate-flag',
+                        person_id: person.id,
+                        hash_key: 'other_different_id',
+                    },
+                ])
+            )
+        })
+
+        it('handles feature flag hash key overrides with no old overrides but existing new person overrides', async () => {
+            const anonPerson = await createPerson(
+                hub,
+                timestamp.minus({ hours: 1 }),
+                {},
+                {},
+                {},
+                teamId,
+                null,
+                false,
+                uuidFromDistinctId(teamId, 'anonymous_id'),
+                [{ distinctId: 'anonymous_id' }]
+            )
+
+            const identifiedPerson = await createPerson(
+                hub,
+                timestamp,
+                {},
+                {},
+                {},
+                teamId,
+                null,
+                false,
+                uuidFromDistinctId(teamId, 'new_distinct_id'),
+                [{ distinctId: 'new_distinct_id' }]
+            )
+            await insertRow(hub.db.postgres, 'posthog_featureflaghashkeyoverride', {
+                team_id: teamId,
+                person_id: identifiedPerson.id,
+                feature_flag_key: 'beta-feature',
+                hash_key: 'example_id',
+            })
+            await insertRow(hub.db.postgres, 'posthog_featureflaghashkeyoverride', {
+                team_id: teamId,
+                person_id: identifiedPerson.id,
+                feature_flag_key: 'multivariate-flag',
+                hash_key: 'different_id',
+            })
+
+            const mergeService = personMergeService({
+                event: '$identify',
+                distinct_id: 'new_distinct_id',
+                properties: {
+                    $anon_distinct_id: 'anonymous_id',
+                },
+            })
+            const [_, kafkaAcks] = await mergeService.handleIdentifyOrAlias()
+            const context = mergeService.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+
+            const [person] = await fetchPostgresPersonsH()
+            expect([identifiedPerson.id, anonPerson.id]).toContain(person.id)
+            expect(await hub.db.fetchDistinctIdValues(person)).toEqual(['anonymous_id', 'new_distinct_id'])
+            expect(person.is_identified).toEqual(true)
+
+            const result = await hub.db.postgres.query(
+                PostgresUse.COMMON_WRITE,
+                `SELECT "feature_flag_key", "person_id", "hash_key" FROM "posthog_featureflaghashkeyoverride" WHERE "team_id" = $1`,
+                [teamId],
+                'testQueryHashKeyOverride'
+            )
+            expect(result.rows).toEqual(
+                expect.arrayContaining([
+                    {
+                        feature_flag_key: 'beta-feature',
+                        person_id: person.id,
+                        hash_key: 'example_id',
+                    },
+                    {
+                        feature_flag_key: 'multivariate-flag',
+                        person_id: person.id,
+                        hash_key: 'different_id',
+                    },
+                ])
+            )
+        })
+    })
+    describe('on persons merges', () => {
+        // For some reason these tests failed if I ran them with a hub shared
+        // with other tests, so I'm creating a new hub for each test.
+        let hub: Hub
+
+        beforeEach(async () => {
+            hub = await createHub({})
+
+            jest.spyOn(hub.db, 'fetchPerson')
+            jest.spyOn(hub.db, 'updatePerson')
+        })
+
+        afterEach(async () => {
+            jest.clearAllTimers()
+            jest.useRealTimers()
+            jest.restoreAllMocks()
+            await closeHub(hub)
+        })
+
+        it(`no-op if persons already merged`, async () => {
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, true, firstUserUuid, [
+                { distinctId: firstUserDistinctId },
+                { distinctId: secondUserDistinctId },
+            ])
+
+            const state: PersonMergeService = personMergeService({}, hub)
+            jest.spyOn(hub.db.kafkaProducer, 'queueMessages')
+            const [person, kafkaAcks] = await state.merge(secondUserDistinctId, firstUserDistinctId, teamId, timestamp)
+            await hub.db.kafkaProducer.flush()
+            await kafkaAcks
+
+            expect(person).toMatchObject({
+                id: expect.any(String),
+                uuid: firstUserUuid,
+                properties: {},
+                created_at: timestamp,
+                version: 0,
+                is_identified: true,
+            })
+            expect(hub.db.updatePerson).not.toHaveBeenCalled()
+            expect(hub.db.kafkaProducer.queueMessages).not.toHaveBeenCalled()
+        })
+
+        it(`postgres and clickhouse get updated`, async () => {
+            const first = await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, firstUserUuid, [
+                { distinctId: firstUserDistinctId },
+            ])
+
+            const second = await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, secondUserUuid, [
+                { distinctId: secondUserDistinctId },
+            ])
+
+            const mergeService: PersonMergeService = personMergeService({}, hub)
+            jest.spyOn(hub.db.kafkaProducer, 'queueMessages')
+            const [person, kafkaAcks] = await mergeService.mergePeople({
+                mergeInto: first,
+                mergeIntoDistinctId: firstUserDistinctId,
+                otherPerson: second,
+                otherPersonDistinctId: secondUserDistinctId,
+            })
+            const context = mergeService.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+
+            expect(person).toMatchObject({
+                id: first.id,
+                uuid: firstUserUuid,
+                properties: {},
+                created_at: timestamp,
+                version: 1,
+                is_identified: true,
+            })
+
+            expect(hub.db.updatePerson).toHaveBeenCalledTimes(1)
+            expect(hub.db.kafkaProducer.queueMessages).toHaveBeenCalledTimes(2)
+            // verify Postgres persons
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(1)
+            expect(persons[0]).toMatchObject({
+                id: first.id,
+                uuid: firstUserUuid,
+                created_at: timestamp,
+                is_identified: true,
+                properties: {},
+                version: 1,
+            })
+
+            // verify Postgres distinct_ids
+            const distinctIds = await hub.db.fetchDistinctIdValues(person)
+            expect(distinctIds).toEqual(expect.arrayContaining([firstUserDistinctId, secondUserDistinctId]))
+
+            // verify ClickHouse persons
+            await delayUntilEventIngested(() => fetchPersonsRowsWithVersionHigerEqualThan(), 2) // wait until merge and delete processed
+            const clickhousePersons = await fetchPersonsRows() // but verify full state
+            expect(clickhousePersons).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        id: firstUserUuid,
+                        properties: '{}',
+                        created_at: timestampch,
+                        version: 1,
+                        is_identified: 1,
+                    }),
+                    expect.objectContaining({
+                        id: secondUserUuid,
+                        is_deleted: 1,
+                        version: 100,
+                    }),
+                ])
+            )
+
+            // verify ClickHouse distinct_ids
+            await delayUntilEventIngested(() => fetchDistinctIdsClickhouseVersion1())
+            const clickHouseDistinctIds = await fetchDistinctIdsClickhouse(person)
+            expect(clickHouseDistinctIds).toEqual(expect.arrayContaining([firstUserDistinctId, secondUserDistinctId]))
+        })
+
+        it(`throws if postgres unavailable`, async () => {
+            const first = await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, firstUserUuid, [
+                { distinctId: firstUserDistinctId },
+            ])
+
+            const second = await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, secondUserUuid, [
+                { distinctId: secondUserDistinctId },
+            ])
+            const state: PersonMergeService = personMergeService({}, hub)
+            // break postgres
+            const error = new DependencyUnavailableError('testing', 'Postgres', new Error('test'))
+            jest.spyOn(hub.db.postgres, 'transaction').mockImplementation(() => {
+                throw error
+            })
+            jest.spyOn(hub.db.kafkaProducer, 'queueMessages')
+            await expect(
+                state.mergePeople({
+                    mergeInto: first,
+                    mergeIntoDistinctId: firstUserDistinctId,
+                    otherPerson: second,
+                    otherPersonDistinctId: secondUserDistinctId,
+                })
+            ).rejects.toThrow(error)
+            await hub.db.kafkaProducer.flush()
+
+            expect(hub.db.postgres.transaction).toHaveBeenCalledTimes(1)
+            jest.spyOn(hub.db.postgres, 'transaction').mockRestore()
+            expect(hub.db.kafkaProducer.queueMessages).not.toBeCalled()
+            // verify Postgres persons
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        id: expect.any(String),
+                        uuid: firstUserUuid,
+                        properties: {},
+                        created_at: timestamp,
+                        version: 0,
+                        is_identified: false,
+                    }),
+                    expect.objectContaining({
+                        id: expect.any(String),
+                        uuid: secondUserUuid,
+                        properties: {},
+                        created_at: timestamp,
+                        version: 0,
+                        is_identified: false,
+                    }),
+                ])
+            )
+        })
+
+        it(`retries merges up to retry limit if postgres down`, async () => {
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, firstUserUuid, [
+                { distinctId: firstUserDistinctId },
+            ])
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, secondUserUuid, [
+                { distinctId: secondUserDistinctId },
+            ])
+            const state: PersonMergeService = personMergeService({}, hub)
+            // break postgres
+            const error = new DependencyUnavailableError('testing', 'Postgres', new Error('test'))
+            jest.spyOn(state, 'mergePeople').mockImplementation(() => {
+                throw error
+            })
+            jest.spyOn(hub.db.kafkaProducer, 'queueMessages')
+            await expect(state.merge(secondUserDistinctId, firstUserDistinctId, teamId, timestamp)).rejects.toThrow(
+                error
+            )
+
+            await hub.db.kafkaProducer.flush()
+
+            expect(state.mergePeople).toHaveBeenCalledTimes(3)
+            jest.spyOn(state, 'mergePeople').mockRestore()
+            expect(hub.db.kafkaProducer.queueMessages).not.toBeCalled()
+            // verify Postgres persons
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        id: expect.any(String),
+                        uuid: firstUserUuid,
+                        properties: {},
+                        created_at: timestamp,
+                        version: 0,
+                        is_identified: false,
+                    }),
+                    expect.objectContaining({
+                        id: expect.any(String),
+                        uuid: secondUserUuid,
+                        properties: {},
+                        created_at: timestamp,
+                        version: 0,
+                        is_identified: false,
+                    }),
+                ])
+            )
+        })
+
+        it(`handleIdentifyOrAlias does not throw on merge failure`, async () => {
+            // TODO: This the current state, we should probably change it
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, firstUserUuid, [
+                { distinctId: firstUserDistinctId },
+            ])
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, secondUserUuid, [
+                { distinctId: secondUserDistinctId },
+            ])
+
+            const state: PersonMergeService = personMergeService(
+                {
+                    event: '$merge_dangerously',
+                    distinct_id: firstUserDistinctId,
+                    properties: { alias: secondUserDistinctId },
+                },
+                hub
+            )
+            // break postgres
+            const error = new DependencyUnavailableError('testing', 'Postgres', new Error('test'))
+            jest.spyOn(state, 'mergePeople').mockImplementation(() => {
+                throw error
+            })
+            jest.spyOn(hub.db.kafkaProducer, 'queueMessages')
+            await state.handleIdentifyOrAlias()
+            await hub.db.kafkaProducer.flush()
+
+            expect(state.mergePeople).toHaveBeenCalledTimes(3)
+            jest.spyOn(state, 'mergePeople').mockRestore()
+            expect(hub.db.kafkaProducer.queueMessages).not.toBeCalled()
+            // verify Postgres persons
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        id: expect.stringMatching(/^[0-9]+$/),
+                        uuid: firstUserUuid,
+                        properties: {},
+                        created_at: timestamp,
+                        version: 0,
+                        is_identified: false,
+                    }),
+                    expect.objectContaining({
+                        id: expect.stringMatching(/^[0-9]+$/),
+                        uuid: secondUserUuid,
+                        properties: {},
+                        created_at: timestamp,
+                        version: 0,
+                        is_identified: false,
+                    }),
+                ])
+            )
+        })
+    })
+})

--- a/plugin-server/tests/worker/ingestion/person-state-batch.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state-batch.test.ts
@@ -740,7 +740,7 @@ describe('PersonState.processEvent()', () => {
     })
 
     describe('on person update', () => {
-        it('updates person properties xx', async () => {
+        it('updates person properties', async () => {
             await createPerson(hub, timestamp, { b: 3, c: 4, toString: {} }, {}, {}, teamId, null, false, newUserUuid, [
                 { distinctId: newUserDistinctId },
             ])


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

This PR addresses some lingering bugs I found in production. Basically there's 3 issues with merging, one major and two minor, this PR addresses all of them.

Known issues:
- If another pod merges the same person the batch has in memory, it holds a wrong id in memory and will attempt to write to the wrong id. 
- Created_at can be updated wrongly on merge
- Some db id return issues on merge

## Changes
- Adds entire person-state.test.ts suite for batching, helped uncover the merge batch issue
- Makes merge retriable when the id is not found in the database
- Makes it so that created_at is always the smallest value provided when merging
- Fixed id management on merge
- Remove WITH_TRANSACTION write mode as it is a performance hit

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
