### PR TITLE
feat(batch-exports): Use new stage activity for sessions model in S3 exports

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -42,11 +42,11 @@ from products.batch_exports.backend.temporal.heartbeat import (
     DateRange,
     should_resume_from_activity_heartbeat,
 )
+from products.batch_exports.backend.temporal.record_batch_model import resolve_batch_exports_model
 from products.batch_exports.backend.temporal.spmc import (
     Consumer,
     Producer,
     RecordBatchQueue,
-    resolve_batch_exports_model,
     run_consumer,
     wait_for_schema_or_producer,
 )

--- a/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
@@ -43,11 +43,11 @@ from products.batch_exports.backend.temporal.heartbeat import (
     DateRange,
     should_resume_from_activity_heartbeat,
 )
+from products.batch_exports.backend.temporal.record_batch_model import resolve_batch_exports_model
 from products.batch_exports.backend.temporal.spmc import (
     Consumer,
     Producer,
     RecordBatchQueue,
-    resolve_batch_exports_model,
     run_consumer,
     wait_for_schema_or_producer,
 )

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -44,11 +44,11 @@ from products.batch_exports.backend.temporal.heartbeat import (
     DateRange,
     should_resume_from_activity_heartbeat,
 )
+from products.batch_exports.backend.temporal.record_batch_model import resolve_batch_exports_model
 from products.batch_exports.backend.temporal.spmc import (
     Consumer,
     Producer,
     RecordBatchQueue,
-    resolve_batch_exports_model,
     run_consumer,
     wait_for_schema_or_producer,
 )

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -946,10 +946,6 @@ def _use_internal_stage(inputs: S3BatchExportInputs) -> bool:
 
     This is just needed while we gradually roll out the pre-export stage.
     """
-    # TODO - support sessions model
-    is_sessions_model = inputs.batch_export_model and inputs.batch_export_model.name == "sessions"
-    if is_sessions_model:
-        return False
     if str(inputs.team_id) in settings.BATCH_EXPORT_USE_INTERNAL_S3_STAGE_TEAM_IDS:
         return True
     return inputs.team_id % 100 < settings.BATCH_EXPORT_S3_USE_INTERNAL_STAGE_ROLLOUT_PERCENTAGE

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -64,11 +64,11 @@ from products.batch_exports.backend.temporal.pipeline.entrypoint import (
 from products.batch_exports.backend.temporal.pipeline.producer import (
     Producer as ProducerFromInternalStage,
 )
+from products.batch_exports.backend.temporal.record_batch_model import resolve_batch_exports_model
 from products.batch_exports.backend.temporal.spmc import (
     Consumer,
     Producer,
     RecordBatchQueue,
-    resolve_batch_exports_model,
     run_consumer,
     wait_for_schema_or_producer,
 )

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -48,11 +48,11 @@ from products.batch_exports.backend.temporal.heartbeat import (
     DateRange,
     should_resume_from_activity_heartbeat,
 )
+from products.batch_exports.backend.temporal.record_batch_model import resolve_batch_exports_model
 from products.batch_exports.backend.temporal.spmc import (
     Consumer,
     Producer,
     RecordBatchQueue,
-    resolve_batch_exports_model,
     run_consumer,
     wait_for_schema_or_producer,
 )

--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -30,12 +30,12 @@ from posthog.temporal.common.clickhouse import (
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import bind_contextvars, get_logger
 from products.batch_exports.backend.temporal.batch_exports import default_fields
+from products.batch_exports.backend.temporal.record_batch_model import resolve_batch_exports_model
 from products.batch_exports.backend.temporal.spmc import (
     RecordBatchModel,
     compose_filters_clause,
     generate_query_ranges,
     is_5_min_batch_export,
-    resolve_batch_exports_model,
     use_distributed_events_recent_table,
     wait_for_delta_past_data_interval_end,
 )

--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -373,7 +373,19 @@ async def _write_batch_export_record_batches_to_internal_stage(
             query_parameters["interval_end"] = interval_end.strftime("%Y-%m-%d %H:%M:%S.%f")
 
             if isinstance(query_or_model, RecordBatchModel):
-                query, query_parameters = await query_or_model.as_query_with_parameters(interval_start, interval_end)
+                s3_folder = _get_clickhouse_s3_staging_folder_url(
+                    batch_export_id=batch_export_id,
+                    data_interval_start=data_interval_start,
+                    data_interval_end=data_interval_end,
+                )
+                query, query_parameters = await query_or_model.as_insert_into_s3_query_with_parameters(
+                    data_interval_start=interval_start,
+                    data_interval_end=interval_end,
+                    s3_folder=s3_folder,
+                    s3_key=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
+                    s3_secret=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
+                    num_partitions=settings.BATCH_EXPORT_CLICKHOUSE_S3_PARTITIONS,
+                )
             else:
                 query = query_or_model
 

--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -378,6 +378,8 @@ async def _write_batch_export_record_batches_to_internal_stage(
                     data_interval_start=data_interval_start,
                     data_interval_end=data_interval_end,
                 )
+                assert settings.OBJECT_STORAGE_ACCESS_KEY_ID is not None
+                assert settings.OBJECT_STORAGE_SECRET_ACCESS_KEY is not None
                 query, query_parameters = await query_or_model.as_insert_into_s3_query_with_parameters(
                     data_interval_start=interval_start,
                     data_interval_end=interval_end,

--- a/products/batch_exports/backend/temporal/pipeline/transformer.py
+++ b/products/batch_exports/backend/temporal/pipeline/transformer.py
@@ -6,6 +6,7 @@ import contextlib
 import gzip
 import io
 import json
+import multiprocessing as mp
 import typing
 
 import brotli
@@ -95,7 +96,9 @@ class JSONLStreamTransformer:
         """
         current_file_size = 0
 
