### PR TITLE
fix(experiments): load estimation after modal mounted

### DIFF
--- a/frontend/src/scenes/experiments/RunningTimeCalculator/RunningTimeCalculatorModal.tsx
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/RunningTimeCalculatorModal.tsx
@@ -58,6 +58,7 @@ export function RunningTimeCalculatorModal(): JSX.Element {
                         })
                         closeCalculateRunningTimeModal()
                     }}
+                    disabled={!recommendedRunningTime || metricResultLoading}
                 />
             }
         >

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/RunningTimeCalculatorModalFooter.tsx
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/RunningTimeCalculatorModalFooter.tsx
@@ -3,9 +3,11 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 export const RunningTimeCalculatorModalFooter = ({
     onClose,
     onSave,
+    disabled = false,
 }: {
     onClose: () => void
     onSave: () => void
+    disabled?: boolean
 }): JSX.Element => {
     return (
         <div className="flex items-center w-full">
@@ -13,7 +15,12 @@ export const RunningTimeCalculatorModalFooter = ({
                 <LemonButton form="edit-experiment-metric-form" type="secondary" onClick={onClose}>
                     Cancel
                 </LemonButton>
-                <LemonButton form="edit-experiment-metric-form" onClick={onSave} type="primary">
+                <LemonButton
+                    form="edit-experiment-metric-form"
+                    onClick={onSave}
+                    type="primary"
+                    disabledReason={disabled ? 'Calculation required before saving' : undefined}
+                >
                     Save
                 </LemonButton>
             </div>

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeCalculatorLogic.tsx
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeCalculatorLogic.tsx
@@ -1,5 +1,5 @@
 import equal from 'fast-deep-equal'
-import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { DEFAULT_MDE, experimentLogic } from 'scenes/experiments/experimentLogic'
@@ -276,6 +276,12 @@ export const runningTimeCalculatorLogic = kea<runningTimeCalculatorLogicType>([
             }
         },
     })),
+    afterMount(({ actions, values }) => {
+        // Initial calculation if we have a valid metric selected and no metric result yet
+        if (values.metric && !values.metricResult && values.metricIndex !== null) {
+            actions.loadMetricResult()
+        }
+    }),
     selectors({
         defaultMetricIndex: [
             (s) => [s.experiment, s.exposureEstimateConfig],


### PR DESCRIPTION
## Problem
Some users were able to save the running time estimation settings before the results were ready.
https://posthoghelp.zendesk.com/agent/tickets/33856 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/36009)

## Changes
- Load the estimation results after the modal mounts, as long as the inputs are valid
- Have the Save button disabled until the estimation result is available

## How did you test this code?
Tested manually