### PR TITLE
feat(web-analytics): use a feature preview flag for the API

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -285,6 +285,7 @@ export const FEATURE_FLAGS = {
     AA_TEST_BAYESIAN_NEW: 'aa-test-bayesian-new', // owner: #team-experiments
     REPLAY_BULK_DELETE_SELECTED_RECORDINGS: 'replay-bulk-delete-selected-recordings', // owner: @veryayskiy #team-replay
     NEW_SCENE_LAYOUT: 'new-scene-layout', // owner: @adamleithp #team-devex
+    WEB_ANALYTICS_API: 'web-analytics-api', // owner: #team-web-analytics
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/posthog/api/external_web_analytics/http.py
+++ b/posthog/api/external_web_analytics/http.py
@@ -1,4 +1,4 @@
-from django.conf import settings
+import posthoganalytics
 from rest_framework import viewsets
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -30,7 +30,7 @@ from posthog.schema import (
 from .data import WebAnalyticsDataFactory
 from .query_adapter import ExternalWebAnalyticsQueryAdapter
 
-TEAM_IDS_WITH_EXTERNAL_WEB_ANALYTICS = [2]
+TEAM_IDS_WITH_EXTERNAL_WEB_ANALYTICS = [1, 2]
 
 
 class ExternalWebAnalyticsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
@@ -44,10 +44,20 @@ class ExternalWebAnalyticsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, vi
         self.factory = WebAnalyticsDataFactory()
 
     def _can_use_external_web_analytics(self) -> None:
-        available = True if settings.DEBUG else self.team_id in TEAM_IDS_WITH_EXTERNAL_WEB_ANALYTICS
+        # if settings.DEBUG:
+        #     return
+
+        available = False
+
+        if self.team_id in TEAM_IDS_WITH_EXTERNAL_WEB_ANALYTICS:
+            user = self.request.user
+
+            web_analytics_api_enabled = posthoganalytics.feature_enabled("web-analytics-api", str(user.distinct_id))
+
+            available = web_analytics_api_enabled
 
         if not available:
-            raise PermissionDenied("External web analytics is not enabled for this team.")
+            raise PermissionDenied("External web analytics is not available for this user - please contact support.")
 
     @extend_schema(
         request=WebAnalyticsExternalSummaryRequest,

--- a/posthog/api/external_web_analytics/http.py
+++ b/posthog/api/external_web_analytics/http.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 import posthoganalytics
 from rest_framework import viewsets
 from rest_framework.request import Request
@@ -8,6 +9,7 @@ from rest_framework.exceptions import PermissionDenied
 from posthog.api.mixins import PydanticModelMixin
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
+from posthog.models.user import User
 
 from posthog.auth import SessionAuthentication, PersonalAPIKeyAuthentication
 
@@ -44,12 +46,12 @@ class ExternalWebAnalyticsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, vi
         self.factory = WebAnalyticsDataFactory()
 
     def _can_use_external_web_analytics(self) -> None:
-        # if settings.DEBUG:
-        #     return
+        if settings.DEBUG:
+            return
 
         available = False
 
-        if self.team_id in TEAM_IDS_WITH_EXTERNAL_WEB_ANALYTICS:
+        if self.team_id in TEAM_IDS_WITH_EXTERNAL_WEB_ANALYTICS and isinstance(self.request.user, User):
             user = self.request.user
 
             web_analytics_api_enabled = posthoganalytics.feature_enabled("web-analytics-api", str(user.distinct_id))


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Use a flag that we can use for gating access to the API - this can be opt-in once pre-aggregated tables are rolled out to all teams

## Changes

- Add a flag

## How did you test this code?

Locally
