### PR TITLE
feat(persons): Retry merge race condition

### DIFF
--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -905,7 +905,7 @@ export interface Person {
 }
 
 export interface DistinctPersonIdentifiers {
-    id: string
+    person_id: string
     uuid: string
     distinct_id: string
     team_id: number

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -904,6 +904,13 @@ export interface Person {
     force_upgrade?: boolean
 }
 
+export interface DistinctPersonIdentifiers {
+    id: string
+    uuid: string
+    distinct_id: string
+    team_id: number
+}
+
 /** Clickhouse Person model. */
 export interface ClickHousePerson {
     id: string

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -591,8 +591,11 @@ export class DB {
         }
     }
 
-    public async fetchPersonIdsById(distinctId: string, teamId: number): Promise<DistinctPersonIdentifiers | null> {
-        const queryString = `SELECT posthog_person.id, posthog_person.uuid, posthog_person.team_id, posthog_persondistinctid.distinct_id
+    public async fetchPersonIdsByDistinctId(
+        distinctId: string,
+        teamId: number
+    ): Promise<DistinctPersonIdentifiers | null> {
+        const queryString = `SELECT posthog_person.id as person_id, posthog_person.uuid, posthog_person.team_id, posthog_persondistinctid.distinct_id
             FROM posthog_person JOIN posthog_persondistinctid ON (posthog_persondistinctid.person_id = posthog_person.id)
             WHERE posthog_persondistinctid.team_id = $1 AND posthog_persondistinctid.distinct_id = $2 LIMIT 1`
 
@@ -600,7 +603,7 @@ export class DB {
             PostgresUse.PERSONS_WRITE,
             queryString,
             [teamId, distinctId],
-            'fetchPersonIdsById'
+            'fetchPersonIdsByDistinctId'
         )
 
         return rows.length > 0 ? rows[0] : null

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -13,7 +13,7 @@ import {
     PropertiesLastUpdatedAt,
     Team,
 } from '../../../types'
-import { DB } from '../../../utils/db/db'
+import { DB, MoveDistinctIdsResult } from '../../../utils/db/db'
 import { MessageSizeTooLarge } from '../../../utils/db/error'
 import { PostgresUse, TransactionClient } from '../../../utils/db/postgres'
 import { logger } from '../../../utils/logger'
@@ -447,7 +447,7 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         target: InternalPerson,
         distinctId: string,
         tx?: TransactionClient
-    ): Promise<TopicMessage[]> {
+    ): Promise<MoveDistinctIdsResult> {
         this.incrementCount('moveDistinctIds', distinctId)
         this.incrementDatabaseOperation('moveDistinctIds', distinctId)
         const start = performance.now()

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -41,7 +41,7 @@ import { PersonsStoreForBatch } from './persons-store-for-batch'
 type MethodName =
     | 'fetchForChecking'
     | 'fetchForUpdate'
-    | 'fetchPersonIdsById'
+    | 'fetchPersonIdsByDistinctId'
     | 'fetchPerson'
     | 'updatePersonAssertVersion'
     | 'updatePersonNoAssert'
@@ -377,10 +377,10 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         }
         return fetchPromise
     }
-    async fetchPersonIdsById(distinctId: string, teamId: number): Promise<DistinctPersonIdentifiers | null> {
-        this.incrementCount('fetchPersonIdsById', distinctId)
-        this.incrementDatabaseOperation('fetchPersonIdsById', distinctId)
-        const result = await this.db.fetchPersonIdsById(distinctId, teamId)
+    async fetchPersonIdsByDistinctId(distinctId: string, teamId: number): Promise<DistinctPersonIdentifiers | null> {
+        this.incrementCount('fetchPersonIdsByDistinctId', distinctId)
+        this.incrementDatabaseOperation('fetchPersonIdsByDistinctId', distinctId)
+        const result = await this.db.fetchPersonIdsByDistinctId(distinctId, teamId)
         return result
     }
 

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -6,6 +6,7 @@ import { NoRowsUpdatedError } from '~/utils/utils'
 
 import { TopicMessage } from '../../../kafka/producer'
 import {
+    DistinctPersonIdentifiers,
     InternalPerson,
     PersonBatchWritingDbWriteMode,
     PropertiesLastOperation,
@@ -40,6 +41,7 @@ import { PersonsStoreForBatch } from './persons-store-for-batch'
 type MethodName =
     | 'fetchForChecking'
     | 'fetchForUpdate'
+    | 'fetchPersonIdsById'
     | 'fetchPerson'
     | 'updatePersonAssertVersion'
     | 'updatePersonNoAssert'
@@ -374,6 +376,12 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
             personFetchForUpdateCacheOperationsCounter.inc({ operation: 'hit' })
         }
         return fetchPromise
+    }
+    async fetchPersonIdsById(distinctId: string, teamId: number): Promise<DistinctPersonIdentifiers | null> {
+        this.incrementCount('fetchPersonIdsById', distinctId)
+        this.incrementDatabaseOperation('fetchPersonIdsById', distinctId)
+        const result = await this.db.fetchPersonIdsById(distinctId, teamId)
+        return result
     }
 
     updatePersonForMerge(

--- a/plugin-server/src/worker/ingestion/persons/measuring-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/measuring-person-store.ts
@@ -33,7 +33,7 @@ type MethodName =
     | 'deletePerson'
     | 'addDistinctId'
     | 'moveDistinctIds'
-    | 'fetchPersonIdsById'
+    | 'fetchPersonIdsByDistinctId'
     | 'updateCohortsAndFeatureFlagsForMerge'
     | 'addPersonlessDistinctId'
     | 'addPersonlessDistinctIdForMerge'
@@ -303,10 +303,10 @@ export class MeasuringPersonsStoreForBatch implements PersonsStoreForBatch {
         return response
     }
 
-    async fetchPersonIdsById(distinctId: string, teamId: number): Promise<DistinctPersonIdentifiers | null> {
-        this.incrementCount('fetchPersonIdsById', distinctId)
-        this.incrementDatabaseOperation('fetchPersonIdsById', distinctId)
-        const result = await this.db.fetchPersonIdsById(distinctId, teamId)
+    async fetchPersonIdsByDistinctId(distinctId: string, teamId: number): Promise<DistinctPersonIdentifiers | null> {
+        this.incrementCount('fetchPersonIdsByDistinctId', distinctId)
+        this.incrementDatabaseOperation('fetchPersonIdsByDistinctId', distinctId)
+        const result = await this.db.fetchPersonIdsByDistinctId(distinctId, teamId)
         return result
     }
 

--- a/plugin-server/src/worker/ingestion/persons/measuring-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/measuring-person-store.ts
@@ -9,7 +9,7 @@ import {
     PropertiesLastUpdatedAt,
     Team,
 } from '../../../types'
-import { DB } from '../../../utils/db/db'
+import { DB, MoveDistinctIdsResult } from '../../../utils/db/db'
 import { PostgresUse, TransactionClient } from '../../../utils/db/postgres'
 import {
     observeLatencyByVersion,
@@ -330,7 +330,7 @@ export class MeasuringPersonsStoreForBatch implements PersonsStoreForBatch {
         target: InternalPerson,
         distinctId: string,
         tx?: TransactionClient
-    ): Promise<TopicMessage[]> {
+    ): Promise<MoveDistinctIdsResult> {
         this.incrementCount('moveDistinctIds', distinctId)
         this.clearCache()
         this.incrementDatabaseOperation('moveDistinctIds', distinctId)

--- a/plugin-server/src/worker/ingestion/persons/person-merge-service.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-merge-service.ts
@@ -529,8 +529,8 @@ export class PersonMergeService {
                         sourceDistinctId,
                     })
 
-                    // Refresh the source person data using fetchPersonIdsById to get latest person ID
-                    const personData = await this.context.personStore.fetchPersonIdsById(
+                    // Refresh the source person data using fetchPersonIdsByDistinctId to get latest person ID
+                    const personData = await this.context.personStore.fetchPersonIdsByDistinctId(
                         sourceDistinctId,
                         this.context.team.id
                     )
@@ -572,8 +572,8 @@ export class PersonMergeService {
                         targetDistinctId,
                     })
 
-                    // Refresh the target person data using fetchPersonIdsById to get latest person ID
-                    const personData = await this.context.personStore.fetchPersonIdsById(
+                    // Refresh the target person data using fetchPersonIdsByDistinctId to get latest person ID
+                    const personData = await this.context.personStore.fetchPersonIdsByDistinctId(
                         targetDistinctId,
                         this.context.team.id
                     )

--- a/plugin-server/src/worker/ingestion/persons/person-store-manager.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-store-manager.test.ts
@@ -87,7 +87,7 @@ describe('PersonStoreManager', () => {
                 return Promise.resolve([])
             }),
             moveDistinctIds: jest.fn().mockImplementation(() => {
-                return Promise.resolve([])
+                return Promise.resolve({ success: true, messages: [] })
             }),
             addDistinctId: jest.fn().mockImplementation(() => {
                 return Promise.resolve([])
@@ -228,7 +228,7 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
                 return Promise.resolve([])
             }),
             moveDistinctIds: jest.fn().mockImplementation(() => {
-                return Promise.resolve([])
+                return Promise.resolve({ success: true, messages: [] })
             }),
             addDistinctId: jest.fn().mockImplementation(() => {
                 return Promise.resolve([])
@@ -1085,7 +1085,6 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
             // Step 4: Flush and check final states
             await shadowManager.flush()
 
-            const metrics = shadowManager.getShadowMetrics()
             const finalStates = shadowManager.getFinalStates()
 
             // Verify final state tracking
@@ -1114,29 +1113,6 @@ describe('PersonStoreManagerForBatch (Shadow Mode)', () => {
                     }),
                 ])
             )
-
-            // Check for any logic errors - this is where the bug might manifest
-            // The bug would be that properties from the merge are missing in the measuring store
-            if (metrics.logicErrors.length > 0) {
-                const logicError = metrics.logicErrors[0]
-                console.log('Detected target person logic error:', logicError.differences)
-
-                // Check if we're missing properties that should have been merged
-                const missingProperties = logicError.differences.filter(
-                    (diff) =>
-                        diff.includes('missing in measuring store') &&
-                        (diff.includes('source_prop') ||
-                            diff.includes('rich_property') ||
-                            diff.includes('merged_from_source'))
-                )
-
-                if (missingProperties.length > 0) {
-                    console.log(
-                        'Bug reproduced! Properties lost in target person after moveDistinctIds:',
-                        missingProperties
-                    )
-                }
-            }
         })
     })
 

--- a/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
@@ -347,8 +347,8 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
         return mainResult
     }
 
-    async fetchPersonIdsById(distinctId: string, teamId: number): Promise<DistinctPersonIdentifiers | null> {
-        const result = await this.mainStore.fetchPersonIdsById(distinctId, teamId)
+    async fetchPersonIdsByDistinctId(distinctId: string, teamId: number): Promise<DistinctPersonIdentifiers | null> {
+        const result = await this.mainStore.fetchPersonIdsByDistinctId(distinctId, teamId)
         return result
     }
 

--- a/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
@@ -10,6 +10,7 @@ import {
     PropertiesLastUpdatedAt,
     Team,
 } from '../../../types'
+import { MoveDistinctIdsResult } from '../../../utils/db/db'
 import { TransactionClient } from '../../../utils/db/postgres'
 import { logger } from '../../../utils/logger'
 import { BatchWritingPersonsStore, BatchWritingPersonsStoreForBatch } from './batch-writing-person-store'
@@ -357,48 +358,54 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
         target: InternalPerson,
         distinctId: string,
         tx?: TransactionClient
-    ): Promise<TopicMessage[]> {
+    ): Promise<MoveDistinctIdsResult> {
         const mainResult = await this.mainStore.moveDistinctIds(source, target, distinctId, tx)
 
-        // Clear the cache for the source person id to ensure deleted person isn't cached
-        this.secondaryStore.clearPersonCacheForPersonId(source.team_id, source.id)
+        // Only proceed with cache updates if the operation was successful
+        if (mainResult.success) {
+            // Clear the cache for the source person id to ensure deleted person isn't cached
+            this.secondaryStore.clearPersonCacheForPersonId(source.team_id, source.id)
 
-        // Update cache for the target person for the current distinct ID
-        // Check if we already have cached data for the target person that includes merged properties
-        const existingTargetCache = this.secondaryStore.getCachedPersonForUpdateByPersonId(target.team_id, target.id)
-        if (existingTargetCache) {
-            // We have existing cached data with merged properties - preserve it
-            // Create a new PersonUpdate for this distinctId that preserves the merged data
-            const mergedPersonUpdate = { ...existingTargetCache, distinct_id: distinctId }
-            this.secondaryStore.setCachedPersonForUpdate(target.team_id, distinctId, mergedPersonUpdate)
-            this.updateFinalState(
+            // Update cache for the target person for the current distinct ID
+            // Check if we already have cached data for the target person that includes merged properties
+            const existingTargetCache = this.secondaryStore.getCachedPersonForUpdateByPersonId(
                 target.team_id,
-                distinctId,
-                target.id,
-                toInternalPerson(mergedPersonUpdate),
-                false,
-                'moveDistinctIds',
-                mergedPersonUpdate.version
+                target.id
             )
-        } else {
-            // No existing cache, create fresh cache from target person
-            this.secondaryStore.setCachedPersonForUpdate(
-                target.team_id,
-                distinctId,
-                fromInternalPerson(target, distinctId)
-            )
-            this.updateFinalState(
-                target.team_id,
-                distinctId,
-                target.id,
-                target,
-                false,
-                'moveDistinctIds',
-                target.version
-            )
+            if (existingTargetCache) {
+                // We have existing cached data with merged properties - preserve it
+                // Create a new PersonUpdate for this distinctId that preserves the merged data
+                const mergedPersonUpdate = { ...existingTargetCache, distinct_id: distinctId }
+                this.secondaryStore.setCachedPersonForUpdate(target.team_id, distinctId, mergedPersonUpdate)
+                this.updateFinalState(
+                    target.team_id,
+                    distinctId,
+                    target.id,
+                    toInternalPerson(mergedPersonUpdate),
+                    false,
+                    'moveDistinctIds',
+                    mergedPersonUpdate.version
+                )
+            } else {
+                // No existing cache, create fresh cache from target person
+                this.secondaryStore.setCachedPersonForUpdate(
+                    target.team_id,
+                    distinctId,
+                    fromInternalPerson(target, distinctId)
+                )
+                this.updateFinalState(
+                    target.team_id,
+                    distinctId,
+                    target.id,
+                    target,
+                    false,
+                    'moveDistinctIds',
+                    target.version
+                )
+            }
+
+            this.updateFinalState(source.team_id, distinctId, source.id, null, false, 'moveDistinctIds', source.version)
         }
-
-        this.updateFinalState(source.team_id, distinctId, source.id, null, false, 'moveDistinctIds', source.version)
 
         return mainResult
     }

--- a/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
@@ -2,7 +2,14 @@ import { Properties } from '@posthog/plugin-scaffold'
 import { DateTime } from 'luxon'
 
 import { TopicMessage } from '../../../kafka/producer'
-import { Hub, InternalPerson, PropertiesLastOperation, PropertiesLastUpdatedAt, Team } from '../../../types'
+import {
+    DistinctPersonIdentifiers,
+    Hub,
+    InternalPerson,
+    PropertiesLastOperation,
+    PropertiesLastUpdatedAt,
+    Team,
+} from '../../../types'
 import { TransactionClient } from '../../../utils/db/postgres'
 import { logger } from '../../../utils/logger'
 import { BatchWritingPersonsStore, BatchWritingPersonsStoreForBatch } from './batch-writing-person-store'
@@ -338,6 +345,11 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
         this.updateFinalState(person.team_id, distinctId, person.id, person, false, 'addDistinctId', person.version)
 
         return mainResult
+    }
+
+    async fetchPersonIdsById(distinctId: string, teamId: number): Promise<DistinctPersonIdentifiers | null> {
+        const result = await this.mainStore.fetchPersonIdsById(distinctId, teamId)
+        return result
     }
 
     async moveDistinctIds(

--- a/plugin-server/src/worker/ingestion/persons/persons-store-for-batch.ts
+++ b/plugin-server/src/worker/ingestion/persons/persons-store-for-batch.ts
@@ -35,7 +35,7 @@ export interface PersonsStoreForBatch extends BatchWritingStore {
     /**
      * Fetches person IDs by distinct ID for retry logic
      */
-    fetchPersonIdsById(distinctId: string, teamId: number): Promise<DistinctPersonIdentifiers | null>
+    fetchPersonIdsByDistinctId(distinctId: string, teamId: number): Promise<DistinctPersonIdentifiers | null>
 
     /**
      * Creates a new person

--- a/plugin-server/src/worker/ingestion/persons/persons-store-for-batch.ts
+++ b/plugin-server/src/worker/ingestion/persons/persons-store-for-batch.ts
@@ -2,7 +2,13 @@ import { Properties } from '@posthog/plugin-scaffold'
 import { DateTime } from 'luxon'
 
 import { TopicMessage } from '../../../kafka/producer'
-import { InternalPerson, PropertiesLastOperation, PropertiesLastUpdatedAt, Team } from '../../../types'
+import {
+    DistinctPersonIdentifiers,
+    InternalPerson,
+    PropertiesLastOperation,
+    PropertiesLastUpdatedAt,
+    Team,
+} from '../../../types'
 import { TransactionClient } from '../../../utils/db/postgres'
 import { BatchWritingStore } from '../stores/batch-writing-store'
 
@@ -25,6 +31,11 @@ export interface PersonsStoreForBatch extends BatchWritingStore {
      * Always uses primary database
      */
     fetchForUpdate(teamId: number, distinctId: string): Promise<InternalPerson | null>
+
+    /**
+     * Fetches person IDs by distinct ID for retry logic
+     */
+    fetchPersonIdsById(distinctId: string, teamId: number): Promise<DistinctPersonIdentifiers | null>
 
     /**
      * Creates a new person

--- a/plugin-server/src/worker/ingestion/persons/persons-store-for-batch.ts
+++ b/plugin-server/src/worker/ingestion/persons/persons-store-for-batch.ts
@@ -9,6 +9,7 @@ import {
     PropertiesLastUpdatedAt,
     Team,
 } from '../../../types'
+import { MoveDistinctIdsResult } from '../../../utils/db/db'
 import { TransactionClient } from '../../../utils/db/postgres'
 import { BatchWritingStore } from '../stores/batch-writing-store'
 
@@ -98,7 +99,7 @@ export interface PersonsStoreForBatch extends BatchWritingStore {
         target: InternalPerson,
         distinctId: string,
         tx?: TransactionClient
-    ): Promise<TopicMessage[]>
+    ): Promise<MoveDistinctIdsResult>
 
     /**
      * Updates cohorts and feature flags for merged persons

--- a/plugin-server/tests/worker/ingestion/person-state-batch.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state-batch.test.ts
@@ -2513,7 +2513,7 @@ describe('PersonState.processEvent()', () => {
             const state: PersonMergeService = personMergeService({}, hub)
             let attemptCount = 0
 
-            jest.spyOn(hub.db, 'fetchPersonIdsById')
+            jest.spyOn(hub.db, 'fetchPersonIdsByDistinctId')
 
             // Mock moveDistinctIds to throw SourcePersonNotFoundError on first attempt, succeed on retry
             const originalMoveDistinctIds = hub.db.moveDistinctIds
@@ -2533,8 +2533,8 @@ describe('PersonState.processEvent()', () => {
             await hub.db.kafkaProducer.flush()
             await kafkaAcks
 
-            // Verify that fetchPersonIdsById was called during retry
-            expect(hub.db.fetchPersonIdsById).toHaveBeenCalledWith(firstUserDistinctId, teamId)
+            // Verify that fetchPersonIdsByDistinctId was called during retry
+            expect(hub.db.fetchPersonIdsByDistinctId).toHaveBeenCalledWith(firstUserDistinctId, teamId)
 
             // Verify that moveDistinctIds was called twice (initial + retry)
             expect(hub.db.moveDistinctIds).toHaveBeenCalledTimes(2)
@@ -2569,7 +2569,7 @@ describe('PersonState.processEvent()', () => {
             const state: PersonMergeService = personMergeService({}, hub)
             let attemptCount = 0
 
-            jest.spyOn(hub.db, 'fetchPersonIdsById')
+            jest.spyOn(hub.db, 'fetchPersonIdsByDistinctId')
 
             // Mock moveDistinctIds to throw TargetPersonNotFoundError on first attempt, succeed on retry
             const originalMoveDistinctIds = hub.db.moveDistinctIds
@@ -2589,8 +2589,8 @@ describe('PersonState.processEvent()', () => {
             await hub.db.kafkaProducer.flush()
             await kafkaAcks
 
-            // Verify that fetchPersonIdsById was called during retry
-            expect(hub.db.fetchPersonIdsById).toHaveBeenCalledWith(secondUserDistinctId, teamId)
+            // Verify that fetchPersonIdsByDistinctId was called during retry
+            expect(hub.db.fetchPersonIdsByDistinctId).toHaveBeenCalledWith(secondUserDistinctId, teamId)
 
             // Verify that moveDistinctIds was called twice (initial + retry)
             expect(hub.db.moveDistinctIds).toHaveBeenCalledTimes(2)
@@ -2625,8 +2625,8 @@ describe('PersonState.processEvent()', () => {
             const state: PersonMergeService = personMergeService({}, hub)
             let attemptCount = 0
 
-            // Mock fetchPersonIdsById to return null on retry (person no longer exists)
-            jest.spyOn(hub.db, 'fetchPersonIdsById').mockResolvedValue(null)
+            // Mock fetchPersonIdsByDistinctId to return null on retry (person no longer exists)
+            jest.spyOn(hub.db, 'fetchPersonIdsByDistinctId').mockResolvedValue(null)
 
             // Mock moveDistinctIds to throw SourcePersonNotFoundError on first attempt
             jest.spyOn(hub.db, 'moveDistinctIds').mockImplementation(() => {
@@ -2645,8 +2645,8 @@ describe('PersonState.processEvent()', () => {
             await hub.db.kafkaProducer.flush()
             await kafkaAcks
 
-            // Verify that fetchPersonIdsById was called during retry
-            expect(hub.db.fetchPersonIdsById).toHaveBeenCalledWith(firstUserDistinctId, teamId)
+            // Verify that fetchPersonIdsByDistinctId was called during retry
+            expect(hub.db.fetchPersonIdsByDistinctId).toHaveBeenCalledWith(firstUserDistinctId, teamId)
 
             // Verify that moveDistinctIds was only called once (no retry since person doesn't exist)
             expect(hub.db.moveDistinctIds).toHaveBeenCalledTimes(1)
@@ -2671,8 +2671,8 @@ describe('PersonState.processEvent()', () => {
             const state: PersonMergeService = personMergeService({}, hub)
             let attemptCount = 0
 
-            // Mock fetchPersonIdsById to return null on retry (person no longer exists)
-            jest.spyOn(hub.db, 'fetchPersonIdsById').mockImplementation(() => {
+            // Mock fetchPersonIdsByDistinctId to return null on retry (person no longer exists)
+            jest.spyOn(hub.db, 'fetchPersonIdsByDistinctId').mockImplementation(() => {
                 return Promise.resolve(null) // Person no longer exists
             })
 
@@ -2693,8 +2693,8 @@ describe('PersonState.processEvent()', () => {
             await hub.db.kafkaProducer.flush()
             await kafkaAcks
 
-            // Verify that fetchPersonIdsById was called during retry
-            expect(hub.db.fetchPersonIdsById).toHaveBeenCalledWith(secondUserDistinctId, teamId)
+            // Verify that fetchPersonIdsByDistinctId was called during retry
+            expect(hub.db.fetchPersonIdsByDistinctId).toHaveBeenCalledWith(secondUserDistinctId, teamId)
 
             // Verify that moveDistinctIds was only called once (no retry since person doesn't exist)
             expect(hub.db.moveDistinctIds).toHaveBeenCalledTimes(1)

--- a/plugin-server/tests/worker/ingestion/person-state-batch.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state-batch.test.ts
@@ -10,6 +10,7 @@ import {
     PropertiesLastUpdatedAt,
     Team,
 } from '../../../src/types'
+import { SourcePersonNotFoundError, TargetPersonNotFoundError } from '../../../src/utils/db/db'
 import { DependencyUnavailableError } from '../../../src/utils/db/error'
 import { closeHub, createHub } from '../../../src/utils/db/hub'
 import { PostgresUse, TransactionClient } from '../../../src/utils/db/postgres'
@@ -2499,6 +2500,212 @@ describe('PersonState.processEvent()', () => {
                     }),
                 ])
             )
+        })
+
+        it(`retries merge when source person is deleted during merge transaction`, async () => {
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, firstUserUuid, [
+                { distinctId: firstUserDistinctId },
+            ])
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, secondUserUuid, [
+                { distinctId: secondUserDistinctId },
+            ])
+
+            const state: PersonMergeService = personMergeService({}, hub)
+            let attemptCount = 0
+
+            jest.spyOn(hub.db, 'fetchPersonIdsById')
+
+            // Mock moveDistinctIds to throw SourcePersonNotFoundError on first attempt, succeed on retry
+            const originalMoveDistinctIds = hub.db.moveDistinctIds
+            jest.spyOn(hub.db, 'moveDistinctIds').mockImplementation(async (...args) => {
+                attemptCount++
+                if (attemptCount === 1) {
+                    throw new SourcePersonNotFoundError('Source person no longer exists')
+                }
+                return originalMoveDistinctIds.call(hub.db, ...args)
+            })
+
+            jest.spyOn(hub.db.kafkaProducer, 'queueMessages')
+            jest.spyOn(hub.db, 'fetchPerson')
+
+            // Should succeed after retry
+            const [person, kafkaAcks] = await state.merge(firstUserDistinctId, secondUserDistinctId, teamId, timestamp)
+            await hub.db.kafkaProducer.flush()
+            await kafkaAcks
+
+            // Verify that fetchPersonIdsById was called during retry
+            expect(hub.db.fetchPersonIdsById).toHaveBeenCalledWith(firstUserDistinctId, teamId)
+
+            // Verify that moveDistinctIds was called twice (initial + retry)
+            expect(hub.db.moveDistinctIds).toHaveBeenCalledTimes(2)
+
+            // Verify merge succeeded
+            expect(person).not.toBeUndefined()
+            expect(person?.uuid).toBe(secondUserUuid) // merged into second user
+
+            // Verify that fetchPerson was called for both users
+            expect(hub.db.fetchPerson).toHaveBeenCalledWith(teamId, firstUserDistinctId, {
+                useReadReplica: false,
+            })
+
+            expect(hub.db.fetchPerson).toHaveBeenCalledWith(teamId, secondUserDistinctId, {
+                useReadReplica: false,
+            })
+
+            // Verify correct number of persons remain
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(1)
+            expect(persons[0].uuid).toBe(secondUserUuid)
+        })
+
+        it(`retries merge when target person is deleted during merge transaction`, async () => {
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, firstUserUuid, [
+                { distinctId: firstUserDistinctId },
+            ])
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, secondUserUuid, [
+                { distinctId: secondUserDistinctId },
+            ])
+
+            const state: PersonMergeService = personMergeService({}, hub)
+            let attemptCount = 0
+
+            jest.spyOn(hub.db, 'fetchPersonIdsById')
+
+            // Mock moveDistinctIds to throw TargetPersonNotFoundError on first attempt, succeed on retry
+            const originalMoveDistinctIds = hub.db.moveDistinctIds
+            jest.spyOn(hub.db, 'moveDistinctIds').mockImplementation(async (...args) => {
+                attemptCount++
+                if (attemptCount === 1) {
+                    throw new TargetPersonNotFoundError('Target person no longer exists')
+                }
+                return originalMoveDistinctIds.call(hub.db, ...args)
+            })
+
+            jest.spyOn(hub.db, 'fetchPerson')
+            jest.spyOn(hub.db.kafkaProducer, 'queueMessages')
+
+            // Should succeed after retry
+            const [person, kafkaAcks] = await state.merge(firstUserDistinctId, secondUserDistinctId, teamId, timestamp)
+            await hub.db.kafkaProducer.flush()
+            await kafkaAcks
+
+            // Verify that fetchPersonIdsById was called during retry
+            expect(hub.db.fetchPersonIdsById).toHaveBeenCalledWith(secondUserDistinctId, teamId)
+
+            // Verify that moveDistinctIds was called twice (initial + retry)
+            expect(hub.db.moveDistinctIds).toHaveBeenCalledTimes(2)
+
+            // Verify merge succeeded
+            expect(person).not.toBeUndefined()
+            expect(person?.uuid).toBe(secondUserUuid) // merged into second user
+
+            // Verify that fetchPerson was called for both users
+            expect(hub.db.fetchPerson).toHaveBeenCalledWith(teamId, firstUserDistinctId, {
+                useReadReplica: false,
+            })
+
+            expect(hub.db.fetchPerson).toHaveBeenCalledWith(teamId, secondUserDistinctId, {
+                useReadReplica: false,
+            })
+
+            // Verify correct number of persons remain
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(1)
+            expect(persons[0].uuid).toBe(secondUserUuid)
+        })
+
+        it(`skips merge when source person no longer exists after retry`, async () => {
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, firstUserUuid, [
+                { distinctId: firstUserDistinctId },
+            ])
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, secondUserUuid, [
+                { distinctId: secondUserDistinctId },
+            ])
+
+            const state: PersonMergeService = personMergeService({}, hub)
+            let attemptCount = 0
+
+            // Mock fetchPersonIdsById to return null on retry (person no longer exists)
+            jest.spyOn(hub.db, 'fetchPersonIdsById').mockResolvedValue(null)
+
+            // Mock moveDistinctIds to throw SourcePersonNotFoundError on first attempt
+            jest.spyOn(hub.db, 'moveDistinctIds').mockImplementation(() => {
+                attemptCount++
+                if (attemptCount === 1) {
+                    throw new SourcePersonNotFoundError('Source person no longer exists')
+                }
+                // Should not reach here since person lookup returns null
+                throw new Error('Should not retry when person no longer exists')
+            })
+
+            jest.spyOn(hub.db.kafkaProducer, 'queueMessages')
+
+            // Should return target person without error
+            const [person, kafkaAcks] = await state.merge(firstUserDistinctId, secondUserDistinctId, teamId, timestamp)
+            await hub.db.kafkaProducer.flush()
+            await kafkaAcks
+
+            // Verify that fetchPersonIdsById was called during retry
+            expect(hub.db.fetchPersonIdsById).toHaveBeenCalledWith(firstUserDistinctId, teamId)
+
+            // Verify that moveDistinctIds was only called once (no retry since person doesn't exist)
+            expect(hub.db.moveDistinctIds).toHaveBeenCalledTimes(1)
+
+            // Verify we got the target person back
+            expect(person).not.toBeUndefined()
+            expect(person?.uuid).toBe(secondUserUuid)
+
+            // Verify both persons still exist since merge was skipped
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(2)
+        })
+
+        it(`skips merge when target person no longer exists after retry`, async () => {
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, firstUserUuid, [
+                { distinctId: firstUserDistinctId },
+            ])
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, secondUserUuid, [
+                { distinctId: secondUserDistinctId },
+            ])
+
+            const state: PersonMergeService = personMergeService({}, hub)
+            let attemptCount = 0
+
+            // Mock fetchPersonIdsById to return null on retry (person no longer exists)
+            jest.spyOn(hub.db, 'fetchPersonIdsById').mockImplementation(() => {
+                return Promise.resolve(null) // Person no longer exists
+            })
+
+            // Mock moveDistinctIds to throw TargetPersonNotFoundError on first attempt
+            jest.spyOn(hub.db, 'moveDistinctIds').mockImplementation(() => {
+                attemptCount++
+                if (attemptCount === 1) {
+                    throw new TargetPersonNotFoundError('Target person no longer exists')
+                }
+                // Should not reach here since person lookup returns null
+                throw new Error('Should not retry when person no longer exists')
+            })
+
+            jest.spyOn(hub.db.kafkaProducer, 'queueMessages')
+
+            // Should return target person without error
+            const [person, kafkaAcks] = await state.merge(firstUserDistinctId, secondUserDistinctId, teamId, timestamp)
+            await hub.db.kafkaProducer.flush()
+            await kafkaAcks
+
+            // Verify that fetchPersonIdsById was called during retry
+            expect(hub.db.fetchPersonIdsById).toHaveBeenCalledWith(secondUserDistinctId, teamId)
+
+            // Verify that moveDistinctIds was only called once (no retry since person doesn't exist)
+            expect(hub.db.moveDistinctIds).toHaveBeenCalledTimes(1)
+
+            // Verify we got the original target person back (which was the second user)
+            expect(person).not.toBeUndefined()
+            expect(person?.uuid).toBe(secondUserUuid)
+
+            // Verify both persons still exist since merge was skipped
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(2)
         })
     })
 })

--- a/plugin-server/tests/worker/ingestion/person-state-batch.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state-batch.test.ts
@@ -10,7 +10,6 @@ import {
     PropertiesLastUpdatedAt,
     Team,
 } from '../../../src/types'
-import { SourcePersonNotFoundError, TargetPersonNotFoundError } from '../../../src/utils/db/db'
 import { DependencyUnavailableError } from '../../../src/utils/db/error'
 import { closeHub, createHub } from '../../../src/utils/db/hub'
 import { PostgresUse, TransactionClient } from '../../../src/utils/db/postgres'
@@ -20,6 +19,10 @@ import { uuidFromDistinctId } from '../../../src/worker/ingestion/person-uuid'
 import { BatchWritingPersonsStoreForBatch } from '../../../src/worker/ingestion/persons/batch-writing-person-store'
 import { PersonContext } from '../../../src/worker/ingestion/persons/person-context'
 import { PersonEventProcessor } from '../../../src/worker/ingestion/persons/person-event-processor'
+import {
+    SourcePersonNotFoundError,
+    TargetPersonNotFoundError,
+} from '../../../src/worker/ingestion/persons/person-merge-service'
 import { PersonMergeService } from '../../../src/worker/ingestion/persons/person-merge-service'
 import { PersonPropertyService } from '../../../src/worker/ingestion/persons/person-property-service'
 import { PersonsStoreForBatch } from '../../../src/worker/ingestion/persons/persons-store-for-batch'

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -10,6 +10,7 @@ import {
     PropertiesLastUpdatedAt,
     Team,
 } from '../../../src/types'
+import { SourcePersonNotFoundError, TargetPersonNotFoundError } from '../../../src/utils/db/db'
 import { DependencyUnavailableError } from '../../../src/utils/db/error'
 import { closeHub, createHub } from '../../../src/utils/db/hub'
 import { PostgresUse, TransactionClient } from '../../../src/utils/db/postgres'
@@ -2348,6 +2349,194 @@ describe('PersonState.processEvent()', () => {
                     }),
                 ])
             )
+        })
+
+        it(`retries merge when source person is deleted during merge transaction`, async () => {
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, firstUserUuid, [
+                { distinctId: firstUserDistinctId },
+            ])
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, secondUserUuid, [
+                { distinctId: secondUserDistinctId },
+            ])
+
+            const state: PersonMergeService = personMergeService({}, hub)
+            let attemptCount = 0
+
+            jest.spyOn(hub.db, 'fetchPersonIdsById')
+
+            // Mock moveDistinctIds to throw SourcePersonNotFoundError on first attempt, succeed on retry
+            const originalMoveDistinctIds = hub.db.moveDistinctIds
+            jest.spyOn(hub.db, 'moveDistinctIds').mockImplementation(async (...args) => {
+                attemptCount++
+                if (attemptCount === 1) {
+                    throw new SourcePersonNotFoundError('Source person no longer exists')
+                }
+                return originalMoveDistinctIds.call(hub.db, ...args)
+            })
+
+            jest.spyOn(hub.db.kafkaProducer, 'queueMessages')
+
+            // Should succeed after retry
+            const [person, kafkaAcks] = await state.merge(firstUserDistinctId, secondUserDistinctId, teamId, timestamp)
+            await hub.db.kafkaProducer.flush()
+            await kafkaAcks
+
+            // Verify that fetchPersonIdsById was called during retry
+            expect(hub.db.fetchPersonIdsById).toHaveBeenCalledWith(firstUserDistinctId, teamId)
+
+            // Verify that moveDistinctIds was called twice (initial + retry)
+            expect(hub.db.moveDistinctIds).toHaveBeenCalledTimes(2)
+
+            // Verify merge succeeded
+            expect(person).not.toBeUndefined()
+            expect(person?.uuid).toBe(secondUserUuid) // merged into second user
+
+            // Verify correct number of persons remain
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(1)
+            expect(persons[0].uuid).toBe(secondUserUuid)
+        })
+
+        it(`retries merge when target person is deleted during merge transaction`, async () => {
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, firstUserUuid, [
+                { distinctId: firstUserDistinctId },
+            ])
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, secondUserUuid, [
+                { distinctId: secondUserDistinctId },
+            ])
+
+            const state: PersonMergeService = personMergeService({}, hub)
+            let attemptCount = 0
+
+            jest.spyOn(hub.db, 'fetchPersonIdsById')
+
+            // Mock moveDistinctIds to throw TargetPersonNotFoundError on first attempt, succeed on retry
+            const originalMoveDistinctIds = hub.db.moveDistinctIds
+            jest.spyOn(hub.db, 'moveDistinctIds').mockImplementation(async (...args) => {
+                attemptCount++
+                if (attemptCount === 1) {
+                    throw new TargetPersonNotFoundError('Target person no longer exists')
+                }
+                return originalMoveDistinctIds.call(hub.db, ...args)
+            })
+
+            jest.spyOn(hub.db.kafkaProducer, 'queueMessages')
+
+            // Should succeed after retry
+            const [person, kafkaAcks] = await state.merge(firstUserDistinctId, secondUserDistinctId, teamId, timestamp)
+            await hub.db.kafkaProducer.flush()
+            await kafkaAcks
+
+            // Verify that fetchPersonIdsById was called during retry
+            expect(hub.db.fetchPersonIdsById).toHaveBeenCalledWith(secondUserDistinctId, teamId)
+
+            // Verify that moveDistinctIds was called twice (initial + retry)
+            expect(hub.db.moveDistinctIds).toHaveBeenCalledTimes(2)
+
+            // Verify merge succeeded
+            expect(person).not.toBeUndefined()
+            expect(person?.uuid).toBe(secondUserUuid) // merged into second user
+
+            // Verify correct number of persons remain
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(1)
+            expect(persons[0].uuid).toBe(secondUserUuid)
+        })
+
+        it(`skips merge when source person no longer exists after retry`, async () => {
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, firstUserUuid, [
+                { distinctId: firstUserDistinctId },
+            ])
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, secondUserUuid, [
+                { distinctId: secondUserDistinctId },
+            ])
+
+            const state: PersonMergeService = personMergeService({}, hub)
+            let attemptCount = 0
+
+            // Mock fetchPersonIdsById to return null on retry (person no longer exists)
+            jest.spyOn(hub.db, 'fetchPersonIdsById').mockImplementation(() => {
+                return Promise.resolve(null) // Person no longer exists
+            })
+
+            // Mock moveDistinctIds to throw SourcePersonNotFoundError on first attempt
+            jest.spyOn(hub.db, 'moveDistinctIds').mockImplementation(() => {
+                attemptCount++
+                if (attemptCount === 1) {
+                    throw new SourcePersonNotFoundError('Source person no longer exists')
+                }
+                // Should not reach here since person lookup returns null
+                throw new Error('Should not retry when person no longer exists')
+            })
+
+            jest.spyOn(hub.db.kafkaProducer, 'queueMessages')
+
+            // Should return target person without error
+            const [person, kafkaAcks] = await state.merge(firstUserDistinctId, secondUserDistinctId, teamId, timestamp)
+            await hub.db.kafkaProducer.flush()
+            await kafkaAcks
+
+            // Verify that fetchPersonIdsById was called during retry
+            expect(hub.db.fetchPersonIdsById).toHaveBeenCalledWith(firstUserDistinctId, teamId)
+
+            // Verify that moveDistinctIds was only called once (no retry since person doesn't exist)
+            expect(hub.db.moveDistinctIds).toHaveBeenCalledTimes(1)
+
+            // Verify we got the target person back
+            expect(person).not.toBeUndefined()
+            expect(person?.uuid).toBe(secondUserUuid)
+
+            // Verify both persons still exist since merge was skipped
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(2)
+        })
+
+        it(`skips merge when target person no longer exists after retry`, async () => {
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, firstUserUuid, [
+                { distinctId: firstUserDistinctId },
+            ])
+            await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, secondUserUuid, [
+                { distinctId: secondUserDistinctId },
+            ])
+
+            const state: PersonMergeService = personMergeService({}, hub)
+            let attemptCount = 0
+
+            // Mock fetchPersonIdsById to return null on retry (person no longer exists)
+            jest.spyOn(hub.db, 'fetchPersonIdsById').mockImplementation(() => {
+                return Promise.resolve(null) // Person no longer exists
+            })
+
+            // Mock moveDistinctIds to throw TargetPersonNotFoundError on first attempt
+            jest.spyOn(hub.db, 'moveDistinctIds').mockImplementation(() => {
+                attemptCount++
+                if (attemptCount === 1) {
+                    throw new TargetPersonNotFoundError('Target person no longer exists')
+                }
+                // Should not reach here since person lookup returns null
+                throw new Error('Should not retry when person no longer exists')
+            })
+
+            jest.spyOn(hub.db.kafkaProducer, 'queueMessages')
+
+            // Should return target person without error
+            const [person, kafkaAcks] = await state.merge(firstUserDistinctId, secondUserDistinctId, teamId, timestamp)
+            await hub.db.kafkaProducer.flush()
+            await kafkaAcks
+
+            // Verify that fetchPersonIdsById was called during retry
+            expect(hub.db.fetchPersonIdsById).toHaveBeenCalledWith(secondUserDistinctId, teamId)
+
+            // Verify that moveDistinctIds was only called once (no retry since person doesn't exist)
+            expect(hub.db.moveDistinctIds).toHaveBeenCalledTimes(1)
+
+            // Verify we got the original target person back (which was the second user)
+            expect(person).not.toBeUndefined()
+            expect(person?.uuid).toBe(secondUserUuid)
+
+            // Verify both persons still exist since merge was skipped
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(2)
         })
     })
 })

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -10,7 +10,6 @@ import {
     PropertiesLastUpdatedAt,
     Team,
 } from '../../../src/types'
-import { SourcePersonNotFoundError, TargetPersonNotFoundError } from '../../../src/utils/db/db'
 import { DependencyUnavailableError } from '../../../src/utils/db/error'
 import { closeHub, createHub } from '../../../src/utils/db/hub'
 import { PostgresUse, TransactionClient } from '../../../src/utils/db/postgres'
@@ -20,6 +19,10 @@ import { uuidFromDistinctId } from '../../../src/worker/ingestion/person-uuid'
 import { MeasuringPersonsStoreForBatch } from '../../../src/worker/ingestion/persons/measuring-person-store'
 import { PersonContext } from '../../../src/worker/ingestion/persons/person-context'
 import { PersonEventProcessor } from '../../../src/worker/ingestion/persons/person-event-processor'
+import {
+    SourcePersonNotFoundError,
+    TargetPersonNotFoundError,
+} from '../../../src/worker/ingestion/persons/person-merge-service'
 import { PersonMergeService } from '../../../src/worker/ingestion/persons/person-merge-service'
 import { PersonPropertyService } from '../../../src/worker/ingestion/persons/person-property-service'
 import { delayUntilEventIngested } from '../../helpers/clickhouse'

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -2362,7 +2362,7 @@ describe('PersonState.processEvent()', () => {
             const state: PersonMergeService = personMergeService({}, hub)
             let attemptCount = 0
 
-            jest.spyOn(hub.db, 'fetchPersonIdsById')
+            jest.spyOn(hub.db, 'fetchPersonIdsByDistinctId')
 
             // Mock moveDistinctIds to throw SourcePersonNotFoundError on first attempt, succeed on retry
             const originalMoveDistinctIds = hub.db.moveDistinctIds
@@ -2381,8 +2381,8 @@ describe('PersonState.processEvent()', () => {
             await hub.db.kafkaProducer.flush()
             await kafkaAcks
 
-            // Verify that fetchPersonIdsById was called during retry
-            expect(hub.db.fetchPersonIdsById).toHaveBeenCalledWith(firstUserDistinctId, teamId)
+            // Verify that fetchPersonIdsByDistinctId was called during retry
+            expect(hub.db.fetchPersonIdsByDistinctId).toHaveBeenCalledWith(firstUserDistinctId, teamId)
 
             // Verify that moveDistinctIds was called twice (initial + retry)
             expect(hub.db.moveDistinctIds).toHaveBeenCalledTimes(2)
@@ -2408,7 +2408,7 @@ describe('PersonState.processEvent()', () => {
             const state: PersonMergeService = personMergeService({}, hub)
             let attemptCount = 0
 
-            jest.spyOn(hub.db, 'fetchPersonIdsById')
+            jest.spyOn(hub.db, 'fetchPersonIdsByDistinctId')
 
             // Mock moveDistinctIds to throw TargetPersonNotFoundError on first attempt, succeed on retry
             const originalMoveDistinctIds = hub.db.moveDistinctIds
@@ -2427,8 +2427,8 @@ describe('PersonState.processEvent()', () => {
             await hub.db.kafkaProducer.flush()
             await kafkaAcks
 
-            // Verify that fetchPersonIdsById was called during retry
-            expect(hub.db.fetchPersonIdsById).toHaveBeenCalledWith(secondUserDistinctId, teamId)
+            // Verify that fetchPersonIdsByDistinctId was called during retry
+            expect(hub.db.fetchPersonIdsByDistinctId).toHaveBeenCalledWith(secondUserDistinctId, teamId)
 
             // Verify that moveDistinctIds was called twice (initial + retry)
             expect(hub.db.moveDistinctIds).toHaveBeenCalledTimes(2)
@@ -2454,8 +2454,8 @@ describe('PersonState.processEvent()', () => {
             const state: PersonMergeService = personMergeService({}, hub)
             let attemptCount = 0
 
-            // Mock fetchPersonIdsById to return null on retry (person no longer exists)
-            jest.spyOn(hub.db, 'fetchPersonIdsById').mockImplementation(() => {
+            // Mock fetchPersonIdsByDistinctId to return null on retry (person no longer exists)
+            jest.spyOn(hub.db, 'fetchPersonIdsByDistinctId').mockImplementation(() => {
                 return Promise.resolve(null) // Person no longer exists
             })
 
@@ -2476,8 +2476,8 @@ describe('PersonState.processEvent()', () => {
             await hub.db.kafkaProducer.flush()
             await kafkaAcks
 
-            // Verify that fetchPersonIdsById was called during retry
-            expect(hub.db.fetchPersonIdsById).toHaveBeenCalledWith(firstUserDistinctId, teamId)
+            // Verify that fetchPersonIdsByDistinctId was called during retry
+            expect(hub.db.fetchPersonIdsByDistinctId).toHaveBeenCalledWith(firstUserDistinctId, teamId)
 
             // Verify that moveDistinctIds was only called once (no retry since person doesn't exist)
             expect(hub.db.moveDistinctIds).toHaveBeenCalledTimes(1)
@@ -2502,8 +2502,8 @@ describe('PersonState.processEvent()', () => {
             const state: PersonMergeService = personMergeService({}, hub)
             let attemptCount = 0
 
-            // Mock fetchPersonIdsById to return null on retry (person no longer exists)
-            jest.spyOn(hub.db, 'fetchPersonIdsById').mockImplementation(() => {
+            // Mock fetchPersonIdsByDistinctId to return null on retry (person no longer exists)
+            jest.spyOn(hub.db, 'fetchPersonIdsByDistinctId').mockImplementation(() => {
                 return Promise.resolve(null) // Person no longer exists
             })
 
@@ -2524,8 +2524,8 @@ describe('PersonState.processEvent()', () => {
             await hub.db.kafkaProducer.flush()
             await kafkaAcks
 
-            // Verify that fetchPersonIdsById was called during retry
-            expect(hub.db.fetchPersonIdsById).toHaveBeenCalledWith(secondUserDistinctId, teamId)
+            // Verify that fetchPersonIdsByDistinctId was called during retry
+            expect(hub.db.fetchPersonIdsByDistinctId).toHaveBeenCalledWith(secondUserDistinctId, teamId)
 
             // Verify that moveDistinctIds was only called once (no retry since person doesn't exist)
             expect(hub.db.moveDistinctIds).toHaveBeenCalledTimes(1)

--- a/plugin-server/tests/worker/ingestion/postgres-parity.test.ts
+++ b/plugin-server/tests/worker/ingestion/postgres-parity.test.ts
@@ -364,8 +364,12 @@ describe('postgres parity', () => {
 
         // move distinct ids from person to to anotherPerson
 
-        const kafkaMessages = await hub.db.moveDistinctIds(person, anotherPerson)
-        await hub.db!.kafkaProducer!.queueMessages(kafkaMessages)
+        const moveDistinctIdsResult = await hub.db.moveDistinctIds(person, anotherPerson)
+        expect(moveDistinctIdsResult.success).toEqual(true)
+
+        if (moveDistinctIdsResult.success) {
+            await hub.db!.kafkaProducer!.queueMessages(moveDistinctIdsResult.messages)
+        }
         await delayUntilEventIngested(() => hub.db.fetchDistinctIdValues(anotherPerson, Database.ClickHouse), 2)
 
         // it got added


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Currently if there is a race condition during a person merge, we just fire a warning and say we couldn't merge it. This PR aims to improve on that by adding some retry logic to the `handleMergeTransaction`. The intent is to be able to refresh the source or target person in case one of them has been merged by another pod concurrently. 

If we exceed the maximum number of retries, we fire the warning and fail gracefully

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
