### PR TITLE
fix(data-warehouse): Dont throw duplicate key error on append sync mode

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -71,7 +71,6 @@ class PipelineNonDLT:
         source: DltSource | SourceResponse,
         logger: FilteringBoundLogger,
         job_id: str,
-        is_incremental: bool,
         reset_pipeline: bool,
         shutdown_monitor: ShutdownMonitor,
     ) -> None:
@@ -93,7 +92,6 @@ class PipelineNonDLT:
             self._resource_name = source.name
 
         self._job = ExternalDataJob.objects.prefetch_related("schema").get(id=job_id)
-        self._is_incremental = is_incremental
         self._reset_pipeline = reset_pipeline
         self._logger = logger
         self._load_id = time.time_ns()
@@ -101,6 +99,7 @@ class PipelineNonDLT:
         schema: ExternalDataSchema | None = self._job.schema
         assert schema is not None
         self._schema = schema
+        self._is_incremental = schema.is_incremental
 
         self._delta_table_helper = DeltaTableHelper(self._resource_name, self._job, self._logger)
         self._internal_schema = HogQLSchema()

--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -885,8 +885,6 @@ def _run(
     reset_pipeline: bool,
     shutdown_monitor: ShutdownMonitor,
 ):
-    pipeline = PipelineNonDLT(
-        source, logger, job_inputs.run_id, schema.should_use_incremental_field, reset_pipeline, shutdown_monitor
-    )
+    pipeline = PipelineNonDLT(source, logger, job_inputs.run_id, reset_pipeline, shutdown_monitor)
     pipeline.run()
     del pipeline


### PR DESCRIPTION
## Problem
- We're raising a `DuplicatePrimaryKeysException` when the sync mode is set to append 
- Raised by https://posthoghelp.zendesk.com/agent/tickets/34071 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/35742)

## Changes
- Dont raise this on append tables