### PR TITLE
fix: use team name for project deletion

### DIFF
--- a/frontend/src/scenes/settings/project/ProjectDangerZone.tsx
+++ b/frontend/src/scenes/settings/project/ProjectDangerZone.tsx
@@ -6,6 +6,7 @@ import { OrganizationMembershipLevel } from 'lib/constants'
 import { Dispatch, SetStateAction, useState } from 'react'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { projectLogic } from 'scenes/projectLogic'
+import { teamLogic } from 'scenes/teamLogic'
 
 export function DeleteProjectModal({
     isOpen,
@@ -76,7 +77,7 @@ export function DeleteProjectModal({
 }
 
 export function ProjectDangerZone(): JSX.Element {
-    const { currentProject } = useValues(projectLogic)
+    const { currentTeam } = useValues(teamLogic)
     const [isModalVisible, setIsModalVisible] = useState(false)
 
     const restrictedReason = useRestrictedArea({
@@ -101,7 +102,7 @@ export function ProjectDangerZone(): JSX.Element {
                         icon={<IconTrash />}
                         disabledReason={restrictedReason}
                     >
-                        Delete {currentProject?.name || 'the current project'}
+                        Delete {currentTeam?.name || 'the current project'}
                     </LemonButton>
                 </div>
             </div>


### PR DESCRIPTION
Replaced usage of projectLogic and currentProject with teamLogic and currentTeam in ProjectDangerZone. This aligns the component with updated state management and ensures correct team data is displayed and used for project deletion.

## Changes

For all users who were never enrolled in the environment's beta, team.name = project.name. There are ~400 teams in the US and 300 in EU where they don't match from being enrolled in the beta. This PR will only affect those users.

The user is deleting the "team" not the "project" so we should be displaying the team name to reduce confusion. Right now it displays project name which is the parent name when you have multiple environments. 

Customer report: https://posthoghelp.zendesk.com/agent/tickets/34256 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/36676)

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
