### PR TITLE
chore(capture): refactor capture_internal API; move /report/ endpoint and test suite

### DIFF
--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -171,7 +171,7 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
         )
 
     @freeze_time("2021-05-02")
-    @mock.patch("ee.clickhouse.views.groups.new_capture_internal")
+    @mock.patch("ee.clickhouse.views.groups.capture_internal")
     @flaky(max_runs=3, min_passes=1)
     def test_group_property_crud_add_success(self, mock_capture):
         group_type_mapping = GroupTypeMapping.objects.create(
@@ -257,7 +257,7 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.json()["results"][0]["detail"]["changes"][0]["after"], "technology")
 
     @freeze_time("2021-05-02")
-    @mock.patch("ee.clickhouse.views.groups.new_capture_internal")
+    @mock.patch("ee.clickhouse.views.groups.capture_internal")
     @flaky(max_runs=3, min_passes=1)
     def test_group_property_crud_update_success(self, mock_capture):
         group_type_mapping = GroupTypeMapping.objects.create(
@@ -382,7 +382,7 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.status_code, 404)
 
     @freeze_time("2021-05-02")
-    @mock.patch("ee.clickhouse.views.groups.new_capture_internal")
+    @mock.patch("ee.clickhouse.views.groups.capture_internal")
     @flaky(max_runs=3, min_passes=1)
     def test_group_property_crud_delete_success(self, mock_capture):
         group_type_mapping = GroupTypeMapping.objects.create(
@@ -504,7 +504,7 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.status_code, 404)
 
     @freeze_time("2021-05-02")
-    @patch("ee.clickhouse.views.groups.new_capture_internal")
+    @patch("ee.clickhouse.views.groups.capture_internal")
     def test_get_group_activities_success(self, mock_capture):
         # Mock the response to return a 200 OK
         mock_response = mock.MagicMock()
@@ -546,7 +546,7 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.json()["results"][0]["detail"]["changes"][0]["action"], "changed")
 
     @freeze_time("2021-05-02")
-    @patch("ee.clickhouse.views.groups.new_capture_internal")
+    @patch("ee.clickhouse.views.groups.capture_internal")
     def test_get_group_activities_invalid_group(self, mock_capture):
         # Mock the response to return a 200 OK
         mock_response = mock.MagicMock()

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -504,9 +504,7 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
     @patch("ee.clickhouse.views.groups.capture_internal")
     def test_get_group_activities_success(self, mock_capture):
         # Mock the response to return a 200 OK
