### PR TITLE
feat(batch-exports): Start tracking bytes exported (part 1)

### DIFF
--- a/products/batch_exports/backend/temporal/batch_exports.py
+++ b/products/batch_exports/backend/temporal/batch_exports.py
@@ -398,6 +398,8 @@ class FinishBatchExportRunInputs:
             See the docstring in 'pause_batch_export_if_over_failure_threshold'.
         failure_check_window: Used when determining to pause a batch export that has failed.
             See the docstring in 'pause_batch_export_if_over_failure_threshold'.
+        bytes_exported: Total number of bytes exported.
+            This is the size of the actual data exported, which takes into account the file type and compression.
     """
 
     id: str
@@ -409,6 +411,7 @@ class FinishBatchExportRunInputs:
     records_total_count: int | None = None
     failure_threshold: int = 10
     failure_check_window: int = 50
+    bytes_exported: int | None = None
 
 
 @activity.defn

--- a/products/batch_exports/backend/temporal/batch_exports.py
+++ b/products/batch_exports/backend/temporal/batch_exports.py
@@ -429,7 +429,14 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
     logger = LOGGER.bind()
     external_logger = EXTERNAL_LOGGER.bind()
 
-    not_model_params = ("id", "team_id", "batch_export_id", "failure_threshold", "failure_check_window")
+    not_model_params = (
+        "id",
+        "team_id",
+        "batch_export_id",
+        "failure_threshold",
+        "failure_check_window",
+        "bytes_exported",  # TODO: once we add this to the model we can remove this
+    )
     update_params = {
         key: value
         for key, value in dataclasses.asdict(inputs).items()

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -35,7 +35,6 @@ from posthog.temporal.common.logger import (
     get_logger,
 )
 from products.batch_exports.backend.temporal.batch_exports import (
-    RecordsCompleted,
     StartBatchExportRunInputs,
     default_fields,
     get_data_interval,
@@ -52,6 +51,7 @@ from products.batch_exports.backend.temporal.pipeline.entrypoint import (
 from products.batch_exports.backend.temporal.pipeline.producer import (
     Producer as ProducerFromInternalStage,
 )
+from products.batch_exports.backend.temporal.pipeline.types import BatchExportResult
 from products.batch_exports.backend.temporal.spmc import (
     RecordBatchQueue,
     wait_for_schema_or_producer,
@@ -332,7 +332,7 @@ class S3BatchExportWorkflow(PostHogWorkflow):
 
 
 @activity.defn
-async def insert_into_s3_activity_from_stage(inputs: S3InsertInputs) -> RecordsCompleted:
+async def insert_into_s3_activity_from_stage(inputs: S3InsertInputs) -> BatchExportResult:
     """Activity to batch export data to a customer's S3.
 
     This is a new version of the `insert_into_s3_activity` activity that reads data from our internal S3 stage
@@ -408,7 +408,7 @@ async def insert_into_s3_activity_from_stage(inputs: S3InsertInputs) -> RecordsC
             max_concurrent_uploads=settings.BATCH_EXPORT_S3_MAX_CONCURRENT_UPLOADS,
         )
 
-        records_completed = await run_consumer_from_stage(
+        return await run_consumer_from_stage(
             queue=queue,
             consumer=consumer,
             producer_task=producer_task,
@@ -419,8 +419,6 @@ async def insert_into_s3_activity_from_stage(inputs: S3InsertInputs) -> RecordsC
             max_file_size_bytes=inputs.max_file_size_mb * 1024 * 1024 if inputs.max_file_size_mb else 0,
             json_columns=("properties", "person_properties", "set", "set_once"),
         )
-
-        return records_completed
 
 
 class ConcurrentS3Consumer(ConsumerFromStage):

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -389,7 +389,7 @@ async def insert_into_s3_activity_from_stage(inputs: S3InsertInputs) -> BatchExp
                 inputs.data_interval_end or "END",
             )
 
