### PR TITLE
fix: Tone down brotli quality

### DIFF
--- a/products/batch_exports/backend/temporal/pipeline/transformer.py
+++ b/products/batch_exports/backend/temporal/pipeline/transformer.py
@@ -223,7 +223,9 @@ class JSONLBrotliStreamTransformer:
     @property
     def brotli_compressor(self) -> brotli._brotli.Compressor:
         if self._brotli_compressor is None:
-            self._brotli_compressor = brotli.Compressor()
+            # Quality goes from 0 to 11.
+            # Default is 11, aka maximum compression and worst performance.
+            self._brotli_compressor = brotli.Compressor(quality=5)
         return self._brotli_compressor
 
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

By default, the python brotli library will use maximum quality for compression. This means the most compression at the cost of the worst performance. We do not want to sacrifice that much performance in this tradeoff.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Bring quality down to 5 from the default (and maximum) of 11.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
