### PR TITLE
feat: Persistent group filters

### DIFF
--- a/frontend/src/scenes/groups/groupsListLogic.test.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.test.ts
@@ -58,10 +58,10 @@ describe('groupsListLogic', () => {
         logic.mount()
 
         // Group 1 logic should not pick up group 0 filters
-        expect((logic.values.query.source as GroupsQuery).properties).toBeUndefined()
+        expect((logic.values.query.source as GroupsQuery).properties).toEqual([])
     })
 
-    it('should clear filters when navigating to clean URL', async () => {
+    it('should not clear filters when navigating to clean URL', async () => {
         logic = groupsListLogic({ groupTypeIndex: 0 })
         logic.mount()
 
@@ -75,7 +75,7 @@ describe('groupsListLogic', () => {
         // Navigate to clean URL (no properties parameter)
         router.actions.push('/groups/0', {})
 
-        expect((logic.values.query.source as GroupsQuery).properties).toBeUndefined()
+        expect((logic.values.query.source as GroupsQuery).properties).toEqual(mockFilters)
     })
 
     it('should update groupFilters state when filters are set', async () => {
@@ -171,7 +171,7 @@ describe('groupsListLogic', () => {
         logic.mount()
 
         // Should not crash and should not apply any filters
-        expect((logic.values.query.source as GroupsQuery).properties).toBeUndefined()
+        expect((logic.values.query.source as GroupsQuery).properties).toEqual([])
     })
 
     it('should handle missing team ID gracefully', async () => {

--- a/frontend/src/scenes/groups/groupsListLogic.test.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.test.ts
@@ -10,7 +10,7 @@ describe('groupsListLogic', () => {
 
     beforeEach(() => {
         initKeaTests()
-        // localStorage.clear()
+        localStorage.clear()
         window.POSTHOG_APP_CONTEXT = { current_team: { id: 123 } } as AppContext
     })
 

--- a/frontend/src/scenes/groups/groupsListLogic.test.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.test.ts
@@ -1,0 +1,229 @@
+import { router } from 'kea-router'
+import { expectLogic } from 'kea-test-utils'
+import { initKeaTests } from '~/test/init'
+import { groupsListLogic } from './groupsListLogic'
+import { NodeKind, GroupsQuery } from '~/queries/schema/schema-general'
+import { AppContext, GroupPropertyFilter, PropertyFilterType } from '~/types'
+
+describe('groupsListLogic', () => {
+    let logic: ReturnType<typeof groupsListLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        localStorage.clear()
+        window.POSTHOG_APP_CONTEXT = { current_team: { id: 123 } } as AppContext
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+    })
+
+    it('should add group-specific properties to URL when filters are set', async () => {
+        logic = groupsListLogic({ groupTypeIndex: 0 })
+        logic.mount()
+
+        const mockFilters = [
+            { key: 'name', value: 'test', operator: 'exact', type: PropertyFilterType.Group },
+        ] as GroupPropertyFilter[]
+
+        await expectLogic(logic, () => {
+            logic.actions.setGroupFilters(mockFilters as GroupPropertyFilter[])
+        }).toMatchValues({
+            groupFilters: mockFilters,
+        })
+
+        expect(router.values.searchParams).toHaveProperty('properties_0')
+        expect(JSON.parse(router.values.searchParams.properties_0)).toEqual(mockFilters)
+    })
+
+    it('should restore filters from group-specific URL parameter', async () => {
+        const mockFilters = [{ key: 'name', value: 'test', operator: 'exact', type: PropertyFilterType.Group }]
+
+        // Simulate navigating to URL with filters
+        router.actions.push('/groups/1', { properties_1: JSON.stringify(mockFilters) })
+
+        logic = groupsListLogic({ groupTypeIndex: 1 })
+        logic.mount()
+
+        expect((logic.values.query.source as GroupsQuery).properties).toEqual(mockFilters)
+    })
+
+    it('should not apply filters from different group types', async () => {
+        const group0Filters = [{ key: 'name', value: 'group0', operator: 'exact', type: PropertyFilterType.Group }]
+
+        // Set URL with group 0 filters
+        router.actions.push('/groups/1', { properties_0: JSON.stringify(group0Filters) })
+
+        logic = groupsListLogic({ groupTypeIndex: 1 })
+        logic.mount()
+
+        // Group 1 logic should not pick up group 0 filters
+        expect((logic.values.query.source as GroupsQuery).properties).toBeUndefined()
+    })
+
+    it('should clear filters when navigating to clean URL', async () => {
+        logic = groupsListLogic({ groupTypeIndex: 0 })
+        logic.mount()
+
+        // Set some filters first
+        const mockFilters = [{ key: 'name', value: 'test', operator: 'exact', type: PropertyFilterType.Group }]
+        logic.actions.setQuery({
+            ...logic.values.query,
+            source: { ...logic.values.query.source, properties: mockFilters } as GroupsQuery,
+        })
+
+        // Navigate to clean URL (no properties parameter)
+        router.actions.push('/groups/0', {})
+
+        expect((logic.values.query.source as GroupsQuery).properties).toBeUndefined()
+    })
+
+    it('should update groupFilters state when filters are set', async () => {
+        logic = groupsListLogic({ groupTypeIndex: 2 })
+        logic.mount()
+
+        const mockFilters = [
+            { key: 'name', value: 'test', operator: 'exact', type: PropertyFilterType.Group },
+        ] as GroupPropertyFilter[]
+
+        await expectLogic(logic, () => {
+            logic.actions.setGroupFilters(mockFilters as GroupPropertyFilter[])
+        }).toMatchValues({
+            groupFilters: mockFilters,
+        })
+
+        // Verify filters are set in state
+        expect(logic.values.groupFilters).toEqual(mockFilters)
+    })
+
+    it('should clear localStorage when filters are removed', async () => {
+        logic = groupsListLogic({ groupTypeIndex: 0 })
+        logic.mount()
+
+        // Set filters first
+        const mockFilters = [{ key: 'name', value: 'test', operator: 'exact', type: PropertyFilterType.Group }]
+        logic.actions.setQuery({
+            ...logic.values.query,
+            source: { ...logic.values.query.source, properties: mockFilters } as GroupsQuery,
+        })
+
+        // Verify stored
+        expect(logic.values.groupFilters).toEqual(mockFilters)
+
+        // Clear filters
+        logic.actions.setQuery({
+            ...logic.values.query,
+            source: { ...logic.values.query.source, properties: [] } as GroupsQuery,
+        })
+
+        expect(logic.values.groupFilters).toEqual([])
+    })
+
+    it('should clear URL parameters when filters are removed', async () => {
+        logic = groupsListLogic({ groupTypeIndex: 0 })
+        logic.mount()
+
+        // Set filters
+        const mockFilters = [{ key: 'name', value: 'test', operator: 'exact', type: PropertyFilterType.Group }]
+        logic.actions.setGroupFilters(mockFilters as GroupPropertyFilter[])
+
+        expect(router.values.searchParams.properties_0).toBeTruthy()
+
+        // Clear filters
+        logic.actions.setGroupFilters([])
+
+        expect(router.values.searchParams.properties_0).toBeUndefined()
+    })
+
+    it('should maintain separate filter state for different group types', async () => {
+        // Test with multiple group types simultaneously
+        const logic0 = groupsListLogic({ groupTypeIndex: 0 })
+        const logic1 = groupsListLogic({ groupTypeIndex: 1 })
+
+        logic0.mount()
+        logic1.mount()
+
+        const filters0 = [{ key: 'name', value: 'group0', operator: 'exact', type: PropertyFilterType.Group }]
+        const filters1 = [{ key: 'name', value: 'group1', operator: 'exact', type: PropertyFilterType.Group }]
+
+        // Set different filters for each group
+        logic0.actions.setQuery({
+            ...logic0.values.query,
+            source: { ...logic0.values.query.source, properties: filters0 } as GroupsQuery,
+        })
+
+        logic1.actions.setQuery({
+            ...logic1.values.query,
+            source: { ...logic1.values.query.source, properties: filters1 } as GroupsQuery,
+        })
+
+        // Verify isolation
+        expect((logic0.values.query.source as GroupsQuery).properties).toEqual(filters0)
+        expect((logic1.values.query.source as GroupsQuery).properties).toEqual(filters1)
+        expect(logic0.values.groupFilters).toEqual(filters0)
+        expect(logic1.values.groupFilters).toEqual(filters1)
+
+        logic0.unmount()
+        logic1.unmount()
+    })
+
+    it('should handle malformed JSON in URL parameters gracefully', async () => {
+        router.actions.push('/groups/0', { properties_0: 'invalid-json' })
+
+        logic = groupsListLogic({ groupTypeIndex: 0 })
+        logic.mount()
+
+        // Should not crash and should not apply any filters
+        expect((logic.values.query.source as GroupsQuery).properties).toBeUndefined()
+    })
+
+    it('should handle missing team ID gracefully', async () => {
+        window.POSTHOG_APP_CONTEXT = { current_team: null } as AppContext
+
+        logic = groupsListLogic({ groupTypeIndex: 0 })
+
+        // Should not crash during initialization
+        expect(() => logic.mount()).not.toThrow()
+    })
+
+    it('should set up default columns while preserving filter persistence', async () => {
+        logic = groupsListLogic({ groupTypeIndex: 0 })
+        logic.mount()
+
+        // Verify query structure is correct
+        expect(logic.values.query.kind).toBe(NodeKind.DataTableNode)
+        expect(logic.values.query.source.kind).toBe(NodeKind.GroupsQuery)
+        expect((logic.values.query.source as GroupsQuery).group_type_index).toBe(0)
+        expect(logic.values.query.propertiesViaUrl).toBe(true)
+    })
+
+    it('should trigger setQueryWasModified when query changes', async () => {
+        logic = groupsListLogic({ groupTypeIndex: 0 })
+        logic.mount()
+
+        const mockFilters = [{ key: 'name', value: 'test', operator: 'exact', type: PropertyFilterType.Group }]
+
+        // Reset the flag first
+        logic.actions.setQueryWasModified(false)
+        expect(logic.values.queryWasModified).toBe(false)
+
+        // Set query should trigger the flag
+        logic.actions.setQuery({
+            ...logic.values.query,
+            source: { ...logic.values.query.source, properties: mockFilters } as GroupsQuery,
+        })
+
+        expect(logic.values.queryWasModified).toBe(true)
+    })
+
+    it('should update groupFilters when setGroupFilters is called', async () => {
+        logic = groupsListLogic({ groupTypeIndex: 0 })
+        logic.mount()
+
+        const mockFilters = [{ key: 'name', value: 'test', operator: 'exact', type: PropertyFilterType.Group }]
+
+        logic.actions.setGroupFilters(mockFilters as GroupPropertyFilter[])
+
+        expect(logic.values.groupFilters).toEqual(mockFilters)
+    })
+})

--- a/frontend/src/scenes/groups/groupsListLogic.test.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.test.ts
@@ -10,7 +10,7 @@ describe('groupsListLogic', () => {
 
     beforeEach(() => {
         initKeaTests()
-        localStorage.clear()
+        // localStorage.clear()
         window.POSTHOG_APP_CONTEXT = { current_team: { id: 123 } } as AppContext
     })
 
@@ -96,21 +96,18 @@ describe('groupsListLogic', () => {
         expect(logic.values.groupFilters).toEqual(mockFilters)
     })
 
-    it('should clear localStorage when filters are removed', async () => {
+    it('should clear groupFilters when filters are removed', async () => {
         logic = groupsListLogic({ groupTypeIndex: 0 })
         logic.mount()
 
-        // Set filters first
         const mockFilters = [{ key: 'name', value: 'test', operator: 'exact', type: PropertyFilterType.Group }]
         logic.actions.setQuery({
             ...logic.values.query,
             source: { ...logic.values.query.source, properties: mockFilters } as GroupsQuery,
         })
 
-        // Verify stored
         expect(logic.values.groupFilters).toEqual(mockFilters)
 
-        // Clear filters
         logic.actions.setQuery({
             ...logic.values.query,
             source: { ...logic.values.query.source, properties: [] } as GroupsQuery,

--- a/frontend/src/scenes/groups/groupsListLogic.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.ts
@@ -125,12 +125,12 @@ export const groupsListLogic = kea<groupsListLogicType>([
                 } catch (error: any) {
                     posthog.captureException('Failed to parse properties', error)
                 }
-            } else if (values.query.source.properties?.length) {
+            } else {
                 actions.setQuery({
                     ...values.query,
                     source: {
                         ...values.query.source,
-                        properties: undefined,
+                        properties: values.groupFilters,
                     },
                 })
             }
@@ -149,21 +149,6 @@ export const groupsListLogic = kea<groupsListLogicType>([
                 },
             })
             actions.setQueryWasModified(false)
-        }
-
-        const shouldRestoreFiltersFromLocalStorage =
-            values.query.source.kind === NodeKind.GroupsQuery &&
-            !values.query.source?.properties?.length &&
-            values.groupFilters?.length
-        // node kind check is repeated because otherwise the type checking fails
-        if (shouldRestoreFiltersFromLocalStorage && values.query.source.kind === NodeKind.GroupsQuery) {
-            actions.setQuery({
-                ...values.query,
-                source: {
-                    ...values.query.source,
-                    properties: values.groupFilters,
-                },
-            })
         }
     }),
 ])

--- a/frontend/src/scenes/groups/groupsListLogic.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.ts
@@ -10,6 +10,7 @@ import { DataTableNode } from '~/queries/schema/schema-general'
 import { GroupPropertyFilter, GroupTypeIndex } from '~/types'
 
 import type { groupsListLogicType } from './groupsListLogicType'
+import posthog from 'posthog-js'
 
 export interface GroupsListLogicProps {
     groupTypeIndex: GroupTypeIndex
@@ -117,7 +118,9 @@ export const groupsListLogic = kea<groupsListLogicType>([
                             },
                         })
                     }
-                } catch {}
+                } catch (error: any) {
+                    posthog.captureException('Failed to parse properties', error)
+                }
             } else if (!properties && values.query.source.kind === NodeKind.GroupsQuery) {
                 if (values.query.source.properties?.length) {
                     actions.setQuery({

--- a/frontend/src/scenes/groups/groupsListLogic.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.ts
@@ -105,8 +105,12 @@ export const groupsListLogic = kea<groupsListLogicType>([
     })),
     urlToAction(({ actions, values, props }) => ({
         [`/groups/${props.groupTypeIndex}`]: (_, searchParams) => {
+            if (values.query.source.kind !== NodeKind.GroupsQuery) {
+                return
+            }
+
             const properties = searchParams[`properties_${props.groupTypeIndex}`]
-            if (properties && values.query.source.kind === NodeKind.GroupsQuery) {
+            if (properties) {
                 try {
                     const parsedProperties = JSON.parse(properties)
                     if (parsedProperties && Array.isArray(parsedProperties)) {
@@ -121,16 +125,14 @@ export const groupsListLogic = kea<groupsListLogicType>([
                 } catch (error: any) {
                     posthog.captureException('Failed to parse properties', error)
                 }
-            } else if (!properties && values.query.source.kind === NodeKind.GroupsQuery) {
-                if (values.query.source.properties?.length) {
-                    actions.setQuery({
-                        ...values.query,
-                        source: {
-                            ...values.query.source,
-                            properties: undefined,
-                        },
-                    })
-                }
+            } else if (values.query.source.properties?.length) {
+                actions.setQuery({
+                    ...values.query,
+                    source: {
+                        ...values.query.source,
+                        properties: undefined,
+                    },
+                })
             }
         },
     })),

--- a/frontend/src/scenes/groups/groupsListLogic.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.ts
@@ -84,15 +84,22 @@ export const groupsListLogic = kea<groupsListLogicType>([
     })),
     actionToUrl(({ values, props }) => ({
         setQuery: () => {
-            if (router.values.location.pathname.includes(`/groups/${props.groupTypeIndex}`)) {
-                const searchParams: Record<string, string> = {}
+            const searchParams: Record<string, string> = {}
 
-                if (values.query.source.kind === NodeKind.GroupsQuery && values.query.source.properties?.length) {
-                    searchParams[`properties_${props.groupTypeIndex}`] = JSON.stringify(values.query.source.properties)
-                }
-
-                return [router.values.location.pathname, searchParams, undefined, { replace: true }]
+            if (values.query.source.kind === NodeKind.GroupsQuery && values.query.source.properties?.length) {
+                searchParams[`properties_${props.groupTypeIndex}`] = JSON.stringify(values.query.source.properties)
             }
+
+            return [router.values.location.pathname, searchParams, undefined, { replace: true }]
+        },
+        setGroupFilters: () => {
+            const searchParams: Record<string, string> = {}
+
+            if (values.groupFilters?.length) {
+                searchParams[`properties_${props.groupTypeIndex}`] = JSON.stringify(values.groupFilters)
+            }
+
+            return [router.values.location.pathname, searchParams, undefined, { replace: true }]
         },
     })),
     urlToAction(({ actions, values, props }) => ({


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
Users are not able to persist filter in groups list page.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Closes #35076
## Changes
This is the first step to make groups list a customizable view of groups.

- Persist filters in local storage
- Url encode filters, so users can share the link
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Unit tests and locally in the UI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
