### PR TITLE
feat(admin): Add Admin tool for looking up API keys

### DIFF
--- a/posthog/templates/admin/index.html
+++ b/posthog/templates/admin/index.html
@@ -3,5 +3,6 @@
 <div id="content-main">
   {% include "admin/app_list.html" with app_list=app_list show_changelinks=True %}
   {% include "redis/app.html" with app_list=app_list %}
+  {% include "api_key_search/app.html" with app_list=app_list %}
 </div>
 {% endblock %}

--- a/posthog/templates/api_key_search/app.html
+++ b/posthog/templates/api_key_search/app.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+<!-- In case there are no apps, we also don't want to appear -->
+{% if app_list %}
+<div class="app-redis module">
+  <table>
+    <caption>
+      API Key
+    </caption>
+    <tr class="model-values">
+      <th scope="row">
+        <a href="{% url 'api_key_search' %}" aria-current="page">Search</a>
+      </th>
+
+      <td>
+        <a href="{% url 'api_key_search' %}" class="viewlink">{% translate 'View' %}</a>
+      </td>
+    </tr>
+  </table>
+</div>
+{% endif %}

--- a/posthog/templates/api_key_search/values.html
+++ b/posthog/templates/api_key_search/values.html
@@ -1,0 +1,116 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static admin_list %}
+
+{% block extrastyle %}
+{{ block.super }}
+<link rel="stylesheet" href="{% static 'admin/css/changelists.css' %}" />
+<link rel="stylesheet" href="{% static 'admin/css/forms.css' %}" />
+{{ media.css }}
+{% endblock %}
+
+{% if not is_popup %}
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+    &rsaquo; API Key search
+</div>
+{% endblock %}
+{% endif %}
+
+{% block content %}
+<div id="content-main">
+    <div class="module filtered">
+        <div>
+            {% block search %} {% load i18n static %}
+            <div id="toolbar">
+                <form method="post" role="search">
+                    {% csrf_token %}
+                    <div>
+                        <!-- DIV needed for valid HTML -->
+                        <label for="searchbar"><img src="{% static 'admin/img/search.svg' %}" alt="Search" /></label>
+                        <input type="text" size="40" name="q" value="{{ query }}" id="searchbar" required autocomplete="off" />
+                        <input type="submit" value="{% translate 'Search' %}" />
+                    </div>
+                </form>
+            </div>
+            {% endblock %}
+            <div class="results">
+                {% if personal_api_key_object %}
+                <table id="results_list">
+                    <thead>
+                        <tr>
+                            <th scope="col">
+                                <div class="text"><span>{% trans "Type" %}</span></div>
+                            </th>
+                            <th scope="col">
+                                <div class="text"><span>{% trans "Label" %}</span></div>
+                            </th>
+                            <th scope="col">
+                                <div class="text"><span>{% trans "User" %}</span></div>
+                            </th>
+                            <th scope="col">
+                                <div class="text"><span>{% trans "Scopes" %}</span></div>
+                            </th>
+                            <th scope="col">
+                                <div class="text"><span>{% trans "Organization/Project scope" %}</span></div>
+                            </th>
+                            <th scope="col">
+                                <div class="text"><span>{% trans "Created" %}</span></div>
+                            </th>
+                            <th scope="col">
+                                <div class="text"><span>{% trans "Last Used" %}</span></div>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Personal API Key ({{ personal_api_key_hash_mode }})</td>
+                            <td>{{ personal_api_key_object.label }}</td>
+                            <td><a href="/admin/posthog/user/{{ personal_api_key_object.user.id }}/change/">{{ personal_api_key_object.user.email }}</a></td>
+                            <td>{{ personal_api_key_object.scopes }}</td>
+                            <td>
+                                {% if personal_api_key_object.scoped_organizations %}
+                                Organization access
+                                {% elif personal_api_key_object.scoped_teams %}
+                                Project access
+                                {% else %}
+                                All access
+                                {% endif %}
+                            </td>
+                            <td>{{ personal_api_key_object.created_at }}</td>
+                            <td>{{ personal_api_key_object.last_used_at }}</td>
+                        </tr>
+                    </tbody>
+                </table>
+                {% elif team_object %}
+                <table id="results_list">
+                    <thead>
+                        <tr>
+                            <th scope="col">
+                                <div class="text"><span>{% trans "Type" %}</span></div>
+                            </th>
+                            <th scope="col">
+                                <div class="text"><span>{% trans "Team" %}</span></div>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>
+                                Team Secret API Token
+                                {% if team_object_key_type == "backup" %}
+                                (Backup)
+                                {% endif %}
+                            </td>
+                            <td><a href="/admin/posthog/team/{{ team_object.id }}/change/">{{ team_object.name }}</a></td>
+                        </tr>
+                    </tbody>
+                </table>
+                {% elif query != "" %}
+                <span>No results found</span>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -52,6 +52,7 @@ from .views import (
     login_required,
     preflight_check,
     redis_values_view,
+    api_key_search_view,
     robots_txt,
     security_txt,
     stats,
@@ -166,6 +167,7 @@ urlpatterns = [
     opt_slash_path("_stats", stats),
     opt_slash_path("_preflight", preflight_check),
     re_path(r"^admin/redisvalues$", redis_values_view, name="redis_values"),
+    re_path(r"^admin/apikeysearch$", api_key_search_view, name="api_key_search"),
     # ee
     *ee_urlpatterns,
     # api


### PR DESCRIPTION
## Problem

When an API key is discovered on the public internet, we want to be able to check if it's still active, and then ideally reach out to the API key owner(s).

## Changes

This tool gives us a single place to search all of our private API key types.

I plan to further expand this tool with the ability to email affected users/orgs about their key being leaked, as well as potentially adding the ability to automatically roll/revoke the key.

<img width="1082" height="229" alt="Screenshot 2025-07-17 at 14 09 48" src="https://github.com/user-attachments/assets/1847ae60-7303-4dda-80c2-8156e705c490" />
(key in screenshot is for my local instance AND has been revoked)

## How did you test this code?

I've performed lookups against PersonalAPIKeys hashed with sha256 and pbkdf2 (legacy), as well as the primary and backup Team API token.

## Did you write or update any docs for this change?

Added to runbook.

Closes [#4661](https://github.com/PostHog/posthog-cloud-infra/issues/4661)