### PR TITLE
feat: add git commit sha as tag, only if ECR registry is set

### DIFF
--- a/.github/actions/build-n-cache-image/action.yml
+++ b/.github/actions/build-n-cache-image/action.yml
@@ -81,8 +81,8 @@ runs:
           shell: bash
           run: |
               TAGS="posthog/posthog:${{ github.sha }}"
-              if [[ "${{ inputs.push-image }}" == "true" ]]; then
-                TAGS="$TAGS,${{ steps.aws-ecr.outputs.registry }}/posthog-cloud:pr-commit-${{ github.sha }}"
+              if [[ -n "${{ steps.aws-ecr.outputs.registry }}" ]]; then
+                TAGS="$TAGS,${{ steps.aws-ecr.outputs.registry }}/posthog-cloud:${{ github.sha }}"
               fi
               if [[ "${{ inputs.pr-number }}" != "" ]]; then
                 TAGS="$TAGS,${{ steps.aws-ecr.outputs.registry }}/posthog-cloud:pr-${{ inputs.pr-number }}"


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

we only use image digests in ECR, which makes it hard to track deployments and versions. 

## Changes

add git commit sha as tag to docker images, only if ECR is set as a target

### Did you write or update any docs for this change?

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
