### PR TITLE
fix: platform plans detection in SupportResponseTimesTable

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
@@ -58,8 +58,10 @@ const SupportResponseTimesTable = ({
     const hasLegacyEnterprisePlan = platformAndSupportProduct?.plans?.some(
         (a) => a.current_plan && a.plan_key?.includes('enterprise')
     )
+    // Treat add-ons without Stripe prices (included_with_main_product) the same as subscribed ones.
     const hasPlatformAndSupportAddon =
-        platformAndSupportProduct?.addons?.find((a) => !!a.subscribed) || hasLegacyEnterprisePlan
+        platformAndSupportProduct?.addons?.find((a) => a.subscribed || a.included_with_main_product) ||
+        hasLegacyEnterprisePlan
 
     // Check for expired trials
     const hasExpiredTrial = billing?.trial?.status === 'expired'
@@ -103,13 +105,22 @@ const SupportResponseTimesTable = ({
                 name: addon.name,
                 // Note(@zach): This is a legacy check that we can remove after migrating users off it.
                 current_plan:
-                    (addon.subscribed || (addon.type === 'enterprise' && hasLegacyEnterprisePlan)) && !hasActiveTrial,
+                    (addon.subscribed ||
+                        addon.included_with_main_product ||
+                        (addon.type === 'enterprise' && hasLegacyEnterprisePlan)) &&
+                    !hasActiveTrial,
                 features: [getResponseTimeFeature(addon.name) || { note: '1 business day' }],
                 plan_key: addon.type,
                 legacy_product: addon.legacy_product,
             }
         }) || []),
     ]
+
+    // Ensure only one plan (the last matching) remains marked as current.
+    const lastActiveIndex = plansToDisplay.map((p) => p.current_plan).lastIndexOf(true)
+    plansToDisplay.forEach((plan, idx) => {
+        plan.current_plan = idx === lastActiveIndex
+    })
 
     return (
         <div className="grid grid-cols-2 border rounded [&_>*]:px-2 [&_>*]:py-0.5 bg-surface-primary mb-2">


### PR DESCRIPTION
## Problem

Some platform plans are assigned for free and don't have corresponding prices in Stripe and therefore don't appear as `subscribed` - we check for this in some other places but not in the context of `SupportResponseTimesTable` so we were showing wrong current plan in this table for various customers (see [here](https://posthog.slack.com/archives/C075D3C5HST/p1752651319040109) for more context).

## Changes

Quick fix to
- Check for `included_with_main_product` besides `subscribed` (which is true for those on plans like `enterprise-addon-20260602` that don't have Stripe prices)
- Only show the highest matching one as current (in case there's more than one)

A proper fix would be to use the `billing_plan` returned from `billing` API response (as we do e.g. in `supportLogic`) but keeping changes minimal in case I'm missing some context, while @slshults is away.

## Did you write or update any docs for this change?

- [x] No docs needed for this change

## How did you test this code?

n/a
