### PR TITLE
fix: Remove distinct id mapping upon person refresh on merge

### DIFF
--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -904,13 +904,6 @@ export interface Person {
     force_upgrade?: boolean
 }
 
-export interface DistinctPersonIdentifiers {
-    person_id: string
-    uuid: string
-    distinct_id: string
-    team_id: number
-}
-
 /** Clickhouse Person model. */
 export interface ClickHousePerson {
     id: string

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -18,7 +18,6 @@ import {
     CohortPeople,
     Database,
     DeadLetterQueueEvent,
-    DistinctPersonIdentifiers,
     Group,
     GroupKey,
     GroupTypeIndex,
@@ -580,24 +579,6 @@ export class DB {
         if (rows.length > 0) {
             return this.toPerson(rows[0])
         }
-    }
-
-    public async fetchPersonIdsByDistinctId(
-        distinctId: string,
-        teamId: number
-    ): Promise<DistinctPersonIdentifiers | null> {
-        const queryString = `SELECT posthog_person.id as person_id, posthog_person.uuid, posthog_person.team_id, posthog_persondistinctid.distinct_id
-            FROM posthog_person JOIN posthog_persondistinctid ON (posthog_persondistinctid.person_id = posthog_person.id)
-            WHERE posthog_persondistinctid.team_id = $1 AND posthog_persondistinctid.distinct_id = $2 LIMIT 1`
-
-        const { rows } = await this.postgres.query<DistinctPersonIdentifiers>(
-            PostgresUse.PERSONS_WRITE,
-            queryString,
-            [teamId, distinctId],
-            'fetchPersonIdsByDistinctId'
-        )
-
-        return rows.length > 0 ? rows[0] : null
     }
 
     public async createPerson(

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -6,7 +6,6 @@ import { NoRowsUpdatedError } from '~/utils/utils'
 
 import { TopicMessage } from '../../../kafka/producer'
 import {
-    DistinctPersonIdentifiers,
     InternalPerson,
     PersonBatchWritingDbWriteMode,
     PropertiesLastOperation,
@@ -41,7 +40,6 @@ import { PersonsStoreForBatch } from './persons-store-for-batch'
 type MethodName =
     | 'fetchForChecking'
     | 'fetchForUpdate'
-    | 'fetchPersonIdsByDistinctId'
     | 'fetchPerson'
     | 'updatePersonAssertVersion'
     | 'updatePersonNoAssert'
@@ -377,12 +375,6 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         }
         return fetchPromise
     }
-    async fetchPersonIdsByDistinctId(distinctId: string, teamId: number): Promise<DistinctPersonIdentifiers | null> {
-        this.incrementCount('fetchPersonIdsByDistinctId', distinctId)
-        this.incrementDatabaseOperation('fetchPersonIdsByDistinctId', distinctId)
-        const result = await this.db.fetchPersonIdsByDistinctId(distinctId, teamId)
-        return result
-    }
 
     updatePersonForMerge(
         person: InternalPerson,
@@ -566,6 +558,10 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
             this.distinctIdToPersonId.delete(distinctCacheKey)
             this.personCheckCache.delete(distinctCacheKey)
         }
+    }
+
+    removeDistinctIdFromCache(teamId: number, distinctId: string): void {
+        this.distinctIdToPersonId.delete(this.getDistinctCacheKey(teamId, distinctId))
     }
 
     clearAllCachesForDistinctId(teamId: number, distinctId: string): void {

--- a/plugin-server/src/worker/ingestion/persons/measuring-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/measuring-person-store.ts
@@ -2,13 +2,7 @@ import { Properties } from '@posthog/plugin-scaffold'
 import { DateTime } from 'luxon'
 
 import { TopicMessage } from '../../../kafka/producer'
-import {
-    DistinctPersonIdentifiers,
-    InternalPerson,
-    PropertiesLastOperation,
-    PropertiesLastUpdatedAt,
-    Team,
-} from '../../../types'
+import { InternalPerson, PropertiesLastOperation, PropertiesLastUpdatedAt, Team } from '../../../types'
 import { DB, MoveDistinctIdsResult } from '../../../utils/db/db'
 import { PostgresUse, TransactionClient } from '../../../utils/db/postgres'
 import {
@@ -33,7 +27,6 @@ type MethodName =
     | 'deletePerson'
     | 'addDistinctId'
     | 'moveDistinctIds'
-    | 'fetchPersonIdsByDistinctId'
     | 'updateCohortsAndFeatureFlagsForMerge'
     | 'addPersonlessDistinctId'
     | 'addPersonlessDistinctIdForMerge'
@@ -301,13 +294,6 @@ export class MeasuringPersonsStoreForBatch implements PersonsStoreForBatch {
         const response = await this.db.deletePerson(person, tx)
         observeLatencyByVersion(person, start, 'deletePerson')
         return response
-    }
-
-    async fetchPersonIdsByDistinctId(distinctId: string, teamId: number): Promise<DistinctPersonIdentifiers | null> {
-        this.incrementCount('fetchPersonIdsByDistinctId', distinctId)
-        this.incrementDatabaseOperation('fetchPersonIdsByDistinctId', distinctId)
-        const result = await this.db.fetchPersonIdsByDistinctId(distinctId, teamId)
-        return result
     }
 
     async addDistinctId(

--- a/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
@@ -2,14 +2,7 @@ import { Properties } from '@posthog/plugin-scaffold'
 import { DateTime } from 'luxon'
 
 import { TopicMessage } from '../../../kafka/producer'
-import {
-    DistinctPersonIdentifiers,
-    Hub,
-    InternalPerson,
-    PropertiesLastOperation,
-    PropertiesLastUpdatedAt,
-    Team,
-} from '../../../types'
+import { Hub, InternalPerson, PropertiesLastOperation, PropertiesLastUpdatedAt, Team } from '../../../types'
 import { MoveDistinctIdsResult } from '../../../utils/db/db'
 import { TransactionClient } from '../../../utils/db/postgres'
 import { logger } from '../../../utils/logger'
@@ -346,11 +339,6 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
         this.updateFinalState(person.team_id, distinctId, person.id, person, false, 'addDistinctId', person.version)
 
         return mainResult
-    }
-
-    async fetchPersonIdsByDistinctId(distinctId: string, teamId: number): Promise<DistinctPersonIdentifiers | null> {
-        const result = await this.mainStore.fetchPersonIdsByDistinctId(distinctId, teamId)
-        return result
     }
 
     async moveDistinctIds(

--- a/plugin-server/src/worker/ingestion/persons/persons-store-for-batch.ts
+++ b/plugin-server/src/worker/ingestion/persons/persons-store-for-batch.ts
@@ -2,13 +2,7 @@ import { Properties } from '@posthog/plugin-scaffold'
 import { DateTime } from 'luxon'
 
 import { TopicMessage } from '../../../kafka/producer'
-import {
-    DistinctPersonIdentifiers,
-    InternalPerson,
-    PropertiesLastOperation,
-    PropertiesLastUpdatedAt,
-    Team,
-} from '../../../types'
+import { InternalPerson, PropertiesLastOperation, PropertiesLastUpdatedAt, Team } from '../../../types'
 import { MoveDistinctIdsResult } from '../../../utils/db/db'
 import { TransactionClient } from '../../../utils/db/postgres'
 import { BatchWritingStore } from '../stores/batch-writing-store'
@@ -32,11 +26,6 @@ export interface PersonsStoreForBatch extends BatchWritingStore {
      * Always uses primary database
      */
     fetchForUpdate(teamId: number, distinctId: string): Promise<InternalPerson | null>
-
-    /**
-     * Fetches person IDs by distinct ID for retry logic
-     */
-    fetchPersonIdsByDistinctId(distinctId: string, teamId: number): Promise<DistinctPersonIdentifiers | null>
 
     /**
      * Creates a new person

--- a/plugin-server/tests/helpers/sql.ts
+++ b/plugin-server/tests/helpers/sql.ts
@@ -530,3 +530,10 @@ export async function fetchPostgresPersons(db: DB, teamId: number) {
             } as InternalPerson)
     )
 }
+
+export async function fetchPostgresDistinctIdsForPerson(db: DB, personId: string): Promise<string[]> {
+    const query = `SELECT distinct_id FROM posthog_persondistinctid WHERE person_id = ${personId} ORDER BY id`
+    return (await db.postgres.query(PostgresUse.PERSONS_READ, query, undefined, 'distinctIds')).rows.map(
+        (row: { distinct_id: string }) => row.distinct_id
+    )
+}

--- a/plugin-server/tests/helpers/sql.ts
+++ b/plugin-server/tests/helpers/sql.ts
@@ -532,7 +532,7 @@ export async function fetchPostgresPersons(db: DB, teamId: number) {
 }
 
 export async function fetchPostgresDistinctIdsForPerson(db: DB, personId: string): Promise<string[]> {
-    const query = `SELECT distinct_id FROM posthog_persondistinctid WHERE person_id = ${personId} ORDER BY id`
+    const query = `SELECT distinct_id FROM posthog_persondistinctid WHERE person_id = $1 ORDER BY id`
     return (await db.postgres.query(PostgresUse.PERSONS_READ, query, undefined, 'distinctIds')).rows.map(
         (row: { distinct_id: string }) => row.distinct_id
     )

--- a/plugin-server/tests/helpers/sql.ts
+++ b/plugin-server/tests/helpers/sql.ts
@@ -532,7 +532,7 @@ export async function fetchPostgresPersons(db: DB, teamId: number) {
 }
 
 export async function fetchPostgresDistinctIdsForPerson(db: DB, personId: string): Promise<string[]> {
-    const query = `SELECT distinct_id FROM posthog_persondistinctid WHERE person_id = $1 ORDER BY id`
+    const query = `SELECT distinct_id FROM posthog_persondistinctid WHERE person_id = ${personId} ORDER BY id`
     return (await db.postgres.query(PostgresUse.PERSONS_READ, query, undefined, 'distinctIds')).rows.map(
         (row: { distinct_id: string }) => row.distinct_id
     )


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We are seeing an issue on merges where we refresh to same person if we already had the previous distinct id in the cache, this is because we are using `fetchForUpdate` to retrieve the person information. This PR makes a critical change, deleting the distinctId map entry in the batch store when we refresh a person. This causes `fetchForUpdate` to always get the most up to date version of that person.

## Changes

- Removes a lot of not useful code on fetching ids, as we need the most up to date version of the person provided by fetchForUpdate to properly update attributes
- removeDistinctIdFromCache is the critical update
- Adds tests both for the already cached distinct scenario and also for `merge_dangerously` merge scenario

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
