### PR TITLE
fix(experiments): experiments list refactor and fixes.

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -222,7 +222,6 @@ export const FEATURE_FLAGS = {
     PATHS_V2: 'paths-v2', // owner: @thmsobrmlr #team-product-analytics
     EXPERIMENTS_NEW_QUERY_RUNNER: 'experiments-new-query-runner', // owner: #team-experiments
     RECORDINGS_AI_REGEX: 'recordings-ai-regex', // owner: @veryayskiy #team-replay
-    EXPERIMENTS_NEW_QUERY_RUNNER_AA_TEST: 'experiments-new-query-runner-aa-test', // #team-experiments
     ONBOARDING_DATA_WAREHOUSE_FOR_PRODUCT_ANALYTICS: 'onboarding-data-warehouse-for-product-analytics', // owner: @joshsny #team-growth
     DELAYED_LOADING_ANIMATION: 'delayed-loading-animation', // owner: @raquelmsmith
     SESSION_RECORDINGS_PLAYLIST_COUNT_COLUMN: 'session-recordings-playlist-count-column', // owner: @pauldambra #team-replay

--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -20,7 +20,7 @@ import stringWithWBR from 'lib/utils/stringWithWBR'
 import { useState } from 'react'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
-
+import { match } from 'ts-pattern'
 import { ActivityScope, Experiment, ExperimentsTabs, ProductKey, ProgressStatus } from '~/types'
 
 import { DuplicateExperimentModal } from './DuplicateExperimentModal'
@@ -262,28 +262,30 @@ export function Experiments(): JSX.Element {
                     },
                 ]}
             />
