### PR TITLE
chore: more resilient kafka defaults

### DIFF
--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -157,17 +157,19 @@ export class KafkaConsumer {
             'queued.min.messages': 100000,
             'queued.max.messages.kbytes': 102400, // 1048576 is the default, we go smaller to reduce mem usage.
             'client.rack': defaultConfig.KAFKA_CLIENT_RACK, // Helps with cross-AZ traffic awareness and is not unique to the consumer
+            'metadata.max.age.ms': 30000, // Refresh metadata every 30s - Relevant for leader loss (MSK Security Patches)
+            'socket.timeout.ms': 30000,
             // Custom settings and overrides - this is where most configuration overrides should be done
             ...getKafkaConfigFromEnv('CONSUMER'),
             // Finally any specifically given consumer config overrides
             ...rdKafkaConfig,
             // Below is config that we explicitly DO NOT want to be overrideable by env vars - i.e. things that would require code changes to change
             'partition.assignment.strategy': isTestEnv() ? 'roundrobin' : 'cooperative-sticky', // Roundrobin is used for testing to avoid flakiness caused by running librdkafka v2.2.0
-            'group.instance.id': this.podName, // https://kafka.apache.org/documentation/#static_membership
             'enable.auto.offset.store': false, // NOTE: This is always false - we handle it using a custom function
             'enable.auto.commit': this.config.autoCommit,
             'enable.partition.eof': true,
             rebalance_cb: true,
+            error_cb: true,
             offset_commit_cb: true,
         }
 
@@ -283,7 +285,13 @@ export class KafkaConsumer {
         })
 
         consumer.on('event.error', (error: LibrdKafkaError) => {
-            logger.error('📝', 'librdkafka error', { log: error })
+            logger.error('📝 librdkafka error', {
+                message: error.message,
+                code: error.code,
+                errno: error.errno,
+                origin: 'event.error',
+                stack: error.stack,
+            })
         })
 
         consumer.on('subscribed', (topics) => {

--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -169,7 +169,6 @@ export class KafkaConsumer {
             'enable.auto.commit': this.config.autoCommit,
             'enable.partition.eof': true,
             rebalance_cb: true,
-            error_cb: true,
             offset_commit_cb: true,
         }
 

--- a/plugin-server/src/kafka/producer.ts
+++ b/plugin-server/src/kafka/producer.ts
@@ -58,6 +58,10 @@ export class KafkaProducerWrapper {
             'queue.buffering.max.messages': 100_000,
             'compression.codec': 'snappy',
             'enable.idempotence': true,
+            'metadata.max.age.ms': 30000, // Refresh metadata every 30s
+            'retry.backoff.ms': 500, // Backoff between retry attempts
+            'socket.timeout.ms': 30000, // Timeout for socket operations
+            'max.in.flight.requests.per.connection': 5, // Required for idempotence ordering
             ...getKafkaConfigFromEnv(mode),
             dr_cb: true,
         }


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

MSK security patching really sends our system down everytime a broker is down. Our system should be able to handle that, likely we are too slow fetching new metadata information for the cluster, these settings should help both the producer and consumer be more resilient

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
