### PR TITLE
feat(max): Interrupt+re-assess on every MaxTool call application

### DIFF
--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -282,13 +282,13 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                                     await values.toolMap[toolName]?.callback(toolResult)
                                     // The `navigate` tool is the only one doing client-side formatting currently
                                     if (toolName === 'navigate') {
-                                        actions.askMax(null) // Continue generation
                                         parsedResponse.content = parsedResponse.content.replace(
                                             toolResult.page_key,
                                             breadcrumbsLogic.values.sceneBreadcrumbsDisplayString
                                         )
                                     }
                                 }
+                                actions.askMax(null) // Continue generation after applying tool
                                 actions.addMessage({
                                     ...parsedResponse,
                                     status: 'completed',


### PR DESCRIPTION
## Summary
This PR implements interrupt and re-assessment functionality on every MaxTool call application, improving the responsiveness and accuracy of the Max AI assistant.

## Changes
- Updated root nodes in `ee/hogai/graph/root/nodes.py` to support interrupt and re-assess logic
- Modified `frontend/src/scenes/max/maxThreadLogic.tsx` to handle interruption and re-assessment workflow

## Test plan
- [ ] Test MaxTool call interruption works correctly
- [ ] Verify re-assessment functionality after tool calls
- [ ] Test that the thread logic handles interrupts properly
- [ ] Ensure no regressions in existing Max functionality

🤖 Generated with [Claude Code](https://claude.ai/code)