### PR TITLE
feat(api): Add `bulk_keys` endpoint for feature flag ID to key mapping

### DIFF
--- a/ee/hogai/graph/test/test_assistant_graph.py
+++ b/ee/hogai/graph/test/test_assistant_graph.py
@@ -13,7 +13,7 @@ class TestAssistantGraph(BaseTest):
         async def runnable(state: AssistantState) -> PartialAssistantState:
             return PartialAssistantState(start_id=None)
 
-        graph = BaseAssistantGraph(self.team, self.user, AssistantState)
+        graph = BaseAssistantGraph(self.team, self.user, state_type=AssistantState)
         compiled_graph = (
             graph.add_node(AssistantNodeName.ROOT, RunnableLambda(runnable))
             .add_edge(AssistantNodeName.START, AssistantNodeName.ROOT)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1431,6 +1431,9 @@ const api = {
         async get(id: FeatureFlagType['id']): Promise<FeatureFlagType> {
             return await new ApiRequest().featureFlag(id).get()
         },
+        async bulkKeys(ids: FeatureFlagType['id'][]): Promise<{ keys: Record<string, string> }> {
+            return await new ApiRequest().featureFlags().withAction('bulk_keys').create({ data: { ids } })
+        },
         async createStaticCohort(id: FeatureFlagType['id']): Promise<{ cohort: CohortType }> {
             return await new ApiRequest().featureFlagCreateStaticCohort(id).create()
         },

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -134,42 +134,6 @@
      HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)
   '''
 # ---
-# name: TestBlastRadius.test_user_blast_radius_with_multiple_precalculated_cohorts.4
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT count(1)
-  FROM
-    (SELECT id
-     FROM person
-     WHERE team_id = 99999
-       AND id in
-         (SELECT DISTINCT person_id
-          FROM cohortpeople
-          WHERE team_id = 99999
-            AND cohort_id = 99999
-            AND version = 0 )
-       AND id in
-         (SELECT DISTINCT person_id
-          FROM cohortpeople
-          WHERE team_id = 99999
-            AND cohort_id = 99999
-            AND version = 0 )
-     GROUP BY id
-     HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)
-  '''
-# ---
-# name: TestBlastRadius.test_user_blast_radius_with_multiple_precalculated_cohorts.5
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT count(1)
-  FROM
-    (SELECT id
-     FROM person
-     WHERE team_id = 99999
-     GROUP BY id
-     HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)
-  '''
-# ---
 # name: TestBlastRadius.test_user_blast_radius_with_multiple_static_cohorts
   '''
   
@@ -260,39 +224,6 @@
      HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)
   '''
 # ---
-# name: TestBlastRadius.test_user_blast_radius_with_multiple_static_cohorts.6
-  '''
-  /* cohort_calculation: */
-  SELECT count(DISTINCT person_id)
-  FROM cohortpeople
-  WHERE team_id = 99999
-    AND cohort_id = 99999
-    AND version = 0
-  '''
-# ---
-# name: TestBlastRadius.test_user_blast_radius_with_multiple_static_cohorts.7
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT count(1)
-  FROM
-    (SELECT id
-     FROM person
-     WHERE team_id = 99999
-       AND id in
-         (SELECT person_id as id
-          FROM person_static_cohort
-          WHERE cohort_id = 99999
-            AND team_id = 99999)
-       AND id in
-         (SELECT DISTINCT person_id
-          FROM cohortpeople
-          WHERE team_id = 99999
-            AND cohort_id = 99999
-            AND version = 0 )
-     GROUP BY id
-     HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)
-  '''
-# ---
 # name: TestBlastRadius.test_user_blast_radius_with_single_cohort
   '''
   /* user_id:0 request:_snapshot_ */
@@ -336,25 +267,6 @@
   '''
 # ---
 # name: TestBlastRadius.test_user_blast_radius_with_single_cohort.3
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT count(1)
-  FROM
-    (SELECT id
-     FROM person
-     INNER JOIN
-       (SELECT DISTINCT person_id
-        FROM cohortpeople
-        WHERE team_id = 99999
-          AND cohort_id = 99999
-          AND version = 0
-        ORDER BY person_id) cohort_persons ON cohort_persons.person_id = person.id
-     WHERE team_id = 99999
-     GROUP BY id
-     HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)
-  '''
-# ---
-# name: TestBlastRadius.test_user_blast_radius_with_single_cohort.4
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT count(1)
@@ -2555,26 +2467,6 @@
   '''
 # ---
 # name: TestFeatureFlag.test_creating_static_cohort.24
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT id
-  FROM person
-  INNER JOIN
-    (SELECT person_id
-     FROM person_static_cohort
-     WHERE team_id = 99999
-       AND cohort_id = 99999
-     GROUP BY person_id,
-              cohort_id,
-              team_id) cohort_persons ON cohort_persons.person_id = person.id
-  WHERE team_id = 99999
-  GROUP BY id
-  HAVING max(is_deleted) = 0
-  ORDER BY argMax(person.created_at, version) DESC, id DESC
-  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
-  '''
-# ---
-# name: TestFeatureFlag.test_creating_static_cohort.25
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT id


### PR DESCRIPTION
This utility API provides the foundation for flag dependency features and can be deployed independently. It's not in use by any current code. The reason for this PR is to break down https://github.com/PostHog/posthog/pull/35284 into manageable chunks for review.

## Problem

We're building the ability for feature flags to have conditions based on how other flags are evaluated. Flag dependencies are referred to by Id. However, when we display that a flag depends on another flag, we want to show the flag key. So this service allows the UI to gather all the flag IDs the current flag is dependent on and return the keys for all the flags in one go.

## Changes

Add a new API endpoint to retrieve feature flag keys by their IDs:
- Backend: POST /api/projects/{id}/feature_flags/bulk_keys/
- Frontend: api.featureFlags.bulkKeys(ids) client method
- Accepts array of flag IDs, returns mapping of ID to flag key

## How did you test this code?

Manual testing and unit tests

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
