### PR TITLE
fix: exceptions that silently failed should show as having failed

### DIFF
--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -56,15 +56,8 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
             and not instance.has_content
             and not instance.exception
         ):
-            timeout_message = f"Export timed out after {HOGQL_INCREASED_MAX_EXECUTION_TIME} seconds"
+            timeout_message = f"Export failed without throwing an exception. Please try to rerun this export and contact support if it fails to complete multiple times."
             data["exception"] = timeout_message
-
-            logger.info(
-                "export_shown_as_timed_out",
-                export_id=instance.id,
-                created_at=instance.created_at.isoformat(),
-                timeout_seconds=HOGQL_INCREASED_MAX_EXECUTION_TIME,
-            )
 
         return data
 

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -49,7 +49,7 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
 
         # Check if this export is stuck (created over HOGQL_INCREASED_MAX_EXECUTION_TIME seconds ago,
         # has no content, and has no recorded exception)
-        timeout_threshold = self.context.get("timeout_threshold")
+        timeout_threshold = now() - timedelta(seconds=HOGQL_INCREASED_MAX_EXECUTION_TIME + 30)
         if (
             timeout_threshold
             and instance.created_at < timeout_threshold
@@ -186,12 +186,6 @@ class ExportedAssetViewSet(
         if self.action == "list":
             return queryset.filter(created_by=self.request.user)
         return queryset
-
-    def get_serializer_context(self):
-        """Add timeout threshold to serializer context."""
-        context = super().get_serializer_context()
-        context["timeout_threshold"] = now() - timedelta(seconds=HOGQL_INCREASED_MAX_EXECUTION_TIME)
-        return context
 
     # TODO: This should be removed as it is only used by frontend exporter and can instead use the api/sharing.py endpoint
     @action(methods=["GET"], detail=True, required_scopes=["export:read"])

--- a/posthog/api/test/test_exports.py
+++ b/posthog/api/test/test_exports.py
@@ -19,6 +19,7 @@ from posthog.models.filters.filter import Filter
 from posthog.models.insight import Insight
 from posthog.models.team import Team
 from posthog.settings import (
+    HOGQL_INCREASED_MAX_EXECUTION_TIME,
     OBJECT_STORAGE_ACCESS_KEY_ID,
     OBJECT_STORAGE_BUCKET,
     OBJECT_STORAGE_ENDPOINT,
@@ -490,6 +491,106 @@ class TestExports(APIBaseTest):
         response = self.client.get(f"/api/projects/{self.team.id}/exports")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.json()["results"]), 2)
+
+    def test_list_shows_stuck_exports_as_failed_in_response(self) -> None:
+        # Create an export that's older than HOGQL_INCREASED_MAX_EXECUTION_TIME
+        stuck_export = ExportedAsset.objects.create(
+            team=self.team,
+            dashboard_id=self.dashboard.id,
+            export_format="image/png",
+            created_by=self.user,
+            created_at=now() - timedelta(seconds=HOGQL_INCREASED_MAX_EXECUTION_TIME + 100),
+            content=None,
+            content_location=None,
+            exception=None,
+        )
+
+        # Create a recent export that should not be marked as failed
+        recent_export = ExportedAsset.objects.create(
+            team=self.team,
+            dashboard_id=self.dashboard.id,
+            export_format="image/png",
+            created_by=self.user,
+            created_at=now() - timedelta(seconds=100),
+            content=None,
+            content_location=None,
+            exception=None,
+        )
+
+        # Create an export that already has content - should not be marked as failed
+        completed_export = ExportedAsset.objects.create(
+            team=self.team,
+            dashboard_id=self.dashboard.id,
+            export_format="image/png",
+            created_by=self.user,
+            created_at=now() - timedelta(seconds=HOGQL_INCREASED_MAX_EXECUTION_TIME + 100),
+            content=b"some content",
+            exception=None,
+        )
+
+        # Create an export that has an exception - should not be overridden
+        errored_export = ExportedAsset.objects.create(
+            team=self.team,
+            dashboard_id=self.dashboard.id,
+            export_format="image/png",
+            created_by=self.user,
+            created_at=now() - timedelta(seconds=HOGQL_INCREASED_MAX_EXECUTION_TIME + 100),
+            content=None,
+            exception="exception",
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/exports")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        results = response.json()["results"]
+        results_by_id = {result["id"]: result for result in results}
+
+        stuck_result = results_by_id[stuck_export.id]
+        self.assertIsNotNone(stuck_result["exception"])
+        self.assertIn(f"Export timed out after {HOGQL_INCREASED_MAX_EXECUTION_TIME} seconds", stuck_result["exception"])
+
+        recent_result = results_by_id[recent_export.id]
+        self.assertIsNone(recent_result["exception"])
+
+        completed_result = results_by_id[completed_export.id]
+        self.assertIsNone(completed_result["exception"])
+
+        completed_result = results_by_id[errored_export.id]
+        self.isEqual("exception", completed_result["exception"])
+
+        # Verify that the database wasn't actually modified
+        stuck_export.refresh_from_db()
+        recent_export.refresh_from_db()
+        completed_export.refresh_from_db()
+        self.assertIsNone(stuck_export.exception)
+        self.assertIsNone(recent_export.exception)
+        self.assertIsNone(completed_export.exception)
+
+    def test_retrieve_shows_stuck_export_as_failed_in_response(self) -> None:
+        # Create an export that's older than HOGQL_INCREASED_MAX_EXECUTION_TIME
+        stuck_export = ExportedAsset.objects.create(
+            team=self.team,
+            dashboard_id=self.dashboard.id,
+            export_format="image/png",
+            created_by=self.user,
+            created_at=now() - timedelta(seconds=HOGQL_INCREASED_MAX_EXECUTION_TIME + 100),
+            content=None,
+            content_location=None,
+            exception=None,
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/exports/{stuck_export.id}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        result = response.json()
+
+        # Check that the stuck export appears to have an exception in the response
+        self.assertIsNotNone(result["exception"])
+        self.assertIn(f"Export timed out after {HOGQL_INCREASED_MAX_EXECUTION_TIME} seconds", result["exception"])
+
+        # Verify that the database wasn't actually modified
+        stuck_export.refresh_from_db()
+        self.assertIsNone(stuck_export.exception)
 
 
 class TestExportMixin(APIBaseTest):

--- a/posthog/api/test/test_exports.py
+++ b/posthog/api/test/test_exports.py
@@ -556,7 +556,7 @@ class TestExports(APIBaseTest):
         self.assertIsNone(completed_result["exception"])
 
         completed_result = results_by_id[errored_export.id]
-        self.isEqual("exception", completed_result["exception"])
+        self.assetEqual("exception", completed_result["exception"])
 
         # Verify that the database wasn't actually modified
         stuck_export.refresh_from_db()

--- a/posthog/api/test/test_exports.py
+++ b/posthog/api/test/test_exports.py
@@ -547,7 +547,7 @@ class TestExports(APIBaseTest):
 
         stuck_result = results_by_id[stuck_export.id]
         self.assertIsNotNone(stuck_result["exception"])
-        self.assertIn(f"Export timed out after {HOGQL_INCREASED_MAX_EXECUTION_TIME} seconds", stuck_result["exception"])
+        self.assertIn(f"Export failed without throwing an exception", stuck_result["exception"])
 
         recent_result = results_by_id[recent_export.id]
         self.assertIsNone(recent_result["exception"])
@@ -586,7 +586,7 @@ class TestExports(APIBaseTest):
 
         # Check that the stuck export appears to have an exception in the response
         self.assertIsNotNone(result["exception"])
-        self.assertIn(f"Export timed out after {HOGQL_INCREASED_MAX_EXECUTION_TIME} seconds", result["exception"])
+        self.assertIn(f"Export failed without throwing an exception", result["exception"])
 
         # Verify that the database wasn't actually modified
         stuck_export.refresh_from_db()


### PR DESCRIPTION
## Problem
Sometimes exports fail. They should store an exception. Sometimes they don't (pod probably died and wasn't able to be caught).

## Changes
If an insight has timed out (30 seconds over our query max for exports), show it as having an exception. If it happens to complete later somehow, it'll show up as completed as soon as it finishes.

## How did you test this code?
Wrote tests
