### PR TITLE
fix: move current query state to end of prompt

### DIFF
--- a/products/error_tracking/backend/max_tools.py
+++ b/products/error_tracking/backend/max_tools.py
@@ -36,13 +36,13 @@ class ErrorTrackingSceneTool(MaxTool):
             + "<system_task>"
             + ERROR_TRACKING_FILTER_INITIAL_PROMPT
             + "</system_task>"
-            + f"\n\n Current issue filters are: {current_query}\n\n"
             + "<properties_taxonomy>"
             + ERROR_TRACKING_FILTER_PROPERTIES_PROMPT
             + "</properties_taxonomy>"
             + "<prefer_filters>"
             + PREFER_FILTERS_PROMPT
             + "</prefer_filters>"
+            + f"\n\n Current issue filters are: {current_query}\n\n"
         )
 
         user_content = f"Update the error tracking issue list filters to: {change}"


### PR DESCRIPTION
tiny fix that should improve generation outputs

branch name is misleading, was working on something larger but maxcontext isn't quite there yet