### PR TITLE
fix: infinite loop on group racce condition

### DIFF
--- a/plugin-server/src/worker/ingestion/groups/batch-writing-group-store.ts
+++ b/plugin-server/src/worker/ingestion/groups/batch-writing-group-store.ts
@@ -142,6 +142,10 @@ export class BatchWritingGroupStoreForBatch implements GroupStoreForBatch {
         this.databaseOperationCounts = new Map()
     }
 
+    getGroupCache(): GroupCache {
+        return this.groupCache
+    }
+
     async flush(): Promise<TopicMessage[]> {
         const pendingUpdates = Array.from(this.groupCache.entries()).filter((entry): entry is [string, GroupUpdate] => {
             const [_, update] = entry
@@ -260,6 +264,13 @@ export class BatchWritingGroupStoreForBatch implements GroupStoreForBatch {
         properties: Properties,
         timestamp: DateTime
     ): Promise<void> {
+        logger.info('🔁', 'Adding to batch', {
+            teamId,
+            groupTypeIndex,
+            groupKey,
+            properties,
+            timestamp,
+        })
         const group = await this.getGroup(teamId, groupTypeIndex, groupKey, false, null)
 
         if (!group) {
@@ -552,6 +563,8 @@ export class BatchWritingGroupStoreForBatch implements GroupStoreForBatch {
             return
         }
         if (error instanceof RaceConditionError) {
+            // Remove from cache to prevent retry, the group was already created by another thread
+            this.groupCache.delete(teamId, groupKey)
             return this.upsertGroup(teamId, projectId, groupTypeIndex, groupKey, properties, timestamp)
         }
         throw error


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

The group batch store has a bug when it deals with a race condition, as it is inadvertently recursive because  of maintaining the previous store's contracts. 

I will follow up this with a proper store Refactor, this just fixes the issue we are seeing 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