-            {tab === ExperimentsTabs.All && (
-                <ProductIntroduction
-                    productName="Experiments"
-                    productKey={ProductKey.EXPERIMENTS}
-                    thingName="experiment"
-                    description={EXPERIMENTS_PRODUCT_DESCRIPTION}
-                    docsURL="https://posthog.com/docs/experiments"
-                    action={() => router.actions.push(urls.experiment('new'))}
-                    isEmpty={shouldShowEmptyState}
-                    customHog={ExperimentsHog}
-                />
-            )}
-            {tab === ExperimentsTabs.Archived && (
-                <ProductIntroduction
-                    productName="Experiments"
-                    productKey={ProductKey.EXPERIMENTS}
-                    thingName="archived experiment"
-                    description={EXPERIMENTS_PRODUCT_DESCRIPTION}
-                    docsURL="https://posthog.com/docs/experiments"
-                    isEmpty={shouldShowEmptyState}
-                />
-            )}
+            {match(tab)
+                .with(ExperimentsTabs.All, () => (
+                    <ProductIntroduction
+                        productName="Experiments"
+                        productKey={ProductKey.EXPERIMENTS}
+                        thingName="experiment"
+                        description={EXPERIMENTS_PRODUCT_DESCRIPTION}
+                        docsURL="https://posthog.com/docs/experiments"
+                        action={() => router.actions.push(urls.experiment('new'))}
+                        isEmpty={shouldShowEmptyState}
+                        customHog={ExperimentsHog}
+                    />
+                ))
+                .with(ExperimentsTabs.Archived, () => (
+                    <ProductIntroduction
+                        productName="Experiments"
+                        productKey={ProductKey.EXPERIMENTS}
+                        thingName="archived experiment"
+                        description={EXPERIMENTS_PRODUCT_DESCRIPTION}
+                        docsURL="https://posthog.com/docs/experiments"
+                        isEmpty={shouldShowEmptyState}
+                    />
+                ))
+                .otherwise(() => null)}
             {!shouldShowEmptyState && (tab === ExperimentsTabs.All || tab === ExperimentsTabs.Archived) && (
                 <>
                     <div className="flex justify-between mb-4 gap-2 flex-wrap">

--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -6,7 +6,6 @@ import { ExperimentsHog } from 'lib/components/hedgehogs'
 import { MemberSelect } from 'lib/components/MemberSelect'
 import { PageHeader } from 'lib/components/PageHeader'
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More } from 'lib/lemon-ui/LemonButton/More'
@@ -16,7 +15,6 @@ import { atColumn, createdAtColumn, createdByColumn } from 'lib/lemon-ui/LemonTa
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { Link } from 'lib/lemon-ui/Link'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import stringWithWBR from 'lib/utils/stringWithWBR'
 import { useState } from 'react'
@@ -43,10 +41,7 @@ export function Experiments(): JSX.Element {
     const { loadExperiments, setExperimentsTab, archiveExperiment, setExperimentsFilters } =
         useActions(experimentsLogic)
 
-    const { featureFlags } = useValues(featureFlagLogic)
     const [duplicateModalExperiment, setDuplicateModalExperiment] = useState<Experiment | null>(null)
-
-    const flagResult = featureFlags[FEATURE_FLAGS.EXPERIMENTS_NEW_QUERY_RUNNER_AA_TEST]
 
     const EXPERIMENTS_PRODUCT_DESCRIPTION =
         'Experiments help you test changes to your product to see which changes will lead to optimal results. Automatic statistical calculations let you see if the results are valid or if they are likely just a chance occurrence.'
@@ -249,10 +244,6 @@ export function Experiments(): JSX.Element {
                 }
                 tabbedPage={true}
             />
-            {/* TODO: Remove this after AA test is over. Just a hidden element. */}
-            <span className="hidden" data-attr="aa-test-flag-result">
-                AA test flag result: {String(flagResult)}
-            </span>
             <LemonTabs
                 activeKey={tab}
                 onChange={(newKey) => setExperimentsTab(newKey)}

--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -296,31 +296,35 @@ export function Experiments(): JSX.Element {
                             value={filters.search || ''}
                         />
                         <div className="flex items-center gap-2">
-                            <span>
-                                <b>Status</b>
-                            </span>
-                            <LemonSelect
-                                size="small"
-                                onChange={(status) => {
-                                    if (status === 'all') {
-                                        const { status: _, ...restFilters } = filters
-                                        setExperimentsFilters({ ...restFilters, page: 1 }, true)
-                                    } else {
-                                        setExperimentsFilters({ status: status as ProgressStatus, page: 1 })
-                                    }
-                                }}
-                                options={
-                                    [
-                                        { label: 'All', value: 'all' },
-                                        { label: 'Draft', value: ProgressStatus.Draft },
-                                        { label: 'Running', value: ProgressStatus.Running },
-                                        { label: 'Complete', value: ProgressStatus.Complete },
-                                    ] as { label: string; value: string }[]
-                                }
-                                value={filters.status ?? 'all'}
-                                dropdownMatchSelectWidth={false}
-                                dropdownMaxContentWidth
-                            />
+                            {ExperimentsTabs.Archived !== tab && (
+                                <>
+                                    <span>
+                                        <b>Status</b>
+                                    </span>
+                                    <LemonSelect
+                                        size="small"
+                                        onChange={(status) => {
+                                            if (status === 'all') {
+                                                const { status: _, ...restFilters } = filters
+                                                setExperimentsFilters({ ...restFilters, page: 1 }, true)
+                                            } else {
+                                                setExperimentsFilters({ status: status as ProgressStatus, page: 1 })
+                                            }
+                                        }}
+                                        options={
+                                            [
+                                                { label: 'All', value: 'all' },
+                                                { label: 'Draft', value: ProgressStatus.Draft },
+                                                { label: 'Running', value: ProgressStatus.Running },
+                                                { label: 'Complete', value: ProgressStatus.Complete },
+                                            ] as { label: string; value: string }[]
+                                        }
+                                        value={filters.status ?? 'all'}
+                                        dropdownMatchSelectWidth={false}
+                                        dropdownMaxContentWidth
+                                    />
+                                </>
+                            )}
                             <span className="ml-1">
                                 <b>Created by</b>
                             </span>

--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -27,7 +27,6 @@ import { DuplicateExperimentModal } from './DuplicateExperimentModal'
 import { EXPERIMENTS_PER_PAGE, experimentsLogic, getExperimentStatus } from './experimentsLogic'
 import { StatusTag } from './ExperimentView/components'
 import { Holdouts } from './Holdouts'
-import { SharedMetrics } from './SharedMetrics/SharedMetrics'
 import { isLegacyExperiment } from './utils'
 
 export const scene: SceneExport = {
@@ -251,7 +250,11 @@ export function Experiments(): JSX.Element {
                     { key: ExperimentsTabs.All, label: 'All experiments' },
                     { key: ExperimentsTabs.Archived, label: 'Archived experiments' },
                     { key: ExperimentsTabs.Holdouts, label: 'Holdout groups', content: <Holdouts /> },
-                    { key: ExperimentsTabs.SharedMetrics, label: 'Shared metrics', content: <SharedMetrics /> },
+                    {
+                        key: ExperimentsTabs.SharedMetrics,
+                        label: 'Shared metrics',
+                        link: urls.experimentsSharedMetrics(),
+                    },
                     {
                         key: ExperimentsTabs.History,
                         label: 'History',

--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -250,128 +250,122 @@ export function Experiments(): JSX.Element {
                 tabs={[
                     { key: ExperimentsTabs.All, label: 'All experiments' },
                     { key: ExperimentsTabs.Archived, label: 'Archived experiments' },
-                    { key: ExperimentsTabs.Holdouts, label: 'Holdout groups' },
-                    { key: ExperimentsTabs.SharedMetrics, label: 'Shared metrics' },
-                    { key: ExperimentsTabs.History, label: 'History' },
+                    { key: ExperimentsTabs.Holdouts, label: 'Holdout groups', content: <Holdouts /> },
+                    { key: ExperimentsTabs.SharedMetrics, label: 'Shared metrics', content: <SharedMetrics /> },
+                    {
+                        key: ExperimentsTabs.History,
+                        label: 'History',
+                        content: <ActivityLog scope={ActivityScope.EXPERIMENT} />,
+                    },
                 ]}
             />
-
-            {tab === ExperimentsTabs.Holdouts ? (
-                <Holdouts />
-            ) : tab === ExperimentsTabs.SharedMetrics ? (
-                <SharedMetrics />
-            ) : tab === ExperimentsTabs.History ? (
-                <ActivityLog scope={ActivityScope.EXPERIMENT} />
-            ) : (
+            {tab === ExperimentsTabs.All && (
+                <ProductIntroduction
+                    productName="Experiments"
+                    productKey={ProductKey.EXPERIMENTS}
+                    thingName="experiment"
+                    description={EXPERIMENTS_PRODUCT_DESCRIPTION}
+                    docsURL="https://posthog.com/docs/experiments"
+                    action={() => router.actions.push(urls.experiment('new'))}
+                    isEmpty={shouldShowEmptyState}
+                    customHog={ExperimentsHog}
+                />
+            )}
+            {tab === ExperimentsTabs.Archived && (
+                <ProductIntroduction
+                    productName="Experiments"
+                    productKey={ProductKey.EXPERIMENTS}
+                    thingName="archived experiment"
+                    description={EXPERIMENTS_PRODUCT_DESCRIPTION}
+                    docsURL="https://posthog.com/docs/experiments"
+                    isEmpty={shouldShowEmptyState}
+                />
+            )}
+            {!shouldShowEmptyState && (tab === ExperimentsTabs.All || tab === ExperimentsTabs.Archived) && (
                 <>
-                    {tab === ExperimentsTabs.Archived ? (
-                        <ProductIntroduction
-                            productName="Experiments"
-                            productKey={ProductKey.EXPERIMENTS}
-                            thingName="archived experiment"
-                            description={EXPERIMENTS_PRODUCT_DESCRIPTION}
-                            docsURL="https://posthog.com/docs/experiments"
-                            isEmpty={shouldShowEmptyState}
+                    <div className="flex justify-between mb-4 gap-2 flex-wrap">
+                        <LemonInput
+                            type="search"
+                            placeholder="Search experiments"
+                            onChange={(search) => setExperimentsFilters({ search, page: 1 })}
+                            value={filters.search || ''}
                         />
-                    ) : (
-                        <ProductIntroduction
-                            productName="Experiments"
-                            productKey={ProductKey.EXPERIMENTS}
-                            thingName="experiment"
-                            description={EXPERIMENTS_PRODUCT_DESCRIPTION}
-                            docsURL="https://posthog.com/docs/experiments"
-                            action={() => router.actions.push(urls.experiment('new'))}
-                            isEmpty={shouldShowEmptyState}
-                            customHog={ExperimentsHog}
-                        />
-                    )}
-                    {!shouldShowEmptyState && (
-                        <>
-                            <div className="flex justify-between mb-4 gap-2 flex-wrap">
-                                <LemonInput
-                                    type="search"
-                                    placeholder="Search experiments"
-                                    onChange={(search) => setExperimentsFilters({ search, page: 1 })}
-                                    value={filters.search || ''}
-                                />
-                                <div className="flex items-center gap-2">
-                                    <span>
-                                        <b>Status</b>
-                                    </span>
-                                    <LemonSelect
-                                        size="small"
-                                        onChange={(status) => {
-                                            if (status === 'all') {
-                                                const { status: _, ...restFilters } = filters
-                                                setExperimentsFilters({ ...restFilters, page: 1 }, true)
-                                            } else {
-                                                setExperimentsFilters({ status: status as ProgressStatus, page: 1 })
-                                            }
-                                        }}
-                                        options={
-                                            [
-                                                { label: 'All', value: 'all' },
-                                                { label: 'Draft', value: ProgressStatus.Draft },
-                                                { label: 'Running', value: ProgressStatus.Running },
-                                                { label: 'Complete', value: ProgressStatus.Complete },
-                                            ] as { label: string; value: string }[]
-                                        }
-                                        value={filters.status ?? 'all'}
-                                        dropdownMatchSelectWidth={false}
-                                        dropdownMaxContentWidth
-                                    />
-                                    <span className="ml-1">
-                                        <b>Created by</b>
-                                    </span>
-                                    <MemberSelect
-                                        defaultLabel="Any user"
-                                        value={filters.created_by_id ?? null}
-                                        onChange={(user) => {
-                                            if (!user) {
-                                                const { created_by_id, ...restFilters } = filters
-                                                setExperimentsFilters({ ...restFilters, page: 1 }, true)
-                                            } else {
-                                                setExperimentsFilters({ created_by_id: user.id, page: 1 })
-                                            }
-                                        }}
-                                    />
-                                </div>
-                            </div>
-                            <LemonDivider className="my-4" />
-                            <div className="mb-4">
-                                <span className="text-secondary">
-                                    {count
-                                        ? `${startCount}${
-                                              endCount - startCount > 1 ? '-' + endCount : ''
-                                          } of ${count} experiment${count === 1 ? '' : 's'}`
-                                        : null}
-                                </span>
-                            </div>
-                            <LemonTable
-                                dataSource={experiments.results}
-                                columns={columns}
-                                rowKey="id"
-                                loading={experimentsLoading}
-                                defaultSorting={{
-                                    columnKey: 'created_at',
-                                    order: -1,
+                        <div className="flex items-center gap-2">
+                            <span>
+                                <b>Status</b>
+                            </span>
+                            <LemonSelect
+                                size="small"
+                                onChange={(status) => {
+                                    if (status === 'all') {
+                                        const { status: _, ...restFilters } = filters
+                                        setExperimentsFilters({ ...restFilters, page: 1 }, true)
+                                    } else {
+                                        setExperimentsFilters({ status: status as ProgressStatus, page: 1 })
+                                    }
                                 }}
-                                noSortingCancellation
-                                pagination={pagination}
-                                nouns={['experiment', 'experiments']}
-                                data-attr="experiment-table"
-                                emptyState="No results for this filter, change filter or create a new experiment."
-                                onSort={(newSorting) =>
-                                    setExperimentsFilters({
-                                        order: newSorting
-                                            ? `${newSorting.order === -1 ? '-' : ''}${newSorting.columnKey}`
-                                            : undefined,
-                                        page: 1,
-                                    })
+                                options={
+                                    [
+                                        { label: 'All', value: 'all' },
+                                        { label: 'Draft', value: ProgressStatus.Draft },
+                                        { label: 'Running', value: ProgressStatus.Running },
+                                        { label: 'Complete', value: ProgressStatus.Complete },
+                                    ] as { label: string; value: string }[]
                                 }
+                                value={filters.status ?? 'all'}
+                                dropdownMatchSelectWidth={false}
+                                dropdownMaxContentWidth
                             />
-                        </>
-                    )}
+                            <span className="ml-1">
+                                <b>Created by</b>
+                            </span>
+                            <MemberSelect
+                                defaultLabel="Any user"
+                                value={filters.created_by_id ?? null}
+                                onChange={(user) => {
+                                    if (!user) {
+                                        const { created_by_id, ...restFilters } = filters
+                                        setExperimentsFilters({ ...restFilters, page: 1 }, true)
+                                    } else {
+                                        setExperimentsFilters({ created_by_id: user.id, page: 1 })
+                                    }
+                                }}
+                            />
+                        </div>
+                    </div>
+                    <LemonDivider className="my-4" />
+                    <div className="mb-4">
+                        <span className="text-secondary">
+                            {count
+                                ? `${startCount}${
+                                      endCount - startCount > 1 ? '-' + endCount : ''
+                                  } of ${count} experiment${count === 1 ? '' : 's'}`
+                                : null}
+                        </span>
+                    </div>
+                    <LemonTable
+                        dataSource={experiments.results}
+                        columns={columns}
+                        rowKey="id"
+                        loading={experimentsLoading}
+                        defaultSorting={{
+                            columnKey: 'created_at',
+                            order: -1,
+                        }}
+                        noSortingCancellation
+                        pagination={pagination}
+                        nouns={['experiment', 'experiments']}
+                        data-attr="experiment-table"
+                        emptyState="No results for this filter, change filter or create a new experiment."
+                        onSort={(newSorting) =>
+                            setExperimentsFilters({
+                                order: newSorting
+                                    ? `${newSorting.order === -1 ? '-' : ''}${newSorting.columnKey}`
+                                    : undefined,
+                                page: 1,
+                            })
+                        }
+                    />
                 </>
             )}
             {duplicateModalExperiment && (

--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -34,6 +34,17 @@ export const scene: SceneExport = {
     logic: experimentsLogic,
 }
 
+const EXPERIMENTS_PRODUCT_DESCRIPTION =
+    'Experiments help you test changes to your product to see which changes will lead to optimal results. Automatic statistical calculations let you see if the results are valid or if they are likely just a chance occurrence.'
+
+const getExperimentDuration = (experiment: Experiment): number | undefined => {
+    return experiment.end_date
+        ? dayjs(experiment.end_date).diff(dayjs(experiment.start_date), 'day')
+        : experiment.start_date
+        ? dayjs().diff(dayjs(experiment.start_date), 'day')
+        : undefined
+}
+
 export function Experiments(): JSX.Element {
     const { currentProjectId, experiments, experimentsLoading, tab, shouldShowEmptyState, filters, count, pagination } =
         useValues(experimentsLogic)
@@ -42,20 +53,9 @@ export function Experiments(): JSX.Element {
 
     const [duplicateModalExperiment, setDuplicateModalExperiment] = useState<Experiment | null>(null)
 
-    const EXPERIMENTS_PRODUCT_DESCRIPTION =
-        'Experiments help you test changes to your product to see which changes will lead to optimal results. Automatic statistical calculations let you see if the results are valid or if they are likely just a chance occurrence.'
-
     const page = filters.page || 1
     const startCount = count === 0 ? 0 : (page - 1) * EXPERIMENTS_PER_PAGE + 1
     const endCount = page * EXPERIMENTS_PER_PAGE < count ? page * EXPERIMENTS_PER_PAGE : count
-
-    const getExperimentDuration = (experiment: Experiment): number | undefined => {
-        return experiment.end_date
-            ? dayjs(experiment.end_date).diff(dayjs(experiment.start_date), 'day')
-            : experiment.start_date
-            ? dayjs().diff(dayjs(experiment.start_date), 'day')
-            : undefined
-    }
 
     const columns: LemonTableColumns<Experiment> = [
         {

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.tsx
@@ -1,23 +1,13 @@
-import { actions, connect, events, kea, listeners, path, reducers } from 'kea'
+import { connect, events, kea, path } from 'kea'
 import { loaders } from 'kea-loaders'
-import { router } from 'kea-router'
 import api from 'lib/api'
 
 import type { SharedMetric } from './sharedMetricLogic'
 import type { sharedMetricsLogicType } from './sharedMetricsLogicType'
 
-export enum SharedMetricsTabs {
-    All = 'all',
-    Yours = 'yours',
-    Archived = 'archived',
-}
-
 export const sharedMetricsLogic = kea<sharedMetricsLogicType>([
     path(['scenes', 'experiments', 'sharedMetricsLogic']),
     connect(() => ({})),
-    actions({
-        setSharedMetricsTab: (tabKey: SharedMetricsTabs) => ({ tabKey }),
-    }),
 
     loaders({
         sharedMetrics: [
@@ -30,20 +20,6 @@ export const sharedMetricsLogic = kea<sharedMetricsLogicType>([
             },
         ],
     }),
-
-    reducers({
-        tab: [
-            SharedMetricsTabs.All as SharedMetricsTabs,
-            {
-                setSharedMetricsTab: (_, { tabKey }) => tabKey,
-            },
-        ],
-    }),
-    listeners(() => ({
-        setSharedMetricsTab: () => {
-            router.actions.push('/experiments/shared-metrics')
-        },
-    })),
     events(({ actions }) => ({
         afterMount: () => {
             actions.loadSharedMetrics()

--- a/frontend/src/scenes/experiments/experimentsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.ts
@@ -103,13 +103,6 @@ export const experimentsLogic = kea<experimentsLogicType>([
             await breakpoint(300)
             actions.loadExperiments()
         },
-        setExperimentsTab: ({ tabKey }) => {
-            if (tabKey === ExperimentsTabs.SharedMetrics) {
-                // Saved Metrics is a fake tab that we use to redirect to the shared metrics page
-                actions.setExperimentsTab(ExperimentsTabs.All)
-                router.actions.push('/experiments/shared-metrics')
-            }
-        },
     })),
     loaders(({ values }) => ({
         experiments: [


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

There are numerous small things (such as the search debounce) and larger components (the experiment table components) that will require their own refactoring. But for now, we focus on these:

### Feature Flag cleanup

We've removed the `experiments-new-query-runner-aa-test` feature flag and related code. Mostly the feature flag declaration and a hidden element on the page for debugging.

### Shared metrics tab routing

The `ExperimentsLogic` was performing somersaults to treat the shared metrics tab as a route, rather than using the `link` property of the tab. So, we've added the link and removed all the code that listens for `tab` changes and pushes segments to the route.

### Shared metrics Tabs?

It appears that in the past, the Shared Metrics page had its own tabs. And there's a log of code in the shared metrics logic file to support that. So, we are removing that code.

### Tabs Matching

The `Experiments` component matches the values of `tabs` to code blocks and components, rather than using `content`. We are removing all the checks for `Holdouts` and `ActivityLog` (`SharedMetrics` is now a route), but we are keeping the checks for the experiments list. That's a lot of code, and it will need some proper refactoring in the future.

Here we are also adding some pattern matching using `ts-pattern` for the Product Introduction.

### ~~Should Show Empty State?~~

~~The empty state was not loading correctly when there were no experiments available because the `shouldShowEmptyState` selector was using a deep equality check with an object (`DEFAULT_FILTERS`) that had a different interface. Another reason to avoid optional properties (`ExperimentsFilters`, I'm looking at you).~~

| Before | After |
| - | - |
| <img width="1600" height="783" alt="image" src="https://github.com/user-attachments/assets/f0b983f9-d5e4-4d3e-b5a4-6eb4504ddaa8" /> | <img width="1600" height="784" alt="image" src="https://github.com/user-attachments/assets/0b8bbc7f-4934-422e-b132-50a365412f07" /> |

~~One aspect that requires further refactoring is the blinking of the empty list when loading the page without any experiments. One solution would be always to show the empty list, which is more in line with `LemonTable` usage across the app. But that's a refactor for a different PR.~~

### ~~Duplicated requests~~

~~We were calling load experiments twice`: once with an `afterMount` call to `loadExperiments`, and again` with `setExperimentsFilters` when the router calls `urlToAction`.
We've removed the `afterMount` call in favor of the router flow to preserve filters. With the added benefit of preventing the display of incorrect content. Now we have a single source of truth (the query string)~~

| Before | After |
| - | - |
| ![before](https://github.com/user-attachments/assets/f23ae3ab-be29-4072-8f61-ee518e7ec812) | ![after](https://github.com/user-attachments/assets/d884a2cf-9b5f-4a0b-8d5d-9e8b2d041d16) |

### Archived Experiments Filters

Only _Complete_ experiments can be archived; ergo, archived experiments have only one state. Considering this, we are hiding the filters on the _Archived_ tab.

| Status filters no longer present on the Archived Experiments view |
| - |
| <img width="1387" height="944" alt="image" src="https://github.com/user-attachments/assets/bfe5b86e-dd6f-489e-9c84-c0c50d841a8e" /> |

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/12afd29e-8c8d-4dfb-85b6-cc1b93b0e766)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
