### PR TITLE
feat: access control API write access

### DIFF
--- a/ee/api/rbac/access_control.py
+++ b/ee/api/rbac/access_control.py
@@ -161,6 +161,11 @@ class AccessControlViewSetMixin(_GenericViewSet):
             "users_with_access",
         ]:
             return ["access_control:read"]
+        elif request.method == "PUT" and self.action in [
+            "access_controls",
+            "global_access_controls",
+        ]:
+            return ["access_control:write"]
 
         return None
 

--- a/frontend/src/lib/scopes.tsx
+++ b/frontend/src/lib/scopes.tsx
@@ -14,7 +14,7 @@ export type APIScope = {
 
 export const API_SCOPES: APIScope[] = [
     { key: 'action', objectPlural: 'actions' },
-    { key: 'access_control', objectPlural: 'access controls', disabledActions: ['write'] },
+    { key: 'access_control', objectPlural: 'access controls' },
     { key: 'activity_log', objectPlural: 'activity logs' },
     { key: 'annotation', objectPlural: 'annotations' },
     { key: 'batch_export', objectPlural: 'batch exports' },


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changes

Adding Write access for the access control scope.

Write access is already open for app access so this is just opening for API keys. 

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

Added test.
