### PR TITLE
fix(data-warehouse): Logs and quicker size estimates

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -392,7 +392,6 @@ posthog/temporal/tests/data_imports/test_compaction_job.py:0: error: Dict entry 
 posthog/temporal/tests/data_imports/test_compaction_job.py:0: error: Dict entry 3 has incompatible type "str": "str | None"; expected "str": "str"  [dict-item]
 posthog/temporal/tests/data_imports/test_end_to_end.py:0: error: Incompatible types in assignment (expression has type "ExternalDataJob | None", variable has type "ExternalDataJob")  [assignment]
 posthog/temporal/tests/data_imports/test_end_to_end.py:0: error: Incompatible types in assignment (expression has type "ExternalDataJob | None", variable has type "ExternalDataJob")  [assignment]
-posthog/temporal/tests/data_imports/test_end_to_end.py:0: error: Incompatible types in assignment (expression has type "ExternalDataJob | None", variable has type "ExternalDataJob")  [assignment]
 posthog/temporal/tests/external_data/test_external_data_job.py:0: error: Invalid index type "str" for "dict[Type, Sequence[str]]"; expected type "Type"  [index]
 posthog/temporal/tests/external_data/test_external_data_job.py:0: error: Invalid index type "str" for "dict[Type, Sequence[str]]"; expected type "Type"  [index]
 posthog/temporal/tests/external_data/test_external_data_job.py:0: error: Invalid index type "str" for "dict[Type, Sequence[str]]"; expected type "Type"  [index]

--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -243,6 +243,11 @@ def create_source_templates(inputs: CreateSourceTemplateInputs) -> None:
 
 @activity.defn
 def trigger_schedule_buffer_one_activity(schedule_id: str) -> None:
+    schema = ExternalDataSchema.objects.get(id=schedule_id)
+    logger = bind_temporal_worker_logger_sync(team_id=schema.team.pk)
+
+    logger.debug(f"Triggering temporal schedule {schedule_id} with policy 'buffer one'")
+
     temporal = sync_connect()
     trigger_schedule_buffer_one(temporal, schedule_id)
 

--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -213,6 +213,7 @@ class PipelineNonDLT:
 
                 # Only raise if we're not running in descending order, otherwise we'll often not
                 # complete the job before the incremental value can be updated
+                # TODO: raise when we're within `x` time of the worker being forced to shutdown
                 if self._schema.should_use_incremental_field and self._resource.sort_mode != "desc":
                     self._shutdown_monitor.raise_if_is_worker_shutdown()
 

--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -1,4 +1,5 @@
 import gc
+import sys
 import time
 from typing import Any, Literal
 
@@ -8,7 +9,6 @@ import pyarrow as pa
 import pyarrow.compute as pc
 from django.db.models import F
 from dlt.sources import DltSource
-from pympler import asizeof
 
 from posthog.exceptions_capture import capture_exception
 from posthog.temporal.common.logger import FilteringBoundLogger
@@ -139,6 +139,7 @@ class PipelineNonDLT:
                     )
 
             buffer: list[Any] = []
+            buffer_size_bytes = 0
             py_table = None
             row_count = 0
             chunk_index = 0
@@ -162,28 +163,34 @@ class PipelineNonDLT:
                 if isinstance(item, list):
                     if len(buffer) > 0:
                         buffer.extend(item)
-                        if asizeof.asizeof(buffer) >= self._chunk_size_bytes or len(buffer) >= self._chunk_size:
+                        buffer_size_bytes += _estimate_size(item)
+                        if buffer_size_bytes >= self._chunk_size_bytes or len(buffer) >= self._chunk_size:
                             self._logger.debug(f"Processing pipeline buffer (list). Length of buffer = {len(buffer)}")
 
                             py_table = table_from_py_list(buffer)
                             buffer = []
+                            buffer_size_bytes = 0
                         else:
                             continue
                     else:
-                        if asizeof.asizeof(item) >= self._chunk_size_bytes or len(item) >= self._chunk_size:
+                        buffer_size_bytes += _estimate_size(item)
+                        if buffer_size_bytes >= self._chunk_size_bytes or len(item) >= self._chunk_size:
                             self._logger.debug(f"Processing pipeline item (list). Length of item = {len(item)}")
                             py_table = table_from_py_list(item)
+                            buffer_size_bytes = 0
                         else:
                             buffer.extend(item)
                             continue
                 elif isinstance(item, dict):
                     buffer.append(item)
-                    if asizeof.asizeof(buffer) < self._chunk_size_bytes and len(buffer) < self._chunk_size:
+                    buffer_size_bytes += _estimate_size(item)
+                    if buffer_size_bytes < self._chunk_size_bytes and len(buffer) < self._chunk_size:
                         continue
 
                     self._logger.debug(f"Processing pipeline buffer (dict). Length of buffer = {len(buffer)}")
                     py_table = table_from_py_list(buffer)
                     buffer = []
+                    buffer_size_bytes = 0
                 elif isinstance(item, pa.Table):
                     py_table = item
                 else:
@@ -204,7 +211,9 @@ class PipelineNonDLT:
                 pa_memory_pool.release_unused()
                 gc.collect()
 
