### PR TITLE
chore: add product tag to some of the session replay celery jobs

### DIFF
--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -115,6 +115,10 @@ class QueryTags(BaseModel):
     cohort_id: Optional[int] = None
     entity_math: Optional[list[str]] = None
 
+    # replays
+    replay_playlist_id: Optional[int] = None
+
+    # experiments
     experiment_feature_flag_key: Optional[str] = None
     experiment_id: Optional[int] = None
     experiment_name: Optional[str] = None

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -301,8 +301,7 @@ class CHQueries:
 
         with suppress(Exception):
             if request_id := structlog.get_context(self.logger).get("request_id"):
-                uuid.UUID(request_id)  # just to verify it is a real UUID
-                tag_queries(http_request_id=request_id)
+                tag_queries(http_request_id=uuid.UUID(request_id))
 
         tag_queries(
             user_id=user.pk,


### PR DESCRIPTION
Adds product query tag to some session replay queries, add replay_playlist_id to QueryTags