-        with concurrent.futures.ProcessPoolExecutor(max_workers=self.max_workers) as executor:
+        with concurrent.futures.ProcessPoolExecutor(
+            max_workers=self.max_workers, mp_context=mp.get_context("fork")
+        ) as executor:
             async with _record_batches_producer(
                 record_batches,
                 executor=executor,
@@ -156,7 +159,9 @@ class JSONLBrotliStreamTransformer:
         """
         current_file_size = 0
 
-        with concurrent.futures.ProcessPoolExecutor(max_workers=self.max_workers) as executor:
+        with concurrent.futures.ProcessPoolExecutor(
+            max_workers=self.max_workers, mp_context=mp.get_context("fork")
+        ) as executor:
             async with _record_batches_producer(
                 record_batches,
                 executor=executor,

--- a/products/batch_exports/backend/temporal/record_batch_model.py
+++ b/products/batch_exports/backend/temporal/record_batch_model.py
@@ -25,9 +25,9 @@ class RecordBatchModel(abc.ABC):
     def __init__(self, team_id: int):
         self.team_id = team_id
 
-    async def get_hogql_context(self, team_id: int) -> HogQLContext:
+    async def get_hogql_context(self) -> HogQLContext:
         """Return a HogQLContext to generate a ClickHouse query."""
-        team = await Team.objects.aget(id=team_id)
+        team = await Team.objects.aget(id=self.team_id)
         context = HogQLContext(
             team=team,
             team_id=team.id,
@@ -121,7 +121,7 @@ class SessionsRecordBatchModel(RecordBatchModel):
     ) -> tuple[Query, QueryParameters]:
         """Produce a printed query and any necessary ClickHouse query parameters."""
         hogql_query = self.get_hogql_query(data_interval_start, data_interval_end)
-        context = await self.get_hogql_context(self.team_id)
+        context = await self.get_hogql_context()
 
         prepared_hogql_query = await database_sync_to_async(prepare_ast_for_printing)(
             hogql_query, context=context, dialect="clickhouse", stack=[]
@@ -147,7 +147,7 @@ class SessionsRecordBatchModel(RecordBatchModel):
     ) -> tuple[Query, QueryParameters]:
         """Produce a printed query and any necessary ClickHouse query parameters."""
         hogql_query = self.get_hogql_query(data_interval_start, data_interval_end)
-        context = await self.get_hogql_context(self.team_id)
+        context = await self.get_hogql_context()
 
         prepared_hogql_query = await database_sync_to_async(prepare_ast_for_printing)(
             hogql_query, context=context, dialect="clickhouse", stack=[]

--- a/products/batch_exports/backend/temporal/record_batch_model.py
+++ b/products/batch_exports/backend/temporal/record_batch_model.py
@@ -12,11 +12,7 @@ from posthog.hogql.hogql import ast
 from posthog.hogql.printer import prepare_ast_for_printing, print_prepared_ast
 from posthog.models import Team
 from posthog.sync import database_sync_to_async
-from posthog.temporal.common.logger import get_external_logger, get_logger
 from products.batch_exports.backend.temporal import sql
-
-LOGGER = get_logger(__name__)
-EXTERNAL_LOGGER = get_external_logger()
 
 Query = str
 QueryParameters = dict[str, typing.Any]

--- a/products/batch_exports/backend/temporal/record_batch_model.py
+++ b/products/batch_exports/backend/temporal/record_batch_model.py
@@ -152,6 +152,7 @@ class SessionsRecordBatchModel(RecordBatchModel):
         prepared_hogql_query = await database_sync_to_async(prepare_ast_for_printing)(
             hogql_query, context=context, dialect="clickhouse", stack=[]
         )
+        assert prepared_hogql_query is not None
         printed = print_prepared_ast(
             prepared_hogql_query,
             context=context,

--- a/products/batch_exports/backend/temporal/record_batch_model.py
+++ b/products/batch_exports/backend/temporal/record_batch_model.py
@@ -1,0 +1,215 @@
+import abc
+import datetime as dt
+import typing
+
+from posthog.batch_exports.service import (
+    BatchExportModel,
+    BatchExportSchema,
+)
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.hogql import ast
+from posthog.hogql.printer import prepare_ast_for_printing, print_prepared_ast
+from posthog.models import Team
+from posthog.sync import database_sync_to_async
+from posthog.temporal.common.logger import get_external_logger, get_logger
+from products.batch_exports.backend.temporal import sql
+
+LOGGER = get_logger(__name__)
+EXTERNAL_LOGGER = get_external_logger()
+
+Query = str
+QueryParameters = dict[str, typing.Any]
+BatchExportDateRange = tuple[dt.datetime | None, dt.datetime]
+
+
+class RecordBatchModel(abc.ABC):
+    """Base class for models that can be produced as record batches."""
+
+    def __init__(self, team_id: int):
+        self.team_id = team_id
+
+    async def get_hogql_context(self, team_id: int) -> HogQLContext:
+        """Return a HogQLContext to generate a ClickHouse query."""
+        team = await Team.objects.aget(id=team_id)
+        context = HogQLContext(
+            team=team,
+            team_id=team.id,
+            enable_select_queries=True,
+            limit_top_select=False,
+        )
+        context.database = await database_sync_to_async(create_hogql_database)(team=team, modifiers=context.modifiers)
+
+        return context
+
+    @abc.abstractmethod
+    async def as_query_with_parameters(
+        self, data_interval_start: dt.datetime | None, data_interval_end: dt.datetime
+    ) -> tuple[Query, QueryParameters]:
+        """Produce a printed query and any necessary ClickHouse query parameters."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    async def as_insert_into_s3_query_with_parameters(
+        self,
+        data_interval_start: dt.datetime | None,
+        data_interval_end: dt.datetime,
+        s3_folder: str,
+        s3_key: str,
+        s3_secret: str,
+        num_partitions: int,
+    ) -> tuple[Query, QueryParameters]:
+        """Produce a printed query and any necessary ClickHouse query parameters."""
+        raise NotImplementedError
+
+
+class SessionsRecordBatchModel(RecordBatchModel):
+    """A model to produce record batches from the sessions table.
+
+    Attributes:
+       team_id: The ID of the team we are producing records for.
+    """
+
+    def __init__(self, team_id: int):
+        super().__init__(team_id)
+
+    def get_hogql_query(
+        self, data_interval_start: dt.datetime | None, data_interval_end: dt.datetime
+    ) -> ast.SelectQuery:
+        """Return the HogQLQuery used for the sessions model."""
+        hogql_query = sql.SELECT_FROM_SESSIONS_HOGQL
+
+        where_and = ast.And(
+            exprs=[
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Eq,
+                    left=ast.Field(chain=["sessions", "team_id"]),
+                    right=ast.Constant(value=self.team_id),
+                ),
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Lt,
+                    left=ast.Field(chain=["_inserted_at"]),
+                    right=ast.Constant(value=data_interval_end),
+                ),
+                # include $end_timestamp because hogql uses this to add a where clause to the inner query
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Lt,
+                    left=ast.Field(chain=["$end_timestamp"]),
+                    right=ast.Constant(value=data_interval_end),
+                ),
+            ]
+        )
+        if data_interval_start is not None:
+            where_and.exprs.extend(
+                [
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.GtEq,
+                        left=ast.Field(chain=["_inserted_at"]),
+                        right=ast.Constant(value=data_interval_start),
+                    ),
+                    # include $end_timestamp because hogql uses this to add a where clause to the inner query
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.GtEq,
+                        left=ast.Field(chain=["$end_timestamp"]),
+                        right=ast.Constant(value=data_interval_start),
+                    ),
+                ]
+            )
+
+        hogql_query.where = where_and
+
+        return hogql_query
+
+    async def as_query_with_parameters(
+        self, data_interval_start: dt.datetime | None, data_interval_end: dt.datetime
+    ) -> tuple[Query, QueryParameters]:
+        """Produce a printed query and any necessary ClickHouse query parameters."""
+        hogql_query = self.get_hogql_query(data_interval_start, data_interval_end)
+        context = await self.get_hogql_context(self.team_id)
+
+        prepared_hogql_query = await database_sync_to_async(prepare_ast_for_printing)(
+            hogql_query, context=context, dialect="clickhouse", stack=[]
+        )
+        assert prepared_hogql_query is not None
+        context.output_format = "ArrowStream"
+        printed = print_prepared_ast(
+            prepared_hogql_query,
+            context=context,
+            dialect="clickhouse",
+            stack=[],
+        )
+        return printed, context.values
+
+    async def as_insert_into_s3_query_with_parameters(
+        self,
+        data_interval_start: dt.datetime | None,
+        data_interval_end: dt.datetime,
+        s3_folder: str,
+        s3_key: str,
+        s3_secret: str,
+        num_partitions: int,
+    ) -> tuple[Query, QueryParameters]:
+        """Produce a printed query and any necessary ClickHouse query parameters."""
+        hogql_query = self.get_hogql_query(data_interval_start, data_interval_end)
+        context = await self.get_hogql_context(self.team_id)
+
+        prepared_hogql_query = await database_sync_to_async(prepare_ast_for_printing)(
+            hogql_query, context=context, dialect="clickhouse", stack=[]
+        )
+        printed = print_prepared_ast(
+            prepared_hogql_query,
+            context=context,
+            dialect="clickhouse",
+            stack=[],
+        )
+        insert_query = f"""
+INSERT INTO FUNCTION
+   s3(
+       '{s3_folder}/export_{{{{_partition_id}}}}.arrow',
+       '{s3_key}',
+       '{s3_secret}',
+       'ArrowStream'
+    )
+    PARTITION BY rand() %% {num_partitions}
+{printed}
+"""
+
+        return insert_query, context.values
+
+
+def resolve_batch_exports_model(
+    team_id: int,
+    batch_export_model: BatchExportModel | None = None,
+    batch_export_schema: BatchExportSchema | None = None,
+):
+    """Resolve which model and model parameters to use for a batch export.
+
+    This function exists to isolate a lot of repetitive checks that deal with deprecated
+    and new parameters. Eventually, once everything is a `RecordBatchModel`, this could
+    be removed.
+    """
+    model: BatchExportModel | BatchExportSchema | None = None
+    record_batch_model = None
+    if batch_export_schema is None:
+        model = batch_export_model
+        if model is not None:
+            model_name = model.name
+            extra_query_parameters = model.schema["values"] if model.schema is not None else None
+            fields = model.schema["fields"] if model.schema is not None else None
+            filters = model.filters
+
+            if model_name == "sessions":
+                record_batch_model = SessionsRecordBatchModel(team_id)
+        else:
+            model_name = "events"
+            extra_query_parameters = None
+            fields = None
+            filters = None
+    else:
+        model = batch_export_schema
+        model_name = "custom"
+        extra_query_parameters = model["values"] if model is not None else {}
+        fields = model["fields"] if model is not None else None
+        filters = None
+
+    return model, record_batch_model, model_name, fields, filters, extra_query_parameters

