### PR TITLE
fix: Use memoryview on asyncpa.py

### DIFF
--- a/posthog/temporal/common/asyncpa.py
+++ b/posthog/temporal/common/asyncpa.py
@@ -1,5 +1,5 @@
 import asyncio
-import typing
+import collections.abc
 
 import pyarrow as pa
 import structlog
@@ -16,7 +16,7 @@ class InvalidMessageFormat(Exception):
 class AsyncMessageReader:
     """Asynchronously read PyArrow messages from bytes iterator."""
 
-    def __init__(self, bytes_iter: typing.AsyncIterator[bytes]):
+    def __init__(self, bytes_iter: collections.abc.AsyncIterator[bytes]):
         self._bytes = bytes_iter
         self._buffer = bytearray()
 
@@ -108,7 +108,7 @@ class AsyncMessageReader:
 class AsyncRecordBatchReader:
     """Asynchronously read PyArrow RecordBatches from an iterator of bytes."""
 
-    def __init__(self, bytes_iter: typing.AsyncIterator[bytes]) -> None:
+    def __init__(self, bytes_iter: collections.abc.AsyncIterator[bytes]) -> None:
         self._reader = AsyncMessageReader(bytes_iter)
         self._schema: None | pa.Schema = None
 
@@ -140,10 +140,10 @@ class AsyncRecordBatchReader:
 
 
 class AsyncRecordBatchProducer(AsyncRecordBatchReader):
-    def __init__(self, bytes_iter: typing.AsyncIterator[bytes]) -> None:
+    def __init__(self, bytes_iter: collections.abc.AsyncIterator[bytes]) -> None:
         super().__init__(bytes_iter)
 
-    async def produce(self, queue: asyncio.Queue):
+    async def produce(self, queue: asyncio.Queue[pa.RecordBatch]):
         """Read all record batches and produce them to a queue for async processing."""
         await logger.adebug("Starting record batch produce loop")
 

--- a/posthog/temporal/common/asyncpa.py
+++ b/posthog/temporal/common/asyncpa.py
@@ -58,7 +58,8 @@ class AsyncMessageReader:
         await self.read_until(total_message_size)
 
         with memoryview(self._buffer) as buffer_view:
-            msg = pa.ipc.read_message(buffer_view[:total_message_size])
+            loop = asyncio.get_running_loop()
+            msg = await loop.run_in_executor(None, pa.ipc.read_message, buffer_view[:total_message_size])
 
         self._buffer = self._buffer[total_message_size:]
 

--- a/posthog/temporal/tests/common/test_asyncpa.py
+++ b/posthog/temporal/tests/common/test_asyncpa.py
@@ -1,0 +1,107 @@
+import collections.abc
+import io
+import random
+import string
+
+import pyarrow as pa
+import pytest
+
+from posthog.temporal.common import asyncpa
+
+pytestmark = [pytest.mark.asyncio]
+
+
+def generate_record_batches(total_records: int = 1_000, total_batches: int = 10, target_size_bytes: int = 10 * 1024):
+    """Generate record batches for testing.
+
+    Currently, all the record batches will have the same schema: Two fields, an
+    `int` id and a `str` text. The text will be random letters to fill up
+    `target_size_bytes`.
+    """
+    records_per_batch = total_records // total_batches
+    remaining_records = total_records % total_batches
+
+    for batch_number in range(total_batches):
+        batch_size = records_per_batch
+        if batch_number == total_batches - 1:
+            # Last batch will contain any remainder.
+            batch_size += remaining_records
+
+        records = [
+            {
+                "id": record_number + (batch_number * records_per_batch),
+                "text": "".join(random.choices(string.ascii_letters, k=target_size_bytes)),
+            }
+            for record_number in range(batch_size)
+        ]
+        yield pa.RecordBatch.from_pylist(records)
+
+
+@pytest.mark.parametrize(
+    "record_batches",
+    [
+        iter(
+            [
+                pa.RecordBatch.from_arrays(
+                    [  # type: ignore
+                        pa.array([2, 2, 4, 4, 5, 100]),
+                        pa.array(["Flamingo", "Parrot", "Dog", "Horse", "Brittle stars", "Centipede"]),
+                    ],
+                    names=["n_legs", "animals"],
+                )
+            ]
+        ),
+        generate_record_batches(),
+    ],
+)
+async def test_record_batch_reader_reads_record_batches(record_batches: collections.abc.Iterator[pa.RecordBatch]):
+    """Test record batches are read correctly."""
+    buffer = io.BytesIO()
+    first_batch = next(record_batches)
+
+    class AsyncWrapper:
+        def __init__(self, buffer: io.BytesIO, chunk_size: int = 1024) -> None:
+            self.buffer = buffer
+            self.chunk_size = chunk_size
+
+        def __aiter__(self) -> "AsyncWrapper":
+            return self
+
+        async def __anext__(self) -> bytes:
+            b = self.buffer.read(self.chunk_size)
+
+            if b == b"":
+                raise StopAsyncIteration
+            else:
+                return b
+
+    reader = asyncpa.AsyncRecordBatchReader(AsyncWrapper(buffer))
+
+    # We write a record batch into a buffer, immediately read it, and compare
+    # the record batch we just wrote with the one we just read.
+    # This way, we avoid having to store all record batches in memory at once.
+    with pa.ipc.new_stream(buffer, schema=first_batch.schema) as writer:
+        writer.write_batch(first_batch)
+
+        _ = buffer.seek(0)
+
+        read_batch = await anext(reader)
+
+        assert first_batch == read_batch
+        assert first_batch is not read_batch
+
+        _ = buffer.seek(0)
+        _ = buffer.truncate()
+
+        for record_batch in record_batches:
+            writer.write_batch(record_batch)
+
+            _ = buffer.seek(0)
+
+            read_batch = await anext(reader)
+
+            assert record_batch == read_batch
+            assert record_batch is not read_batch
+
+            _ = buffer.seek(0)
+            _ = buffer.truncate()


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Each slice of `bytearray` copies (potentially a lot of) data.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Use `memoryview`s to avoid copying data when not necessary in `asyncpa.py`. Realistically, I don't expect much from this change, as we were already using a memoryview when reading a message. This just adds the same when parsing the body's length.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
