### PR TITLE
feat(revenue-analytics): implement cache target age logic for revenue syncing

### DIFF
--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_query_runner.py
@@ -1,12 +1,13 @@
 import dataclasses
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 from typing import Literal, Optional, Union, cast
 from posthog.hogql.property import property_to_expr
 from posthog.hogql_queries.query_runner import QueryRunnerWithHogQLContext
 from posthog.hogql import ast
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
+from posthog.warehouse.models import ExternalDataSource, ExternalDataSchema
 from posthog.models.filters.mixins.utils import cached_property
 from posthog.schema import (
     RevenueAnalyticsArpuQuery,
@@ -475,3 +476,36 @@ class RevenueAnalyticsQueryRunner(QueryRunnerWithHogQLContext):
             return self.revenue_subqueries.subscription
         else:
             raise ValueError(f"Invalid view: {view}")
+
+    # If we can detect we're syncing Revenue data for the first time, cache for just 1 minute
+    # Otherwise, cache it for half the frequency we sync data from Stripe
+    def cache_target_age(self, last_refresh: Optional[datetime], lazy: bool = False) -> Optional[datetime]:
+        if last_refresh is None:
+            return None
+
+        # All schemas syncing revenue data
+        schemas = ExternalDataSchema.objects.filter(
+            team=self.team,
+            should_sync=True,
+            source__revenue_analytics_enabled=True,
+            source__source_type=ExternalDataSource.Type.STRIPE,
+        )
+
+        # If we can detect we're syncing Revenue data for the first time, cache for just 1 minute
+        # this guarantees we'll "always" have fresh data for the first sync
+        if any(
+            schema.status == ExternalDataSchema.Status.RUNNING and schema.last_synced_at is None for schema in schemas
+        ):
+            return last_refresh + timedelta(minutes=1)
+
+        # Otherwise, let's check the frequency of the schemas that are syncing revenue data
+        # In the rare case where we can't figure out the interval, default to caching for 6 hours
+        intervals = [schema.sync_frequency_interval for schema in schemas if schema.sync_frequency_interval is not None]
+        if not intervals:
+            return last_refresh + timedelta(hours=6)
+
+        # If we can figure out the interval, let's cache for half of that
+        # to guarantee that - on average - we'll have fresh data for the next sync
+        min_interval = min(intervals)
+        adjusted_interval = min_interval / 2
+        return last_refresh + adjusted_interval

--- a/products/revenue_analytics/backend/hogql_queries/test/test_revenue_analytics_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/test/test_revenue_analytics_query_runner.py
@@ -32,8 +32,8 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
         self.assertEqual(runner.cache_target_age(None), None)
 
     def test_cache_target_age_without_sources(self):
-        """Test that when there are no sources, we use the default 6 hours"""
-        self.assertDiff(timedelta(hours=6))
+        """Test that when there are no sources, we use our default cache target age"""
+        self.assertDiff(RevenueAnalyticsQueryRunner.DEFAULT_CACHE_TARGET_AGE)
 
     def test_cache_target_age_first_time_sync(self):
         """Test that first-time sync (RUNNING status with no last_synced_at) returns 1 minute cache"""
@@ -57,7 +57,7 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
             last_synced_at=None,  # Never synced before
         )
 
-        self.assertDiff(timedelta(minutes=1))
+        self.assertDiff(RevenueAnalyticsQueryRunner.SMALL_CACHE_TARGET_AGE)
 
     def test_cache_target_age_with_sync_intervals(self):
         """Test that when schemas have sync intervals, we cache for half the minimum interval"""
@@ -96,7 +96,7 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
         self.assertDiff(timedelta(hours=2))
 
     def test_cache_target_age_without_sync_intervals(self):
-        """Test that when schemas have no sync intervals, we default to 6 hours"""
+        """Test that when schemas have no sync intervals, we use our default cache target age"""
 
         # Create a Stripe source with revenue analytics enabled
         source = ExternalDataSource.objects.create(
@@ -128,7 +128,7 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
             sync_frequency_interval=None,  # No interval
         )
 
