### PR TITLE
fix(experiments): expose statistic error to the client.

### DIFF
--- a/posthog/hogql_queries/experiments/utils.py
+++ b/posthog/hogql_queries/experiments/utils.py
@@ -135,9 +135,6 @@ def get_frequentist_experiment_result_legacy_format(
     for test_variant in test_variants:
         try:
             test_stat = metric_variant_to_statistic(metric, test_variant)
-        except StatisticError as e:
-            raise ExposedCHQueryError(str(e), code=None) from e
-        try:
             result = method.run_test(test_stat, control_stat)
         except StatisticError as e:
             raise ExposedCHQueryError(str(e), code=None) from e

--- a/posthog/hogql_queries/experiments/utils.py
+++ b/posthog/hogql_queries/experiments/utils.py
@@ -15,9 +15,11 @@ from products.experiments.stats.shared.enums import DifferenceType
 from products.experiments.stats.shared.statistics import (
     SampleMeanStatistic,
     ProportionStatistic,
+    StatisticError,
 )
 from products.experiments.stats.bayesian.method import BayesianMethod, BayesianConfig
 from posthog.hogql_queries.experiments import CONTROL_VARIANT_KEY
+from posthog.errors import ExposedCHQueryError
 
 V = TypeVar("V", ExperimentVariantTrendsBaseStats, ExperimentVariantFunnelsBaseStats, ExperimentStatsBase)
 
@@ -123,13 +125,22 @@ def get_frequentist_experiment_result_legacy_format(
     significance_code = ExperimentSignificanceCode.LOW_WIN_PROBABILITY
     significant = False
 
-    control_stat = metric_variant_to_statistic(metric, control_variant)
+    try:
+        control_stat = metric_variant_to_statistic(metric, control_variant)
+    except StatisticError as e:
+        raise ExposedCHQueryError(str(e), code=None) from e
     mu_control = control_stat.sum / control_stat.n
 
     # Run the test for each test variant.
     for test_variant in test_variants:
-        test_stat = metric_variant_to_statistic(metric, test_variant)
-        result = method.run_test(test_stat, control_stat)
+        try:
+            test_stat = metric_variant_to_statistic(metric, test_variant)
+        except StatisticError as e:
+            raise ExposedCHQueryError(str(e), code=None) from e
+        try:
+            result = method.run_test(test_stat, control_stat)
+        except StatisticError as e:
+            raise ExposedCHQueryError(str(e), code=None) from e
 
         # For now, we just store the p-values in the probabilties dict.
         probabilities[test_variant.key] = result.p_value
@@ -178,13 +189,22 @@ def get_frequentist_experiment_result_new_format(
     config = FrequentistConfig(alpha=0.05, test_type=TestType.TWO_SIDED, difference_type=DifferenceType.RELATIVE)
     method = FrequentistMethod(config)
 
-    control_stat = metric_variant_to_statistic(metric, control_variant)
+    try:
+        control_stat = metric_variant_to_statistic(metric, control_variant)
+    except StatisticError as e:
+        raise ExposedCHQueryError(str(e), code=None) from e
 
     variants: list[ExperimentVariantResultFrequentist] = []
 
     for test_variant in test_variants:
-        test_stat = metric_variant_to_statistic(metric, test_variant)
-        result = method.run_test(test_stat, control_stat)
+        try:
+            test_stat = metric_variant_to_statistic(metric, test_variant)
+        except StatisticError as e:
+            raise ExposedCHQueryError(str(e), code=None) from e
+        try:
+            result = method.run_test(test_stat, control_stat)
+        except StatisticError as e:
+            raise ExposedCHQueryError(str(e), code=None) from e
         variants.append(
             ExperimentVariantResultFrequentist(
                 key=test_variant.key,
@@ -221,13 +241,22 @@ def get_bayesian_experiment_result_new_format(
     )
     method = BayesianMethod(config)
 
-    control_stat = metric_variant_to_statistic(metric, control_variant)
+    try:
+        control_stat = metric_variant_to_statistic(metric, control_variant)
+    except StatisticError as e:
+        raise ExposedCHQueryError(str(e), code=None) from e
 
     variants: list[ExperimentVariantResultBayesian] = []
 
     for test_variant in test_variants:
-        test_stat = metric_variant_to_statistic(metric, test_variant)
-        result = method.run_test(test_stat, control_stat)
+        try:
+            test_stat = metric_variant_to_statistic(metric, test_variant)
+        except StatisticError as e:
+            raise ExposedCHQueryError(str(e), code=None) from e
+        try:
+            result = method.run_test(test_stat, control_stat)
+        except StatisticError as e:
+            raise ExposedCHQueryError(str(e), code=None) from e
 
         # Convert credible interval to percentage
         credible_interval = [result.credible_interval[0], result.credible_interval[1]]

--- a/products/experiments/stats/shared/statistics.py
+++ b/products/experiments/stats/shared/statistics.py
@@ -1,15 +1,11 @@
 from dataclasses import dataclass
 import numpy as np
 
-from posthog.errors import ExposedCHQueryError
 
-
-class StatisticError(ExposedCHQueryError):
+class StatisticError(ValueError):
     """Base exception for statistic-related errors."""
 
-    def __init__(self, message: str):
-        # Call ExposedCHQueryError with no code since this isn't from ClickHouse
-        super().__init__(message, code=None)
+    pass
 
 
 class InvalidStatisticError(StatisticError):

--- a/products/experiments/stats/shared/statistics.py
+++ b/products/experiments/stats/shared/statistics.py
@@ -1,11 +1,15 @@
 from dataclasses import dataclass
 import numpy as np
 
+from posthog.errors import ExposedCHQueryError
 
-class StatisticError(Exception):
+
+class StatisticError(ExposedCHQueryError):
     """Base exception for statistic-related errors."""
 
-    pass
+    def __init__(self, message: str):
+        # Call ExposedCHQueryError with no code since this isn't from ClickHouse
+        super().__init__(message, code=None)
 
 
 class InvalidStatisticError(StatisticError):


### PR DESCRIPTION
## Problem

Some errors coming from the experiment query runner are still hidden from the user, returning an opaque `"error_message": null`.

This is an alternative to #35237

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We make the `StatisticError` error by inheriting from `ExposedCHQueryError` instead of `Exception`. This will allow the error message to be sent back to the client for better handling.

> [!IMPORTANT]
We are not including UI changes to display a more informative error message. We'll implement that once we confirm this is working as expected.

| Before | After |
| - | - |
| <img width="440" height="121" alt="image" src="https://github.com/user-attachments/assets/bc42e9f3-c6b3-40cf-b6b3-c2cbb662acc3" /> | <img width="420" height="132" alt="image" src="https://github.com/user-attachments/assets/80734fe6-32bf-453e-b288-7edfdf280892" /> |


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/ad4ba30e-0c83-47be-9234-3639f42d45c7)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
