### PR TITLE
fix(web-analytics): handle multi-set partitions on asset backfills

### DIFF
--- a/dags/tests/test_web_preaggregated_partitions.py
+++ b/dags/tests/test_web_preaggregated_partitions.py
@@ -1,0 +1,147 @@
+import pytest
+from datetime import datetime, UTC
+from unittest.mock import Mock, patch, call
+
+import dagster
+from dagster import TimeWindow
+
+from dags.web_preaggregated_daily import (
+    pre_aggregate_web_analytics_data,
+)
+from posthog.models.web_preaggregated.sql import DROP_PARTITION_SQL
+
+
+class TestPartitionHandling:
+    def setup_method(self):
+        self.mock_context = Mock(spec=dagster.AssetExecutionContext)
+        self.mock_context.log = Mock()
+        self.mock_context.op_config = {"team_ids": [1, 2], "extra_clickhouse_settings": ""}
+
+    @pytest.mark.parametrize(
+        "start_date_str,end_date_str,expected_partitions",
+        [
+            # Single day partition
+            ("2024-01-01", "2024-01-02", ["2024-01-01"]),
+            # Two day partition
+            ("2024-01-01", "2024-01-03", ["2024-01-01", "2024-01-02"]),
+            # Week-long partition
+            (
+                "2024-01-01",
+                "2024-01-08",
+                ["2024-01-01", "2024-01-02", "2024-01-03", "2024-01-04", "2024-01-05", "2024-01-06", "2024-01-07"],
+            ),
+            # Month-long partition (testing edge case)
+            ("2024-01-01", "2024-02-01", [f"2024-01-{day:02d}" for day in range(1, 32)]),
+        ],
+    )
+    @patch("dags.web_preaggregated_daily.sync_execute")
+    def test_partition_dropping_for_different_time_windows(
+        self, mock_sync_execute, start_date_str, end_date_str, expected_partitions
+    ):
+        start_datetime = datetime.fromisoformat(start_date_str).replace(tzinfo=UTC)
+        end_datetime = datetime.fromisoformat(end_date_str).replace(tzinfo=UTC)
+        self.mock_context.partition_time_window = TimeWindow(start_datetime, end_datetime)
+
+        mock_sql_generator = Mock(return_value="INSERT INTO test_table ...")
+        pre_aggregate_web_analytics_data(
+            context=self.mock_context,
+            table_name="web_stats_daily",
+            sql_generator=mock_sql_generator,
+        )
+
+        actual_drop_calls = [
+            call_args for call_args in mock_sync_execute.call_args_list if "DROP PARTITION" in str(call_args)
+        ]
+        assert len(actual_drop_calls) == len(expected_partitions)
+
+    @patch("dags.web_preaggregated_daily.sync_execute")
+    def test_partition_drop_error_handling(self, mock_sync_execute):
+        start_datetime = datetime(2024, 1, 1, tzinfo=UTC)
+        end_datetime = datetime(2024, 1, 3, tzinfo=UTC)
+        self.mock_context.partition_time_window = TimeWindow(start_datetime, end_datetime)
+
+        def side_effect(sql):
+            if "DROP PARTITION" in sql:
+                raise Exception("Partition doesn't exist")
+            return None
+
+        mock_sync_execute.side_effect = side_effect
+        mock_sql_generator = Mock(return_value="INSERT INTO test_table ...")
+
+        pre_aggregate_web_analytics_data(
+            context=self.mock_context,
+            table_name="web_stats_daily",
+            sql_generator=mock_sql_generator,
+        )
+
+        assert self.mock_context.log.info.call_count >= 4
+        insert_calls = [call_args for call_args in mock_sync_execute.call_args_list if "INSERT INTO" in str(call_args)]
+        assert len(insert_calls) == 1
+
+    @patch("dags.web_preaggregated_daily.sync_execute")
+    def test_granularity_parameter_usage(self, mock_sync_execute):
+        start_datetime = datetime(2024, 1, 1, tzinfo=UTC)
+        end_datetime = datetime(2024, 1, 2, tzinfo=UTC)
+        self.mock_context.partition_time_window = TimeWindow(start_datetime, end_datetime)
+
+        mock_sql_generator = Mock(return_value="INSERT INTO test_table ...")
+        pre_aggregate_web_analytics_data(
+            context=self.mock_context,
+            table_name="web_stats_daily",
+            sql_generator=mock_sql_generator,
+        )
+
+        expected_sql = DROP_PARTITION_SQL("web_stats_daily", "2024-01-01", granularity="daily")
+        assert call(expected_sql) in mock_sync_execute.call_args_list
+        assert "'20240101'" in expected_sql
+
+    def test_missing_partition_time_window_raises_error(self):
+        self.mock_context.partition_time_window = None
+        mock_sql_generator = Mock()
+
+        with pytest.raises(dagster.Failure, match="This asset should only be run with a partition_time_window"):
+            pre_aggregate_web_analytics_data(
+                context=self.mock_context,
+                table_name="web_stats_daily",
+                sql_generator=mock_sql_generator,
+            )
+
+    @patch("dags.web_preaggregated_daily.sync_execute")
+    def test_insert_query_failure_raises_dagster_failure(self, mock_sync_execute):
+        start_datetime = datetime(2024, 1, 1, tzinfo=UTC)
+        end_datetime = datetime(2024, 1, 2, tzinfo=UTC)
+        self.mock_context.partition_time_window = TimeWindow(start_datetime, end_datetime)
+
+        def side_effect(sql):
+            if "INSERT INTO" in sql:
+                raise Exception("Insert failed")
+            return None
+
+        mock_sync_execute.side_effect = side_effect
+        mock_sql_generator = Mock(return_value="INSERT INTO test_table ...")
+
+        with pytest.raises(dagster.Failure, match="Failed to pre-aggregate web_stats_daily"):
+            pre_aggregate_web_analytics_data(
+                context=self.mock_context,
+                table_name="web_stats_daily",
+                sql_generator=mock_sql_generator,
+            )
+
+    @patch("dags.web_preaggregated_daily.sync_execute")
+    def test_same_start_and_end_date_drops_partition(self, mock_sync_execute):
+        start_datetime = datetime(2024, 1, 1, tzinfo=UTC)
+        end_datetime = datetime(2024, 1, 1, tzinfo=UTC)
+        self.mock_context.partition_time_window = TimeWindow(start_datetime, end_datetime)
+
+        mock_sql_generator = Mock(return_value="INSERT INTO test_table ...")
+        pre_aggregate_web_analytics_data(
+            context=self.mock_context,
+            table_name="web_stats_daily",
+            sql_generator=mock_sql_generator,
+        )
+
+        drop_calls = [call_args for call_args in mock_sync_execute.call_args_list if "DROP PARTITION" in str(call_args)]
+        assert len(drop_calls) == 1
+
+        insert_calls = [call_args for call_args in mock_sync_execute.call_args_list if "INSERT INTO" in str(call_args)]
+        assert len(insert_calls) == 1

