### PR TITLE
feat(experiments): add activity logging to experiments.

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -2,6 +2,7 @@ from enum import Enum
 from typing import Any, Literal
 
 from django.db.models import Q, QuerySet
+from django.dispatch import receiver
 from rest_framework import serializers, viewsets
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
@@ -25,7 +26,9 @@ from posthog.models.experiment import (
 )
 from posthog.models.feature_flag.feature_flag import FeatureFlag
 from posthog.models.filters.filter import Filter
+from posthog.models.signals import model_activity_signal
 from posthog.models.team.team import Team
+from posthog.models.activity_logging.activity_log import Detail, log_activity, changes_between
 from posthog.schema import ExperimentEventExposureConfig
 
 
@@ -627,3 +630,21 @@ class EnterpriseExperimentsViewSet(ForbidDestroyModel, TeamAndOrgViewSetMixin, v
         experiment.exposure_cohort = cohort
         experiment.save(update_fields=["exposure_cohort"])
         return Response({"cohort": cohort_serializer.data}, status=201)
+
+
+@receiver(model_activity_signal, sender=Experiment)
+def handle_experiment_change(sender, scope, before_update, after_update, activity, was_impersonated=False, **kwargs):
+    log_activity(
+        organization_id=after_update.team.organization_id,
+        team_id=after_update.team_id,
+        user=after_update.created_by
+        if activity == "created"
+        else getattr(after_update, "last_modified_by", after_update.created_by),
+        was_impersonated=was_impersonated,
+        item_id=after_update.id,
+        scope=scope,
+        activity=activity,
+        detail=Detail(
+            changes=changes_between(scope, previous=before_update, current=after_update), name=after_update.name
+        ),
+    )

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -193,6 +193,13 @@ field_exclusions: dict[ActivityScope, list[str]] = {
         "usage_dashboard",
         "analytics_dashboards",
     ],
+    "Experiment": [
+        "feature_flag",
+        "exposure_cohort",
+        "holdout",
+        "saved_metrics",
+        "experimenttosavedmetric_set",
+    ],
     "Person": [
         "distinct_ids",
         "name",

--- a/posthog/models/experiment.py
+++ b/posthog/models/experiment.py
@@ -6,13 +6,14 @@ from posthog.models.file_system.file_system_mixin import FileSystemSyncMixin
 from posthog.models.file_system.file_system_representation import FileSystemRepresentation
 from django.db.models import QuerySet
 from posthog.models.utils import RootTeamMixin
+from posthog.models.activity_logging.model_activity import ModelActivityMixin
 
 
 if TYPE_CHECKING:
     from posthog.models.team import Team
 
 
-class Experiment(FileSystemSyncMixin, RootTeamMixin, models.Model):
+class Experiment(FileSystemSyncMixin, ModelActivityMixin, RootTeamMixin, models.Model):
     class ExperimentType(models.TextChoices):
         WEB = "web", "web"
         PRODUCT = "product", "product"


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

There's no traceability of changes made to experiments or their related entities, like holdouts or shared metrics.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

This is the first change needed to add activity logging to experiments, by adding the `ModelActivityMixin` to the `Experiment` model, storing all changes in the activity log.

This PR only covers the backend and only the `Experiment` model. We'll be adding frontend descriptors and related models in subsequent PRs.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/2c1ce78c-dd4f-4ae8-92e7-825f125eae41)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
