### PR TITLE
chore(capture): wrap use of capture_internal (get_event) in CSP API for replacement

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -478,7 +478,7 @@ def get_csp_event(request):
         first_distinct_id = csp_report.get("distinct_id", None)
     else:
         # mimic what get_event does if no data is returned from process_csp_report
-        cors_response(
+        return cors_response(
             request,
             generate_exception_response(
                 "csp_report_capture",

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -6,7 +6,7 @@ from concurrent.futures import ThreadPoolExecutor, Future
 
 import structlog
 import time
-from requests import Response, Session
+from requests import HTTPError, Response, Session
 from requests.adapters import HTTPAdapter, Retry
 from collections.abc import Iterator
 from datetime import datetime, timedelta, UTC
@@ -470,8 +470,52 @@ def get_csp_event(request):
     if error_response:
         return error_response
 
-    # Explicit mark for get_event pipeline to handle CSP reports on this flow
-    return get_event(request, csp_report=csp_report)
+    if posthoganalytics.feature_enabled("ingestion-new-capture-internal", csp_report.get("distinct_id", None)):
+        try:
+            token = get_token(csp_report, request)
+            resp = new_capture_internal(token, csp_report.get("distinct_id", None), csp_report, False)
+            if resp.status_code < 400:
+                return cors_response(request, HttpResponse(status=status.HTTP_204_NO_CONTENT))
+            else:
+                return cors_response(
+                    request,
+                    generate_exception_response(
+                        "csp_report_capture",
+                        "Failed to submit CSP report",
+                        code="capture_http_error",
+                        type="capture_http_error",
+                        status_code=resp.status_code,
+                    ),
+                )
+        except HTTPError as hte:
+            capture_exception(hte, {"capture-http": "csp_report", "ph-team-token": token})
+            logger.exception("csp_report_capture_http_error", exc_info=hte)
+            return cors_response(
+                request,
+                generate_exception_response(
+                    "csp_report_capture",
+                    f"Failed to submit CSP report: {hte}",
+                    code="capture_http_error",
+                    type="capture_http_error",
+                    status_code=hte.response.status_code,
+                ),
+            )
+        except Exception as e:
+            capture_exception(e, {"capture-pathway": "csp_report", "ph-team-token": token})
+            logger.exception("csp_report_capture_error", exc_info=e)
+            return cors_response(
+                request,
+                generate_exception_response(
+                    "csp_report_capture",
+                    f"Failed to submit CSP report: {e}",
+                    code="capture_error",
+                    type="capture_error",
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                ),
+            )
+    else:
+        # Explicit mark for get_event pipeline to handle CSP reports on this flow
+        return get_event(request, csp_report=csp_report)
 
 
 @csrf_exempt

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -472,9 +472,12 @@ def get_csp_event(request):
     if csp_report and isinstance(csp_report, list):
         # For list of reports, use the first one's distinct_id for feature flag check
         first_distinct_id = csp_report[0].get("distinct_id", None)
-    else:
+    elif csp_report and isinstance(csp_report, dict):
         # For single report, use the distinct_id for the same
         first_distinct_id = csp_report.get("distinct_id", None)
+    else:
+        # if a CSP report is submitted without one of the two accepted Content-Types, we bail
+        return cors_response(request, HttpResponse(status=status.HTTP_400_BAD_REQUEST))
 
     if first_distinct_id and posthoganalytics.feature_enabled("ingestion-new-capture-internal-csp", first_distinct_id):
         try:

--- a/posthog/api/csp.py
+++ b/posthog/api/csp.py
@@ -1,6 +1,6 @@
 import json
 import structlog
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Optional
 
 from django.http import HttpResponse
@@ -124,6 +124,7 @@ def build_csp_event(props: dict, distinct_id: str, session_id: str, version: str
     return {
         "event": "$csp_violation",
         "distinct_id": distinct_id,
+        "timestamp": datetime.now(UTC).isoformat(),
         "properties": {
             "$session_id": session_id,
             "$csp_version": version,

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -2592,7 +2592,7 @@ class TestCapture(BaseTest):
 
         assert status.HTTP_400_BAD_REQUEST == response.status_code
         assert response.json()["code"] == "invalid_payload"
-        assert "All events must have the event name field" in response.json()["detail"]
+        assert "Failed to submit CSP report" in response.json()["detail"]
 
     def test_integration_csp_report_with_report_to_format_returns_204(self):
         report_to_format = [

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -2399,7 +2399,7 @@ class TestCapture(BaseTest):
             f"/report/?token={self.team.api_token}", data=json.dumps(payload), content_type="application/csp-report"
         )
         assert resp.status_code == status.HTTP_204_NO_CONTENT
-        mock_new_capture.assert_called_count(1)
+        assert mock_new_capture.call_count == 1
 
     @patch("posthog.api.capture.new_capture_internal")
     @patch("posthog.api.capture.posthoganalytics.feature_enabled", return_value=True)
@@ -2457,7 +2457,7 @@ class TestCapture(BaseTest):
             content_type="application/reports+json",
         )
         assert resp.status_code == status.HTTP_204_NO_CONTENT
-        mock_new_capture.assert_called_count(3)
+        assert mock_new_capture.call_count == 3
 
     @patch("posthog.kafka_client.client._KafkaProducer.produce")
     def test_capture_csp_violation(self, kafka_produce):


### PR DESCRIPTION
## Problem
As part of the `capture-rs` migration, we need to replace all uses of direct-to-Kafka capture event publishing with code that `POST`s to `capture-rs` instead.

## Changes


## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Locally and in CI
