### PR TITLE
chore: Add option to reset sorting in DataTable

### DIFF
--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -294,9 +294,24 @@ export function DataTable({
                                 >
                                     Sort descending
                                 </LemonButton>
-                                <LemonDivider />
+                                <LemonButton
+                                    fullWidth
+                                    data-attr="datatable-reset-sort"
+                                    onClick={() => {
+                                        setQuery?.({
+                                            ...query,
+                                            source: {
+                                                ...query.source,
+                                                orderBy: [],
+                                            } as EventsQuery,
+                                        })
+                                    }}
+                                >
+                                    Reset sorting
+                                </LemonButton>
                             </>
                         ) : null}
+                        <LemonDivider />
                         <TaxonomicPopover
                             groupType={TaxonomicFilterGroupType.HogQLExpression}
                             value=""


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
Users are not able to reset the sorting of a table after the chose one. Only way I could find to do it is to reset the whole table, losing all columns added).
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Add an option below sort asc/desc to reset sorting
<!-- If there are frontend changes, please include screenshots. -->
<img width="467" height="399" alt="image" src="https://github.com/user-attachments/assets/ec5a7f64-8268-4aae-be8c-033b1502f51b" />
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
sorted the table by a column then clicked new reset option to reset.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

