### PR TITLE
feat: Merge dau and unique groups math selectors

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -206,27 +206,33 @@ export function ActionFilterRow({
     const onClose = (): void => {
         removeLocalFilter({ ...filter, index })
     }
+
     const onMathSelect = (_: unknown, selectedMath?: string): void => {
-        const mathProperties = selectedMath
-            ? {
-                  ...mathTypeToApiValues(selectedMath),
-                  math_property:
-                      mathDefinitions[selectedMath]?.category === MathCategory.PropertyValue
-                          ? mathProperty ?? '$time'
-                          : undefined,
-                  math_hogql:
-                      mathDefinitions[selectedMath]?.category === MathCategory.HogQLExpression
-                          ? mathHogQL ?? 'count()'
-                          : undefined,
-                  mathPropertyType,
-              }
-            : {
-                  math_property: undefined,
-                  mathPropertyType: undefined,
-                  math_hogql: undefined,
-                  math_group_type_index: undefined,
-                  math: undefined,
-              }
+        let mathProperties
+        if (selectedMath) {
+            const math_property =
+                mathDefinitions[selectedMath]?.category === MathCategory.PropertyValue
+                    ? mathProperty ?? '$time'
+                    : undefined
+            const math_hogql =
+                mathDefinitions[selectedMath]?.category === MathCategory.HogQLExpression
+                    ? mathHogQL ?? 'count()'
+                    : undefined
+            mathProperties = {
+                ...mathTypeToApiValues(selectedMath),
+                math_property,
+                math_hogql,
+                mathPropertyType,
+            }
+        } else {
+            mathProperties = {
+                math_property: undefined,
+                mathPropertyType: undefined,
+                math_hogql: undefined,
+                math_group_type_index: undefined,
+                math: undefined,
+            }
+        }
 
         updateFilterMath({
             index,
@@ -234,6 +240,7 @@ export function ActionFilterRow({
             ...mathProperties,
         })
     }
+
     const onMathPropertySelect = (_: unknown, property: string, groupType: TaxonomicFilterGroupType): void => {
         updateFilterMath({
             ...filter,

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -910,12 +910,16 @@ function useMathSelectorOptions({
             (option) => 'value' in option && option.value === BaseMathType.UniqueUsers
         )
         if (uniqueUsersIndex !== -1) {
-            const value = uniqueActorsShown === 'users' ? BaseMathType.UniqueUsers : uniqueActorsShown
-            const label =
-                uniqueActorsShown === 'users' ? 'Unique users' : `Unique ${aggregationLabel(mathGroupTypeIndex).plural}`
+            const isDau = uniqueActorsShown === 'users'
+            const value = isDau ? BaseMathType.UniqueUsers : uniqueActorsShown
+            const label = isDau ? 'Unique users' : `Unique ${aggregationLabel(mathGroupTypeIndex).plural}`
+            const tooltip = isDau
+                ? options[uniqueUsersIndex].tooltip
+                : uniqueGroupsMathDefinitions[uniqueActorsShown].description
             options[uniqueUsersIndex] = {
                 value,
                 label,
+                tooltip,
                 labelInMenu: (
                     <div className="flex items-center gap-2">
                         <span>Unique</span>
@@ -934,7 +938,6 @@ function useMathSelectorOptions({
                         />
                     </div>
                 ),
-                tooltip: `Unique ${uniqueActorsShown}`,
                 'data-attr': `math-node-unique-actors-${index}`,
             }
         }

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -723,7 +723,7 @@ function useMathSelectorOptions({
         staticActorsOnlyMathDefinitions,
         calendarHeatmapMathDefinitions,
         aggregationLabel,
-        uniqueGroupsMathDefinitions,
+        groupsMathDefinitions,
     } = useValues(mathsLogic)
 
     const [propertyMathTypeShown, setPropertyMathTypeShown] = useState<PropertyMathType>(
@@ -737,7 +737,7 @@ function useMathSelectorOptions({
     const [uniqueActorsShown, setUniqueActorsShown] = useState<string>(() => {
         if (math === 'unique_group' && mathGroupTypeIndex !== undefined) {
             const groupKey = `unique_group::${mathGroupTypeIndex}`
-            const groupDef = uniqueGroupsMathDefinitions[groupKey]
+            const groupDef = groupsMathDefinitions[groupKey]
             return groupDef ? groupKey : 'users'
         }
         return 'users'
@@ -759,11 +759,6 @@ function useMathSelectorOptions({
             if (isStickiness) {
                 // Remove WAU and MAU from stickiness insights
                 return !TRAILING_MATH_TYPES.has(mathTypeKey)
-            }
-
-            if (key.startsWith('unique_group::')) {
-                // Remove unique group options, as they're being grouped with DAU
-                return false
             }
 
             if (allowedMathTypes) {
@@ -899,7 +894,7 @@ function useMathSelectorOptions({
                 label: 'users',
                 'data-attr': `math-users-${index}`,
             },
-            ...Object.entries(uniqueGroupsMathDefinitions).map(([key, definition]) => ({
+            ...Object.entries(groupsMathDefinitions).map(([key, definition]) => ({
                 value: key,
                 label: definition.shortName,
                 'data-attr': `math-${key}-${index}`,
@@ -915,7 +910,7 @@ function useMathSelectorOptions({
             const label = isDau ? 'Unique users' : `Unique ${aggregationLabel(mathGroupTypeIndex).plural}`
             const tooltip = isDau
                 ? options[uniqueUsersIndex].tooltip
-                : uniqueGroupsMathDefinitions[uniqueActorsShown].description
+                : groupsMathDefinitions[uniqueActorsShown].description
             options[uniqueUsersIndex] = {
                 value,
                 label,

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -751,7 +751,7 @@ function useMathSelectorOptions({
     } else if (mathAvailability === MathAvailability.CalendarHeatmapOnly) {
         definitions = calendarHeatmapMathDefinitions
     }
-    const isGroupsEnabled = !needsUpgradeForGroups || !canStartUsingGroups
+    const isGroupsEnabled = !needsUpgradeForGroups && !canStartUsingGroups
 
     const options: LemonSelectOption<string>[] = Object.entries(definitions)
         .filter(([key]) => {

--- a/frontend/src/scenes/trends/mathsLogic.tsx
+++ b/frontend/src/scenes/trends/mathsLogic.tsx
@@ -489,6 +489,22 @@ export const mathsLogic = kea<mathsLogicType>([
                 ) as Partial<Record<MathType, MathDefinition>>
             },
         ],
+        uniqueGroupsMathDefinitions: [
+            (s) => [s.groupTypes, s.aggregationLabel],
+            (groupTypes, aggregationLabel): Partial<Record<MathType, MathDefinition>> =>
+                Object.fromEntries(
+                    Array.from(groupTypes.values())
+                        .map((groupType) => [
+                            apiValueToMathType('unique_group', groupType.group_type_index),
+                            {
+                                name: `${aggregationLabel(groupType.group_type_index).plural}`,
+                                shortName: `${aggregationLabel(groupType.group_type_index).plural}`,
+                                category: MathCategory.ActorCount,
+                            } as MathDefinition,
+                        ])
+                        .filter(Boolean)
+                ),
+        ],
         // Definitions based on group types present in the project
         groupsMathDefinitions: [
             (s) => [s.groupTypes, s.aggregationLabel],

--- a/frontend/src/scenes/trends/mathsLogic.tsx
+++ b/frontend/src/scenes/trends/mathsLogic.tsx
@@ -499,6 +499,19 @@ export const mathsLogic = kea<mathsLogicType>([
                             {
                                 name: `${aggregationLabel(groupType.group_type_index).plural}`,
                                 shortName: `${aggregationLabel(groupType.group_type_index).plural}`,
+                                description: (
+                                    <>
+                                        Number of unique {aggregationLabel(groupType.group_type_index).plural} who
+                                        performed the event in the specified period.
+                                        <br />
+                                        <br />
+                                        <i>
+                                            Example: If 7 users in a single $
+                                            {aggregationLabel(groupType.group_type_index).singular} perform an event 9
+                                            times in the given period, it counts only as 1.
+                                        </i>
+                                    </>
+                                ),
                                 category: MathCategory.ActorCount,
                             } as MathDefinition,
                         ])

--- a/frontend/src/scenes/trends/mathsLogic.tsx
+++ b/frontend/src/scenes/trends/mathsLogic.tsx
@@ -469,16 +469,7 @@ export const mathsLogic = kea<mathsLogicType>([
             },
         ],
         // Static means the options do not have nested selectors (like math function)
-        staticMathDefinitions: [
-            (s) => [s.groupsMathDefinitions, s.needsUpgradeForGroups],
-            (groupsMathDefinitions, needsUpgradeForGroups): Partial<Record<MathType, MathDefinition>> => {
-                const staticMathDefinitions: Partial<Record<MathType, MathDefinition>> = {
-                    ...BASE_MATH_DEFINITIONS,
-                    ...(!needsUpgradeForGroups ? groupsMathDefinitions : {}),
-                }
-                return staticMathDefinitions
-            },
-        ],
+        staticMathDefinitions: [() => [], (): Partial<Record<MathType, MathDefinition>> => BASE_MATH_DEFINITIONS],
         staticActorsOnlyMathDefinitions: [
             (s) => [s.staticMathDefinitions],
             (staticMathDefinitions): Partial<Record<MathType, MathDefinition>> => {
@@ -489,35 +480,6 @@ export const mathsLogic = kea<mathsLogicType>([
                 ) as Partial<Record<MathType, MathDefinition>>
             },
         ],
-        uniqueGroupsMathDefinitions: [
-            (s) => [s.groupTypes, s.aggregationLabel],
-            (groupTypes, aggregationLabel): Partial<Record<MathType, MathDefinition>> =>
-                Object.fromEntries(
-                    Array.from(groupTypes.values())
-                        .map((groupType) => [
-                            apiValueToMathType('unique_group', groupType.group_type_index),
-                            {
-                                name: `${aggregationLabel(groupType.group_type_index).plural}`,
-                                shortName: `${aggregationLabel(groupType.group_type_index).plural}`,
-                                description: (
-                                    <>
-                                        Number of unique {aggregationLabel(groupType.group_type_index).plural} who
-                                        performed the event in the specified period.
-                                        <br />
-                                        <br />
-                                        <i>
-                                            Example: If 7 users in a single $
-                                            {aggregationLabel(groupType.group_type_index).singular} perform an event 9
-                                            times in the given period, it counts only as 1.
-                                        </i>
-                                    </>
-                                ),
-                                category: MathCategory.ActorCount,
-                            } as MathDefinition,
-                        ])
-                        .filter(Boolean)
-                ),
-        ],
         // Definitions based on group types present in the project
         groupsMathDefinitions: [
             (s) => [s.groupTypes, s.aggregationLabel],
@@ -527,8 +489,8 @@ export const mathsLogic = kea<mathsLogicType>([
                         .map((groupType) => [
                             apiValueToMathType('unique_group', groupType.group_type_index),
                             {
-                                name: `Unique ${aggregationLabel(groupType.group_type_index).plural}`,
-                                shortName: `unique ${aggregationLabel(groupType.group_type_index).plural}`,
+                                name: `${aggregationLabel(groupType.group_type_index).plural}`,
+                                shortName: `${aggregationLabel(groupType.group_type_index).plural}`,
                                 description: (
                                     <>
                                         Number of unique {aggregationLabel(groupType.group_type_index).plural} who


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
First stab at #24721. Grouping `dau` and `unique_groups` maths into a single dropdown item, with a nested dropdown to select the actor.

WAU and MAU for groups will come in separate PRs, I've split them to make it easier to review.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Closes #35132
## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?
<img width="681" height="450" alt="image" src="https://github.com/user-attachments/assets/d0860c44-37d9-4126-91e1-9e5f88c3f2c2" />

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