-        self.assertDiff(timedelta(hours=6))
+        self.assertDiff(RevenueAnalyticsQueryRunner.DEFAULT_CACHE_TARGET_AGE)
 
     def test_cache_target_age_mixed_sync_intervals(self):
         """Test that when some schemas have intervals and others don't, we use the minimum"""
@@ -199,8 +199,8 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
             sync_frequency_interval=timedelta(hours=2),
         )
 
-        # Should default to 6 hours since no Stripe sources
-        self.assertDiff(timedelta(hours=6))
+        # Should use our default cache target age since no Stripe sources
+        self.assertDiff(RevenueAnalyticsQueryRunner.DEFAULT_CACHE_TARGET_AGE)
 
     def test_cache_target_age_revenue_analytics_disabled_ignored(self):
         """Test that sources with revenue_analytics_enabled=False are ignored"""
@@ -225,8 +225,8 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
             sync_frequency_interval=timedelta(hours=2),
         )
 
-        # Should default to 6 hours since revenue analytics is disabled
-        self.assertDiff(timedelta(hours=6))
+        # Should use our default cache target age since revenue analytics is disabled
+        self.assertDiff(RevenueAnalyticsQueryRunner.DEFAULT_CACHE_TARGET_AGE)
 
     def test_cache_target_age_should_sync_false_ignored(self):
         """Test that schemas with should_sync=False are ignored"""
@@ -251,8 +251,8 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
             sync_frequency_interval=timedelta(hours=2),
         )
 
-        # Should default to 6 hours since schema shouldn't sync
-        self.assertDiff(timedelta(hours=6))
+        # Should use our default cache target age since schema shouldn't sync
+        self.assertDiff(RevenueAnalyticsQueryRunner.DEFAULT_CACHE_TARGET_AGE)
 
     def test_cache_target_age_first_time_sync_priority(self):
         """Test that first-time sync takes priority over sync intervals"""
@@ -287,8 +287,8 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
             sync_frequency_interval=timedelta(hours=4),
         )
 
-        # Should return 1 minute due to first-time sync, not 2 hours from interval
-        self.assertDiff(timedelta(minutes=1))
+        # Should return our small cache target age since it's the first time syncing
+        self.assertDiff(RevenueAnalyticsQueryRunner.SMALL_CACHE_TARGET_AGE)
 
     def test_cache_target_age_complex_scenario(self):
         """Test a complex scenario with multiple schemas and edge cases"""
@@ -343,5 +343,5 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
             sync_frequency_interval=None,  # Should be ignored for interval calculation
         )
 
-        # Should return 1 minute due to first-time sync, not 3 hours from minimum interval
-        self.assertDiff(timedelta(minutes=1))
+        # Should return our small cache target age since it's the first time syncing
+        self.assertDiff(RevenueAnalyticsQueryRunner.SMALL_CACHE_TARGET_AGE)

