### PR TITLE
fix: remove links from docker ci

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -48,9 +48,6 @@ jobs:
                     - image: log-capture
                       dockerfile: ./rust/Dockerfile
                       project: c1bwj4j4qg
-                    - image: links
-                      dockerfile: ./rust/Dockerfile
-                      project: c1bwj4j4qg
         runs-on: depot-ubuntu-22.04
         permissions:
             id-token: write # allow issuing OIDC tokens for this workflow run
@@ -69,7 +66,6 @@ jobs:
             cymbal_digest: ${{ steps.digest.outputs.cymbal_digest }}
             feature-flags_digest: ${{ steps.digest.outputs.feature-flags_digest }}
             log-capture_digest: ${{ steps.digest.outputs.log-capture_digest }}
-            links_digest: ${{ steps.digest.outputs.links_digest }}
         defaults:
             run:
                 working-directory: rust
@@ -197,10 +193,6 @@ jobs:
                       values:
                           image:
                               sha: '${{ needs.build.outputs.log-capture_digest }}'
-                    - release: links
-                      values:
-                          image:
-                              sha: '${{ needs.build.outputs.links_digest }}'
         steps:
             - name: get deployer token
               id: deployer


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Links rust code was removed as part of this PR: https://github.com/PostHog/posthog/pull/34525

However, the docker builds CI is failing because we are still trying to build the links https://github.com/PostHog/posthog/actions/workflows/rust-docker-build.yml

https://posthog.slack.com/archives/C07Q2U4BH4L/p1752631232364509

## Changes

remove links from rust-docker-build.yml

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [x] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
