### PR TITLE
fix: Log connection error message on PostgreSQL batch export

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
@@ -184,7 +184,8 @@ class PostgreSQLClient:
         except psycopg.OperationalError as err:
             raise PostgreSQLConnectionError(
                 f"Failed to connect after {max_attempts} attempts due to an unrecoverable error. "
-                f"Please review connection configuration. Error message: {str(err)}"
+                "Please review connection configuration. "
+                f"Error message: {str(err)}"
             ) from err
 
         async with connection as connection:

--- a/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
@@ -120,7 +120,6 @@ class PostgreSQLClient:
         self.port = port
         self.has_self_signed_cert = has_self_signed_cert
         self.connection_timeout = connection_timeout
-        self.external_logger = EXTERNAL_LOGGER.bind()
 
         self._connection: None | psycopg.AsyncConnection = None
 

--- a/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
@@ -183,13 +183,9 @@ class PostgreSQLClient:
                 "TCP/IP connections?"
             ) from err
         except psycopg.OperationalError as err:
-            # Include the error message in the external logs for the user, as
-            # they won't see tracebacks in the UI.
-            self.external_logger.exception(
-                "An unrecoverable connection error has been detected: %s", str(err), exc_info=err
-            )
             raise PostgreSQLConnectionError(
-                f"Failed to connect after {max_attempts} attempts. Please review connection configuration."
+                f"Failed to connect after {max_attempts} attempts due to an unrecoverable error. "
+                f"Please review connection configuration. Error message: {str(err)}"
             ) from err
 
         async with connection as connection:


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We do not include PostgreSQL connection error messages when a connection fails. This leads to a poor debug experience for users.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Include the error message in the exception message. This will be caught by our usual logging systems and print the error message next to the generic connection error we already provide.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
