### PR TITLE
chore: Update manifest.toml to add docker compose up instruction back

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -128,9 +128,10 @@ if [[ -t 0 ]]; then
   # Print intro message
   echo -e "
 \033[3mRun the following commands in the given order to get the stack up and running:\033[0m
-1. Run all migrations - \033[31mbin/migrate\033[0m
-2. Start the stack - \033[32mbin/start\033[0m
-3. (optional) Create a user with demo data - \033[34m./manage.py generate_demo_data\033[0m
+1. Spin up containers - \033[33mdocker compose -f docker-compose.dev.yml up -d\033[0m
+2. Run all migrations - \033[31mbin/migrate\033[0m
+3. Start the stack - \033[32mbin/start\033[0m
+4. (optional) Create a user with demo data - \033[34m./manage.py generate_demo_data\033[0m
 "
 fi
 '''


### PR DESCRIPTION
## Problem

The docker compose command from flox onboarding instructions was previously removed, but still needs to be run before the subsequent commands. This adds it back to avoid confusion.

## Changes

- Re-added the `docker compose -f docker-compose.dev.yml up -d` command to `manifest.toml` instructions.

## How did you test this code?

No testing required.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._