### PR TITLE
fix(experiments): frequentist fails when control is zero

### DIFF
--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_frequentist_method.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_frequentist_method.py
@@ -71,3 +71,111 @@ class TestFrequentistMethod(ExperimentQueryRunnerBaseTest):
         self.assertEqual(test_variant.confidence_interval, [-1.9807682951982126, 1.9807682951982126])
         self.assertFalse(test_variant.significant)
         self.assertEqual(test_variant.p_value, 1.0)
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_frequentist_zero_control_mean_fallback(self):
+        """Test that frequentist method handles zero control mean by falling back to absolute difference"""
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.stats_config = {"method": "frequentist"}
+        experiment.save()
+
+        metric = ExperimentMeanMetric(
+            source=EventsNode(
+                event="purchase",
+                math=ExperimentMetricMathType.SUM,
+                math_property="amount",
+            ),
+        )
+
+        experiment_query = ExperimentQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentQuery",
+            metric=metric,
+        )
+
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        # Create events where control group has zero sum
+        # but test group has non-zero sum
+        self.create_test_events_zero_control(feature_flag)
+
+        flush_persons_and_events()
+
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+
+        # This should not raise StatisticError
+        result = cast(NewExperimentQueryResponse, query_runner.calculate())
+
+        self.assertEqual(len(result.variant_results), 1)
+
+        control_variant = result.baseline
+        test_variant = result.variant_results[0]
+        assert isinstance(test_variant, ExperimentVariantResultFrequentist)
+
+        # Control should have zero sum
+        self.assertEqual(control_variant.sum, 0)
+        # Test variant should have non-zero sum
+        self.assertGreater(test_variant.sum, 0)
+        # Should have sample sizes
+        self.assertGreater(control_variant.number_of_samples, 0)
+        self.assertGreater(test_variant.number_of_samples, 0)
+        # Should have computed confidence interval and p-value (using absolute difference)
+        self.assertIsNotNone(test_variant.confidence_interval)
+        self.assertIsNotNone(test_variant.p_value)
+
+    def create_test_events_zero_control(self, feature_flag):
+        """
+        Creates test events where control group has zero sum (no amount values)
+        but test group has non-zero sum. This tests the zero control mean scenario.
+        """
+        from posthog.test.base import _create_event, _create_person
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        # Control variant: 10 users, all have purchase events but with amount=0 or no amount
+        for i in range(10):
+            _create_person(distinct_ids=[f"user_control_{i}"], team_id=self.team.pk)
+            _create_event(
+                team=self.team,
+                event="$feature_flag_called",
+                distinct_id=f"user_control_{i}",
+                timestamp="2020-01-02T12:00:00Z",
+                properties={
+                    feature_flag_property: "control",
+                    "$feature_flag_response": "control",
+                    "$feature_flag": feature_flag.key,
+                },
+            )
+            # Control purchases with zero amount (or missing amount)
+            _create_event(
+                team=self.team,
+                event="purchase",
+                distinct_id=f"user_control_{i}",
+                timestamp="2020-01-02T12:01:00Z",
+                properties={feature_flag_property: "control", "amount": 0},  # Zero amount!
+            )
+
+        # Test variant: 10 users, some have purchase events with positive amounts
+        for i in range(10):
+            _create_person(distinct_ids=[f"user_test_{i}"], team_id=self.team.pk)
+            _create_event(
+                team=self.team,
+                event="$feature_flag_called",
+                distinct_id=f"user_test_{i}",
+                timestamp="2020-01-02T12:00:00Z",
+                properties={
+                    feature_flag_property: "test",
+                    "$feature_flag_response": "test",
+                    "$feature_flag": feature_flag.key,
+                },
+            )
+            if i < 6:  # 6 out of 10 users make purchases
+                _create_event(
+                    team=self.team,
+                    event="purchase",
+                    distinct_id=f"user_test_{i}",
+                    timestamp="2020-01-02T12:01:00Z",
+                    properties={feature_flag_property: "test", "amount": 10},  # Positive amount
+                )


### PR DESCRIPTION
## Problem

The frequentist method is configured to use "relative difference" calculation, and it fails when the control group has zero mean.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

When `get_frequentist_experiment_result_new_format` calls `run_test`, we catch the `StatisticError` and run the test again  using absolute difference type.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/6ce5012c-6438-4567-9a57-9636265519ab)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
