### PR TITLE
refactor(dashboards): improve readability with comments and minor cleanups

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -97,7 +97,7 @@ export interface RefreshStatus {
 export enum DashboardLoadAction {
     /** Initial dashboard load, when no variables are present. */
     InitialLoad = 'initial_load',
-    /** Initial dashboard load, when variables are present. Deferred until variables are loaded. */
+    /** Initial dashboard load, when variables are present in the URL. Deferred until variables are loaded. */
     InitialLoadWithVariables = 'initial_load_with_variables',
     /** Get a fresh copy of the dashboard after it was updated (e.g. a tile was duplicated or removed). */
     Update = 'update',

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -89,13 +89,21 @@ export interface RefreshStatus {
     timer?: Date | null
 }
 
+/**
+ * Loading the dashboard serves two mostly separate purposes:
+ * 1. Fetching dashboard metadata (name, description, settings, etc.)
+ * 2. Retrieving an initial cached version of its insights for fast display.
+ */
 export enum DashboardLoadAction {
+    /** Initial dashboard load, when no variables are present. */
     InitialLoad = 'initial_load',
+    /** Initial dashboard load, when variables are present. Deferred until variables are loaded. */
     InitialLoadWithVariables = 'initial_load_with_variables',
+    /** Get a fresh copy of the dashboard after it was updated (e.g. a tile was duplicated or removed). */
     Update = 'update',
+    /** Automatic or manual refresh of the dashboard. */
     Refresh = 'refresh',
-    LoadMissing = 'load_missing',
-    RefreshInsightsOnFiltersUpdated = 'refresh_insights_on_filters_updated',
+    /** Refresh to apply temporary filters and variables. */
     Preview = 'preview',
 }
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -90,7 +90,7 @@ export interface RefreshStatus {
 }
 
 /**
- * Loading the dashboard serves two mostly separate purposes:
+ * Loading the dashboard serves two separate purposes:
  * 1. Fetching dashboard metadata (name, description, settings, etc.)
  * 2. Retrieving an initial cached version of its insights for fast display.
  */

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1261,9 +1261,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
             actions.setProperties(values.filters.properties ?? null)
             actions.setBreakdownFilter(values.filters.breakdown_filter ?? null)
         },
-        updateFiltersAndLayoutsAndVariablesSuccess: () => {
-            actions.loadDashboard({ action: DashboardLoadAction.Update })
-        },
         setRefreshError: sharedListeners.reportRefreshTiming,
         setRefreshStatuses: sharedListeners.reportRefreshTiming,
         setRefreshStatus: sharedListeners.reportRefreshTiming,

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -9,7 +9,7 @@ import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { objectsEqual } from 'lib/utils'
 import { eventUsageLogic, InsightEventSource } from 'lib/utils/eventUsageLogic'
-import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
+import { DashboardLoadAction, dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 import { summarizeInsight } from 'scenes/insights/summarizeInsight'
@@ -429,7 +429,7 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
             // we need to trigger dashboard reload to pick up results for updated insight
             savedInsight.dashboard_tiles?.forEach(({ dashboard_id }) =>
                 dashboardLogic.findMounted({ id: dashboard_id })?.actions.loadDashboard({
-                    action: 'update',
+                    action: DashboardLoadAction.Update,
                     manualDashboardRefresh: false,
                 })
             )

--- a/frontend/src/scenes/max/maxContextLogic.ts
+++ b/frontend/src/scenes/max/maxContextLogic.ts
@@ -24,7 +24,7 @@ import {
     MaxContextInput,
 } from './maxTypes'
 import { subscriptions } from 'kea-subscriptions'
-import { dashboardLogic, RefreshStatus } from 'scenes/dashboard/dashboardLogic'
+import { DashboardLoadAction, dashboardLogic, RefreshStatus } from 'scenes/dashboard/dashboardLogic'
 import {
     actionToMaxContextPayload,
     dashboardToMaxContext,
@@ -207,7 +207,7 @@ export const maxContextLogic = kea<maxContextLogicType>([
                 dashboardLogicInstance.mount()
 
                 try {
-                    dashboardLogicInstance.actions.loadDashboard({ action: 'initial_load' })
+                    dashboardLogicInstance.actions.loadDashboard({ action: DashboardLoadAction.InitialLoad })
 
                     await breakpoint(50)
                     while (!dashboardLogicInstance.values.dashboard) {

--- a/frontend/src/scenes/saved-insights/addSavedInsightsModalLogic.ts
+++ b/frontend/src/scenes/saved-insights/addSavedInsightsModalLogic.ts
@@ -5,7 +5,7 @@ import { Sorting } from 'lib/lemon-ui/LemonTable'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { objectsEqual, toParams } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
-import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
+import { DashboardLoadAction, dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { insightsApi } from 'scenes/insights/utils/api'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -156,7 +156,7 @@ export const addSavedInsightsModalLogic = kea<addSavedInsightsModalLogicType>([
                     actions.updateInsight(response)
                     const logic = dashboardLogic({ id: dashboardId })
                     logic.mount()
-                    logic.actions.loadDashboard({ action: 'update' })
+                    logic.actions.loadDashboard({ action: DashboardLoadAction.Update })
                     logic.unmount()
                     lemonToast.success('Insight added to dashboard')
                 }
@@ -176,7 +176,7 @@ export const addSavedInsightsModalLogic = kea<addSavedInsightsModalLogicType>([
                     actions.updateInsight(response)
                     const logic = dashboardLogic({ id: dashboardId })
                     logic.mount()
-                    logic.actions.loadDashboard({ action: 'update' })
+                    logic.actions.loadDashboard({ action: DashboardLoadAction.Update })
                     logic.unmount()
                     lemonToast.success('Insight removed from dashboard')
                 }


### PR DESCRIPTION
## Problem

The dashboard code is hard to understand.

## Changes

- Adds comments and groups actions
- Extracts dashboard load options to a `DashboardLoadAction` enum, and removes unused options
- Removes the `updateFiltersAndLayoutsAndVariablesSuccess` listener, as there is no `updateFiltersAndLayoutsAndVariablesSuccess` action

## How did you test this code?

The changes should not affect functionality