--- a/products/batch_exports/backend/temporal/spmc.py
+++ b/products/batch_exports/backend/temporal/spmc.py
@@ -13,8 +13,6 @@ from django.conf import settings
 
 from posthog.batch_exports.service import (
     BackfillDetails,
-    BatchExportModel,
-    BatchExportSchema,
 )
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import create_hogql_database
@@ -28,7 +26,6 @@ from posthog.sync import database_sync_to_async
 from posthog.temporal.common.clickhouse import get_client
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_external_logger, get_logger
-from products.batch_exports.backend.temporal import sql
 from products.batch_exports.backend.temporal.heartbeat import (
     BatchExportRangeHeartbeatDetails,
     DateRange,
@@ -37,6 +34,7 @@ from products.batch_exports.backend.temporal.metrics import (
     get_bytes_exported_metric,
     get_rows_exported_metric,
 )
+from products.batch_exports.backend.temporal.record_batch_model import RecordBatchModel
 from products.batch_exports.backend.temporal.sql import (
     SELECT_FROM_DISTRIBUTED_EVENTS_RECENT,
     SELECT_FROM_EVENTS_VIEW,
@@ -491,203 +489,6 @@ async def run_consumer(
     consumer.complete_heartbeat()
 
     return records_completed
-
-
-Query = str
-QueryParameters = dict[str, typing.Any]
-BatchExportDateRange = tuple[dt.datetime | None, dt.datetime]
-
-
-class RecordBatchModel(abc.ABC):
-    """Base class for models that can be produced as record batches."""
-
-    def __init__(self, team_id: int):
-        self.team_id = team_id
-
-    async def get_hogql_context(self, team_id: int) -> HogQLContext:
-        """Return a HogQLContext to generate a ClickHouse query."""
-        team = await Team.objects.aget(id=team_id)
-        context = HogQLContext(
-            team=team,
-            team_id=team.id,
-            enable_select_queries=True,
-            limit_top_select=False,
-        )
-        context.database = await database_sync_to_async(create_hogql_database)(team=team, modifiers=context.modifiers)
-
-        return context
-
-    @abc.abstractmethod
-    async def as_query_with_parameters(
-        self, data_interval_start: dt.datetime | None, data_interval_end: dt.datetime
-    ) -> tuple[Query, QueryParameters]:
-        """Produce a printed query and any necessary ClickHouse query parameters."""
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    async def as_insert_into_s3_query_with_parameters(
-        self,
-        data_interval_start: dt.datetime | None,
-        data_interval_end: dt.datetime,
-        s3_folder: str,
-        s3_key: str,
-        s3_secret: str,
-        num_partitions: int,
-    ) -> tuple[Query, QueryParameters]:
-        """Produce a printed query and any necessary ClickHouse query parameters."""
-        raise NotImplementedError
-
-
-class SessionsRecordBatchModel(RecordBatchModel):
-    """A model to produce record batches from the sessions table.
-
-    Attributes:
-       team_id: The ID of the team we are producing records for.
-    """
-
-    def __init__(self, team_id: int):
-        super().__init__(team_id)
-
-    def get_hogql_query(
-        self, data_interval_start: dt.datetime | None, data_interval_end: dt.datetime
-    ) -> ast.SelectQuery:
-        """Return the HogQLQuery used for the sessions model."""
-        hogql_query = sql.SELECT_FROM_SESSIONS_HOGQL
-
-        where_and = ast.And(
-            exprs=[
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.Eq,
-                    left=ast.Field(chain=["sessions", "team_id"]),
-                    right=ast.Constant(value=self.team_id),
-                ),
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.Lt,
-                    left=ast.Field(chain=["_inserted_at"]),
-                    right=ast.Constant(value=data_interval_end),
-                ),
-                # include $end_timestamp because hogql uses this to add a where clause to the inner query
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.Lt,
-                    left=ast.Field(chain=["$end_timestamp"]),
-                    right=ast.Constant(value=data_interval_end),
-                ),
-            ]
-        )
-        if data_interval_start is not None:
-            where_and.exprs.extend(
-                [
-                    ast.CompareOperation(
-                        op=ast.CompareOperationOp.GtEq,
-                        left=ast.Field(chain=["_inserted_at"]),
-                        right=ast.Constant(value=data_interval_start),
-                    ),
-                    # include $end_timestamp because hogql uses this to add a where clause to the inner query
-                    ast.CompareOperation(
-                        op=ast.CompareOperationOp.GtEq,
-                        left=ast.Field(chain=["$end_timestamp"]),
-                        right=ast.Constant(value=data_interval_start),
-                    ),
-                ]
-            )
-
-        hogql_query.where = where_and
-
-        return hogql_query
-
-    async def as_query_with_parameters(
-        self, data_interval_start: dt.datetime | None, data_interval_end: dt.datetime
-    ) -> tuple[Query, QueryParameters]:
-        """Produce a printed query and any necessary ClickHouse query parameters."""
-        hogql_query = self.get_hogql_query(data_interval_start, data_interval_end)
-        context = await self.get_hogql_context(self.team_id)
-
-        prepared_hogql_query = await database_sync_to_async(prepare_ast_for_printing)(
-            hogql_query, context=context, dialect="clickhouse", stack=[]
-        )
-        assert prepared_hogql_query is not None
-        context.output_format = "ArrowStream"
-        printed = print_prepared_ast(
-            prepared_hogql_query,
-            context=context,
-            dialect="clickhouse",
-            stack=[],
-        )
-        return printed, context.values
-
-    async def as_insert_into_s3_query_with_parameters(
-        self,
-        data_interval_start: dt.datetime | None,
-        data_interval_end: dt.datetime,
-        s3_folder: str,
-        s3_key: str,
-        s3_secret: str,
-        num_partitions: int,
-    ) -> tuple[Query, QueryParameters]:
-        """Produce a printed query and any necessary ClickHouse query parameters."""
-        hogql_query = self.get_hogql_query(data_interval_start, data_interval_end)
-        context = await self.get_hogql_context(self.team_id)
-
-        prepared_hogql_query = await database_sync_to_async(prepare_ast_for_printing)(
-            hogql_query, context=context, dialect="clickhouse", stack=[]
-        )
-        printed = print_prepared_ast(
-            prepared_hogql_query,
-            context=context,
-            dialect="clickhouse",
-            stack=[],
-        )
-        insert_query = f"""
-INSERT INTO FUNCTION
-   s3(
-       '{s3_folder}/export_{{{{_partition_id}}}}.arrow',
-       '{s3_key}',
-       '{s3_secret}',
-       'ArrowStream'
-    )
-    PARTITION BY rand() %% {num_partitions}
-{printed}
-"""
-
-        return insert_query, context.values
-
-
-def resolve_batch_exports_model(
-    team_id: int,
-    batch_export_model: BatchExportModel | None = None,
-    batch_export_schema: BatchExportSchema | None = None,
-):
-    """Resolve which model and model parameters to use for a batch export.
-
-    This function exists to isolate a lot of repetitive checks that deal with deprecated
-    and new parameters. Eventually, once everything is a `RecordBatchModel`, this could
-    be removed.
-    """
-    model: BatchExportModel | BatchExportSchema | None = None
-    record_batch_model = None
-    if batch_export_schema is None:
-        model = batch_export_model
-        if model is not None:
-            model_name = model.name
-            extra_query_parameters = model.schema["values"] if model.schema is not None else None
-            fields = model.schema["fields"] if model.schema is not None else None
-            filters = model.filters
-
-            if model_name == "sessions":
-                record_batch_model = SessionsRecordBatchModel(team_id)
-        else:
-            model_name = "events"
-            extra_query_parameters = None
-            fields = None
-            filters = None
-    else:
-        model = batch_export_schema
-        model_name = "custom"
-        extra_query_parameters = model["values"] if model is not None else {}
-        fields = model["fields"] if model is not None else None
-        filters = None
-
-    return model, record_batch_model, model_name, fields, filters, extra_query_parameters
 
 
 class BatchExportField(typing.TypedDict):

