### PR TITLE
feat(max): Include general context in prompt in MaxChatOpenAI

### DIFF
--- a/ee/hogai/README.md
+++ b/ee/hogai/README.md
@@ -24,8 +24,8 @@ You'll need to set [env vars](https://posthog.slack.com/docs/TSS5W8YQZ/F08UU1LJF
     ```python
     from ee.hogai.tool import MaxTool
     from pydantic import BaseModel, Field
-    from langchain_openai import ChatOpenAI
     from langchain_core.prompts import ChatPromptTemplate
+    from ee.hogai.llm import MaxChatOpenAI
 
     # Define your tool's arguments schema
     class YourToolArgs(BaseModel):
@@ -45,7 +45,7 @@ You'll need to set [env vars](https://posthog.slack.com/docs/TSS5W8YQZ/F08UU1LJF
             
             # Optional: Use LLM to process inputs or generate structured outputs
             model = (
-                ChatOpenAI(model="gpt-4o", temperature=0.2)
+                MaxChatOpenAI(model="gpt-4o", temperature=0.2)
                 .with_structured_output(OutputType)
                 .with_retry()
             )

--- a/ee/hogai/graph/inkeep_docs/nodes.py
+++ b/ee/hogai/graph/inkeep_docs/nodes.py
@@ -1,7 +1,7 @@
 from typing import Literal
 from uuid import uuid4
 from django.conf import settings
-from langchain_openai import ChatOpenAI
+from ee.hogai.llm import MaxChatOpenAI
 from langchain_core.messages import (
     AIMessage as LangchainAIMessage,
     HumanMessage as LangchainHumanMessage,
@@ -52,13 +52,15 @@ class InkeepDocsNode(RootNode):  # Inheriting from RootNode to use the same mess
         return messages
 
     def _get_model(self):  # type: ignore
-        return ChatOpenAI(
+        return MaxChatOpenAI(
             model="inkeep-qa-sonnet-4",
             base_url="https://api.inkeep.com/v1/",
             api_key=settings.INKEEP_API_KEY,
             streaming=True,
             stream_usage=True,
             max_retries=3,
+            user=self._user,
+            team=self._team,
         )
 
     def router(self, state: AssistantState) -> Literal["end", "root"]:

--- a/ee/hogai/graph/inkeep_docs/nodes.py
+++ b/ee/hogai/graph/inkeep_docs/nodes.py
@@ -58,7 +58,6 @@ class InkeepDocsNode(RootNode):  # Inheriting from RootNode to use the same mess
             api_key=settings.INKEEP_API_KEY,
             streaming=True,
             stream_usage=True,
-            max_retries=3,
             user=self._user,
             team=self._team,
         )

--- a/ee/hogai/graph/inkeep_docs/test/test_nodes.py
+++ b/ee/hogai/graph/inkeep_docs/test/test_nodes.py
@@ -167,7 +167,7 @@ class TestInkeepDocsNode(ClickhouseTestMixin, BaseTest):
             self.assertNotEqual(first_message.id, second_message.id)
 
     def test_model_has_correct_max_retries(self) -> None:
-        with patch("ee.hogai.graph.inkeep_docs.nodes.ChatOpenAI") as mock_chat_openai:
+        with patch("ee.hogai.graph.inkeep_docs.nodes.MaxChatOpenAI") as mock_chat_openai:
             mock_model = MagicMock()
             mock_chat_openai.return_value = mock_model
 

--- a/ee/hogai/graph/inkeep_docs/test/test_nodes.py
+++ b/ee/hogai/graph/inkeep_docs/test/test_nodes.py
@@ -1,5 +1,5 @@
 from typing import cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from uuid import uuid4
 
 from langchain_core.messages import (
@@ -165,16 +165,3 @@ class TestInkeepDocsNode(ClickhouseTestMixin, BaseTest):
             self.assertIsNotNone(first_message.id)
             self.assertIsNotNone(second_message.id)
             self.assertNotEqual(first_message.id, second_message.id)
-
-    def test_model_has_correct_max_retries(self) -> None:
-        with patch("ee.hogai.graph.inkeep_docs.nodes.MaxChatOpenAI") as mock_chat_openai:
-            mock_model = MagicMock()
-            mock_chat_openai.return_value = mock_model
-
-            node = InkeepDocsNode(self.team, self.user)
-
-            node._get_model()
-
-            mock_chat_openai.assert_called_once()
-            call_args = mock_chat_openai.call_args
-            self.assertEqual(call_args.kwargs["max_retries"], 3)

--- a/ee/hogai/graph/memory/nodes.py
+++ b/ee/hogai/graph/memory/nodes.py
@@ -14,7 +14,7 @@ from langchain_core.messages import (
 from langchain_core.output_parsers import PydanticToolsParser, StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnableConfig
-from langchain_openai import ChatOpenAI
+from ee.hogai.llm import MaxChatOpenAI
 from langgraph.errors import NodeInterrupt
 from pydantic import BaseModel, Field, ValidationError
 
@@ -292,8 +292,14 @@ class MemoryOnboardingEnquiryNode(AssistantNode):
 
     @property
     def _model(self):
-        return ChatOpenAI(
-            model="gpt-4.1", temperature=0.3, disable_streaming=True, stop_sequences=["[Done]"], max_retries=3
+        return MaxChatOpenAI(
+            model="gpt-4.1",
+            temperature=0.3,
+            disable_streaming=True,
+            stop_sequences=["[Done]"],
+            max_retries=3,
+            user=self._user,
+            team=self._team,
         )
 
     def router(self, state: AssistantState) -> Literal["continue", "interrupt"]:
@@ -348,8 +354,14 @@ class MemoryOnboardingFinalizeNode(AssistantNode):
 
     @property
     def _model(self):
-        return ChatOpenAI(
-            model="gpt-4.1", temperature=0.3, disable_streaming=True, stop_sequences=["[Done]"], max_retries=3
+        return MaxChatOpenAI(
+            model="gpt-4.1",
+            temperature=0.3,
+            disable_streaming=True,
+            stop_sequences=["[Done]"],
+            max_retries=3,
+            user=self._user,
+            team=self._team,
         )
 
     def router(self, state: AssistantState) -> Literal["continue", "insights"]:
@@ -418,9 +430,9 @@ class MemoryCollectorNode(MemoryOnboardingShouldRunMixin):
 
     @property
     def _model(self):
-        return ChatOpenAI(model="gpt-4o", temperature=0.3, disable_streaming=True, max_retries=3).bind_tools(
-            memory_collector_tools
-        )
+        return MaxChatOpenAI(
+            model="gpt-4o", temperature=0.3, disable_streaming=True, max_retries=3, user=self._user, team=self._team
+        ).bind_tools(memory_collector_tools)
 
     def _construct_messages(self, state: AssistantState) -> list[BaseMessage]:
         node_messages = state.memory_collection_messages or []

--- a/ee/hogai/graph/memory/nodes.py
+++ b/ee/hogai/graph/memory/nodes.py
@@ -297,7 +297,6 @@ class MemoryOnboardingEnquiryNode(AssistantNode):
             temperature=0.3,
             disable_streaming=True,
             stop_sequences=["[Done]"],
-            max_retries=3,
             user=self._user,
             team=self._team,
         )
@@ -359,7 +358,6 @@ class MemoryOnboardingFinalizeNode(AssistantNode):
             temperature=0.3,
             disable_streaming=True,
             stop_sequences=["[Done]"],
-            max_retries=3,
             user=self._user,
             team=self._team,
         )
@@ -431,7 +429,7 @@ class MemoryCollectorNode(MemoryOnboardingShouldRunMixin):
     @property
     def _model(self):
         return MaxChatOpenAI(
-            model="gpt-4o", temperature=0.3, disable_streaming=True, max_retries=3, user=self._user, team=self._team
+            model="gpt-4o", temperature=0.3, disable_streaming=True, user=self._user, team=self._team
         ).bind_tools(memory_collector_tools)
 
     def _construct_messages(self, state: AssistantState) -> list[BaseMessage]:

--- a/ee/hogai/graph/root/nodes.py
+++ b/ee/hogai/graph/root/nodes.py
@@ -350,7 +350,6 @@ class RootNode(RootNodeUIContextMixin):
             temperature=0.3,
             streaming=True,
             stream_usage=True,
-            max_retries=3,
             user=self._user,
             team=self._team,
         )

--- a/ee/hogai/graph/root/nodes.py
+++ b/ee/hogai/graph/root/nodes.py
@@ -12,14 +12,13 @@ from langchain_core.messages import (
 )
 from langchain_core.prompts import ChatPromptTemplate, PromptTemplate
 from langchain_core.runnables import RunnableConfig
-from langchain_openai import ChatOpenAI
+from ee.hogai.llm import MaxChatOpenAI
 from langgraph.errors import NodeInterrupt
 from posthoganalytics import capture_exception
 from pydantic import BaseModel
 
 from ee.hogai.graph.memory.nodes import should_run_onboarding_before_insights
 from ee.hogai.graph.query_executor.query_executor import AssistantQueryExecutor, SupportedQueryTypes
-from ee.hogai.graph.shared_prompts import PROJECT_ORG_USER_CONTEXT_PROMPT
 
 # Import moved inside functions to avoid circular imports
 from ee.hogai.utils.types import AssistantState, PartialAssistantState
@@ -293,7 +292,6 @@ class RootNode(RootNodeUIContextMixin):
             ChatPromptTemplate.from_messages(
                 [
                     ("system", ROOT_SYSTEM_PROMPT),
-                    ("system", PROJECT_ORG_USER_CONTEXT_PROMPT),
                     *[
                         (
                             "system",
@@ -347,7 +345,15 @@ class RootNode(RootNodeUIContextMixin):
         # It _probably_ doesn't matter, but let's use a lower temperature for _maybe_ less of a risk of hallucinations.
         # We were previously using 0.0, but that wasn't useful, as the false determinism didn't help in any way,
         # only made evals less useful precisely because of the false determinism.
-        base_model = ChatOpenAI(model="gpt-4o", temperature=0.3, streaming=True, stream_usage=True, max_retries=3)
+        base_model = MaxChatOpenAI(
+            model="gpt-4o",
+            temperature=0.3,
+            streaming=True,
+            stream_usage=True,
+            max_retries=3,
+            user=self._user,
+            team=self._team,
+        )
 
         # The agent can now be in loops. Since insight building is an expensive operation, we want to limit a recursion depth.
         # This will remove the functions, so the agent doesn't have any other option but to exit.

--- a/ee/hogai/graph/root/test/test_nodes.py
+++ b/ee/hogai/graph/root/test/test_nodes.py
@@ -1,5 +1,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from langchain_core.outputs import ChatResult, ChatGeneration
+from langchain_core.messages import AIMessage
 from langchain_core.messages import (
     AIMessage as LangchainAIMessage,
     HumanMessage as LangchainHumanMessage,
@@ -519,12 +521,10 @@ class TestRootNode(ClickhouseTestMixin, BaseTest):
 
     def test_node_includes_project_org_user_context_in_prompt_template(self):
         with (
+            patch("os.environ", {"OPENAI_API_KEY": "foo"}),
             patch("langchain_openai.chat_models.base.ChatOpenAI._generate") as mock_generate,
             patch("ee.hogai.graph.root.nodes.RootNode._find_new_window_id", return_value=None),
         ):
-            from langchain_core.outputs import ChatResult, ChatGeneration
-            from langchain_core.messages import AIMessage
-
             mock_generate.return_value = ChatResult(
                 generations=[ChatGeneration(message=AIMessage(content="Test response"))],
                 llm_output={},

--- a/ee/hogai/graph/root/test/test_nodes.py
+++ b/ee/hogai/graph/root/test/test_nodes.py
@@ -540,23 +540,6 @@ class TestRootNode(ClickhouseTestMixin, BaseTest):
             self.assertIn("You are currently in project ", system_content)
             self.assertIn("The user's name appears to be ", system_content)
 
-    def test_model_has_correct_max_retries(self):
-        with patch("ee.hogai.graph.root.nodes.MaxChatOpenAI") as mock_chat_openai:
-            mock_model = MagicMock()
-            mock_model.get_num_tokens_from_messages.return_value = 100
-            mock_model.bind_tools.return_value = mock_model
-            mock_chat_openai.return_value = mock_model
-
-            node = RootNode(self.team, self.user)
-            state = AssistantState(messages=[HumanMessage(content="test")])
-
-            node._get_model(state, {})
-
-            # Verify ChatOpenAI was called with max_retries=3
-            mock_chat_openai.assert_called_once()
-            call_args = mock_chat_openai.call_args
-            self.assertEqual(call_args.kwargs["max_retries"], 3)
-
 
 class TestRootNodeTools(BaseTest):
     def test_node_tools_router(self):

--- a/ee/hogai/graph/root/test/test_nodes.py
+++ b/ee/hogai/graph/root/test/test_nodes.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from langchain_core.messages import (
     AIMessage as LangchainAIMessage,
     HumanMessage as LangchainHumanMessage,
+    SystemMessage,
     ToolMessage as LangchainToolMessage,
 )
 from langgraph.errors import NodeInterrupt
@@ -518,25 +519,32 @@ class TestRootNode(ClickhouseTestMixin, BaseTest):
 
     def test_node_includes_project_org_user_context_in_prompt_template(self):
         with (
-            # This test mocks deeper than ideal, and really it should be spying on the actual LLM call, rather than
-            # prompt template construction. However, LangChain's chaining mechanics make it even more painful to
-            # mock the "right" thing, so going for a kludge here.
-            patch("ee.hogai.graph.root.nodes.ChatPromptTemplate.from_messages") as mock_chat_prompt_template,
-            patch("ee.hogai.graph.root.nodes.MaxChatOpenAI") as mock_chat_openai,
+            patch("langchain_openai.chat_models.base.ChatOpenAI._generate") as mock_generate,
             patch("ee.hogai.graph.root.nodes.RootNode._find_new_window_id", return_value=None),
         ):
-            mock_model = MagicMock()
-            mock_model.bind_tools.return_value = mock_model
-            mock_chat_openai.return_value = mock_model
+            from langchain_core.outputs import ChatResult, ChatGeneration
+            from langchain_core.messages import AIMessage
+
+            mock_generate.return_value = ChatResult(
+                generations=[ChatGeneration(message=AIMessage(content="Test response"))],
+                llm_output={},
+            )
 
             node = RootNode(self.team, self.user)
 
             node.run(AssistantState(messages=[HumanMessage(content="Foo?")]), {})
 
-            mock_chat_prompt_template.assert_called_once()
-            system_content = "\n\n".join(
-                content for role, content in mock_chat_prompt_template.call_args[0][0] if role == "system"
-            )
+            # Verify _generate was called
+            mock_generate.assert_called_once()
+
+            # Get the messages passed to _generate
+            call_args = mock_generate.call_args
+            messages = call_args[0][0]  # First argument is messages
+
+            # Check that the system messages contain the project/org/user context
+            system_messages = [msg for msg in messages if isinstance(msg, SystemMessage)]
+            system_content = "\n\n".join(msg.content for msg in system_messages)
+
             self.assertIn("You are currently in project ", system_content)
             self.assertIn("The user's name appears to be ", system_content)
 

--- a/ee/hogai/graph/root/test/test_nodes.py
+++ b/ee/hogai/graph/root/test/test_nodes.py
@@ -269,7 +269,7 @@ class TestRootNode(ClickhouseTestMixin, BaseTest):
         mock_with_tokens.get_num_tokens_from_messages = MagicMock(return_value=1)
 
         with patch(
-            "ee.hogai.graph.root.nodes.ChatOpenAI",
+            "ee.hogai.graph.root.nodes.MaxChatOpenAI",
             return_value=mock_with_tokens,
         ):
             node = RootNode(self.team, self.user)
@@ -433,7 +433,7 @@ class TestRootNode(ClickhouseTestMixin, BaseTest):
         self.assertEqual(messages[0].content, "Question")  # Starts from the window ID message
 
     def test_node_gets_contextual_tool(self):
-        with patch("ee.hogai.graph.root.nodes.ChatOpenAI") as mock_chat_openai:
+        with patch("ee.hogai.graph.root.nodes.MaxChatOpenAI") as mock_chat_openai:
             mock_model = MagicMock()
             mock_model.get_num_tokens_from_messages.return_value = 100
             mock_model.bind_tools.return_value = mock_model
@@ -522,7 +522,7 @@ class TestRootNode(ClickhouseTestMixin, BaseTest):
             # prompt template construction. However, LangChain's chaining mechanics make it even more painful to
             # mock the "right" thing, so going for a kludge here.
             patch("ee.hogai.graph.root.nodes.ChatPromptTemplate.from_messages") as mock_chat_prompt_template,
-            patch("ee.hogai.graph.root.nodes.ChatOpenAI") as mock_chat_openai,
+            patch("ee.hogai.graph.root.nodes.MaxChatOpenAI") as mock_chat_openai,
             patch("ee.hogai.graph.root.nodes.RootNode._find_new_window_id", return_value=None),
         ):
             mock_model = MagicMock()
@@ -541,7 +541,7 @@ class TestRootNode(ClickhouseTestMixin, BaseTest):
             self.assertIn("The user's name appears to be ", system_content)
 
     def test_model_has_correct_max_retries(self):
-        with patch("ee.hogai.graph.root.nodes.ChatOpenAI") as mock_chat_openai:
+        with patch("ee.hogai.graph.root.nodes.MaxChatOpenAI") as mock_chat_openai:
             mock_model = MagicMock()
             mock_model.get_num_tokens_from_messages.return_value = 100
             mock_model.bind_tools.return_value = mock_model

--- a/ee/hogai/graph/schema_generator/nodes.py
+++ b/ee/hogai/graph/schema_generator/nodes.py
@@ -52,7 +52,7 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
     @property
     def _model(self):
         return MaxChatOpenAI(
-            model="gpt-4.1", temperature=0.3, disable_streaming=True, max_retries=3, user=self._user, team=self._team
+            model="gpt-4.1", temperature=0.3, disable_streaming=True, user=self._user, team=self._team
         ).with_structured_output(
             self.OUTPUT_SCHEMA,
             method="function_calling",

--- a/ee/hogai/graph/schema_generator/nodes.py
+++ b/ee/hogai/graph/schema_generator/nodes.py
@@ -11,7 +11,6 @@ from langchain_core.messages import (
 )
 from langchain_core.prompts import ChatPromptTemplate, HumanMessagePromptTemplate
 from langchain_core.runnables import RunnableConfig
-from langchain_openai import ChatOpenAI
 from pydantic import BaseModel
 
 from .parsers import (
@@ -27,6 +26,7 @@ from .prompts import (
     QUESTION_PROMPT,
 )
 from .utils import SchemaGeneratorOutput
+from ee.hogai.llm import MaxChatOpenAI
 from ee.hogai.utils.helpers import find_start_message
 from ..base import AssistantNode
 from ee.hogai.utils.types import AssistantState, PartialAssistantState
@@ -51,8 +51,8 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
 
     @property
     def _model(self):
-        return ChatOpenAI(
-            model="gpt-4.1", temperature=0.3, disable_streaming=True, max_retries=3
+        return MaxChatOpenAI(
+            model="gpt-4.1", temperature=0.3, disable_streaming=True, max_retries=3, user=self._user, team=self._team
         ).with_structured_output(
             self.OUTPUT_SCHEMA,
             method="function_calling",

--- a/ee/hogai/graph/schema_generator/test/test_nodes.py
+++ b/ee/hogai/graph/schema_generator/test/test_nodes.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from django.test import override_settings
 from langchain_core.agents import AgentAction
@@ -449,17 +449,3 @@ class TestSchemaGeneratorToolsNode(BaseTest):
         self.assertIsNotNone("validationerror", state.intermediate_steps[0][1])
         self.assertIn("validationerror", state.intermediate_steps[0][1])
         self.assertIn("pydanticexception", state.intermediate_steps[0][1])
-
-    def test_model_has_correct_max_retries(self):
-        with patch("ee.hogai.graph.schema_generator.nodes.MaxChatOpenAI") as mock_chat_openai:
-            mock_model = MagicMock()
-            mock_model.with_structured_output.return_value = mock_model
-            mock_chat_openai.return_value = mock_model
-
-            node = DummyGeneratorNode(self.team, self.user)
-
-            _ = node._model
-
-            mock_chat_openai.assert_called_once()
-            call_args = mock_chat_openai.call_args
-            self.assertEqual(call_args.kwargs["max_retries"], 3)

--- a/ee/hogai/graph/schema_generator/test/test_nodes.py
+++ b/ee/hogai/graph/schema_generator/test/test_nodes.py
@@ -451,7 +451,7 @@ class TestSchemaGeneratorToolsNode(BaseTest):
         self.assertIn("pydanticexception", state.intermediate_steps[0][1])
 
     def test_model_has_correct_max_retries(self):
-        with patch("ee.hogai.graph.schema_generator.nodes.ChatOpenAI") as mock_chat_openai:
+        with patch("ee.hogai.graph.schema_generator.nodes.MaxChatOpenAI") as mock_chat_openai:
             mock_model = MagicMock()
             mock_model.with_structured_output.return_value = mock_model
             mock_chat_openai.return_value = mock_model

--- a/ee/hogai/graph/shared_prompts.py
+++ b/ee/hogai/graph/shared_prompts.py
@@ -1,5 +1,0 @@
-PROJECT_ORG_USER_CONTEXT_PROMPT = """
-You are currently in project {{{project_name}}}, which is part of the {{{organization_name}}} organization.
-The user's name appears to be {{{user_full_name}}} ({{{user_email}}}). Feel free to use their first name when greeting. DO NOT use this name if it appears possibly fake.
-Current time in the project's timezone, {{{project_timezone}}}: {{{project_datetime}}}.
-""".strip()

--- a/ee/hogai/graph/taxonomy_agent/nodes.py
+++ b/ee/hogai/graph/taxonomy_agent/nodes.py
@@ -143,7 +143,6 @@ class TaxonomyAgentPlannerNode(AssistantNode):
             temperature=0.3,
             streaming=True,
             stream_usage=True,
-            max_retries=3,
             user=self._user,
             team=self._team,
         )

--- a/ee/hogai/graph/taxonomy_agent/nodes.py
+++ b/ee/hogai/graph/taxonomy_agent/nodes.py
@@ -13,7 +13,7 @@ from langchain_core.messages import (
 )
 from langchain_core.prompts import ChatPromptTemplate, HumanMessagePromptTemplate
 from langchain_core.runnables import RunnableConfig
-from langchain_openai import ChatOpenAI
+from ee.hogai.llm import MaxChatOpenAI
 from pydantic import ValidationError
 
 from .parsers import (
@@ -137,8 +137,16 @@ class TaxonomyAgentPlannerNode(AssistantNode):
         )
 
     @property
-    def _model(self) -> ChatOpenAI:
-        return ChatOpenAI(model="gpt-4o", temperature=0.3, streaming=True, stream_usage=True, max_retries=3)
+    def _model(self) -> MaxChatOpenAI:
+        return MaxChatOpenAI(
+            model="gpt-4o",
+            temperature=0.3,
+            streaming=True,
+            stream_usage=True,
+            max_retries=3,
+            user=self._user,
+            team=self._team,
+        )
 
     def _get_react_format_prompt(self, toolkit: TaxonomyAgentToolkit) -> str:
         return cast(

--- a/ee/hogai/graph/title_generator/nodes.py
+++ b/ee/hogai/graph/title_generator/nodes.py
@@ -1,7 +1,7 @@
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnableConfig
-from langchain_openai import ChatOpenAI
+from ee.hogai.llm import MaxChatOpenAI
 
 from ee.hogai.graph.base import AssistantNode
 from ee.hogai.graph.title_generator.prompts import TITLE_GENERATION_PROMPT
@@ -35,4 +35,11 @@ class TitleGeneratorNode(AssistantNode):
 
     @property
     def _model(self):
-        return ChatOpenAI(model="gpt-4.1-nano", temperature=0.7, max_completion_tokens=100, max_retries=3)
+        return MaxChatOpenAI(
+            model="gpt-4.1-nano",
+            temperature=0.7,
+            max_completion_tokens=100,
+            max_retries=3,
+            user=self._user,
+            team=self._team,
+        )

--- a/ee/hogai/graph/title_generator/nodes.py
+++ b/ee/hogai/graph/title_generator/nodes.py
@@ -39,7 +39,6 @@ class TitleGeneratorNode(AssistantNode):
             model="gpt-4.1-nano",
             temperature=0.7,
             max_completion_tokens=100,
-            max_retries=3,
             user=self._user,
             team=self._team,
         )

--- a/ee/hogai/llm.py
+++ b/ee/hogai/llm.py
@@ -1,0 +1,85 @@
+import datetime
+from typing import TYPE_CHECKING, Any
+
+from langchain_core.messages import BaseMessage, SystemMessage
+from langchain_core.outputs import ChatResult
+from langchain_core.prompts import SystemMessagePromptTemplate
+from langchain_openai import ChatOpenAI
+import pytz
+
+from asgiref.sync import sync_to_async
+
+if TYPE_CHECKING:
+    from posthog.models import Team, User
+
+PROJECT_ORG_USER_CONTEXT_PROMPT = """
+You are currently in project {{{project_name}}}, which is part of the {{{organization_name}}} organization.
+The user's name appears to be {{{user_full_name}}} ({{{user_email}}}). Feel free to use their first name when greeting. DO NOT use this name if it appears possibly fake.
+Current time in the project's timezone, {{{project_timezone}}}: {{{project_datetime}}}.
+""".strip()
+
+
+class MaxChatOpenAI(ChatOpenAI):
+    """PostHog-tuned subclass of ChatOpenAI.
+
+    This subclass automatically injects project, organization, and user context as the final part of the system prompt.
+    It also makes sure we retry automatically in case of an OpenAI API error.
+    """
+
+    def __init__(self, *args, user: "User", team: "Team", **kwargs):
+        if "max_retries" not in kwargs:
+            kwargs["max_retries"] = 3
+        super().__init__(*args, **kwargs)
+        self._user = user
+        self._team = team
+
+    def _get_project_org_user_variables(self) -> dict[str, Any]:
+        """Note: this function may perform Postgres queries on `self._team`, `self._team.organization`, and `self._user`."""
+        project_timezone = self._team.timezone
+        project_datetime = datetime.datetime.now(tz=pytz.timezone(project_timezone))
+
+        return {
+            "project_name": self._team.name,
+            "project_timezone": project_timezone,
+            "project_datetime": project_datetime.strftime("%Y-%m-%d %H:%M:%S"),
+            "organization_name": self._team.organization.name,
+            "user_full_name": self._user.get_full_name(),
+            "user_email": self._user.email,
+        }
+
+    def _enrich_messages(self, messages: list[list[BaseMessage]], project_org_user_variables: dict[str, Any]):
+        for message_sublist in messages:
+            # In every sublist (which becomes a separate generation) insert our shared prompt at the very end
+            # of the system messages block
+            for msg_index, msg in enumerate(message_sublist):
+                if isinstance(msg, SystemMessage):
+                    continue  # Keep going
+                else:
+                    # Here's our end of the system messages block
+                    message_sublist.insert(
+                        msg_index,
+                        SystemMessagePromptTemplate.from_template(
+                            PROJECT_ORG_USER_CONTEXT_PROMPT, template_format="mustache"
+                        ).format(**project_org_user_variables),
+                    )
+                    break
+
+    def generate(
+        self,
+        messages: list[list[BaseMessage]],
+        *args,
+        **kwargs: Any,
+    ) -> ChatResult:
+        project_org_user_variables = self._get_project_org_user_variables()
+        self._enrich_messages(messages, project_org_user_variables)
+        return super().generate(messages, *args, **kwargs)
+
+    async def agenerate(
+        self,
+        messages: list[list[BaseMessage]],
+        *args,
+        **kwargs: Any,
+    ) -> ChatResult:
+        project_org_user_variables = await sync_to_async(self._get_project_org_user_variables)()
+        self._enrich_messages(messages, project_org_user_variables)
+        return await super().agenerate(messages, *args, **kwargs)

--- a/ee/hogai/llm.py
+++ b/ee/hogai/llm.py
@@ -1,8 +1,8 @@
 import datetime
 from typing import TYPE_CHECKING, Any
 
+from langchain_core.outputs import LLMResult
 from langchain_core.messages import BaseMessage, SystemMessage
-from langchain_core.outputs import ChatResult
 from langchain_core.prompts import SystemMessagePromptTemplate
 from langchain_openai import ChatOpenAI
 import pytz
@@ -68,8 +68,8 @@ class MaxChatOpenAI(ChatOpenAI):
         self,
         messages: list[list[BaseMessage]],
         *args,
-        **kwargs: Any,
-    ) -> ChatResult:
+        **kwargs,
+    ) -> LLMResult:
         project_org_user_variables = self._get_project_org_user_variables()
         self._enrich_messages(messages, project_org_user_variables)
         return super().generate(messages, *args, **kwargs)
@@ -78,8 +78,8 @@ class MaxChatOpenAI(ChatOpenAI):
         self,
         messages: list[list[BaseMessage]],
         *args,
-        **kwargs: Any,
-    ) -> ChatResult:
+        **kwargs,
+    ) -> LLMResult:
         project_org_user_variables = await sync_to_async(self._get_project_org_user_variables)()
         self._enrich_messages(messages, project_org_user_variables)
         return await super().agenerate(messages, *args, **kwargs)


### PR DESCRIPTION
## Changes

This is a better version of #34395, which addresses the same problem…

> Every LLM call in PostHog – pretty much – should be aware of the current date and time (crucial), project and organization (fairly important) and the user it's serving (nice to have). Especially date and time missing can be catastrophic for querying any data. This was addressed for the "Search session recordings" tool specifically in [#34350](https://github.com/PostHog/posthog/issues/34350), but we actually already have `shared_prompts.py` with `PROJECT_ORG_USER_CONTEXT_PROMPT`, which we just haven't rolled it out Max-wide.

…but here we are doing something more fun: subclassing `ChatOpenAI`, which makes it a one-line change to get the shared prompt injected anywhere. Doing this per @kappa90's [suggestion](https://github.com/PostHog/posthog/pull/34395#pullrequestreview-3002427650) – much less context needed for devs using the MaxTool API for instance.

Closes #34395.

## How did you test this code?

Updated `test_node_includes_project_org_user_context_in_prompt_template`.