### PR TITLE
feat(web-analytics): Make revenue hidden if empty

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1852,7 +1852,7 @@ export function isNumeric(x: any): boolean {
 }
 
 /**
- * Check if the argument is nullish (null or undefined).
+ * Check if the argument is not nullish (null or undefined).
  *
  * Useful as a typeguard, e.g. when passed to Array.filter()
  *

--- a/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
+++ b/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
@@ -54,7 +54,7 @@ export function WebOverview(props: {
 
     const samplingRate = webOverviewQueryResponse?.samplingRate
 
-    const numSkeletons = props.query.conversionGoal ? 5 : 6
+    const numSkeletons = props.query.conversionGoal ? 4 : 5
 
     const canUseWebAnalyticsPreAggregatedTables = useFeatureFlag('SETTINGS_WEB_ANALYTICS_PRE_AGGREGATED_TABLES')
     const usedWebAnalyticsPreAggregatedTables =
@@ -71,13 +71,15 @@ export function WebOverview(props: {
             >
                 {responseLoading
                     ? range(numSkeletons).map((i) => <WebOverviewItemCellSkeleton key={i} />)
-                    : webOverviewQueryResponse?.results?.map((item) => (
-                          <WebOverviewItemCell
-                              key={item.key}
-                              item={item}
-                              usedPreAggregatedTables={usedWebAnalyticsPreAggregatedTables}
-                          />
-                      )) || []}
+                    : webOverviewQueryResponse?.results
+                          ?.filter(filterEmptyRevenue)
+                          .map((item) => (
+                              <WebOverviewItemCell
+                                  key={item.key}
+                                  item={item}
+                                  usedPreAggregatedTables={usedWebAnalyticsPreAggregatedTables}
+                              />
+                          )) || []}
             </EvenlyDistributedRows>
             {samplingRate && !(samplingRate.numerator === 1 && (samplingRate.denominator ?? 1) === 1) ? (
                 <LemonBanner type="info" className="my-4">
@@ -244,9 +246,9 @@ const labelFromKey = (key: string): string => {
         case 'unique conversions':
             return 'Unique conversions'
         case 'revenue':
-            return 'Events revenue'
+            return 'Revenue'
         case 'conversion revenue':
-            return 'Conversion events revenue'
+            return 'Conversion revenue'
         default:
             return key
                 .split(' ')
@@ -273,4 +275,8 @@ const dashboardLinkFromKey = (key: string): string | null => {
         default:
             return null
     }
+}
+
+const filterEmptyRevenue = (item: WebOverviewItem): boolean => {
+    return !(['revenue', 'conversion revenue'].includes(item.key) && item.value == null && item.previous == null)
 }


### PR DESCRIPTION
## Problem

The empty state for revenue is pretty bad right now, we need to think it through a bit. For now, let's just hide it unless there's a value.

## Changes
Hide revenue unless there's a value

## How did you test this code?

Just ran it locally

