### PR TITLE
fix(web-analytics): Don't use person properties for web analytics to replay cross sell

### DIFF
--- a/frontend/src/scenes/web-analytics/CrossSellButtons/ReplayButton.tsx
+++ b/frontend/src/scenes/web-analytics/CrossSellButtons/ReplayButton.tsx
@@ -8,17 +8,17 @@ import { FilterLogicalOperator, ProductKey, PropertyFilterType, PropertyOperator
 
 /**
  * Map breakdown types to their corresponding property filter type
- * Outside the replayButton function
+ * Outside the replayButton function.
+ *
+ * Prefer not to use Person properties, are the user might be using anonymous events.
  */
-const BREAKDOWN_TYPE_MAP: Partial<
-    Record<WebStatsBreakdown, PropertyFilterType.Event | PropertyFilterType.Person | PropertyFilterType.Session>
-> = {
-    [WebStatsBreakdown.DeviceType]: PropertyFilterType.Person,
+const BREAKDOWN_TYPE_MAP: Partial<Record<WebStatsBreakdown, PropertyFilterType.Event | PropertyFilterType.Session>> = {
+    [WebStatsBreakdown.DeviceType]: PropertyFilterType.Event,
     [WebStatsBreakdown.InitialPage]: PropertyFilterType.Session,
     [WebStatsBreakdown.ExitPage]: PropertyFilterType.Session,
     [WebStatsBreakdown.Page]: PropertyFilterType.Event,
-    [WebStatsBreakdown.Browser]: PropertyFilterType.Person,
-    [WebStatsBreakdown.OS]: PropertyFilterType.Person,
+    [WebStatsBreakdown.Browser]: PropertyFilterType.Event,
+    [WebStatsBreakdown.OS]: PropertyFilterType.Event,
     [WebStatsBreakdown.InitialChannelType]: PropertyFilterType.Session,
     [WebStatsBreakdown.InitialReferringDomain]: PropertyFilterType.Session,
     [WebStatsBreakdown.InitialUTMSource]: PropertyFilterType.Session,


### PR DESCRIPTION
## Problem

See https://posthoghelp.zendesk.com/agent/tickets/34435 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/36309)

## Changes

Switch those person properties to event properties

## How did you test this code?

Local dev, go to web analytics, click the replay cross-sell button.

Previously, it would have a Latest OS filter (person property), now it has an OS filter (event property)

<img width="775" height="361" alt="Screenshot 2025-07-21 at 09 40 22" src="https://github.com/user-attachments/assets/6888e7c5-c518-4f54-8d57-d2d942787623" />


## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
