### PR TITLE
fix(export): Exporting csv should use expression comment for table headers if its available

### DIFF
--- a/posthog/tasks/exports/ordered_csv_renderer.py
+++ b/posthog/tasks/exports/ordered_csv_renderer.py
@@ -55,7 +55,7 @@ class OrderedCsvRenderer(
         if labels:
             yield [labels.get(x, x) for x in field_headers]
         else:
-            yield [extract_expression_comment(key) for key in field_headers]
+            yield [extract_expression_comment(header) for header in field_headers]
 
         # Create a row for each dictionary, filling in columns for which the
         # item has no data with None values.
@@ -63,7 +63,7 @@ class OrderedCsvRenderer(
             yield [item.get(key, None) for key in field_headers]
 
 
-def extract_expression_comment(query: str) -> str:
-    if "--" in query:
-        return query.split("--")[-1].strip() or query
-    return query
+def extract_expression_comment(header: str) -> str:
+    if "--" in header:
+        return header.split("--")[-1].strip() or header
+    return header

--- a/posthog/tasks/exports/ordered_csv_renderer.py
+++ b/posthog/tasks/exports/ordered_csv_renderer.py
@@ -55,9 +55,15 @@ class OrderedCsvRenderer(
         if labels:
             yield [labels.get(x, x) for x in field_headers]
         else:
-            yield field_headers
+            yield [extract_expression_comment(key) for key in field_headers]
 
         # Create a row for each dictionary, filling in columns for which the
         # item has no data with None values.
         for item in data:
             yield [item.get(key, None) for key in field_headers]
+
+
+def extract_expression_comment(query: str) -> str:
+    if "--" in query:
+        return query.split("--")[-1].strip() or query
+    return query


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

When exporting data table as a csv file, the headers are often too long due to the sql expression:



<img width="976" height="299" alt="Screenshot 2025-07-14 at 12 42 17 PM" src="https://github.com/user-attachments/assets/502a058f-7fd3-40d4-9634-ceff0bf9e1d4" />


## Changes

While generating the table for csv export, the renderer now looks for expression comments and return it as headers:

<img width="964" height="126" alt="Screenshot 2025-07-14 at 12 43 19 PM" src="https://github.com/user-attachments/assets/5b569fb7-f5f5-4621-ae1f-06bcf29ab112" />



## Did you write or update any docs for this change?
- [x] No docs needed for this change

## How did you test this code?

Locally, how to reproduce:

1) Go to a survey with results
2) Click on export -> export current columns -> csv
3) Download the exported file
4) You should see that the column headers are no longer the sql expressions but the comment expression
