### PR TITLE
fix(experiments): format metric value nicely

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -173,7 +173,8 @@ export function MetricRowGroup({
                     <div className="text-sm">
                         <div className="text-text-primary">{formatData(baselineResult)}</div>
                         <div className="text-xs text-muted">
-                            {baselineResult.sum} / {humanFriendlyNumber(baselineResult.number_of_samples || 0)}
+                            {humanFriendlyNumber(baselineResult.sum)} /{' '}
+                            {humanFriendlyNumber(baselineResult.number_of_samples || 0)}
                         </div>
                     </div>
                 </td>
@@ -277,7 +278,8 @@ export function MetricRowGroup({
                             <div className="text-sm">
                                 <div className="text-text-primary">{formatData(variant)}</div>
                                 <div className="text-xs text-muted">
-                                    {variant.sum} / {humanFriendlyNumber(variant.number_of_samples || 0)}
+                                    {humanFriendlyNumber(variant.sum)} /{' '}
+                                    {humanFriendlyNumber(variant.number_of_samples || 0)}
                                 </div>
                             </div>
                         </td>


### PR DESCRIPTION
## Problem
In the new metrics table all decimals are currently shown in the metric value sum

## Changes
Use `humanFriendlyNumber` to only show 2 decimals.
<img width="602" height="240" alt="Screenshot 2025-07-21 at 10 22 59" src="https://github.com/user-attachments/assets/e336e158-f94f-4d18-8d0b-ab266d063162" />


## How did you test this code?
* 👀 