### PR TITLE
feat(marketing-analytics): enhance sorting functionality

### DIFF
--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsTable/MarketingAnalyticsTable.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsTable/MarketingAnalyticsTable.tsx
@@ -1,5 +1,5 @@
-import { IconEllipsis, IconSort, IconChevronDown } from '@posthog/icons'
-import clsx from 'clsx'
+import { IconEllipsis, IconSort } from '@posthog/icons'
+import { IconArrowUp, IconArrowDown } from 'lib/lemon-ui/icons'
 import { useActions, useValues } from 'kea'
 import { useCallback, useMemo } from 'react'
 
@@ -73,26 +73,24 @@ export const MarketingAnalyticsTable = ({ query, insightProps }: MarketingAnalyt
                 const menuItems = [
                     {
                         title: 'Sorting',
+                        icon: <IconSort />,
                         items: [
                             {
                                 label: 'Sort ascending',
-                                icon: <IconSort className="rotate-180" />,
+                                icon: <IconArrowUp />,
                                 onClick: () => setMarketingAnalyticsOrderBy(index, 'ASC'),
-                                active: isSortedByMyField && isAscending,
                                 disabled: isSortedByMyField && isAscending,
                             },
                             {
                                 label: 'Sort descending',
-                                icon: <IconSort />,
+                                icon: <IconArrowDown />,
                                 onClick: () => setMarketingAnalyticsOrderBy(index, 'DESC'),
-                                active: isSortedByMyField && isDescending,
                                 disabled: isSortedByMyField && isDescending,
                             },
                             ...(isSortedByMyField
                                 ? [
                                       {
                                           label: 'Clear sort',
-                                          icon: <IconSort />,
                                           onClick: () => clearMarketingAnalyticsOrderBy(),
                                       },
                                   ]
@@ -106,12 +104,11 @@ export const MarketingAnalyticsTable = ({ query, insightProps }: MarketingAnalyt
                         <span className="group cursor-pointer inline-flex items-center">
                             {name}
                             {isSortedByMyField ? (
-                                <IconChevronDown
-                                    className={clsx('ml-1 transition-transform', {
-                                        'rotate-180': isAscending,
-                                        'rotate-0': isDescending,
-                                    })}
-                                />
+                                isAscending ? (
+                                    <IconArrowUp className="ml-1" />
+                                ) : (
+                                    <IconArrowDown className="ml-1" />
+                                )
                             ) : (
                                 <IconEllipsis className="ml-1 opacity-0 group-hover:opacity-100" />
                             )}

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsTable/MarketingAnalyticsTable.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsTable/MarketingAnalyticsTable.tsx
@@ -105,9 +105,15 @@ export const MarketingAnalyticsTable = ({ query, insightProps }: MarketingAnalyt
                             {name}
                             {isSortedByMyField ? (
                                 isAscending ? (
-                                    <IconArrowUp className="ml-1" />
+                                    <>
+                                        <IconArrowUp className="ml-1 group-hover:hidden" />
+                                        <IconEllipsis className="ml-1 hidden group-hover:inline" />
+                                    </>
                                 ) : (
-                                    <IconArrowDown className="ml-1" />
+                                    <>
+                                        <IconArrowDown className="ml-1 group-hover:hidden" />
+                                        <IconEllipsis className="ml-1 hidden group-hover:inline" />
+                                    </>
                                 )
                             ) : (
                                 <IconEllipsis className="ml-1 opacity-0 group-hover:opacity-100" />

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsTable/MarketingAnalyticsTable.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsTable/MarketingAnalyticsTable.tsx
@@ -1,4 +1,4 @@
-import { IconChevronDown } from '@posthog/icons'
+import { IconEllipsis, IconSort, IconChevronDown } from '@posthog/icons'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { useCallback, useMemo } from 'react'
@@ -14,6 +14,7 @@ import {
 } from '~/queries/schema/schema-general'
 import { QueryContext, QueryContextColumn } from '~/queries/types'
 import { InsightLogicProps } from '~/types'
+import { LemonMenu } from '@posthog/lemon-ui'
 
 import { webAnalyticsDataTableQueryContext } from '../../../../../tiles/WebAnalyticsTile'
 import { marketingAnalyticsLogic } from '../../logic/marketingAnalyticsLogic'
@@ -69,31 +70,53 @@ export const MarketingAnalyticsTable = ({ query, insightProps }: MarketingAnalyt
                 const isAscending = orderDirection === 'ASC'
                 const isDescending = orderDirection === 'DESC'
 
-                const onClick = useCallback(() => {
-                    // 3-state cycle: None -> DESC -> ASC -> None (clear/reset to default)
-                    if (!isSortedByMyField) {
-                        // Not currently sorted by this field, start with DESC
-                        setMarketingAnalyticsOrderBy(index, 'DESC')
-                    } else if (isDescending) {
-                        // Currently DESC, change to ASC
-                        setMarketingAnalyticsOrderBy(index, 'ASC')
-                    } else if (isAscending) {
-                        // Currently ASC, clear the sort (reset to default order)
-                        clearMarketingAnalyticsOrderBy()
-                    }
-                }, [isSortedByMyField, isAscending, isDescending])
+                const menuItems = [
+                    {
+                        title: 'Sorting',
+                        items: [
+                            {
+                                label: 'Sort ascending',
+                                icon: <IconSort className="rotate-180" />,
+                                onClick: () => setMarketingAnalyticsOrderBy(index, 'ASC'),
+                                active: isSortedByMyField && isAscending,
+                                disabled: isSortedByMyField && isAscending,
+                            },
+                            {
+                                label: 'Sort descending',
+                                icon: <IconSort />,
+                                onClick: () => setMarketingAnalyticsOrderBy(index, 'DESC'),
+                                active: isSortedByMyField && isDescending,
+                                disabled: isSortedByMyField && isDescending,
+                            },
+                            ...(isSortedByMyField
+                                ? [
+                                      {
+                                          label: 'Clear sort',
+                                          icon: <IconSort />,
+                                          onClick: () => clearMarketingAnalyticsOrderBy(),
+                                      },
+                                  ]
+                                : []),
+                        ],
+                    },
+                ]
 
                 return (
-                    <span onClick={onClick} className="group cursor-pointer inline-flex items-center">
-                        {name}
-                        <IconChevronDown
-                            fontSize="20px"
-                            className={clsx('-mr-1 ml-1 text-muted-alt opacity-0 group-hover:opacity-100', {
-                                'text-primary opacity-100': isSortedByMyField,
-                                'rotate-180': isSortedByMyField && isAscending,
-                            })}
-                        />
-                    </span>
+                    <LemonMenu items={menuItems}>
+                        <span className="group cursor-pointer inline-flex items-center">
+                            {name}
+                            {isSortedByMyField ? (
+                                <IconChevronDown
+                                    className={clsx('ml-1 transition-transform', {
+                                        'rotate-180': isAscending,
+                                        'rotate-0': isDescending,
+                                    })}
+                                />
+                            ) : (
+                                <IconEllipsis className="ml-1 opacity-0 group-hover:opacity-100" />
+                            )}
+                        </span>
+                    </LemonMenu>
                 )
             }
         },

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsLogic.ts
@@ -1,4 +1,5 @@
 import { actions, connect, kea, path, reducers, selectors } from 'kea'
+import { actionToUrl, urlToAction } from 'kea-router'
 import { dataWarehouseSettingsLogic } from 'scenes/data-warehouse/settings/dataWarehouseSettingsLogic'
 import { mapUrlToProvider } from 'scenes/data-warehouse/settings/DataWarehouseSourceIcon'
 import { teamLogic } from 'scenes/teamLogic'
@@ -221,4 +222,38 @@ export const marketingAnalyticsLogic = kea<marketingAnalyticsLogicType>([
             },
         ],
     }),
+    actionToUrl(() => ({
+        setMarketingAnalyticsOrderBy: ({ orderBy, direction }) => {
+            const searchParams = new URLSearchParams(window.location.search)
+            if (orderBy !== null && direction) {
+                searchParams.set('sort_field', orderBy.toString())
+                searchParams.set('sort_direction', direction)
+            } else {
+                searchParams.delete('sort_field')
+                searchParams.delete('sort_direction')
+            }
+            return [window.location.pathname, searchParams.toString()]
+        },
+        clearMarketingAnalyticsOrderBy: () => {
+            const searchParams = new URLSearchParams(window.location.search)
+            searchParams.delete('sort_field')
+            searchParams.delete('sort_direction')
+            return [window.location.pathname, searchParams.toString()]
+        },
+    })),
+    urlToAction(({ actions, values }) => ({
+        '*': (_, searchParams) => {
+            const sortField = searchParams.sort_field
+            const sortDirection = searchParams.sort_direction
+
+            if (sortField && sortDirection && (sortDirection === 'ASC' || sortDirection === 'DESC')) {
+                const orderBy = parseInt(sortField, 10)
+                if (!isNaN(orderBy) && values.marketingAnalyticsOrderBy?.[0] !== orderBy) {
+                    actions.setMarketingAnalyticsOrderBy(orderBy, sortDirection as 'ASC' | 'DESC')
+                }
+            } else if (!sortField && !sortDirection && values.marketingAnalyticsOrderBy) {
+                actions.clearMarketingAnalyticsOrderBy()
+            }
+        },
+    })),
 ])


### PR DESCRIPTION
## Changes

Enhancing how you sort by adding a clear dropdown menu with the options.

## How did you test this code?
(the hide and pin is something WIP in another PR)

Full menu for sorted column:
<img width="843" height="360" alt="image" src="https://github.com/user-attachments/assets/4e94503c-3636-4e17-9c84-365583da0f0e" />


The icon shows the column that is sorted by:
<img width="881" height="53" alt="image" src="https://github.com/user-attachments/assets/f756fe2a-3492-4d13-bcc0-22131f7cecb7" />


Clear sorting is only applicable when sorted:
<img width="511" height="314" alt="image" src="https://github.com/user-attachments/assets/622938ab-2943-4b4d-a2d8-e4dc8b8ad000" />

