### PR TITLE
chore(capture-rs): reduce Kafka metadata refresh interval config

### DIFF
--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -129,12 +129,14 @@ pub struct KafkaConfig {
     pub kafka_tls: bool,
     #[envconfig(default = "")]
     pub kafka_client_id: String,
-    #[envconfig(default = "60000")]
-    pub kafka_metadata_max_age_ms: u32,
     #[envconfig(default = "2")]
     pub kafka_producer_max_retries: u32,
     #[envconfig(default = "all")]
     pub kafka_producer_acks: String,
-    #[envconfig(default = "60000")]
+    // interval between metadata refreshes from the Kafka brokers
+    #[envconfig(default = "20000")]
     pub kafka_topic_metadata_refresh_interval_ms: u32,
+    // default is 3x metadata refresh interval so we maintain that here
+    #[envconfig(default = "60000")]
+    pub kafka_metadata_max_age_ms: u32,
 }


### PR DESCRIPTION
## Problem

[I noted some processing gaps in `capture-rs` this morning during the EU MSK patching event](https://grafana.prod-eu.posthog.dev/d/b2348f37-f276-498e-b72e-7cc2b5ec1455/new-capture?var-role=capture&from=2025-07-17T15:08:14.745Z&to=2025-07-17T16:07:08.386Z&timezone=utc&tab=queries&viewPanel=panel-23), where each Kafka broker is lost one at a time. The downtime for each `capure-rs` producer lines up roughly with the 5min default for metadata refresh times.

Luckily, the capture sink retries and we didn't see evidence of data loss during this or previous patching events, but let's go ahead and shorten that interval some more to minimize this in the future.

Hopefully this won't page so aggressively during the next patching event 👍 

## Changes

* Reduce metadata refresh interval in `capture-rs` `KakfaSink` and `KafkaConfig`
* I didn't see defaults overridden in deploy envs so I think this will be the extent of the change for now

## How did you test this code?
Locally + CI; will test deploy and observe as well

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
