### PR TITLE
fix(experiments): remove calculator mean metric math override

### DIFF
--- a/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeCalculatorLogic.tsx
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeCalculatorLogic.tsx
@@ -6,21 +6,13 @@ import { DEFAULT_MDE, experimentLogic } from 'scenes/experiments/experimentLogic
 import { performQuery } from '~/queries/query'
 import {
     ExperimentMetric,
-    ExperimentMetricType,
     FunnelsQuery,
     isExperimentFunnelMetric,
     isExperimentMeanMetric,
     TrendsQuery,
     TrendsQueryResponse,
 } from '~/queries/schema/schema-general'
-import {
-    AnyPropertyFilter,
-    BaseMathType,
-    CountPerActorMathType,
-    Experiment,
-    ExperimentMetricMathType,
-    FunnelVizType,
-} from '~/types'
+import { AnyPropertyFilter, BaseMathType, Experiment, ExperimentMetricMathType, FunnelVizType } from '~/types'
 
 import { calculateRecommendedSampleSize, calculateVariance } from './experimentStatisticsUtils'
 import type { runningTimeCalculatorLogicType } from './runningTimeCalculatorLogicType'
@@ -78,28 +70,6 @@ const defaultExposureEstimateConfig: ExposureEstimateConfig = {
     manualConversionRate: 2,
     uniqueUsers: null,
 }
-
-const applyMathTrendsQuery =
-    (metric: ExperimentMetric) =>
-    (query: TrendsQuery | FunnelsQuery | undefined): TrendsQuery | FunnelsQuery | undefined => {
-        if (!query) {
-            return undefined
-        }
-
-        if (metric.metric_type === ExperimentMetricType.MEAN) {
-            return {
-                ...query,
-                series: [
-                    ...query.series.slice(0, -1)!,
-                    {
-                        ...query.series.at(-1)!,
-                        math: CountPerActorMathType.Average,
-                    },
-                ],
-            }
-        }
-        return query
-    }
 
 export const runningTimeCalculatorLogic = kea<runningTimeCalculatorLogicType>([
     path(['scenes', 'experiments', 'RunningTimeCalculator', 'runningTimeCalculatorLogic']),
@@ -176,7 +146,6 @@ export const runningTimeCalculatorLogic = kea<runningTimeCalculatorLogicType>([
                 const queryBuilder = compose<
                     ExperimentMetric,
                     FunnelsQuery | TrendsQuery | undefined,
-                    FunnelsQuery | TrendsQuery | undefined,
                     FunnelsQuery | TrendsQuery | undefined
                 >(
                     getQuery({
@@ -187,8 +156,7 @@ export const runningTimeCalculatorLogic = kea<runningTimeCalculatorLogicType>([
                         },
                         trendsFilter: {},
                     }),
-                    addExposureToQuery(exposureEventNode),
-                    applyMathTrendsQuery(metric)
+                    addExposureToQuery(exposureEventNode)
                 )
 
                 const query = queryBuilder(metric)


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

> [!NOTE]
> Related to Zendesk ticket [34369](https://posthoghelp.zendesk.com/agent/tickets/34369)

## Problem

The Running Time Calculator is overriding the `math` property of the selected metric with `CountPerActorMathType.Average`.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Instead of overriding it, we are passing the metric math down to the query.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/0b275fb9-efc2-4c78-986f-6b6b1d230f5b)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