--- a/dags/web_preaggregated_daily.py
+++ b/dags/web_preaggregated_daily.py
@@ -76,7 +76,8 @@ def pre_aggregate_web_analytics_data(
         current_date = start_datetime.date()
         end_date = end_datetime.date()
 
-        while current_date <= end_date:
+        # For time windows: start is inclusive, end is exclusive (except for single-day partitions)
+        while current_date < end_date or (current_date == start_datetime.date() == end_date):
             partition_date_str = current_date.strftime("%Y-%m-%d")
             drop_partition_query = DROP_PARTITION_SQL(table_name, partition_date_str, granularity="daily")
             context.log.info(f"Dropping partition for {partition_date_str}: {drop_partition_query}")

--- a/dags/web_preaggregated_daily.py
+++ b/dags/web_preaggregated_daily.py
@@ -71,17 +71,26 @@ def pre_aggregate_web_analytics_data(
     date_end = end_datetime.strftime("%Y-%m-%d")
 
     try:
-        # Drop the partition first, ensuring a clean state before insertion
+        # Drop all partitions in the time window, ensuring a clean state before insertion
         # Note: No ON CLUSTER needed since tables are replicated (not sharded) and replication handles distribution
-        drop_partition_query = DROP_PARTITION_SQL(table_name, date_start)
-        context.log.info(f"Dropping partition for {date_start}: {drop_partition_query}")
+        current_date = start_datetime.date()
+        end_date = end_datetime.date()
 
-        try:
-            sync_execute(drop_partition_query)
-            context.log.info(f"Successfully dropped partition for {date_start}")
-        except Exception as drop_error:
-            # Partition might not exist when running for the first time or when running in a empty backfill, which is fine
-            context.log.info(f"Partition for {date_start} doesn't exist or couldn't be dropped: {drop_error}")
+        while current_date <= end_date:
+            partition_date_str = current_date.strftime("%Y-%m-%d")
+            drop_partition_query = DROP_PARTITION_SQL(table_name, partition_date_str, granularity="daily")
+            context.log.info(f"Dropping partition for {partition_date_str}: {drop_partition_query}")
+
+            try:
+                sync_execute(drop_partition_query)
+                context.log.info(f"Successfully dropped partition for {partition_date_str}")
+            except Exception as drop_error:
+                # Partition might not exist when running for the first time or when running in a empty backfill, which is fine
+                context.log.info(
+                    f"Partition for {partition_date_str} doesn't exist or couldn't be dropped: {drop_error}"
+                )
+
+            current_date += timedelta(days=1)
 
         insert_query = sql_generator(
             date_start=date_start,


### PR DESCRIPTION
## Problem

We usually use single day partitions but we can run backfill for multiple partitions, specially on dev or the US cluster. We need to make sure we're dropping all partitions on that timeframe correctly.

## Changes

- Handle multi-date-range partition dropping correctly

## How did you test this code?

Manually and covering the unit tests

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
