### PR TITLE
chore: we've set a global max_threads to 64, let's lower API max_threads to 60

### DIFF
--- a/posthog/hogql_queries/hogql_query_runner.py
+++ b/posthog/hogql_queries/hogql_query_runner.py
@@ -82,7 +82,7 @@ class HogQLQueryRunner(QueryRunner):
         ):
             assert self.settings is not None
             # p95 threads is 102
-            self.settings.max_threads = 80
+            self.settings.max_threads = 60
             # p95 duration of HogQL query is 2.78sec
             self.settings.max_execution_time = 10
 

--- a/posthog/hogql_queries/hogql_query_runner.py
+++ b/posthog/hogql_queries/hogql_query_runner.py
@@ -81,7 +81,7 @@ class HogQLQueryRunner(QueryRunner):
             and self.team.pk not in app_settings.API_QUERIES_LEGACY_TEAM_LIST
         ):
             assert self.settings is not None
-            # p95 threads is 102
+            # p95 threads is 102, limiting to 60 (below global max_threads of 64)
             self.settings.max_threads = 60
             # p95 duration of HogQL query is 2.78sec
             self.settings.max_execution_time = 10


### PR DESCRIPTION
## Problem

The limit was higher than a global limit

## Changes

set API max_thread to 60