### PR TITLE
fix(insights): adjust loading message toggle interval for better UX

### DIFF
--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -243,9 +243,10 @@ export function StatelessInsightLoadingState({
         }
     }, [pollResponse, showLoadingDetails])
 
-    // Toggle between loading messages every 3 seconds, with 300ms fade out, then change text, keep in sync with the transition duration below
+    // Toggle between loading messages every 2.5-3.5 seconds, with 300ms fade out, then change text, keep in sync with the transition duration below
     useEffect(() => {
-        const TOGGLE_INTERVAL = 3000
+        const TOGGLE_INTERVAL_MIN = 2500
+        const TOGGLE_INTERVAL_JITTER = 1000
         const FADE_OUT_DURATION = 300
 
         // Don't toggle loading messages in storybook, will make tests flaky if so
@@ -266,7 +267,7 @@ export function StatelessInsightLoadingState({
                 })
                 setIsLoadingMessageVisible(true)
             }, FADE_OUT_DURATION)
-        }, TOGGLE_INTERVAL)
+        }, TOGGLE_INTERVAL_MIN + Math.random() * TOGGLE_INTERVAL_JITTER)
 
         return () => clearInterval(interval)
     }, [])


### PR DESCRIPTION
Updated the loading message toggle interval to vary between 2.5 and 3.5 seconds, plus an additional jitter effect. This might make it less monotonous in screens like Revenue Analytics/Web Analytics where we have a lot of dashboards loading at the same time.


https://github.com/user-attachments/assets/445e41aa-bf7a-424c-8953-ea7e9f379f60

