### PR TITLE
chore: some dagester fields may be empty

### DIFF
--- a/dags/common.py
+++ b/dags/common.py
@@ -108,7 +108,11 @@ def dagster_tags(
     )
 
     with suppress(Exception):
-        if isinstance(context, dagster.OpExecutionContext):
+        if isinstance(context, dagster.AssetCheckExecutionContext):
+            op = context.op_execution_context
+            if op and op.op:
+                tags.op_name = op.op.name
+        elif isinstance(context, dagster.OpExecutionContext):
             if context.op:
                 tags.op_name = context.op.name
         elif isinstance(context, dagster.AssetExecutionContext):

--- a/dags/common.py
+++ b/dags/common.py
@@ -109,11 +109,11 @@ def dagster_tags(
 
     with suppress(Exception):
         if isinstance(context, dagster.OpExecutionContext):
-            tags.op_name = context.op.name
-        elif isinstance(context, dagster.AssetExecutionContext) or isinstance(
-            context, dagster.AssetCheckExecutionContext
-        ):
-            tags.asset_key = context.asset_key.to_user_string()
+            if context.op:
+                tags.op_name = context.op.name
+        elif isinstance(context, dagster.AssetExecutionContext):
+            if context.asset_key:
+                tags.asset_key = context.asset_key.to_user_string()
 
     return tags
 

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -61,8 +61,8 @@ class DagsterTags(BaseModel):
     Check: https://docs.dagster.io/api/dagster/internals#dagster.DagsterRun
     """
 
-    job_name: str
-    run_id: str
+    job_name: Optional[str]
+    run_id: Optional[str]
     tags: Optional[dict[str, str]]
     root_run_id: Optional[str]
     parent_run_id: Optional[str]

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -61,16 +61,16 @@ class DagsterTags(BaseModel):
     Check: https://docs.dagster.io/api/dagster/internals#dagster.DagsterRun
     """
 
-    job_name: Optional[str]
-    run_id: Optional[str]
-    tags: Optional[dict[str, str]]
-    root_run_id: Optional[str]
-    parent_run_id: Optional[str]
-    job_snapshot_id: Optional[str]
-    execution_plan_snapshot_id: Optional[str]
+    job_name: Optional[str] = None
+    run_id: Optional[str] = None
+    tags: Optional[dict[str, str]] = None
+    root_run_id: Optional[str] = None
+    parent_run_id: Optional[str] = None
+    job_snapshot_id: Optional[str] = None
+    execution_plan_snapshot_id: Optional[str] = None
 
-    op_name: Optional[str]
-    asset_key: Optional[str]
+    op_name: Optional[str] = None
+    asset_key: Optional[str] = None
 
 
 class QueryTags(BaseModel):


### PR DESCRIPTION
## Problem

for assets checks the job may be emtpy

## Changes

make job_name and run_id optional


