### PR TITLE
fix: Add error message on postgresql connection failure

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
@@ -183,7 +183,9 @@ class PostgreSQLClient:
             ) from err
         except psycopg.OperationalError as err:
             raise PostgreSQLConnectionError(
-                f"Failed to connect after {max_attempts} attempts. Please review connection configuration."
+                f"Failed to connect after {max_attempts} attempts due to an unrecoverable error. "
+                "Please review connection configuration. "
+                f"Error message: {str(err)}"
             ) from err
 
         async with connection as connection:


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We do not include PostgreSQL connection error messages when a connection fails. This leads to a poor debug experience for users.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Include the error message in the exception message. This will be caught by our usual logging systems and print the error message next to the generic connection error we already provide.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
