### PR TITLE
fix(dashboards): do not refresh dashboard tiles for exports

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1504,10 +1504,12 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 return // We hit a 404
             }
 
-            // access stored values from dashboardLoadData
-            // as we can't pass them down to this listener
-            const { action, manualDashboardRefresh } = values.dashboardLoadData
-            actions.updateDashboardItems({ action, manualDashboardRefresh })
+            if (values.placement !== DashboardPlacement.Export) {
+                // access stored values from dashboardLoadData
+                // as we can't pass them down to this listener
+                const { action, manualDashboardRefresh } = values.dashboardLoadData
+                actions.updateDashboardItems({ action, manualDashboardRefresh })
+            }
 
             if (values.shouldReportOnAPILoad) {
                 actions.setShouldReportOnAPILoad(false)


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C0368RPHLQH/p1752833585632619

## Changes

Does not trigger the dashboard refresh for exported dashboards.

## How did you test this code?

Debugger