### PR TITLE
chore: update setting name for enabling analyzer 'enable_analyzer'

### DIFF
--- a/docker/clickhouse/users.xml
+++ b/docker/clickhouse/users.xml
@@ -9,8 +9,8 @@
             <!-- Maximum memory usage for processing single query, in bytes. -->
             <max_memory_usage>10000000000</max_memory_usage>
 
-            <!-- Disable experimental analyzer -->
-            <allow_experimental_analyzer>0</allow_experimental_analyzer>
+            <!-- Disable analyzer -->
+            <enable_analyzer>0</enable_analyzer>
 
             <!-- How to choose between replicas during distributed query processing.
                  random - choose random replica from set of replicas with minimum number of errors


### PR DESCRIPTION
This brings this setting up to date with 24.3 clickhouse
