### PR TITLE
fix(dashboard): Order of tiles in email subscriptions is different from the dashboard

### DIFF
--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -31,7 +31,7 @@ def generate_assets(
 ) -> tuple[list[Insight], list[ExportedAsset]]:
     with SUBSCRIPTION_ASSET_GENERATION_TIMER.time():
         if resource.dashboard:
-            tiles = get_tiles_ordered_by_position(resource.dashboard)
+            tiles = get_tiles_ordered_by_position(resource.dashboard, "sm")
             insights = [tile.insight for tile in tiles if tile.insight]
         elif resource.insight:
             insights = [resource.insight]

--- a/posthog/models/dashboard_tile.py
+++ b/posthog/models/dashboard_tile.py
@@ -144,5 +144,5 @@ def get_tiles_ordered_by_position(dashboard: Dashboard, size: str = "xs") -> lis
         .order_by("insight__order")
         .all()
     )
-    tiles.sort(key=lambda x: (x.layouts.get(size, {}).get("y", 100), x.layouts.get(size, {}).get("y", 100)))
+    tiles.sort(key=lambda x: (x.layouts.get(size, {}).get("y", 100), x.layouts.get(size, {}).get("x", 100)))
     return tiles

--- a/posthog/models/dashboard_tile.py
+++ b/posthog/models/dashboard_tile.py
@@ -144,5 +144,5 @@ def get_tiles_ordered_by_position(dashboard: Dashboard, size: str = "xs") -> lis
         .order_by("insight__order")
         .all()
     )
-    tiles.sort(key=lambda x: x.layouts.get(size, {}).get("y", 100))
+    tiles.sort(key=lambda x: (x.layouts.get(size, {}).get("y", 100), x.layouts.get(size, {}).get("y", 100)))
     return tiles


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Closes #35022

## Changes

The sorting order for dashboard and email is different.

For email: 

https://github.com/PostHog/posthog/blob/196ffa1871db707da43c5b5fe227b129094d2fcf/posthog/models/dashboard_tile.py#L141-L147

For dashboard:
https://github.com/PostHog/posthog/blob/196ffa1871db707da43c5b5fe227b129094d2fcf/posthog/api/dashboards/dashboard.py#L456-L462

I have updated the sorting for email to be the same as the dashboard.

I currently can't test this in local directly because I have not set up my email config yet.

## Did you write or update any docs for this change?
- [x] No docs needed for this change

## How did you test this code?

I tested locally by checking the order of the sorted tiles, but not by the actual email. So the testing for this PR is not comprehensive. 
