### PR TITLE
chore: increase timeout for hourly pre-agg table swap

### DIFF
--- a/ee/hogai/assistant.py
+++ b/ee/hogai/assistant.py
@@ -193,8 +193,8 @@ class Assistant:
                 # Send the last message with the initialized id.
                 yield AssistantEventType.MESSAGE, self._latest_message
 
-            last_ai_message: AssistantMessage = None
-            last_viz_message: VisualizationMessage = None
+            last_ai_message: AssistantMessage | None = None
+            last_viz_message: VisualizationMessage | None = None
             try:
                 async for update in generator:
                     if messages := await self._process_update(update):


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We're seeing a increased number of errors in EU regarding this when swaping the intray-day tables, and they look like they're just on the limit of the timeout to wait for the replication: https://posthog.dagster.cloud/prod-eu/overview/activity/timeline

## Changes

- Increase the timeout to keep the operation SYNC while we're not swapping the partitions.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Locally
