### PR TITLE
fix: raise LTS max recording age to 90 days

### DIFF
--- a/ee/session_recordings/session_recording_extensions.py
+++ b/ee/session_recordings/session_recording_extensions.py
@@ -18,7 +18,7 @@ MINIMUM_AGE_FOR_RECORDING = timedelta(
 )
 
 MAXIMUM_AGE_FOR_RECORDING_V2 = timedelta(
-    minutes=int(settings.get_from_env("SESSION_RECORDING_V2_MAXIMUM_AGE_MINUTES", 7 * 24 * 60))
+    minutes=int(settings.get_from_env("SESSION_RECORDING_V2_MAXIMUM_AGE_MINUTES", 90 * 24 * 60))
 )
 
 # we have 30, 90, and 365-day retention possible


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

The default for max recording age of V2 recordings for LTS persistence was set on a wrong assumption and causes some recordings to be skipped.

## Changes

Changes the max recording age to be 90 days - the maximum time we retain the non-lts recordings.

## Did you write or update any docs for this change?

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [X] No docs needed for this change

## How did you test this code?

Already includes tests, this is just a config change.