### PR TITLE
feat: Add more properties to matrix

### DIFF
--- a/posthog/demo/matrix/models.py
+++ b/posthog/demo/matrix/models.py
@@ -49,6 +49,11 @@ EVENT_IDENTIFY = "$identify"
 EVENT_GROUP_IDENTIFY = "$groupidentify"
 
 PROPERTY_GEOIP_COUNTRY_CODE = "$geoip_country_code"
+PROPERTY_GEOIP_REGION = "$geoip_subdivision_1_code"
+PROPERTY_GEOIP_CITY = "$geoip_city_name"
+PROPERTY_TIMEZONE = "$timezone"
+PROPERTY_TIMEZONE_OFFSET = "$timezone_offset"
+PROPERTY_BROWSER_LANGUAGE = "$browser_language"
 
 UTM_QUERY_PROPERTIES = {"utm_source", "utm_campaign", "utm_medium", "utm_term", "utm_content"}
 
@@ -314,9 +319,17 @@ class SimBrowserClient(SimClient):
                 combined_properties["$set"].update(referrer_properties)
                 combined_properties["$referring_domain"] = referring_domain
             combined_properties.update(properties)
-        # GeoIP
-        combined_properties[PROPERTY_GEOIP_COUNTRY_CODE] = self.person.country_code
-        combined_properties["$set"][PROPERTY_GEOIP_COUNTRY_CODE] = self.person.country_code
+        # GeoIP and other person properties on events
+        for key, value in {
+            PROPERTY_GEOIP_COUNTRY_CODE: self.person.country_code,
+            PROPERTY_GEOIP_CITY: self.person.city,
+            PROPERTY_GEOIP_REGION: self.person.region,
+            PROPERTY_TIMEZONE: self.person.timezone,
+            PROPERTY_TIMEZONE_OFFSET: self.person.timezone_offset,
+            PROPERTY_BROWSER_LANGUAGE: self.person.language,
+        }.items():
+            combined_properties[key] = value
+            combined_properties["$set"][PROPERTY_GEOIP_COUNTRY_CODE] = value
         # Saving
         super()._capture_raw(event, combined_properties, distinct_id=self.active_distinct_id)
 
@@ -397,7 +410,11 @@ class SimPerson(ABC):
     in_product_id: str  # User ID within the product being simulated (freeform string)
     in_posthog_id: Optional[UUID]  # PostHog person ID (must be a UUID)
     country_code: str
+    region: str
+    city: str
     timezone: str
+    timezone_offset: int  # Offset in seconds from UTC
+    language: str
 
     # Exposed state - present
     past_events: list[SimEvent]
@@ -430,6 +447,10 @@ class SimPerson(ABC):
         self.in_posthog_id = None
         self.active_client = SimBrowserClient(self)
         self.country_code = "US"
+        self.region = "California"
+        self.city = "San Francisco"
+        self.timezone = "America/Los_Angeles"
+        self.timezone_offset = 420
         self.all_time_pageview_counts = defaultdict(int)
         self.session_pageview_counts = defaultdict(int)
         self.active_session_intent = None

--- a/posthog/demo/matrix/models.py
+++ b/posthog/demo/matrix/models.py
@@ -452,6 +452,7 @@ class SimPerson(ABC):
         self.region = "California"
         self.city = "San Francisco"
         self.timezone = "America/Los_Angeles"
+        self.language = "en-US"
         self.all_time_pageview_counts = defaultdict(int)
         self.session_pageview_counts = defaultdict(int)
         self.active_session_intent = None

--- a/posthog/demo/matrix/models.py
+++ b/posthog/demo/matrix/models.py
@@ -329,7 +329,7 @@ class SimBrowserClient(SimClient):
             PROPERTY_BROWSER_LANGUAGE: self.person.language,
         }.items():
             combined_properties[key] = value
-            combined_properties["$set"][PROPERTY_GEOIP_COUNTRY_CODE] = value
+            combined_properties["$set"][key] = value
         # Saving
         super()._capture_raw(event, combined_properties, distinct_id=self.active_distinct_id)
 

--- a/posthog/demo/matrix/models.py
+++ b/posthog/demo/matrix/models.py
@@ -325,7 +325,7 @@ class SimBrowserClient(SimClient):
             PROPERTY_GEOIP_CITY: self.person.city,
             PROPERTY_GEOIP_REGION: self.person.region,
             PROPERTY_TIMEZONE: self.person.timezone,
-            PROPERTY_TIMEZONE_OFFSET: self.person.timezone_offset,
+            PROPERTY_TIMEZONE_OFFSET: self.person.timezone_offset_minutes,
             PROPERTY_BROWSER_LANGUAGE: self.person.language,
         }.items():
             combined_properties[key] = value
@@ -413,7 +413,7 @@ class SimPerson(ABC):
     region: str
     city: str
     timezone: str
-    timezone_offset: int  # Offset in seconds from UTC
+    timezone_offset_minutes: int
     language: str
 
     # Exposed state - present
@@ -450,7 +450,7 @@ class SimPerson(ABC):
         self.region = "California"
         self.city = "San Francisco"
         self.timezone = "America/Los_Angeles"
-        self.timezone_offset = 420
+        self.timezone_offset_minutes = 420
         self.all_time_pageview_counts = defaultdict(int)
         self.session_pageview_counts = defaultdict(int)
         self.active_session_intent = None

