### PR TITLE
fix(batch-exports): Fix flaky transformer test

### DIFF
--- a/products/batch_exports/backend/temporal/pipeline/transformer.py
+++ b/products/batch_exports/backend/temporal/pipeline/transformer.py
@@ -322,7 +322,7 @@ def dump_dict(d: dict[str, typing.Any]) -> bytes:
             else:
                 # In this case, we fallback to the slower but more permissive stdlib
                 # json.
-                logger.exception("Orjson detected a deeply nested dict: %s", d)
+                logger.exception("Orjson detected a deeply nested dict")
                 dumped = json.dumps(d, default=str).encode("utf-8") + b"\n"
         elif str(err) == "Integer exceeds 64-bit range":
             logger.warning("Failed to encode with orjson: Integer exceeds 64-bit range: %s", d)


### PR DESCRIPTION
## Problem

One of the batch export tests is being a bit flaky so try a couple of things to fix it.

## Changes

- Remove some logging (we don't need to log the full JSON when we hit a recursion depth error).
- Remove `autouse=True` for some of our ClickHouse fixtures, which run unnecessarily on some tests that don't interact with ClickHouse (this should also speed up our tests a bit).

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
