### PR TITLE
refactor: simplify populateTeamDataStep

### DIFF
--- a/plugin-server/src/ingestion/ingestion-e2e.test.ts
+++ b/plugin-server/src/ingestion/ingestion-e2e.test.ts
@@ -52,6 +52,7 @@ class EventBuilder {
         }
         this.event.distinct_id = distinctId
         this.event.team_id = team.id
+        this.event.token = team.api_token
     }
 
     withEvent(event: string) {
@@ -292,8 +293,7 @@ describe('Event Pipeline E2E tests', () => {
     })
 
     testWithTeamIngester('should process events without a team_id', {}, async (ingester, hub, team) => {
-        const token = team.api_token
-        const events = [new EventBuilder(team).withEvent('test event').withToken(token).build()]
+        const events = [new EventBuilder(team).withEvent('test event').build()]
 
         await ingester.handleKafkaBatch(createKafkaMessages(events))
 


### PR DESCRIPTION
## Problem

Fetching team data by team id from the token in `populateTeamDataStep` is a bit sketchy and we should only rely on the tokens in the ingestion pipeline.

Looking at the following metric, we haven't had any events that have team ID and don't carry a token for at least 90 days:

```
sum(rate(ingestion_event_hasauthinfo_total{team_id_present="true"}[$__rate_interval])) by (token_present)
```

## Changes

- Removes the `team_id` handling logic in populateTeamData step
- Removes the token normalization, which is already performed earlier in the pipeline

## How did you test this code?

- Updated the unit tests
- There are sufficient integration tests

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [X] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
