### PR TITLE
feat: Endpoint to create groups

### DIFF
--- a/ee/clickhouse/views/exceptions.py
+++ b/ee/clickhouse/views/exceptions.py
@@ -1,0 +1,4 @@
+class TriggerGroupIdentifyException(Exception):
+    def __init__(self, exception_data: dict, status_code: int):
+        self.exception_data = exception_data
+        self.status_code = status_code

--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -1,13 +1,17 @@
 from collections import defaultdict
+
+from django.db import IntegrityError
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from requests import HTTPError
-from typing import cast
+from typing import cast, Optional
 
 from django.db.models import Q
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter
 from rest_framework import mixins, request, response, serializers, viewsets, status
+
+from ee.clickhouse.views.exceptions import TriggerGroupIdentifyException
 from posthog.api.capture import capture_internal
 from posthog.api.utils import action
 from rest_framework.exceptions import NotFound, ValidationError
@@ -21,8 +25,9 @@ from posthog.clickhouse.client import sync_execute
 from posthog.helpers.dashboard_templates import create_group_type_mapping_detail_dashboard
 from posthog.models.activity_logging.activity_log import Change, Detail, load_activity, log_activity
 from posthog.models.activity_logging.activity_page import activity_page_response
+from posthog.models.filters.utils import GroupTypeIndex
 from posthog.models.group import Group
-from posthog.models.group.util import raw_create_group_ch
+from posthog.models.group.util import raw_create_group_ch, create_group
 from posthog.models.group_type_mapping import GroupTypeMapping, GROUP_TYPE_MAPPING_SERIALIZER_FIELDS
 from loginas.utils import is_impersonated_session
 
@@ -100,7 +105,15 @@ class GroupSerializer(serializers.HyperlinkedModelSerializer):
         fields = ["group_type_index", "group_key", "group_properties", "created_at"]
 
 
-class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, viewsets.GenericViewSet):
+class CreateGroupSerializer(serializers.ModelSerializer):
+    group_properties = serializers.JSONField(default=dict, required=False, allow_null=True)
+
+    class Meta:
+        model = Group
+        fields = ["group_type_index", "group_key", "group_properties"]
+
+
+class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.CreateModelMixin, viewsets.GenericViewSet):
     scope_object = "group"
     serializer_class = GroupSerializer
     queryset = Group.objects.all()
@@ -119,6 +132,48 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, viewsets.Gene
         )
 
         return get_object_or_404(queryset)
