### PR TITLE
fix: respect week start day in insights table

### DIFF
--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -86,7 +86,7 @@ export function InsightsTable({
         getTrendsColor,
         insightData,
     } = useValues(trendsDataLogic(insightProps))
-    const { timezone } = useValues(teamLogic)
+    const { weekStartDay, timezone } = useValues(teamLogic)
     const { toggleHiddenLegendIndex, updateHiddenLegendIndexes } = useActions(trendsDataLogic(insightProps))
     const { aggregation, allowAggregation } = useValues(insightsTableDataLogic(insightProps))
     const { setAggregationType } = useActions(insightsTableDataLogic(insightProps))
@@ -293,6 +293,7 @@ export function InsightsTable({
                     interval={interval}
                     resolvedDateRange={insightData?.resolved_date_range}
                     timezone={timezone}
+                    weekStartDay={weekStartDay}
                 />
             ),
             render: (_, item: IndexedTrendResult) => {

--- a/frontend/src/scenes/insights/views/InsightsTable/columns/ValueColumn.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/columns/ValueColumn.tsx
@@ -17,6 +17,7 @@ type ValueColumnTitleProps = {
     interval?: IntervalType | null
     resolvedDateRange?: ResolvedDateRangeResponse
     timezone?: string
+    weekStartDay?: number
 }
 
 export function ValueColumnTitle({
@@ -26,6 +27,7 @@ export function ValueColumnTitle({
     interval,
     resolvedDateRange,
     timezone,
+    weekStartDay,
 }: ValueColumnTitleProps): JSX.Element {
     const previousResult = compare ? indexedResults.find((r) => r.compare_label === 'previous') : undefined
 
@@ -34,6 +36,7 @@ export function ValueColumnTitle({
             interval={interval || 'day'}
             resolvedDateRange={resolvedDateRange}
             timezone={timezone}
+            weekStartDay={weekStartDay}
             date={(indexedResults[0].dates || indexedResults[0].days)[index]} // current
             secondaryDate={previousResult ? (previousResult.dates || previousResult.days)[index] : undefined} // previous
             hideWeekRange


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

The week start day was always being set to Sunday on insight tables regardless of user setting:

<img width="990" height="72" alt="Image" src="https://github.com/user-attachments/assets/9896de4e-b8f7-4f61-84a1-c6de7c39052b" />

<img width="650" height="47" alt="Image" src="https://github.com/user-attachments/assets/bf409d8f-cecc-4249-bb34-ce4b732ab8f8" />

Closes #35282

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

This adds a `weekStartDay` property to the `ValueColumn` component so we can pass it on to the `DateDisplay` to render the correct date.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

-  Set Monday in Settings > Product Analytics > Date & Time > Week Starts On
-  Create a new Insight
-  For page views, group by week, select a date range for at least a couple of weeks
-  Confirm the dates on the table below the chart are set to Monday and not Sunday


## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
