### PR TITLE
chore(graph-updates): Dependency graph UI updates

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryInfo.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryInfo.tsx
@@ -493,9 +493,7 @@ export function QueryInfo({ codeEditorKey }: QueryInfoProps): JSX.Element {
                                 dataSource={upstream.nodes}
                             />
                         ) : (
-                            <div className="h-96 border border-border rounded-lg overflow-hidden">
-                                <UpstreamGraph codeEditorKey={codeEditorKey} />
-                            </div>
+                            <UpstreamGraph codeEditorKey={codeEditorKey} />
                         )}
                     </>
                 )}

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/graph/UpstreamGraph.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/graph/UpstreamGraph.tsx
@@ -40,7 +40,7 @@ interface LineageNodeProps {
 const MAT_VIEW_HEIGHT = 92
 const TABLE_HEIGHT = 68
 
-const NODE_WIDTH = 240
+const NODE_WIDTH = 300
 
 const MARKER_SIZE = 20
 
@@ -50,7 +50,7 @@ const RANK_SEP = 160
 function LineageNode({ data, edges }: LineageNodeProps): JSX.Element {
     const getNodeType = (type: string, lastRunAt?: string): string => {
         if (type === 'view') {
-            return lastRunAt ? 'Mat. View' : 'View'
+            return lastRunAt ? 'Mat. view' : 'View'
         }
         return 'Table'
     }
@@ -72,7 +72,7 @@ function LineageNode({ data, edges }: LineageNodeProps): JSX.Element {
 
     return (
         <div
-            className="bg-bg-light border border-border rounded-lg p-3 min-w-[240px] shadow-sm"
+            className="bg-bg-light border border-border rounded-md p-3 min-w-[300px] shadow-sm"
             style={{ minHeight: nodeHeight }}
         >
             {hasIncoming && <Handle type="target" position={Position.Left} className="w-2 h-2 bg-primary" />}
@@ -84,7 +84,7 @@ function LineageNode({ data, edges }: LineageNodeProps): JSX.Element {
                     </Tooltip>
                 )}
                 <Tooltip title={data.name} placement="top">
-                    <span className="font-medium text-sm truncate max-w-[180px] block">{data.name}</span>
+                    <span className="font-medium text-sm truncate max-w-[280px] block">{data.name}</span>
                 </Tooltip>
             </div>
 
@@ -157,7 +157,7 @@ const getLayoutedElements = (
         id: `edge-${index}`,
         source: edge.source,
         target: edge.target,
-        type: 'smoothstep',
+        type: 'bezier',
         animated: false,
         markerEnd: {
             type: MarkerType.ArrowClosed,
@@ -207,9 +207,6 @@ function UpstreamGraphContent({ codeEditorKey }: UpstreamGraphProps): JSX.Elemen
     return (
         <div className="w-full h-full">
             <ReactFlow
-                proOptions={{
-                    hideAttribution: true,
-                }}
                 colorMode={isDarkModeOn ? 'dark' : 'light'}
                 nodes={nodes}
                 edges={edges}
@@ -221,7 +218,7 @@ function UpstreamGraphContent({ codeEditorKey }: UpstreamGraphProps): JSX.Elemen
             >
                 <Background variant={BackgroundVariant.Dots} gap={20} size={1} />
                 <Controls showInteractive={false} position="bottom-right" />
-                <MiniMap zoomable pannable position="bottom-left" nodeStrokeWidth={2} />
+                <MiniMap zoomable pannable position="bottom-left" nodeStrokeWidth={2} className="hidden lg:block" />
             </ReactFlow>
         </div>
     )
@@ -229,10 +226,12 @@ function UpstreamGraphContent({ codeEditorKey }: UpstreamGraphProps): JSX.Elemen
 
 export function UpstreamGraph({ codeEditorKey }: UpstreamGraphProps): JSX.Element {
     return (
-        <div className="w-full h-full">
-            <ReactFlowProvider>
-                <UpstreamGraphContent codeEditorKey={codeEditorKey} />
-            </ReactFlowProvider>
+        <div className="h-[500px] border border-border rounded-md overflow-hidden">
+            <div className="w-full h-full">
+                <ReactFlowProvider>
+                    <UpstreamGraphContent codeEditorKey={codeEditorKey} />
+                </ReactFlowProvider>
+            </div>
         </div>
     )
 }

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/graph/UpstreamGraph.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/graph/UpstreamGraph.tsx
@@ -102,7 +102,7 @@ function LineageNode({ data, edges }: LineageNodeProps): JSX.Element {
                 <Tooltip title={data.name} placement="top">
                     <div className="flex items-center w-full justify-between">
                         <div className="font-medium text-sm truncate max-w-[240px] block">{data.name}</div>
-                        {data.type === 'view' && (
+                        {data.type === 'view' && !data.isCurrentView && (
                             <LemonButton
                                 size="xxsmall"
                                 type="secondary"


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
This includes a couple of quality of life UI updates for our graph.

<img width="1166" height="572" alt="image" src="https://github.com/user-attachments/assets/0f1acfe7-98cf-4e6a-86ff-f1fca36e727b" />


## Changes

- [x] Physically taller graph
- [x] Memoized node structure (We had some complaints from React flow)
- [x] Non conjoining edge layout strategy, linking
- [x] Interaction with upstream views to edit them.
- [x] Wider nodes (Text truncation still an issue for longish names)
- [x] Remove MiniMap on small screens     
- [x] Including attribution as I learned we don't have a license anymore. 

## How did you test this code?
Visual updates