+
+    def get_group_type_mapping_or_404(self, group_type_index: GroupTypeIndex) -> GroupTypeMapping:
+        try:
+            return GroupTypeMapping.objects.get(project_id=self.team.project_id, group_type_index=group_type_index)
+        except GroupTypeMapping.DoesNotExist:
+            raise NotFound()
+
+    def trigger_group_identify(self, group: Group, operation: str, group_properties: Optional[dict] = None):
+        group_type_mapping = self.get_group_type_mapping_or_404(group.group_type_index)
+        properties = {
+            "$group_type": group_type_mapping.group_type,
+            "$group_key": group.group_key,
+            "$group_set": group_properties or group.group_properties,
+        }
+        try:
+            capture_internal(
+                token=self.team.api_token,
+                event_name="$groupidentify",
+                event_source="ee_ch_views_groups",
+                distinct_id=str(self.team.uuid),
+                timestamp=timezone.now(),
+                properties=properties,
+                process_person_profile=False,
+            ).raise_for_status()
+        except HTTPError as error:
+            raise TriggerGroupIdentifyException(
+                exception_data={
+                    "code": f"Failed to submit {operation} event.",
+                    "detail": "capture_http_error",
+                    "type": "capture_http_error",
+                },
+                status_code=error.response.status_code,
+            )
+        except Exception:
+            raise TriggerGroupIdentifyException(
+                exception_data={
+                    "code": f"Failed to submit {operation} event.",
+                    "detail": "capture_error",
+                    "type": "capture_error",
+                },
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
 
     @extend_schema(
         parameters=[
@@ -161,6 +216,57 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, viewsets.Gene
 
         serializer = self.get_serializer(queryset, many=True)
         return response.Response(serializer.data)
+
+    @extend_schema(request=CreateGroupSerializer, responses={status.HTTP_201_CREATED: serializer_class})
+    def create(self, request, *args, **kwargs):
+        request_data = CreateGroupSerializer(data=request.data)
+        request_data.is_valid(raise_exception=True)
+
+        try:
+            group = create_group(
+                group_key=request_data.validated_data["group_key"],
+                group_type_index=request_data.validated_data["group_type_index"],
+                properties=request_data.validated_data["group_properties"],
+                team_id=self.team.pk,
+                timestamp=timezone.now(),
+            )
+        except IntegrityError as exc:
+            if "unique team_id/group_key/group_type_index combo" in str(exc):
+                raise ValidationError({"detail": "A group with this key already exists"})
+            raise
+
+        try:
+            self.trigger_group_identify(group=group, operation="group create")
+        except TriggerGroupIdentifyException as exc:
+            return response.Response(data=exc.exception_data, status=exc.status_code)
+
+        details = [
+            Detail(
+                name=str(name),
+                changes=[
+                    Change(
+                        type="Group",
+                        action="created",
+                        before=None,
+                        after=value,
+                    )
+                ],
+            )
+            for name, value in group.group_properties.items()
+        ]
+        for detail in details:
+            log_activity(
+                organization_id=self.organization.id,
+                team_id=self.team.id,
+                user=cast(User, request.user),
+                was_impersonated=is_impersonated_session(request),
+                item_id=group.pk,
+                scope="Group",
+                activity="create_group",
+                detail=detail,
+            )
+
+        return response.Response(data=self.get_serializer(group).data, status=status.HTTP_201_CREATED)
 
     @extend_schema(
         parameters=[
@@ -218,13 +324,6 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, viewsets.Gene
                         },
                         status=400,
                     )
-            try:
-                group_type_mapping = GroupTypeMapping.objects.get(
-                    project_id=self.team.project_id, group_type_index=group.group_type_index
-                )
-            except GroupTypeMapping.DoesNotExist:
-                raise NotFound()
-
             original_value = group.group_properties.get(request.data["key"], None)
             group.group_properties[request.data["key"]] = request.data["value"]
             group.save()
@@ -241,44 +340,14 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, viewsets.Gene
             )
 
             # another internal event submission where we best-effort and don't handle failures...
-            team_uuid_as_distinct_id = str(self.team.uuid)
-            event_name = "$groupidentify"
-            properties = {
-                "$group_type": group_type_mapping.group_type,
-                "$group_key": group.group_key,
-                "$group_set": {request.data["key"]: request.data["value"]},
-            }
-
             try:
-                resp = capture_internal(
-                    token=self.team.api_token,
-                    event_name=event_name,
-                    event_source="ee_ch_views_groups",
-                    distinct_id=team_uuid_as_distinct_id,
-                    timestamp=timestamp,
-                    properties=properties,
-                    process_person_profile=False,  # don't process person profile
+                self.trigger_group_identify(
+                    group=group,
+                    operation="group property update",
+                    group_properties={request.data["key"]: request.data["value"]},
                 )
-                resp.raise_for_status()
-
-            except HTTPError as e:
-                return response.Response(
-                    {
-                        "code": "Failed to submit group property update event.",
-                        "detail": "capture_http_error",
-                        "type": "capture_http_error",
-                    },
-                    status=e.response.status_code,
-                )
-            except Exception:
-                return response.Response(
-                    {
-                        "code": "Failed to submit group property update event.",
-                        "detail": "capture_error",
-                        "type": "capture_error",
-                    },
-                    status=400,
-                )
+            except TriggerGroupIdentifyException as exc:
+                return response.Response(data=exc.exception_data, status=exc.status_code)
 
             log_activity(
                 organization_id=self.organization.id,

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -1,9 +1,11 @@
+import json
 from unittest import mock
 from uuid import UUID
 
 from freezegun.api import freeze_time
 from orjson import orjson
 from flaky import flaky
+from rest_framework import status
 
 from posthog.helpers.dashboard_templates import create_group_type_mapping_detail_dashboard
 from posthog.hogql.parser import parse_select
@@ -169,6 +171,205 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
                 "group_type_index": 1,
             },
         )
+
+    @freeze_time("2021-05-02")
+    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    def test_create_group_missing_group_properties(self, mock_capture):
+        group_type_mapping = GroupTypeMapping.objects.create(
+            team=self.team,
+            project_id=self.team.project_id,
+            group_type_index=0,
+            group_type="organization",
+        )
+        group_key = "1234"
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/groups",
+            {
+                "group_key": group_key,
+                "group_type_index": group_type_mapping.group_type_index,
+                "group_properties": None,
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(
+            response.json(),
+            {
+                "created_at": "2021-05-02T00:00:00Z",
+                "group_key": group_key,
+                "group_properties": {},
+                "group_type_index": group_type_mapping.group_type_index,
+            },
+        )
+        mock_capture.assert_called_once()
+
+    @freeze_time("2021-05-02")
+    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    @flaky(max_runs=3, min_passes=1)
+    def test_create_group(self, mock_capture):
+        group_type_mapping = GroupTypeMapping.objects.create(
+            team=self.team,
+            project_id=self.team.project_id,
+            group_type_index=0,
+            group_type="organization",
+        )
+        group_properties = {"name": "Group Name", "industry": "finance"}
+        group_key = "1234"
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/groups",
+            {
+                "group_key": group_key,
+                "group_type_index": group_type_mapping.group_type_index,
+                "group_properties": group_properties,
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(
+            response.json(),
+            {
+                "created_at": "2021-05-02T00:00:00Z",
+                "group_key": group_key,
+                "group_properties": group_properties,
+                "group_type_index": 0,
+            },
+        )
+        response = execute_hogql_query(
+            parse_select(
+                """
+                select properties
+                from groups
+                where index = {index}
+                  and key = {key}
+                """,
+                placeholders={
+                    "index": ast.Constant(value=group_type_mapping.group_type_index),
+                    "key": ast.Constant(value=group_key),
+                },
+            ),
+            self.team,
+        )
+        self.assertEqual(response.results, [(json.dumps(group_properties),)])
+        mock_capture.assert_called_once_with(
+            token=self.team.api_token,
+            event_name="$groupidentify",
+            event_source="ee_ch_views_groups",
+            distinct_id=str(self.team.uuid),
+            timestamp=mock.ANY,
+            properties={
+                "$group_type": group_type_mapping.group_type,
+                "$group_key": group_key,
+                "$group_set": group_properties,
+            },
+            process_person_profile=False,
+        )
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/groups/activity?group_key={group_key}&group_type_index=0",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        results = response.json()["results"]
+        self.assertEqual(len(results), 2)
+        for result in results:
+            self.assertEqual(result["activity"], "create_group")
+            self.assertEqual(result["scope"], "Group")
+            self.assertEqual(result["detail"]["changes"][0]["action"], "created")
+            self.assertIsNone(result["detail"]["changes"][0]["before"])
+            prop_name = result["detail"]["name"]
+            self.assertEqual(result["detail"]["changes"][0]["after"], group_properties[prop_name])
+
+    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    def test_create_group_duplicated_group_key(self, mock_capture):
+        group_type_mapping = GroupTypeMapping.objects.create(
+            team=self.team,
+            project_id=self.team.project_id,
+            group_type_index=0,
+            group_type="organization",
+        )
+        group_key = "1234"
+        create_group(
+            team_id=self.team.pk,
+            group_type_index=group_type_mapping.group_type_index,
+            group_key=group_key,
+            properties={},
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/groups",
+            {
+                "group_key": group_key,
+                "group_type_index": 0,
+                "group_properties": {},
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            {
+                "type": "validation_error",
+                "code": "invalid_input",
+                "detail": "A group with this key already exists",
+                "attr": "detail",
+            },
+        )
+        mock_capture.assert_not_called()
+
+    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    def test_create_group_missing_group_key(self, mock_capture):
+        group_type_mapping = GroupTypeMapping.objects.create(
+            team=self.team,
+            project_id=self.team.project_id,
+            group_type_index=0,
+            group_type="organization",
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/groups",
+            {
+                "group_key": None,
+                "group_type_index": group_type_mapping.group_type_index,
+                "group_properties": {},
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            {
+                "attr": "group_key",
+                "code": "null",
+                "detail": "This field may not be null.",
+                "type": "validation_error",
+            },
+        )
+        mock_capture.assert_not_called()
+
+    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    def test_create_group_missing_group_type_index(self, mock_capture):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/groups",
+            {
+                "group_key": "foo",
+                "group_type_index": None,
+                "group_properties": {},
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            {
+                "attr": "group_type_index",
+                "code": "null",
+                "detail": "This field may not be null.",
+                "type": "validation_error",
+            },
+        )
+        mock_capture.assert_not_called()
 
     @freeze_time("2021-05-02")
     @mock.patch("ee.clickhouse.views.groups.capture_internal")


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Closes https://github.com/PostHog/posthog/issues/35275
## Changes
Create an endpoint to create a new group manually.
- Leverages ingestion pipeline to update CH
- Persists new group data in postgres syncrhonously
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally, via UI (code for the UI coming in another PR) and unit tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
