### PR TITLE
chore: fewer warning in test output

### DIFF
--- a/posthog/clickhouse/test/test_explain.py
+++ b/posthog/clickhouse/test/test_explain.py
@@ -13,7 +13,7 @@ from posthog.schema import QueryIndexUsage
 
 
 @dataclass
-class TestCaseData:
+class DataTestCase:
     query: str
     reads: int
     reads_use: list[ReadIndexUsage]
@@ -21,8 +21,8 @@ class TestCaseData:
     plan: str
 
 
-test_cases: list[TestCaseData] = [
-    TestCaseData(
+test_cases: list[DataTestCase] = [
+    DataTestCase(
         query="a proper query with all filters on events",
         reads=1,
         reads_use=[ReadIndexUsage(table="posthog.sharded_events", use=QueryIndexUsage.YES)],
@@ -94,7 +94,7 @@ test_cases: list[TestCaseData] = [
 ]
 """,
     ),
-    TestCaseData(
+    DataTestCase(
         query="missing timestamp condition",
         reads=1,
         reads_use=[ReadIndexUsage(table="posthog.sharded_events", use=QueryIndexUsage.NO)],
@@ -160,7 +160,7 @@ test_cases: list[TestCaseData] = [
 ]
 """,
     ),
-    TestCaseData(
+    DataTestCase(
         query="production query often failing cause ClickHouse not using index",
         reads=2,
         reads_use=[
@@ -324,7 +324,7 @@ test_cases: list[TestCaseData] = [
 ]
 """,
     ),
-    TestCaseData(
+    DataTestCase(
         query="local query little granules",
         reads=1,
         reads_use=[ReadIndexUsage(table="default.sharded_events", use=QueryIndexUsage.NO)],
@@ -384,7 +384,7 @@ test_cases: list[TestCaseData] = [
 ]
 """,
     ),
-    TestCaseData(
+    DataTestCase(
         query="local query little granules, using index",
         reads=1,
         reads_use=[ReadIndexUsage(table="default.sharded_events", use=QueryIndexUsage.YES)],
@@ -445,7 +445,7 @@ test_cases: list[TestCaseData] = [
 ]
 """,
     ),
-    TestCaseData(
+    DataTestCase(
         query="session query not using indices",
         reads=1,
         reads_use=[ReadIndexUsage(table="posthog.sharded_raw_sessions", use=QueryIndexUsage.PARTIAL)],

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -22,8 +22,8 @@ from posthog.schema import (
     PersonsOnEventsMode,
     SessionsV2JoinMode,
     SessionTableVersion,
-    TestBasicQueryResponse,
-    TestCachedBasicQueryResponse,
+    TestBasicQueryResponse as TheTestBasicQueryResponse,
+    TestCachedBasicQueryResponse as TheTestCachedBasicQueryResponse,
     IntervalType,
 )
 from posthog.test.base import BaseTest
@@ -47,11 +47,11 @@ class TestQueryRunner(BaseTest):
 
         class TestQueryRunner(QueryRunner):
             query: TestQuery
-            response: TestBasicQueryResponse
-            cached_response: TestCachedBasicQueryResponse
+            response: TheTestBasicQueryResponse
+            cached_response: TheTestCachedBasicQueryResponse
 
             def calculate(self):
-                return TestBasicQueryResponse(
+                return TheTestBasicQueryResponse(
                     results=[
                         ["row", 1, 2, 3],
                         (i for i in range(10)),  # Test support of cache.set with iterators
@@ -182,46 +182,46 @@ class TestQueryRunner(BaseTest):
 
             # returns fresh response if uncached
             response = runner.run(execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE)
-            self.assertIsInstance(response, TestCachedBasicQueryResponse)
+            self.assertIsInstance(response, TheTestCachedBasicQueryResponse)
             self.assertEqual(response.is_cached, False)
             self.assertEqual(response.last_refresh.isoformat(), "2023-02-04T13:37:42+00:00")
             self.assertEqual(response.next_allowed_client_refresh.isoformat(), "2023-02-04T13:41:42+00:00")
 
             # returns cached response afterwards
             response = runner.run(execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE)
-            self.assertIsInstance(response, TestCachedBasicQueryResponse)
+            self.assertIsInstance(response, TheTestCachedBasicQueryResponse)
             self.assertEqual(response.is_cached, True)
 
             # return fresh response if refresh requested
             response = runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
-            self.assertIsInstance(response, TestCachedBasicQueryResponse)
+            self.assertIsInstance(response, TheTestCachedBasicQueryResponse)
             self.assertEqual(response.is_cached, False)
 
         with freeze_time(datetime(2023, 2, 4, 13, 37 + 11, 42)):
             # returns fresh response if stale
             response = runner.run(execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE)
-            self.assertIsInstance(response, TestCachedBasicQueryResponse)
+            self.assertIsInstance(response, TheTestCachedBasicQueryResponse)
             self.assertEqual(response.is_cached, False)
             mock_on_commit.assert_not_called()
 
         with freeze_time(datetime(2023, 2, 4, 13, 37 + 11 + 5, 42)):
             # returns cached response - does not kick off calculation in the background
             response = runner.run(execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE)
-            self.assertIsInstance(response, TestCachedBasicQueryResponse)
+            self.assertIsInstance(response, TheTestCachedBasicQueryResponse)
             self.assertEqual(response.is_cached, True)
             mock_on_commit.assert_not_called()
 
         with freeze_time(datetime(2023, 2, 4, 13, 37 + 11 + 11, 42)):
             # returns cached response but kicks off calculation in the background
             response = runner.run(execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE)
-            self.assertIsInstance(response, TestCachedBasicQueryResponse)
+            self.assertIsInstance(response, TheTestCachedBasicQueryResponse)
             self.assertEqual(response.is_cached, True)
             mock_on_commit.assert_called_once()
 
         with freeze_time(datetime(2023, 2, 4, 23, 55, 42)):
             # returns cached response for extended time
             response = runner.run(execution_mode=ExecutionMode.EXTENDED_CACHE_CALCULATE_ASYNC_IF_STALE)
-            self.assertIsInstance(response, TestCachedBasicQueryResponse)
+            self.assertIsInstance(response, TheTestCachedBasicQueryResponse)
             self.assertEqual(response.is_cached, True)
             mock_on_commit.assert_called_once()  # still once
 
@@ -229,7 +229,7 @@ class TestQueryRunner(BaseTest):
         with freeze_time(datetime(2023, 2, 5, 23, 55, 42)):
             # returns cached response for extended time but finally kicks off calculation in the background
             response = runner.run(execution_mode=ExecutionMode.EXTENDED_CACHE_CALCULATE_ASYNC_IF_STALE)
-            self.assertIsInstance(response, TestCachedBasicQueryResponse)
+            self.assertIsInstance(response, TheTestCachedBasicQueryResponse)
             self.assertEqual(response.is_cached, True)
             mock_on_commit.assert_called_once()
 
@@ -247,7 +247,7 @@ class TestQueryRunner(BaseTest):
             response = runner.run(
                 execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS
             )
-            self.assertIsInstance(response, TestCachedBasicQueryResponse)
+            self.assertIsInstance(response, TheTestCachedBasicQueryResponse)
             self.assertEqual(response.is_cached, False)
             self.assertEqual(response.last_refresh.isoformat(), "2023-02-04T13:37:42+00:00")
             self.assertEqual(response.next_allowed_client_refresh.isoformat(), "2023-02-04T13:41:42+00:00")
@@ -256,7 +256,7 @@ class TestQueryRunner(BaseTest):
             response = runner.run(
                 execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS
             )
-            self.assertIsInstance(response, TestCachedBasicQueryResponse)
+            self.assertIsInstance(response, TheTestCachedBasicQueryResponse)
             self.assertEqual(response.is_cached, True)
 
         with freeze_time(datetime(2023, 2, 4, 13, 37 + 11, 42)):
@@ -264,7 +264,7 @@ class TestQueryRunner(BaseTest):
             response = runner.run(
                 execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS
             )
-            self.assertIsInstance(response, TestCachedBasicQueryResponse)
+            self.assertIsInstance(response, TheTestCachedBasicQueryResponse)
             # Should kick off the calculation in the background
             self.assertEqual(response.is_cached, True)
             self.assertEqual(response.last_refresh.isoformat(), "2023-02-04T13:37:42+00:00")

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -29,7 +29,7 @@ from posthog.schema import (
 from posthog.test.base import BaseTest
 
 
-class TestQuery(BaseModel):
+class TheTestQuery(BaseModel):
     kind: Literal["TestQuery"] = "TestQuery"
     some_attr: str
     other_attr: Optional[list[Any]] = []
@@ -46,7 +46,7 @@ class TestQueryRunner(BaseTest):
         """Setup required methods and attributes of the abstract base class."""
 
         class TestQueryRunner(QueryRunner):
-            query: TestQuery
+            query: TheTestQuery
             response: TheTestBasicQueryResponse
             cached_response: TheTestCachedBasicQueryResponse
 
@@ -76,16 +76,16 @@ class TestQueryRunner(BaseTest):
     def test_init_with_query_instance(self):
         TestQueryRunner = self.setup_test_query_runner_class()
 
-        runner = TestQueryRunner(query=TestQuery(some_attr="bla"), team=self.team)
+        runner = TestQueryRunner(query=TheTestQuery(some_attr="bla"), team=self.team)
 
-        self.assertEqual(runner.query, TestQuery(some_attr="bla"))
+        self.assertEqual(runner.query, TheTestQuery(some_attr="bla"))
 
     def test_init_with_query_dict(self):
         TestQueryRunner = self.setup_test_query_runner_class()
 
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=self.team)
 
-        self.assertEqual(runner.query, TestQuery(some_attr="bla"))
+        self.assertEqual(runner.query, TheTestQuery(some_attr="bla"))
 
     def test_cache_payload(self):
         TestQueryRunner = self.setup_test_query_runner_class()

--- a/posthog/warehouse/api/test/test_log_entry.py
+++ b/posthog/warehouse/api/test/test_log_entry.py
@@ -1,7 +1,7 @@
 import datetime as dt
 
 import pytest
-from django.test.client import Client as TestClient
+from django.test.client import Client as DjangoTestClient
 
 from posthog.api.test.test_organization import create_organization
 from posthog.api.test.test_team import create_team
@@ -108,7 +108,9 @@ def external_data_resources(client, organization, team):
     }
 
 
-def get_external_data_schema_run_log_entries(client: TestClient, team_id: int, external_data_schema_id: str, **extra):
+def get_external_data_schema_run_log_entries(
+    client: DjangoTestClient, team_id: int, external_data_schema_id: str, **extra
+):
     return client.get(
         f"/api/environments/{team_id}/external_data_schemas/{external_data_schema_id}/logs",
         data=encode_get_request_params(extra),

--- a/products/experiments/stats/tests/test_frequentist.py
+++ b/products/experiments/stats/tests/test_frequentist.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from products.experiments.stats.frequentist.method import FrequentistConfig, FrequentistMethod, TestType
+from products.experiments.stats.frequentist.method import FrequentistConfig, FrequentistMethod
 from products.experiments.stats.shared.statistics import (
     ProportionStatistic,
     SampleMeanStatistic,
@@ -27,6 +27,10 @@ def create_test_result_dict(result):
 class TestTwoSidedTTest(TestCase):
     def test_two_sided_ttest_with_sample_mean(self):
         """Test basic two-sided t-test with sample mean statistics."""
+
+        # imported here so that pytest doesn't try to discover tests inside it
+        from products.experiments.stats.frequentist.method import TestType
+
         stat_a = SampleMeanStatistic(sum=1922.7, sum_squares=94698.29, n=2461)
         stat_b = SampleMeanStatistic(sum=1196.87, sum_squares=37377.9767, n=2507)
 
@@ -53,6 +57,10 @@ class TestTwoSidedTTest(TestCase):
 
     def test_two_sided_ttest_with_sample_proportion(self):
         """Test basic two-sided t-test with sample proportion statistics."""
+
+        # imported here so that pytest doesn't try to discover tests inside it
+        from products.experiments.stats.frequentist.method import TestType
+
         stat_a = ProportionStatistic(sum=62, n=1471)
         stat_b = ProportionStatistic(sum=87, n=1529)
 


### PR DESCRIPTION
we get a bunch of warnings at the start of test output because we have things called TestFoo in test context and so pytest tries to discover tests inside the thing and then complains

noise is bad