### PR TITLE
fix(devex): #panel=feature-previews redirect to settings

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
@@ -161,12 +161,13 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
         return {
             '/': (_, _searchParams, hashParams): void => {
                 // Redirect old feature preview side panel links to new settings page
-                if (hashParams.panel?.includes('feature-previews')) {
+                if (hashParams.panel?.startsWith('feature-previews')) {
+                    // it will be encoded as %3A, so we need to split on :
                     const parts = hashParams.panel.split(':')
                     // from: ${url}/#panel=feature-previews
                     // to:   ${url}/settings/user-feature-previews
                     if (parts.length > 1) {
-                        // from: ${url}/#panel=feature-previews%3A${flagKey}
+                        // from: ${url}/#panel=feature-previews%3A${flagKey} or ${url}/#panel=feature-previews:${flagKey}
                         // to:   ${url}/settings/user-feature-previews#${flagKey}
                         router.actions.replace(combineUrl(urls.settings('user-feature-previews'), {}, parts[1]).url)
                     } else {

--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
@@ -9,6 +9,8 @@ import { userLogic } from 'scenes/userLogic'
 import { activationLogic } from '~/layout/navigation-3000/sidepanel/panels/activation/activationLogic'
 import { AvailableFeature, SidePanelTab } from '~/types'
 
+import { combineUrl, router, urlToAction } from 'kea-router'
+import { urls } from 'scenes/urls'
 import { sidePanelActivityLogic } from './panels/activity/sidePanelActivityLogic'
 import { sidePanelContextLogic } from './panels/sidePanelContextLogic'
 import { sidePanelStatusLogic } from './panels/sidePanelStatusLogic'
@@ -154,5 +156,24 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
                 return enabledTabs.filter((tab: any) => !visibleTabs.includes(tab))
             },
         ],
+    }),
+    urlToAction(() => {
+        return {
+            '/': (_, _searchParams, hashParams): void => {
+                // Redirect old feature preview side panel links to new settings page
+                if (hashParams.panel?.includes('feature-previews')) {
+                    const parts = hashParams.panel.split(':')
+                    // from: ${url}/#panel=feature-previews
+                    // to:   ${url}/settings/user-feature-previews
+                    if (parts.length > 1) {
+                        // from: ${url}/#panel=feature-previews%3A${flagKey}
+                        // to:   ${url}/settings/user-feature-previews#${flagKey}
+                        router.actions.replace(combineUrl(urls.settings('user-feature-previews'), {}, parts[1]).url)
+                    } else {
+                        router.actions.replace(urls.settings('user-feature-previews'))
+                    }
+                }
+            },
+        }
     }),
 ])

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -569,6 +569,15 @@ export const redirects: Record<
     '/settings/organization-rbac': urls.settings('organization-roles'),
     '/data-pipelines': urls.dataPipelines('overview'),
     '/data-warehouse/sources/:id': ({ id }) => urls.dataWarehouseSource(id, 'schemas'),
+    '/': (_params, _searchParams, hashParams) => {
+        if (hashParams.panel?.includes('feature-previews')) {
+            if (hashParams.panel?.includes('%3A')) {
+                return combineUrl(urls.settings('user-feature-previews'), {}, hashParams.panel.split('%3A')[1]).url
+            }
+            return urls.settings('user-feature-previews')
+        }
+        return urls.dashboards()
+    },
     ...productRedirects,
 }
 

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -569,15 +569,6 @@ export const redirects: Record<
     '/settings/organization-rbac': urls.settings('organization-roles'),
     '/data-pipelines': urls.dataPipelines('overview'),
     '/data-warehouse/sources/:id': ({ id }) => urls.dataWarehouseSource(id, 'schemas'),
-    '/': (_params, _searchParams, hashParams) => {
-        if (hashParams.panel?.includes('feature-previews')) {
-            if (hashParams.panel?.includes('%3A')) {
-                return combineUrl(urls.settings('user-feature-previews'), {}, hashParams.panel.split('%3A')[1]).url
-            }
-            return urls.settings('user-feature-previews')
-        }
-        return urls.dashboards()
-    },
     ...productRedirects,
 }
 


### PR DESCRIPTION

## Problem
Add redirect for older side panel feature preview links
Old links will still exist in emails/older marketing stuff 

## Changes
* Add `urlToAction` redirect 
`.../#panel=feature-previews%3Allm-observability` => `.../settings/user-feature-previews#llm-observability`
`.../#panel=feature-previews` => `.../settings/user-feature-previews`

#### Redirect working
![2025-07-16 23 38 23](https://github.com/user-attachments/assets/e3b1eea0-52da-4809-9330-fbec4d459fa8)

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Locally