### PR TITLE
feat(experiments): Enable property groups optimization for metric properties

### DIFF
--- a/posthog/hogql_queries/experiments/base_query_utils.py
+++ b/posthog/hogql_queries/experiments/base_query_utils.py
@@ -62,10 +62,8 @@ def get_metric_value(metric: ExperimentMeanMetric) -> ast.Expr:
             if isinstance(metric.source, ExperimentDataWarehouseNode):
                 return parse_expr(metric_property)
             else:
-                return parse_expr(
-                    "toFloat(JSONExtractRaw(properties, {property}))",
-                    placeholders={"property": ast.Constant(value=metric_property)},
-                )
+                # Use the same property access pattern as trends to get property groups optimization
+                return ast.Call(name="toFloat", args=[ast.Field(chain=["properties", metric_property])])
 
     elif metric.source.math == ExperimentMetricMathType.UNIQUE_SESSION:
         return ast.Field(chain=["$session_id"])

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_base.ambr
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_base.ambr
@@ -320,7 +320,7 @@
                events.`$group_0` AS entity_id,
                exposure_data.variant AS variant,
                events.event AS event,
-               accurateCastOrNull(JSONExtractRaw(events.properties, 'amount'), 'Float64') AS value
+               accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'amount'), ''), 'null'), '^"|"$', ''), 'Float64') AS value
         FROM events
         INNER JOIN
           (SELECT events.`$group_0` AS entity_id,

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_frequentist_method.ambr
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_frequentist_method.ambr
@@ -28,7 +28,7 @@
                if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
                exposure_data.variant AS variant,
                events.event AS event,
-               accurateCastOrNull(JSONExtractRaw(events.properties, 'amount'), 'Float64') AS value
+               accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'amount'), ''), 'null'), '^"|"$', ''), 'Float64') AS value
         FROM events
         LEFT OUTER JOIN
           (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_mean_metric.ambr
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_mean_metric.ambr
@@ -156,7 +156,7 @@
                   if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
                   exposure_data.variant AS variant,
                   events.event AS event,
-                  accurateCastOrNull(JSONExtractRaw(events.properties, 'amount'), 'Float64') AS value
+                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'amount'), ''), 'null'), '^"|"$', ''), 'Float64') AS value
            FROM events
            LEFT OUTER JOIN
              (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -208,7 +208,7 @@
                      if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
                      exposure_data.variant AS variant,
                      events.event AS event,
-                     accurateCastOrNull(JSONExtractRaw(events.properties, 'amount'), 'Float64') AS value
+                     accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'amount'), ''), 'null'), '^"|"$', ''), 'Float64') AS value
               FROM events
               LEFT OUTER JOIN
                 (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -276,7 +276,7 @@
                if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
                exposure_data.variant AS variant,
                events.event AS event,
-               accurateCastOrNull(JSONExtractRaw(events.properties, 'amount'), 'Float64') AS value
+               accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'amount'), ''), 'null'), '^"|"$', ''), 'Float64') AS value
         FROM events
         LEFT OUTER JOIN
           (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -344,7 +344,7 @@
                if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
                exposure_data.variant AS variant,
                events.event AS event,
-               accurateCastOrNull(JSONExtractRaw(events.properties, 'amount'), 'Float64') AS value
+               accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'amount'), ''), 'null'), '^"|"$', ''), 'Float64') AS value
         FROM events
         LEFT OUTER JOIN
           (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -412,7 +412,7 @@
                if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
                exposure_data.variant AS variant,
                events.event AS event,
-               accurateCastOrNull(JSONExtractRaw(events.properties, 'amount'), 'Float64') AS value
+               accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'amount'), ''), 'null'), '^"|"$', ''), 'Float64') AS value
         FROM events
         LEFT OUTER JOIN
           (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -480,7 +480,7 @@
                if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
                exposure_data.variant AS variant,
                events.event AS event,
-               accurateCastOrNull(JSONExtractRaw(events.properties, 'amount'), 'Float64') AS value
+               accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'amount'), ''), 'null'), '^"|"$', ''), 'Float64') AS value
         FROM events
         LEFT OUTER JOIN
           (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,


### PR DESCRIPTION
## Problem

* Numerical string values like `"5.32"` will currently be returned as 0 in the experiment query runner
* As we have a `parse_expr` like `toFloat(JSONExtractRaw(properties, {property}))`, we also don't hit the HogQL printer optimizations that swaps out property fields with materialized columns. Thus, we end up scanning a lot more data than required.

## Changes

Use ast.Field instead of JSONExtractRaw for property access in experiments
to enable automatic property groups optimization. This allows experiments
to benefit from the same performance optimizations as trends queries when
accessing event properties.

Previously, experiments used JSONExtractRaw which bypassed the property
groups system. Now, using ast.Field(chain=["properties", property_name])
allows the HogQL printer to detect property access and automatically use
optimized materialized columns like properties_group_custom when available.

## How did you test this code?
- existing tests passes
