### PR TITLE
refactor(experiments): remove duplicated status tag.

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/Info.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Info.tsx
@@ -59,32 +59,33 @@ export function Info(): JSX.Element {
         primaryMetricsResults?.[0]?.last_refresh ||
         secondaryMetricsResults?.[0]?.last_refresh
 
+    const status = getExperimentStatus(experiment)
+
     return (
         <div>
             <div className="flex flex-wrap justify-between gap-4">
                 <div className="inline-flex deprecated-space-x-8">
                     <div className="block" data-attr="experiment-status">
                         <div className="text-xs font-semibold uppercase tracking-wide">Status</div>
-                        <StatusTag experiment={experiment} />
+                        <StatusTag status={status} />
                     </div>
                     {experiment.feature_flag && (
                         <div className="block">
                             <div className="text-xs font-semibold uppercase tracking-wide">
                                 <span>Feature flag</span>
                             </div>
-                            {getExperimentStatus(experiment) === ProgressStatus.Running &&
-                                !experiment.feature_flag.active && (
-                                    <Tooltip
-                                        placement="bottom"
-                                        title="Your experiment is running, but the linked flag is disabled. No data is being collected."
-                                    >
-                                        <IconWarning
-                                            style={{ transform: 'translateY(2px)' }}
-                                            className="mr-1 text-danger"
-                                            fontSize="18px"
-                                        />
-                                    </Tooltip>
-                                )}
+                            {status === ProgressStatus.Running && !experiment.feature_flag.active && (
+                                <Tooltip
+                                    placement="bottom"
+                                    title="Your experiment is running, but the linked flag is disabled. No data is being collected."
+                                >
+                                    <IconWarning
+                                        style={{ transform: 'translateY(2px)' }}
+                                        className="mr-1 text-danger"
+                                        fontSize="18px"
+                                    />
+                                </Tooltip>
+                            )}
                             <CopyToClipboardInline
                                 iconStyle={{ color: 'var(--lemon-button-icon-opacity)' }}
                                 className="font-normal text-sm"

--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -40,18 +40,18 @@ import {
     ActionFilter,
     AnyPropertyFilter,
     Experiment,
-    Experiment as ExperimentType,
     ExperimentConclusion,
     ExperimentIdType,
     InsightShortId,
+    ProgressStatus,
 } from '~/types'
 
 import { CONCLUSION_DISPLAY_CONFIG, EXPERIMENT_VARIANT_MULTIPLE } from '../constants'
-import { getIndexForVariant } from '../legacyExperimentCalculations'
 import { experimentLogic, FORM_MODES } from '../experimentLogic'
-import { getExperimentStatus, getExperimentStatusColor } from '../experimentsLogic'
-import { getExperimentInsightColour } from '../utils'
+import { getExperimentStatusColor } from '../experimentsLogic'
+import { getIndexForVariant } from '../legacyExperimentCalculations'
 import { modalsLogic } from '../modalsLogic'
+import { getExperimentInsightColour } from '../utils'
 
 export function VariantTag({
     experimentId,
@@ -691,8 +691,7 @@ export const ResetButton = ({ experimentId }: { experimentId: ExperimentIdType }
     )
 }
 
-export function StatusTag({ experiment }: { experiment: ExperimentType }): JSX.Element {
-    const status = getExperimentStatus(experiment)
+export function StatusTag({ status }: { status: ProgressStatus }): JSX.Element {
     return (
         <LemonTag type={getExperimentStatusColor(status)}>
             <b className="uppercase">{status}</b>

--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -113,7 +113,7 @@ export function Experiments(): JSX.Element {
             title: 'Status',
             key: 'status',
             render: function Render(_, experiment: Experiment) {
-                return <StatusTag experiment={experiment} />
+                return <StatusTag status={getExperimentStatus(experiment)} />
             },
             align: 'center',
             sorter: (a, b) => {

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
@@ -1,33 +1,17 @@
 import { ActivityLogItem, HumanizedChange, userNameForLogItem } from 'lib/components/ActivityLog/humanizeActivity'
 import { SentenceList } from 'lib/components/ActivityLog/SentenceList'
 import { LemonCard } from 'lib/lemon-ui/LemonCard'
-import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { Link } from 'lib/lemon-ui/Link'
 import { urls } from 'scenes/urls'
 import { match } from 'ts-pattern'
 import { ProgressStatus } from '~/types'
-import { getExperimentStatusColor } from './experimentsLogic'
+import { StatusTag } from './ExperimentView/components'
 
 function nameOrLinkToExperiment(id: string | undefined, name: string | null): JSX.Element | string {
     if (id) {
         return <Link to={urls.experiment(id)}>{name}</Link>
     }
     return name || '(unknown)'
-}
-
-/**
- * TODO: refactor the experiment view component to take a status prop so we can remove this component
- */
-const StatusTag = ({
-    status,
-}: {
-    status: ProgressStatus.Draft | ProgressStatus.Running | ProgressStatus.Complete
-}): JSX.Element => {
-    return (
-        <LemonTag type={getExperimentStatusColor(status)}>
-            <b className="uppercase">{status}</b>
-        </LemonTag>
-    )
 }
 
 //exporting so the linter doesn't complain about this not being used

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeExperiment.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeExperiment.tsx
@@ -5,6 +5,7 @@ import { NotFound } from 'lib/components/NotFound'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { useEffect } from 'react'
 import { experimentLogic } from 'scenes/experiments/experimentLogic'
+import { getExperimentStatus } from 'scenes/experiments/experimentsLogic'
 import { LegacyResultsQuery, ResultsTag, StatusTag } from 'scenes/experiments/ExperimentView/components'
 import { Info } from 'scenes/experiments/ExperimentView/Info'
 import { SummaryTable } from 'scenes/experiments/ExperimentView/SummaryTable'
@@ -54,7 +55,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeExperimentAttri
                     ) : (
                         <>
                             <span className="flex-1 font-semibold truncate">{experiment.name}</span>
-                            <StatusTag experiment={experiment} />
+                            <StatusTag status={getExperimentStatus(experiment)} />
                             <ResultsTag />
                         </>
                     )}


### PR DESCRIPTION
## Problem

On #35065, we've included the `StatusTag` component in the activity log, duplicating the component we use everywhere else because we don't have access to `experiment` in the log context, which the component requires as its only prop.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We are changing the signature of the `StatusTag` component to take a `status` prop, and removing the duplicated component from the activity describer.

There are no other changes in the code or functionality.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/6809e5eb-bab4-47ef-a9a1-2e1ba55b0583)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