-            return 0
+            return BatchExportResult(records_completed=0, bytes_exported=0)
 
         record_batch_schema = pa.schema(
             # NOTE: For some reason, some batches set non-nullable fields as non-nullable, whereas other

--- a/products/batch_exports/backend/temporal/pipeline/consumer.py
+++ b/products/batch_exports/backend/temporal/pipeline/consumer.py
@@ -18,6 +18,7 @@ from products.batch_exports.backend.temporal.spmc import (
     RecordBatchQueue,
     raise_on_task_failure,
 )
+from products.batch_exports.backend.temporal.pipeline.types import BatchExportResult
 from products.batch_exports.backend.temporal.utils import (
     cast_record_batch_json_columns,
     cast_record_batch_schema_json_columns,
@@ -68,7 +69,7 @@ class Consumer:
         include_inserted_at: bool = False,
         max_file_size_bytes: int = 0,
         json_columns: collections.abc.Sequence[str] = ("properties", "person_properties", "set", "set_once"),
-    ) -> int:
+    ) -> BatchExportResult:
         """Start consuming record batches from queue.
 
         Record batches will be processed by the `transformer`, which transforms the record batch into chunks of bytes,
@@ -86,7 +87,10 @@ class Consumer:
         multiple files that must each individually be valid.
 
         Returns:
-            Total number of records in all consumed record batches.
+            BatchExportResult (A tuple containing):
+                - The total number of records in all consumed record batches.
+                - The total number of bytes exported (this is the size of the actual data exported, which takes into
+                    account the file type and compression).
         """
 
         schema = cast_record_batch_schema_json_columns(schema, json_columns=json_columns)
@@ -158,7 +162,7 @@ class Consumer:
             f"from {total_record_batches_count:,} record batches. "
             f"Total file MiB: {total_file_bytes_count / 1024**2:.2f}"
         )
-        return total_records_count
+        return BatchExportResult(total_records_count, total_file_bytes_count)
 
     async def generate_record_batches_from_queue(
         self,
@@ -210,7 +214,7 @@ async def run_consumer_from_stage(
     include_inserted_at: bool = False,
     max_file_size_bytes: int = 0,
     json_columns: collections.abc.Sequence[str] = ("properties", "person_properties", "set", "set_once"),
-) -> int:
+) -> BatchExportResult:
     """Run a consumer that takes record batches from a queue and writes them to a destination.
 
     This uses a newer version of the consumer that works with the internal S3 stage activities.
@@ -227,9 +231,12 @@ async def run_consumer_from_stage(
         json_columns: The columns which contain JSON data.
 
     Returns:
-        Number of records exported. Not the number of record batches, but the number of records in all record batches.
+        BatchExportResult (A tuple containing):
+            - The total number of records in all consumed record batches.
+            - The total number of bytes exported (this is the size of the actual data exported, which takes into
+                account the file type and compression).
     """
