### PR TITLE
refactor(security): Update tooltip messages in PersonalAPIKeys component to use JSX Directly

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -2157,10 +2157,3 @@ export function getRelativeNextPath(nextPath: string | null | undefined, locatio
         return null
     }
 }
-
-export function escapeHtml(raw: string): string {
-    // renders a string safe to use in dangerouslySetInnerHTML
-    const div = document.createElement('div')
-    div.textContent = raw
-    return div.innerHTML
-}

--- a/frontend/src/scenes/settings/user/PersonalAPIKeys.tsx
+++ b/frontend/src/scenes/settings/user/PersonalAPIKeys.tsx
@@ -15,14 +15,13 @@ import {
     Tooltip,
 } from '@posthog/lemon-ui'
 import clsx from 'clsx'
-import DOMPurify from 'dompurify'
 import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { IconErrorOutline } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { API_KEY_SCOPE_PRESETS, API_SCOPES, MAX_API_KEYS_PER_USER } from 'lib/scopes'
-import { capitalizeFirstLetter, escapeHtml, humanFriendlyDetailedTime } from 'lib/utils'
+import { capitalizeFirstLetter, humanFriendlyDetailedTime } from 'lib/utils'
 import { Fragment, useEffect } from 'react'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
@@ -297,25 +296,21 @@ function PersonalAPIKeysTable(): JSX.Element {
 
                         if (keyDisabled) {
                             const orgNames = restrictedOrgs.map((org: any) => org.name)
-                            const tooltipMessage =
-                                orgNames.length === 1
-                                    ? `Organization <strong>${escapeHtml(
-                                          orgNames[0]
-                                      )}</strong> has restricted the use of personal API keys.`
-                                    : `Organizations <strong>${escapeHtml(
-                                          orgNames.join(', ')
-                                      )}</strong> have restricted the use of personal API keys.`
 
                             return (
                                 <Tooltip
                                     title={
-                                        <span
-                                            dangerouslySetInnerHTML={{
-                                                __html: DOMPurify.sanitize(tooltipMessage, {
-                                                    ALLOWED_TAGS: ['strong'],
-                                                }),
-                                            }}
-                                        />
+                                        orgNames.length === 1 ? (
+                                            <span>
+                                                Organization <strong>{orgNames[0]}</strong> has restricted the use of
+                                                personal API keys.
+                                            </span>
+                                        ) : (
+                                            <span>
+                                                Organizations <strong>{orgNames.join(', ')}</strong> have restricted the
+                                                use of personal API keys.
+                                            </span>
+                                        )
                                     }
                                 >
                                     <LemonTag type="danger">Disabled</LemonTag>
@@ -324,7 +319,7 @@ function PersonalAPIKeysTable(): JSX.Element {
                         }
 
                         if (hasPartialRestrictions) {
-                            let tooltipMessage = ''
+                            let tooltipMessage: JSX.Element = <span />
 
                             // Handle project-scoped keys with restrictions
                             if (restrictedTeams.length > 0) {
@@ -332,51 +327,51 @@ function PersonalAPIKeysTable(): JSX.Element {
                                 const restrictedOrgNames = restrictedOrgs.map((org: any) => org.name)
 
                                 if (restrictedOrgNames.length === 1 && restrictedTeamNames.length === 1) {
-                                    tooltipMessage = `Organization <strong>${escapeHtml(
-                                        restrictedOrgNames[0]
-                                    )}</strong> has restricted the use of personal API keys. This key will not work for project <strong>${escapeHtml(
-                                        restrictedTeamNames[0]
-                                    )}</strong>.`
+                                    tooltipMessage = (
+                                        <span>
+                                            Organization <strong>{restrictedOrgNames[0]}</strong> has restricted the use
+                                            of personal API keys. This key will not work for project{' '}
+                                            <strong>{restrictedTeamNames[0]}</strong>.
+                                        </span>
+                                    )
                                 } else if (restrictedOrgNames.length === 1) {
-                                    tooltipMessage = `Organization <strong>${escapeHtml(
-                                        restrictedOrgNames[0]
-                                    )}</strong> has restricted the use of personal API keys. This key will not work for projects: <strong>${escapeHtml(
-                                        restrictedTeamNames.join(', ')
-                                    )}</strong>.`
+                                    tooltipMessage = (
+                                        <span>
+                                            Organization <strong>{restrictedOrgNames[0]}</strong> has restricted the use
+                                            of personal API keys. This key will not work for projects:{' '}
+                                            <strong>{restrictedTeamNames.join(', ')}</strong>.
+                                        </span>
+                                    )
                                 } else {
                                     // Multiple organizations affecting projects
-                                    tooltipMessage = `Multiple organizations have restricted personal API keys. This key will not work for projects: <strong>${escapeHtml(
-                                        restrictedTeamNames.join(', ')
-                                    )}</strong>.`
+                                    tooltipMessage = (
+                                        <span>
+                                            Multiple organizations have restricted personal API keys. This key will not
+                                            work for projects: <strong>{restrictedTeamNames.join(', ')}</strong>.
+                                        </span>
+                                    )
                                 }
                             }
                             // Handle organization-scoped keys with restrictions
                             else if (restrictedOrgs.length > 0) {
                                 const restrictedOrgNames = restrictedOrgs.map((org: any) => org.name)
 
-                                if (restrictedOrgNames.length === 1) {
-                                    tooltipMessage = `Organization <strong>${escapeHtml(
-                                        restrictedOrgNames[0]
-                                    )}</strong> has restricted the use of personal API keys.`
-                                } else {
-                                    tooltipMessage = `Organizations <strong>${escapeHtml(
-                                        restrictedOrgNames.join(', ')
-                                    )}</strong> have restricted the use of personal API keys.`
-                                }
+                                tooltipMessage =
+                                    restrictedOrgNames.length === 1 ? (
+                                        <span>
+                                            Organization <strong>{restrictedOrgNames[0]}</strong> has restricted the use
+                                            of personal API keys.
+                                        </span>
+                                    ) : (
+                                        <span>
+                                            Organizations <strong>{restrictedOrgNames.join(', ')}</strong> have
+                                            restricted the use of personal API keys.
+                                        </span>
+                                    )
                             }
 
                             return (
-                                <Tooltip
-                                    title={
-                                        <span
-                                            dangerouslySetInnerHTML={{
-                                                __html: DOMPurify.sanitize(tooltipMessage, {
-                                                    ALLOWED_TAGS: ['strong'],
-                                                }),
-                                            }}
-                                        />
-                                    }
-                                >
+                                <Tooltip title={tooltipMessage}>
                                     <LemonTag type="warning">Partial restrictions</LemonTag>
                                 </Tooltip>
                             )


### PR DESCRIPTION
Follow-up to https://github.com/PostHog/posthog/pull/35174

We were doing a lot of extra DOMPurify/escaping here but that's not needed if we simply stop using strings and instead use JSX. The browser/React will handle that for us just fine.
