### PR TITLE
feat(messaging): fix filter dropdown for hogfunction logs

### DIFF
--- a/frontend/src/scenes/hog-functions/logs/LogsViewer.tsx
+++ b/frontend/src/scenes/hog-functions/logs/LogsViewer.tsx
@@ -81,7 +81,12 @@ export function LogsViewer({ renderColumns = (c) => c, ...props }: LogsViewerPro
                                         <LemonButton
                                             key={level}
                                             fullWidth
-                                            sideIcon={<LemonCheckbox checked={filters.levels.includes(level)} />}
+                                            icon={
+                                                <LemonCheckbox
+                                                    checked={filters.levels.includes(level)}
+                                                    className="pointer-events-none"
+                                                />
+                                            }
                                             onClick={() => {
                                                 setFilters({
                                                     levels: filters.levels.includes(level)


### PR DESCRIPTION
## Problem

(de)selecting does only work when clicking on the text and the checkbox is on the right (which is inconsistent with e.g. the metrics view where it is on the left). annoying inconsistency and bug.

![2025-07-18 14 41 19](https://github.com/user-attachments/assets/33c7a5e0-8c3b-4e22-9062-a184d74c9600)


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

![2025-07-18 14 41 41](https://github.com/user-attachments/assets/59aa6054-1858-4761-9bd5-94fada8c6f04)

make it work as the metrics filter

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- local dev

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
