### PR TITLE
fix(data-warehouse): Chunk pipeline on size of bytes as well as length of list

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -8,6 +8,7 @@ import pyarrow as pa
 import pyarrow.compute as pc
 from django.db.models import F
 from dlt.sources import DltSource
+from pympler import asizeof
 
 from posthog.exceptions_capture import capture_exception
 from posthog.temporal.common.logger import FilteringBoundLogger
@@ -63,6 +64,7 @@ class PipelineNonDLT:
     _internal_schema = HogQLSchema()
     _load_id: int
     _chunk_size: int = 5000
+    _chunk_size_bytes: int = 200 * 1024 * 1024  # 200 MiB
 
     def __init__(
         self,
@@ -161,20 +163,24 @@ class PipelineNonDLT:
                 if isinstance(item, list):
                     if len(buffer) > 0:
                         buffer.extend(item)
-                        if len(buffer) >= self._chunk_size:
+                        if asizeof.asizeof(buffer) >= self._chunk_size_bytes or len(buffer) >= self._chunk_size:
+                            self._logger.debug(f"Processing pipeline buffer (list). Length of buffer = {len(buffer)}")
+
                             py_table = table_from_py_list(buffer)
                             buffer = []
                     else:
-                        if len(item) >= self._chunk_size:
+                        if asizeof.asizeof(item) >= self._chunk_size_bytes or len(item) >= self._chunk_size:
+                            self._logger.debug(f"Processing pipeline item (list). Length of item = {len(item)}")
                             py_table = table_from_py_list(item)
                         else:
                             buffer.extend(item)
                             continue
                 elif isinstance(item, dict):
                     buffer.append(item)
-                    if len(buffer) < self._chunk_size:
+                    if asizeof.asizeof(buffer) < self._chunk_size_bytes and len(buffer) < self._chunk_size:
                         continue
 
+                    self._logger.debug(f"Processing pipeline buffer (dict). Length of buffer = {len(buffer)}")
                     py_table = table_from_py_list(buffer)
                     buffer = []
                 elif isinstance(item, pa.Table):


### PR DESCRIPTION
## Problem
- It looks like we have some `full_refresh` chargebee tables causing pods to OOM in EU
- I'm concerned that we're potentially queueing up too much data if the API responses are giant due to the likes of metadata

## Changes
- Chunk the pipeline on both the number of items (previous behavior) and size of data, ensuring the size doesn't go over 200MiB, if it does, then we process that batch immediately 
- Not 100% if this is the cause, but this is generally a good thing to do anyway

## How did you test this code?
Added a unit test
