### PR TITLE
feat(devex): scene layout (dashboards + actions)

### DIFF
--- a/frontend/src/layout/scenes/SceneHeader.tsx
+++ b/frontend/src/layout/scenes/SceneHeader.tsx
@@ -26,7 +26,7 @@ export function SceneHeader({ className }: { className?: string }): JSX.Element 
     const { showLayoutNavBar } = useActions(panelLayoutLogic)
     const { isLayoutNavbarVisibleForMobile } = useValues(panelLayoutLogic)
     const { projectTreeRefEntry } = useValues(projectTreeDataLogic)
-    const { scenePanelOpen, scenePanelIsPresent } = useValues(sceneLayoutLogic)
+    const { scenePanelOpen, scenePanelIsPresent, scenePanelIsOverlay } = useValues(sceneLayoutLogic)
     const { setScenePanelOpen } = useActions(sceneLayoutLogic)
 
     return breadcrumbs.length || projectTreeRefEntry ? (
@@ -66,10 +66,12 @@ export function SceneHeader({ className }: { className?: string }): JSX.Element 
                         </ScrollableShadows>
                     )}
 
-                    <div className="flex gap-1 items-center shrink-0">
+                    <div className={cn('flex gap-1 items-center shrink-0', {
+                        'pr-px': !scenePanelIsOverlay,
+                    })}>
                         <div className="contents" ref={setActionsContainer} />
 
