### PR TITLE
feat(max): Support multiple state types

### DIFF
--- a/ee/hogai/assistant.py
+++ b/ee/hogai/assistant.py
@@ -26,7 +26,7 @@ from ee.hogai.graph import (
     SQLGeneratorNode,
     TrendsGeneratorNode,
 )
-from ee.hogai.graph.base import BaseAssistantNode
+from ee.hogai.graph.base import AssistantNode
 from ee.hogai.tool import CONTEXTUAL_TOOL_NAME_TO_TOOL
 from ee.hogai.utils.exceptions import GenerationCanceled
 from ee.hogai.utils.helpers import find_last_ui_context, should_output_assistant_message
@@ -72,7 +72,7 @@ VISUALIZATION_NODES: dict[AssistantNodeName, type[SchemaGeneratorNode]] = {
     AssistantNodeName.SQL_GENERATOR: SQLGeneratorNode,
 }
 
-VISUALIZATION_NODES_TOOL_CALL_MODE: dict[AssistantNodeName, type[BaseAssistantNode]] = {
+VISUALIZATION_NODES_TOOL_CALL_MODE: dict[AssistantNodeName, type[AssistantNode]] = {
     **VISUALIZATION_NODES,
     AssistantNodeName.QUERY_EXECUTOR: QueryExecutorNode,
 }
@@ -417,7 +417,7 @@ class Assistant:
         state_update = validate_value_update(maybe_state_update)
         # this needs full type annotation otherwise mypy complains
         visualization_nodes: (
-            dict[AssistantNodeName, type[BaseAssistantNode]] | dict[AssistantNodeName, type[SchemaGeneratorNode]]
+            dict[AssistantNodeName, type[AssistantNode]] | dict[AssistantNodeName, type[SchemaGeneratorNode]]
         ) = VISUALIZATION_NODES if self._mode == AssistantMode.ASSISTANT else VISUALIZATION_NODES_TOOL_CALL_MODE
         if intersected_nodes := state_update.keys() & visualization_nodes.keys():
             # Reset chunks when schema validation fails.

--- a/ee/hogai/assistant.py
+++ b/ee/hogai/assistant.py
@@ -26,7 +26,7 @@ from ee.hogai.graph import (
     SQLGeneratorNode,
     TrendsGeneratorNode,
 )
-from ee.hogai.graph.base import AssistantNode
+from ee.hogai.graph.base import BaseAssistantNode
 from ee.hogai.tool import CONTEXTUAL_TOOL_NAME_TO_TOOL
 from ee.hogai.utils.exceptions import GenerationCanceled
 from ee.hogai.utils.helpers import find_last_ui_context, should_output_assistant_message
@@ -72,7 +72,7 @@ VISUALIZATION_NODES: dict[AssistantNodeName, type[SchemaGeneratorNode]] = {
     AssistantNodeName.SQL_GENERATOR: SQLGeneratorNode,
 }
 
-VISUALIZATION_NODES_TOOL_CALL_MODE: dict[AssistantNodeName, type[AssistantNode]] = {
+VISUALIZATION_NODES_TOOL_CALL_MODE: dict[AssistantNodeName, type[BaseAssistantNode]] = {
     **VISUALIZATION_NODES,
     AssistantNodeName.QUERY_EXECUTOR: QueryExecutorNode,
 }
@@ -417,7 +417,7 @@ class Assistant:
         state_update = validate_value_update(maybe_state_update)
         # this needs full type annotation otherwise mypy complains
         visualization_nodes: (
-            dict[AssistantNodeName, type[AssistantNode]] | dict[AssistantNodeName, type[SchemaGeneratorNode]]
+            dict[AssistantNodeName, type[BaseAssistantNode]] | dict[AssistantNodeName, type[SchemaGeneratorNode]]
         ) = VISUALIZATION_NODES if self._mode == AssistantMode.ASSISTANT else VISUALIZATION_NODES_TOOL_CALL_MODE
         if intersected_nodes := state_update.keys() & visualization_nodes.keys():
             # Reset chunks when schema validation fails.

--- a/ee/hogai/graph/base.py
+++ b/ee/hogai/graph/base.py
@@ -14,11 +14,15 @@ from posthog.models import Team
 from posthog.models.user import User
 from posthog.schema import AssistantMessage, AssistantToolCall, MaxUIContext
 from posthog.sync import database_sync_to_async
-
+from pydantic import BaseModel
+from typing import TypeVar, Generic
 from ..utils.types import AssistantMessageUnion, AssistantState, PartialAssistantState
 
+StateType = TypeVar("StateType", bound=BaseModel)
+PartialStateType = TypeVar("PartialStateType", bound=BaseModel)
 
-class AssistantNode(ABC):
+
+class BaseAssistantNode(ABC, Generic[StateType, PartialStateType]):
     _team: Team
     _user: User
 
@@ -26,7 +30,7 @@ class AssistantNode(ABC):
         self._team = team
         self._user = user
 
-    async def __call__(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState | None:
+    async def __call__(self, state: StateType, config: RunnableConfig) -> PartialStateType | None:
         """
         Run the assistant node and handle cancelled conversation before the node is run.
         """
@@ -39,11 +43,11 @@ class AssistantNode(ABC):
             return await database_sync_to_async(self.run, thread_sensitive=False)(state, config)
 
     # DEPRECATED: Use `arun` instead
-    def run(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState | None:
+    def run(self, state: StateType, config: RunnableConfig) -> PartialStateType | None:
         """DEPRECATED. Use `arun` instead."""
         raise NotImplementedError
 
-    async def arun(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState | None:
+    async def arun(self, state: StateType, config: RunnableConfig) -> PartialStateType | None:
         raise NotImplementedError
 
     async def _aget_conversation(self, conversation_id: UUID) -> Conversation | None:
@@ -126,11 +130,13 @@ class AssistantNode(ABC):
             raise ValueError("Contextual tools must be a dictionary of tool names to tool context")
         return contextual_tools
 
-    def _get_ui_context(self, state: AssistantState) -> MaxUIContext | None:
+    def _get_ui_context(self, state: StateType) -> MaxUIContext | None:
         """
         Extracts the UI context from the latest human message.
         """
-        return find_last_ui_context(state.messages)
+        if hasattr(state, "messages"):
+            return find_last_ui_context(state.messages)
+        return None
 
     def _get_user_distinct_id(self, config: RunnableConfig) -> Any | None:
         """
@@ -143,3 +149,6 @@ class AssistantNode(ABC):
         Extracts the trace ID from the runnable config.
         """
         return (config.get("configurable") or {}).get("trace_id") or None
+
+
+AssistantNode = BaseAssistantNode[AssistantState, PartialAssistantState]

--- a/ee/hogai/graph/graph.py
+++ b/ee/hogai/graph/graph.py
@@ -1,15 +1,13 @@
 from collections.abc import Hashable
-from typing import Literal, Optional, cast, TypeVar, Generic
+from typing import Literal, Optional, cast, Generic
 
 from langchain_core.runnables.base import RunnableLike
 from langgraph.graph.state import StateGraph
-
 
 from ee.hogai.django_checkpoint.checkpointer import DjangoCheckpointer
 from ee.hogai.graph.query_planner.nodes import QueryPlannerNode, QueryPlannerToolsNode
 from ee.hogai.graph.title_generator.nodes import TitleGeneratorNode
 from ee.hogai.utils.types import AssistantNodeName, AssistantState
-from .base import AssistantNode, BaseAssistantNode, StateType
 from posthog.models.team.team import Team
 from posthog.models.user import User
 
@@ -37,16 +35,16 @@ from .retention.nodes import (
 from .root.nodes import RootNode, RootNodeTools
 from .sql.nodes import SQLGeneratorNode, SQLGeneratorToolsNode
 from .trends.nodes import TrendsGeneratorNode, TrendsGeneratorToolsNode
-
+from .base import StateType
 from .insights.nodes import InsightSearchNode
 
 global_checkpointer = DjangoCheckpointer()
 
-# Type variable for assistant node types
-NodeType = TypeVar("NodeType", bound="BaseAssistantNode")
+# Type variable for assistant state types
+# StateType = TypeVar("StateType", bound=BaseModel)
 
 
-class BaseAssistantGraph(Generic[NodeType]):
+class BaseAssistantGraph(Generic[StateType]):
     _team: Team
     _user: User
     _graph: StateGraph
@@ -73,7 +71,7 @@ class BaseAssistantGraph(Generic[NodeType]):
         return self._graph.compile(checkpointer=checkpointer or global_checkpointer)
 
 
-class InsightsAssistantGraph(BaseAssistantGraph[AssistantNode]):
+class InsightsAssistantGraph(BaseAssistantGraph[AssistantState]):
     def __init__(self, team: Team, user: User):
         super().__init__(team, user, AssistantState)
 
@@ -222,7 +220,7 @@ class InsightsAssistantGraph(BaseAssistantGraph[AssistantNode]):
         return self.add_query_creation_flow().add_query_executor().compile(checkpointer=checkpointer)
 
 
-class AssistantGraph(BaseAssistantGraph[AssistantNode]):
+class AssistantGraph(BaseAssistantGraph[AssistantState]):
     def __init__(self, team: Team, user: User):
         super().__init__(team, user, AssistantState)
 

--- a/ee/hogai/graph/graph.py
+++ b/ee/hogai/graph/graph.py
@@ -40,9 +40,6 @@ from .insights.nodes import InsightSearchNode
 
 global_checkpointer = DjangoCheckpointer()
 
-# Type variable for assistant state types
-# StateType = TypeVar("StateType", bound=BaseModel)
-
 
 class BaseAssistantGraph(Generic[StateType]):
     _team: Team


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
In order to build more complicated workflows and to be able to support subgraphs with different states in a graph we should extend the classes to support generic state types and generic node types.

## Changes
1. Introduced Generic StateType and PartialStateType
3. Used the Generic types in the AssistantGraph and the InsightsAssistantGraph

## How did you test this code?
1. Unnittests all pass
2. Manual testing things like insight creation etc.

## Did you write or update any docs for this change?
No

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