--- a/products/revenue_analytics/backend/hogql_queries/test/test_revenue_analytics_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/test/test_revenue_analytics_query_runner.py
@@ -1,0 +1,347 @@
+from datetime import datetime, timedelta
+
+from products.revenue_analytics.backend.hogql_queries.revenue_analytics_revenue_query_runner import (
+    RevenueAnalyticsQueryRunner,
+)
+from posthog.schema import RevenueAnalyticsRevenueQuery, IntervalType
+from posthog.test.base import APIBaseTest
+from posthog.warehouse.models import ExternalDataSource, ExternalDataSchema
+
+
+# This is required because we can't instantiate the base class directly
+# since it doesn't implement two abstract methods
+class RevenueAnalyticsQueryRunnerImpl(RevenueAnalyticsQueryRunner):
+    def calculate(self):
+        raise NotImplementedError()
+
+    def to_query(self):
+        raise NotImplementedError()
+
+
+class TestRevenueAnalyticsQueryRunner(APIBaseTest):
+    query = RevenueAnalyticsRevenueQuery(groupBy=[], properties=[], interval=IntervalType.MONTH)
+    date = datetime(2025, 1, 1)
+
+    def assertDiff(self, diff: timedelta | None):
+        runner = RevenueAnalyticsQueryRunnerImpl(team=self.team, query=self.query)
+        self.assertEqual(runner.cache_target_age(self.date), self.date + diff)
+
+    def test_cache_target_age_without_last_refresh(self):
+        """Test that when there is no last refresh, we return None"""
+        runner = RevenueAnalyticsQueryRunnerImpl(team=self.team, query=self.query)
+        self.assertEqual(runner.cache_target_age(None), None)
+
+    def test_cache_target_age_without_sources(self):
+        """Test that when there are no sources, we use the default 6 hours"""
+        self.assertDiff(timedelta(hours=6))
+
+    def test_cache_target_age_first_time_sync(self):
+        """Test that first-time sync (RUNNING status with no last_synced_at) returns 1 minute cache"""
+
+        # Create a Stripe source with revenue analytics enabled
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="src_test",
+            connection_id="conn_test",
+            source_type=ExternalDataSource.Type.STRIPE,
+            revenue_analytics_enabled=True,
+        )
+
+        # Create a schema that's running but has never synced
+        ExternalDataSchema.objects.create(
+            team=self.team,
+            source=source,
+            name="test_schema",
+            should_sync=True,
+            status=ExternalDataSchema.Status.RUNNING,
+            last_synced_at=None,  # Never synced before
+        )
+
+        self.assertDiff(timedelta(minutes=1))
+
+    def test_cache_target_age_with_sync_intervals(self):
+        """Test that when schemas have sync intervals, we cache for half the minimum interval"""
+
+        # Create a Stripe source with revenue analytics enabled
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="src_test",
+            connection_id="conn_test",
+            source_type=ExternalDataSource.Type.STRIPE,
+            revenue_analytics_enabled=True,
+        )
+
+        # Create schemas with different sync intervals
+        ExternalDataSchema.objects.create(
+            team=self.team,
+            source=source,
+            name="schema_1",
+            should_sync=True,
+            status=ExternalDataSchema.Status.COMPLETED,
+            last_synced_at=datetime.now(),
+            sync_frequency_interval=timedelta(hours=4),  # 4 hours
+        )
+
+        ExternalDataSchema.objects.create(
+            team=self.team,
+            source=source,
+            name="schema_2",
+            should_sync=True,
+            status=ExternalDataSchema.Status.COMPLETED,
+            last_synced_at=datetime.now(),
+            sync_frequency_interval=timedelta(hours=8),  # 8 hours
+        )
+
+        # Should cache for half of the minimum interval (4 hours / 2 = 2 hours)
+        self.assertDiff(timedelta(hours=2))
+
+    def test_cache_target_age_without_sync_intervals(self):
+        """Test that when schemas have no sync intervals, we default to 6 hours"""
+
+        # Create a Stripe source with revenue analytics enabled
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="src_test",
+            connection_id="conn_test",
+            source_type=ExternalDataSource.Type.STRIPE,
+            revenue_analytics_enabled=True,
+        )
+
+        # Create schemas without sync intervals
+        ExternalDataSchema.objects.create(
+            team=self.team,
+            source=source,
+            name="schema_1",
+            should_sync=True,
+            status=ExternalDataSchema.Status.COMPLETED,
+            last_synced_at=datetime.now(),
+            sync_frequency_interval=None,  # No interval
+        )
+
+        ExternalDataSchema.objects.create(
+            team=self.team,
+            source=source,
+            name="schema_2",
+            should_sync=True,
+            status=ExternalDataSchema.Status.COMPLETED,
+            last_synced_at=datetime.now(),
+            sync_frequency_interval=None,  # No interval
+        )
+
+        self.assertDiff(timedelta(hours=6))
+
+    def test_cache_target_age_mixed_sync_intervals(self):
+        """Test that when some schemas have intervals and others don't, we use the minimum"""
+
+        # Create a Stripe source with revenue analytics enabled
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="src_test",
+            connection_id="conn_test",
+            source_type=ExternalDataSource.Type.STRIPE,
+            revenue_analytics_enabled=True,
+        )
+
+        # Create schemas with mixed sync intervals
+        ExternalDataSchema.objects.create(
+            team=self.team,
+            source=source,
+            name="schema_1",
+            should_sync=True,
+            status=ExternalDataSchema.Status.COMPLETED,
+            last_synced_at=datetime.now(),
+            sync_frequency_interval=timedelta(hours=6),  # 6 hours
+        )
+
+        ExternalDataSchema.objects.create(
+            team=self.team,
+            source=source,
+            name="schema_2",
+            should_sync=True,
+            status=ExternalDataSchema.Status.COMPLETED,
+            last_synced_at=datetime.now(),
+            sync_frequency_interval=None,  # No interval
+        )
+
+        ExternalDataSchema.objects.create(
+            team=self.team,
+            source=source,
+            name="schema_3",
+            should_sync=True,
+            status=ExternalDataSchema.Status.COMPLETED,
+            last_synced_at=datetime.now(),
+            sync_frequency_interval=timedelta(hours=2),  # 2 hours (minimum)
+        )
+
+        # Should cache for half of the minimum interval (2 hours / 2 = 1 hour)
+        self.assertDiff(timedelta(hours=1))
+
+    def test_cache_target_age_non_stripe_sources_ignored(self):
+        """Test that non-Stripe sources are ignored"""
+
+        # Create a non-Stripe source with revenue analytics enabled
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="src_test",
+            connection_id="conn_test",
+            source_type=ExternalDataSource.Type.POSTGRES,  # Not Stripe
+            revenue_analytics_enabled=True,
+        )
+
+        # Create a schema for the non-Stripe source
+        ExternalDataSchema.objects.create(
+            team=self.team,
+            source=source,
+            name="schema_1",
+            should_sync=True,
+            status=ExternalDataSchema.Status.COMPLETED,
+            last_synced_at=datetime.now(),
+            sync_frequency_interval=timedelta(hours=2),
+        )
+
+        # Should default to 6 hours since no Stripe sources
+        self.assertDiff(timedelta(hours=6))
+
+    def test_cache_target_age_revenue_analytics_disabled_ignored(self):
+        """Test that sources with revenue_analytics_enabled=False are ignored"""
+
+        # Create a Stripe source with revenue analytics disabled
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="src_test",
+            connection_id="conn_test",
+            source_type=ExternalDataSource.Type.STRIPE,
+            revenue_analytics_enabled=False,  # Disabled
+        )
+
+        # Create a schema for the disabled source
+        ExternalDataSchema.objects.create(
+            team=self.team,
+            source=source,
+            name="schema_1",
+            should_sync=True,
+            status=ExternalDataSchema.Status.COMPLETED,
+            last_synced_at=datetime.now(),
+            sync_frequency_interval=timedelta(hours=2),
+        )
+
+        # Should default to 6 hours since revenue analytics is disabled
+        self.assertDiff(timedelta(hours=6))
+
+    def test_cache_target_age_should_sync_false_ignored(self):
+        """Test that schemas with should_sync=False are ignored"""
+
+        # Create a Stripe source with revenue analytics enabled
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="src_test",
+            connection_id="conn_test",
+            source_type=ExternalDataSource.Type.STRIPE,
+            revenue_analytics_enabled=True,
+        )
+
+        # Create a schema that shouldn't sync
+        ExternalDataSchema.objects.create(
+            team=self.team,
+            source=source,
+            name="schema_1",
+            should_sync=False,  # Should not sync
+            status=ExternalDataSchema.Status.COMPLETED,
+            last_synced_at=datetime.now(),
+            sync_frequency_interval=timedelta(hours=2),
+        )
+
+        # Should default to 6 hours since schema shouldn't sync
+        self.assertDiff(timedelta(hours=6))
+
+    def test_cache_target_age_first_time_sync_priority(self):
+        """Test that first-time sync takes priority over sync intervals"""
+
+        # Create a Stripe source with revenue analytics enabled
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="src_test",
+            connection_id="conn_test",
+            source_type=ExternalDataSource.Type.STRIPE,
+            revenue_analytics_enabled=True,
+        )
+
+        # Create a schema that's running but has never synced (first-time sync)
+        ExternalDataSchema.objects.create(
+            team=self.team,
+            source=source,
+            name="schema_1",
+            should_sync=True,
+            status=ExternalDataSchema.Status.RUNNING,
+            last_synced_at=None,  # Never synced before
+        )
+
+        # Create another schema with sync interval
+        ExternalDataSchema.objects.create(
+            team=self.team,
+            source=source,
+            name="schema_2",
+            should_sync=True,
+            status=ExternalDataSchema.Status.COMPLETED,
+            last_synced_at=datetime.now(),
+            sync_frequency_interval=timedelta(hours=4),
+        )
+
+        # Should return 1 minute due to first-time sync, not 2 hours from interval
+        self.assertDiff(timedelta(minutes=1))
+
+    def test_cache_target_age_complex_scenario(self):
+        """Test a complex scenario with multiple schemas and edge cases"""
+
+        # Create a Stripe source with revenue analytics enabled
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="src_test",
+            connection_id="conn_test",
+            source_type=ExternalDataSource.Type.STRIPE,
+            revenue_analytics_enabled=True,
+        )
+
+        # Create multiple schemas with different configurations
+        ExternalDataSchema.objects.create(
+            team=self.team,
+            source=source,
+            name="schema_1",
+            should_sync=True,
+            status=ExternalDataSchema.Status.RUNNING,
+            last_synced_at=None,  # First-time sync (should take priority)
+            sync_frequency_interval=timedelta(hours=8),
+        )
+
+        ExternalDataSchema.objects.create(
+            team=self.team,
+            source=source,
+            name="schema_2",
+            should_sync=True,
+            status=ExternalDataSchema.Status.COMPLETED,
+            last_synced_at=datetime.now(),
+            sync_frequency_interval=timedelta(hours=6),
+        )
+
+        ExternalDataSchema.objects.create(
+            team=self.team,
+            source=source,
+            name="schema_3",
+            should_sync=False,  # Should be ignored
+            status=ExternalDataSchema.Status.COMPLETED,
+            last_synced_at=datetime.now(),
+            sync_frequency_interval=timedelta(hours=2),
+        )
+
+        ExternalDataSchema.objects.create(
+            team=self.team,
+            source=source,
+            name="schema_4",
+            should_sync=True,
+            status=ExternalDataSchema.Status.COMPLETED,
+            last_synced_at=datetime.now(),
+            sync_frequency_interval=None,  # Should be ignored for interval calculation
+        )
+
+        # Should return 1 minute due to first-time sync, not 3 hours from minimum interval
+        self.assertDiff(timedelta(minutes=1))


### PR DESCRIPTION
## Problem

We're hitting a major problem with Revenue Analytics that's hurting our onboarding process. Users add their first revenue source to PostHog and then open the Revenue Analytics dashboard. We'll then query their partial data and display the results, but we also display a big banner saying that we're still syncing their data so it's still in progress. This is all fine.

What happens, however, is that people come back to the UI after 30 minutes (enough time to sync medium-sized accounts) and the banner is gone, but the charts are still displaying stale data because we've cached all those insights. They can just click the `refresh` button, but that's not obvious.

## Changes

To reduce that problem, let's be much smarter with our caching mechanism:
- when we detect we're syncing data from a revenue source, let's implement a minimal cache (just 1min to avoid flooding)
- when not syncing, rather than using the default caching period, let's look at the sync frequency for the sources and use half the shortest sync period as our cache

This will guarantee that customers should see non-stale data very frequently. We're, of course, sacrificing speed/CPU for this, but I believe it's acceptable given the increase in user satisfaction.

If we ever think this is hurting our CPU, we can find smarter ways to bust the query - for example, clear the cache when DWH syncing finishes via some kind of hook (that doesnt exist yet).

Closes #34650
