### PR TITLE
feat(experiments): return raw SQL in the response

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -3219,6 +3219,9 @@
                     "description": "What triggered the calculation of the query, leave empty if user/immediate",
                     "type": "string"
                 },
+                "clickhouse_sql": {
+                    "type": "string"
+                },
                 "credible_intervals": {
                     "additionalProperties": {
                         "items": {
@@ -10773,6 +10776,9 @@
                 "baseline": {
                     "$ref": "#/definitions/ExperimentStatsBase"
                 },
+                "clickhouse_sql": {
+                    "type": "string"
+                },
                 "credible_intervals": {
                     "additionalProperties": {
                         "items": {
@@ -16397,6 +16403,9 @@
                     "properties": {
                         "baseline": {
                             "$ref": "#/definitions/ExperimentStatsBase"
+                        },
+                        "clickhouse_sql": {
+                            "type": "string"
                         },
                         "credible_intervals": {
                             "additionalProperties": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2419,6 +2419,7 @@ export interface ExperimentQueryResponse {
     stats_version?: integer
     p_value?: number
     credible_intervals?: Record<string, [number, number]>
+    clickhouse_sql?: string
 
     // New fields
     baseline?: ExperimentStatsBase

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -10838,6 +10838,7 @@ class ExperimentQueryResponse(BaseModel):
         extra="forbid",
     )
     baseline: Optional[ExperimentStatsBase] = None
+    clickhouse_sql: Optional[str] = None
     credible_intervals: Optional[dict[str, list[float]]] = None
     insight: Optional[list[dict[str, Any]]] = None
     kind: Literal["ExperimentQuery"] = "ExperimentQuery"
@@ -11333,6 +11334,7 @@ class QueryResponseAlternative16(BaseModel):
         extra="forbid",
     )
     baseline: Optional[ExperimentStatsBase] = None
+    clickhouse_sql: Optional[str] = None
     credible_intervals: Optional[dict[str, list[float]]] = None
     insight: Optional[list[dict[str, Any]]] = None
     kind: Literal["ExperimentQuery"] = "ExperimentQuery"
@@ -11482,6 +11484,7 @@ class CachedExperimentQueryResponse(BaseModel):
     calculation_trigger: Optional[str] = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
+    clickhouse_sql: Optional[str] = None
     credible_intervals: Optional[dict[str, list[float]]] = None
     insight: Optional[list[dict[str, Any]]] = None
     is_cached: bool


### PR DESCRIPTION
## Changes
Added raw ClickHouse SQL to the experiment result response. This makes it easier to debug issues.

## How did you test this code?
Locally, the query is returned and works in TablePlus:
<img width="843" height="386" alt="image" src="https://github.com/user-attachments/assets/cf2c4089-8f82-421a-974b-8b97578e1622" />