### PR TITLE
fix(ci): attempt to fix storybook ci for external repos

### DIFF
--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -50,7 +50,9 @@ jobs:
             - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               if: needs.changes.outputs.frontend == 'true'
               with:
-                  ref: ${{ github.event.pull_request.head.ref }}
+                  ref: ${{ github.event.pull_request.head.sha }}
+                  # Use PostHog Bot token when not on forks to enable proper snapshot updating
+                  token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN || github.token }}
 
             - name: Install pnpm
               if: needs.changes.outputs.frontend == 'true'
@@ -109,7 +111,9 @@ jobs:
             - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               if: needs.changes.outputs.frontend == 'true'
               with:
-                  ref: ${{ github.event.pull_request.head.ref }}
+                  ref: ${{ github.event.pull_request.head.sha }}
+                  # Use PostHog Bot token when not on forks to enable proper snapshot updating
+                  token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN || github.token }}
                   fetch-depth: 0 # 👈 Required to retrieve git history (https://www.chromatic.com/docs/github-actions)
 
             - name: Install pnpm
@@ -341,7 +345,7 @@ jobs:
             - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               if: needs.changes.outputs.frontend == 'true'
               with:
-                  ref: ${{ github.event.pull_request.head.ref }}
+                  ref: ${{ github.event.pull_request.head.sha }}
                   # Use PostHog Bot token when not on forks to enable proper snapshot updating
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN || github.token }}
 


### PR DESCRIPTION
## Problem

The update reference [here](https://github.com/PostHog/posthog/pull/34770/files) likely is causing external contributor PRs to [fail CI](https://github.com/PostHog/posthog/actions/runs/16260835693/job/45905537915?pr=34942).

## Changes

GitHub only fetches the default branch and the PR merge ref, thus if the PR is from a fork, the head branch (like fix-member-select) does not exist in origin and the fetch fails. Using the full ref should fix this, mabye.

## How did you test this code?

CI run on external contributor PR after this is in master