--- a/products/batch_exports/backend/tests/temporal/destinations/test_bigquery_batch_export_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/test_bigquery_batch_export_workflow.py
@@ -50,11 +50,11 @@ from products.batch_exports.backend.temporal.destinations.bigquery_batch_export 
     get_bigquery_fields_from_record_schema,
     insert_into_bigquery_activity,
 )
+from products.batch_exports.backend.temporal.record_batch_model import SessionsRecordBatchModel
 from products.batch_exports.backend.temporal.spmc import (
     Producer,
     RecordBatchQueue,
     RecordBatchTaskError,
-    SessionsRecordBatchModel,
 )
 from products.batch_exports.backend.tests.temporal.utils import (
     FlakyClickHouseClient,

--- a/products/batch_exports/backend/tests/temporal/destinations/test_postgres_batch_export_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/test_postgres_batch_export_workflow.py
@@ -51,11 +51,11 @@ from products.batch_exports.backend.temporal.destinations.postgres_batch_export 
     postgres_default_fields,
     remove_invalid_json,
 )
+from products.batch_exports.backend.temporal.record_batch_model import SessionsRecordBatchModel
 from products.batch_exports.backend.temporal.spmc import (
     Producer,
     RecordBatchQueue,
     RecordBatchTaskError,
-    SessionsRecordBatchModel,
 )
 from products.batch_exports.backend.tests.temporal.utils import (
     FlakyClickHouseClient,

--- a/products/batch_exports/backend/tests/temporal/destinations/test_redshift_batch_export_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/test_redshift_batch_export_workflow.py
@@ -50,11 +50,11 @@ from products.batch_exports.backend.temporal.destinations.redshift_batch_export 
     insert_into_redshift_activity,
     redshift_default_fields,
 )
