### PR TITLE
refactor: Add global scene padding bottom for Max

### DIFF
--- a/frontend/src/layout/scenes/SceneLayout.tsx
+++ b/frontend/src/layout/scenes/SceneLayout.tsx
@@ -159,7 +159,7 @@ export function SceneLayout({ children, className, layoutConfig }: SceneLayoutPr
                 )}
                 <div
                     className={cn(
-                        'flex-1 flex flex-col p-4 w-full order-1 row-span-1 col-span-1 col-start-1 relative',
+                        'flex-1 flex flex-col p-4 pb-16 w-full order-1 row-span-1 col-span-1 col-start-1 relative',
                         {
                             'p-0 h-screen': layoutConfig?.layout === 'app-raw-no-header',
                             'p-0 h-[calc(100vh-var(--scene-layout-header-height))]': layoutConfig?.layout === 'app-raw',


### PR DESCRIPTION
Max is sometimes on top of buttons that exist on the bottom right part of the app. Let's make sure Max is never on top of that by adding some global padding to our scene, this should guarantee there's always *some* space around him

| Before| After |
|--------|--------|
| <img width="924" height="423" alt="image" src="https://github.com/user-attachments/assets/9a5cd2eb-5e38-4f85-aa61-be280831bae9" /> | <img width="926" height="470" alt="image" src="https://github.com/user-attachments/assets/66a22983-8958-42e3-bda2-82685d3ed653" /> | 
