### PR TITLE
feat(insights): persist q in url hash, remove beforeUnload

### DIFF
--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -1,6 +1,6 @@
 import { IconInfo, IconWarning } from '@posthog/icons'
 import { useActions, useMountedLogic, useValues } from 'kea'
-import { router } from 'kea-router'
+import { router, combineUrl } from 'kea-router'
 import { AccessControlledLemonButton } from 'lib/components/AccessControlledLemonButton'
 import { AddToDashboard } from 'lib/components/AddToDashboard/AddToDashboard'
 import { AddToDashboardModal } from 'lib/components/AddToDashboard/AddToDashboardModal'
@@ -226,7 +226,13 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                         if (isDataVisualizationNode(query) && insight.short_id) {
                                             router.actions.push(urls.sqlEditor(undefined, undefined, insight.short_id))
                                         } else if (insight.short_id) {
-                                            push(urls.insightEdit(insight.short_id))
+                                            push(
+                                                combineUrl(
+                                                    urls.insightEdit(insight.short_id),
+                                                    undefined,
+                                                    queryChanged ? { q: query } : undefined
+                                                ).url
+                                            )
                                         } else {
                                             setInsightMode(ItemMode.Edit, null)
                                         }

--- a/frontend/src/scenes/insights/insightDataLogic.tsx
+++ b/frontend/src/scenes/insights/insightDataLogic.tsx
@@ -245,11 +245,7 @@ export const insightDataLogic = kea<insightDataLogicType>([
     }),
     actionToUrl(({ values }) => ({
         setQuery: ({ query }) => {
-            if (
-                values.queryChanged &&
-                insightSceneLogic.values.activeScene === Scene.Insight &&
-                insightSceneLogic.values.insightId === 'new'
-            ) {
+            if (values.queryChanged && insightSceneLogic.values.activeScene === Scene.Insight) {
                 // query is changed and we are in edit mode
                 return [
                     router.values.currentLocation.pathname,
@@ -259,6 +255,9 @@ export const insightDataLogic = kea<insightDataLogicType>([
                     {
                         ...router.values.currentLocation.hashParams,
                         q: crushDraftQueryForURL(query),
+                    },
+                    {
+                        replace: true,
                     },
                 ]
             }

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -1,6 +1,5 @@
 import { actions, BuiltLogic, connect, kea, listeners, path, reducers, selectors, sharedListeners } from 'kea'
-import { actionToUrl, beforeUnload, router, urlToAction } from 'kea-router'
-import { CombinedLocation } from 'kea-router/lib/utils'
+import { actionToUrl, router, urlToAction } from 'kea-router'
 import { objectsEqual } from 'kea-test-utils'
 import { AlertType } from 'lib/components/Alerts/types'
 import { isEmptyObject } from 'lib/utils'
@@ -32,7 +31,7 @@ import {
 import { insightDataLogic } from './insightDataLogic'
 import { insightDataLogicType } from './insightDataLogicType'
 import type { insightSceneLogicType } from './insightSceneLogicType'
-import { parseDraftQueryFromLocalStorage, parseDraftQueryFromURL } from './utils'
+import { parseDraftQueryFromURL } from './utils'
 import api from 'lib/api'
 import { checkLatestVersionsOnQuery } from '~/queries/utils'
 
@@ -418,21 +417,32 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
         },
     })),
     actionToUrl(({ values }) => {
-        // Use the browser redirect to determine state to hook into beforeunload prevention
         const actionToUrl = ({
             insightMode = values.insightMode,
             insightId = values.insightId,
         }: {
             insightMode?: ItemMode
             insightId?: InsightShortId | 'new' | null
-        }): string | undefined => {
-            if (!insightId || insightId === 'new') {
-                return undefined
-            }
+        }): [
+            string,
+            string | Record<string, any> | undefined,
+            string | Record<string, any> | undefined,
+            { replace?: boolean }
+        ] => {
+            const baseUrl =
+                !insightId || insightId === 'new'
+                    ? urls.insightNew()
+                    : insightMode === ItemMode.View
+                    ? urls.insightView(insightId)
+                    : urls.insightEdit(insightId)
+            const searchParams = router.values.currentLocation.searchParams
+            // TODO: also kepe these in the URL?
+            // const metadataChanged = !!values.insightLogicRef?.logic.values.insightChanged
+            const queryChanged = !!values.insightDataLogicRef?.logic.values.queryChanged
+            const query = values.insightDataLogicRef?.logic.values.query
+            const hashParams = queryChanged ? { q: query } : undefined
 
-            const baseUrl = insightMode === ItemMode.View ? urls.insightView(insightId) : urls.insightEdit(insightId)
-            const searchParams = window.location.search
-            return searchParams ? `${baseUrl}${searchParams}` : baseUrl
+            return [baseUrl, searchParams, hashParams, { replace: true }]
         }
 
         return {
@@ -440,66 +450,4 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
             setInsightMode: actionToUrl,
         }
     }),
-    beforeUnload(({ values }) => ({
-        enabled: (newLocation?: CombinedLocation) => {
-            // Don't run this check on other scenes
-            if (values.activeScene !== Scene.Insight) {
-                return false
-            }
-
-            if (values.disableNavigationHooks) {
-                return false
-            }
-
-            // If just the hash or project part changes, don't show the prompt
-            const currentPathname = router.values.currentLocation.pathname.replace(/\/project\/\d+/, '')
-            const newPathname = newLocation?.pathname.replace(/\/project\/\d+/, '')
-            if (currentPathname === newPathname) {
-                return false
-            }
-
-            // Don't show the prompt if we're in edit mode (just exploring)
-            if (values.insightMode !== ItemMode.Edit) {
-                return false
-            }
-
-            const metadataChanged = !!values.insightLogicRef?.logic.values.insightChanged
-            const queryChanged = !!values.insightDataLogicRef?.logic.values.queryChanged
-            const draftQueryFromLocalStorage = localStorage.getItem(`draft-query-${values.currentTeamId}`)
-            let draftQuery: { query: Node; timestamp: number } | null = null
-            if (draftQueryFromLocalStorage) {
-                const parsedQuery = parseDraftQueryFromLocalStorage(draftQueryFromLocalStorage)
-                if (parsedQuery) {
-                    draftQuery = parsedQuery
-                } else {
-                    // If the draft query is invalid, remove it
-                    localStorage.removeItem(`draft-query-${values.currentTeamId}`)
-                }
-            }
-            const query = values.insightDataLogicRef?.logic.values.query
-
-            if (draftQuery && query && objectsEqual(draftQuery.query, query)) {
-                return false
-            }
-
-            const isChanged = metadataChanged || queryChanged
-
-            if (!isChanged) {
-                return false
-            }
-
-            // Do not show confirmation if newPathname is undefined; this usually means back button in browser
-            if (newPathname === undefined) {
-                const savedQuery = values.insightDataLogicRef?.logic.values.savedInsight.query
-                values.insightDataLogicRef?.logic.actions.setQuery(savedQuery || null)
-                return false
-            }
-
-            return true
-        },
-        message: 'Leave insight?\nChanges you made will be discarded.',
-        onConfirm: () => {
-            values.insightDataLogicRef?.logic.actions.cancelChanges()
-        },
-    })),
 ])


### PR DESCRIPTION
## Problem

The `beforeUnload` is not working well for insights. It never has and it never will. So let's cut the losses.

## Changes

Pushes the query into the URL with `#q=`. This is used when you load the page, also when you go back/forward between scenes and between insights.

![2025-07-15 12 49 50](https://github.com/user-attachments/assets/cc1f156c-c28a-4575-9dea-5712d42c43da)

Now users can leave the insight, and come back to how it was.

Some things:
- if the user updates the insight's metadata (name/description), that won't be persisted in the URL. 
- I'm not sure what dragons are still out to get us, but even with some bugs, I think this is a much better experience
- It would be nice to show, even in the "view" mode when you're not editing the insight (but can edit a lot of parameters), what changed, and a save button. However that's outside of the immediate scope of this PR.

## How did you test this code?

Locally, see screencast.