### PR TITLE
chore: add move distinct ids metric

### DIFF
--- a/plugin-server/src/utils/db/metrics.ts
+++ b/plugin-server/src/utils/db/metrics.ts
@@ -1,4 +1,4 @@
-import { Counter } from 'prom-client'
+import { Counter, Histogram } from 'prom-client'
 
 export const personUpdateVersionMismatchCounter = new Counter({
     name: 'person_update_version_mismatch',
@@ -15,4 +15,10 @@ export const pluginLogEntryCounter = new Counter({
     name: 'plugin_log_entry',
     help: 'Plugin log entry created by plugin',
     labelNames: ['plugin_id', 'source'],
+})
+
+export const moveDistinctIdsCountHistogram = new Histogram({
+    name: 'move_distinct_ids_count',
+    help: 'Number of distinct IDs moved in merge operations',
+    buckets: [0, 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, Infinity],
 })


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We want to follow up on an incident involving moving a large number of distinct ids when merging persons. We'd like to understand the distribution of the number of distinct ids moved when merging before adding limits to the system.

## Changes

Adds a metric that counts the number of moved distinct ids.

## Did you write or update any docs for this change?

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [X] No docs needed for this change

## How did you test this code?

No need for extra tests for the metric.