+from products.batch_exports.backend.temporal.record_batch_model import SessionsRecordBatchModel
 from products.batch_exports.backend.temporal.spmc import (
     Producer,
     RecordBatchQueue,
     RecordBatchTaskError,
-    SessionsRecordBatchModel,
 )
 from products.batch_exports.backend.temporal.temporary_file import (
     remove_escaped_whitespace_recursive,

--- a/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
@@ -516,9 +516,6 @@ class TestInsertIntoS3Activity:
         ):
             pytest.skip(f"Unnecessary test case as {model.name} batch export is not affected by 'exclude_events'")
 
-        if use_internal_s3_stage and isinstance(model, BatchExportModel) and model.name == "sessions":
-            pytest.skip("Sessions batch export is not supported with internal S3 stage at this time")
-
         if compression and compression not in SUPPORTED_COMPRESSIONS[file_format]:
             pytest.skip(f"Compression {compression} is not supported for file format {file_format}")
 
@@ -1243,9 +1240,6 @@ async def test_s3_export_workflow_with_s3_bucket_with_various_intervals_and_mode
     """
     if isinstance(model, BatchExportModel) and model.name == "persons" and exclude_events is not None:
         pytest.skip("Unnecessary test case as person batch export is not affected by 'exclude_events'")
-
-    if use_internal_s3_stage and isinstance(model, BatchExportModel) and model.name == "sessions":
-        pytest.skip("Sessions batch export is not supported with internal S3 stage at this time")
 
     destination_config = s3_batch_export.destination.config | {
         "endpoint_url": None,

--- a/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
@@ -69,10 +69,10 @@ from products.batch_exports.backend.temporal.pipeline.internal_stage import (
     BatchExportInsertIntoInternalStageInputs,
     insert_into_internal_stage_activity,
 )
+from products.batch_exports.backend.temporal.record_batch_model import SessionsRecordBatchModel
 from products.batch_exports.backend.temporal.spmc import (
     Producer,
     RecordBatchQueue,
-    SessionsRecordBatchModel,
 )
 from products.batch_exports.backend.temporal.temporary_file import (
     UnsupportedFileFormatError,

--- a/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
@@ -2447,9 +2447,6 @@ async def test_insert_into_s3_activity_executes_the_expected_query_for_events_mo
 @pytest.mark.parametrize(
     "team_id,batch_export_model,team_ids_in_settings,rollout_percentage,expected",
     [
-        # Sessions model should always return False (for now, until we support it)
-        (1, BatchExportModel(name="sessions", schema=None), [], 0, False),
-        (1, BatchExportModel(name="sessions", schema=None), ["1"], 50, False),
         # Team ID in settings should return True (regardless of rollout percentage)
         (1, BatchExportModel(name="events", schema=None), ["1"], 0, True),
         (5, BatchExportModel(name="events", schema=None), ["5"], 50, True),
@@ -2469,7 +2466,7 @@ async def test_insert_into_s3_activity_executes_the_expected_query_for_events_mo
         (1, None, [], 0, False),
         (1, None, ["1"], 0, True),
         (1, None, [], 50, True),
-        # Different model names (not sessions)
+        # Different model names
         (1, BatchExportModel(name="persons", schema=None), [], 50, True),
         (1, BatchExportModel(name="custom_model", schema=None), [], 50, True),
     ],
@@ -2477,9 +2474,7 @@ async def test_insert_into_s3_activity_executes_the_expected_query_for_events_mo
 def test_use_internal_stage(team_id, batch_export_model, team_ids_in_settings, rollout_percentage, expected):
     """Test the _use_internal_stage function with various inputs.
 