--- a/posthog/demo/products/hedgebox/models.py
+++ b/posthog/demo/products/hedgebox/models.py
@@ -201,8 +201,24 @@ class HedgeboxPerson(SimPerson):
             self.country_code = (
                 "US" if self.cluster.random.random() < 0.7132 else self.cluster.address_provider.country_code()
             )
+            # mimesis doesn't support choosing cities in a specific country, so these will be pretty odd until they fix this
+            self.region = (
+                "California"
+                if self.country_code == "US" and self.cluster.random.random() < 0.5
+                else self.cluster.address_provider.region()
+            )
+            self.city = (
+                "San Francisco"
+                if self.region == "California" and self.cluster.random.random() < 0.3
+                else self.cluster.address_provider.city()
+            )
+            self.language = "en-GB" if self.country_code == "GB" else "en-US"
+
             try:  # Some tiny regions aren't in pytz - we want to omit those
                 self.timezone = self.cluster.random.choice(pytz.country_timezones[self.country_code])
+                self.timezone_offset = math.floor(
+                    ZoneInfo(self.timezone).utcoffset(dt.datetime.now(tz=ZoneInfo(self.timezone))).total_seconds() / 60
+                )
             except KeyError:
                 continue
             else:

--- a/posthog/demo/products/hedgebox/models.py
+++ b/posthog/demo/products/hedgebox/models.py
@@ -216,8 +216,6 @@ class HedgeboxPerson(SimPerson):
 
             try:  # Some tiny regions aren't in pytz - we want to omit those
                 self.timezone = self.cluster.random.choice(pytz.country_timezones[self.country_code])
-                utc_offset = ZoneInfo(self.timezone).utcoffset(dt.datetime.now(tz=ZoneInfo(self.timezone)))
-                self.timezone_offset = utc_offset.total_seconds() / 60 if utc_offset else 0
             except KeyError:
                 continue
             else:

--- a/posthog/demo/products/hedgebox/models.py
+++ b/posthog/demo/products/hedgebox/models.py
@@ -216,9 +216,8 @@ class HedgeboxPerson(SimPerson):
 
             try:  # Some tiny regions aren't in pytz - we want to omit those
                 self.timezone = self.cluster.random.choice(pytz.country_timezones[self.country_code])
-                self.timezone_offset = math.floor(
-                    ZoneInfo(self.timezone).utcoffset(dt.datetime.now(tz=ZoneInfo(self.timezone))).total_seconds() / 60
-                )
+                utc_offset = ZoneInfo(self.timezone).utcoffset(dt.datetime.now(tz=ZoneInfo(self.timezone)))
+                self.timezone_offset = utc_offset.total_seconds() / 60 if utc_offset else 0
             except KeyError:
                 continue
             else:

--- a/posthog/demo/products/spikegpt/models.py
+++ b/posthog/demo/products/spikegpt/models.py
@@ -2,7 +2,6 @@ import datetime as dt
 from enum import auto
 from typing import TYPE_CHECKING, Any, Optional
 from urllib.parse import urlencode, urlparse, urlunparse
-from zoneinfo import ZoneInfo
 
 import pytz
 
@@ -69,8 +68,6 @@ class SpikeGPTPerson(SimPerson):
 
             try:  # Some tiny regions aren't in pytz - we want to omit those
                 self.timezone = self.cluster.random.choice(pytz.country_timezones[self.country_code])
-                utc_offset = ZoneInfo(self.timezone).utcoffset(dt.datetime.now(tz=ZoneInfo(self.timezone)))
-                self.timezone_offset_minutes = utc_offset.total_seconds() / 60 if utc_offset else 0
             except KeyError:
                 continue
             else:

--- a/posthog/demo/products/spikegpt/models.py
+++ b/posthog/demo/products/spikegpt/models.py
@@ -1,5 +1,4 @@
 import datetime as dt
-import math
 from enum import auto
 from typing import TYPE_CHECKING, Any, Optional
 from urllib.parse import urlencode, urlparse, urlunparse
@@ -70,9 +69,8 @@ class SpikeGPTPerson(SimPerson):
 
             try:  # Some tiny regions aren't in pytz - we want to omit those
                 self.timezone = self.cluster.random.choice(pytz.country_timezones[self.country_code])
-                self.timezone_offset = math.floor(
-                    ZoneInfo(self.timezone).utcoffset(dt.datetime.now(tz=ZoneInfo(self.timezone))).total_seconds() / 60
-                )
+                utc_offset = ZoneInfo(self.timezone).utcoffset(dt.datetime.now(tz=ZoneInfo(self.timezone)))
+                self.timezone_offset_minutes = utc_offset.total_seconds() / 60 if utc_offset else 0
             except KeyError:
                 continue
             else:


### PR DESCRIPTION
Disabled by default, checks that services are up before running

> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Some default insights on web analytics don't have any data as we don't write to those properties

## Changes

There are some limitations around mimesis as a library to generate these, but populate:
* city
* region
* timezone_offset
* browser language

You can see the limitation here, 
<img width="1765" height="354" alt="Screenshot 2025-07-14 at 11 47 51" src="https://github.com/user-attachments/assets/61bf74f7-600d-4c84-b460-1456cae1db6b" />

FWIW it looks like `py_countries_states_cities_database` would have the relevant data, but I'm trying to avoid getting sniped

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Ran the demo script and opened web analytics