### PR TITLE
fix(posthog): Add warning toast for feature flag loading errors due to adblockers

### DIFF
--- a/frontend/src/lib/dayjs.ts
+++ b/frontend/src/lib/dayjs.ts
@@ -8,6 +8,7 @@ import quarterOfYear from 'dayjs/plugin/quarterOfYear'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import timezone from 'dayjs/plugin/timezone'
 import utc from 'dayjs/plugin/utc'
+import weekOfYear from 'dayjs/plugin/weekOfYear'
 
 // necessary for any localized date formatting to work
 dayjs.extend(LocalizedFormat)
@@ -18,6 +19,7 @@ dayjs.extend(utc)
 dayjs.extend(timezone)
 dayjs.extend(duration)
 dayjs.extend(quarterOfYear)
+dayjs.extend(weekOfYear)
 
 const now = (): Dayjs => dayjs()
 

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1948,6 +1948,17 @@ export function calculateDays(timeValue: number, timeUnit: TimeUnitType): number
     return timeValue
 }
 
+// Compute the ISO week string for a given date
+// Useful above to show the toast once per week
+export function getISOWeekString(date = new Date()): string {
+    const dayjs_date = dayjs(date)
+
+    const year = dayjs_date.year()
+    const week = dayjs_date.week()
+
+    return `${year}-W${week}`
+}
+
 export function range(startOrEnd: number, end?: number): number[] {
     let length = startOrEnd
     let start = 0

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -109,7 +109,7 @@ export function loadPostHogJS(): void {
                 <div className="flex flex-col gap-2">
                     <span>We couldn't load our feature flags.</span>
                     <span>
-                        This is likely due to the presence of adblockers running in your browser. This might affect the
+                        This could be due to the presence of adblockers running in your browser. This might affect the
                         platform usability since some features might not be available.
                     </span>
                 </div>,

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -1,6 +1,6 @@
 import { lemonToast } from '@posthog/lemon-ui'
 import { FEATURE_FLAGS } from 'lib/constants'
-import { inStorybook, inStorybookTestRunner } from 'lib/utils'
+import { getISOWeekString, inStorybook, inStorybookTestRunner } from 'lib/utils'
 import posthog, { CaptureResult } from 'posthog-js'
 
 interface WindowWithCypressCaptures extends Window {
@@ -99,6 +99,12 @@ export function loadPostHogJS(): void {
                 return
             }
 
+            // Show this toast once per week by using YYYY-WW format for the ID
+            const toastId = `toast-feature-flags-error-${getISOWeekString()}`
+            if (window.localStorage.getItem(toastId)) {
+                return
+            }
+
             lemonToast.warning(
                 <div className="flex flex-col gap-2">
                     <span>We couldn't load our feature flags.</span>
@@ -108,7 +114,8 @@ export function loadPostHogJS(): void {
                     </span>
                 </div>,
                 {
-                    toastId: 'feature-flags-error',
+                    toastId: toastId,
+                    onClose: () => window.localStorage.setItem(toastId, 'true'),
                     autoClose: false,
                 }
             )

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -1,4 +1,6 @@
+import { lemonToast } from '@posthog/lemon-ui'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { inStorybook, inStorybookTestRunner } from 'lib/utils'
 import posthog, { CaptureResult } from 'posthog-js'
 
 interface WindowWithCypressCaptures extends Window {
@@ -90,6 +92,26 @@ export function loadPostHogJS(): void {
             person_profiles: 'always',
             __preview_remote_config: true,
             __preview_flags_v2: true,
+        })
+
+        posthog.onFeatureFlags((_flags, _variants, context) => {
+            if (inStorybook() || inStorybookTestRunner() || !context?.errorsLoading) {
+                return
+            }
+
+            lemonToast.warning(
+                <div className="flex flex-col gap-2">
+                    <span>We couldn't load our feature flags.</span>
+                    <span>
+                        This is likely due to the presence of adblockers running in your browser. This might affect the
+                        platform usability since some features might not be available.
+                    </span>
+                </div>,
+                {
+                    toastId: 'feature-flags-error',
+                    autoClose: false,
+                }
+            )
         })
     } else {
         posthog.init('fake token', {


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Some customers are reaching out to support because they aren't seeing some of our features, turns out this happens because people have adblocks running and they can't see the stuff we've hidden behind FFs.

https://posthog.slack.com/archives/C02E3BKC78F/p1752414902229679

## Changes

Let's let them know about the problem. This message will show once a week.

<img width="439" height="158" alt="image" src="https://github.com/user-attachments/assets/8856c97c-3c8f-41cd-8d35-2b43c453897f" />