### PR TITLE
fix: fail open on deserialization errors

### DIFF
--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -52,7 +52,7 @@ impl FeatureFlagList {
     pub async fn from_pg(
         client: PostgresReader,
         project_id: i64,
-    ) -> Result<FeatureFlagList, FlagError> {
+    ) -> Result<(FeatureFlagList, bool), FlagError> {
         let mut conn = client.get_connection().await.map_err(|e| {
             tracing::error!(
                 "Failed to get database connection for project {}: {}",
@@ -91,35 +91,44 @@ impl FeatureFlagList {
                 FlagError::Internal(format!("Database query error: {}", e))
             })?;
 
-        let flags_list = flags_row
+        let mut had_deserialization_errors = false;
+        let flags_list: Vec<FeatureFlag> = flags_row
             .into_iter()
-            .map(|row| {
-                let filters = serde_json::from_value(row.filters).map_err(|e| {
-                    tracing::error!(
-                        "Failed to deserialize filters for flag {} in project {} (team {}): {}",
-                        row.key,
-                        project_id,
-                        row.team_id,
-                        e
-                    );
-                    FlagError::DeserializeFiltersError
-                })?;
-
-                Ok(FeatureFlag {
-                    id: row.id,
-                    team_id: row.team_id,
-                    name: row.name,
-                    key: row.key,
-                    filters,
-                    deleted: row.deleted,
-                    active: row.active,
-                    ensure_experience_continuity: row.ensure_experience_continuity,
-                    version: row.version,
-                })
+            .filter_map(|row| {
+                match serde_json::from_value(row.filters) {
+                    Ok(filters) => Some(FeatureFlag {
+                        id: row.id,
+                        team_id: row.team_id,
+                        name: row.name,
+                        key: row.key,
+                        filters,
+                        deleted: row.deleted,
+                        active: row.active,
+                        ensure_experience_continuity: row.ensure_experience_continuity,
+                        version: row.version,
+                    }),
+                    Err(e) => {
+                        tracing::error!(
+                            "Failed to deserialize filters for flag {} in project {} (team {}): {}",
+                            row.key,
+                            project_id,
+                            row.team_id,
+                            e
+                        );
+                        had_deserialization_errors = true;
+                        None // Skip this flag, continue with others
+                    }
+                }
             })
-            .collect::<Result<Vec<FeatureFlag>, FlagError>>()?;
+            .collect();
 
-        Ok(FeatureFlagList { flags: flags_list })
+        tracing::debug!(
+            "Successfully fetched {} flags from database for project {}",
+            flags_list.len(),
+            project_id
+        );
+
+        Ok((FeatureFlagList { flags: flags_list }, had_deserialization_errors))
     }
 
     pub async fn update_flags_in_redis(
@@ -227,7 +236,7 @@ mod tests {
             .await
             .expect("Failed to insert flag");
 
-        let flags_from_pg = FeatureFlagList::from_pg(reader.clone(), team.project_id)
+        let (flags_from_pg, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
             .await
             .expect("Failed to fetch flags from pg");
 
@@ -243,7 +252,7 @@ mod tests {
     async fn test_fetch_empty_team_from_pg() {
         let reader = setup_pg_reader_client(None).await;
 
-        let FeatureFlagList { flags } = FeatureFlagList::from_pg(reader.clone(), 1234)
+        let (FeatureFlagList { flags }, _) = FeatureFlagList::from_pg(reader.clone(), 1234)
             .await
             .expect("Failed to fetch flags from pg");
 
@@ -255,7 +264,7 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
 
         match FeatureFlagList::from_pg(reader.clone(), -1).await {
-            Ok(flags) => assert_eq!(flags.flags.len(), 0),
+            Ok((flags, _)) => assert_eq!(flags.flags.len(), 0),
             Err(err) => panic!("Expected empty result, got error: {:?}", err),
         }
     }
@@ -317,7 +326,7 @@ mod tests {
             .await
             .expect("Failed to insert flags");
 
-        let flags_from_pg = FeatureFlagList::from_pg(reader.clone(), team.project_id)
+        let (flags_from_pg, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
             .await
             .expect("Failed to fetch flags from pg");
 

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -128,7 +128,10 @@ impl FeatureFlagList {
             project_id
         );
 
-        Ok((FeatureFlagList { flags: flags_list }, had_deserialization_errors))
+        Ok((
+            FeatureFlagList { flags: flags_list },
+            had_deserialization_errors,
+        ))
     }
 
     pub async fn update_flags_in_redis(

--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -476,10 +476,9 @@ mod tests {
         assert_eq!(redis_flag.get_variants().len(), 3);
 
         // Fetch and verify from Postgres
-        let pg_flags = FeatureFlagList::from_pg(reader, team.project_id)
+        let (pg_flags, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
             .await
-            .expect("Failed to fetch flags from Postgres");
-
+            .expect("Failed to fetch flags from pg");
         assert_eq!(pg_flags.flags.len(), 1);
         let pg_flag = &pg_flags.flags[0];
         assert_eq!(pg_flag.key, "multivariate_flag");
@@ -575,10 +574,9 @@ mod tests {
         assert_eq!(redis_flag.key, "multivariate_flag_with_payloads");
 
         // Fetch and verify from Postgres
-        let pg_flags = FeatureFlagList::from_pg(reader, team.project_id)
+        let (pg_flags, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
             .await
-            .expect("Failed to fetch flags from Postgres");
-
+            .expect("Failed to fetch flags from pg");
         assert_eq!(pg_flags.flags.len(), 1);
         let pg_flag = &pg_flags.flags[0];
         assert_eq!(pg_flag.key, "multivariate_flag_with_payloads");
@@ -711,10 +709,9 @@ mod tests {
         assert_eq!(redis_flag.filters.super_groups.as_ref().unwrap().len(), 1);
 
         // Fetch and verify from Postgres
-        let pg_flags = FeatureFlagList::from_pg(reader, team.project_id)
+        let (pg_flags, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
             .await
-            .expect("Failed to fetch flags from Postgres");
-
+            .expect("Failed to fetch flags from pg");
         assert_eq!(pg_flags.flags.len(), 1);
         let pg_flag = &pg_flags.flags[0];
         assert_eq!(pg_flag.key, "flag_with_super_groups");
@@ -811,10 +808,9 @@ mod tests {
         assert_eq!(redis_properties[2].prop_type, PropertyType::Cohort);
 
         // Fetch and verify from Postgres
-        let pg_flags = FeatureFlagList::from_pg(reader, team.project_id)
+        let (pg_flags, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
             .await
-            .expect("Failed to fetch flags from Postgres");
-
+            .expect("Failed to fetch flags from pg");
         assert_eq!(pg_flags.flags.len(), 1);
         let pg_flag = &pg_flags.flags[0];
         assert_eq!(pg_flag.key, "flag_with_different_properties");
@@ -914,10 +910,9 @@ mod tests {
             .any(|f| f.key == "inactive_flag" && !f.active));
 
         // Fetch and verify from Postgres
-        let pg_flags = FeatureFlagList::from_pg(reader, team.project_id)
+        let (pg_flags, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
             .await
-            .expect("Failed to fetch flags from Postgres");
-
+            .expect("Failed to fetch flags from pg");
         assert_eq!(pg_flags.flags.len(), 0);
         assert!(!pg_flags.flags.iter().any(|f| f.deleted)); // no deleted flags
         assert!(!pg_flags.flags.iter().any(|f| f.active)); // no inactive flags
@@ -1007,7 +1002,7 @@ mod tests {
                 let redis_flags = FeatureFlagList::from_redis(redis_client, project_id)
                     .await
                     .unwrap();
-                let pg_flags = FeatureFlagList::from_pg(reader, project_id).await.unwrap();
+                let (pg_flags, _) = FeatureFlagList::from_pg(reader, project_id).await.unwrap();
                 (redis_flags, pg_flags)
             });
 
@@ -1085,7 +1080,7 @@ mod tests {
         let redis_duration = start.elapsed();
 
         let start = Instant::now();
-        let pg_flags = FeatureFlagList::from_pg(reader, team.project_id)
+        let (pg_flags, _) = FeatureFlagList::from_pg(reader, team.project_id)
             .await
             .expect("Failed to fetch flags from Postgres");
         let pg_duration = start.elapsed();
@@ -1173,10 +1168,9 @@ mod tests {
         let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id)
             .await
             .expect("Failed to fetch flags from Redis");
-        let pg_flags = FeatureFlagList::from_pg(reader, team.project_id)
+        let (pg_flags, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
             .await
-            .expect("Failed to fetch flags from Postgres");
-
+            .expect("Failed to fetch flags from pg");
         assert_eq!(redis_flags.flags.len(), 3);
         assert_eq!(pg_flags.flags.len(), 3);
 
@@ -1259,9 +1253,9 @@ mod tests {
         let mut redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id)
             .await
             .expect("Failed to fetch flags from Redis");
-        let mut pg_flags = FeatureFlagList::from_pg(reader, team.project_id)
+        let (mut pg_flags, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
             .await
-            .expect("Failed to fetch flags from Postgres");
+            .expect("Failed to fetch flags from pg");
 
         // Sort flags by key to ensure consistent order
         redis_flags.flags.sort_by(|a, b| a.key.cmp(&b.key));
@@ -1373,9 +1367,9 @@ mod tests {
         let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id)
             .await
             .expect("Failed to fetch flags from Redis");
-        let pg_flags = FeatureFlagList::from_pg(reader, team.project_id)
+        let (pg_flags, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
             .await
-            .expect("Failed to fetch flags from Postgres");
+            .expect("Failed to fetch flags from pg");
 
         // Verify rollout percentages
         for flags in &[redis_flags, pg_flags] {

--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -478,7 +478,7 @@ mod tests {
         // Fetch and verify from Postgres
         let (pg_flags, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
             .await
-            .expect("Failed to fetch flags from pg");
+            .expect("Failed to fetch flags from Postgres");
         assert_eq!(pg_flags.flags.len(), 1);
         let pg_flag = &pg_flags.flags[0];
         assert_eq!(pg_flag.key, "multivariate_flag");
@@ -576,7 +576,7 @@ mod tests {
         // Fetch and verify from Postgres
         let (pg_flags, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
             .await
-            .expect("Failed to fetch flags from pg");
+            .expect("Failed to fetch flags from Postgres");
         assert_eq!(pg_flags.flags.len(), 1);
         let pg_flag = &pg_flags.flags[0];
         assert_eq!(pg_flag.key, "multivariate_flag_with_payloads");
@@ -711,7 +711,7 @@ mod tests {
         // Fetch and verify from Postgres
         let (pg_flags, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
             .await
-            .expect("Failed to fetch flags from pg");
+            .expect("Failed to fetch flags from Postgres");
         assert_eq!(pg_flags.flags.len(), 1);
         let pg_flag = &pg_flags.flags[0];
         assert_eq!(pg_flag.key, "flag_with_super_groups");
@@ -810,7 +810,7 @@ mod tests {
         // Fetch and verify from Postgres
         let (pg_flags, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
             .await
-            .expect("Failed to fetch flags from pg");
+            .expect("Failed to fetch flags from Postgres");
         assert_eq!(pg_flags.flags.len(), 1);
         let pg_flag = &pg_flags.flags[0];
         assert_eq!(pg_flag.key, "flag_with_different_properties");
@@ -912,7 +912,7 @@ mod tests {
         // Fetch and verify from Postgres
         let (pg_flags, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
             .await
-            .expect("Failed to fetch flags from pg");
+            .expect("Failed to fetch flags from Postgres");
         assert_eq!(pg_flags.flags.len(), 0);
         assert!(!pg_flags.flags.iter().any(|f| f.deleted)); // no deleted flags
         assert!(!pg_flags.flags.iter().any(|f| f.active)); // no inactive flags
@@ -1170,7 +1170,7 @@ mod tests {
             .expect("Failed to fetch flags from Redis");
         let (pg_flags, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
             .await
-            .expect("Failed to fetch flags from pg");
+            .expect("Failed to fetch flags from Postgres");
         assert_eq!(redis_flags.flags.len(), 3);
         assert_eq!(pg_flags.flags.len(), 3);
 
@@ -1255,7 +1255,7 @@ mod tests {
             .expect("Failed to fetch flags from Redis");
         let (mut pg_flags, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
             .await
-            .expect("Failed to fetch flags from pg");
+            .expect("Failed to fetch flags from Postgres");
 
         // Sort flags by key to ensure consistent order
         redis_flags.flags.sort_by(|a, b| a.key.cmp(&b.key));
@@ -1369,7 +1369,7 @@ mod tests {
             .expect("Failed to fetch flags from Redis");
         let (pg_flags, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
             .await
-            .expect("Failed to fetch flags from pg");
+            .expect("Failed to fetch flags from Postgres");
 
         // Verify rollout percentages
         for flags in &[redis_flags, pg_flags] {

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -124,7 +124,7 @@ impl FlagService {
     ) -> Result<(FeatureFlagList, bool), FlagError> {
         let (flags_result, cache_hit) =
             match FeatureFlagList::from_redis(self.redis_reader.clone(), project_id).await {
-                Ok(flags) => (Ok((flags, false)), true), // Redis doesn't have deserialization errors
+                Ok(flags) => (Ok((flags, false)), true),
                 Err(_) => {
                     match FeatureFlagList::from_pg(self.pg_client.clone(), project_id).await {
                         Ok((flags, had_errors)) => {

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -116,18 +116,18 @@ impl FlagService {
     }
 
     /// Fetches the flags from the cache or the database. Returns a tuple containing
-    /// the flags and a boolean indicating whether the flags came from cache.  Also, it
-    /// tracks cache hits and misses for a given project_id.
+    /// the flags and a boolean indicating whether there were deserialization errors.
+    /// Also tracks cache hits and misses for a given project_id.
     pub async fn get_flags_from_cache_or_pg(
         &self,
         project_id: i64,
-    ) -> Result<FeatureFlagList, FlagError> {
+    ) -> Result<(FeatureFlagList, bool), FlagError> {
         let (flags_result, cache_hit) =
             match FeatureFlagList::from_redis(self.redis_reader.clone(), project_id).await {
-                Ok(flags) => (Ok(flags), true),
+                Ok(flags) => (Ok((flags, false)), true), // Redis doesn't have deserialization errors
                 Err(_) => {
                     match FeatureFlagList::from_pg(self.pg_client.clone(), project_id).await {
-                        Ok(flags) => {
+                        Ok((flags, had_errors)) => {
                             inc(DB_FLAG_READS_COUNTER, &[], 1);
                             if (FeatureFlagList::update_flags_in_redis(
                                 self.redis_writer.clone(),
@@ -143,7 +143,7 @@ impl FlagService {
                                     1,
                                 );
                             }
-                            (Ok(flags), false)
+                            (Ok((flags, had_errors)), false)
                         }
                         Err(e) => (Err(e), false),
                     }
@@ -364,7 +364,7 @@ mod tests {
             .get_flags_from_cache_or_pg(team.project_id)
             .await;
         assert!(result.is_ok());
-        let fetched_flags = result.unwrap();
+        let (fetched_flags, _) = result.unwrap();
         assert_eq!(fetched_flags.flags.len(), mock_flags.flags.len());
 
         // Verify the contents of the fetched flags

--- a/rust/feature-flags/src/handler/flags.rs
+++ b/rust/feature-flags/src/handler/flags.rs
@@ -21,8 +21,8 @@ pub async fn fetch_and_filter(
     flag_service: &FlagService,
     project_id: i64,
     query_params: &FlagsQueryParams,
-) -> Result<FeatureFlagList, FlagError> {
-    let all_flags = flag_service.get_flags_from_cache_or_pg(project_id).await?;
+) -> Result<(FeatureFlagList, bool), FlagError> {
+    let (all_flags, had_deserialization_errors) = flag_service.get_flags_from_cache_or_pg(project_id).await?;
 
     let flags_after_survey_filter = filter_survey_flags(
         all_flags.flags,
@@ -31,7 +31,10 @@ pub async fn fetch_and_filter(
             .unwrap_or(false),
     );
 
-    Ok(FeatureFlagList::new(flags_after_survey_filter))
+    Ok((
+        FeatureFlagList::new(flags_after_survey_filter),
+        had_deserialization_errors,
+    ))
 }
 
 /// Filters flags to only include survey flags if requested

--- a/rust/feature-flags/src/handler/flags.rs
+++ b/rust/feature-flags/src/handler/flags.rs
@@ -22,7 +22,8 @@ pub async fn fetch_and_filter(
     project_id: i64,
     query_params: &FlagsQueryParams,
 ) -> Result<(FeatureFlagList, bool), FlagError> {
-    let (all_flags, had_deserialization_errors) = flag_service.get_flags_from_cache_or_pg(project_id).await?;
+    let (all_flags, had_deserialization_errors) =
+        flag_service.get_flags_from_cache_or_pg(project_id).await?;
 
     let flags_after_survey_filter = filter_survey_flags(
         all_flags.flags,

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -1174,55 +1174,29 @@ async fn test_fetch_and_filter_flags() {
         only_evaluate_survey_feature_flags: Some(true),
         ..Default::default()
     };
-    let result = fetch_and_filter(&flag_service, team.project_id, &query_params)
+    let (result, had_errors) = fetch_and_filter(&flag_service, team.project_id, &query_params)
         .await
         .unwrap();
     assert_eq!(result.flags.len(), 2);
-    assert!(result
-        .flags
-        .iter()
-        .all(|f| f.key.starts_with(SURVEY_TARGETING_FLAG_PREFIX)));
+    assert!(result.flags.iter().all(|f| f.key.starts_with(SURVEY_TARGETING_FLAG_PREFIX)));
+    assert!(!had_errors);
 
     // Test 2: only_evaluate_survey_feature_flags = false
     let query_params = FlagsQueryParams {
         only_evaluate_survey_feature_flags: Some(false),
         ..Default::default()
     };
-    let result = fetch_and_filter(&flag_service, team.project_id, &query_params)
+    let (result, had_errors) = fetch_and_filter(&flag_service, team.project_id, &query_params)
         .await
         .unwrap();
     assert_eq!(result.flags.len(), 4);
-    assert!(result
-        .flags
-        .iter()
-        .any(|f| !f.key.starts_with(SURVEY_TARGETING_FLAG_PREFIX)));
+    assert!(!had_errors);
 
-    // Test 3: only_evaluate_survey_feature_flags not set
+    // Test 3: default behavior (should return all flags)
     let query_params = FlagsQueryParams::default();
-    let result = fetch_and_filter(&flag_service, team.project_id, &query_params)
+    let (result, had_errors) = fetch_and_filter(&flag_service, team.project_id, &query_params)
         .await
         .unwrap();
     assert_eq!(result.flags.len(), 4);
-    assert!(result
-        .flags
-        .iter()
-        .any(|f| !f.key.starts_with(SURVEY_TARGETING_FLAG_PREFIX)));
-
-    // Test 4: Survey filter only (flag_keys filtering now happens in evaluation logic)
-    let query_params = FlagsQueryParams {
-        only_evaluate_survey_feature_flags: Some(true),
-        ..Default::default()
-    };
-
-    let result = fetch_and_filter(&flag_service, team.project_id, &query_params)
-        .await
-        .unwrap();
-
-    // Should return all survey flags since flag_keys filtering now happens in evaluation logic
-    // Survey filter keeps only survey flags, but flag_keys filtering is deferred to evaluation
-    assert_eq!(result.flags.len(), 2);
-    assert!(result
-        .flags
-        .iter()
-        .all(|f| f.key.starts_with(SURVEY_TARGETING_FLAG_PREFIX)));
+    assert!(!had_errors);
 }

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -1178,7 +1178,10 @@ async fn test_fetch_and_filter_flags() {
         .await
         .unwrap();
     assert_eq!(result.flags.len(), 2);
-    assert!(result.flags.iter().all(|f| f.key.starts_with(SURVEY_TARGETING_FLAG_PREFIX)));
+    assert!(result
+        .flags
+        .iter()
+        .all(|f| f.key.starts_with(SURVEY_TARGETING_FLAG_PREFIX)));
     assert!(!had_errors);
 
     // Test 2: only_evaluate_survey_feature_flags = false


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

We currently throw a 500 when a team has a malformed flag. For example, this team has a flag where `variant` is boolean `false`. This flag was probably created through the API directly and not the UI.
```
{
    "groups": [
        {
            "variant": false,
            "properties": [
                {
                    "key": "user_origin",
                    "type": "person",
                    "value": [
                        "ar"
                    ],
                    "operator": "exact"
                }
            ],
            "rollout_percentage": 100
        }
    ],
    "payloads": {},
    "multivariate": false
}
```
https://metabase.prod-eu.posthog.dev/question/497-invalid-flag
If you try and curl `/flags` for this team you'll get the following response `Failed to deserialize property filters. This is likely a temporary issue. Please try again later.` However, `/decide` returns the valid flags excluding this invalid one, i.e. fails open. 

More context: https://posthog.slack.com/archives/C0185UNBSJZ/p1752661260805279

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Make `/flags` should also fail open on deserialization errors and have `errors_while_computing_flags=true`



## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [x] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
