### PR TITLE
fix(web-analytics): truncate being called more than it should

### DIFF
--- a/dags/web_preaggregated_hourly.py
+++ b/dags/web_preaggregated_hourly.py
@@ -9,7 +9,9 @@ from dags.web_preaggregated_utils import (
     CLICKHOUSE_SETTINGS_HOURLY,
     merge_clickhouse_settings,
     WEB_ANALYTICS_CONFIG_SCHEMA,
+    web_analytics_retry_policy_def,
 )
+from clickhouse_driver import Client
 from posthog.clickhouse import query_tagging
 from posthog.clickhouse.client import sync_execute
 
@@ -17,7 +19,7 @@ from posthog.models.web_preaggregated.sql import (
     WEB_BOUNCES_INSERT_SQL,
     WEB_STATS_INSERT_SQL,
 )
-from posthog.clickhouse.cluster import ON_CLUSTER_CLAUSE, ClickhouseCluster
+from posthog.clickhouse.cluster import ClickhouseCluster
 
 
 WEB_ANALYTICS_HOURLY_CONFIG_SCHEMA = {
@@ -30,21 +32,33 @@ WEB_ANALYTICS_HOURLY_CONFIG_SCHEMA = {
 }
 
 
+def verify_table_empty_on_all_hosts(cluster: ClickhouseCluster, table_name: str) -> None:
+    def check_table_empty(client: Client) -> bool:
+        result = client.execute(f"SELECT count() FROM {table_name}")
+        return result[0][0] == 0
+
+    verification_results = cluster.map_all_hosts(check_table_empty).result()
+    if not all(verification_results.values()):
+        failed_hosts = [host for host, is_empty in verification_results.items() if not is_empty]
+        raise Exception(f"Table {table_name} is not empty on hosts: {failed_hosts}")
+
+
+def truncate_and_verify_table_is_empty(cluster: ClickhouseCluster, table_name: str) -> None:
+    cluster.map_all_hosts(lambda client: client.execute(f"TRUNCATE TABLE {table_name} SYNC")).result()
+    verify_table_empty_on_all_hosts(cluster, table_name)
+
+
 def pre_aggregate_web_analytics_hourly_data(
     context: dagster.AssetExecutionContext,
     table_name: str,
     sql_generator: Callable,
+    cluster: ClickhouseCluster,
 ) -> None:
     config = context.op_config
     team_ids = config.get("team_ids", TEAM_IDS_WITH_WEB_PREAGGREGATED_ENABLED)
     extra_settings = config.get("extra_clickhouse_settings", "")
     hours_back = config["hours_back"]
-
-    # Merge hourly settings with any extra settings
     clickhouse_settings = merge_clickhouse_settings(CLICKHOUSE_SETTINGS_HOURLY, extra_settings)
-    swap_settings = {
-        "distributed_ddl_task_timeout": "600",
-    }
 
     # Process the last N hours to handle any late-arriving data
     # Align with hour boundaries to match toStartOfHour() used in SQL, where we convert this to UTC,
@@ -67,10 +81,8 @@ def pre_aggregate_web_analytics_hourly_data(
         granularity="hourly",
     )
 
-    sync_execute(
-        f"TRUNCATE TABLE {staging_table_name} {ON_CLUSTER_CLAUSE(on_cluster=True)} SYNC",
-        settings=swap_settings,
-    )
+    context.log.info(f"Truncating staging table {staging_table_name}")
+    truncate_and_verify_table_is_empty(cluster, staging_table_name)
 
     # We intentionally log the query to make it easier to debug using the UI
     context.log.info(f"Processing hourly data from {date_start} to {date_end}")
@@ -79,9 +91,10 @@ def pre_aggregate_web_analytics_hourly_data(
     # Insert into staging table
     sync_execute(insert_query)
 
-    # Truncate main table and insert from staging
+    context.log.info(f"Truncating main table {table_name}")
+    truncate_and_verify_table_is_empty(cluster, table_name)
+
     context.log.info(f"Swapping data from {staging_table_name} to {table_name}")
-    sync_execute(f"TRUNCATE TABLE {table_name} {ON_CLUSTER_CLAUSE(on_cluster=True)} SYNC", settings=swap_settings)
     sync_execute(f"INSERT INTO {table_name} SELECT * FROM {staging_table_name}")
 
 
@@ -91,6 +104,7 @@ def pre_aggregate_web_analytics_hourly_data(
     config_schema=WEB_ANALYTICS_HOURLY_CONFIG_SCHEMA,
     metadata={"table": "web_bounces_hourly"},
     tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
+    retry_policy=web_analytics_retry_policy_def,
 )
 def web_bounces_hourly(
     context: dagster.AssetExecutionContext,
@@ -101,7 +115,7 @@ def web_bounces_hourly(
     """
     query_tagging.get_query_tags().with_dagster(dagster_tags(context))
     return pre_aggregate_web_analytics_hourly_data(
-        context=context, table_name="web_bounces_hourly", sql_generator=WEB_BOUNCES_INSERT_SQL
+        context=context, table_name="web_bounces_hourly", sql_generator=WEB_BOUNCES_INSERT_SQL, cluster=cluster
     )
 
 
@@ -111,6 +125,7 @@ def web_bounces_hourly(
     config_schema=WEB_ANALYTICS_HOURLY_CONFIG_SCHEMA,
     metadata={"table": "web_stats_hourly"},
     tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
+    retry_policy=web_analytics_retry_policy_def,
 )
 def web_stats_hourly(
     context: dagster.AssetExecutionContext,
@@ -124,6 +139,7 @@ def web_stats_hourly(
         context=context,
         table_name="web_stats_hourly",
         sql_generator=WEB_STATS_INSERT_SQL,
+        cluster=cluster,
     )
 
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

- We have overlapping commands happening on this process due to the ON CLUSTER clause usage.
More context: https://posthog.slack.com/archives/C076R4753Q8/p1752529232929289?thread_ts=1749234931.281369&cid=C076R4753Q8

## Changes

- Removed the ON CLUSTER clause in favor of `cluster.any_host`

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Locally and trusting Jams