### PR TITLE
chore(web-analytics): adjust cron and dag timeout settings

### DIFF
--- a/dags/web_preaggregated_daily.py
+++ b/dags/web_preaggregated_daily.py
@@ -8,6 +8,7 @@ import structlog
 import chdb
 from dags.common import JobOwners, dagster_tags
 from dags.web_preaggregated_utils import (
+    HISTORICAL_DAILY_CRON_SCHEDULE,
     TEAM_IDS_WITH_WEB_PREAGGREGATED_ENABLED,
     CLICKHOUSE_SETTINGS,
     merge_clickhouse_settings,
@@ -323,7 +324,7 @@ web_pre_aggregate_daily_job = dagster.define_asset_job(
 
 
 @dagster.schedule(
-    cron_schedule="0 1 * * *",
+    cron_schedule=HISTORICAL_DAILY_CRON_SCHEDULE,
     job=web_pre_aggregate_daily_job,
     execution_timezone="UTC",
     tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},

--- a/dags/web_preaggregated_hourly.py
+++ b/dags/web_preaggregated_hourly.py
@@ -5,6 +5,7 @@ import dagster
 from dagster import Field
 from dags.common import JobOwners, dagster_tags
 from dags.web_preaggregated_utils import (
+    INTRA_DAY_HOURLY_CRON_SCHEDULE,
     TEAM_IDS_WITH_WEB_PREAGGREGATED_ENABLED,
     CLICKHOUSE_SETTINGS_HOURLY,
     merge_clickhouse_settings,
@@ -142,7 +143,7 @@ web_pre_aggregate_current_day_hourly_job = dagster.define_asset_job(
 
 
 @dagster.schedule(
-    cron_schedule="*/10 * * * *",
+    cron_schedule=INTRA_DAY_HOURLY_CRON_SCHEDULE,
     job=web_pre_aggregate_current_day_hourly_job,
     execution_timezone="UTC",
     tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},

--- a/dags/web_preaggregated_utils.py
+++ b/dags/web_preaggregated_utils.py
@@ -7,6 +7,12 @@ from dagster import Backoff, Field, Array, Jitter, RetryPolicy
 TEAM_IDS_WITH_WEB_PREAGGREGATED_ENABLED = [1, 2, 55348, 47074, 12669, 1589, 117126]
 TEAM_ID_FOR_WEB_ANALYTICS_ASSET_CHECKS = os.getenv("TEAM_ID_FOR_WEB_ANALYTICS_ASSET_CHECKS", 1 if DEBUG else 2)
 
+INTRA_DAY_HOURLY_CRON_SCHEDULE = os.getenv("WEB_PREAGGREGATED_INTRA_DAY_HOURLY_CRON_SCHEDULE", "*/10 * * * *")
+HISTORICAL_DAILY_CRON_SCHEDULE = os.getenv("WEB_PREAGGREGATED_HISTORICAL_DAILY_CRON_SCHEDULE", "0 1 * * *")
+
+DAILY_MAX_EXECUTION_TIME = os.getenv("WEB_PREAGGREGATED_DAILY_MAX_EXECUTION_TIME", "1600")
+INTRA_DAY_HOURLY_MAX_EXECUTION_TIME = os.getenv("WEB_PREAGGREGATED_INTRA_DAY_HOURLY_MAX_EXECUTION_TIME", "900")
+
 web_analytics_retry_policy_def = RetryPolicy(
     max_retries=3,
     delay=60,
@@ -16,17 +22,17 @@ web_analytics_retry_policy_def = RetryPolicy(
 
 # Shared ClickHouse settings for web analytics pre-aggregation
 CLICKHOUSE_SETTINGS = {
-    "max_execution_time": "1600",
+    "max_execution_time": DAILY_MAX_EXECUTION_TIME,
     "max_bytes_before_external_group_by": "51474836480",
     "max_memory_usage": "107374182400",
     "distributed_aggregation_memory_efficient": "1",
     "s3_truncate_on_insert": "1",
 }
 
-# Lighter settings for hourly processing (more frequent, smaller time windows)
 CLICKHOUSE_SETTINGS_HOURLY = {
-    "max_execution_time": "300",
-    "max_bytes_before_external_group_by": "21474836480",
+    "max_execution_time": INTRA_DAY_HOURLY_MAX_EXECUTION_TIME,
+    "max_bytes_before_external_group_by": "51474836480",
+    "max_memory_usage": "107374182400",
     "distributed_aggregation_memory_efficient": "1",
 }
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We're facing some timeouts, and the values are likely different per environment (e.g, EU can/should have a longer wait between runs). I will change this and follow up with a Charts PR to configure them more effectively.

## Changes

- Increased resources for intra-day queries, they're doing the same as the daily jobs now, so it is only fair that they have the same resources.
- Changed some settings so they can be changed using env vars.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Locally