-                if self._schema.should_use_incremental_field:
+                # Only raise if we're not running in descending order, otherwise we'll often not
+                # complete the job before the incremental value can be updated
+                if self._schema.should_use_incremental_field and self._resource.sort_mode != "desc":
                     self._shutdown_monitor.raise_if_is_worker_shutdown()
 
             if len(buffer) > 0:
@@ -450,3 +459,12 @@ def _notify_revenue_analytics_that_sync_has_completed(schema: ExternalDataSchema
         # Sending an email is not critical to the pipeline
         logger.exception(f"Error notifying revenue analytics that sync has completed: {e}")
         capture_exception(e)
+
+
+def _estimate_size(obj: Any) -> int:
+    if isinstance(obj, dict):
+        return sys.getsizeof(obj) + sum(_estimate_size(k) + _estimate_size(v) for k, v in obj.items())
+    elif isinstance(obj, list | tuple | set):
+        return sys.getsizeof(obj) + sum(_estimate_size(i) for i in obj)
+    else:
+        return sys.getsizeof(obj)

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -2228,7 +2228,9 @@ async def test_append_only_table(team, mock_stripe_client):
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
-async def test_worker_shutdown_triggers_schedule_buffer_one(team, stripe_price, mock_stripe_client):
+async def test_worker_shutdown_desc_sort_order(team, stripe_price, mock_stripe_client):
+    """Testing that a descending sort ordered source will not trigger the rescheduling"""
+
     def mock_raise_if_is_worker_shutdown(self):
         raise WorkerShuttingDownError("test_id", "test_type", "test_queue", 1, "test_workflow", "test_workflow_type")
 
@@ -2251,12 +2253,54 @@ async def test_worker_shutdown_triggers_schedule_buffer_one(team, stripe_price, 
             ignore_assertions=True,
         )
 
+    # assert that the running job was completed successfully and that the new workflow was NOT triggered
+    mock_trigger_schedule_buffer_one.assert_not_called()
+
+    run: ExternalDataJob | None = await get_latest_run_if_exists(
+        team_id=inputs.team_id, pipeline_id=inputs.external_data_source_id
+    )
+
+    assert run is not None
+    assert run.status == ExternalDataJob.Status.COMPLETED
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_worker_shutdown_triggers_schedule_buffer_one(team, zendesk_brands):
+    def mock_raise_if_is_worker_shutdown(self):
+        raise WorkerShuttingDownError("test_id", "test_type", "test_queue", 1, "test_workflow", "test_workflow_type")
+
+    with (
+        mock.patch.object(ShutdownMonitor, "raise_if_is_worker_shutdown", mock_raise_if_is_worker_shutdown),
+        mock.patch(
+            "posthog.temporal.data_imports.external_data_job.trigger_schedule_buffer_one"
+        ) as mock_trigger_schedule_buffer_one,
+        mock.patch.object(PipelineNonDLT, "_chunk_size", 1),
+    ):
+        _, inputs = await _run(
+            team=team,
+            schema_name="brands",
+            table_name="zendesk_brands",
+            source_type="Zendesk",
+            job_inputs={
+                "zendesk_subdomain": "test",
+                "zendesk_api_key": "test_api_key",
+                "zendesk_email_address": "test@posthog.com",
+            },
+            mock_data_response=zendesk_brands["brands"],
+            sync_type=ExternalDataSchema.SyncType.INCREMENTAL,
+            sync_type_config={"incremental_field": "created_at", "incremental_field_type": "datetime"},
+            ignore_assertions=True,
+        )
+
     # assert that the running job was completed successfully and that the new workflow was triggered
     mock_trigger_schedule_buffer_one.assert_called_once_with(mock.ANY, str(inputs.external_data_schema_id))
 
-    run: ExternalDataJob = await get_latest_run_if_exists(
+    run: ExternalDataJob | None = await get_latest_run_if_exists(
         team_id=inputs.team_id, pipeline_id=inputs.external_data_source_id
     )
+
+    assert run is not None
     assert run.status == ExternalDataJob.Status.COMPLETED
 
 


### PR DESCRIPTION
## Problem
- https://github.com/PostHog/posthog/pull/34854 was originally sloppy by me
- It calculated the size of `buffer` on every iteration. Considering we would run up to many many iterations (100 items per iteration for the likes of Stripe = 50 iterations), we would be recalculating the size of the same object repeatedly, for example, on the first iteration of stripe we'd calculate the size of 100 items, on the second it'd be 200 items, on the third it'd be 300, etc. So before you write to deltalake, we would be calculating the size of `100 + 200 + 300 + 400 + ... + 5000 = 127,500` dicts. This is super slow, we're maxing out the CPU of our pods with this and syncs were taking forever to run.

## Changes
- Added some extra logs in restarting the job on worker shutdown, too
- Don't raise worker shutdown error if we're running a descending-ordered source
  - Otherwise, it's hard to sync long-running tables here
- Changing to only calculating the size of the incoming items and tracking the buffer size separately is a 25x speed improvement. Ditching `asizeof` in favour of our own size estimator is another 5x improvement (see benchmark below)

**Benchmarks:**
The test was an array of 1_000_000 dicts with nested arrays and dicts:
```
Pympler time: 24.56404995918274
Pympler size: 1891255136
Custom estimator time: 5.486032724380493
Custom estimator size: 1842000000
```

I'm happy with the speed increase for a 2% margin of error on the accuracy of the size 🤝 

## How did you test this code?
unit tests