### PR TITLE
fix: Slice record batches based on user input

### DIFF
--- a/products/batch_exports/backend/temporal/pipeline/consumer.py
+++ b/products/batch_exports/backend/temporal/pipeline/consumer.py
@@ -14,11 +14,11 @@ from products.batch_exports.backend.temporal.metrics import (
 from products.batch_exports.backend.temporal.pipeline.transformer import (
     get_stream_transformer,
 )
+from products.batch_exports.backend.temporal.pipeline.types import BatchExportResult
 from products.batch_exports.backend.temporal.spmc import (
     RecordBatchQueue,
     raise_on_task_failure,
 )
-from products.batch_exports.backend.temporal.pipeline.types import BatchExportResult
 from products.batch_exports.backend.temporal.utils import (
     cast_record_batch_json_columns,
     cast_record_batch_schema_json_columns,


### PR DESCRIPTION
## Problem

Files are usually above `max_file_size_mb` as we yield chunks by processing one record batch at a time, and each record batch is based on a 60MB hardcoded limit. 
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
