### PR TITLE
fix: update default sync method selection logic in SyncMethodForm

### DIFF
--- a/frontend/src/scenes/data-warehouse/external/forms/SyncMethodForm.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SyncMethodForm.tsx
@@ -82,13 +82,13 @@ export const SyncMethodForm = ({ schema, onClose, onSave, saveButtonIsLoading }:
     const appendSyncSupported = getAppendOnlySyncSupported(schema)
 
     const [radioValue, setRadioValue] = useState(
-        schema.sync_type ?? (!incrementalSyncSupported.disabled ? 'incremental' : undefined)
+        schema.sync_type ?? (incrementalSyncSupported.disabled ? 'append' : 'incremental')
     )
     const [incrementalFieldValue, setIncrementalFieldValue] = useState(schema.incremental_field ?? null)
     const [appendFieldValue, setAppendFieldValue] = useState(schema.incremental_field ?? null)
 
     useEffect(() => {
-        setRadioValue(schema.sync_type ?? (!incrementalSyncSupported.disabled ? 'incremental' : undefined))
+        setRadioValue(schema.sync_type ?? (incrementalSyncSupported.disabled ? 'append' : 'incremental'))
         setIncrementalFieldValue(schema.incremental_field ?? null)
         setAppendFieldValue(schema.incremental_field ?? null)
     }, [schema.table])


### PR DESCRIPTION
Changed the logic for setting the default radio button value in SyncMethodForm. Now, if incremental sync is disabled, it defaults to 'append' rather than having nothing selected. This means setting up all sources is slightly faster (as fast as it was before when "incremental" was always selected)