### PR TITLE
chore(capture): eliminate feature flag gating for new capture_internal in Persons API

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -10,7 +10,6 @@ from django.shortcuts import get_object_or_404
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiExample, OpenApiParameter
 from loginas.utils import is_impersonated_session
-import posthoganalytics
 from posthog.api.insight import capture_legacy_api_call
 from prometheus_client import Counter
 from rest_framework import request, response, serializers, viewsets
@@ -22,7 +21,7 @@ from rest_framework.settings import api_settings
 from rest_framework_csv import renderers as csvrenderers
 from statshog.defaults.django import statsd
 
-from posthog.api.capture import capture_internal, new_capture_internal, CaptureInternalError
+from posthog.api.capture import new_capture_internal
 from posthog.api.documentation import PersonPropertiesSerializer, extend_schema
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import (
@@ -554,57 +553,40 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     def delete_property(self, request: request.Request, pk=None, **kwargs) -> response.Response:
         person: Person = get_pk_or_uuid(Person.objects.filter(team_id=self.team_id), pk).get()
 
-        if posthoganalytics.feature_enabled("ingestion-new-capture-internal", person.distinct_ids[0]):
-            try:
-                event = {
-                    "event": "$delete_person_property",
-                    "properties": {
-                        "$unset": [request.data["$unset"]],
-                    },
-                    "timestamp": datetime.now().isoformat(),
-                }
-                resp = new_capture_internal(
-                    self.team.api_token,
-                    person.distinct_ids[0],
-                    event,
-                    True,
-                )
-                resp.raise_for_status()
-
-            except HTTPError as he:
-                return response.Response(
-                    {
-                        "success": False,
-                        "detail": "Unable to delete property",
-                    },
-                    status=he.response.status_code,
-                )
-
-            except CaptureInternalError:
-                return response.Response(
-                    {
-                        "success": False,
-                        "detail": f"Unable to delete property",
-                    },
-                    status=400,
-                )
-
-        else:
-            capture_internal(
-                distinct_id=person.distinct_ids[0],
-                ip=None,
-                site_url=None,
-                token=self.team.api_token,
-                now=datetime.now(),
-                sent_at=None,
-                event={
-                    "event": "$delete_person_property",
-                    "properties": {
-                        "$unset": [request.data["$unset"]],
-                    },
-                    "distinct_id": person.distinct_ids[0],
-                    "timestamp": datetime.now().isoformat(),
+        try:
+            event = {
+                "event": "$delete_person_property",
+                "properties": {
+                    "$unset": [request.data["$unset"]],
                 },
+                "timestamp": datetime.now().isoformat(),
+            }
+            resp = new_capture_internal(
+                self.team.api_token,
+                person.distinct_ids[0],
+                event,
+                True,
+            )
+            resp.raise_for_status()
+
+        # HTTP error - if applicable, thrown after retires are exhausted
+        except HTTPError as he:
+            return response.Response(
+                {
+                    "success": False,
+                    "detail": "Unable to delete property",
+                },
+                status=he.response.status_code,
+            )
+
+        # catches event payload errors (CaptureInternalError) and misc. (timeout etc.)
+        except Exception:
+            return response.Response(
+                {
+                    "success": False,
+                    "detail": f"Unable to delete property",
+                },
+                status=400,
             )
 
         log_activity(
@@ -697,44 +679,25 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         instance = self.get_object()
         distinct_id = instance.distinct_ids[0]
 
-        if posthoganalytics.feature_enabled("ingestion-new-capture-internal", distinct_id):
-            try:
-                event = {
-                    "event": "$set",
-                    "properties": {
-                        "$set": properties,
-                    },
-                    "timestamp": datetime.now().isoformat(),
-                }
-                resp = new_capture_internal(
-                    instance.team.api_token,
-                    distinct_id,
-                    event,
-                    True,
-                )
-                resp.raise_for_status()
-
-            # Failures in this codepath (old and new) are ignored here
-            except (HTTPError, CaptureInternalError):
-                pass
-
-        else:
-            capture_internal(
-                distinct_id=distinct_id,
-                ip=None,
-                site_url=None,
-                token=instance.team.api_token,
-                now=datetime.now(),
-                sent_at=None,
-                event={
-                    "event": "$set",
-                    "properties": {
-                        "$set": properties,
-                    },
-                    "distinct_id": distinct_id,
-                    "timestamp": datetime.now().isoformat(),
+        try:
+            event = {
+                "event": "$set",
+                "properties": {
+                    "$set": properties,
                 },
+                "timestamp": datetime.now().isoformat(),
+            }
+            resp = new_capture_internal(
+                instance.team.api_token,
+                distinct_id,
+                event,
+                True,
             )
+            resp.raise_for_status()
+
+        # Failures in this codepath (old and new) are ignored here
+        except Exception:
+            pass
 
         if self.organization.id:  # should always be true, but mypy...
             log_activity(


### PR DESCRIPTION
## Problem
Remove feature flag gating on new `capture_internal` use in Persons API

## Changes
As it says on the tin. Planning to land this Monday after the feature flag has been ramped to 100% without incident for 4+ days 👍 

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Locally, in CI, and in production