### PR TITLE
fix(dashboards): determine last effective refresh date

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -60,11 +60,9 @@ function DashboardScene(): JSX.Element {
         dashboardMode,
         dashboardFailedToLoad,
         accessDeniedToDashboard,
-        dashboardVariables,
+        hasVariables,
     } = useValues(dashboardLogic)
     const { setDashboardMode, reportDashboardViewed, abortAnyRunningQuery } = useActions(dashboardLogic)
-
-    const hasVariables = Object.keys(dashboardVariables).length > 0
 
     useEffect(() => {
         reportDashboardViewed()

--- a/frontend/src/scenes/dashboard/DashboardEditBar.tsx
+++ b/frontend/src/scenes/dashboard/DashboardEditBar.tsx
@@ -24,13 +24,11 @@ export function DashboardEditBar(): JSX.Element {
         temporaryFilters,
         dashboardMode,
         filtersUpdated,
-        dashboardVariables,
+        hasVariables,
     } = useValues(dashboardLogic)
     const { setDates, setProperties, setBreakdownFilter, setDashboardMode, previewTemporaryFilters } =
         useActions(dashboardLogic)
     const { groupsTaxonomicTypes } = useValues(groupsModel)
-
-    const hasVariables = Object.keys(dashboardVariables).length > 0
 
     const insightProps: InsightLogicProps = {
         dashboardItemId: 'new',

--- a/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
+++ b/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
@@ -13,13 +13,13 @@ import { humanFriendlyDuration } from 'lib/utils'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 
 export const LastRefreshText = (): JSX.Element => {
-    const { lastDashboardRefresh } = useValues(dashboardLogic)
+    const { effectiveLastRefresh } = useValues(dashboardLogic)
     return (
         <div className="flex items-center gap-1">
-            {lastDashboardRefresh && dayjs().diff(dayjs(lastDashboardRefresh), 'hour') < 24 ? (
+            {effectiveLastRefresh && dayjs().diff(dayjs(effectiveLastRefresh), 'hour') < 24 ? (
                 <div className="flex items-center gap-1">
                     <span>Last refreshed</span>
-                    <TZLabel time={lastDashboardRefresh} />
+                    <TZLabel time={effectiveLastRefresh} />
                 </div>
             ) : (
                 'Refresh'

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1068,6 +1068,25 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 return sortDayJsDates(validDates)
             },
         ],
+        oldestRefreshed: [
+            // selecting page visibility to update the refresh when a page comes back into view
+            (s) => [s.sortedDates, s.pageVisibility],
+            (sortedDates): Dayjs | null => {
+                if (!sortedDates.length) {
+                    return null
+                }
+
+                return sortedDates[0]
+            },
+        ],
+        effectiveLastRefresh: [
+            (s) => [s.lastDashboardRefresh, s.oldestRefreshed],
+            (lastDashboardRefresh, oldestRefreshed): Dayjs | null => {
+                const dates = [lastDashboardRefresh, oldestRefreshed].filter((d) => d != null)
+                return sortDayJsDates(dates)[dates.length - 1]
+            },
+        ],
+
         nextAllowedDashboardRefresh: [
             (s) => [s.lastDashboardRefresh],
             (lastDashboardRefresh): Dayjs | null => {

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -979,6 +979,10 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     .filter((n): n is { variable: Variable; insights: string[] } => Boolean(n?.variable))
             },
         ],
+        hasVariables: [
+            (s) => [s.dashboardVariables],
+            (dashboardVariables) => Object.keys(dashboardVariables).length > 0,
+        ],
         asDashboardTemplate: [
             (s) => [s.dashboard],
             (dashboard: DashboardType): DashboardTemplateEditorType | undefined => {

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1068,20 +1068,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 return sortDayJsDates(validDates)
             },
         ],
-        sortedClientRefreshAllowed: [
-            (s) => [s.insightTiles],
-            (insightTiles): Dayjs[] => {
-                if (!insightTiles || !insightTiles.length) {
-                    return []
-                }
-
-                const validDates = insightTiles
-                    .filter((i) => !!i.insight?.cache_target_age || !!i.insight?.next_allowed_client_refresh)
-                    .map((i) => dayjs(i.insight?.cache_target_age ?? i.insight?.next_allowed_client_refresh))
-                    .filter((date) => date.isValid())
-                return sortDayJsDates(validDates)
-            },
-        ],
         nextAllowedDashboardRefresh: [
             (s) => [s.lastDashboardRefresh],
             (lastDashboardRefresh): Dayjs | null => {

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1086,7 +1086,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
         effectiveLastRefresh: [
             (s) => [s.lastDashboardRefresh, s.oldestRefreshed],
             (lastDashboardRefresh, oldestRefreshed): Dayjs | null => {
-                const dates = [lastDashboardRefresh, oldestRefreshed].filter((d) => d != null)
+                const dates = [lastDashboardRefresh, oldestRefreshed].filter((d): d is Dayjs => d != null)
                 return sortDayJsDates(dates)[dates.length - 1]
             },
         ],


### PR DESCRIPTION
## Problem

The time in the refresh button is based on the last time the whole dashboard was refreshed. If all insights are refreshed independently, it displays an outdated time.

## Changes

- Displays either the time the dashboard was refreshed or the time the oldest insight was refreshed, whichever is newer.
- Also removes the unused sortedClientRefreshAllowed selector.
- Adds a hasVariables selector

## How did you test this code?

Refreshed all insights on a dashboard manually
