### PR TITLE
fix(product analytics): Add feature flag for calendar heatmap

### DIFF
--- a/products/product_analytics/manifest.tsx
+++ b/products/product_analytics/manifest.tsx
@@ -1,7 +1,7 @@
 import { IconGraph } from '@posthog/icons'
 import { combineUrl } from 'kea-router'
 import { AlertType } from 'lib/components/Alerts/types'
-import { INSIGHT_VISUAL_ORDER } from 'lib/constants'
+import { FEATURE_FLAGS, INSIGHT_VISUAL_ORDER } from 'lib/constants'
 import { urls } from 'scenes/urls'
 
 import { HogQLFilters, HogQLVariable, Node, NodeKind } from '~/queries/schema/schema-general'
@@ -128,6 +128,7 @@ export const manifest: ProductManifest = {
             href: urls.insightNew({ type: InsightType.CALENDAR_HEATMAP }),
             iconType: 'insightCalendarHeatmap',
             visualOrder: INSIGHT_VISUAL_ORDER.calendarHeatmap,
+            flag: FEATURE_FLAGS.CALENDAR_HEATMAP_INSIGHT,
         },
     ],
     treeItemsProducts: [


### PR DESCRIPTION
This adds a missing ff to the calendar heatmap insight entry point that was missing