### PR TITLE
feat: password change email

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -211,6 +211,8 @@ export class ApiError extends Error {
     code: string | null
     /** Django REST Framework `statusText` - used in downstream error handling. */
     statusText: string | null
+    /** Django REST Framework `attr` - used in downstream error handling. */
+    attr: string | null
 
     /** Link to external resources, e.g. stripe invoices */
     link: string | null
@@ -222,6 +224,7 @@ export class ApiError extends Error {
         this.detail = data?.detail || null
         this.code = data?.code || null
         this.link = data?.link || null
+        this.attr = data?.attr || null
     }
 
     /**

--- a/frontend/src/scenes/authentication/passwordResetLogic.ts
+++ b/frontend/src/scenes/authentication/passwordResetLogic.ts
@@ -81,7 +81,9 @@ export const passwordResetLogic = kea<passwordResetLogicType>([
         passwordReset: {
             defaults: {} as unknown as PasswordResetForm,
             errors: ({ password, passwordConfirm }) => ({
-                password: !password ? 'Please enter your password to continue' : values.validatedPassword.feedback,
+                password: !password
+                    ? 'Please enter your password to continue'
+                    : values.validatedPassword.feedback || undefined,
                 passwordConfirm: !passwordConfirm
                     ? 'Please confirm your password to continue'
                     : password !== passwordConfirm

--- a/frontend/src/scenes/settings/user/changePasswordLogic.ts
+++ b/frontend/src/scenes/settings/user/changePasswordLogic.ts
@@ -25,7 +25,9 @@ export const changePasswordLogic = kea<changePasswordLogicType>([
                     (!values.user || values.user.has_password) && !current_password
                         ? 'Please enter your current password'
                         : undefined,
-                password: !password ? 'Please enter your password to continue' : values.validatedPassword.feedback,
+                password: !password
+                    ? 'Please enter your password to continue'
+                    : values.validatedPassword.feedback || undefined,
             }),
             submit: async ({ password, current_password }, breakpoint) => {
                 await breakpoint(150)

--- a/frontend/src/scenes/settings/user/changePasswordLogic.ts
+++ b/frontend/src/scenes/settings/user/changePasswordLogic.ts
@@ -40,7 +40,10 @@ export const changePasswordLogic = kea<changePasswordLogicType>([
                     actions.resetChangePassword({ password: '', current_password: '' })
                     lemonToast.success('Password changed')
                 } catch (e: any) {
-                    actions.setChangePasswordManualErrors({ [e.attr]: e.detail })
+                    setTimeout(() => {
+                        // TRICKY: We want to run on the next tick otherwise the errors don't show (possibly because of the async wait in the submit)
+                        actions.setChangePasswordManualErrors({ [e.attr]: e.detail })
+                    }, 1)
                 }
             },
         },

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -331,8 +331,8 @@ class UserSerializer(serializers.ModelSerializer):
             instance.save()
             update_session_auth_hash(self.context["request"], instance)
             updated_attrs.append("password")
-
             send_password_changed_email.delay(instance.id)
+
         report_user_updated(instance, updated_attrs)
 
         return instance

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -67,6 +67,7 @@ from posthog.tasks.email import (
     send_email_change_emails,
     send_two_factor_auth_disabled_email,
     send_two_factor_auth_enabled_email,
+    send_password_changed_email,
 )
 from posthog.user_permissions import UserPermissions
 
@@ -331,6 +332,7 @@ class UserSerializer(serializers.ModelSerializer):
             update_session_auth_hash(self.context["request"], instance)
             updated_attrs.append("password")
 
+            send_password_changed_email.delay(instance.id)
         report_user_updated(instance, updated_attrs)
 
         return instance

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -313,14 +313,14 @@ class UserSerializer(serializers.ModelSerializer):
             instance.save()
             EmailVerifier.create_token_and_send_email_verification(instance)
 
+        if validated_data.get("notification_settings"):
+            validated_data["partial_notification_settings"] = validated_data.pop("notification_settings")
+
         # Update password
         current_password = validated_data.pop("current_password", None)
         password = self.validate_password_change(
             cast(User, instance), current_password, validated_data.pop("password", None)
         )
-
-        if validated_data.get("notification_settings"):
-            validated_data["partial_notification_settings"] = validated_data.pop("notification_settings")
 
         updated_attrs = list(validated_data.keys())
         instance = cast(User, super().update(instance, validated_data))

--- a/posthog/email.py
+++ b/posthog/email.py
@@ -90,6 +90,7 @@ CUSTOMER_IO_TEMPLATE_ID_MAP = {
     "email_verification": "35",
     "email_change_old_address": "36",
     "email_change_new_address": "37",
+    "password_changed": "42",
 }
 
 

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -198,7 +198,7 @@ def send_password_changed_email(user_id: int) -> None:
         },
     )
     message.add_recipient(user.email)
-    message.send(send_async=False)
+    message.send()
 
 
 @shared_task(**EMAIL_TASK_KWARGS)

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -189,7 +189,7 @@ def send_password_changed_email(user_id: int) -> None:
     message = EmailMessage(
         use_http=True,
         campaign_key=f"password-changed-{user.uuid}-{timezone.now().timestamp()}",
-        subject=f"Your password has been changed",
+        subject="Your password has been changed",
         template_name="password_changed",
         template_context={
             "preheader": "Your password has been changed",

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -184,6 +184,24 @@ def send_password_reset(user_id: int, token: str) -> None:
 
 
 @shared_task(**EMAIL_TASK_KWARGS)
+def send_password_changed_email(user_id: int) -> None:
+    user = User.objects.get(pk=user_id)
+    message = EmailMessage(
+        use_http=True,
+        campaign_key=f"password-changed-{user.uuid}-{timezone.now().timestamp()}",
+        subject=f"Your password has been changed",
+        template_name="password_changed",
+        template_context={
+            "preheader": "Your password has been changed",
+            "cloud": is_cloud(),
+            "site_url": settings.SITE_URL,
+        },
+    )
+    message.add_recipient(user.email)
+    message.send()
+
+
+@shared_task(**EMAIL_TASK_KWARGS)
 def send_email_verification(user_id: int, token: str, next_url: str | None = None) -> None:
     user: User = User.objects.get(pk=user_id)
     message = EmailMessage(

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -198,7 +198,7 @@ def send_password_changed_email(user_id: int) -> None:
         },
     )
     message.add_recipient(user.email)
-    message.send()
+    message.send(send_async=False)
 
 
 @shared_task(**EMAIL_TASK_KWARGS)

--- a/posthog/templates/email/password_changed.html
+++ b/posthog/templates/email/password_changed.html
@@ -1,0 +1,6 @@
+{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}{% block section %}
+<p>
+    Someone (hopefully you) changed the password on your PostHog account{% if cloud %} on PostHog Cloud.{%else%}
+    hosted on {% strip_protocol site_url %}{% endif %}.
+</p>
+{% endblock %}


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changes

We don't have an email to the user when their password is changed, this adds one.

- add new customer.io template
- add django template 
- add task to send email
- trigger task when password is changed

email
<img width="814" height="722" alt="Screenshot 2025-07-10 at 12 17 35 PM" src="https://github.com/user-attachments/assets/0369ef6a-6e60-46e4-866d-2575fd237d1b" />

Other fixes
- API error `attr` fix
- change password erroring rendering fix 

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

Manually
