### PR TITLE
fix(web-analytics): list explicit columns to workaround migration reorder

### DIFF
--- a/posthog/models/web_preaggregated/test_web_preaggregated_sql.py
+++ b/posthog/models/web_preaggregated/test_web_preaggregated_sql.py
@@ -1,11 +1,20 @@
+from freezegun import freeze_time
 import pytest
+from posthog.clickhouse.client.execute import sync_execute
+from posthog.hogql_queries.web_analytics.test.web_preaggregated_test_base import WebAnalyticsPreAggregatedTestBase
+from posthog.models.utils import uuid7
 from posthog.models.web_preaggregated.sql import (
     DROP_PARTITION_SQL,
     TABLE_TEMPLATE,
     HOURLY_TABLE_TEMPLATE,
     WEB_STATS_COLUMNS,
     WEB_STATS_ORDER_BY_FUNC,
+    WEB_STATS_INSERT_SQL,
+    WEB_BOUNCES_INSERT_SQL,
+    get_web_stats_insert_columns,
+    get_web_bounces_insert_columns,
 )
+from posthog.test.base import _create_event, _create_person
 
 
 class TestPartitionDropSQL:
@@ -192,3 +201,81 @@ class TestHourlyPartitioningIntegration:
         # (This tests the else clause in the function)
         invalid_sql = DROP_PARTITION_SQL("test_table", date, granularity="invalid")
         assert "'20240115'" in invalid_sql
+
+
+class TestWebPreaggregatedInserts(WebAnalyticsPreAggregatedTestBase):
+    def _setup_test_data(self):
+        with freeze_time("2024-01-01T09:00:00Z"):
+            _create_person(team_id=self.team.pk, distinct_ids=["user_0"])
+
+            _create_event(
+                team=self.team,
+                event="$pageview",
+                distinct_id="user_0",
+                timestamp="2024-01-01T10:00:00Z",
+                properties={
+                    "$session_id": str(uuid7("2024-01-01")),
+                    "$current_url": "https://example.com/landing",
+                    "$pathname": "/landing",
+                    "$device_type": "Desktop",
+                    "$browser": "Chrome",
+                    "$os": "Windows",
+                    "$viewport_width": 1920,
+                    "$viewport_height": 1080,
+                    "$geoip_country_code": "US",
+                    "$geoip_city_name": "New York",
+                    "$geoip_subdivision_1_code": "NY",
+                    "utm_source": "google",
+                    "utm_medium": "cpc",
+                    "utm_campaign": "summer_sale",
+                    "$referring_domain": "google.com",
+                },
+            )
+
+    def test_insert_queries_can_execute(self, date_start: str = "2024-01-01", date_end: str = "2024-01-02"):
+        bounces_insert = WEB_BOUNCES_INSERT_SQL(
+            date_start=date_start,
+            date_end=date_end,
+            team_ids=[self.team.pk],
+        )
+        stats_insert = WEB_STATS_INSERT_SQL(
+            date_start=date_start,
+            date_end=date_end,
+            team_ids=[self.team.pk],
+        )
+        sync_execute(stats_insert)
+        sync_execute(bounces_insert)
+
+        # Very basic, but makes sure they
+        assert True
+
+    def test_insert_queries_contain_all_columns_for_stats(self):
+        stats_insert = WEB_STATS_INSERT_SQL(
+            date_start="2024-01-01",
+            date_end="2024-01-02",
+            team_ids=[self.team.pk],
+        )
+
+        expected_stats_columns = get_web_stats_insert_columns()
+        for column in expected_stats_columns:
+            assert f"\n    {column}" in stats_insert
+
+        # Verify it has explicit column list format
+        assert "INSERT INTO web_stats_daily\n(" in stats_insert
+        assert ")\n\n    SELECT" in stats_insert
+
+    def test_insert_queries_contain_all_columns_for_bounces(self):
+        # Test WEB_BOUNCES_INSERT_SQL contains correct columns
+        bounces_insert = WEB_BOUNCES_INSERT_SQL(
+            date_start="2024-01-01",
+            date_end="2024-01-02",
+            team_ids=[self.team.pk],
+        )
+
+        expected_bounces_columns = get_web_bounces_insert_columns()
+        for column in expected_bounces_columns:
+            assert f"\n    {column}" in bounces_insert
+
+        # Verify it has explicit column list format
+        assert "INSERT INTO web_bounces_daily\n(" in bounces_insert
+        assert ")\n\n    SELECT" in bounces_insert

--- a/posthog/models/web_preaggregated/test_web_preaggregated_sql.py
+++ b/posthog/models/web_preaggregated/test_web_preaggregated_sql.py
@@ -246,7 +246,7 @@ class TestWebPreaggregatedInserts(WebAnalyticsPreAggregatedTestBase):
         sync_execute(stats_insert)
         sync_execute(bounces_insert)
 
-        # Very basic, but makes sure they
+        # Very basic smoke test - ensures both insert queries execute without errors
         assert True
 
     def test_insert_queries_contain_all_columns_for_stats(self):


### PR DESCRIPTION
## Problem

We had to rerun the latest migration and got different column orderings.

## Changes

Doing what we had to since before that is listing the columns on the insert.

## How did you test this code?

Added some smoke tests and ran it locally.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
