### PR TITLE
feat(experiments): experiment's activity log (page & sidebar)

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1637,7 +1637,10 @@ const api = {
             const scopes = Array.isArray(props.scope) ? [...props.scope] : [props.scope]
 
             // Opt into the new /activity_log API
-            if ([ActivityScope.PLUGIN, ActivityScope.HOG_FUNCTION].includes(scopes[0]) || scopes.length > 1) {
+            if (
+                [ActivityScope.PLUGIN, ActivityScope.HOG_FUNCTION, ActivityScope.EXPERIMENT].includes(scopes[0]) ||
+                scopes.length > 1
+            ) {
                 return api.activity
                     .listRequest({
                         scopes,

--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
@@ -15,6 +15,7 @@ import { PaginationManual } from 'lib/lemon-ui/PaginationControl'
 import { cohortActivityDescriber } from 'scenes/cohorts/activityDescriptions'
 import { dataManagementActivityDescriber } from 'scenes/data-management/dataManagementDescribers'
 import { dataWarehouseSavedQueryActivityDescriber } from 'scenes/data-warehouse/saved_queries/activityDescriptions'
+import { experimentActivityDescriber } from 'scenes/experiments/experimentActivityDescriber'
 import { flagActivityDescriber } from 'scenes/feature-flags/activityDescriptions'
 import { groupActivityDescriber } from 'scenes/groups/activityDescriptions'
 import { hogFunctionActivityDescriber } from 'scenes/hog-functions/misc/activityDescriptions'
@@ -22,9 +23,9 @@ import { notebookActivityDescriber } from 'scenes/notebooks/Notebook/notebookAct
 import { personActivityDescriber } from 'scenes/persons/activityDescriptions'
 import { pluginActivityDescriber } from 'scenes/pipeline/pipelinePluginActivityDescriptions'
 import { insightActivityDescriber } from 'scenes/saved-insights/activityDescriptions'
+import { replayActivityDescriber } from 'scenes/session-recordings/activityDescription'
 import { surveyActivityDescriber } from 'scenes/surveys/surveyActivityDescriber'
 import { teamActivityDescriber } from 'scenes/team-activity/teamActivityDescriber'
-import { replayActivityDescriber } from 'scenes/session-recordings/activityDescription'
 import { urls } from 'scenes/urls'
 
 import { ActivityScope, PipelineNodeTab, PipelineStage, PipelineTab } from '~/types'
@@ -68,6 +69,8 @@ export const describerFor = (logItem?: ActivityLogItem): Describer | undefined =
             return dataWarehouseSavedQueryActivityDescriber
         case ActivityScope.REPLAY:
             return replayActivityDescriber
+        case ActivityScope.EXPERIMENT:
+            return experimentActivityDescriber
         default:
             return (logActivity, asNotification) => defaultDescriber(logActivity, asNotification)
     }

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -1,9 +1,10 @@
 import { LemonTabs } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
+import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { WebExperimentImplementationDetails } from 'scenes/experiments/WebExperimentImplementationDetails'
 
 import type { CachedExperimentQueryResponse } from '~/queries/schema/schema-general'
-
+import { ActivityScope } from '~/types'
 import { AISummary } from '../components/AISummary'
 import {
     ExploreAsInsightButton,
@@ -196,6 +197,11 @@ export function ExperimentView(): JSX.Element {
                                     key: 'variants',
                                     label: 'Variants',
                                     content: <VariantsTab />,
+                                },
+                                {
+                                    key: 'history',
+                                    label: 'History',
+                                    content: <ActivityLog scope={ActivityScope.EXPERIMENT} id={experimentId} />,
                                 },
                             ]}
                         />

--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -1,6 +1,7 @@
 import { LemonDialog, LemonInput, LemonSelect, LemonTag, Tooltip } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
+import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { ExperimentsHog } from 'lib/components/hedgehogs'
 import { MemberSelect } from 'lib/components/MemberSelect'
 import { PageHeader } from 'lib/components/PageHeader'
@@ -21,7 +22,7 @@ import stringWithWBR from 'lib/utils/stringWithWBR'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
-import { Experiment, ExperimentsTabs, ProductKey, ProgressStatus } from '~/types'
+import { ActivityScope, Experiment, ExperimentsTabs, ProductKey, ProgressStatus } from '~/types'
 
 import { EXPERIMENTS_PER_PAGE, experimentsLogic, getExperimentStatus } from './experimentsLogic'
 import { StatusTag } from './ExperimentView/components'
@@ -257,6 +258,7 @@ export function Experiments(): JSX.Element {
                     { key: ExperimentsTabs.Archived, label: 'Archived experiments' },
                     { key: ExperimentsTabs.Holdouts, label: 'Holdout groups' },
                     { key: ExperimentsTabs.SharedMetrics, label: 'Shared metrics' },
+                    { key: ExperimentsTabs.History, label: 'History' },
                 ]}
             />
 
@@ -264,6 +266,8 @@ export function Experiments(): JSX.Element {
                 <Holdouts />
             ) : tab === ExperimentsTabs.SharedMetrics ? (
                 <SharedMetrics />
+            ) : tab === ExperimentsTabs.History ? (
+                <ActivityLog scope={ActivityScope.EXPERIMENT} />
             ) : (
                 <>
                     {tab === ExperimentsTabs.Archived ? (

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
@@ -1,0 +1,194 @@
+import { ActivityLogItem, HumanizedChange, userNameForLogItem } from 'lib/components/ActivityLog/humanizeActivity'
+import { SentenceList } from 'lib/components/ActivityLog/SentenceList'
+import { LemonCard } from 'lib/lemon-ui/LemonCard'
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { Link } from 'lib/lemon-ui/Link'
+import { urls } from 'scenes/urls'
+import { match } from 'ts-pattern'
+import { ProgressStatus } from '~/types'
+import { getExperimentStatusColor } from './experimentsLogic'
+
+function nameOrLinkToExperiment(id: string | undefined, name: string | null): JSX.Element | string {
+    if (id) {
+        return <Link to={urls.experiment(id)}>{name}</Link>
+    }
+    return name || '(unknown)'
+}
+
+const StatusTag = ({
+    status,
+}: {
+    status: ProgressStatus.Draft | ProgressStatus.Running | ProgressStatus.Complete
+}): JSX.Element => {
+    return (
+        <LemonTag type={getExperimentStatusColor(status)}>
+            <b className="uppercase">{status}</b>
+        </LemonTag>
+    )
+}
+
+//exporting so the linter doesn't complain about this not being used
+export const ExperimentDetails = ({
+    logItem,
+    status,
+}: {
+    logItem: ActivityLogItem
+    status: ProgressStatus
+}): JSX.Element => {
+    return (
+        <LemonCard className="flex items-center justify-between gap-3 p-4">
+            <div className="flex flex-col gap-1">
+                <strong className="text-sm font-semibold">
+                    {nameOrLinkToExperiment(logItem?.item_id, logItem?.detail.name)}
+                </strong>
+                <span className="text-xs text-muted">Experiment</span>
+            </div>
+            <StatusTag status={status} />
+        </LemonCard>
+    )
+}
+
+const UnknownAction = ({ logItem }: { logItem: ActivityLogItem }): JSX.Element => {
+    return (
+        <SentenceList
+            prefix={<strong>{userNameForLogItem(logItem)}</strong>}
+            listParts={['performed an unknown action on']}
+            suffix={nameOrLinkToExperiment(logItem.item_id, logItem.detail.name)}
+        />
+    )
+}
+
+export const experimentActivityDescriber = (logItem: ActivityLogItem): HumanizedChange => {
+    return match(logItem.activity)
+        .with('created', () => {
+            /**
+             * created experiments always have the draft status.
+             */
+            return {
+                description: (
+                    <SentenceList
+                        prefix={<strong>{userNameForLogItem(logItem)}</strong>}
+                        listParts={[
+                            <span>
+                                created a new <StatusTag status={ProgressStatus.Draft} /> experiment:
+                            </span>,
+                        ]}
+                        suffix={nameOrLinkToExperiment(logItem?.item_id, logItem?.detail.name)}
+                    />
+                ),
+            }
+        })
+        .with('updated', () => {
+            /**
+             * the experiment UI only allows for atomic updates of a single property at a time.
+             */
+            const changes = logItem.detail?.changes || []
+
+            /**
+             * if there are no changes, we don't need to describe the update.
+             */
+            if (changes.length === 0) {
+                return {
+                    description: (
+                        <SentenceList
+                            prefix={<strong>{userNameForLogItem(logItem)}</strong>}
+                            listParts={['updated']}
+                            suffix={nameOrLinkToExperiment(logItem?.item_id, logItem?.detail.name)}
+                        />
+                    ),
+                }
+            }
+
+            /**
+             * this needs to be refactored to handle multiple changes, for example,
+             * when an experiment stops and we set a conclusion.
+             */
+            const change = changes[0]
+
+            /**
+             * if a start date is created, the experiment has been launched.
+             */
+            if (
+                change.action === 'created' &&
+                change.field === 'start_date' &&
+                change.before === null &&
+                change.after !== null
+            ) {
+                return {
+                    description: (
+                        <SentenceList
+                            prefix={<strong>{userNameForLogItem(logItem)}</strong>}
+                            listParts={['launched']}
+                            suffix={nameOrLinkToExperiment(logItem?.item_id, logItem?.detail.name)}
+                        />
+                    ),
+                }
+            }
+
+            /**
+             * if an end date is created, the experiment has been completed.
+             */
+            if (
+                change.action == 'created' &&
+                change.field === 'end_date' &&
+                change.before === null &&
+                change.after !== null
+            ) {
+                return {
+                    description: (
+                        <SentenceList
+                            prefix={<strong>{userNameForLogItem(logItem)}</strong>}
+                            listParts={['stopped']}
+                            suffix={nameOrLinkToExperiment(logItem?.item_id, logItem?.detail.name)}
+                        />
+                    ),
+                }
+            }
+
+            /**
+             * if a metric is created, the user has added the first metric to the experiment.
+             */
+            if (
+                change.action === 'created' &&
+                change.field === 'metrics' &&
+                change.before === null &&
+                change.after !== null
+            ) {
+                return {
+                    description: (
+                        <SentenceList
+                            prefix={<strong>{userNameForLogItem(logItem)}</strong>}
+                            listParts={['added the first metric to']}
+                            suffix={nameOrLinkToExperiment(logItem?.item_id, logItem?.detail.name)}
+                        />
+                    ),
+                }
+            }
+
+            /**
+             * TODO: return null for now, until we cover all existing uses.
+             */
+            return {
+                description: null,
+            }
+        })
+        .with('deleted', () => {
+            /**
+             * today we do soft deletes, so we keep this for future proofing
+             */
+            return {
+                description: (
+                    <SentenceList
+                        listParts={['deleted experiment']}
+                        prefix={<strong>{userNameForLogItem(logItem)}</strong>}
+                        suffix={logItem?.detail.name}
+                    />
+                ),
+            }
+        })
+        .otherwise(() => {
+            return {
+                description: <UnknownAction logItem={logItem} />,
+            }
+        })
+}

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
@@ -118,7 +118,7 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
                     description: (
                         <SentenceList
                             prefix={<strong>{userNameForLogItem(logItem)}</strong>}
-                            listParts={['launched']}
+                            listParts={['launched experiment']}
                             suffix={nameOrLinkToExperiment(logItem?.item_id, logItem?.detail.name)}
                         />
                     ),
@@ -138,7 +138,7 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
                     description: (
                         <SentenceList
                             prefix={<strong>{userNameForLogItem(logItem)}</strong>}
-                            listParts={['stopped']}
+                            listParts={['stopped experiment']}
                             suffix={nameOrLinkToExperiment(logItem?.item_id, logItem?.detail.name)}
                         />
                     ),
@@ -159,6 +159,21 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
                         <SentenceList
                             prefix={<strong>{userNameForLogItem(logItem)}</strong>}
                             listParts={['added the first metric to']}
+                            suffix={nameOrLinkToExperiment(logItem?.item_id, logItem?.detail.name)}
+                        />
+                    ),
+                }
+            }
+
+            /**
+             * soft deletes
+             */
+            if (change.action === 'changed' && change.field === 'deleted' && !change.before && change.after) {
+                return {
+                    description: (
+                        <SentenceList
+                            prefix={<strong>{userNameForLogItem(logItem)}</strong>}
+                            listParts={['deleted experiment']}
                             suffix={nameOrLinkToExperiment(logItem?.item_id, logItem?.detail.name)}
                         />
                     ),

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
@@ -15,6 +15,9 @@ function nameOrLinkToExperiment(id: string | undefined, name: string | null): JS
     return name || '(unknown)'
 }
 
+/**
+ * TODO: refactor the experiment view component to take a status prop so we can remove this component
+ */
 const StatusTag = ({
     status,
 }: {

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
@@ -129,7 +129,7 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
              * if an end date is created, the experiment has been completed.
              */
             if (
-                change.action == 'created' &&
+                change.action === 'created' &&
                 change.field === 'end_date' &&
                 change.before === null &&
                 change.after !== null

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -816,6 +816,7 @@ export enum ExperimentsTabs {
     Archived = 'archived',
     Holdouts = 'holdouts',
     SharedMetrics = 'shared-metrics',
+    History = 'history',
 }
 
 export enum ActivityTab {


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

> [!NOTE]
> Follow-up of #35027 

## Problem

We weren't showing any activity logs for experiments.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

> [!WARNING]
> This is just the first version and covers a limited number of activities.

We are adding a describer to cover the status changes and the creation of the first metric. This still needs work to cover other changes to experiments, shared metrics, and holdouts, and only supports a single change. This will all be addressed in future PRs that'll expand the feature coverage. But for now, this has decent defaults.

To support a _History_ tag using the `ActivityLog` component, we are adding the `Experiment` model to the opt in list of models using the new mixin and `/activity_log` endpoint.

| Experiment Activity Log Sidebar | Experiments List | Experiment Page |
| - | - | - |
|  <img width="514" height="563" alt="image" src="https://github.com/user-attachments/assets/3314314c-edbf-40a3-855b-8dbf61e24d8c" /> | <img width="1600" height="1244" alt="image" src="https://github.com/user-attachments/assets/844e5380-e21f-4149-8c1d-6aa627b0d0bd" /> |  <img width="1600" height="1244" alt="image" src="https://github.com/user-attachments/assets/0be81d52-113f-4a52-a864-c4e33d73963c" /> |

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/1375ae4d-e78b-4996-bab9-8c8c75e96c30)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
