### PR TITLE
feat: currently we don't support groups in calendar insight

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -42,7 +42,13 @@ import {
 
 import { actionsModel } from '~/models/actionsModel'
 import { MathType, NodeKind } from '~/queries/schema/schema-general'
-import { getMathTypeWarning, isInsightVizNode, isStickinessQuery, TRAILING_MATH_TYPES } from '~/queries/utils'
+import {
+    getMathTypeWarning,
+    isCalendarHeatmapQuery,
+    isInsightVizNode,
+    isStickinessQuery,
+    TRAILING_MATH_TYPES,
+} from '~/queries/utils'
 import {
     ActionFilter,
     ActionFilter as ActionFilterType,
@@ -714,6 +720,7 @@ function useMathSelectorOptions({
     mathGroupTypeIndex,
 }: MathSelectorProps): LemonSelectOptions<string> {
     const isStickiness = query && isInsightVizNode(query) && isStickinessQuery(query.source)
+    const isCalendarHeatmap = query && isInsightVizNode(query) && isCalendarHeatmapQuery(query.source)
 
     const {
         needsUpgradeForGroups,
@@ -887,7 +894,7 @@ function useMathSelectorOptions({
         }
     }
 
-    if (isGroupsEnabled) {
+    if (isGroupsEnabled && !isCalendarHeatmap) {
         const uniqueActorsOptions = [
             {
                 value: 'users',


### PR DESCRIPTION
For people that have groups they insight allows them to filter for not only unique users but more filters:
<img width="774" height="416" alt="image" src="https://github.com/user-attachments/assets/18b33997-d76b-48de-a3d0-b5f881be8b3e" />


In this change I'm disabling that behavior:
<img width="660" height="193" alt="image" src="https://github.com/user-attachments/assets/15846bcb-61c9-4769-8f1c-82a58bf1bb43" />

Because since we don't support it if the user click one of them it would fallback to total count except for unique users.