### PR TITLE
refactor: remove `repository`, `ref`

### DIFF
--- a/.github/workflows/foss-sync.yml
+++ b/.github/workflows/foss-sync.yml
@@ -52,5 +52,3 @@ jobs:
                   remove: '["-r ee/"]'
                   default_author: github_actions
                   github_token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
-                  repository: 'posthog/posthog-foss'
-                  ref: master


### PR DESCRIPTION
## Problem

The [Sync posthog-foss with posthog](https://github.com/PostHog/posthog/actions/runs/15942894108/job/44973318279#logs) job has `1 warning`. This pull request fixes that.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Fixes #35318

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change