### PR TITLE
refactor: verify event headers in ingestion

### DIFF
--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -726,6 +726,7 @@ export class IngestionConsumer {
             headerEventMismatchCounter.labels(tokenStatus, distinctIdStatus).inc()
 
             logger.warn('🔍', `Header/event validation issue detected`, {
+                eventUuid: event.uuid,
                 headerToken,
                 eventToken: event.token,
                 headerDistinctId,


### PR DESCRIPTION
## Problem

We want to rely more on Kafka headers in ingestion-events and there's some confusion in the code.

## Changes

- Fixes how drop events restrictions use message headers
- Adds a metric to verify that all events have matching headers

## How did you test this code?

- Has existing integration tests

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [X] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
