### PR TITLE
chore: Fully rollout Zapier via hog functions

### DIFF
--- a/ee/api/hooks.py
+++ b/ee/api/hooks.py
@@ -7,18 +7,11 @@ from rest_framework.response import Response
 from django.core.exceptions import ValidationError
 
 from ee.models.hook import Hook, HOOK_EVENTS
-from django.conf import settings
 from posthog.api.hog_function import HogFunctionSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.models.hog_functions.hog_function import HogFunction
-from posthog.models.team.team import Team
 from posthog.models.user import User
 from posthog.cdp.templates.zapier.template_zapier import template as template_zapier
-
-
-def hog_functions_enabled(team: Team) -> bool:
-    enabled_teams = settings.HOOK_HOG_FUNCTION_TEAMS.split(",")
-    return "*" in enabled_teams or str(team.id) in enabled_teams
 
 
 def create_zapier_hog_function(hook: Hook, serializer_context: dict, from_migration: bool = False) -> HogFunction:
@@ -104,9 +97,6 @@ class HookViewSet(
     serializer_class = HookSerializer
 
     def create(self, request, *args, **kwargs):
-        if not hog_functions_enabled(self.team):
-            return super().create(request, *args, **kwargs)
-
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         hook = Hook(**serializer.validated_data)

--- a/ee/api/test/test_hooks.py
+++ b/ee/api/test/test_hooks.py
@@ -29,54 +29,6 @@ class TestHooksAPI(ClickhouseTestMixin, APILicensedTest):
             ],
         )
 
-    def test_create_hook(self):
-        data = {"target": "https://hooks.zapier.com/abcd/", "event": "action_performed"}
-        response = self.client.post(f"/api/projects/{self.team.id}/hooks/", data)
-        response_data = response.json()
-
-        hook = Hook.objects.get(id=response_data["id"])
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(hook.team, self.team)
-        self.assertEqual(hook.target, data["target"])
-        self.assertEqual(hook.event, data["event"])
-        self.assertEqual(hook.resource_id, None)
-        self.assertDictContainsSubset(
-            {
-                "id": hook.id,
-                "event": data["event"],
-                "target": data["target"],
-                "resource_id": None,
-                "team": self.team.id,
-            },
-            cast(dict, response.json()),
-        )
-
-    def test_create_hook_with_resource_id(self):
-        data = {
-            "target": "https://hooks.zapier.com/abcd/",
-            "event": "action_performed",
-            "resource_id": "66",
-        }
-        response = self.client.post(f"/api/projects/{self.team.id}/hooks/", data)
-        response_data = response.json()
-
-        hook = Hook.objects.get(id=response_data["id"])
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(hook.team, self.team)
-        self.assertEqual(hook.target, data["target"])
-        self.assertEqual(hook.event, data["event"])
-        self.assertEqual(str(hook.resource_id), data["resource_id"])
-        self.assertDictContainsSubset(
-            {
-                "id": hook.id,
-                "event": data["event"],
-                "target": data["target"],
-                "resource_id": int(data["resource_id"]),
-                "team": self.team.id,
-            },
-            cast(dict, response.json()),
-        )
-
     def test_delete_hook(self):
         hook_id = "abc123"
         Hook.objects.create(id=hook_id, user=self.user, team=self.team, resource_id=20)
@@ -98,8 +50,7 @@ class TestHooksAPI(ClickhouseTestMixin, APILicensedTest):
             "resource_id": self.action.id,
         }
 
-        with self.settings(HOOK_HOG_FUNCTION_TEAMS="*"):
-            res = self.client.post(f"/api/projects/{self.team.id}/hooks/", data)
+        res = self.client.post(f"/api/projects/{self.team.id}/hooks/", data)
 
         assert res.status_code == 201, res.json()
         json = res.json()
@@ -217,8 +168,7 @@ if (inputs.debug) {
             "resource_id": self.action.id,
         }
 
-        with self.settings(HOOK_HOG_FUNCTION_TEAMS="*"):
-            res = self.client.post(f"/api/projects/{self.team.id}/hooks/", data)
+        res = self.client.post(f"/api/projects/{self.team.id}/hooks/", data)
 
         hook_id = res.json()["id"]
 

--- a/ee/api/test/test_hooks.py
+++ b/ee/api/test/test_hooks.py
@@ -1,4 +1,3 @@
-from typing import cast
 import uuid
 
 from inline_snapshot import snapshot

--- a/ee/settings.py
+++ b/ee/settings.py
@@ -70,8 +70,6 @@ PARALLEL_ASSET_GENERATION_MAX_TIMEOUT_MINUTES = get_from_env(
     "PARALLEL_ASSET_GENERATION_MAX_TIMEOUT_MINUTES", 10.0, type_cast=float
 )
 
-HOOK_HOG_FUNCTION_TEAMS = get_from_env("HOOK_HOG_FUNCTION_TEAMS", "", type_cast=str)
-
 # Assistant
 ANTHROPIC_API_KEY = get_from_env("ANTHROPIC_API_KEY", "")
 OPENAI_API_KEY = get_from_env("OPENAI_API_KEY", "")

--- a/posthog/management/commands/migrate_hooks.py
+++ b/posthog/management/commands/migrate_hooks.py
@@ -36,17 +36,21 @@ def migrate_hooks(hook_ids: list[str], team_ids: list[int], dry_run: bool = Fals
         hog_functions: list[HogFunction] = []
 
         for hook in page.object_list:
-            hog_function = create_zapier_hog_function(
-                hook, {"user": hook.user, "get_team": lambda hook=hook: hook.team}, from_migration=True
-            )
-            hog_functions.append(hog_function)
+            try:
+                hog_function = create_zapier_hog_function(
+                    hook, {"user": hook.user, "get_team": lambda hook=hook: hook.team}, from_migration=True
+                )
+                hog_functions.append(hog_function)
+            except Exception as e:
+                print(f"Error migrating hook {hook.id}: {e}")  # noqa: T201
+                continue
 
         if not dry_run:
             HogFunction.objects.bulk_create(hog_functions)
         else:
             print("Would have created the following HogFunctions:")  # noqa: T201
             for hog_function in hog_functions:
-                print(hog_function, hog_function.inputs, hog_function.filters)  # noqa: T201
+                print(hog_function)  # noqa: T201
 
     if not dry_run:
         query.delete()


### PR DESCRIPTION
## Problem

We've had the flag on forever.

## Changes

* Removes the setting
* Fixes the migration script to skip erroring hooks (mostly due to cohort filters - will check those out and see what we can do later)

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