-    The function should return True if:
-    1. The batch export model is NOT "sessions" AND
-    2. Either:
+    The function should return True if either:
        - The team_id is in BATCH_EXPORT_USE_INTERNAL_S3_STAGE_TEAM_IDS, OR
        - team_id % 100 < BATCH_EXPORT_S3_USE_INTERNAL_STAGE_ROLLOUT_PERCENTAGE
 

--- a/products/batch_exports/backend/tests/temporal/destinations/test_snowflake_batch_export_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/test_snowflake_batch_export_workflow.py
@@ -59,11 +59,11 @@ from products.batch_exports.backend.temporal.destinations.snowflake_batch_export
     load_private_key,
     snowflake_default_fields,
 )
+from products.batch_exports.backend.temporal.record_batch_model import SessionsRecordBatchModel
 from products.batch_exports.backend.temporal.spmc import (
     Producer,
     RecordBatchQueue,
     RecordBatchTaskError,
-    SessionsRecordBatchModel,
 )
 from products.batch_exports.backend.tests.temporal.utils import (
     FlakyClickHouseClient,

--- a/products/batch_exports/backend/tests/temporal/test_record_batch_model.py
+++ b/products/batch_exports/backend/tests/temporal/test_record_batch_model.py
@@ -1,0 +1,83 @@
+import pytest
+
+from posthog.hogql.hogql import ast
+from products.batch_exports.backend.temporal.record_batch_model import (
+    SessionsRecordBatchModel,
+)
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
+
+
+class TestSessionsRecordBatchModel:
+    async def test_get_hogql_query(self, ateam, data_interval_start, data_interval_end):
+        model = SessionsRecordBatchModel(
+            team_id=ateam.id,
+        )
+        hogql_query = model.get_hogql_query(data_interval_start, data_interval_end)
+        team_id_filter = ast.CompareOperation(
+            op=ast.CompareOperationOp.Eq,
+            left=ast.Field(chain=["sessions", "team_id"]),
+            right=ast.Constant(value=ateam.id),
+        )
+
+        assert hogql_query.where is not None
+        assert isinstance(hogql_query.where, ast.And)
+        assert team_id_filter in hogql_query.where.exprs
+
+    async def test_as_query_with_parameters(self, ateam, data_interval_start, data_interval_end):
+        model = SessionsRecordBatchModel(
+            team_id=ateam.id,
+        )
+        printed_query, _ = await model.as_query_with_parameters(data_interval_start, data_interval_end)
+
+        assert f"equals(raw_sessions.team_id, {ateam.id})" in printed_query
+        assert "FORMAT ArrowStream" in printed_query
+        assert (
+            f"greaterOrEquals(_inserted_at, toDateTime64('{data_interval_start:%Y-%m-%d %H:%M:%S.%f}', 6, 'UTC')"
+            in printed_query
+        )
+        assert f"less(_inserted_at, toDateTime64('{data_interval_end:%Y-%m-%d %H:%M:%S.%f}', 6, 'UTC')" in printed_query
+
+        # check that we have a date range set on the inner query using the session ID
+        assert (
+            "lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus("
+            in printed_query
+        )
+        assert (
+            "greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus("
+            in printed_query
+        )
+
+    async def test_as_insert_into_s3_query_with_parameters(self, ateam, data_interval_start, data_interval_end):
+        model = SessionsRecordBatchModel(
+            team_id=ateam.id,
+        )
+        printed_query, _ = await model.as_insert_into_s3_query_with_parameters(
+            data_interval_start=data_interval_start,
+            data_interval_end=data_interval_end,
+            s3_folder="https://test-bucket.s3.amazonaws.com/test-prefix",
+            s3_key="test-key",
+            s3_secret="test-secret",
+            num_partitions=5,
+        )
+
+        assert "INSERT INTO FUNCTION" in printed_query
+        # parition_id is a ClickHouse variable, so we need to escape it
+        assert "https://test-bucket.s3.amazonaws.com/test-prefix/export_{{_partition_id}}.arrow" in printed_query
+        assert "PARTITION BY rand() %% 5" in printed_query
+        assert f"equals(raw_sessions.team_id, {ateam.id})" in printed_query
+        assert (
+            f"greaterOrEquals(_inserted_at, toDateTime64('{data_interval_start:%Y-%m-%d %H:%M:%S.%f}', 6, 'UTC')"
+            in printed_query
+        )
+        assert f"less(_inserted_at, toDateTime64('{data_interval_end:%Y-%m-%d %H:%M:%S.%f}', 6, 'UTC')" in printed_query
+
+        # check that we have a date range set on the inner query using the session ID
+        assert (
+            "lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus("
+            in printed_query
+        )
+        assert (
+            "greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus("
+            in printed_query
+        )


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

For S3 batch exports we're still using the old workflow for the sessions model.

## Changes

- Use the new stage workflow for sessions model for S3 batch exports
- Fix local tests by ensuring we always run transformer code in separate processes using `fork` start method
- Move batch export models into a new `products/batch_exports/backend/temporal/record_batch_model.py` module
  - The only new code in this module is the `as_insert_into_s3_query_with_parameters` method
    - Here we wrap the HogQL query in a `INSERT INTO FUNCTION` statement; I'm not confident enough working with HogQL to know if there's a better way to do this or not, but seems HogQL only supports `SELECT` statements?  

## TODO in follow up PRs

- Clean up the old workflow code
- Support `log_comment`

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Existing tests

Also ran a sessions batch export locally
