### PR TITLE
feat: restrict invite deletion to authorized users

### DIFF
--- a/posthog/api/organization_invite.py
+++ b/posthog/api/organization_invite.py
@@ -296,13 +296,13 @@ class OrganizationInviteViewSet(
     ordering = "-created_at"
 
     def dangerously_get_permissions(self):
-        if self.action == "create":
-            create_permissions = [
+        if self.action in ["create", "destroy"]:
+            write_permissions = [
                 permission()
                 for permission in [permissions.IsAuthenticated, OrganizationMemberPermissions, UserCanInvitePermission]
             ]
 
-            return create_permissions
+            return write_permissions
 
         raise NotImplementedError()
 


### PR DESCRIPTION
Updated permission logic to require appropriate permissions for both creating and deleting organization invites. Added a test to ensure members cannot delete invites when 'members_can_invite' is set to False.

> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changes

We have recently released a feature that restricts members from inviting others to the organization. The PR is adding a check to the API that when that setting is true, members can also not delete invites. If the setting is false, then members can invite so they should be able to delete invites.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

Added a test
