### PR TITLE
chore(capture): migrate ee/clickhouse/groups to new_capture_internal

### DIFF
--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -258,7 +258,6 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, viewsets.Gene
             except HTTPError as e:
                 return response.Response(
                     {
-                        "attr": key,
                         "code": "Failed to submit group property update event.",
                         "detail": "capture_http_error",
                         "type": "capture_http_error",
@@ -268,7 +267,6 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, viewsets.Gene
             except Exception:
                 return response.Response(
                     {
-                        "attr": key,
                         "code": "Failed to submit group property update event.",
                         "detail": "capture_error",
                         "type": "capture_error",

--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -1,13 +1,14 @@
 from collections import defaultdict
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
+from requests import HTTPError
 from typing import cast
 
 from django.db.models import Q
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter
 from rest_framework import mixins, request, response, serializers, viewsets, status
-from posthog.api.capture import capture_internal
+from posthog.api.capture import new_capture_internal
 from posthog.api.utils import action
 from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.pagination import CursorPagination
@@ -203,7 +204,7 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, viewsets.Gene
         ]
     )
     @action(methods=["POST"], detail=False, required_scopes=["group:write"])
-    def update_property(self, request: request.Request, **kw) -> response.Response:
+    def update_property(self, request: request.Request, **_kw) -> response.Response:
         try:
             group = self.get_object()
             for key in ["value", "key"]:
@@ -235,24 +236,46 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, viewsets.Gene
                 created_at=group.created_at,
                 timestamp=timezone.now(),
             )
-            capture_internal(
-                distinct_id=str(self.team.uuid),
-                ip=None,
-                site_url=None,
-                token=self.team.api_token,
-                now=timezone.now(),
-                sent_at=None,
-                event={
-                    "event": "$groupidentify",
-                    "properties": {
-                        "$group_type": group_type_mapping.group_type,
-                        "$group_key": group.group_key,
-                        "$group_set": {request.data["key"]: request.data["value"]},
+
+            # another internal event submission where we best-effort and don't handle failures...
+            team_uuid_as_distinct_id = str(self.team.uuid)
+            try:
+                resp = new_capture_internal(
+                    self.team.api_token,
+                    team_uuid_as_distinct_id,
+                    {
+                        "event": "$groupidentify",
+                        "properties": {
+                            "$group_type": group_type_mapping.group_type,
+                            "$group_key": group.group_key,
+                            "$group_set": {request.data["key"]: request.data["value"]},
+                        },
+                        "timestamp": timezone.now().isoformat(),
                     },
-                    "distinct_id": str(self.team.uuid),
-                    "timestamp": timezone.now().isoformat(),
-                },
-            )
+                    False,  # don't process person profile
+                )
+                resp.raise_for_status()
+            except HTTPError as e:
+                return response.Response(
+                    {
+                        "attr": key,
+                        "code": "Failed to submit group property update event.",
+                        "detail": "capture_http_error",
+                        "type": "capture_http_error",
+                    },
+                    status=e.response.status_code,
+                )
+            except Exception:
+                return response.Response(
+                    {
+                        "attr": key,
+                        "code": "Failed to submit group property update event.",
+                        "detail": "capture_error",
+                        "type": "capture_error",
+                    },
+                    status=400,
+                )
+
             log_activity(
                 organization_id=self.organization.id,
                 team_id=self.team.id,
@@ -326,24 +349,46 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, viewsets.Gene
                 created_at=group.created_at,
                 timestamp=timezone.now(),
             )
-            capture_internal(
-                distinct_id=str(self.team.uuid),
-                ip=None,
-                site_url=None,
-                token=self.team.api_token,
-                now=timezone.now(),
-                sent_at=None,
-                event={
-                    "event": "$delete_group_property",
-                    "properties": {
-                        "$group_type": group_type_mapping.group_type,
-                        "$group_key": group.group_key,
-                        "$group_unset": [request.data["$unset"]],
+
+            # another internal event submission where we best-effort and don't handle failures...
+            team_uuid_as_distinct_id = str(self.team.uuid)
+            try:
+                resp = new_capture_internal(
+                    self.team.api_token,
+                    team_uuid_as_distinct_id,
+                    {
+                        "event": "$delete_group_property",
+                        "properties": {
+                            "$group_type": group_type_mapping.group_type,
+                            "$group_key": group.group_key,
+                            "$group_unset": [request.data["$unset"]],
+                        },
+                        "timestamp": timezone.now().isoformat(),
                     },
-                    "distinct_id": str(self.team.uuid),
-                    "timestamp": timezone.now().isoformat(),
-                },
-            )
+                    False,  # don't process person profile
+                )
+                resp.raise_for_status()
+            except HTTPError as e:
+                return response.Response(
+                    {
+                        "attr": key,
+                        "code": "Failed to submit group property deletion event.",
+                        "detail": "capture_http_error",
+                        "type": "capture_http_error",
+                    },
+                    status=e.response.status_code,
+                )
+            except Exception:
+                return response.Response(
+                    {
+                        "attr": key,
+                        "code": "Failed to submit group property deletion event.",
+                        "detail": "capture_error",
+                        "type": "capture_error",
+                    },
+                    status=400,
+                )
+
             log_activity(
                 organization_id=self.organization.id,
                 team_id=self.team.id,

--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -317,7 +317,7 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, viewsets.Gene
         ]
     )
     @action(methods=["POST"], detail=False, required_scopes=["group:write"])
-    def delete_property(self, request: request.Request, **kw) -> response.Response:
+    def delete_property(self, request: request.Request, **_kw) -> response.Response:
         try:
             group = self.get_object()
             for key in ["$unset"]:

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -3,7 +3,6 @@ from uuid import UUID
 
 from freezegun.api import freeze_time
 from orjson import orjson
-
 from flaky import flaky
 
 from posthog.helpers.dashboard_templates import create_group_type_mapping_detail_dashboard
@@ -21,6 +20,7 @@ from posthog.test.base import (
     _create_event,
     snapshot_clickhouse_queries,
 )
+from unittest.mock import patch
 
 
 class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
@@ -504,7 +504,13 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.status_code, 404)
 
     @freeze_time("2021-05-02")
-    def test_get_group_activities_success(self):
+    @patch("ee.clickhouse.views.groups.new_capture_internal")
+    def test_get_group_activities_success(self, mock_capture):
+        # Mock the response to return a 200 OK
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 200
+        mock_capture.return_value = mock_response
+
         group_type_mapping = GroupTypeMapping.objects.create(
             team=self.team,
             project_id=self.team.project_id,
@@ -540,7 +546,13 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.json()["results"][0]["detail"]["changes"][0]["action"], "changed")
 
     @freeze_time("2021-05-02")
-    def test_get_group_activities_invalid_group(self):
+    @patch("ee.clickhouse.views.groups.new_capture_internal")
+    def test_get_group_activities_invalid_group(self, mock_capture):
+        # Mock the response to return a 200 OK
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 200
+        mock_capture.return_value = mock_response
+
         group_type_mapping = GroupTypeMapping.objects.create(
             team=self.team,
             project_id=self.team.project_id,

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -171,7 +171,7 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
         )
 
     @freeze_time("2021-05-02")
-    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    @mock.patch("ee.clickhouse.views.groups.new_capture_internal")
     @flaky(max_runs=3, min_passes=1)
     def test_group_property_crud_add_success(self, mock_capture):
         group_type_mapping = GroupTypeMapping.objects.create(
@@ -227,22 +227,18 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.results, [('{"name": "Mr. Krabs", "industry": "technology"}',)])
 
         mock_capture.assert_called_once_with(
-            distinct_id=str(self.team.uuid),
-            ip=None,
-            site_url=None,
-            token=self.team.api_token,
-            now=mock.ANY,
-            sent_at=None,
-            event={
+            self.team.api_token,
+            str(self.team.uuid),
+            {
                 "event": "$groupidentify",
+                "timestamp": mock.ANY,
                 "properties": {
                     "$group_type": group_type_mapping.group_type,
                     "$group_key": group.group_key,
                     "$group_set": {"industry": "technology"},
                 },
-                "distinct_id": str(self.team.uuid),
-                "timestamp": mock.ANY,
             },
+            False,
         )
 
         response = self.client.get(
@@ -261,7 +257,7 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.json()["results"][0]["detail"]["changes"][0]["after"], "technology")
 
     @freeze_time("2021-05-02")
-    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    @mock.patch("ee.clickhouse.views.groups.new_capture_internal")
     @flaky(max_runs=3, min_passes=1)
     def test_group_property_crud_update_success(self, mock_capture):
         group_type_mapping = GroupTypeMapping.objects.create(
@@ -314,22 +310,18 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(orjson.loads(response.results[0][0]), {"name": "Mr. Krabs", "industry": "technology"})
 
         mock_capture.assert_called_once_with(
-            distinct_id=str(self.team.uuid),
-            ip=None,
-            site_url=None,
-            token=self.team.api_token,
-            now=mock.ANY,
-            sent_at=None,
-            event={
+            self.team.api_token,
+            str(self.team.uuid),
+            {
                 "event": "$groupidentify",
+                "timestamp": mock.ANY,
                 "properties": {
                     "$group_type": group_type_mapping.group_type,
                     "$group_key": group.group_key,
                     "$group_set": {"industry": "technology"},
                 },
-                "distinct_id": str(self.team.uuid),
-                "timestamp": mock.ANY,
             },
+            False,
         )
 
         response = self.client.get(
@@ -390,7 +382,7 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.status_code, 404)
 
     @freeze_time("2021-05-02")
-    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    @mock.patch("ee.clickhouse.views.groups.new_capture_internal")
     @flaky(max_runs=3, min_passes=1)
     def test_group_property_crud_delete_success(self, mock_capture):
         group_type_mapping = GroupTypeMapping.objects.create(
@@ -440,22 +432,18 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.results, [('{"name": "Mr. Krabs"}',)])
 
         mock_capture.assert_called_once_with(
-            distinct_id=str(self.team.uuid),
-            ip=None,
-            site_url=None,
-            token=self.team.api_token,
-            now=mock.ANY,
-            sent_at=None,
-            event={
+            self.team.api_token,
+            str(self.team.uuid),
+            {
                 "event": "$delete_group_property",
+                "timestamp": mock.ANY,
                 "properties": {
                     "$group_type": group_type_mapping.group_type,
                     "$group_key": group.group_key,
                     "$group_unset": ["industry"],
                 },
-                "distinct_id": str(self.team.uuid),
-                "timestamp": mock.ANY,
             },
+            False,
         )
 
         response = self.client.get(


### PR DESCRIPTION
## Problem
Need to migrate all Django app call site of `cature_internal` to `new_capture_internal` to unblock removing legacy `capture.py` code 🔥 

## Changes
* Implement usage of `new_capture_internal` in `ee/clickhouse/groups` prop mutation view
* Update test suite

Didn't bother with a feature-flag rollout this time around as the other call sites paved the path for us, and this code doesn't execute in a scope where that would be useful.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Locally and in CI (test suite changes only!)