-        mock_response = mock.MagicMock()
-        mock_response.status_code = 200
-        mock_capture.return_value = mock_response
+        mock_capture.return_value = mock.MagicMock(status_code=200)
 
         group_type_mapping = GroupTypeMapping.objects.create(
             team=self.team,
@@ -546,9 +544,7 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
     @patch("ee.clickhouse.views.groups.capture_internal")
     def test_get_group_activities_invalid_group(self, mock_capture):
         # Mock the response to return a 200 OK
-        mock_response = mock.MagicMock()
-        mock_response.status_code = 200
-        mock_capture.return_value = mock_response
+        mock_capture.return_value = mock.MagicMock(status_code=200)
 
         group_type_mapping = GroupTypeMapping.objects.create(
             team=self.team,

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -227,18 +227,16 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.results, [('{"name": "Mr. Krabs", "industry": "technology"}',)])
 
         mock_capture.assert_called_once_with(
-            self.team.api_token,
-            str(self.team.uuid),
-            {
-                "event": "$groupidentify",
-                "timestamp": mock.ANY,
-                "properties": {
-                    "$group_type": group_type_mapping.group_type,
-                    "$group_key": group.group_key,
-                    "$group_set": {"industry": "technology"},
-                },
+            token=self.team.api_token,
+            event_name="$groupidentify",
+            event_source="ee_ch_views_groups",
+            timestamp=mock.ANY,
+            properties={
+                "$group_type": group_type_mapping.group_type,
+                "$group_key": group.group_key,
+                "$group_set": {"industry": "technology"},
             },
-            False,
+            process_person_profile=False,
         )
 
         response = self.client.get(
@@ -310,18 +308,17 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(orjson.loads(response.results[0][0]), {"name": "Mr. Krabs", "industry": "technology"})
 
         mock_capture.assert_called_once_with(
-            self.team.api_token,
-            str(self.team.uuid),
-            {
-                "event": "$groupidentify",
-                "timestamp": mock.ANY,
-                "properties": {
-                    "$group_type": group_type_mapping.group_type,
-                    "$group_key": group.group_key,
-                    "$group_set": {"industry": "technology"},
-                },
+            token=self.team.api_token,
+            event_name="$groupidentify",
+            event_source="ee_ch_views_groups",
+            distinct_id=str(self.team.uuid),
+            timestamp=mock.ANY,
+            properties={
+                "$group_type": group_type_mapping.group_type,
+                "$group_key": group.group_key,
+                "$group_set": {"industry": "technology"},
             },
-            False,
+            process_person_profile=False,
         )
 
         response = self.client.get(
@@ -432,18 +429,17 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.results, [('{"name": "Mr. Krabs"}',)])
 
         mock_capture.assert_called_once_with(
-            self.team.api_token,
-            str(self.team.uuid),
-            {
-                "event": "$delete_group_property",
-                "timestamp": mock.ANY,
-                "properties": {
-                    "$group_type": group_type_mapping.group_type,
-                    "$group_key": group.group_key,
-                    "$group_unset": ["industry"],
-                },
+            token=self.team.api_token,
+            event_name="$delete_group_property",
+            event_source="ee_ch_views_groups",
+            distinct_id=str(self.team.uuid),
+            timestamp=mock.ANY,
+            properties={
+                "$group_type": group_type_mapping.group_type,
+                "$group_key": group.group_key,
+                "$group_unset": ["industry"],
             },
-            False,
+            process_person_profile=False,
         )
 
         response = self.client.get(

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -230,6 +230,7 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
             token=self.team.api_token,
             event_name="$groupidentify",
             event_source="ee_ch_views_groups",
+            distinct_id=str(self.team.uuid),
             timestamp=mock.ANY,
             properties={
                 "$group_type": group_type_mapping.group_type,

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -101,6 +101,7 @@ def capture_internal(
 
 
 def capture_batch_internal(
+    *,
     events: list[dict[str, Any]],
     event_source: str,
     token: str,

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -114,8 +114,9 @@ def capture_batch_internal(
     event submission is not supported.
 
     Args:
-        events: List of event dictionaries to capture. The payloads MUST include well-formed
-                distinct_id, timestamp, and optional properties map.
+        events: List of event dictionaries to capture. The payloads MUST include
+                well-formed distinct_id, timestamp, and optional properties map
+        event_source: observability tag for error logging
         token: Optional API token to use for all events (overrides individual event tokens)
         process_person_profile: if FALSE (default) specifically disable person processing on each event
 

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -66,7 +66,7 @@ def capture_internal(
         Response object, the result of POSTing the event payload to the capture-rs backend service.
     """
     logger.debug(
-        "new_capture_internal",
+        "capture_internal",
         token=token,
         distinct_id=distinct_id,
         event_name=event_name,
@@ -134,7 +134,7 @@ def capture_batch_internal(
     with ThreadPoolExecutor(max_workers=CAPTURE_INTERNAL_MAX_WORKERS) as executor:
         # Note:
         # 1. token should be supplied by caller, and be consistent per batch submitted.
-        #    new_capture_internal will attempt to extract from each event if missing
+        #    new capture_internal will attempt to extract from each event if missing
         # 2. distinct_id should be present on each event since these can differ within a batch
         for event in events:
             future = executor.submit(
@@ -152,7 +152,7 @@ def capture_batch_internal(
     return futures
 
 
-# prep payload for new_capture_internal to POST to capture-rs
+# prep payload for new capture_internal to POST to capture-rs
 def prepare_capture_internal_payload(
     token: str,
     event_name: str,

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -27,8 +27,8 @@ SESSION_RECORDING_EVENT_NAMES = ("$snapshot", "$performance_event", *SESSION_REC
 # let's track who is using this to detect new (ab)usive call sites quickly
 CAPTURE_INTERNAL_EVENT_SUBMITTED_COUNTER = Counter(
     "capture_internal_event_submitted",
-    "Events received by capture_internal, tagged by resource type.",
-    labelnames=["event_source"],
+    "Events received by capture_internal, tagged by source.",
+    labelnames=["event_source"],  # which internal codepath submitted this event
 )
 
 

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -1,7 +1,7 @@
 import builtins
 import json
 from collections.abc import Callable
-from datetime import datetime
+from datetime import datetime, UTC
 from requests import HTTPError
 from typing import Any, List, Optional, TypeVar, Union, cast  # noqa: UP035
 
@@ -21,7 +21,7 @@ from rest_framework.settings import api_settings
 from rest_framework_csv import renderers as csvrenderers
 from statshog.defaults.django import statsd
 
-from posthog.api.capture import new_capture_internal
+from posthog.api.capture import capture_internal
 from posthog.api.documentation import PersonPropertiesSerializer, extend_schema
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import (
@@ -553,19 +553,22 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     def delete_property(self, request: request.Request, pk=None, **kwargs) -> response.Response:
         person: Person = get_pk_or_uuid(Person.objects.filter(team_id=self.team_id), pk).get()
 
+        event_name = "$delete_person_property"
+        distinct_id = person.distinct_id[0]
+        timestamp = datetime.now(UTC)
+        properties = {
+            "$unset": [request.data["$unset"]],
+        }
+
         try:
-            event = {
-                "event": "$delete_person_property",
-                "properties": {
-                    "$unset": [request.data["$unset"]],
-                },
-                "timestamp": datetime.now().isoformat(),
-            }
-            resp = new_capture_internal(
-                self.team.api_token,
-                person.distinct_ids[0],
-                event,
-                True,
+            resp = capture_internal(
+                token=self.team.api_token,
+                event_name=event_name,
+                event_source="person_viewset",
+                distinct_id=distinct_id,
+                timestamp=timestamp,
+                properties=properties,
+                process_person_profile=True,
             )
             resp.raise_for_status()
 
@@ -678,20 +681,21 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     def _set_properties(self, properties, user):
         instance = self.get_object()
         distinct_id = instance.distinct_ids[0]
+        event_name = "$set"
+        timestamp = datetime.now(UTC)
+        properties = {
+            "$set": properties,
+        }
 
         try:
-            event = {
-                "event": "$set",
-                "properties": {
-                    "$set": properties,
-                },
-                "timestamp": datetime.now().isoformat(),
-            }
-            resp = new_capture_internal(
-                instance.team.api_token,
-                distinct_id,
-                event,
-                True,
+            resp = capture_internal(
+                token=instance.team.api_token,
+                event_name=event_name,
+                event_source="person_viewset",
+                distinct_id=distinct_id,
+                timestamp=timestamp,
+                properties=properties,
+                process_person_profile=True,
             )
             resp.raise_for_status()
 

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -554,7 +554,7 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         person: Person = get_pk_or_uuid(Person.objects.filter(team_id=self.team_id), pk).get()
 
         event_name = "$delete_person_property"
-        distinct_id = person.distinct_id[0]
+        distinct_id = person.distinct_ids[0]
         timestamp = datetime.now(UTC)
         properties = {
             "$unset": [request.data["$unset"]],

--- a/posthog/api/report.py
+++ b/posthog/api/report.py
@@ -1,0 +1,103 @@
+import structlog
+
+from requests import HTTPError
+from django.http import HttpResponse, JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework import status
+
+from posthog.api.utils import get_token
+from posthog.api.capture import new_capture_internal, new_capture_batch_internal
+from posthog.api.csp import process_csp_report
+from posthog.exceptions import generate_exception_response
+from posthog.exceptions_capture import capture_exception
+from posthog.logging.timing import timed
+from posthog.utils_cors import cors_response
+
+logger = structlog.get_logger(__name__)
+
+
+@csrf_exempt
+@timed("posthog_cloud_csp_event_endpoint")
+def get_csp_event(request):
+    # we want to handle this as early as possible and avoid any processing
+    if request.method == "OPTIONS":
+        return cors_response(request, JsonResponse({"status": 1}))
+
+    debug_enabled = request.GET.get("debug", "").lower() == "true"
+    if debug_enabled:
+        logger.exception(
+            "CSP debug request",
+            error=ValueError("CSP debug request"),
+            method=request.method,
+            url=request.build_absolute_uri(),
+            content_type=request.content_type,
+            headers=dict(request.headers),
+            query_params=dict(request.GET),
+            body_size=len(request.body) if request.body else 0,
+            body=request.body.decode("utf-8", errors="ignore") if request.body else None,
+        )
+
+    csp_report, error_response = process_csp_report(request)
+    if error_response:
+        return error_response
+
+    first_distinct_id = None  # temp: only used for feature flag check
+    if csp_report and isinstance(csp_report, list):
+        # For list of reports, use the first one's distinct_id for feature flag check
+        first_distinct_id = csp_report[0].get("distinct_id", None)
+    elif csp_report and isinstance(csp_report, dict):
+        # For single report, use the distinct_id for the same
+        first_distinct_id = csp_report.get("distinct_id", None)
+    else:
+        # mimic what get_event does if no data is returned from process_csp_report
+        return cors_response(
+            request,
+            generate_exception_response(
+                "csp_report_capture",
+                f"Failed to submit CSP report",
+                code="invalid_payload",
+                type="invalid_payload",
+                status_code=status.HTTP_400_BAD_REQUEST,
+            ),
+        )
+
+    try:
+        token = get_token(csp_report, request)
+
+        if isinstance(csp_report, list):
+            futures = new_capture_batch_internal(csp_report, token, False)
+            for future in futures:
+                result = future.result()
+                result.raise_for_status()
+        else:
+            resp = new_capture_internal(token, first_distinct_id, csp_report, False)
+            resp.raise_for_status()
+
+        return cors_response(request, HttpResponse(status=status.HTTP_204_NO_CONTENT))
+
+    except HTTPError as hte:
+        capture_exception(hte, {"capture-http": "csp_report", "ph-team-token": token})
+        logger.exception("csp_report_capture_http_error", exc_info=hte)
+        return cors_response(
+            request,
+            generate_exception_response(
+                "csp_report_capture",
+                f"Failed to submit CSP report",
+                code="capture_http_error",
+                type="capture_http_error",
+                status_code=hte.response.status_code,
+            ),
+        )
+    except Exception as e:
+        capture_exception(e, {"capture-pathway": "csp_report", "ph-team-token": token})
+        logger.exception("csp_report_capture_error", exc_info=e)
+        return cors_response(
+            request,
+            generate_exception_response(
+                "csp_report_capture",
+                f"Failed to submit CSP report",
+                code="capture_error",
+                type="capture_error",
+                status_code=status.HTTP_400_BAD_REQUEST,
+            ),
+        )

--- a/posthog/api/report.py
+++ b/posthog/api/report.py
@@ -67,7 +67,9 @@ def get_csp_event(request):
             token = ""
 
         if isinstance(csp_report, list):
-            futures = capture_batch_internal(csp_report, "get_csp_report", token, False)
+            futures = capture_batch_internal(
+                events=csp_report, event_source="get_csp_report", token=token, process_person_profile=False
+            )
             for future in futures:
                 result = future.result()
                 result.raise_for_status()

--- a/posthog/api/report.py
+++ b/posthog/api/report.py
@@ -41,15 +41,8 @@ def get_csp_event(request):
     if error_response:
         return error_response
 
-    first_distinct_id = None  # temp: only used for feature flag check
-    if csp_report and isinstance(csp_report, list):
-        # For list of reports, use the first one's distinct_id for feature flag check
-        first_distinct_id = csp_report[0].get("distinct_id", None)
-    elif csp_report and isinstance(csp_report, dict):
-        # For single report, use the distinct_id for the same
-        first_distinct_id = csp_report.get("distinct_id", None)
-    else:
-        # mimic what get_event does if no data is returned from process_csp_report
+    # mimic what get_event does if no data is returned from process_csp_report
+    if not csp_report:
         return cors_response(
             request,
             generate_exception_response(
@@ -78,8 +71,8 @@ def get_csp_event(request):
                 token=token,
                 event_name=csp_report.get("event", ""),
                 event_source="get_csp_report",
-                distinct_id=first_distinct_id,
-                timestamp=csp_report.get("timestamp", ""),
+                distinct_id=csp_report.get("distinct_id", ""),
+                timestamp=csp_report.get("timestamp", None),
                 properties=csp_report.get("properties", {}),
                 process_person_profile=False,
             )

--- a/posthog/api/test/test_capture_internal.py
+++ b/posthog/api/test/test_capture_internal.py
@@ -61,17 +61,15 @@ class TestCaptureInternal(BaseTest):
         event_name = "test_event"
         timestamp = datetime.now(UTC)
 
-        test_props = (
-            {
-                "$current_url": "https://example.com",
-                "$ip": "127.0.0.1",
-                "$lib": "python",
-                "$lib_version": "1.0.0",
-                "$screen_width": 1920,
-                "$screen_height": 1080,
-                "some_custom_property": True,
-            },
-        )
+        test_props = {
+            "$current_url": "https://example.com",
+            "$ip": "127.0.0.1",
+            "$lib": "python",
+            "$lib_version": "1.0.0",
+            "$screen_width": 1920,
+            "$screen_height": 1080,
+            "some_custom_property": True,
+        }
 
         spy = InstallCapturePostSpy(mock_session_class)
         response = capture_internal(
@@ -460,7 +458,10 @@ class TestCaptureInternal(BaseTest):
         for future in resp_futures:
             with self.assertRaises(CaptureInternalError) as e:
                 future.result()
-            assert str(e.exception) == "capture_internal: distinct ID is required"
+                err_msg = str(e.exception)
+                assert "capture_internal" in err_msg
+                assert "test_capture_batch_internal_invalid_payload" in err_msg
+                assert "distinct ID is required" in err_msg
 
     @patch("posthog.api.capture.Session")
     def test_capture_batch_internal_bad_req(self, mock_session_class):

--- a/posthog/api/test/test_capture_internal.py
+++ b/posthog/api/test/test_capture_internal.py
@@ -90,7 +90,7 @@ class TestCaptureInternal(BaseTest):
         assert spied_calls[0]["event_payload"]["event"] == event_name
         assert spied_calls[0]["event_payload"]["distinct_id"] == distinct_id
         assert spied_calls[0]["event_payload"]["api_key"] == token
-        assert spied_calls[0]["event_payload"]["timestamp"] == timestamp
+        assert spied_calls[0]["event_payload"]["timestamp"] == timestamp.isoformat()
         # note: event payload passed to new capture_internal is mutated. here we inject a source marker
         assert spied_calls[0]["event_payload"]["properties"]["capture_internal"] is True
         assert len(spied_calls[0]["event_payload"]["properties"]) == len(test_props)
@@ -139,7 +139,7 @@ class TestCaptureInternal(BaseTest):
         assert spied_calls[0]["event_payload"]["event"] == event_name
         assert spied_calls[0]["event_payload"]["distinct_id"] == distinct_id
         assert spied_calls[0]["event_payload"]["api_key"] == token
-        assert spied_calls[0]["event_payload"]["timestamp"] == timestamp
+        assert spied_calls[0]["event_payload"]["timestamp"] == timestamp.isoformat()
         assert spied_calls[0]["event_payload"]["properties"]["capture_internal"] is True
         assert len(spied_calls[0]["event_payload"]["properties"]) == len(test_props)
         # when new capture_internal is called with process_person_profile == True, we don't alter the event payload
@@ -274,7 +274,7 @@ class TestCaptureInternal(BaseTest):
         assert spied_calls[0]["event_payload"]["event"] == event_name
         assert spied_calls[0]["event_payload"]["distinct_id"] == distinct_id
         assert spied_calls[0]["event_payload"]["api_key"] == token
-        assert spied_calls[0]["event_payload"]["timestamp"] == timestamp
+        assert spied_calls[0]["event_payload"]["timestamp"] == timestamp.isoformat()
         assert spied_calls[0]["event_payload"]["properties"]["capture_internal"] is True
         assert len(spied_calls[0]["event_payload"]["properties"]) == len(test_replay_props)
         assert spied_calls[0]["event_payload"]["properties"].get("$process_person_profile", None) is not None

--- a/posthog/api/test/test_capture_internal.py
+++ b/posthog/api/test/test_capture_internal.py
@@ -79,7 +79,7 @@ class TestCaptureInternal(BaseTest):
             event_name=event_name,
             event_source="test_capture_internal",
             distinct_id=distinct_id,
-            timsestamp=timestamp,
+            timestamp=timestamp,
             properties=test_props,
         )
         assert response.status_code == 200
@@ -127,7 +127,7 @@ class TestCaptureInternal(BaseTest):
             event_name=event_name,
             event_source="test_capture_internal_with_persons_processing",
             distinct_id=distinct_id,
-            timsestamp=timestamp,
+            timestamp=timestamp,
             properties=test_props,
             process_person_profile=True,
         )
@@ -168,7 +168,7 @@ class TestCaptureInternal(BaseTest):
             event_name=event_name,
             event_source="test_capture_internal_with_capture_post_server_error",
             distinct_id=distinct_id,
-            timsestamp=timestamp,
+            timestamp=timestamp,
             properties=test_props,
         )
         assert response.status_code == 503
@@ -263,7 +263,7 @@ class TestCaptureInternal(BaseTest):
             event_name=event_name,
             event_source="test_capture_internal_replay",
             distinct_id=distinct_id,
-            timsestamp=timestamp,
+            timestamp=timestamp,
             properties=test_replay_props,
         )
         assert response.status_code == 200
@@ -303,7 +303,7 @@ class TestCaptureInternal(BaseTest):
                 event_name=event_name,
                 event_source="test_capture_internal_invalid_token",
                 distinct_id=distinct_id,
-                timsestamp=timestamp,
+                timestamp=timestamp,
                 properties=test_props,
             )
         assert (
@@ -334,7 +334,7 @@ class TestCaptureInternal(BaseTest):
                 event_name=event_name,
                 event_source="test_capture_internal_invalid_distinct_id",
                 distinct_id=distinct_id,
-                timsestamp=timestamp,
+                timestamp=timestamp,
                 properties=test_props,
             )
         assert (
@@ -365,7 +365,7 @@ class TestCaptureInternal(BaseTest):
                 event_name=event_name,
                 event_source="test_capture_internal_invalid_event_name",
                 distinct_id=distinct_id,
-                timsestamp=timestamp,
+                timestamp=timestamp,
                 properties=test_props,
             )
         assert str(e.exception) == "capture_internal (test_capture_internal_invalid_event_name): event name is required"

--- a/posthog/api/test/test_capture_internal.py
+++ b/posthog/api/test/test_capture_internal.py
@@ -1,7 +1,10 @@
-from typing import Any
+import pathlib
+
+from typing import Any, cast
 from datetime import datetime, UTC
 from unittest.mock import patch, MagicMock
 from uuid import uuid4
+from prance import ResolvingParser
 
 from posthog.api.capture import new_capture_internal, new_capture_batch_internal, CaptureInternalError
 from posthog.test.base import BaseTest
@@ -11,6 +14,12 @@ from posthog.settings.ingestion import (
     NEW_ANALYTICS_CAPTURE_ENDPOINT,
     REPLAY_CAPTURE_ENDPOINT,
 )
+
+parser = ResolvingParser(
+    url=str(pathlib.Path(__file__).parent / "../../../openapi/capture.yaml"),
+    strict=True,
+)
+openapi_spec = cast(dict[str, Any], parser.specification)
 
 
 class InstallCapturePostSpy:

--- a/posthog/api/test/test_capture_internal.py
+++ b/posthog/api/test/test_capture_internal.py
@@ -6,7 +6,7 @@ from unittest.mock import patch, MagicMock
 from uuid import uuid4
 from prance import ResolvingParser
 
-from posthog.api.capture import new_capture_internal, new_capture_batch_internal, CaptureInternalError
+from posthog.api.capture import capture_internal, capture_batch_internal, CaptureInternalError
 from posthog.test.base import BaseTest
 from posthog.settings.ingestion import (
     CAPTURE_INTERNAL_URL,
@@ -48,25 +48,21 @@ class InstallCapturePostSpy:
 
 class TestCaptureInternal(BaseTest):
     """
-    Tests the `new_capture_internal` function.
+    Tests the new `capture_internal` function.
     """
 
     def setUp(self):
         super().setUp()
 
     @patch("posthog.api.capture.Session")
-    def test_new_capture_internal(self, mock_session_class):
+    def test_capture_internal(self, mock_session_class):
         token = "abc123"
         distinct_id = "xyz987"
         event_name = "test_event"
-        timestamp = datetime.now(UTC).isoformat()
+        timestamp = datetime.now(UTC)
 
-        test_event = {
-            "event": event_name,
-            "distinct_id": distinct_id,
-            "api_key": token,
-            "timestamp": timestamp,
-            "properties": {
+        test_props = (
+            {
                 "$current_url": "https://example.com",
                 "$ip": "127.0.0.1",
                 "$lib": "python",
@@ -75,10 +71,17 @@ class TestCaptureInternal(BaseTest):
                 "$screen_height": 1080,
                 "some_custom_property": True,
             },
-        }
+        )
 
         spy = InstallCapturePostSpy(mock_session_class)
-        response = new_capture_internal(token, distinct_id, test_event)
+        response = capture_internal(
+            token=token,
+            event_name=event_name,
+            event_source="test_capture_internal",
+            distinct_id=distinct_id,
+            timsestamp=timestamp,
+            properties=test_props,
+        )
         assert response.status_code == 200
 
         spied_calls = spy.get_calls()
@@ -88,21 +91,21 @@ class TestCaptureInternal(BaseTest):
         assert spied_calls[0]["event_payload"]["distinct_id"] == distinct_id
         assert spied_calls[0]["event_payload"]["api_key"] == token
         assert spied_calls[0]["event_payload"]["timestamp"] == timestamp
-        # note: event payload passed to new_capture_internal is mutated. here we inject a source marker
+        # note: event payload passed to new capture_internal is mutated. here we inject a source marker
         assert spied_calls[0]["event_payload"]["properties"]["capture_internal"] is True
-        assert len(spied_calls[0]["event_payload"]["properties"]) == len(test_event["properties"])
-        # when process_person_profile is False, new_capture_internal explicitly sets this on the event
+        assert len(spied_calls[0]["event_payload"]["properties"]) == len(test_props)
+        # when process_person_profile is False, new capture_internal explicitly sets this on the event
         assert spied_calls[0]["event_payload"]["properties"].get("$process_person_profile", None) is not None
         assert spied_calls[0]["event_payload"]["properties"]["$process_person_profile"] is False
 
     @patch("posthog.api.capture.Session")
-    def test_new_capture_internal_with_persons_processing(self, mock_session_class):
+    def test_capture_internal_with_persons_processing(self, mock_session_class):
         token = "abc123"
         distinct_id = "xyz987"
         event_name = "test_event"
-        timestamp = datetime.now(UTC).isoformat()
+        timestamp = datetime.now(UTC)
 
-        test_event = {
+        test_props = {
             "event": event_name,
             "distinct_id": distinct_id,
             "api_key": token,
@@ -119,7 +122,15 @@ class TestCaptureInternal(BaseTest):
         }
 
         spy = InstallCapturePostSpy(mock_session_class)
-        response = new_capture_internal(token, distinct_id, test_event, True)
+        response = capture_internal(
+            token=token,
+            event_name=event_name,
+            event_source="test_capture_internal_with_persons_processing",
+            distinct_id=distinct_id,
+            timsestamp=timestamp,
+            properties=test_props,
+            process_person_profile=True,
+        )
         assert response.status_code == 200
 
         spied_calls = spy.get_calls()
@@ -130,129 +141,131 @@ class TestCaptureInternal(BaseTest):
         assert spied_calls[0]["event_payload"]["api_key"] == token
         assert spied_calls[0]["event_payload"]["timestamp"] == timestamp
         assert spied_calls[0]["event_payload"]["properties"]["capture_internal"] is True
-        assert len(spied_calls[0]["event_payload"]["properties"]) == len(test_event["properties"])
-        # when new_capture_internal is called with process_person_profile == True, we don't alter the event payload
+        assert len(spied_calls[0]["event_payload"]["properties"]) == len(test_props)
+        # when new capture_internal is called with process_person_profile == True, we don't alter the event payload
         assert spied_calls[0]["event_payload"]["properties"].get("$process_person_profile", None) is None
 
     @patch("posthog.api.capture.Session")
-    def test_new_capture_internal_with_capture_post_server_error(self, mock_session_class):
+    def test_capture_internal_with_capture_post_server_error(self, mock_session_class):
         token = "abc123"
         distinct_id = "xyz987"
         event_name = "test_event"
-        timestamp = datetime.now(UTC).isoformat()
+        timestamp = datetime.now(UTC)
 
-        test_event = {
-            "event": event_name,
-            "distinct_id": distinct_id,
-            "api_key": token,
-            "timestamp": timestamp,
-            "properties": {
-                "$current_url": "https://example.com",
-                "$ip": "127.0.0.1",
-                "$lib": "python",
-                "$lib_version": "1.0.0",
-                "$screen_width": 1920,
-                "$screen_height": 1080,
-                "some_custom_property": True,
-            },
+        test_props = {
+            "$current_url": "https://example.com",
+            "$ip": "127.0.0.1",
+            "$lib": "python",
+            "$lib_version": "1.0.0",
+            "$screen_width": 1920,
+            "$screen_height": 1080,
+            "some_custom_property": True,
         }
 
         InstallCapturePostSpy(mock_session_class, status_code=503)
-        response = new_capture_internal(token, distinct_id, test_event, False)
+        response = capture_internal(
+            token=token,
+            event_name=event_name,
+            event_source="test_capture_internal_with_capture_post_server_error",
+            distinct_id=distinct_id,
+            timsestamp=timestamp,
+            properties=test_props,
+        )
         assert response.status_code == 503
         # note: retry mechanism is disabled since we mocked requests.Session
 
     @patch("posthog.api.capture.Session")
-    def test_new_capture_internal_replay(self, mock_session_class):
+    def test_capture_internal_replay(self, mock_session_class):
         token = "abc123"
         distinct_id = "xyz987"
         event_name = "$snapshot"
-        timestamp = datetime.now(UTC).isoformat()
+        timestamp = datetime.now(UTC)
 
-        test_replay_event = {
-            "event": event_name,
-            "distinct_id": distinct_id,
-            "api_key": token,
-            "timestamp": timestamp,
-            "properties": {
-                "$screen_density": 2.75,
-                "$screen_height": 2154,
-                "$screen_width": 1080,
-                "$app_version": "1.0",
-                "$app_namespace": "com.posthog.android.sample",
-                "$app_build": 1,
-                "$app_name": "PostHog Android Sample",
-                "$device_manufacturer": "Google",
-                "$device_model": "sdk_gphone64_arm64",
-                "$device_name": "emu64a",
-                "$device_type": "Mobile",
-                "$os_name": "Android",
-                "$os_version": "14",
-                "$lib": "posthog-android",
-                "$lib_version": "3.0.0-beta.3",
-                "$is_emulator": True,
-                "$locale": "en-US",
-                "$user_agent": "Dalvik/2.1.0 (Linux; U; Android 14; sdk_gphone64_arm64 Build/UPB5.230623.003)",
-                "$timezone": "Europe/Vienna",
-                "$network_wifi": True,
-                "$network_bluetooth": False,
-                "$network_cellular": False,
-                "$network_carrier": "T-Mobile",
-                "$snapshot_data": [
-                    {"timestamp": 1699354586963, "type": 0},
-                    {"timestamp": 1699354586963, "type": 1},
-                    {
-                        "data": {"href": "http://localhost", "width": 1080, "height": 2220},
-                        "timestamp": 1699354586963,
-                        "type": 4,
+        test_replay_props = {
+            "$screen_density": 2.75,
+            "$screen_height": 2154,
+            "$screen_width": 1080,
+            "$app_version": "1.0",
+            "$app_namespace": "com.posthog.android.sample",
+            "$app_build": 1,
+            "$app_name": "PostHog Android Sample",
+            "$device_manufacturer": "Google",
+            "$device_model": "sdk_gphone64_arm64",
+            "$device_name": "emu64a",
+            "$device_type": "Mobile",
+            "$os_name": "Android",
+            "$os_version": "14",
+            "$lib": "posthog-android",
+            "$lib_version": "3.0.0-beta.3",
+            "$is_emulator": True,
+            "$locale": "en-US",
+            "$user_agent": "Dalvik/2.1.0 (Linux; U; Android 14; sdk_gphone64_arm64 Build/UPB5.230623.003)",
+            "$timezone": "Europe/Vienna",
+            "$network_wifi": True,
+            "$network_bluetooth": False,
+            "$network_cellular": False,
+            "$network_carrier": "T-Mobile",
+            "$snapshot_data": [
+                {"timestamp": 1699354586963, "type": 0},
+                {"timestamp": 1699354586963, "type": 1},
+                {
+                    "data": {"href": "http://localhost", "width": 1080, "height": 2220},
+                    "timestamp": 1699354586963,
+                    "type": 4,
+                },
+                {
+                    "data": {
+                        "node": {
+                            "id": 1,
+                            "type": 0,
+                            "childNodes": [
+                                {"type": 1, "name": "html", "id": 2, "childNodes": []},
+                                {
+                                    "id": 3,
+                                    "type": 2,
+                                    "tagName": "html",
+                                    "childNodes": [
+                                        {
+                                            "id": 5,
+                                            "type": 2,
+                                            "tagName": "body",
+                                            "childNodes": [
+                                                {
+                                                    "type": 2,
+                                                    "tagName": "canvas",
+                                                    "id": 7,
+                                                    "attributes": {
+                                                        "id": "canvas",
+                                                        "width": "1080",
+                                                        "height": "2220",
+                                                    },
+                                                    "childNodes": [],
+                                                }
+                                            ],
+                                        }
+                                    ],
+                                },
+                            ],
+                            "initialOffset": {"left": 0, "top": 0},
+                        }
                     },
-                    {
-                        "data": {
-                            "node": {
-                                "id": 1,
-                                "type": 0,
-                                "childNodes": [
-                                    {"type": 1, "name": "html", "id": 2, "childNodes": []},
-                                    {
-                                        "id": 3,
-                                        "type": 2,
-                                        "tagName": "html",
-                                        "childNodes": [
-                                            {
-                                                "id": 5,
-                                                "type": 2,
-                                                "tagName": "body",
-                                                "childNodes": [
-                                                    {
-                                                        "type": 2,
-                                                        "tagName": "canvas",
-                                                        "id": 7,
-                                                        "attributes": {
-                                                            "id": "canvas",
-                                                            "width": "1080",
-                                                            "height": "2220",
-                                                        },
-                                                        "childNodes": [],
-                                                    }
-                                                ],
-                                            }
-                                        ],
-                                    },
-                                ],
-                                "initialOffset": {"left": 0, "top": 0},
-                            }
-                        },
-                        "timestamp": 1699354586963,
-                        "type": 2,
-                    },
-                ],
-                "$session_id": "bceaa9ce-dc9d-4728-8a90-4a7c249604b1",
-                "$window_id": "31bfffdc-79fc-4504-9ff4-0216a58bf7f6",
-            },
+                    "timestamp": 1699354586963,
+                    "type": 2,
+                },
+            ],
+            "$session_id": "bceaa9ce-dc9d-4728-8a90-4a7c249604b1",
+            "$window_id": "31bfffdc-79fc-4504-9ff4-0216a58bf7f6",
         }
 
         spy = InstallCapturePostSpy(mock_session_class)
-        response = new_capture_internal(token, distinct_id, test_replay_event)
+        response = capture_internal(
+            token=token,
+            event_name=event_name,
+            event_source="test_capture_internal_replay",
+            distinct_id=distinct_id,
+            timsestamp=timestamp,
+            properties=test_replay_props,
+        )
         assert response.status_code == 200
 
         spied_calls = spy.get_calls()
@@ -263,86 +276,102 @@ class TestCaptureInternal(BaseTest):
         assert spied_calls[0]["event_payload"]["api_key"] == token
         assert spied_calls[0]["event_payload"]["timestamp"] == timestamp
         assert spied_calls[0]["event_payload"]["properties"]["capture_internal"] is True
-        assert len(spied_calls[0]["event_payload"]["properties"]) == len(test_replay_event["properties"])
+        assert len(spied_calls[0]["event_payload"]["properties"]) == len(test_replay_props)
+        assert spied_calls[0]["event_payload"]["properties"].get("$process_person_profile", None) is not None
+        assert spied_calls[0]["event_payload"]["properties"]["$process_person_profile"] is False
 
-    def test_new_capture_internal_invalid_token(self):
-        token = None
+    def test_capture_internal_invalid_token(self):
+        token = ""
         distinct_id = "xyz987"
         event_name = "test_event"
-        timestamp = datetime.now(UTC).isoformat()
+        timestamp = datetime.now(UTC)
 
         # no fallback token provided in event payload
-        test_event = {
-            "event": event_name,
-            "distinct_id": distinct_id,
-            "timestamp": timestamp,
-            "properties": {
-                "$current_url": "https://example.com",
-                "$ip": "127.0.0.1",
-                "$lib": "python",
-                "$lib_version": "1.0.0",
-                "$screen_width": 1920,
-                "$screen_height": 1080,
-                "some_custom_property": True,
-            },
+        test_props = {
+            "$current_url": "https://example.com",
+            "$ip": "127.0.0.1",
+            "$lib": "python",
+            "$lib_version": "1.0.0",
+            "$screen_width": 1920,
+            "$screen_height": 1080,
+            "some_custom_property": True,
         }
 
         with self.assertRaises(CaptureInternalError) as e:
-            new_capture_internal(token, distinct_id, test_event)
-        assert str(e.exception) == "capture_internal: API token is required"
+            capture_internal(
+                token=token,
+                event_name=event_name,
+                event_source="test_capture_internal_invalid_token",
+                distinct_id=distinct_id,
+                timsestamp=timestamp,
+                properties=test_props,
+            )
+        assert (
+            str(e.exception)
+            == "capture_internal (test_capture_internal_invalid_token, test_event): API token is required"
+        )
 
-    def test_new_capture_internal_invalid_distinct_id(self):
+    def test_capture_internal_invalid_distinct_id(self):
         token = "abc123"
-        distinct_id = None
+        distinct_id = ""
         event_name = "test_event"
-        timestamp = datetime.now(UTC).isoformat()
+        timestamp = datetime.now(UTC)
 
         # no fallback distinct ID provided in event payload (top-level or in properties)
-        test_event = {
-            "event": event_name,
-            "api_key": token,
-            "timestamp": timestamp,
-            "properties": {
-                "$current_url": "https://example.com",
-                "$ip": "127.0.0.1",
-                "$lib": "python",
-                "$lib_version": "1.0.0",
-                "$screen_width": 1920,
-                "$screen_height": 1080,
-                "some_custom_property": True,
-            },
+        test_props = {
+            "$current_url": "https://example.com",
+            "$ip": "127.0.0.1",
+            "$lib": "python",
+            "$lib_version": "1.0.0",
+            "$screen_width": 1920,
+            "$screen_height": 1080,
+            "some_custom_property": True,
         }
 
         with self.assertRaises(CaptureInternalError) as e:
-            new_capture_internal(token, distinct_id, test_event)
-        assert str(e.exception) == "capture_internal: distinct ID is required"
+            capture_internal(
+                token=token,
+                event_name=event_name,
+                event_source="test_capture_internal_invalid_distinct_id",
+                distinct_id=distinct_id,
+                timsestamp=timestamp,
+                properties=test_props,
+            )
+        assert (
+            str(e.exception)
+            == "capture_internal (test_capture_internal_invalid_distinct_id, test_event): distinct ID is required"
+        )
 
-    def test_new_capture_internal_invalid_event_name(self):
+    def test_capture_internal_invalid_event_name(self):
+        event_name = ""
         token = "abc123"
         distinct_id = "xyz678"
-        timestamp = datetime.now(UTC).isoformat()
+        timestamp = datetime.now(UTC)
 
         # no event name supplied in payload
-        test_event = {
-            "api_key": token,
-            "timestamp": timestamp,
-            "properties": {
-                "$current_url": "https://example.com",
-                "$ip": "127.0.0.1",
-                "$lib": "python",
-                "$lib_version": "1.0.0",
-                "$screen_width": 1920,
-                "$screen_height": 1080,
-                "some_custom_property": True,
-            },
+        test_props = {
+            "$current_url": "https://example.com",
+            "$ip": "127.0.0.1",
+            "$lib": "python",
+            "$lib_version": "1.0.0",
+            "$screen_width": 1920,
+            "$screen_height": 1080,
+            "some_custom_property": True,
         }
 
         with self.assertRaises(CaptureInternalError) as e:
-            new_capture_internal(token, distinct_id, test_event)
-        assert str(e.exception) == "capture_internal: event name is required"
+            capture_internal(
+                token=token,
+                event_name=event_name,
+                event_source="test_capture_internal_invalid_event_name",
+                distinct_id=distinct_id,
+                timsestamp=timestamp,
+                properties=test_props,
+            )
+        assert str(e.exception) == "capture_internal (test_capture_internal_invalid_event_name): event name is required"
 
     @patch("posthog.api.capture.Session")
-    def test_new_capture_batch_internal(self, mock_session_class):
+    def test_capture_batch_internal(self, mock_session_class):
         token = "abc123"
         base_event_name = "test_event"
         timestamp = datetime.now(UTC).isoformat()
@@ -368,7 +397,7 @@ class TestCaptureInternal(BaseTest):
             )
 
         spy = InstallCapturePostSpy(mock_session_class)
-        resp_futures = new_capture_batch_internal(test_events, token, False)
+        resp_futures = capture_batch_internal(test_events, "test_capture_batch_internal", token, False)
 
         for future in resp_futures:
             resp = future.result()
@@ -393,7 +422,7 @@ class TestCaptureInternal(BaseTest):
             assert spied_calls[i]["event_payload"]["properties"].get("$process_person_profile", None) is not None
             assert spied_calls[i]["event_payload"]["properties"]["$process_person_profile"] is False
 
-    def test_new_capture_batch_internal_invalid_payload(self):
+    def test_capture_batch_internal_invalid_payload(self):
         token = "abc123"
         base_event_name = "test_event"
         timestamp = datetime.now(UTC).isoformat()
@@ -418,7 +447,7 @@ class TestCaptureInternal(BaseTest):
                 }
             )
 
-        resp_futures = new_capture_batch_internal(test_events, token, False)
+        resp_futures = capture_batch_internal(test_events, "test_capture_batch_internal_invalid_payload", token, False)
         assert len(resp_futures) == 3
 
         for future in resp_futures:
@@ -427,7 +456,7 @@ class TestCaptureInternal(BaseTest):
             assert str(e.exception) == "capture_internal: distinct ID is required"
 
     @patch("posthog.api.capture.Session")
-    def test_new_capture_batch_internal_bad_req(self, mock_session_class):
+    def test_capture_batch_internal_bad_req(self, mock_session_class):
         token = "abc123"
         base_event_name = "test_event"
         timestamp = datetime.now(UTC).isoformat()
@@ -453,7 +482,7 @@ class TestCaptureInternal(BaseTest):
             )
 
         InstallCapturePostSpy(mock_session_class, status_code=400)
-        resp_futures = new_capture_batch_internal(test_events, token, False)
+        resp_futures = capture_batch_internal(test_events, "test_capture_batch_internal_bad_req", token, False)
         assert len(resp_futures) == 3
 
         for future in resp_futures:

--- a/posthog/api/test/test_capture_internal.py
+++ b/posthog/api/test/test_capture_internal.py
@@ -397,7 +397,9 @@ class TestCaptureInternal(BaseTest):
             )
 
         spy = InstallCapturePostSpy(mock_session_class)
-        resp_futures = capture_batch_internal(test_events, "test_capture_batch_internal", token, False)
+        resp_futures = capture_batch_internal(
+            events=test_events, event_source="test_capture_batch_internal", token=token, process_person_profile=False
+        )
 
         for future in resp_futures:
             resp = future.result()
@@ -447,7 +449,12 @@ class TestCaptureInternal(BaseTest):
                 }
             )
 
-        resp_futures = capture_batch_internal(test_events, "test_capture_batch_internal_invalid_payload", token, False)
+        resp_futures = capture_batch_internal(
+            events=test_events,
+            event_source="test_capture_batch_internal_invalid_payload",
+            token=token,
+            process_person_profile=False,
+        )
         assert len(resp_futures) == 3
 
         for future in resp_futures:
@@ -482,7 +489,12 @@ class TestCaptureInternal(BaseTest):
             )
 
         InstallCapturePostSpy(mock_session_class, status_code=400)
-        resp_futures = capture_batch_internal(test_events, "test_capture_batch_internal_bad_req", token, False)
+        resp_futures = capture_batch_internal(
+            events=test_events,
+            event_source="test_capture_batch_internal_bad_req",
+            token=token,
+            process_person_profile=False,
+        )
         assert len(resp_futures) == 3
 
         for future in resp_futures:

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -555,16 +555,15 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         self.client.post(f"/api/person/{person.uuid}/update_property", {"key": "foo", "value": "bar"})
 
         mock_capture.assert_called_once_with(
-            self.team.api_token,
-            "some_distinct_id",
-            {
-                "event": "$set",
-                "properties": {
-                    "$set": {"foo": "bar"},
-                },
-                "timestamp": mock.ANY,
+            token=self.team.api_token,
+            event_name="$set",
+            event_source="person_viewset",
+            distinct_id="some_distinct_id",
+            timestamp=mock.ANY,
+            properties={
+                "$set": {"foo": "bar"},
             },
-            True,
+            process_person_profile=True,
         )
 
     @mock.patch("posthog.api.person.capture_internal")
@@ -579,16 +578,15 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         self.client.post(f"/api/person/{person.uuid}/delete_property", {"$unset": "foo"})
 
         mock_capture.assert_called_once_with(
-            self.team.api_token,
-            "some_distinct_id",
-            {
-                "event": "$delete_person_property",
-                "properties": {
-                    "$unset": ["foo"],
-                },
-                "timestamp": mock.ANY,
+            token=self.team.api_token,
+            event_name="$delete_person_property",
+            event_source="person_viewset",
+            distinct_id="some_distinct_id",
+            timestamp=mock.ANY,
+            properties={
+                "$unset": ["foo"],
             },
-            True,
+            process_person_profile=True,
         )
 
     def test_return_non_anonymous_name(self) -> None:

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -543,8 +543,8 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
             self.validation_error_response("required", "This field is required.", "properties"),
         )
 
-    @mock.patch("posthog.api.person.new_capture_internal")
-    def test_new_update_single_person_property(self, mock_new_capture) -> None:
+    @mock.patch("posthog.api.person.capture_internal")
+    def test_new_update_single_person_property(self, mock_capture) -> None:
         person = _create_person(
             team=self.team,
             distinct_ids=["some_distinct_id"],
@@ -554,7 +554,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
 
         self.client.post(f"/api/person/{person.uuid}/update_property", {"key": "foo", "value": "bar"})
 
-        mock_new_capture.assert_called_once_with(
+        mock_capture.assert_called_once_with(
             self.team.api_token,
             "some_distinct_id",
             {
@@ -567,8 +567,8 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
             True,
         )
 
-    @mock.patch("posthog.api.person.new_capture_internal")
-    def test_new_delete_person_properties(self, mock_new_capture) -> None:
+    @mock.patch("posthog.api.person.capture_internal")
+    def test_new_delete_person_properties(self, mock_capture) -> None:
         person = _create_person(
             team=self.team,
             distinct_ids=["some_distinct_id"],
@@ -578,7 +578,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
 
         self.client.post(f"/api/person/{person.uuid}/delete_property", {"$unset": "foo"})
 
-        mock_new_capture.assert_called_once_with(
+        mock_capture.assert_called_once_with(
             self.team.api_token,
             "some_distinct_id",
             {

--- a/posthog/api/test/test_report.py
+++ b/posthog/api/test/test_report.py
@@ -42,9 +42,9 @@ class TestCspReport(BaseTest):
         assert resp.status_code == status.HTTP_204_NO_CONTENT
         assert mock_capture.call_count == 1
 
-    @patch("posthog.api.capture.new_capture_internal")
-    def test_submit_csp_report_list_to_new_internal_capture(self, mock_new_capture) -> None:
-        mock_new_capture.return_value = MagicMock(status_code=204)
+    @patch("posthog.api.capture.capture_internal")
+    def test_submit_csp_report_list_to_new_internal_capture(self, mock_capture) -> None:
+        mock_capture.return_value = MagicMock(status_code=204)
 
         multiple_violations = [
             {
@@ -99,7 +99,7 @@ class TestCspReport(BaseTest):
             content_type="application/reports+json",
         )
         assert resp.status_code == status.HTTP_204_NO_CONTENT
-        assert mock_new_capture.call_count == 3
+        assert mock_capture.call_count == 3
 
     @patch("posthog.api.report.capture_internal")
     def test_capture_csp_violation(self, mock_capture):
@@ -229,7 +229,7 @@ class TestCspReport(BaseTest):
         assert response.json()["code"] == "invalid_payload"
         assert "Failed to submit CSP report" in response.json()["detail"]
 
-    @patch("posthog.api.capture.new_capture_internal")
+    @patch("posthog.api.capture.capture_internal")
     def test_integration_csp_report_with_report_to_format_returns_204(self, mock_capture):
         mock_capture.return_value = MagicMock(status_code=204, content=b"")
 
@@ -260,7 +260,7 @@ class TestCspReport(BaseTest):
         assert response.content == b""
         mock_capture.assert_called_once()
 
-    @patch("posthog.api.capture.new_capture_internal")
+    @patch("posthog.api.capture.capture_internal")
     def test_capture_csp_report_to_violation(self, mock_capture):
         mock_capture.return_value = MagicMock(status_code=204)
 
@@ -314,7 +314,7 @@ class TestCspReport(BaseTest):
         # Verify we processed both events
         assert mock_capture.call_count == 2
 
-    @patch("posthog.api.report.new_capture_internal")
+    @patch("posthog.api.report.capture_internal")
     @patch("posthog.api.report.logger")
     def test_csp_debug_logging_enabled(self, mock_logger, mock_capture):
         mock_capture.return_value = MagicMock(status_code=204)
@@ -344,7 +344,7 @@ class TestCspReport(BaseTest):
         assert call_args[1]["content_type"] == "application/csp-report"
         assert "body" in call_args[1]
 
-    @patch("posthog.api.report.new_capture_internal")
+    @patch("posthog.api.report.capture_internal")
     @patch("posthog.api.report.logger")
     def test_csp_debug_logging_disabled(self, mock_logger, mock_capture):
         mock_capture.return_value = MagicMock(status_code=204)
@@ -366,7 +366,7 @@ class TestCspReport(BaseTest):
         mock_capture.assert_called_once()
         mock_logger.exception.assert_not_called()
 
-    @patch("posthog.api.report.new_capture_internal")
+    @patch("posthog.api.report.capture_internal")
     @patch("posthog.api.report.logger")
     def test_csp_debug_logging_case_insensitive(self, mock_logger, mock_capture):
         mock_capture.return_value = MagicMock(status_code=204)

--- a/posthog/api/test/test_report.py
+++ b/posthog/api/test/test_report.py
@@ -1,23 +1,13 @@
 import json
-import pathlib
 
-from typing import Any, cast
 from django.test.client import Client
-from prance import ResolvingParser
 from rest_framework import status
 from unittest.mock import MagicMock, patch
 
 from posthog.test.base import BaseTest
 
-# TODO: update this to openapi/report.yaml
-parser = ResolvingParser(
-    url=str(pathlib.Path(__file__).parent / "../../../openapi/capture.yaml"),
-    strict=True,
-)
-openapi_spec = cast(dict[str, Any], parser.specification)
 
-
-class TestCapture(BaseTest):
+class TestCspReport(BaseTest):
     """
     Tests all data capture endpoints (e.g. `/capture` `/batch/`).
     We use Django's base test class instead of DRF's because we need granular control over the Content-Type sent over.

--- a/posthog/management/commands/plugin_server_load_test.py
+++ b/posthog/management/commands/plugin_server_load_test.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 from kafka import KafkaAdminClient, KafkaConsumer, TopicPartition
 
-from posthog.api.capture import new_capture_batch_internal
+from posthog.api.capture import capture_batch_internal
 from posthog.demo.products.hedgebox import HedgeboxMatrix
 from posthog.models import Team
 from posthog.kafka_client.topics import KAFKA_EVENTS_PLUGIN_INGESTION
@@ -113,8 +113,9 @@ class Command(BaseCommand):
         # returning a list of futures (previously ignored!) so final event
         # ordering in the ingest topic is not guaranteed here
         start_time = time.monotonic()
-        results = new_capture_batch_internal(
+        results = capture_batch_internal(
             events,
+            "plugin_server_load_test",
             token,
             True,  # allow person profile processing to occur as cfg for this token (team/project)
         )

--- a/posthog/management/commands/plugin_server_load_test.py
+++ b/posthog/management/commands/plugin_server_load_test.py
@@ -114,10 +114,10 @@ class Command(BaseCommand):
         # ordering in the ingest topic is not guaranteed here
         start_time = time.monotonic()
         results = capture_batch_internal(
-            events,
-            "plugin_server_load_test",
-            token,
-            True,  # allow person profile processing to occur as cfg for this token (team/project)
+            events=events,
+            event_source="plugin_server_load_test",
+            token=token,
+            process_person_profile=True,  # allow person profile processing to occur as cfg for this token (team/project)
         )
         for future in results:
             try:

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -24,10 +24,10 @@ from two_factor.urls import urlpatterns as tf_urls
 from posthog.api import (
     api_not_found,
     authentication,
-    capture,
     decide,
     hog_function_template,
     remote_config,
+    report,
     router,
     sharing,
     signup,
@@ -221,7 +221,7 @@ urlpatterns = [
     # ingestion
     # NOTE: When adding paths here that should be public make sure to update ALWAYS_ALLOWED_ENDPOINTS in middleware.py
     opt_slash_path("decide", decide.get_decide),
-    opt_slash_path("report", capture.get_csp_event),  # CSP violation reports
+    opt_slash_path("report", report.get_csp_event),  # CSP violation reports
     opt_slash_path("robots.txt", robots_txt),
     opt_slash_path(".well-known/security.txt", security_txt),
     # auth


### PR DESCRIPTION
## Problem
We should decouple `capture.py` (capture internal functionality) from `/report/` endpoint handling (now `report.py`) and remove the `new_*` prefix from call sites now that new `capture_internal` is live in the Django app.

## Changes
* Migrate `/report/` endpoint handler and test to `report.py` (etc.)
* Remove `new_*` prefix from capture internal API and call sites
* Update new `capture_internal` contract and function signatures
* Misc. test suite updates & cleanup from deprecation of "classic" capture

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Locally and in CI