### PR TITLE
fix: replace null bytes in distinct_id in capture

### DIFF
--- a/rust/capture/tests/events.rs
+++ b/rust/capture/tests/events.rs
@@ -1004,6 +1004,45 @@ async fn it_trims_distinct_id() -> Result<()> {
 }
 
 #[tokio::test]
+async fn it_replaces_null_chars_in_distinct_id() -> Result<()> {
+    setup_tracing();
+    let token = random_string("token", 16);
+
+    let main_topic = EphemeralTopic::new().await;
+    let histo_topic = EphemeralTopic::new().await;
+    let server = ServerHandle::for_topics(&main_topic, &histo_topic).await;
+
+    // Test cases with null bytes in different positions
+    let test_cases = [
+        ("user123\0\0\0id", "user123\u{FFFD}\u{FFFD}\u{FFFD}id"), // nulls in middle
+        ("\0\0user123", "\u{FFFD}\u{FFFD}user123"), // nulls at beginning
+        ("user123\0\0", "user123\u{FFFD}\u{FFFD}"), // nulls at end
+        ("\0user\0id\0", "\u{FFFD}user\u{FFFD}id\u{FFFD}"), // nulls scattered
+    ];
+
+    for (input_id, expected_id) in test_cases {
+        let event = json!({
+            "token": token,
+            "event": "testing",
+            "distinct_id": input_id
+        });
+        let res = server.capture_events(event.to_string()).await;
+        assert_eq!(StatusCode::OK, res.status());
+
+        let event = main_topic.next_event()?;
+        assert_json_include!(
+            actual: event,
+            expected: json!({
+                "token": token,
+                "distinct_id": expected_id
+            })
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn it_applies_billing_limits() -> Result<()> {
     setup_tracing();
     let token1 = random_string("token", 16);

--- a/rust/capture/tests/events.rs
+++ b/rust/capture/tests/events.rs
@@ -1015,9 +1015,9 @@ async fn it_replaces_null_chars_in_distinct_id() -> Result<()> {
     // Test cases with null bytes in different positions
     let test_cases = [
         ("user123\0\0\0id", "user123\u{FFFD}\u{FFFD}\u{FFFD}id"), // nulls in middle
-        ("\0\0user123", "\u{FFFD}\u{FFFD}user123"), // nulls at beginning
-        ("user123\0\0", "user123\u{FFFD}\u{FFFD}"), // nulls at end
-        ("\0user\0id\0", "\u{FFFD}user\u{FFFD}id\u{FFFD}"), // nulls scattered
+        ("\0\0user123", "\u{FFFD}\u{FFFD}user123"),               // nulls at beginning
+        ("user123\0\0", "user123\u{FFFD}\u{FFFD}"),               // nulls at end
+        ("\0user\0id\0", "\u{FFFD}user\u{FFFD}id\u{FFFD}"),       // nulls scattered
     ];
 
     for (input_id, expected_id) in test_cases {

--- a/rust/common/types/src/event.rs
+++ b/rust/common/types/src/event.rs
@@ -208,6 +208,10 @@ impl RawEvent {
             .as_str()
             .map(|s| s.to_owned())
             .unwrap_or_else(|| value.to_string());
+
+        // Replace null characters with Unicode replacement character
+        let distinct_id = distinct_id.replace('\0', "\u{FFFD}");
+
         match distinct_id.len() {
             0 => None,
             1..=200 => Some(distinct_id),


### PR DESCRIPTION
## Problem

We allow null bytes in distinct_ids in capture and that causes some mismatches with headers in ingestion.

## Changes

- Replaces null bytes in distinct ids with unicode replacement characters, as in ingestion

## How did you test this code?

- Added a unit test

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [X] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
