### PR TITLE
chore: bump to newest version of 25.3 for bugfixes

### DIFF
--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -235,7 +235,7 @@ runs:
 
         - name: Upload updated timing data as artifacts
           uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
-          if: ${{ inputs.person-on-events != 'true' && inputs.clickhouse-server-image == 'clickhouse/clickhouse-server:25.3.5.42' }}
+          if: ${{ inputs.person-on-events != 'true' && inputs.clickhouse-server-image == 'clickhouse/clickhouse-server:25.3.6.56' }}
           with:
               name: timing_data-${{ inputs.segment }}-${{ inputs.group }}
               path: .test_durations

--- a/.github/workflows/ci-backend-update-test-timing.yml
+++ b/.github/workflows/ci-backend-update-test-timing.yml
@@ -29,13 +29,13 @@ jobs:
                   group: 1
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
                   python-version: '3.11.9'
-                  clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.5.42'
+                  clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.6.56'
                   segment: 'FOSS'
                   person-on-events: false
 
             - name: Upload updated timing data as artifacts
               uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
-              if: ${{ inputs.person-on-events != 'true' && inputs.clickhouse-server-image == 'clickhouse/clickhouse-server:25.3.5.42' }}
+              if: ${{ inputs.person-on-events != 'true' && inputs.clickhouse-server-image == 'clickhouse/clickhouse-server:25.3.6.56' }}
               with:
                   name: timing_data-${{ inputs.segment }}-${{ inputs.group }}
                   path: .test_durations

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -253,7 +253,7 @@ jobs:
             fail-fast: false
             matrix:
                 python-version: ['3.11.9']
-                clickhouse-server-image: ['clickhouse/clickhouse-server:25.3.5.42']
+                clickhouse-server-image: ['clickhouse/clickhouse-server:25.3.6.56']
                 segment: ['Core']
                 person-on-events: [false]
                 # :NOTE: Keep concurrency and groups in sync
@@ -304,121 +304,121 @@ jobs:
                 include:
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.5.42'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.6.56'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 1
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.5.42'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.6.56'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 2
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.5.42'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.6.56'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 3
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.5.42'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.6.56'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 4
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.5.42'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.6.56'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 5
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.5.42'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.6.56'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 6
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.5.42'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.6.56'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 7
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.5.42'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.6.56'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 8
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.5.42'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.6.56'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 9
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.5.42'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.6.56'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 10
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.5.42'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.6.56'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 1
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.5.42'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.6.56'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 2
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.5.42'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.6.56'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 3
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.5.42'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.6.56'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 4
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.5.42'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.6.56'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 5
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.5.42'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.6.56'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 6
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.5.42'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.6.56'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 7
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.5.42'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.6.56'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 8
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.5.42'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.6.56'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 9
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.5.42'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.3.6.56'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 10
@@ -689,7 +689,7 @@ jobs:
 
             - name: Upload updated timing data as artifacts
               uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
-              if: ${{ needs.changes.outputs.backend == 'true' && !matrix.person-on-events && matrix.clickhouse-server-image == 'clickhouse/clickhouse-server:25.3.5.42' }}
+              if: ${{ needs.changes.outputs.backend == 'true' && !matrix.person-on-events && matrix.clickhouse-server-image == 'clickhouse/clickhouse-server:25.3.6.56' }}
               with:
                   name: timing_data-${{ matrix.segment }}-${{ matrix.group }}
                   path: .test_durations
@@ -738,7 +738,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                clickhouse-server-image: ['clickhouse/clickhouse-server:25.3.5.42']
+                clickhouse-server-image: ['clickhouse/clickhouse-server:25.3.6.56']
         if: needs.changes.outputs.backend == 'true'
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -63,7 +63,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                clickhouse-server-image: ['clickhouse/clickhouse-server:25.3.5.42']
+                clickhouse-server-image: ['clickhouse/clickhouse-server:25.3.6.56']
         if: needs.changes.outputs.dagster == 'true'
         runs-on: depot-ubuntu-latest
         steps:

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -273,7 +273,7 @@ jobs:
               if: needs.changes.outputs.shouldRun == 'true'
               shell: bash
               run: |
-                  export CLICKHOUSE_SERVER_IMAGE=clickhouse/clickhouse-server:25.3.5.42
+                  export CLICKHOUSE_SERVER_IMAGE=clickhouse/clickhouse-server:25.3.6.56
                   export DOCKER_REGISTRY_PREFIX="us-east1-docker.pkg.dev/posthog-301601/mirror/"
                   cp posthog/user_scripts/latest_user_defined_function.xml docker/clickhouse/user_defined_function.xml
 

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -98,7 +98,7 @@ services:
         # Note: please keep the default version in sync across
         #       `posthog` and the `charts-clickhouse` repos
         #
-        image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:25.3.5.42}
+        image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:25.3.6.56}
         restart: on-failure
         environment:
             CLICKHOUSE_SKIP_USER_SETUP: 1


### PR DESCRIPTION
previous version of 25.3 apparently has some bad bugs, moving to newest patch version
