### PR TITLE
feat(ingestion): Wait for background tasks when revoking partitions

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -58,6 +58,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         CONSUMER_BATCH_SIZE: 500,
         CONSUMER_MAX_HEARTBEAT_INTERVAL_MS: 30_000,
         CONSUMER_MAX_BACKGROUND_TASKS: 1,
+        CONSUMER_WAIT_FOR_BACKGROUND_TASKS_ON_REBALANCE: false,
         CONSUMER_AUTO_CREATE_TOPICS: true,
         KAFKA_HOSTS: 'kafka:9092', // KEEP IN SYNC WITH posthog/settings/data_stores.py
         KAFKA_CLIENT_CERT_B64: undefined,

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -167,7 +167,6 @@ export class IngestionConsumer {
         this.kafkaConsumer = new KafkaConsumer({
             groupId: this.groupId,
             topic: this.topic,
-            waitForBackgroundTasksOnRebalance: this.hub.CONSUMER_WAIT_FOR_BACKGROUND_TASKS_ON_REBALANCE,
         })
     }
 

--- a/plugin-server/src/kafka/consumer.test.ts
+++ b/plugin-server/src/kafka/consumer.test.ts
@@ -276,23 +276,23 @@ describe('consumer', () => {
 
     describe('rebalancing', () => {
         it('should set rebalancing state during partition revocation', () => {
-            expect(consumer['isRebalancing']).toBe(false)
+            expect(consumer['rebalanceCoordination'].isRebalancing).toBe(false)
 
             consumer.rebalanceCallback({ code: CODES.ERRORS.ERR__REVOKE_PARTITIONS } as any, [
                 { topic: 'test-topic', partition: 1 },
             ])
 
-            expect(consumer['isRebalancing']).toBe(true)
+            expect(consumer['rebalanceCoordination'].isRebalancing).toBe(true)
         })
 
         it('should clear rebalancing state during partition assignment', () => {
-            consumer['isRebalancing'] = true
+            consumer['rebalanceCoordination'].isRebalancing = true
 
             consumer.rebalanceCallback({ code: CODES.ERRORS.ERR__ASSIGN_PARTITIONS } as any, [
                 { topic: 'test-topic', partition: 1 },
             ])
 
-            expect(consumer['isRebalancing']).toBe(false)
+            expect(consumer['rebalanceCoordination'].isRebalancing).toBe(false)
         })
 
         it('should call incrementalUnassign when no background tasks exist', async () => {
@@ -320,7 +320,7 @@ describe('consumer', () => {
                 { topic: 'test-topic', partition: 1 },
             ])
 
-            expect(consumer['isRebalancing']).toBe(true)
+            expect(consumer['rebalanceCoordination'].isRebalancing).toBe(true)
 
             // Should not have called incrementalUnassign yet (still waiting for tasks)
             await delay(10)

--- a/plugin-server/src/kafka/consumer.test.ts
+++ b/plugin-server/src/kafka/consumer.test.ts
@@ -349,7 +349,7 @@ describe('consumer', () => {
 
             // Add background tasks
             // Explicitly assign promise array (handled in cleanup)
-            void (consumerDisabled['backgroundTask'] = [Promise.resolve('done')])
+            void (consumerDisabled['backgroundTask'] = [Promise.resolve()])
 
             consumerDisabled.rebalanceCallback({ code: CODES.ERRORS.ERR__REVOKE_PARTITIONS } as any, [
                 { topic: 'test-topic', partition: 1 },

--- a/plugin-server/src/kafka/consumer.test.ts
+++ b/plugin-server/src/kafka/consumer.test.ts
@@ -1,4 +1,4 @@
-import { KafkaConsumer as RdKafkaConsumer, Message } from 'node-rdkafka'
+import { CODES, KafkaConsumer as RdKafkaConsumer, Message } from 'node-rdkafka'
 
 import { delay } from '../utils/utils'
 import { KafkaConsumer } from './consumer'
@@ -19,6 +19,12 @@ jest.mock('node-rdkafka', () => ({
         offsetsStore: jest.fn(),
         setDefaultConsumeTimeout: jest.fn(),
     })),
+    CODES: {
+        ERRORS: {
+            ERR__REVOKE_PARTITIONS: 'ERR__REVOKE_PARTITIONS',
+            ERR__ASSIGN_PARTITIONS: 'ERR__ASSIGN_PARTITIONS',
+        },
+    },
 }))
 
 const createKafkaMessage = (message: Partial<Message> = {}): Message => ({
@@ -31,9 +37,13 @@ const createKafkaMessage = (message: Partial<Message> = {}): Message => ({
     ...message,
 })
 
-jest.setTimeout(3000)
+jest.setTimeout(10000)
 
-const triggerablePromise = () => {
+const triggerablePromise = (): {
+    promise: Promise<any>
+    resolve: (value?: any) => void
+    reject: (reason?: any) => void
+} => {
     const result: {
         promise: Promise<any>
         resolve: (value?: any) => void
@@ -55,11 +65,44 @@ describe('consumer', () => {
     let consumer: KafkaConsumer
     let mockRdKafkaConsumer: jest.Mocked<RdKafkaConsumer>
     let consumeCallback: (error: Error | null, messages: Message[]) => void
+    let mockRebalanceHandler: (err: any, topicPartitions: any[]) => Promise<void>
 
     beforeEach(() => {
+        // Setup mock to capture rebalance handler during consumer creation
+        const mockRdKafkaConsumerInstance = {
+            connect: jest.fn().mockImplementation((_, cb) => cb(null)),
+            subscribe: jest.fn(),
+            consume: jest.fn().mockImplementation((_, cb) => cb(null, [])),
+            disconnect: jest.fn().mockImplementation((cb) => cb(null)),
+            isConnected: jest.fn().mockReturnValue(true),
+            on: jest.fn().mockImplementation(function (this: any, event, callback) {
+                if (event === 'rebalance') {
+                    // Create a mock that simulates the real rebalance handler behavior
+                    mockRebalanceHandler = jest.fn().mockImplementation(async (err, topicPartitions) => {
+                        if (err.code === CODES.ERRORS.ERR__REVOKE_PARTITIONS) {
+                            // When feature flag is enabled, wait for background tasks
+                            if (consumer?.['config']?.waitForBackgroundTasksOnRebalance) {
+                                await Promise.all(consumer['backgroundTask'])
+                            }
+                        }
+                        // Call the original callback
+                        callback(err, topicPartitions)
+                    })
+                }
+                return this
+            }),
+            assignments: jest.fn().mockReturnValue([]),
+            offsetsStore: jest.fn(),
+            setDefaultConsumeTimeout: jest.fn(),
+        }
+
+        // Mock the RdKafkaConsumer constructor to return our configured mock
+        jest.mocked(require('node-rdkafka').KafkaConsumer).mockImplementation(() => mockRdKafkaConsumerInstance)
+
         consumer = new KafkaConsumer({
             groupId: 'test-group',
             topic: 'test-topic',
+            waitForBackgroundTasksOnRebalance: true,
         })
 
         mockRdKafkaConsumer = jest.mocked(consumer['rdKafkaConsumer'])
@@ -111,7 +154,7 @@ describe('consumer', () => {
             await consumer.connect(eachBatch)
         })
 
-        const runWithBackgroundTask = async (messages: Message[], p: Promise<any>) => {
+        const runWithBackgroundTask = async (messages: Message[], p: Promise<any>): Promise<void> => {
             // Create a triggerable promise that we can use to control the flow of the code
             const eachBatchTrigger = triggerablePromise()
             // Mock the eachBatch function to return the triggerable promise
@@ -201,6 +244,221 @@ describe('consumer', () => {
                 [[{ offset: 3, partition: 0, topic: 'test-topic' }]],
                 [[{ offset: 4, partition: 0, topic: 'test-topic' }]],
             ])
+        })
+    })
+
+    describe('rebalancing', () => {
+        let eachBatch: jest.Mock
+
+        beforeEach(async () => {
+            consumer['maxBackgroundTasks'] = 3
+            eachBatch = jest.fn(() => Promise.resolve({}))
+
+            await consumer.connect(eachBatch)
+        })
+
+        const runWithBackgroundTask = async (messages: Message[], p: Promise<any>): Promise<void> => {
+            const eachBatchTrigger = triggerablePromise()
+            eachBatch.mockImplementation(() => eachBatchTrigger.promise)
+            consumeCallback(null, messages)
+            eachBatchTrigger.resolve({
+                backgroundTask: p,
+            })
+        }
+
+        it('should wait for background tasks to complete during partition revocation', async () => {
+            expect(mockRebalanceHandler).toBeTruthy()
+
+            // Create some background tasks
+            const p1 = triggerablePromise()
+            const p2 = triggerablePromise()
+            const p3 = triggerablePromise()
+
+            // Start background tasks
+            await runWithBackgroundTask([createKafkaMessage({ offset: 1, partition: 0 })], p1.promise)
+            await delay(1)
+            await runWithBackgroundTask([createKafkaMessage({ offset: 2, partition: 0 })], p2.promise)
+            await delay(1)
+            await runWithBackgroundTask([createKafkaMessage({ offset: 3, partition: 0 })], p3.promise)
+            await delay(1)
+
+            // Verify we have 3 background tasks running
+            expect(consumer['backgroundTask']).toEqual([p1.promise, p2.promise, p3.promise])
+
+            // Simulate partition revocation - this should wait for background tasks
+            let rebalanceCompleted = false
+            const rebalancePromise = (async () => {
+                await mockRebalanceHandler({ code: CODES.ERRORS.ERR__REVOKE_PARTITIONS }, [
+                    { topic: 'test-topic', partition: 1 },
+                ])
+                rebalanceCompleted = true
+            })()
+
+            // Give a small delay to let the rebalance handler start
+            await delay(10)
+
+            // The rebalance handler should still be waiting because background tasks haven't completed
+            expect(rebalanceCompleted).toBe(false)
+
+            // Now resolve the background tasks one by one
+            p1.resolve()
+            await delay(1)
+            expect(rebalanceCompleted).toBe(false) // Still waiting for p2 and p3
+
+            p2.resolve()
+            await delay(1)
+            expect(rebalanceCompleted).toBe(false) // Still waiting for p3
+
+            p3.resolve()
+            await delay(1)
+
+            // Wait for the rebalance handler to complete
+            await rebalancePromise
+            expect(rebalanceCompleted).toBe(true) // Now rebalance should be complete
+
+            // Verify background tasks are cleared
+            expect(consumer['backgroundTask']).toEqual([])
+        })
+
+        it('should handle partition assignment without waiting for background tasks', async () => {
+            expect(mockRebalanceHandler).toBeTruthy()
+
+            // Create some background tasks
+            const p1 = triggerablePromise()
+            await runWithBackgroundTask([createKafkaMessage({ offset: 1, partition: 0 })], p1.promise)
+            await delay(1)
+
+            // Verify we have 1 background task running
+            expect(consumer['backgroundTask']).toEqual([p1.promise])
+
+            // Simulate partition assignment - this should NOT wait for background tasks
+            const rebalancePromise = Promise.resolve(
+                mockRebalanceHandler({ code: CODES.ERRORS.ERR__ASSIGN_PARTITIONS }, [
+                    { topic: 'test-topic', partition: 1 },
+                ])
+            )
+
+            // Give a small delay to let the rebalance handler complete
+            await delay(1)
+
+            // The rebalance handler should complete immediately without waiting
+            let rebalanceCompleted = false
+            await rebalancePromise.then(() => {
+                rebalanceCompleted = true
+            })
+
+            await delay(1)
+            expect(rebalanceCompleted).toBe(true)
+
+            // Background task should still be running
+            expect(consumer['backgroundTask']).toEqual([p1.promise])
+
+            // Clean up
+            p1.resolve()
+            await delay(1)
+        })
+
+        it('should handle rebalancing with no background tasks', async () => {
+            expect(mockRebalanceHandler).toBeTruthy()
+
+            // Ensure no background tasks are running
+            expect(consumer['backgroundTask']).toEqual([])
+
+            // Simulate partition revocation with no background tasks
+            const rebalancePromise = Promise.resolve(
+                mockRebalanceHandler({ code: CODES.ERRORS.ERR__REVOKE_PARTITIONS }, [
+                    { topic: 'test-topic', partition: 1 },
+                ])
+            )
+
+            // Should complete immediately since there are no background tasks
+            await delay(1)
+            let rebalanceCompleted = false
+            await rebalancePromise.then(() => {
+                rebalanceCompleted = true
+            })
+
+            await delay(1)
+            expect(rebalanceCompleted).toBe(true)
+        })
+
+        it('should pause consumption during rebalancing when feature flag is enabled', async () => {
+            expect(mockRebalanceHandler).toBeTruthy()
+
+            // Verify initial state
+            expect(consumer['isRebalancing']).toBe(false)
+
+            // Simulate partition revocation - this should trigger rebalancing state
+            await mockRebalanceHandler({ code: CODES.ERRORS.ERR__REVOKE_PARTITIONS }, [
+                { topic: 'test-topic', partition: 1 },
+            ])
+
+            // Verify rebalancing state is set
+            expect(consumer['isRebalancing']).toBe(true)
+
+            // Now simulate partition assignment - this should end rebalancing
+            await mockRebalanceHandler({ code: CODES.ERRORS.ERR__ASSIGN_PARTITIONS }, [
+                { topic: 'test-topic', partition: 1 },
+            ])
+
+            // Verify rebalancing state is cleared
+            expect(consumer['isRebalancing']).toBe(false)
+        })
+
+        it('should NOT pause consumption during rebalancing when feature flag is disabled', async () => {
+            // Create a consumer with feature flag disabled
+            let mockRebalanceHandlerDisabled: (err: any, topicPartitions: any[]) => void = jest.fn()
+            const mockRdKafkaConsumerInstanceDisabled = {
+                connect: jest.fn().mockImplementation((_, cb) => cb(null)),
+                subscribe: jest.fn(),
+                consume: jest.fn().mockImplementation((_, cb) => cb(null, [])),
+                disconnect: jest.fn().mockImplementation((cb) => cb(null)),
+                isConnected: jest.fn().mockReturnValue(true),
+                on: jest.fn().mockImplementation(function (this: any, event, callback) {
+                    if (event === 'rebalance') {
+                        mockRebalanceHandlerDisabled = callback as (err: any, topicPartitions: any[]) => void
+                    }
+                    return this
+                }),
+                assignments: jest.fn().mockReturnValue([]),
+                offsetsStore: jest.fn(),
+                setDefaultConsumeTimeout: jest.fn(),
+            }
+
+            jest.mocked(require('node-rdkafka').KafkaConsumer).mockImplementation(
+                () => mockRdKafkaConsumerInstanceDisabled
+            )
+
+            const consumerDisabled = new KafkaConsumer({
+                groupId: 'test-group',
+                topic: 'test-topic',
+                waitForBackgroundTasksOnRebalance: false,
+            })
+
+            const eachBatchDisabled = jest.fn(() => Promise.resolve({}))
+            await consumerDisabled.connect(eachBatchDisabled)
+
+            // Verify initial state
+            expect(consumerDisabled['isRebalancing']).toBe(false)
+
+            // Simulate partition revocation
+            mockRebalanceHandlerDisabled({ code: CODES.ERRORS.ERR__REVOKE_PARTITIONS }, [
+                { topic: 'test-topic', partition: 1 },
+            ])
+
+            // Even with flag disabled, isRebalancing should still be set (the pausing logic just won't use it)
+            expect(consumerDisabled['isRebalancing']).toBe(true)
+
+            // Simulate partition assignment
+            mockRebalanceHandlerDisabled({ code: CODES.ERRORS.ERR__ASSIGN_PARTITIONS }, [
+                { topic: 'test-topic', partition: 1 },
+            ])
+
+            // Rebalancing should be cleared
+            expect(consumerDisabled['isRebalancing']).toBe(false)
+
+            // Clean up
+            await consumerDisabled.disconnect()
         })
     })
 })

--- a/plugin-server/src/kafka/consumer.test.ts
+++ b/plugin-server/src/kafka/consumer.test.ts
@@ -19,6 +19,8 @@ jest.mock('node-rdkafka', () => ({
         offsetsStore: jest.fn(),
         setDefaultConsumeTimeout: jest.fn(),
         incrementalUnassign: jest.fn(),
+        incrementalAssign: jest.fn(),
+        rebalanceProtocol: jest.fn().mockReturnValue('COOPERATIVE'),
     })),
     CODES: {
         ERRORS: {
@@ -108,6 +110,8 @@ describe('consumer', () => {
             offsetsStore: jest.fn(),
             setDefaultConsumeTimeout: jest.fn(),
             incrementalUnassign: jest.fn(),
+            incrementalAssign: jest.fn(),
+            rebalanceProtocol: jest.fn().mockReturnValue('COOPERATIVE'),
         }
 
         // Mock the RdKafkaConsumer constructor to return our configured mock

--- a/plugin-server/src/kafka/consumer.test.ts
+++ b/plugin-server/src/kafka/consumer.test.ts
@@ -1,5 +1,7 @@
 import { CODES, KafkaConsumer as RdKafkaConsumer, Message } from 'node-rdkafka'
 
+import { defaultConfig } from '~/config/config'
+
 import { delay } from '../utils/utils'
 import { KafkaConsumer } from './consumer'
 
@@ -113,6 +115,7 @@ describe('consumer', () => {
             incrementalAssign: jest.fn(),
             rebalanceProtocol: jest.fn().mockReturnValue('COOPERATIVE'),
         }
+        defaultConfig.CONSUMER_WAIT_FOR_BACKGROUND_TASKS_ON_REBALANCE = true
 
         // Mock the RdKafkaConsumer constructor to return our configured mock
         jest.mocked(require('node-rdkafka').KafkaConsumer).mockImplementation(() => mockRdKafkaConsumerInstance)
@@ -120,7 +123,6 @@ describe('consumer', () => {
         consumer = new KafkaConsumer({
             groupId: 'test-group',
             topic: 'test-topic',
-            waitForBackgroundTasksOnRebalance: true,
         })
 
         mockRdKafkaConsumer = jest.mocked(consumer['rdKafkaConsumer'])
@@ -342,11 +344,11 @@ describe('consumer', () => {
         })
 
         it('should not wait when waitForBackgroundTasksOnRebalance is disabled', async () => {
+            defaultConfig.CONSUMER_WAIT_FOR_BACKGROUND_TASKS_ON_REBALANCE = false
             // Create a consumer with feature disabled
             const consumerDisabled = new KafkaConsumer({
                 groupId: 'test-group',
                 topic: 'test-topic',
-                waitForBackgroundTasksOnRebalance: false,
             })
 
             const mockConsumerDisabled = jest.mocked(consumerDisabled['rdKafkaConsumer'])

--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -152,7 +152,7 @@ export class KafkaConsumer {
         this.config.autoCommit ??= true
         this.config.autoOffsetStore ??= true
         this.config.callEachBatchWhenEmpty ??= false
-        this.config.waitForBackgroundTasksOnRebalance ??= false
+        this.config.waitForBackgroundTasksOnRebalance = defaultConfig.CONSUMER_WAIT_FOR_BACKGROUND_TASKS_ON_REBALANCE
         this.maxBackgroundTasks = defaultConfig.CONSUMER_MAX_BACKGROUND_TASKS
         this.fetchBatchSize = defaultConfig.CONSUMER_BATCH_SIZE
         this.maxHealthHeartbeatIntervalMs =

--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -264,7 +264,7 @@ export class KafkaConsumer {
         if (err.code === CODES.ERRORS.ERR__ASSIGN_PARTITIONS) {
             // Mark rebalancing as complete when partitions are assigned
             if (this.config.waitForBackgroundTasksOnRebalance) {
-                this.rebalanceCoordination.isRebalancing = false
+                this.resetRebalanceCoordination()
             }
             assignments.forEach((tp) => {
                 kafkaConsumerAssignment.set(
@@ -308,6 +308,9 @@ export class KafkaConsumer {
                             this.rdKafkaConsumer.unassign()
                         }
                         this.updateMetricsAfterRevocation(assignments)
+                        if (this.assignments().length === 0) {
+                            this.resetRebalanceCoordination()
+                        }
                     })
                     .catch((error) => {
                         logger.error('🔁', 'background_task_error_during_revocation', { error })
@@ -318,6 +321,9 @@ export class KafkaConsumer {
                             this.rdKafkaConsumer.unassign()
                         }
                         this.updateMetricsAfterRevocation(assignments)
+                        if (this.assignments().length === 0) {
+                            this.resetRebalanceCoordination()
+                        }
                     })
             } else {
                 // No background tasks or feature disabled, proceed immediately

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -233,6 +233,7 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
     CONSUMER_BATCH_SIZE: number // Primarily for kafka consumers the batch size to use
     CONSUMER_MAX_HEARTBEAT_INTERVAL_MS: number // Primarily for kafka consumers the max heartbeat interval to use after which it will be considered unhealthy
     CONSUMER_MAX_BACKGROUND_TASKS: number
+    CONSUMER_WAIT_FOR_BACKGROUND_TASKS_ON_REBALANCE: boolean
     CONSUMER_AUTO_CREATE_TOPICS: boolean
 
     // Kafka params - identical for client and producer


### PR DESCRIPTION
## Problem

Currently we do not wait for background tasks to finish when rebalancing, this means that the same batch can be processed by multiple pods, causing duplicates. We did a [study](https://posthog.slack.com/archives/C08JQTX5RRP/p1752667806001649) that showed that out of 1024 partitions, 997 partitions/offset pairs were processed by at least 2 pods during a deployment.

## Changes

This PR guarantees that we process all background tasks and commit offsets before rebalancing. Additionally, during the rebalancing process we stop consuming events (this needs to be tested to understand if we have big performance drops). 

This is a very simple approach to wait for the background tasks, ideally, we would have a mapping between partitions and background tasks so that we could continue processing partitions that have not been revoked.