-                        {scenePanelIsPresent && (
+                        {scenePanelIsPresent && scenePanelIsOverlay && (
                             <LemonButton
                                 onClick={() => setScenePanelOpen(!scenePanelOpen)}
                                 icon={<IconInfo className="text-primary" />}

--- a/frontend/src/layout/scenes/SceneHeader.tsx
+++ b/frontend/src/layout/scenes/SceneHeader.tsx
@@ -66,9 +66,11 @@ export function SceneHeader({ className }: { className?: string }): JSX.Element 
                         </ScrollableShadows>
                     )}
 
-                    <div className={cn('flex gap-1 items-center shrink-0', {
-                        'pr-px': !scenePanelIsOverlay,
-                    })}>
+                    <div
+                        className={cn('flex gap-1 items-center shrink-0', {
+                            'pr-px': !scenePanelIsOverlay,
+                        })}
+                    >
                         <div className="contents" ref={setActionsContainer} />
 
                         {scenePanelIsPresent && scenePanelIsOverlay && (

--- a/frontend/src/layout/scenes/SceneLayout.tsx
+++ b/frontend/src/layout/scenes/SceneLayout.tsx
@@ -128,11 +128,11 @@ export function SceneLayout({ children, className, layoutConfig }: SceneLayoutPr
                         >
                             <div className="h-[var(--scene-layout-header-height)] flex items-center justify-between gap-2 -mx-2 px-4 py-1 border-b border-primary shrink-0">
                                 <div className="flex items-center gap-2">
-                                    <IconInfo className="size-5 text-tertiary" />
+                                    {scenePanelIsOverlay && <IconInfo className="size-5 text-tertiary" />}
                                     <h4 className="text-base font-medium text-primary m-0">Info</h4>
                                 </div>
 
-                                {scenePanelOpen && (
+                                {scenePanelIsOverlay && scenePanelOpen && (
                                     <ButtonPrimitive iconOnly onClick={() => setScenePanelOpen(false)}>
                                         <IconX className="size-4" />
                                     </ButtonPrimitive>

--- a/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneAddToDropdownMenu.tsx
+++ b/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneAddToDropdownMenu.tsx
@@ -13,22 +13,28 @@ import {
 import { SceneNotebookMenuItems } from './SceneNotebookMenuItems'
 import { NotebookNodeType } from '~/types'
 import { NodeKind } from '~/queries/schema/schema-general'
+import { SceneDataAttrKeyProps } from '../utils'
 
 type SceneAddToDropdownMenuProps = {
     onClick?: () => void
 }
 
-type SceneNotebookDropdownMenuProps = {
+type SceneNotebookDropdownMenuProps = SceneDataAttrKeyProps & {
     notebook?: boolean
     dashboard?: SceneAddToDropdownMenuProps
     shortId?: string
 }
 
-export function SceneAddToDropdownMenu({ notebook, dashboard, shortId }: SceneNotebookDropdownMenuProps): JSX.Element {
+export function SceneAddToDropdownMenu({
+    notebook,
+    dashboard,
+    shortId,
+    dataAttrKey,
+}: SceneNotebookDropdownMenuProps): JSX.Element {
     return (
         <DropdownMenu>
             <DropdownMenuTrigger asChild>
-                <ButtonPrimitive menuItem>
+                <ButtonPrimitive menuItem data-attr={`${dataAttrKey}-add-to-dropdown-menu`}>
                     <IconPlus />
                     Add to...
                     <DropdownMenuOpenIndicator />
@@ -39,7 +45,7 @@ export function SceneAddToDropdownMenu({ notebook, dashboard, shortId }: SceneNo
                     {notebook && (
                         <>
                             <DropdownMenuSubTrigger asChild>
-                                <ButtonPrimitive menuItem>
+                                <ButtonPrimitive menuItem data-attr={`${dataAttrKey}-add-to-notebook-dropdown-menu`}>
                                     Notebook
                                     <DropdownMenuOpenIndicator intent="sub" />
                                 </ButtonPrimitive>
@@ -57,6 +63,7 @@ export function SceneAddToDropdownMenu({ notebook, dashboard, shortId }: SceneNo
                                             },
                                         },
                                     }}
+                                    dataAttrKey={dataAttrKey}
                                 />
                             </DropdownMenuSubContent>
                         </>
@@ -69,6 +76,7 @@ export function SceneAddToDropdownMenu({ notebook, dashboard, shortId }: SceneNo
                             onClick={() => {
                                 dashboard.onClick?.()
                             }}
+                            data-attr={`${dataAttrKey}-add-to-dashboard-dropdown-menu`}
                         >
                             Dashboard
                         </ButtonPrimitive>

--- a/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneExportDropdownMenu.tsx
+++ b/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneExportDropdownMenu.tsx
@@ -15,7 +15,7 @@ import { exportsLogic } from '../../ExportButton/exportsLogic'
 interface SceneExportDropdownMenuProps extends SubscriptionBaseProps {
     dropdownMenuItems: {
         label?: string
-        dataAttr?: string
+        dataAttr: string
         format: ExporterFormat
         insight?: number
         dashboard?: number

--- a/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneNotebookMenuItems.tsx
+++ b/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneNotebookMenuItems.tsx
@@ -19,8 +19,9 @@ import {
 import { notebooksModel, openNotebook } from '~/models/notebooksModel'
 import { AccessControlLevel, AccessControlResourceType, NotebookListItemType, NotebookTarget } from '~/types'
 import { AccessControlAction } from '../../AccessControlAction'
+import { SceneDataAttrKeyProps } from '../utils'
 
-type SceneNotebookDropdownMenuProps = {
+type SceneNotebookDropdownMenuProps = SceneDataAttrKeyProps & {
     notebookSelectButtonProps?: NotebookSelectButtonLogicProps
     newNotebookTitle?: string
     onNotebookOpened?: (
@@ -33,6 +34,7 @@ export function SceneNotebookMenuItems({
     notebookSelectButtonProps,
     newNotebookTitle,
     onNotebookOpened,
+    dataAttrKey,
 }: SceneNotebookDropdownMenuProps): JSX.Element {
     const logic = notebookSelectButtonLogic({ ...notebookSelectButtonProps })
     const { loadNotebooksContainingResource, loadAllNotebooks } = useActions(logic)
@@ -87,8 +89,13 @@ export function SceneNotebookMenuItems({
                             asChild
                             disabled={!!disabledReason}
                             {...(disabledReason && { tooltip: disabledReason })}
+                            data-attr={`${dataAttrKey}-new-notebook-dropdown-menu-item`}
                         >
-                            <ButtonPrimitive menuItem onClick={openNewNotebook}>
+                            <ButtonPrimitive
+                                menuItem
+                                onClick={openNewNotebook}
+                                data-attr={`${dataAttrKey}-new-notebook-button`}
+                            >
                                 <IconPlus />
                                 New notebook
                             </ButtonPrimitive>
@@ -101,6 +108,7 @@ export function SceneNotebookMenuItems({
                         onClick={() => {
                             openAndAddToNotebook('scratchpad', false)
                         }}
+                        data-attr={`${dataAttrKey}-my-scratchpad-dropdown-menu-item`}
                     >
                         <IconNotebook />
                         My scratchpad
@@ -132,6 +140,7 @@ export function SceneNotebookMenuItems({
                                             onClick={() => {
                                                 openAndAddToNotebook(notebook.short_id, true)
                                             }}
+                                            data-attr={`${dataAttrKey}-continue-in-notebook-dropdown-menu-item`}
                                         >
                                             <ButtonPrimitive menuItem tooltip={notebook.title} tooltipPlacement="left">
                                                 <IconNotebook />
@@ -141,7 +150,7 @@ export function SceneNotebookMenuItems({
                                     ))
                                 ) : (
                                     <DropdownMenuItem>
-                                        <ButtonPrimitive menuItem disabled>
+                                        <ButtonPrimitive menuItem inert>
                                             <IconNotebook />
                                             No notebooks found
                                         </ButtonPrimitive>
@@ -158,6 +167,7 @@ export function SceneNotebookMenuItems({
                                     onClick={() => {
                                         openAndAddToNotebook(notebook.short_id, false)
                                     }}
+                                    data-attr={`${dataAttrKey}-add-to-notebook-dropdown-menu-item`}
                                 >
                                     <ButtonPrimitive menuItem tooltip={notebook.title} tooltipPlacement="left">
                                         <IconNotebook />
@@ -167,7 +177,7 @@ export function SceneNotebookMenuItems({
                             ))
                         ) : (
                             <DropdownMenuItem>
-                                <ButtonPrimitive menuItem disabled>
+                                <ButtonPrimitive menuItem inert>
                                     <IconNotebook />
                                     No notebooks found
                                 </ButtonPrimitive>

--- a/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneNotificationDropdownMenu.tsx
+++ b/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneNotificationDropdownMenu.tsx
@@ -14,7 +14,6 @@ import { urls } from 'scenes/urls'
 import { InsightLogicProps, QueryBasedInsightModel } from '~/types'
 import { insightAlertsLogic } from '../../Alerts/insightAlertsLogic'
 import { SubscriptionBaseProps, urlForSubscriptions } from '../../Subscriptions/utils'
-
 interface SceneNotificationDropdownMenuProps extends SubscriptionBaseProps {
     insight?: Partial<QueryBasedInsightModel>
     insightLogicProps?: InsightLogicProps
@@ -23,13 +22,13 @@ interface SceneNotificationDropdownMenuProps extends SubscriptionBaseProps {
 }
 
 interface AlertsDropdownMenuItemProps extends SubscriptionBaseProps {
-    insight?: Partial<QueryBasedInsightModel>
-    insightLogicProps?: InsightLogicProps
+    insight: Partial<QueryBasedInsightModel>
+    insightLogicProps: InsightLogicProps
 }
 
 function AlertsDropdownMenuItem({ insight, insightLogicProps }: AlertsDropdownMenuItemProps): JSX.Element {
     const { push } = useActions(router)
-    const logic = insightAlertsLogic({ insightId: insight?.id, insightLogicProps: insightLogicProps! })
+    const logic = insightAlertsLogic({ insightId: insight?.id, insightLogicProps: insightLogicProps })
     const { alerts } = useValues(logic)
 
     return (
@@ -62,7 +61,9 @@ export function SceneNotificationDropdownMenu({
                 </ButtonPrimitive>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start" matchTriggerWidth>
-                {insight && <AlertsDropdownMenuItem insight={insight} insightLogicProps={insightLogicProps} />}
+                {insight && insightLogicProps && (
+                    <AlertsDropdownMenuItem insight={insight} insightLogicProps={insightLogicProps} />
+                )}
                 <DropdownMenuItem className="w-full">
                     <ButtonPrimitive
                         menuItem

--- a/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneNotificationDropdownMenu.tsx
+++ b/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneNotificationDropdownMenu.tsx
@@ -11,7 +11,7 @@ import {
     DropdownMenuTrigger,
 } from 'lib/ui/DropdownMenu/DropdownMenu'
 import { urls } from 'scenes/urls'
-import { InsightLogicProps, QueryBasedInsightModel } from '~/types'
+import { InsightLogicProps, InsightShortId, QueryBasedInsightModel } from '~/types'
 import { insightAlertsLogic } from '../../Alerts/insightAlertsLogic'
 import { SubscriptionBaseProps, urlForSubscriptions } from '../../Subscriptions/utils'
 
@@ -22,19 +22,25 @@ interface SceneNotificationDropdownMenuProps extends SubscriptionBaseProps {
     buttonProps?: Omit<ButtonPrimitiveProps, 'children'>
 }
 
-interface AlertsDropdownMenuItemProps extends SubscriptionBaseProps {
-    insight: Partial<QueryBasedInsightModel>
+interface AlertsDropdownMenuItemProps {
+    insightId: number
+    insightShortId: InsightShortId
     insightLogicProps: InsightLogicProps
 }
 
-function AlertsDropdownMenuItem({ insight, insightLogicProps }: AlertsDropdownMenuItemProps): JSX.Element {
+function AlertsDropdownMenuItem({
+    insightId,
+    insightShortId,
+    insightLogicProps,
+}: AlertsDropdownMenuItemProps): JSX.Element {
     const { push } = useActions(router)
-    const logic = insightAlertsLogic({ insightId: insight?.id, insightLogicProps: insightLogicProps })
+
+    const logic = insightAlertsLogic({ insightId, insightLogicProps })
     const { alerts } = useValues(logic)
 
     return (
         <DropdownMenuItem className="w-full">
-            <ButtonPrimitive menuItem onClick={() => push(urls.insightAlerts(insight?.short_id))}>
+            <ButtonPrimitive menuItem onClick={() => push(urls.insightAlerts(insightShortId))}>
                 <IconWithCount count={alerts?.length} showZero={false}>
                     <IconWarning />
                 </IconWithCount>
@@ -62,8 +68,12 @@ export function SceneNotificationDropdownMenu({
                 </ButtonPrimitive>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start" matchTriggerWidth>
-                {insight && insightLogicProps && (
-                    <AlertsDropdownMenuItem insight={insight} insightLogicProps={insightLogicProps} />
+                {insight && insight.id && insight.short_id && insightLogicProps && (
+                    <AlertsDropdownMenuItem
+                        insightId={insight.id}
+                        insightShortId={insight.short_id}
+                        insightLogicProps={insightLogicProps}
+                    />
                 )}
                 <DropdownMenuItem className="w-full">
                     <ButtonPrimitive

--- a/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneNotificationDropdownMenu.tsx
+++ b/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneNotificationDropdownMenu.tsx
@@ -14,15 +14,16 @@ import { urls } from 'scenes/urls'
 import { InsightLogicProps, InsightShortId, QueryBasedInsightModel } from '~/types'
 import { insightAlertsLogic } from '../../Alerts/insightAlertsLogic'
 import { SubscriptionBaseProps, urlForSubscriptions } from '../../Subscriptions/utils'
+import { SceneDataAttrKeyProps } from '../utils'
 
-interface SceneNotificationDropdownMenuProps extends SubscriptionBaseProps {
+interface SceneNotificationDropdownMenuProps extends SubscriptionBaseProps, SceneDataAttrKeyProps {
     insight?: Partial<QueryBasedInsightModel>
     insightLogicProps?: InsightLogicProps
     dashboardId?: number
     buttonProps?: Omit<ButtonPrimitiveProps, 'children'>
 }
 
-interface AlertsDropdownMenuItemProps {
+interface AlertsDropdownMenuItemProps extends SceneDataAttrKeyProps {
     insightId: number
     insightShortId: InsightShortId
     insightLogicProps: InsightLogicProps
@@ -32,6 +33,7 @@ function AlertsDropdownMenuItem({
     insightId,
     insightShortId,
     insightLogicProps,
+    dataAttrKey,
 }: AlertsDropdownMenuItemProps): JSX.Element {
     const { push } = useActions(router)
 
@@ -40,7 +42,11 @@ function AlertsDropdownMenuItem({
 
     return (
         <DropdownMenuItem className="w-full">
-            <ButtonPrimitive menuItem onClick={() => push(urls.insightAlerts(insightShortId))}>
+            <ButtonPrimitive
+                menuItem
+                onClick={() => push(urls.insightAlerts(insightShortId))}
+                data-attr={`${dataAttrKey}-alerts-dropdown-menu-item`}
+            >
                 <IconWithCount count={alerts?.length} showZero={false}>
                     <IconWarning />
                 </IconWithCount>
@@ -55,13 +61,14 @@ export function SceneNotificationDropdownMenu({
     insight,
     insightLogicProps,
     dashboardId,
+    dataAttrKey,
 }: SceneNotificationDropdownMenuProps): JSX.Element | null {
     const { push } = useActions(router)
 
     return (
         <DropdownMenu>
             <DropdownMenuTrigger asChild>
-                <ButtonPrimitive menuItem {...buttonProps}>
+                <ButtonPrimitive menuItem {...buttonProps} data-attr={`${dataAttrKey}-notifications-dropdown-menu`}>
                     <IconNotification />
                     Notifications
                     <DropdownMenuOpenIndicator className="ml-auto" />
@@ -73,12 +80,14 @@ export function SceneNotificationDropdownMenu({
                         insightId={insight.id}
                         insightShortId={insight.short_id}
                         insightLogicProps={insightLogicProps}
+                        dataAttrKey={dataAttrKey}
                     />
                 )}
                 <DropdownMenuItem className="w-full">
                     <ButtonPrimitive
                         menuItem
                         onClick={() => push(urlForSubscriptions({ insightShortId: insight?.short_id, dashboardId }))}
+                        data-attr={`${dataAttrKey}-subscribe-dropdown-menu-item`}
                     >
                         <IconBell />
                         Subscribe

--- a/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneNotificationDropdownMenu.tsx
+++ b/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneNotificationDropdownMenu.tsx
@@ -16,10 +16,32 @@ import { insightAlertsLogic } from '../../Alerts/insightAlertsLogic'
 import { SubscriptionBaseProps, urlForSubscriptions } from '../../Subscriptions/utils'
 
 interface SceneNotificationDropdownMenuProps extends SubscriptionBaseProps {
-    insight: Partial<QueryBasedInsightModel>
-    insightLogicProps: InsightLogicProps
+    insight?: Partial<QueryBasedInsightModel>
+    insightLogicProps?: InsightLogicProps
     dashboardId?: number
     buttonProps?: Omit<ButtonPrimitiveProps, 'children'>
+}
+
+interface AlertsDropdownMenuItemProps extends SubscriptionBaseProps {
+    insight?: Partial<QueryBasedInsightModel>
+    insightLogicProps?: InsightLogicProps
+}
+
+function AlertsDropdownMenuItem({ insight, insightLogicProps }: AlertsDropdownMenuItemProps): JSX.Element {
+    const { push } = useActions(router)
+    const logic = insightAlertsLogic({ insightId: insight?.id, insightLogicProps: insightLogicProps! })
+    const { alerts } = useValues(logic)
+
+    return (
+        <DropdownMenuItem className="w-full">
+            <ButtonPrimitive menuItem onClick={() => push(urls.insightAlerts(insight?.short_id))}>
+                <IconWithCount count={alerts?.length} showZero={false}>
+                    <IconWarning />
+                </IconWithCount>
+                Alerts
+            </ButtonPrimitive>
+        </DropdownMenuItem>
+    )
 }
 
 export function SceneNotificationDropdownMenu({
@@ -29,8 +51,6 @@ export function SceneNotificationDropdownMenu({
     dashboardId,
 }: SceneNotificationDropdownMenuProps): JSX.Element | null {
     const { push } = useActions(router)
-    const logic = insightAlertsLogic({ insightId: insight.id!, insightLogicProps })
-    const { alerts } = useValues(logic)
 
     return (
         <DropdownMenu>
@@ -42,18 +62,11 @@ export function SceneNotificationDropdownMenu({
                 </ButtonPrimitive>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start" matchTriggerWidth>
-                <DropdownMenuItem className="w-full">
-                    <ButtonPrimitive menuItem onClick={() => push(urls.insightAlerts(insight.short_id!))}>
-                        <IconWithCount count={alerts?.length} showZero={false}>
-                            <IconWarning />
-                        </IconWithCount>
-                        Alerts
-                    </ButtonPrimitive>
-                </DropdownMenuItem>
+                {insight && <AlertsDropdownMenuItem insight={insight} insightLogicProps={insightLogicProps} />}
                 <DropdownMenuItem className="w-full">
                     <ButtonPrimitive
                         menuItem
-                        onClick={() => push(urlForSubscriptions({ insightShortId: insight.short_id, dashboardId }))}
+                        onClick={() => push(urlForSubscriptions({ insightShortId: insight?.short_id, dashboardId }))}
                     >
                         <IconBell />
                         Subscribe

--- a/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneNotificationDropdownMenu.tsx
+++ b/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneNotificationDropdownMenu.tsx
@@ -14,6 +14,7 @@ import { urls } from 'scenes/urls'
 import { InsightLogicProps, QueryBasedInsightModel } from '~/types'
 import { insightAlertsLogic } from '../../Alerts/insightAlertsLogic'
 import { SubscriptionBaseProps, urlForSubscriptions } from '../../Subscriptions/utils'
+
 interface SceneNotificationDropdownMenuProps extends SubscriptionBaseProps {
     insight?: Partial<QueryBasedInsightModel>
     insightLogicProps?: InsightLogicProps

--- a/frontend/src/lib/components/Scenes/SceneCommonButtons.tsx
+++ b/frontend/src/lib/components/Scenes/SceneCommonButtons.tsx
@@ -1,9 +1,11 @@
-import { IconCopy, IconExpand45, IconPin, IconPinFilled, IconStar, IconStarFilled } from '@posthog/icons'
+import { IconCopy, IconExpand45, IconPin, IconPinFilled, IconRewindPlay, IconStar, IconStarFilled } from '@posthog/icons'
+import { Link } from '@posthog/lemon-ui'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 
 type SceneCommonButtonsButtonProps = {
     onClick?: () => void
     active?: boolean
+    to?: string
 }
 
 type SceneCommonButtonsProps = {
@@ -11,9 +13,10 @@ type SceneCommonButtonsProps = {
     favorite?: SceneCommonButtonsButtonProps
     pinned?: SceneCommonButtonsButtonProps
     fullscreen?: SceneCommonButtonsButtonProps
+    recordings?: SceneCommonButtonsButtonProps
 }
 
-export function SceneCommonButtons({ duplicate, favorite, pinned, fullscreen }: SceneCommonButtonsProps): JSX.Element {
+export function SceneCommonButtons({ duplicate, favorite, pinned, fullscreen, recordings }: SceneCommonButtonsProps): JSX.Element {
     return (
         <div className="flex gap-1">
             {favorite && (
@@ -61,6 +64,20 @@ export function SceneCommonButtons({ duplicate, favorite, pinned, fullscreen }: 
                 >
                     <IconExpand45 />
                 </ButtonPrimitive>
+            )}
+
+            {recordings && (
+                <Link
+                    onClick={recordings.onClick}
+                    to={recordings.to}
+                    tooltip="View recordings"
+                    className="justify-center flex-1"
+                    buttonProps={{
+                        menuItem: true,
+                    }}
+                >
+                    <IconRewindPlay />
+                </Link>
             )}
         </div>
     )

--- a/frontend/src/lib/components/Scenes/SceneCommonButtons.tsx
+++ b/frontend/src/lib/components/Scenes/SceneCommonButtons.tsx
@@ -1,6 +1,15 @@
-import { IconCopy, IconExpand45, IconPin, IconPinFilled, IconRewindPlay, IconStar, IconStarFilled } from '@posthog/icons'
+import {
+    IconCopy,
+    IconExpand45,
+    IconPin,
+    IconPinFilled,
+    IconRewindPlay,
+    IconStar,
+    IconStarFilled,
+} from '@posthog/icons'
 import { Link } from '@posthog/lemon-ui'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+import { SceneDataAttrKeyProps } from './utils'
 
 type SceneCommonButtonsButtonProps = {
     onClick?: () => void
@@ -8,7 +17,7 @@ type SceneCommonButtonsButtonProps = {
     to?: string
 }
 
-type SceneCommonButtonsProps = {
+type SceneCommonButtonsProps = SceneDataAttrKeyProps & {
     duplicate?: SceneCommonButtonsButtonProps
     favorite?: SceneCommonButtonsButtonProps
     pinned?: SceneCommonButtonsButtonProps
@@ -16,7 +25,14 @@ type SceneCommonButtonsProps = {
     recordings?: SceneCommonButtonsButtonProps
 }
 
-export function SceneCommonButtons({ duplicate, favorite, pinned, fullscreen, recordings }: SceneCommonButtonsProps): JSX.Element {
+export function SceneCommonButtons({
+    duplicate,
+    favorite,
+    pinned,
+    fullscreen,
+    recordings,
+    dataAttrKey,
+}: SceneCommonButtonsProps): JSX.Element {
     return (
         <div className="flex gap-1">
             {favorite && (
@@ -37,6 +53,7 @@ export function SceneCommonButtons({ duplicate, favorite, pinned, fullscreen, re
                     tooltip="Duplicate"
                     className="justify-center flex-1"
                     menuItem
+                    data-attr={`${dataAttrKey}-duplicate`}
                 >
                     <IconCopy />
                 </ButtonPrimitive>
@@ -49,6 +66,7 @@ export function SceneCommonButtons({ duplicate, favorite, pinned, fullscreen, re
                     active={pinned.active}
                     className="justify-center flex-1"
                     menuItem
+                    data-attr={`${dataAttrKey}-pin`}
                 >
                     {pinned.active ? <IconPinFilled className="text-warning" /> : <IconPin />}
                 </ButtonPrimitive>
@@ -61,6 +79,7 @@ export function SceneCommonButtons({ duplicate, favorite, pinned, fullscreen, re
                     active={fullscreen.active}
                     className="justify-center flex-1"
                     menuItem
+                    data-attr={`${dataAttrKey}-fullscreen`}
                 >
                     <IconExpand45 />
                 </ButtonPrimitive>
@@ -75,6 +94,7 @@ export function SceneCommonButtons({ duplicate, favorite, pinned, fullscreen, re
                     buttonProps={{
                         menuItem: true,
                     }}
+                    data-attr={`${dataAttrKey}-view-recordings`}
                 >
                     <IconRewindPlay />
                 </Link>

--- a/frontend/src/lib/components/Scenes/SceneCommonButtons.tsx
+++ b/frontend/src/lib/components/Scenes/SceneCommonButtons.tsx
@@ -1,4 +1,4 @@
-import { IconCopy, IconStar, IconStarFilled } from '@posthog/icons'
+import { IconCopy, IconExpand45, IconPin, IconPinFilled, IconStar, IconStarFilled } from '@posthog/icons'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 
 type SceneCommonButtonsButtonProps = {
@@ -9,18 +9,19 @@ type SceneCommonButtonsButtonProps = {
 type SceneCommonButtonsProps = {
     duplicate?: SceneCommonButtonsButtonProps
     favorite?: SceneCommonButtonsButtonProps
+    pinned?: SceneCommonButtonsButtonProps
+    fullscreen?: SceneCommonButtonsButtonProps
 }
 
-export function SceneCommonButtons({ duplicate, favorite }: SceneCommonButtonsProps): JSX.Element {
+export function SceneCommonButtons({ duplicate, favorite, pinned, fullscreen }: SceneCommonButtonsProps): JSX.Element {
     return (
-        <div className="grid grid-cols-2 gap-1">
+        <div className="flex gap-1">
             {favorite && (
                 <ButtonPrimitive
                     onClick={favorite.onClick}
                     tooltip={favorite.active ? 'Remove from favorites' : 'Add to favorites'}
                     active={favorite.active}
-                    fullWidth
-                    className="justify-center"
+                    className="justify-center flex-1"
                     menuItem
                 >
                     {favorite.active ? <IconStarFilled className="text-warning" /> : <IconStar />}
@@ -31,11 +32,34 @@ export function SceneCommonButtons({ duplicate, favorite }: SceneCommonButtonsPr
                 <ButtonPrimitive
                     onClick={duplicate.onClick}
                     tooltip="Duplicate"
-                    fullWidth
-                    className="justify-center"
+                    className="justify-center flex-1"
                     menuItem
                 >
                     <IconCopy />
+                </ButtonPrimitive>
+            )}
+
+            {pinned && (
+                <ButtonPrimitive
+                    onClick={pinned.onClick}
+                    tooltip={pinned.active ? 'Unpin' : 'Pin'}
+                    active={pinned.active}
+                    className="justify-center flex-1"
+                    menuItem
+                >
+                    {pinned.active ? <IconPinFilled className="text-warning" /> : <IconPin />}
+                </ButtonPrimitive>
+            )}
+
+            {fullscreen && (
+                <ButtonPrimitive
+                    onClick={fullscreen.onClick}
+                    tooltip={fullscreen.active ? 'Exit fullscreen' : 'Fullscreen'}
+                    active={fullscreen.active}
+                    className="justify-center flex-1"
+                    menuItem
+                >
+                    <IconExpand45 />
                 </ButtonPrimitive>
             )}
         </div>

--- a/frontend/src/lib/components/Scenes/SceneDescription.tsx
+++ b/frontend/src/lib/components/Scenes/SceneDescription.tsx
@@ -46,7 +46,7 @@ export function SceneDescription({
                     onChange={(e) => {
                         setLocalValue(e.target.value)
                     }}
-                    placeholder="Description (optional)"
+                    placeholder={optional ? "Description (optional)" : "Description"}
                     id="page-description-input"
                     data-attr={`${dataAttrKey}-description-input`}
                     autoFocus

--- a/frontend/src/lib/components/Scenes/SceneDescription.tsx
+++ b/frontend/src/lib/components/Scenes/SceneDescription.tsx
@@ -3,17 +3,21 @@ import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { Label } from 'lib/ui/Label/Label'
 import { TextareaPrimitive } from 'lib/ui/TextareaPrimitive/TextareaPrimitive'
 import { useEffect, useState } from 'react'
+import { SceneInputProps } from './utils'
 
-type SceneDescriptionProps = {
-    defaultValue: string
-    onSave: (value: string) => void
-    dataAttr?: string
-}
+type SceneDescriptionProps = SceneInputProps
 
-export function SceneDescription({ defaultValue, onSave, dataAttr }: SceneDescriptionProps): JSX.Element {
+export function SceneDescription({
+    defaultValue,
+    onSave,
+    dataAttrKey,
+    optional = false,
+    canEdit = true,
+}: SceneDescriptionProps): JSX.Element {
     const [localValue, setLocalValue] = useState(defaultValue)
     const [localIsEditing, setLocalIsEditing] = useState(false)
     const [hasChanged, setHasChanged] = useState(false)
+    const [error, setError] = useState<string | null>(null)
 
     const handleSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
         e.preventDefault()
@@ -24,6 +28,11 @@ export function SceneDescription({ defaultValue, onSave, dataAttr }: SceneDescri
 
     useEffect(() => {
         setHasChanged(localValue !== defaultValue)
+        if (localValue.length === 0 && !optional) {
+            setError('Description is required')
+        } else {
+            setError(null)
+        }
     }, [localValue, defaultValue])
 
     return localIsEditing ? (
@@ -39,8 +48,9 @@ export function SceneDescription({ defaultValue, onSave, dataAttr }: SceneDescri
                     }}
                     placeholder="Description (optional)"
                     id="page-description-input"
-                    data-attr={`${dataAttr}-description-input`}
+                    data-attr={`${dataAttrKey}-description-input`}
                     autoFocus
+                    error={!!error}
                     className="-ml-1.5"
                 />
             </div>
@@ -48,9 +58,9 @@ export function SceneDescription({ defaultValue, onSave, dataAttr }: SceneDescri
                 <ButtonPrimitive
                     type="submit"
                     variant="outline"
-                    disabled={!hasChanged}
+                    disabled={!hasChanged || !!error}
                     tooltip={hasChanged ? 'Update description' : 'No changes to update'}
-                    data-attr={`${dataAttr}-description-update-button`}
+                    data-attr={`${dataAttrKey}-description-update-button`}
                 >
                     <IconCheck />
                 </ButtonPrimitive>
@@ -75,11 +85,16 @@ export function SceneDescription({ defaultValue, onSave, dataAttr }: SceneDescri
                     className="hyphens-auto flex gap-1 items-center"
                     lang="en"
                     onClick={() => setLocalIsEditing(true)}
-                    tooltip="Edit description"
+                    tooltip={canEdit ? 'Edit description' : 'Description is read-only'}
                     autoHeight
                     menuItem
+                    inert={!canEdit}
                 >
-                    {defaultValue || <span className="text-tertiary font-normal">Description (optional)</span>}
+                    {defaultValue !== '' ? (
+                        defaultValue
+                    ) : (
+                        <span className="text-tertiary font-normal">No description {optional ? '(optional)' : ''}</span>
+                    )}
                 </ButtonPrimitive>
             </div>
         </div>

--- a/frontend/src/lib/components/Scenes/SceneDescription.tsx
+++ b/frontend/src/lib/components/Scenes/SceneDescription.tsx
@@ -46,7 +46,7 @@ export function SceneDescription({
                     onChange={(e) => {
                         setLocalValue(e.target.value)
                     }}
-                    placeholder={optional ? "Description (optional)" : "Description"}
+                    placeholder={optional ? 'Description (optional)' : 'Description'}
                     id="page-description-input"
                     data-attr={`${dataAttrKey}-description-input`}
                     autoFocus

--- a/frontend/src/lib/components/Scenes/SceneFile.tsx
+++ b/frontend/src/lib/components/Scenes/SceneFile.tsx
@@ -16,7 +16,7 @@ import {
 } from 'lib/ui/DropdownMenu/DropdownMenu'
 import { Label } from 'lib/ui/Label/Label'
 
-export function SceneFile(): JSX.Element | null {
+export function SceneFile({ dataAttrKey }: { dataAttrKey: string }): JSX.Element | null {
     const { assureVisibility } = useActions(projectTreeLogic({ key: PROJECT_TREE_KEY }))
     const { showLayoutPanel, setActivePanelIdentifier } = useActions(panelLayoutLogic)
     const { addShortcutItem } = useActions(projectTreeDataLogic)
@@ -29,7 +29,7 @@ export function SceneFile(): JSX.Element | null {
             <DropdownMenu>
                 <div className="-ml-1.5">
                     <DropdownMenuTrigger asChild>
-                        <ButtonPrimitive menuItem>
+                        <ButtonPrimitive menuItem data-attr={`${dataAttrKey}-file-dropdown-menu-trigger`}>
                             <IconFolderOpen />
                             {splitPath(projectTreeRefEntry.path).slice(0, -1).join('/')}
                             <DropdownMenuOpenIndicator className="ml-auto" />
@@ -51,13 +51,21 @@ export function SceneFile(): JSX.Element | null {
                         </ButtonPrimitive>
                     </DropdownMenuItem>
                     <DropdownMenuItem asChild>
-                        <ButtonPrimitive menuItem onClick={() => openMoveToModal([projectTreeRefEntry])}>
+                        <ButtonPrimitive
+                            menuItem
+                            onClick={() => openMoveToModal([projectTreeRefEntry])}
+                            data-attr={`${dataAttrKey}-move-to-dropdown-menu-item`}
+                        >
                             <IconFolderMove />
                             Move to another folder
                         </ButtonPrimitive>
                     </DropdownMenuItem>
                     <DropdownMenuItem asChild>
-                        <ButtonPrimitive menuItem onClick={() => addShortcutItem(projectTreeRefEntry)}>
+                        <ButtonPrimitive
+                            menuItem
+                            onClick={() => addShortcutItem(projectTreeRefEntry)}
+                            data-attr={`${dataAttrKey}-add-to-shortcuts-dropdown-menu-item`}
+                        >
                             <IconShortcut />
                             Add to shortcuts panel
                         </ButtonPrimitive>

--- a/frontend/src/lib/components/Scenes/SceneMetalyticsSummaryButton.tsx
+++ b/frontend/src/lib/components/Scenes/SceneMetalyticsSummaryButton.tsx
@@ -8,8 +8,9 @@ import { SidePanelTab } from '~/types'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { FlaggedFeature } from '../FlaggedFeature'
 import { metalyticsLogic } from '../Metalytics/metalyticsLogic'
+import { SceneDataAttrKeyProps } from './utils'
 
-export function SceneMetalyticsSummaryButton(): JSX.Element | null {
+export function SceneMetalyticsSummaryButton({ dataAttrKey }: SceneDataAttrKeyProps): JSX.Element | null {
     const { instanceId, viewCount, viewCountLoading } = useValues(metalyticsLogic)
     const safeViewCount = viewCount?.views ?? 0
     const safeUniqueUsers = viewCount?.users ?? 0
@@ -26,6 +27,7 @@ export function SceneMetalyticsSummaryButton(): JSX.Element | null {
                 tooltip={`${safeUniqueUsers} PostHog members have viewed this a total of ${safeViewCount} times. Click to see more.`}
                 menuItem
                 disabled={viewCountLoading}
+                data-attr={`${dataAttrKey}-metalytics-summary-button`}
             >
                 {viewCountLoading ? <Spinner textColored /> : <IconPulse />}
                 Metalytics

--- a/frontend/src/lib/components/Scenes/SceneName.tsx
+++ b/frontend/src/lib/components/Scenes/SceneName.tsx
@@ -1,29 +1,33 @@
 import { IconCheck, IconX } from '@posthog/icons'
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { Label } from 'lib/ui/Label/Label'
 import { TextareaPrimitive } from 'lib/ui/TextareaPrimitive/TextareaPrimitive'
+import { cn } from 'lib/utils/css-classes'
 import { useEffect, useState } from 'react'
 import { breadcrumbsLogic } from '~/layout/navigation/Breadcrumbs/breadcrumbsLogic'
+import { sceneLayoutLogic } from '~/layout/scenes/sceneLayoutLogic'
 
 type SceneNameProps = {
     defaultValue: string
-    onSave: (value: string) => void
+    onSave?: (value: string) => void
     dataAttr?: string
+    forceLocalEditing?: boolean
 }
 
-export function SceneName({ defaultValue, onSave, dataAttr }: SceneNameProps): JSX.Element {
+export function SceneName({ defaultValue, onSave, dataAttr, forceLocalEditing = false }:SceneNameProps): JSX.Element {
     const { breadcrumbs } = useValues(breadcrumbsLogic)
     const lastBreadcrumb = breadcrumbs[breadcrumbs.length - 1]
     const value = typeof lastBreadcrumb?.name === 'string' ? (lastBreadcrumb.name as string) : defaultValue
     const [localValue, setLocalValue] = useState(value)
-    const [localIsEditing, setLocalIsEditing] = useState(false)
+    const [localIsEditing, setLocalIsEditing] = useState(forceLocalEditing)
     const [hasChanged, setHasChanged] = useState(false)
     const [error, setError] = useState<string | null>(null)
+    const { setScenePanelOpen } = useActions(sceneLayoutLogic)
 
     const handleSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
         e.preventDefault()
-        onSave(localValue)
+        onSave?.(localValue)
         setHasChanged(false)
         setLocalIsEditing(false)
     }
@@ -37,7 +41,14 @@ export function SceneName({ defaultValue, onSave, dataAttr }: SceneNameProps): J
         }
     }, [localValue, defaultValue])
 
-    return localIsEditing ? (
+    useEffect(() => {
+        if (forceLocalEditing) {
+            setScenePanelOpen(true)
+            setLocalIsEditing(true)
+        }
+    }, [forceLocalEditing])
+
+    return localIsEditing && onSave ? (
         <form onSubmit={handleSubmit} name="page-name-form" className="flex flex-col gap-1">
             <div className="flex flex-col gap-0">
                 <Label intent="menu" htmlFor="page-name-input">
@@ -84,12 +95,13 @@ export function SceneName({ defaultValue, onSave, dataAttr }: SceneNameProps): J
             <Label intent="menu">Name</Label>
             <div className="-ml-1.5">
                 <ButtonPrimitive
-                    className="hyphens-auto flex gap-1 items-center"
+                    className={cn("hyphens-auto flex gap-1 items-center")}
                     lang="en"
                     onClick={() => setLocalIsEditing(true)}
-                    tooltip="Edit name"
+                    tooltip={onSave ? "Edit name" : "Name is read-only"}
                     autoHeight
                     menuItem
+                    inert={!onSave}
                 >
                     {value || <span className="text-tertiary font-normal">No name</span>}
                 </ButtonPrimitive>

--- a/frontend/src/lib/components/Scenes/SceneShareButton.tsx
+++ b/frontend/src/lib/components/Scenes/SceneShareButton.tsx
@@ -3,7 +3,6 @@ import { SceneDataAttrKeyProps } from './utils'
 
 type SceneShareButtonProps = SceneDataAttrKeyProps & {
     buttonProps?: Omit<ButtonPrimitiveProps, 'children' | 'data-attr'>
-    onClick?: () => void
     children?: React.ReactNode
 }
 

--- a/frontend/src/lib/components/Scenes/SceneShareButton.tsx
+++ b/frontend/src/lib/components/Scenes/SceneShareButton.tsx
@@ -1,11 +1,16 @@
 import { ButtonPrimitive, ButtonPrimitiveProps } from 'lib/ui/Button/ButtonPrimitives'
+import { SceneDataAttrKeyProps } from './utils'
 
-type SceneShareButtonProps = {
-    buttonProps?: Omit<ButtonPrimitiveProps, 'children'>
+type SceneShareButtonProps = SceneDataAttrKeyProps & {
+    buttonProps?: Omit<ButtonPrimitiveProps, 'children' | 'data-attr'>
     onClick?: () => void
     children?: React.ReactNode
 }
 
-export function SceneShareButton({ buttonProps, children }: SceneShareButtonProps): JSX.Element {
-    return <ButtonPrimitive {...buttonProps}>{children}</ButtonPrimitive>
+export function SceneShareButton({ buttonProps, children, dataAttrKey }: SceneShareButtonProps): JSX.Element {
+    return (
+        <ButtonPrimitive {...buttonProps} data-attr={`${dataAttrKey}-share-button`}>
+            {children}
+        </ButtonPrimitive>
+    )
 }

--- a/frontend/src/lib/components/Scenes/SceneTags.tsx
+++ b/frontend/src/lib/components/Scenes/SceneTags.tsx
@@ -89,7 +89,7 @@ export function SceneTags({ onSave, tags, tagsAvailable, dataAttr }: SceneDescri
                     menuItem
                 >
                     {tags && tags.length > 0 ? (
-                        <ObjectTags tags={tags ?? []} data-attr="scene-tags" staticOnly />
+                        <ObjectTags tags={tags} data-attr="scene-tags" staticOnly />
                     ) : (
                         <>{onSave ? 'Add tags' : 'No tags'}</>
                     )}

--- a/frontend/src/lib/components/Scenes/SceneTags.tsx
+++ b/frontend/src/lib/components/Scenes/SceneTags.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from 'react'
 import { ObjectTags } from '../ObjectTags/ObjectTags'
 
 type SceneDescriptionProps = {
-    onSave: (value: string[]) => void
+    onSave?: (value: string[]) => void
     tags?: string[]
     tagsAvailable?: string[]
     dataAttr?: string
@@ -19,7 +19,7 @@ export function SceneTags({ onSave, tags, tagsAvailable, dataAttr }: SceneDescri
 
     const handleSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
         e.preventDefault()
-        onSave(localTags ?? [])
+        onSave?.(localTags ?? [])
         setHasChanged(false)
         setLocalIsEditing(false)
     }
@@ -83,7 +83,7 @@ export function SceneTags({ onSave, tags, tagsAvailable, dataAttr }: SceneDescri
                 <ButtonPrimitive
                     className="hyphens-auto flex gap-1 items-center"
                     lang="en"
-                    onClick={() => setLocalIsEditing(true)}
+                    onClick={() => onSave && setLocalIsEditing(true)}
                     tooltip="Edit tags"
                     autoHeight
                     menuItem
@@ -91,7 +91,7 @@ export function SceneTags({ onSave, tags, tagsAvailable, dataAttr }: SceneDescri
                     {tags && tags.length > 0 ? (
                         <ObjectTags tags={tags ?? []} data-attr="scene-tags" staticOnly />
                     ) : (
-                        <>Add tags</>
+                        <>{onSave ? 'Add tags' : 'No tags'}</>
                     )}
                 </ButtonPrimitive>
             </div>

--- a/frontend/src/lib/components/Scenes/SceneTags.tsx
+++ b/frontend/src/lib/components/Scenes/SceneTags.tsx
@@ -4,15 +4,16 @@ import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { Label } from 'lib/ui/Label/Label'
 import { useEffect, useState } from 'react'
 import { ObjectTags } from '../ObjectTags/ObjectTags'
+import { SceneCanEditProps, SceneDataAttrKeyProps } from './utils'
 
-type SceneDescriptionProps = {
-    onSave?: (value: string[]) => void
-    tags?: string[]
-    tagsAvailable?: string[]
-    dataAttr?: string
-}
+type SceneTagsProps = SceneCanEditProps &
+    SceneDataAttrKeyProps & {
+        onSave?: (value: string[]) => void
+        tags?: string[]
+        tagsAvailable?: string[]
+    }
 
-export function SceneTags({ onSave, tags, tagsAvailable, dataAttr }: SceneDescriptionProps): JSX.Element {
+export function SceneTags({ onSave, tags, tagsAvailable, dataAttrKey, canEdit = true }: SceneTagsProps): JSX.Element {
     const [localTags, setLocalTags] = useState(tags)
     const [localIsEditing, setLocalIsEditing] = useState(false)
     const [hasChanged, setHasChanged] = useState(false)
@@ -45,7 +46,7 @@ export function SceneTags({ onSave, tags, tagsAvailable, dataAttr }: SceneDescri
                     options={tagsAvailable?.map((t) => ({ key: t, label: t }))}
                     onChange={setLocalTags}
                     loading={false}
-                    data-attr="new-tag-input"
+                    data-attr={`${dataAttrKey}-new-tag-input`}
                     placeholder='try "official"'
                     size="xsmall"
                     autoFocus
@@ -58,7 +59,7 @@ export function SceneTags({ onSave, tags, tagsAvailable, dataAttr }: SceneDescri
                     variant="outline"
                     disabled={!hasChanged}
                     tooltip={hasChanged ? 'Update tags' : 'No changes to update'}
-                    data-attr={`${dataAttr}-tags-update-button`}
+                    data-attr={`${dataAttrKey}-tags-update-button`}
                 >
                     <IconCheck />
                 </ButtonPrimitive>
@@ -70,7 +71,7 @@ export function SceneTags({ onSave, tags, tagsAvailable, dataAttr }: SceneDescri
                         setLocalIsEditing(false)
                     }}
                     tooltip="Cancel"
-                    data-attr={`${dataAttr}-tags-undo-button`}
+                    data-attr={`${dataAttrKey}-tags-undo-button`}
                 >
                     <IconX />
                 </ButtonPrimitive>
@@ -83,15 +84,23 @@ export function SceneTags({ onSave, tags, tagsAvailable, dataAttr }: SceneDescri
                 <ButtonPrimitive
                     className="hyphens-auto flex gap-1 items-center"
                     lang="en"
-                    onClick={() => onSave && setLocalIsEditing(true)}
-                    tooltip="Edit tags"
+                    onClick={() => onSave && canEdit && setLocalIsEditing(true)}
+                    tooltip={canEdit ? 'Edit tags' : 'Tags are read-only'}
                     autoHeight
                     menuItem
+                    inert={!canEdit}
+                    data-attr={`${dataAttrKey}-tags-button`}
                 >
                     {tags && tags.length > 0 ? (
-                        <ObjectTags tags={tags} data-attr="scene-tags" staticOnly />
+                        <ObjectTags tags={tags} data-attr={`${dataAttrKey}-tags`} staticOnly />
                     ) : (
-                        <>{onSave ? 'Add tags' : 'No tags'}</>
+                        <>
+                            {onSave && canEdit ? (
+                                'Click to add tags'
+                            ) : (
+                                <span className="text-tertiary font-normal">No tags</span>
+                            )}
+                        </>
                     )}
                 </ButtonPrimitive>
             </div>

--- a/frontend/src/lib/components/Scenes/utils.tsx
+++ b/frontend/src/lib/components/Scenes/utils.tsx
@@ -1,0 +1,15 @@
+export type SceneCanEditProps = {
+    canEdit?: boolean
+}
+
+export type SceneDataAttrKeyProps = {
+    dataAttrKey: string
+}
+
+// Common props for all scene inputs
+export type SceneInputProps = SceneCanEditProps &
+    SceneDataAttrKeyProps & {
+        defaultValue: string
+        onSave: (value: string) => void
+        optional?: boolean
+    }

--- a/frontend/src/lib/ui/Button/ButtonPrimitives.tsx
+++ b/frontend/src/lib/ui/Button/ButtonPrimitives.tsx
@@ -40,7 +40,7 @@ type ButtonBaseProps = {
     tooltipDocLink?: TooltipProps['docLink']
     tooltipPlacement?: TooltipProps['placement']
     buttonWrapper?: (button: JSX.Element) => JSX.Element
-    // Like disabled but doesn't show the disabled state
+    // Like disabled but doesn't show the disabled state or focus state (still shows tooltip)
     inert?: boolean
 } & VariantProps<typeof buttonPrimitiveVariants>
 

--- a/frontend/src/lib/ui/Button/ButtonPrimitives.tsx
+++ b/frontend/src/lib/ui/Button/ButtonPrimitives.tsx
@@ -40,6 +40,8 @@ type ButtonBaseProps = {
     tooltipDocLink?: TooltipProps['docLink']
     tooltipPlacement?: TooltipProps['placement']
     buttonWrapper?: (button: JSX.Element) => JSX.Element
+    // Like disabled but doesn't show the disabled state
+    inert?: boolean
 } & VariantProps<typeof buttonPrimitiveVariants>
 
 /* -------------------------------------------------------------------------- */
@@ -166,6 +168,10 @@ export const buttonPrimitiveVariants = cva({
             true: 'disabled:opacity-50',
             false: '',
         },
+        inert: {
+            true: 'cursor-default hover:bg-inherit',
+            false: '',
+        },
         hasSideActionRight: {
             true: 'rounded',
             false: '',
@@ -224,6 +230,7 @@ export const ButtonPrimitive = forwardRef<HTMLButtonElement, ButtonPrimitiveProp
         tooltipPlacement,
         tooltipDocLink,
         autoHeight,
+        inert,
         ...rest
     } = props
     // If inside a ButtonGroup, use the context values, otherwise use props
@@ -245,6 +252,7 @@ export const ButtonPrimitive = forwardRef<HTMLButtonElement, ButtonPrimitiveProp
                     hasSideActionRight,
                     isSideActionRight,
                     autoHeight,
+                    inert,
                     className,
                 })
             ),

--- a/frontend/src/lib/ui/TextareaPrimitive/TextareaPrimitive.tsx
+++ b/frontend/src/lib/ui/TextareaPrimitive/TextareaPrimitive.tsx
@@ -1,13 +1,12 @@
 import { cn } from 'lib/utils/css-classes'
 import TextareaAutosize, { TextareaAutosizeProps } from 'react-textarea-autosize'
 import { TextInputBaseProps, textInputVariants } from '../TextInputPrimitive/TextInputPrimitive'
+import { forwardRef } from 'react'
 
 type TextareaPrimitiveProps = TextareaAutosizeProps &
     TextInputBaseProps & {
         error?: boolean
     }
-
-import { forwardRef } from 'react'
 
 export const TextareaPrimitive = forwardRef<HTMLTextAreaElement, TextareaPrimitiveProps>(
     ({ className, variant, error, ...rest }, ref): JSX.Element => {

--- a/frontend/src/lib/ui/TextareaPrimitive/TextareaPrimitive.tsx
+++ b/frontend/src/lib/ui/TextareaPrimitive/TextareaPrimitive.tsx
@@ -7,7 +7,10 @@ type TextareaPrimitiveProps = TextareaAutosizeProps &
         error?: boolean
     }
 
-export function TextareaPrimitive({ className, variant, error, ...rest }: TextareaPrimitiveProps): JSX.Element {
+import { forwardRef } from 'react'
+
+export const TextareaPrimitive = forwardRef<HTMLTextAreaElement, TextareaPrimitiveProps>(
+    ({ className, variant, error, ...rest }, ref): JSX.Element => {
     // Ensure cursor is at the end of the textarea when it is focused
     function onFocus(e: React.FocusEvent<HTMLTextAreaElement>): void {
         e.currentTarget.setSelectionRange(e.currentTarget.value.length, e.currentTarget.value.length)
@@ -15,9 +18,10 @@ export function TextareaPrimitive({ className, variant, error, ...rest }: Textar
 
     return (
         <TextareaAutosize
+            ref={ref}
             onFocus={onFocus}
             {...rest}
             className={cn(textInputVariants({ variant, error: !!error }), className)}
         />
     )
-}
+})

--- a/frontend/src/lib/ui/TextareaPrimitive/TextareaPrimitive.tsx
+++ b/frontend/src/lib/ui/TextareaPrimitive/TextareaPrimitive.tsx
@@ -11,17 +11,18 @@ import { forwardRef } from 'react'
 
 export const TextareaPrimitive = forwardRef<HTMLTextAreaElement, TextareaPrimitiveProps>(
     ({ className, variant, error, ...rest }, ref): JSX.Element => {
-    // Ensure cursor is at the end of the textarea when it is focused
-    function onFocus(e: React.FocusEvent<HTMLTextAreaElement>): void {
-        e.currentTarget.setSelectionRange(e.currentTarget.value.length, e.currentTarget.value.length)
-    }
+        // Ensure cursor is at the end of the textarea when it is focused
+        function onFocus(e: React.FocusEvent<HTMLTextAreaElement>): void {
+            e.currentTarget.setSelectionRange(e.currentTarget.value.length, e.currentTarget.value.length)
+        }
 
-    return (
-        <TextareaAutosize
-            ref={ref}
-            onFocus={onFocus}
-            {...rest}
-            className={cn(textInputVariants({ variant, error: !!error }), className)}
-        />
-    )
-})
+        return (
+            <TextareaAutosize
+                ref={ref}
+                onFocus={onFocus}
+                {...rest}
+                className={cn(textInputVariants({ variant, error: !!error }), className)}
+            />
+        )
+    }
+)

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -73,6 +73,7 @@ export enum DashboardEventSource {
     AddDescription = 'add_dashboard_description',
     MainNavigation = 'main_nav',
     DashboardsList = 'dashboards_list',
+    SceneCommonButtons = 'scene_common_buttons',
 }
 
 export enum InsightEventSource {

--- a/frontend/src/scenes/actions/ActionEdit.tsx
+++ b/frontend/src/scenes/actions/ActionEdit.tsx
@@ -217,7 +217,7 @@ export function ActionEdit({ action: loadedAction, id }: ActionEditLogicProps): 
                     <ScenePanelMetaInfo>
                         <SceneName
                             defaultValue={action.name || ''}
-                            dataAttr={RESOURCE_TYPE}
+                            dataAttrKey={RESOURCE_TYPE}
                             onSave={(value) => {
                                 setActionValue('name', value)
                             }}
@@ -226,7 +226,7 @@ export function ActionEdit({ action: loadedAction, id }: ActionEditLogicProps): 
                         <SceneDescription
                             defaultValue={action.description || ''}
                             onSave={(value) => setActionValue('description', value)}
-                            dataAttr={RESOURCE_TYPE}
+                            dataAttrKey={RESOURCE_TYPE}
                             optional
                         />
 
@@ -236,10 +236,10 @@ export function ActionEdit({ action: loadedAction, id }: ActionEditLogicProps): 
                             }}
                             tags={action.tags || []}
                             tagsAvailable={tags}
-                            dataAttr={RESOURCE_TYPE}
+                            dataAttrKey={RESOURCE_TYPE}
                         />
 
-                        <SceneFile />
+                        <SceneFile dataAttrKey={RESOURCE_TYPE} />
 
                         <SceneActivityIndicator at={action.created_at} by={action.created_by} prefix="Created" />
                     </ScenePanelMetaInfo>

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -37,13 +37,33 @@ import {
     QueryBasedInsightModel,
 } from '~/types'
 
+import { IconGridMasonry, IconNotebook, IconPalette, IconScreen, IconTrash } from '@posthog/icons'
+import { AccessControlAction } from 'lib/components/AccessControlAction'
+import { SceneExportDropdownMenu } from 'lib/components/Scenes/InsightOrDashboard/SceneExportDropdownMenu'
+import { SceneNotificationDropdownMenu } from 'lib/components/Scenes/InsightOrDashboard/SceneNotificationDropdownMenu'
+import { SceneCommonButtons } from 'lib/components/Scenes/SceneCommonButtons'
+import { SceneDescription } from 'lib/components/Scenes/SceneDescription'
+import { SceneFile } from 'lib/components/Scenes/SceneFile'
+import { SceneMetalyticsSummaryButton } from 'lib/components/Scenes/SceneMetalyticsSummaryButton'
+import { SceneName } from 'lib/components/Scenes/SceneName'
+import { SceneTags } from 'lib/components/Scenes/SceneTags'
+import { SceneActivityIndicator } from 'lib/components/Scenes/SceneUpdateActivityInfo'
+import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+import { useEffect, useState } from 'react'
+import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
+import {
+    ScenePanel,
+    ScenePanelActions,
+    ScenePanelCommonActions,
+    ScenePanelDivider,
+    ScenePanelMetaInfo,
+} from '~/layout/scenes/SceneLayout'
 import { addInsightToDashboardLogic } from './addInsightToDashboardModalLogic'
 import { DASHBOARD_RESTRICTION_OPTIONS } from './DashboardCollaborators'
 import { dashboardCollaboratorsLogic } from './dashboardCollaboratorsLogic'
 import { DashboardInsightColorsModal } from './DashboardInsightColorsModal'
 import { dashboardInsightColorsModalLogic } from './dashboardInsightColorsModalLogic'
 import { dashboardLogic } from './dashboardLogic'
-import { DashboardTemplateEditor } from './DashboardTemplateEditor'
 import { dashboardTemplateEditorLogic } from './dashboardTemplateEditorLogic'
 
 export const DASHBOARD_CANNOT_EDIT_MESSAGE =
@@ -77,6 +97,12 @@ export function DashboardHeader(): JSX.Element | null {
     const { tags } = useValues(tagsModel)
 
     const { push } = useActions(router)
+
+    const [isPinned, setIsPinned] = useState(dashboard?.pinned)
+
+    useEffect(() => {
+        setIsPinned(dashboard?.pinned)
+    }, [dashboard?.pinned, dashboardLoading])
 
     const hasDashboardColors = useFeatureFlag('DASHBOARD_COLORS')
 
@@ -181,6 +207,7 @@ export function DashboardHeader(): JSX.Element | null {
                                 overlay={
                                     dashboard ? (
                                         <>
+                                            {/* ✅ transfered to scene */}
                                             {dashboard.created_by && (
                                                 <>
                                                     <div className="flex p-2 text-secondary">
@@ -193,6 +220,7 @@ export function DashboardHeader(): JSX.Element | null {
                                                     <LemonDivider />
                                                 </>
                                             )}
+                                            {/* ✅ transfered to scene */}
                                             {canEditDashboard && hasDashboardColors && (
                                                 <LemonButton
                                                     onClick={() => showInsightColorsModal(dashboard.id)}
@@ -201,6 +229,8 @@ export function DashboardHeader(): JSX.Element | null {
                                                     Customize colors
                                                 </LemonButton>
                                             )}
+
+                                            {/* ✅ transfered to scene */}
                                             {canEditDashboard && (
                                                 <LemonButton
                                                     onClick={() =>
@@ -214,6 +244,8 @@ export function DashboardHeader(): JSX.Element | null {
                                                     Edit layout (E)
                                                 </LemonButton>
                                             )}
+
+                                            {/* ✅ transfered to scene */}
                                             <LemonButton
                                                 onClick={() =>
                                                     setDashboardMode(
@@ -225,6 +257,8 @@ export function DashboardHeader(): JSX.Element | null {
                                             >
                                                 Go full screen (F)
                                             </LemonButton>
+
+                                            {/* ✅ transfered to scene */}
                                             {canEditDashboard &&
                                                 (dashboard.pinned ? (
                                                     <LemonButton
@@ -251,8 +285,11 @@ export function DashboardHeader(): JSX.Element | null {
                                                         Pin dashboard
                                                     </LemonButton>
                                                 ))}
+                                            {/* ✅ transfered to scene */}
                                             <SubscribeButton dashboardId={dashboard.id} />
+                                            {/* ✅ transfered to scene */}
                                             <ExportButton fullWidth items={exportOptions} />
+                                            {/* ✅ transfered to scene */}
                                             {user?.is_staff && (
                                                 <LemonButton
                                                     onClick={() => {
@@ -267,6 +304,8 @@ export function DashboardHeader(): JSX.Element | null {
                                                 </LemonButton>
                                             )}
                                             <LemonDivider />
+
+                                            {/* ✅ transfered to scene */}
                                             <LemonButton
                                                 onClick={() => {
                                                     showDuplicateDashboardModal(dashboard.id, dashboard.name)
@@ -275,6 +314,8 @@ export function DashboardHeader(): JSX.Element | null {
                                             >
                                                 Duplicate dashboard
                                             </LemonButton>
+
+                                            {/* ✅ transfered to scene */}
                                             <LemonButton
                                                 onClick={() => createNotebookFromDashboard(dashboard)}
                                                 fullWidth
@@ -282,6 +323,7 @@ export function DashboardHeader(): JSX.Element | null {
                                                 Create notebook from dashboard
                                             </LemonButton>
 
+                                            {/* ✅ transfered to scene */}
                                             {canEditDashboard && (
                                                 <AccessControlledLemonButton
                                                     userAccessLevel={dashboard.user_access_level}
@@ -396,7 +438,196 @@ export function DashboardHeader(): JSX.Element | null {
                     </>
                 }
             />
-            <DashboardTemplateEditor />
+
+            <ScenePanel>
+                <ScenePanelMetaInfo>
+                    {dashboard && !!(canEditDashboard || dashboard.name) && (
+                        <>
+                            <SceneName
+                                defaultValue={dashboard.name || ''}
+                                onSave={(value) => updateDashboard({ id: dashboard.id, name: value, allowUndo: true })}
+                                dataAttr="dashboard-name"
+                            />
+                        </>
+                    )}
+                    {dashboard && !!(canEditDashboard || dashboard.description) && (
+                        <>
+                            <SceneDescription
+                                defaultValue={dashboard.description || ''}
+                                onSave={(value) =>
+                                    updateDashboard({ id: dashboard.id, description: value, allowUndo: true })
+                                }
+                                dataAttr="dashboard-description"
+                            />
+                        </>
+                    )}
+
+                    {dashboard?.tags && (
+                        <>
+                            {canEditDashboard ? (
+                                <SceneTags
+                                    onSave={(tags) => {
+                                        triggerDashboardUpdate({ tags })
+                                    }}
+                                    tags={dashboard.tags}
+                                    tagsAvailable={tags.filter((tag) => !dashboard.tags?.includes(tag))}
+                                    dataAttr="dashboard-tags"
+                                />
+                            ) : dashboard.tags.length ? (
+                                <SceneTags
+                                    tags={dashboard.tags}
+                                    tagsAvailable={tags.filter((tag) => !dashboard.tags?.includes(tag))}
+                                    dataAttr="dashboard-tags"
+                                />
+                            ) : null}
+                        </>
+                    )}
+                    <SceneFile />
+
+                    <SceneActivityIndicator at={dashboard?.created_at} by={dashboard?.created_by} prefix="Created" />
+                </ScenePanelMetaInfo>
+                <ScenePanelDivider />
+                <ScenePanelCommonActions>
+                    <SceneCommonButtons
+                        duplicate={
+                            dashboard
+                                ? { onClick: () => showDuplicateDashboardModal(dashboard.id, dashboard.name) }
+                                : undefined
+                        }
+                        {...(canEditDashboard &&
+                            dashboard && {
+                                pinned: {
+                                    onClick: () => {
+                                        if (isPinned) {
+                                            unpinDashboard(dashboard.id, DashboardEventSource.SceneCommonButtons)
+                                            setIsPinned(false)
+                                        } else {
+                                            pinDashboard(dashboard.id, DashboardEventSource.SceneCommonButtons)
+                                            setIsPinned(true)
+                                        }
+                                    },
+                                    active: isPinned,
+                                },
+                            })}
+                        fullscreen={
+                            dashboard
+                                ? {
+                                      onClick: () => {
+                                          if (dashboardMode === DashboardMode.Fullscreen) {
+                                              setDashboardMode(null, DashboardEventSource.SceneCommonButtons)
+                                          } else {
+                                              setDashboardMode(
+                                                  DashboardMode.Fullscreen,
+                                                  DashboardEventSource.SceneCommonButtons
+                                              )
+                                          }
+                                      },
+                                      active: dashboardMode === DashboardMode.Fullscreen,
+                                  }
+                                : undefined
+                        }
+                    />
+                </ScenePanelCommonActions>
+
+                <ScenePanelActions>
+                    {dashboard && <SceneMetalyticsSummaryButton />}
+
+                    {dashboard && canEditDashboard && hasDashboardColors && (
+                        <ButtonPrimitive onClick={() => showInsightColorsModal(dashboard.id)} menuItem>
+                            <IconPalette />
+                            Customize colors
+                        </ButtonPrimitive>
+                    )}
+                    {dashboard && canEditDashboard && (
+                        <ButtonPrimitive
+                            onClick={() =>
+                                setDashboardMode(DashboardMode.Edit, DashboardEventSource.SceneCommonButtons)
+                            }
+                            menuItem
+                            active={dashboardMode === DashboardMode.Edit}
+                        >
+                            <IconGridMasonry />
+                            Edit layout <KeyboardShortcut e />
+                        </ButtonPrimitive>
+                    )}
+
+                    {dashboard && canEditDashboard && (
+                        <ButtonPrimitive onClick={() => createNotebookFromDashboard(dashboard)} menuItem>
+                            <IconNotebook />
+                            Create notebook from dashboard
+                        </ButtonPrimitive>
+                    )}
+
+                    {dashboard && canEditDashboard && <SceneNotificationDropdownMenu dashboardId={dashboard.id} />}
+
+                    {dashboard && canEditDashboard && (
+                        <SceneExportDropdownMenu
+                            dropdownMenuItems={[
+                                {
+                                    format: ExporterFormat.PNG,
+                                    dashboard: dashboard.id,
+                                    context: {
+                                        path: apiUrl(),
+                                    },
+                                },
+                                ...(user?.is_staff
+                                    ? [
+                                          {
+                                              format: ExporterFormat.JSON,
+                                              context: {
+                                                  localData: JSON.stringify(asDashboardTemplate),
+                                                  filename: `dashboard-${slugify(
+                                                      dashboard?.name || 'nameless dashboard'
+                                                  )}.json`,
+                                                  mediaType: ExporterFormat.JSON,
+                                              },
+                                          },
+                                      ]
+                                    : []),
+                            ]}
+                        />
+                    )}
+
+                    {user?.is_staff && (
+                        <ButtonPrimitive
+                            onClick={() => {
+                                if (asDashboardTemplate) {
+                                    setDashboardTemplate(asDashboardTemplate)
+                                    openDashboardTemplateEditor()
+                                }
+                            }}
+                            menuItem
+                        >
+                            <IconScreen />
+                            Save as template
+                        </ButtonPrimitive>
+                    )}
+
+                    {dashboard && canEditDashboard && (
+                        <>
+                            <ScenePanelDivider />
+                            <AccessControlAction
+                                resourceType={AccessControlResourceType.Dashboard}
+                                minAccessLevel={AccessControlLevel.Editor}
+                                userAccessLevel={dashboard.user_access_level}
+                            >
+                                {({ disabledReason }) => (
+                                    <ButtonPrimitive
+                                        menuItem
+                                        variant="danger"
+                                        disabled={!!disabledReason}
+                                        {...(disabledReason && { tooltip: disabledReason })}
+                                        onClick={() => showDeleteDashboardModal(dashboard.id)}
+                                    >
+                                        <IconTrash />
+                                        Delete dashboard
+                                    </ButtonPrimitive>
+                                )}
+                            </AccessControlAction>
+                        </>
+                    )}
+                </ScenePanelActions>
+            </ScenePanel>
         </>
     ) : null
 }

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -126,7 +126,7 @@ export function DashboardHeader(): JSX.Element | null {
     }
     useEffect(() => {
         setIsPinned(dashboard?.pinned)
-    }, [dashboard?.pinned, dashboardLoading])
+    }, [dashboard?.pinned])
 
     return dashboard || dashboardLoading ? (
         <>

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -67,6 +67,8 @@ import { dashboardLogic } from './dashboardLogic'
 import { dashboardTemplateEditorLogic } from './dashboardTemplateEditorLogic'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
+const RESOURCE_TYPE = 'dashboard'
+
 export const DASHBOARD_CANNOT_EDIT_MESSAGE =
     "You don't have edit permissions for this dashboard. Ask a dashboard collaborator with edit access to add you."
 
@@ -448,54 +450,39 @@ export function DashboardHeader(): JSX.Element | null {
 
             <ScenePanel>
                 <ScenePanelMetaInfo>
-                    {dashboard && !!(canEditDashboard || dashboard.name) && (
-                        <>
-                            <SceneName
-                                defaultValue={dashboard.name || ''}
-                                onSave={(value) => updateDashboard({ id: dashboard.id, name: value, allowUndo: true })}
-                                dataAttr="dashboard-name"
-                            />
-                        </>
-                    )}
-                    {dashboard && !!(canEditDashboard || dashboard.description) && (
-                        <>
-                            <SceneDescription
-                                defaultValue={dashboard.description || ''}
-                                onSave={(value) =>
-                                    updateDashboard({ id: dashboard.id, description: value, allowUndo: true })
-                                }
-                                dataAttr="dashboard-description"
-                            />
-                        </>
-                    )}
+                    <SceneName
+                        defaultValue={dashboard?.name || ''}
+                        onSave={(value) => updateDashboard({ id: dashboard?.id, name: value, allowUndo: true })}
+                        dataAttrKey={RESOURCE_TYPE}
+                        canEdit={canEditDashboard}
+                    />
 
-                    {dashboard?.tags && (
-                        <>
-                            {canEditDashboard ? (
-                                <SceneTags
-                                    onSave={(tags) => {
-                                        triggerDashboardUpdate({ tags })
-                                    }}
-                                    tags={dashboard.tags}
-                                    tagsAvailable={tags.filter((tag) => !dashboard.tags?.includes(tag))}
-                                    dataAttr="dashboard-tags"
-                                />
-                            ) : dashboard.tags.length ? (
-                                <SceneTags
-                                    tags={dashboard.tags}
-                                    tagsAvailable={tags.filter((tag) => !dashboard.tags?.includes(tag))}
-                                    dataAttr="dashboard-tags"
-                                />
-                            ) : null}
-                        </>
-                    )}
-                    <SceneFile />
+                    <SceneDescription
+                        defaultValue={dashboard?.description || ''}
+                        onSave={(value) => updateDashboard({ id: dashboard?.id, description: value, allowUndo: true })}
+                        dataAttrKey={RESOURCE_TYPE}
+                        optional
+                        canEdit={canEditDashboard}
+                    />
+
+                    <SceneTags
+                        onSave={(tags) => {
+                            triggerDashboardUpdate({ tags })
+                        }}
+                        canEdit={canEditDashboard}
+                        tags={dashboard?.tags}
+                        tagsAvailable={tags.filter((tag) => !dashboard?.tags?.includes(tag))}
+                        dataAttrKey={RESOURCE_TYPE}
+                    />
+
+                    <SceneFile dataAttrKey={RESOURCE_TYPE} />
 
                     <SceneActivityIndicator at={dashboard?.created_at} by={dashboard?.created_by} prefix="Created" />
                 </ScenePanelMetaInfo>
                 <ScenePanelDivider />
                 <ScenePanelCommonActions>
                     <SceneCommonButtons
+                        dataAttrKey={RESOURCE_TYPE}
                         duplicate={
                             dashboard
                                 ? { onClick: () => showDuplicateDashboardModal(dashboard.id, dashboard.name) }
@@ -537,10 +524,14 @@ export function DashboardHeader(): JSX.Element | null {
                 </ScenePanelCommonActions>
 
                 <ScenePanelActions>
-                    {dashboard && <SceneMetalyticsSummaryButton />}
+                    {dashboard && <SceneMetalyticsSummaryButton dataAttrKey={RESOURCE_TYPE} />}
 
                     {dashboard && canEditDashboard && hasDashboardColors && (
-                        <ButtonPrimitive onClick={() => showInsightColorsModal(dashboard.id)} menuItem>
+                        <ButtonPrimitive
+                            onClick={() => showInsightColorsModal(dashboard.id)}
+                            menuItem
+                            data-attr={`${RESOURCE_TYPE}-customize-colors`}
+                        >
                             <IconPalette />
                             Customize colors
                         </ButtonPrimitive>
@@ -552,6 +543,7 @@ export function DashboardHeader(): JSX.Element | null {
                             }
                             menuItem
                             active={dashboardMode === DashboardMode.Edit}
+                            data-attr={`${RESOURCE_TYPE}-edit-layout`}
                         >
                             <IconGridMasonry />
                             Edit layout <KeyboardShortcut e />
@@ -559,13 +551,19 @@ export function DashboardHeader(): JSX.Element | null {
                     )}
 
                     {dashboard && canEditDashboard && (
-                        <ButtonPrimitive onClick={() => createNotebookFromDashboard(dashboard)} menuItem>
+                        <ButtonPrimitive
+                            onClick={() => createNotebookFromDashboard(dashboard)}
+                            menuItem
+                            data-attr={`${RESOURCE_TYPE}-create-notebook-from-dashboard`}
+                        >
                             <IconNotebook />
                             Create notebook from dashboard
                         </ButtonPrimitive>
                     )}
 
-                    {dashboard && canEditDashboard && <SceneNotificationDropdownMenu dashboardId={dashboard.id} />}
+                    {dashboard && canEditDashboard && (
+                        <SceneNotificationDropdownMenu dashboardId={dashboard.id} dataAttrKey={RESOURCE_TYPE} />
+                    )}
 
                     {dashboard && canEditDashboard && (
                         <SceneExportDropdownMenu
@@ -576,6 +574,7 @@ export function DashboardHeader(): JSX.Element | null {
                                     context: {
                                         path: apiUrl(),
                                     },
+                                    dataAttr: `${RESOURCE_TYPE}-export-png`,
                                 },
                                 ...(user?.is_staff
                                     ? [
@@ -588,6 +587,7 @@ export function DashboardHeader(): JSX.Element | null {
                                                   )}.json`,
                                                   mediaType: ExporterFormat.JSON,
                                               },
+                                              dataAttr: `${RESOURCE_TYPE}-export-json`,
                                           },
                                       ]
                                     : []),

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -86,6 +86,8 @@ import {
     QueryBasedInsightModel,
 } from '~/types'
 
+const RESOURCE_TYPE = 'insight'
+
 export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: InsightLogicProps }): JSX.Element {
     // insightSceneLogic
     const { insightMode, itemId, alertId, filtersOverride, variablesOverride } = useValues(insightSceneLogic)
@@ -580,38 +582,33 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
             <ScenePanel>
                 <>
                     <ScenePanelMetaInfo>
-                        {!!(canEditInsight || insight.name) && (
-                            <>
-                                <SceneName
-                                    defaultValue={insight.name || insight.derived_name || ''}
-                                    onSave={(value) => setInsightMetadata({ name: value })}
-                                    dataAttr="insight-name"
-                                />
-                            </>
-                        )}
+                        <SceneName
+                            defaultValue={insight.name || insight.derived_name || ''}
+                            onSave={(value) => setInsightMetadata({ name: value })}
+                            dataAttrKey={RESOURCE_TYPE}
+                            canEdit={canEditInsight}
+                        />
 
-                        {!!(canEditInsight || insight.description) && (
-                            <>
-                                <SceneDescription
-                                    defaultValue={insight.description || ''}
-                                    onSave={(value) => setInsightMetadata({ description: value })}
-                                    dataAttr="insight-description"
-                                />
-                            </>
-                        )}
+                        <SceneDescription
+                            defaultValue={insight.description || ''}
+                            onSave={(value) => setInsightMetadata({ description: value })}
+                            dataAttrKey={RESOURCE_TYPE}
+                            optional
+                            canEdit={canEditInsight}
+                        />
 
-                        {canEditInsight && (
-                            <SceneTags
-                                onSave={(tags) => {
-                                    setInsightMetadata({ tags })
-                                    setTags(tags)
-                                }}
-                                tags={tags}
-                                tagsAvailable={allExistingTags}
-                                dataAttr="insight-tags"
-                            />
-                        )}
-                        <SceneFile />
+                        <SceneTags
+                            onSave={(tags) => {
+                                setInsightMetadata({ tags })
+                                setTags(tags)
+                            }}
+                            tags={tags}
+                            tagsAvailable={allExistingTags}
+                            dataAttrKey={RESOURCE_TYPE}
+                            canEdit={canEditInsight}
+                        />
+
+                        <SceneFile dataAttrKey={RESOURCE_TYPE} />
                         <SceneActivityIndicator
                             at={insight.last_modified_at}
                             by={insight.last_modified_by}
@@ -623,6 +620,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
 
                     <ScenePanelCommonActions>
                         <SceneCommonButtons
+                            dataAttrKey={RESOURCE_TYPE}
                             duplicate={
                                 hasDashboardItemId
                                     ? {
@@ -640,7 +638,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                     </ScenePanelCommonActions>
 
                     <ScenePanelActions>
-                        {hasDashboardItemId && <SceneMetalyticsSummaryButton />}
+                        {hasDashboardItemId && <SceneMetalyticsSummaryButton dataAttrKey={RESOURCE_TYPE} />}
 
                         <SceneAddToDropdownMenu
                             notebook={hasDashboardItemId}
@@ -657,7 +655,11 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                         />
 
                         {hasDashboardItemId && (
-                            <SceneNotificationDropdownMenu insight={insight} insightLogicProps={insightLogicProps} />
+                            <SceneNotificationDropdownMenu
+                                insight={insight}
+                                insightLogicProps={insightLogicProps}
+                                dataAttrKey={RESOURCE_TYPE}
+                            />
                         )}
 
                         {hasDashboardItemId && (
@@ -667,6 +669,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                     onClick: () =>
                                         insight.short_id ? push(urls.insightSharing(insight.short_id)) : null,
                                 }}
+                                dataAttrKey={RESOURCE_TYPE}
                             >
                                 <IconShare />
                                 Share or embed
@@ -719,14 +722,17 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                     {
                                         format: ExporterFormat.PNG,
                                         insight: insight.id,
+                                        dataAttr: `${RESOURCE_TYPE}-export-png`,
                                     },
                                     {
                                         format: ExporterFormat.CSV,
                                         context: exportContext,
+                                        dataAttr: `${RESOURCE_TYPE}-export-csv`,
                                     },
                                     {
                                         format: ExporterFormat.XLSX,
                                         context: exportContext,
+                                        dataAttr: `${RESOURCE_TYPE}-export-xlsx`,
                                     },
                                 ]}
                             />
@@ -736,7 +742,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                             !isHogQLQuery(query) &&
                             !(isDataVisualizationNode(query) && isHogQLQuery(query.source)) && (
                                 <ButtonPrimitive
-                                    data-attr="edit-insight-sql"
+                                    data-attr={`${RESOURCE_TYPE}-edit-sql`}
                                     onClick={() => {
                                         router.actions.push(urls.sqlEditor(hogQL))
                                     }}
@@ -749,7 +755,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
 
                         {hogQL && showCohortButton && (
                             <ButtonPrimitive
-                                data-attr="edit-insight-sql"
+                                data-attr={`${RESOURCE_TYPE}-save-as-cohort`}
                                 onClick={() => {
                                     LemonDialog.openForm({
                                         title: 'Save as static cohort',
@@ -766,7 +772,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                         content: (
                                             <LemonField name="name">
                                                 <LemonInput
-                                                    data-attr="insight-name"
+                                                    data-attr={`${RESOURCE_TYPE}-save-as-cohort-name`}
                                                     placeholder="Name of the new cohort"
                                                     autoFocus
                                                 />
@@ -791,7 +797,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                         <ScenePanelDivider />
 
                         <LemonSwitch
-                            data-attr={`${showQueryEditor ? 'hide' : 'show'}-insight-source`}
+                            data-attr={`${RESOURCE_TYPE}-${showQueryEditor ? 'hide' : 'show'}-source`}
                             className="px-2 py-1"
                             checked={showQueryEditor}
                             onChange={() => {
@@ -813,7 +819,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
 
                         {hasDashboardItemId && (user?.is_staff || user?.is_impersonated || !preflight?.cloud) ? (
                             <LemonSwitch
-                                data-attr="toggle-debug-panel"
+                                data-attr={`${RESOURCE_TYPE}-toggle-debug-panel`}
                                 className="px-2 py-1"
                                 checked={showDebugPanel}
                                 onChange={() => {
@@ -837,6 +843,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                             variant="danger"
                                             disabled={!!disabledReason}
                                             {...(disabledReason && { tooltip: disabledReason })}
+                                            data-attr={`${RESOURCE_TYPE}-delete`}
                                             onClick={() =>
                                                 void deleteInsightWithUndo({
                                                     object: insight as QueryBasedInsightModel,

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -652,6 +652,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                     : undefined
                             }
                             shortId={insight.short_id}
+                            dataAttrKey={RESOURCE_TYPE}
                         />
 
                         {hasDashboardItemId && (


### PR DESCRIPTION
## Problem
Converting all products to new minimal layout

- [x] [Product analytics](https://github.com/PostHog/posthog/pull/35033) 
- [ ] Dashboards
- [ ] Actions

## Changes
Add `<SceneLayout>` to dashboard header & ActionEdit, recreate any buttons in there/ or re-use common `components/Scenes/` components. Hide page captions and More dropdowns.
Add required `dataAttrKey` to most new scene components to ensure proper tracking is done at a resource level.
Hide X (close panel) and Info icon when new scene panel is `relative` (no overlay)

> !!! Sorry for the big PR, but it's necessary as we want to force tracking (people are getting interested)

#### Dashboars
![2025-07-17 14 28 24](https://github.com/user-attachments/assets/decd5e3f-6fd2-4527-8264-47d51be93f0f)

#### Actions
![2025-07-21 12 05 10](https://github.com/user-attachments/assets/4959d3a9-0810-4fe2-8a8b-e1fda8b3580e)


## How did you test this code?
Manually

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change
