### PR TITLE
feat(dashboard): bring back edit button

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -23,6 +23,7 @@ import { useSummarizeInsight } from 'scenes/insights/summarizeInsight'
 import { urls } from 'scenes/urls'
 
 import { dashboardsModel } from '~/models/dashboardsModel'
+import { isDataVisualizationNode } from '~/queries/utils'
 import { ExporterFormat, InsightColor, QueryBasedInsightModel } from '~/types'
 
 import { InsightCardProps } from './InsightCard'
@@ -119,9 +120,21 @@ export function InsightMeta({
                 <>
                     {/* Insight related */}
                     {editable && (
-                        <LemonButton onClick={rename} fullWidth>
-                            Rename
-                        </LemonButton>
+                        <>
+                            <LemonButton
+                                to={
+                                    isDataVisualizationNode(insight.query)
+                                        ? urls.sqlEditor(undefined, undefined, short_id)
+                                        : urls.insightEdit(short_id)
+                                }
+                                fullWidth
+                            >
+                                Edit
+                            </LemonButton>
+                            <LemonButton onClick={rename} fullWidth>
+                                Rename
+                            </LemonButton>
+                        </>
                     )}
                     <LemonButton
                         onClick={duplicate}


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C011L071P8U/p1752266395119749?thread_ts=1752222930.713829&cid=C011L071P8U

## Changes

Brings back the edit button.

## How did you test this code?

<img width="302" height="448" alt="Screenshot 2025-07-11 at 23 11 47" src="https://github.com/user-attachments/assets/726860e6-ec01-483f-9b34-f51a8acd937d" />
