### PR TITLE
chore(flags): refactor to be more readable

### DIFF
--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -108,7 +108,7 @@ impl FeatureFlagList {
                         version: row.version,
                     }),
                     Err(e) => {
-                        tracing::error!(
+                        tracing::warn!(
                             "Failed to deserialize filters for flag {} in project {} (team {}): {}",
                             row.key,
                             project_id,

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -13,6 +13,14 @@ use common_metrics::inc;
 use common_redis::Client as RedisClient;
 use std::sync::Arc;
 
+/// Result of fetching feature flags, including cache hit status and deserialization errors status
+#[derive(Debug, Clone)]
+pub struct FlagResult {
+    pub flag_list: FeatureFlagList,
+    pub was_cache_hit: bool,
+    pub had_deserialization_errors: bool,
+}
+
 /// Service layer for handling feature flag operations
 pub struct FlagService {
     redis_reader: Arc<dyn RedisClient + Send + Sync>,
@@ -121,18 +129,22 @@ impl FlagService {
     pub async fn get_flags_from_cache_or_pg(
         &self,
         project_id: i64,
-    ) -> Result<(FeatureFlagList, bool), FlagError> {
-        let (flags_result, cache_hit) =
+    ) -> Result<FlagResult, FlagError> {
+        let flag_result =
             match FeatureFlagList::from_redis(self.redis_reader.clone(), project_id).await {
-                Ok(flags) => (Ok((flags, false)), true),
+                Ok(flags_from_redis) => Ok(FlagResult { 
+                    flag_list: flags_from_redis, 
+                    was_cache_hit: true,
+                    had_deserialization_errors: false 
+                }),
                 Err(_) => {
                     match FeatureFlagList::from_pg(self.pg_client.clone(), project_id).await {
-                        Ok((flags, had_errors)) => {
+                        Ok((flags_from_pg, had_deserialization_errors)) => {
                             inc(DB_FLAG_READS_COUNTER, &[], 1);
                             if (FeatureFlagList::update_flags_in_redis(
                                 self.redis_writer.clone(),
                                 project_id,
-                                &flags,
+                                &flags_from_pg,
                             )
                             .await)
                                 .is_err()
@@ -143,21 +155,27 @@ impl FlagService {
                                     1,
                                 );
                             }
-                            (Ok((flags, had_errors)), false)
+                            Ok(FlagResult { 
+                                flag_list: flags_from_pg, 
+                                was_cache_hit: false,
+                                had_deserialization_errors 
+                            })
                         }
-                        Err(e) => (Err(e), false),
+                        Err(database_error) => Err(database_error),
                     }
                 }
             };
 
         // Track cache hits and misses
-        inc(
-            FLAG_CACHE_HIT_COUNTER,
-            &[("cache_hit".to_string(), cache_hit.to_string())],
-            1,
-        );
+        if let Ok(ref result) = flag_result {
+            inc(
+                FLAG_CACHE_HIT_COUNTER,
+                &[("cache_hit".to_string(), result.was_cache_hit.to_string())],
+                1,
+            );
+        }
 
-        flags_result
+        flag_result
     }
 }
 
@@ -364,11 +382,12 @@ mod tests {
             .get_flags_from_cache_or_pg(team.project_id)
             .await;
         assert!(result.is_ok());
-        let (fetched_flags, _) = result.unwrap();
-        assert_eq!(fetched_flags.flags.len(), mock_flags.flags.len());
+        let flag_result = result.unwrap();
+        assert_eq!(flag_result.flag_list.flags.len(), mock_flags.flags.len());
 
         // Verify the contents of the fetched flags
-        let beta_feature = fetched_flags
+        let beta_feature = flag_result
+            .flag_list
             .flags
             .iter()
             .find(|f| f.key == "beta_feature")
@@ -383,7 +402,8 @@ mod tests {
             "country"
         );
 
-        let new_ui = fetched_flags
+        let new_ui = flag_result
+            .flag_list
             .flags
             .iter()
             .find(|f| f.key == "new_ui")
@@ -391,7 +411,8 @@ mod tests {
         assert!(!new_ui.active);
         assert!(new_ui.filters.groups.is_empty());
 
-        let premium_feature = fetched_flags
+        let premium_feature = flag_result
+            .flag_list
             .flags
             .iter()
             .find(|f| f.key == "premium_feature")

--- a/rust/feature-flags/src/handler/flags.rs
+++ b/rust/feature-flags/src/handler/flags.rs
@@ -22,8 +22,7 @@ pub async fn fetch_and_filter(
     project_id: i64,
     query_params: &FlagsQueryParams,
 ) -> Result<(FeatureFlagList, bool), FlagError> {
-    let flag_result =
-        flag_service.get_flags_from_cache_or_pg(project_id).await?;
+    let flag_result = flag_service.get_flags_from_cache_or_pg(project_id).await?;
 
     let flags_after_survey_filter = filter_survey_flags(
         flag_result.flag_list.flags,

--- a/rust/feature-flags/src/handler/flags.rs
+++ b/rust/feature-flags/src/handler/flags.rs
@@ -22,11 +22,11 @@ pub async fn fetch_and_filter(
     project_id: i64,
     query_params: &FlagsQueryParams,
 ) -> Result<(FeatureFlagList, bool), FlagError> {
-    let (all_flags, had_deserialization_errors) =
+    let flag_result =
         flag_service.get_flags_from_cache_or_pg(project_id).await?;
 
     let flags_after_survey_filter = filter_survey_flags(
-        all_flags.flags,
+        flag_result.flag_list.flags,
         query_params
             .only_evaluate_survey_feature_flags
             .unwrap_or(false),
@@ -34,7 +34,7 @@ pub async fn fetch_and_filter(
 
     Ok((
         FeatureFlagList::new(flags_after_survey_filter),
-        had_deserialization_errors,
+        flag_result.had_deserialization_errors,
     ))
 }
 


### PR DESCRIPTION
Just a follow-up on https://github.com/PostHog/posthog/pull/35154. Adding some structs for readability. 
Also making the dieselization error log a warn instead to avoid polluting out logs
