### PR TITLE
fix(node): Added logging for bad groups

### DIFF
--- a/plugin-server/src/cdp/services/managers/groups-manager.service.ts
+++ b/plugin-server/src/cdp/services/managers/groups-manager.service.ts
@@ -127,7 +127,7 @@ export class GroupsManagerService {
                 groupIndexes,
                 groupKeys,
             })
-            return []
+            throw e
         }
     }
 

--- a/plugin-server/src/cdp/services/managers/groups-manager.service.ts
+++ b/plugin-server/src/cdp/services/managers/groups-manager.service.ts
@@ -1,5 +1,6 @@
 import LRUCache from 'lru-cache'
 
+import { sanitizeString } from '~/utils/db/utils'
 import { logger } from '~/utils/logger'
 
 import { Hub, Team } from '../../../types'
@@ -152,7 +153,7 @@ export class GroupsManagerService {
             if (typeof groupsProperty === 'object' && groupsProperty !== null) {
                 Object.entries(groupsProperty).forEach(([groupType, groupKey]) => {
                     if (typeof groupType === 'string' && typeof groupKey === 'string') {
-                        validGroupsProperty[groupType] = groupKey
+                        validGroupsProperty[sanitizeString(groupType)] = sanitizeString(groupKey)
                     }
                 })
             }


### PR DESCRIPTION
## Problem

Sometimes the group manager can crash due to bad inputs

## Changes

- [x] Adds more logging when this happens to help with debugging
- [x] Sanitize the strings before using them

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
