### PR TITLE
fix(bi): Check for NaN in data viz logic

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -654,6 +654,14 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                                         )
                                     }
 
+                                    const isNotANumber =
+                                        Number.isNaN(n[column.dataIndex]) ||
+                                        n[column.dataIndex] === undefined ||
+                                        n[column.dataIndex] === null
+                                    if (isNotANumber) {
+                                        return 0
+                                    }
+
                                     const isInt = Number.isInteger(n[column.dataIndex])
                                     return isInt
                                         ? parseInt(n[column.dataIndex], 10) * multiplier


### PR DESCRIPTION
## Problem
- if a dataset has a null then using trendlines in a data viz node breaks the page 
- https://posthog.slack.com/archives/C019RAX2XBN/p1752577788783629

## Changes
- Check to see if the value is null-ish or NaN and return 0 if so 
