### PR TITLE
fix: Fix channel type property not working in activity view

### DIFF
--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -407,10 +407,7 @@ def property_to_expr(
         operator = cast(Optional[PropertyOperator], property.operator) or PropertyOperator.EXACT
         value = property.value
 
-        if property.key.startswith("$virt") and property.type == "person":
-            # we pretend virtual person properties are regular properties, but they are ExpressionFields on the Persons table
-            chain = ["person"] if scope != "person" else []
-        elif property.type == "person" and scope != "person":
+        if property.type == "person" and scope != "person":
             chain = ["person", "properties"]
         elif property.type == "event" and scope == "replay_entity":
             chain = ["events", "properties"]
@@ -470,7 +467,7 @@ def property_to_expr(
         else:
             field = ast.Field(chain=[*chain, property.key])
 
-        expr: ast.Expr = field
+        expr: ast.Expr = map_virtual_properties(field)
 
         if property.type == "recording" and property.key == "snapshot_source":
             expr = ast.Call(name="argMinMerge", args=[field])
@@ -656,6 +653,18 @@ def property_to_expr(
     raise NotImplementedError(
         f"property_to_expr not implemented for filter type {type(property).__name__} and {property.type}"
     )
+
+
+def map_virtual_properties(e: ast.Expr):
+    if (
+        isinstance(e, ast.Field)
+        and len(e.chain) >= 2
+        and e.chain[-2] == "properties"
+        and e.chain[-1].startswith("$virt")
+    ):
+        # we pretend virtual properties are regular properties, but they should map to the same field directly on the parent table
+        return ast.Field(chain=e.chain[:-2] + [e.chain[-1]])
+    return e
 
 
 def create_expr_for_revenue_analytics_property(property: RevenueAnalyticsPropertyFilter) -> ast.Expr:

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -660,6 +660,7 @@ def map_virtual_properties(e: ast.Expr):
         isinstance(e, ast.Field)
         and len(e.chain) >= 2
         and e.chain[-2] == "properties"
+        and isinstance(e.chain[-1], str)
         and e.chain[-1].startswith("$virt")
     ):
         # we pretend virtual properties are regular properties, but they should map to the same field directly on the parent table

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -950,12 +950,16 @@ class TestProperty(BaseTest):
         assert map_virtual_properties(
             ast.Field(chain=["person", "properties", "$virt_initial_channel_type"])
         ) == ast.Field(chain=["person", "$virt_initial_channel_type"])
-        assert map_virtual_properties(ast.Field(chain=["person", "properties", "other property"])) == ast.Field(
-            chain=["person", "properties", "other property"]
-        )
         assert map_virtual_properties(ast.Field(chain=["properties", "$virt_initial_channel_type"])) == ast.Field(
             chain=["$virt_initial_channel_type"]
+        )
+        assert map_virtual_properties(ast.Field(chain=["person", "properties", "other property"])) == ast.Field(
+            chain=["person", "properties", "other property"]
         )
         assert map_virtual_properties(ast.Field(chain=["properties", "other property"])) == ast.Field(
             chain=["properties", "other property"]
         )
+        assert map_virtual_properties(ast.Field(chain=["person", "properties", 42])) == ast.Field(
+            chain=["person", "properties", 42]
+        )
+        assert map_virtual_properties(ast.Field(chain=["properties", 42])) == ast.Field(chain=["properties", 42])

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -13,6 +13,7 @@ from posthog.hogql.property import (
     selector_to_expr,
     tag_name_to_expr,
     entity_to_expr,
+    map_virtual_properties,
 )
 from posthog.hogql.visitor import clear_locations
 from posthog.models import (
@@ -944,3 +945,17 @@ class TestProperty(BaseTest):
         assert self._property_to_expr(
             {"type": "person", "key": "$virt_initial_channel_type", "value": "Organic Search"}, scope="event"
         ) == self._parse_expr("person.$virt_initial_channel_type = 'Organic Search'")
+
+    def test_map_virtual_properties(self):
+        assert map_virtual_properties(
+            ast.Field(chain=["person", "properties", "$virt_initial_channel_type"])
+        ) == ast.Field(chain=["person", "$virt_initial_channel_type"])
+        assert map_virtual_properties(ast.Field(chain=["person", "properties", "other property"])) == ast.Field(
+            chain=["person", "properties", "other property"]
+        )
+        assert map_virtual_properties(ast.Field(chain=["properties", "$virt_initial_channel_type"])) == ast.Field(
+            chain=["$virt_initial_channel_type"]
+        )
+        assert map_virtual_properties(ast.Field(chain=["properties", "other property"])) == ast.Field(
+            chain=["properties", "other property"]
+        )

--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -12,7 +12,7 @@ from posthog.api.utils import get_pk_or_uuid
 from posthog.hogql import ast
 from posthog.hogql.ast import Alias
 from posthog.hogql.parser import parse_expr, parse_order_expr, parse_select
-from posthog.hogql.property import action_to_expr, has_aggregation, property_to_expr
+from posthog.hogql.property import action_to_expr, has_aggregation, property_to_expr, map_virtual_properties
 from posthog.hogql_queries.insights.insight_actors_query_runner import InsightActorsQueryRunner
 from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
 from posthog.hogql_queries.query_runner import QueryRunner, get_query_runner
@@ -83,7 +83,9 @@ class EventsQueryRunner(QueryRunner):
                 select_input.append(expr)
             else:
                 select_input.append(col)
-        return select_input, [parse_expr(column, timings=self.timings) for column in select_input]
+        return select_input, [
+            map_virtual_properties(parse_expr(column, timings=self.timings)) for column in select_input
+        ]
 
     def to_query(self) -> ast.SelectQuery:
         # Note: This code is inefficient and problematic, see https://github.com/PostHog/posthog/issues/13485 for details.

--- a/posthog/hogql_queries/test/test_events_query_runner.py
+++ b/posthog/hogql_queries/test/test_events_query_runner.py
@@ -663,3 +663,36 @@ class TestEventsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert isinstance(response, CachedEventsQueryResponse)
         display_names = [row[1]["display_name"] for row in response.results]
         assert set(display_names) == {"Test User With Spaces"}
+
+    def test_virtual_property(self):
+        _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["id_spaced"],
+            properties={
+                "email": "user@email.com",
+                "Property With Spaces": "Test User With Spaces",
+                "$initial_utm_source": "facebook",
+            },
+        )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="id_spaced",
+            properties={"utm_source": "facebook"},
+        )
+        flush_persons_and_events()
+
+        # Configure the team to use the property with spaces as display name
+        self.team.person_display_name_properties = ["Property With Spaces"]
+        self.team.save()
+        self.team.refresh_from_db()
+
+        query = EventsQuery(
+            kind="EventsQuery",
+            select=["event", "person_display_name -- Person", "person.properties.$virt_initial_channel_type"],
+            orderBy=["timestamp ASC"],
+        )
+        runner = EventsQueryRunner(query=query, team=self.team)
+        response = runner.run()
+        assert isinstance(response, CachedEventsQueryResponse)
+        assert response.results[0][2] == "Organic Social"


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
The Events query doesn't handle virtual properties, it tries to access a property by that name isntead

## Changes

Add handling code

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Added a couple of tests

Tested locally with the demo project http://localhost:8010/project/1/activity/explore#q=%7B%22kind%22%3A%22DataTableNode%22%2C%22full%22%3Atrue%2C%22source%22%3A%7B%22kind%22%3A%22EventsQuery%22%2C%22select%22%3A%5B%22*%22%2C%22event%22%2C%22person_display_name%20--%20Person%20%22%2C%22coalesce(properties.%24current_url%2C%20properties.%24screen_name)%20--%20Url%20%2F%20Screen%22%2C%22properties.%24lib%22%2C%22timestamp%22%2C%22person.properties.%24virt_initial_channel_type%22%5D%2C%22orderBy%22%3A%5B%22timestamp%20DESC%22%5D%2C%22after%22%3A%22-24h%22%2C%22modifiers%22%3A%7B%22usePresortedEventsTable%22%3Atrue%7D%7D%2C%22propertiesViaUrl%22%3Atrue%2C%22showSavedQueries%22%3Atrue%2C%22showPersistentColumnConfigurator%22%3Atrue%7D

<img width="1726" height="702" alt="Screenshot 2025-07-13 at 14 00 05" src="https://github.com/user-attachments/assets/e428a08d-1e89-4db9-9e47-5cfee65aec63" />
