### PR TITLE
fix(max): Fix misaligned tools bar

### DIFF
--- a/frontend/src/scenes/max/components/QuestionInput.tsx
+++ b/frontend/src/scenes/max/components/QuestionInput.tsx
@@ -159,7 +159,7 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
                         </AIConsentPopoverWrapper>
                     </div>
                 </div>
-                <div className="flex items-center w-full gap-1 justify-between">
+                <div className="flex items-center w-full gap-1 justify-center">
                     {tools.length > 0 && (
                         <div
                             className={clsx(
@@ -180,7 +180,7 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
                             ))}
                         </div>
                     )}
-                    <div className="ml-auto">{bottomActions}</div>
+                    {bottomActions && <div className="ml-auto">{bottomActions}</div>}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Problem

This alignment has been broken since #34327:

<img width="537" height="114" alt="Screenshot 2025-07-16 at 18 59 57" src="https://github.com/user-attachments/assets/8255499a-b552-4c9e-9b4d-223c1fdc4e52" />
 
We missed that there.

## Changes

Layout fixed.

## How did you test this code?

Hopefully evidenced by UI snapshots.