### PR TITLE
fix: add explicit capture exception to v2 loading

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -868,24 +868,30 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
 
         with GATHER_RECORDING_SOURCES_HISTOGRAM.labels(blob_version="v2" if is_v2_enabled else "v1").time():
             if is_v2_enabled:
-                if is_v2_lts_enabled and recording.full_recording_v2_path:
-                    LOADING_V2_LTS_COUNTER.inc()
-                    blob_prefix = recording.full_recording_v2_path
-                    blob_keys = object_storage.list_objects(cast(str, blob_prefix))
-                    might_have_realtime = False
-                else:
-                    with timer("list_blocks__gather_session_recording_sources"):
-                        blocks = list_blocks(recording)
+                with posthoganalytics.new_context():
+                    posthoganalytics.tag("gather_session_recording_sources_version", "2")
+                    if is_v2_lts_enabled and recording.full_recording_v2_path:
+                        posthoganalytics.tag("recording_location", "recording.full_recording_v2_path")
+                        LOADING_V2_LTS_COUNTER.inc()
+                        try:
+                            blob_prefix = recording.full_recording_v2_path
+                            blob_keys = object_storage.list_objects(cast(str, blob_prefix))
+                            might_have_realtime = False
+                        except Exception as e:
+                            capture_exception(e)
+                    else:
+                        with timer("list_blocks__gather_session_recording_sources"):
+                            blocks = list_blocks(recording)
 
-                    for i, block in enumerate(blocks):
-                        sources.append(
-                            {
-                                "source": "blob_v2",
-                                "start_timestamp": block.start_time,
-                                "end_timestamp": block.end_time,
-                                "blob_key": str(i),
-                            }
-                        )
+                        for i, block in enumerate(blocks):
+                            sources.append(
+                                {
+                                    "source": "blob_v2",
+                                    "start_timestamp": block.start_time,
+                                    "end_timestamp": block.end_time,
+                                    "blob_key": str(i),
+                                }
+                            )
             else:
                 with timer("list_objects__gather_session_recording_sources"):
                     if recording.object_storage_path:


### PR DESCRIPTION
let's add some context to errors if we're not able to read LTS v2