-    records_completed = await consumer.start(
+    result = await consumer.start(
         queue=queue,
         producer_task=producer_task,
         schema=schema,
@@ -241,4 +248,4 @@ async def run_consumer_from_stage(
     )
 
     await raise_on_task_failure(producer_task)
-    return records_completed
+    return result

--- a/products/batch_exports/backend/temporal/pipeline/entrypoint.py
+++ b/products/batch_exports/backend/temporal/pipeline/entrypoint.py
@@ -1,3 +1,4 @@
+import collections.abc
 import datetime as dt
 
 from django.conf import settings
@@ -8,7 +9,6 @@ from posthog.batch_exports.models import BatchExportRun
 from posthog.settings.base_variables import TEST
 from posthog.temporal.common.logger import get_logger
 from products.batch_exports.backend.temporal.batch_exports import (
-    BatchExportActivity,
     FinishBatchExportRunInputs,
     finish_batch_export_run,
 )
@@ -20,12 +20,15 @@ from products.batch_exports.backend.temporal.pipeline.internal_stage import (
     BatchExportInsertIntoInternalStageInputs,
     insert_into_internal_stage_activity,
 )
+from products.batch_exports.backend.temporal.pipeline.types import BatchExportResult
 
 LOGGER = get_logger(__name__)
 
+BatchExportInsertActivity = collections.abc.Callable[..., collections.abc.Awaitable[BatchExportResult]]
+
 
 async def execute_batch_export_using_internal_stage(
-    activity: BatchExportActivity,
+    activity: BatchExportInsertActivity,
     inputs,
     non_retryable_error_types: list[str],
     interval: str,
@@ -51,7 +54,6 @@ async def execute_batch_export_using_internal_stage(
         activity: The 'insert_into_*' activity function to execute.
         inputs: The inputs to the activity.
         non_retryable_error_types: A list of errors to not retry on when executing the activity.
-        finish_inputs: Inputs to the 'finish_batch_export_run' to run at the end.
         interval: The interval of the batch export used to set the start to close timeout.
         maximum_attempts: Maximum number of retries for the 'insert_into_*' activity function.
             Assuming the error that triggered the retry is not in non_retryable_error_types.
@@ -114,7 +116,7 @@ async def execute_batch_export_using_internal_stage(
             retry_policy=retry_policy,
         )
 
-        records_completed = await workflow.execute_activity(
+        records_completed, bytes_exported = await workflow.execute_activity(
             activity,
             inputs,
             start_to_close_timeout=start_to_close_timeout,
@@ -122,6 +124,7 @@ async def execute_batch_export_using_internal_stage(
             retry_policy=retry_policy,
         )
         finish_inputs.records_completed = records_completed
+        finish_inputs.bytes_exported = bytes_exported
 
     except exceptions.ActivityError as e:
         if isinstance(e.cause, exceptions.CancelledError):

--- a/products/batch_exports/backend/temporal/pipeline/types.py
+++ b/products/batch_exports/backend/temporal/pipeline/types.py
@@ -1,0 +1,6 @@
+import typing
+
+
+class BatchExportResult(typing.NamedTuple):
+    records_completed: int
+    bytes_exported: int

--- a/products/batch_exports/backend/temporal/pipeline/types.py
+++ b/products/batch_exports/backend/temporal/pipeline/types.py
@@ -2,5 +2,9 @@ import typing
 
 
 class BatchExportResult(typing.NamedTuple):
+    # This is the total number of records that were successfully exported
+    # (not the number of record batches, but the number of records in all record batches)
     records_completed: int
+    # This is the number of bytes of data exported (i.e. not the number of bytes in ClickHouse or the internal stage)
+    # and therefore takes into account things like the file type and compression
     bytes_exported: int

--- a/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
@@ -73,6 +73,7 @@ from products.batch_exports.backend.tests.temporal.utils import (
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
 
+COMPRESSION_OPTIONS = [*COMPRESSION_EXTENSIONS.keys(), None]
 TEST_DATA_INTERVAL_END = dt.datetime.now(tz=dt.UTC).replace(hour=0, minute=0, second=0, microsecond=0)
 TEST_ROOT_BUCKET = "test-batch-exports"
 SESSION = aioboto3.Session()
@@ -434,7 +435,7 @@ class TestInsertIntoS3ActivityFromStage:
             BATCH_EXPORT_S3_UPLOAD_CHUNK_SIZE_BYTES=5 * 1024**2,
         ):  # 5MB, the minimum for Multipart uploads
             assert insert_inputs.batch_export_id is not None
-            records_exported = await activity_environment.run(
+            await activity_environment.run(
                 insert_into_internal_stage_activity,
                 BatchExportInsertIntoInternalStageInputs(
                     team_id=insert_inputs.team_id,
@@ -451,9 +452,9 @@ class TestInsertIntoS3ActivityFromStage:
                 ),
             )
 
-            records_exported = await activity_environment.run(insert_into_s3_activity_from_stage, insert_inputs)
+            result = await activity_environment.run(insert_into_s3_activity_from_stage, insert_inputs)
 
-        return records_exported
+        return result
 
     @pytest.mark.parametrize("compression", COMPRESSION_EXTENSIONS.keys(), indirect=True)
     @pytest.mark.parametrize("exclude_events", [None, ["test-exclude"]], indirect=True)
@@ -527,7 +528,7 @@ class TestInsertIntoS3ActivityFromStage:
             destination_default_fields=s3_default_fields(),
         )
 
-        records_exported = await self._run_activity(activity_environment, insert_inputs)
+        records_exported, bytes_exported = await self._run_activity(activity_environment, insert_inputs)
         events_to_export_created, persons_to_export_created = generate_test_data
         assert (
             records_exported == len(events_to_export_created)
@@ -536,6 +537,9 @@ class TestInsertIntoS3ActivityFromStage:
             # NOTE: Sometimes a random extra session will pop up and I haven't figured out why.
             or (isinstance(model, BatchExportModel) and model.name == "sessions" and 1 <= records_exported <= 2)
         )
+
+        assert isinstance(bytes_exported, int)
+        assert bytes_exported > 0
 
         sort_key = "uuid"
         if isinstance(model, BatchExportModel) and model.name == "persons":
@@ -560,7 +564,7 @@ class TestInsertIntoS3ActivityFromStage:
             sort_key=sort_key,
         )
 
-    @pytest.mark.parametrize("compression", COMPRESSION_EXTENSIONS.keys(), indirect=True)
+    @pytest.mark.parametrize("compression", COMPRESSION_OPTIONS, indirect=True)
     @pytest.mark.parametrize("model", [BatchExportModel(name="events", schema=None)])
     @pytest.mark.parametrize("file_format", FILE_FORMAT_EXTENSIONS.keys())
     # Use 0 to test that the file is not split up and 6MB since this is slightly
@@ -643,9 +647,11 @@ class TestInsertIntoS3ActivityFromStage:
             destination_default_fields=s3_default_fields(),
         )
 
-        records_exported = await self._run_activity(activity_environment, insert_inputs)
+        records_exported, bytes_exported = await self._run_activity(activity_environment, insert_inputs)
 
         assert records_exported == len(events_to_export_created)
+        assert isinstance(bytes_exported, int)
+        assert bytes_exported > 0
 
         # Takes a long time to re-read this data from ClickHouse, so we just make sure that:
         # 1. The file exists in S3.
@@ -726,16 +732,10 @@ class TestInsertIntoS3ActivityFromStage:
         file_format,
         data_interval_start,
         data_interval_end,
-        model: BatchExportModel | BatchExportSchema | None,
+        model: BatchExportModel,
         ateam,
     ):
         """Test the insert_into_s3_activity_from_stage_activity function fails with an invalid file format."""
-        batch_export_schema: BatchExportSchema | None = None
-        batch_export_model: BatchExportModel | None = None
-        if isinstance(model, BatchExportModel):
-            batch_export_model = model
-        elif model is not None:
-            batch_export_schema = model
 
         insert_inputs = S3InsertInputs(
             bucket_name=bucket_name,
@@ -750,8 +750,8 @@ class TestInsertIntoS3ActivityFromStage:
             compression=compression,
             exclude_events=exclude_events,
             file_format=file_format,
-            batch_export_schema=batch_export_schema,
-            batch_export_model=batch_export_model,
+            batch_export_schema=None,
+            batch_export_model=model,
             batch_export_id=str(uuid.uuid4()),
             destination_default_fields=s3_default_fields(),
         )
@@ -892,8 +892,14 @@ async def _run_s3_batch_export_workflow(
             and run.records_completed is not None
             and run.records_completed <= 1
         )
+        # TODO: once we add this to the run node, we can assert this
+        # assert run.bytes_exported == 0
         await assert_no_files_in_s3(s3_client, bucket_name, expected_key_prefix)
         return run
+
+    # TODO: once we add this to the run node, we can assert this
+    # assert run.bytes_exported is not None
+    # assert run.bytes_exported > 0
 
     sort_key = "uuid"
     if isinstance(model, BatchExportModel) and model.name == "persons":
@@ -970,7 +976,7 @@ class TestS3BatchExportWorkflowWithMinioBucket:
     @pytest.mark.parametrize("interval", ["hour"], indirect=True)
     @pytest.mark.parametrize("model", [BatchExportModel(name="events", schema=None)])
     @pytest.mark.parametrize("exclude_events", [None], indirect=True)
-    @pytest.mark.parametrize("compression", COMPRESSION_EXTENSIONS.keys(), indirect=True)
+    @pytest.mark.parametrize("compression", COMPRESSION_OPTIONS, indirect=True)
     @pytest.mark.parametrize("file_format", FILE_FORMAT_EXTENSIONS.keys(), indirect=True)
     async def test_s3_export_workflow_with_minio_bucket_with_various_compression_and_file_formats(
         self,
@@ -1271,7 +1277,7 @@ class TestS3BatchExportWorkflowWithS3Bucket:
 
     @pytest.mark.parametrize("file_format", FILE_FORMAT_EXTENSIONS.keys(), indirect=True)
     @pytest.mark.parametrize("encryption", [None, "AES256", "aws:kms"], indirect=True)
-    @pytest.mark.parametrize("compression", COMPRESSION_EXTENSIONS.keys(), indirect=True)
+    @pytest.mark.parametrize("compression", COMPRESSION_OPTIONS, indirect=True)
     @pytest.mark.parametrize("model", [BatchExportModel(name="events", schema=None)])
     @pytest.mark.parametrize("interval", ["hour"], indirect=True)
     @pytest.mark.parametrize("exclude_events", [None], indirect=True)


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We don't store the bytes exported for a given batch export run.

## Changes

Starting tracking bytes exported for the new `insert_into_s3_activity_from_stage` activity.

We define bytes exported as the total number of bytes in the exported files rather than the data size in ClickHouse. (i.e. taking into account the file type and compression).

**Note we're not yet storing this information in the database - this will be done in a follow up PR.**

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Updated existing tests
