### PR TITLE
refactor(max): Improve session replay prompts

### DIFF
--- a/ee/hogai/eval/eval_session_recording_filters.py
+++ b/ee/hogai/eval/eval_session_recording_filters.py
@@ -1,0 +1,507 @@
+import pytest
+from braintrust import EvalCase
+
+from posthog.schema import (
+    DurationType,
+    FilterLogicalOperator,
+    MaxInnerUniversalFiltersGroup,
+    MaxOuterUniversalFiltersGroup,
+    MaxRecordingUniversalFilters,
+    PropertyOperator,
+    RecordingDurationFilter,
+    EventPropertyFilter,
+    PersonPropertyFilter,
+)
+from products.replay.backend.max_tools import SearchSessionRecordingsTool
+
+from ee.hogai.utils.types import AssistantState
+from .conftest import MaxEval
+import json
+from autoevals.partial import ScorerWithPartial
+from braintrust import Score
+
+
+class FilterScorer(ScorerWithPartial):
+    def _name(self):
+        return "recording_filter_scorer"
+
+    def _run_eval_sync(self, output, expected=None, **kwargs):
+        # Compare Pydantic models by their dictionary representation
+        if expected is None:
+            return Score(name=self._name(), score=0, metadata={"description": "No expected value provided"})
+
+        # Convert both to dict for comparison, handling None cases
+        output_dict = output.model_dump() if hasattr(output, "model_dump") else output
+        expected_dict = expected.model_dump() if hasattr(expected, "model_dump") else expected
+
+        if output_dict == expected_dict:
+            return Score(name=self._name(), score=1, metadata={"description": "Filters are correct"})
+        else:
+            return Score(name=self._name(), score=0, metadata={"description": "Filters are incorrect"})
+
+
+@pytest.fixture
+def call_search_session_recordings(demo_org_team_user):
+    def callable(change: str) -> MaxRecordingUniversalFilters:
+        """Call the SearchSessionRecordingsTool and return the generated filters."""
+        tool = SearchSessionRecordingsTool()
+        # Initialize required attributes manually since we're not using the proper constructor
+        tool._context = {
+            "current_filters": json.dumps(
+                MaxRecordingUniversalFilters(
+                    date_from="-30d",
+                    date_to=None,
+                    filter_test_accounts=True,
+                    duration=[
+                        RecordingDurationFilter(
+                            key=DurationType.DURATION,
+                            operator=PropertyOperator.EXACT,
+                            value=60.0,
+                            type="recording",
+                        )
+                    ],
+                    filter_group=MaxOuterUniversalFiltersGroup(
+                        type=FilterLogicalOperator.AND_,
+                        values=[
+                            MaxInnerUniversalFiltersGroup(
+                                type=FilterLogicalOperator.AND_,
+                                values=[
+                                    EventPropertyFilter(
+                                        key="$level",
+                                        value=["error"],
+                                        operator=PropertyOperator.EXACT,
+                                        type="event",
+                                    )
+                                ],
+                            )
+                        ],
+                    ),
+                ).model_dump_json()
+            )
+        }
+        tool._team = demo_org_team_user[1]
+        tool._user = demo_org_team_user[2]
+        tool._config = {}
+        tool._state = AssistantState(messages=[])
+
+        # The tool returns a tuple of (message, filters)
+        _, filters = tool._run_impl(change)
+        return filters
+
+    return callable
+
+
+@pytest.mark.django_db
+async def eval_session_recording_filters(call_search_session_recordings):
+    await MaxEval(
+        experiment_name="session_recording_filters",
+        task=call_search_session_recordings,
+        scores=[FilterScorer()],
+        data=[
+            EvalCase(
+                input="Show me recordings where users in Germany signed up and had an ai error",
+                expected=MaxRecordingUniversalFilters(
+                    date_from="-30d",
+                    date_to=None,
+                    filter_test_accounts=True,
+                    filter_group=MaxOuterUniversalFiltersGroup(
+                        type=FilterLogicalOperator.AND_,
+                        values=[
+                            MaxInnerUniversalFiltersGroup(
+                                type=FilterLogicalOperator.AND_,
+                                values=[
+                                    PersonPropertyFilter(
+                                        key="$geoip_country_name",
+                                        value=["Germany"],
+                                        operator=PropertyOperator.EXACT,
+                                        type="person",
+                                    ),
+                                    EventPropertyFilter(
+                                        key="$signup",
+                                        value=["true"],
+                                        operator=PropertyOperator.EXACT,
+                                        type="event",
+                                    ),
+                                    EventPropertyFilter(
+                                        key="$ai_error",
+                                        value=["error"],
+                                        operator=PropertyOperator.EXACT,
+                                        type="event",
+                                    ),
+                                    EventPropertyFilter(
+                                        key="$level",
+                                        value=["error"],
+                                        operator=PropertyOperator.EXACT,
+                                        type="event",
+                                    ),
+                                ],
+                            )
+                        ],
+                    ),
+                    duration=[
+                        RecordingDurationFilter(
+                            key=DurationType.DURATION,
+                            operator=PropertyOperator.EXACT,
+                            value=60.0,
+                            type="recording",
+                        )
+                    ],
+                    order=None,
+                ),
+            ),
+            EvalCase(
+                input="Show me recordings where users converted or used an ai model named gpt4o",
+                expected=MaxRecordingUniversalFilters(
+                    date_from="-30d",
+                    date_to=None,
+                    filter_test_accounts=True,
+                    filter_group=MaxOuterUniversalFiltersGroup(
+                        type=FilterLogicalOperator.AND_,
+                        values=[
+                            MaxInnerUniversalFiltersGroup(
+                                type=FilterLogicalOperator.AND_,
+                                values=[
+                                    EventPropertyFilter(
+                                        key="$level",
+                                        value=["error"],
+                                        operator=PropertyOperator.EXACT,
+                                        type="event",
+                                    )
+                                ],
+                            ),
+                            MaxInnerUniversalFiltersGroup(
+                                type=FilterLogicalOperator.OR_,
+                                values=[
+                                    EventPropertyFilter(
+                                        key="converted",
+                                        value=["true"],
+                                        operator=PropertyOperator.EXACT,
+                                        type="event",
+                                    ),
+                                    EventPropertyFilter(
+                                        key="$ai_model",
+                                        value=["gpt4o"],
+                                        operator=PropertyOperator.EXACT,
+                                        type="event",
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                    duration=[
+                        RecordingDurationFilter(
+                            key=DurationType.DURATION,
+                            operator=PropertyOperator.EXACT,
+                            value=60.0,
+                            type="recording",
+                        )
+                    ],
+                    order=None,
+                ),
+            ),
+            # EvalCase(
+            #     input="Show recordings longer than 5 minutes",
+            #     expected=MaxRecordingUniversalFilters(
+            #         date_from="-30d",
+            #         date_to=None,
+            #         filter_test_accounts=True,
+            #         filter_group={
+            #             "type": "AND",
+            #             "values": [
+            #                 {
+            #                     "type": "AND",
+            #                     "values": [
+            #                         {
+            #                         }
+            #                     ],
+            #                 }
+            #             ],
+            #         },
+            #         duration=[
+            #             RecordingDurationFilter(
+            #                 key=DurationType.DURATION,
+            #                 operator=PropertyOperator.GT,
+            #                 value=300.0,
+            #                 type="recording",
+            #             )
+            #         ],
+            #         order=None,
+            #     ),
+            # ),
+            # EvalCase(
+            #     input="Find recordings where users visited the pricing page and are from the US",
+            #     expected=MaxRecordingUniversalFilters(
+            #         date_from="-30d",
+            #         date_to=None,
+            #         filter_test_accounts=True,
+            #         filter_group={
+            #             "type": "AND",
+            #             "values": [
+            #                 {
+            #                     "type": "AND",
+            #                     "values": [
+            #                         {
+            #                             "id": "$pageview",
+            #                             "name": "$pageview",
+            #                             "type": "events",
+            #                             "properties": [
+            #                                 {
+            #                                     "key": "$current_url",
+            #                                     "value": ["pricing"],
+            #                                     "operator": "icontains",
+            #                                     "type": "event",
+            #                                 }
+            #                             ],
+            #                         },
+            #                         {
+            #                             "key": "$geoip_country_code",
+            #                             "value": ["US"],
+            #                             "operator": "exact",
+            #                             "type": "person",
+            #                         },
+            #                     ],
+            #                 }
+            #             ],
+            #         },
+            #         duration=[],
+            #         order=None,
+            #     ),
+            # ),
+            # EvalCase(
+            #     input="Show recordings with rage clicks or console errors",
+            #     expected=MaxRecordingUniversalFilters(
+            #         date_from="-30d",
+            #         date_to=None,
+            #         filter_test_accounts=True,
+            #         filter_group={
+            #             "type": "OR",
+            #             "values": [
+            #                 {
+            #                     "id": "$rageclick",
+            #                     "name": "$rageclick",
+            #                     "type": "events",
+            #                 },
+            #                 {
+            #                     "key": "level",
+            #                     "value": ["error"],
+            #                     "operator": "exact",
+            #                     "type": "log_entry",
+            #                 },
+            #             ],
+            #         },
+            #         duration=[RecordingDurationFilter(
+            #             key=DurationType.ACTIVE_SECONDS,
+            #             operator=PropertyOperator.LT,
+            #             value=30,
+            #             type="recording",
+            #         )],
+            #         order=None,
+            #     ),
+            # ),
+            # EvalCase(
+            #     input="Find recordings from mobile users who signed up",
+            #     expected=MaxRecordingUniversalFilters(
+            #         date_from="-30d",
+            #         date_to=None,
+            #         filter_test_accounts=True,
+            #         filter_group={
+            #             "type": "AND",
+            #             "values": [
+            #                 {
+            #                     "type": "AND",
+            #                     "values": [
+            #                         {
+            #                             "id": "signed_up",
+            #                             "name": "signed_up",
+            #                             "type": "events",
+            #                         },
+            #                         {
+            #                             "key": "$device_type",
+            #                             "value": ["mobile"],
+            #                             "operator": "exact",
+            #                             "type": "person",
+            #                         },
+            #                     ],
+            #                 }
+            #             ],
+            #         },
+            #         duration=[RecordingDurationFilter(
+            #             key=DurationType.ACTIVE_SECONDS,
+            #             operator=PropertyOperator.LT,
+            #             value=30,
+            #             type="recording",
+            #         )],
+            #         order=None,
+            #     ),
+            # ),
+            # EvalCase(
+            #     input="Show recordings with console warnings containing 'deprecated'",
+            #     expected=MaxRecordingUniversalFilters(
+            #         date_from="-30d",
+            #         date_to=None,
+            #         filter_test_accounts=True,
+            #         filter_group={
+            #             "type": "AND",
+            #             "values": [
+            #                 {
+            #                     "type": "AND",
+            #                     "values": [
+            #                         {
+            #                             "key": "level",
+            #                             "value": ["warn"],
+            #                             "operator": "exact",
+            #                             "type": "log_entry",
+            #                         },
+            #                         {
+            #                             "key": "message",
+            #                             "value": ["deprecated"],
+            #                             "operator": "icontains",
+            #                             "type": "log_entry",
+            #                         },
+            #                     ],
+            #                 }
+            #             ],
+            #         },
+            #         duration=[RecordingDurationFilter(
+            #             key=DurationType.ACTIVE_SECONDS,
+            #             operator=PropertyOperator.LT,
+            #             value=30,
+            #             type="recording",
+            #         )],
+            #         order=None,
+            #     ),
+            # ),
+            # EvalCase(
+            #     input="Find recordings with active time less than 30 seconds",
+            #     expected=MaxRecordingUniversalFilters(
+            #         date_from="-30d",
+            #         date_to=None,
+            #         filter_test_accounts=True,
+            #         filter_group={
+            #             "type": "AND",
+            #             "values": [
+            #                 {
+            #                     "type": "AND",
+            #                     "values": [],
+            #                 }
+            #             ],
+            #         },
+            #         duration=[
+            #             {
+            #                 "key": "active_seconds",
+            #                 "operator": "lt",
+            #                 "value": 30,
+            #                 "type": "recording",
+            #             }
+            #         ],
+            #         order=None,
+            #     ),
+            # ),
+            # EvalCase(
+            #     input="Show recordings from users with email containing '@gmail.com' who visited the dashboard",
+            #     expected=MaxRecordingUniversalFilters(
+            #         date_from="-30d",
+            #         date_to=None,
+            #         filter_test_accounts=True,
+            #         filter_group={
+            #             "type": "AND",
+            #             "values": [
+            #                 {
+            #                     "type": "AND",
+            #                     "values": [
+            #                         {
+            #                             "id": "$pageview",
+            #                             "name": "$pageview",
+            #                             "type": "events",
+            #                             "properties": [
+            #                                 {
+            #                                     "key": "$current_url",
+            #                                     "value": ["dashboard"],
+            #                                     "operator": "icontains",
+            #                                     "type": "event",
+            #                                 }
+            #                             ],
+            #                         },
+            #                         {
+            #                             "key": "email",
+            #                             "value": ["@gmail.com"],
+            #                             "operator": "icontains",
+            #                             "type": "person",
+            #                         },
+            #                     ],
+            #                 }
+            #             ],
+            #         },
+            #         duration=[],
+            #         order=None,
+            #     ),
+            # ),
+            # EvalCase(
+            #     input="Find recordings from the last 7 days with more than 10 console logs",
+            #     expected=MaxRecordingUniversalFilters(
+            #         date_from="-7d",
+            #         date_to=None,
+            #         filter_test_accounts=True,
+            #         filter_group={
+            #             "type": "AND",
+            #             "values": [
+            #                 {
+            #                     "type": "AND",
+            #                     "values": [
+            #                         {
+            #                             "key": "console_log_count",
+            #                             "value": [10],
+            #                             "operator": "gt",
+            #                             "type": "recording",
+            #                         }
+            #                     ],
+            #                 }
+            #             ],
+            #         },
+            #         duration=[],
+            #         order=None,
+            #     ),
+            # ),
+            # EvalCase(
+            #     input="Show recordings where users either clicked a button or submitted a form",
+            #     expected=MaxRecordingUniversalFilters(
+            #         date_from="-30d",
+            #         date_to=None,
+            #         filter_test_accounts=True,
+            #         filter_group={
+            #             "type": "OR",
+            #             "values": [
+            #                 {
+            #                     "id": "$autocapture",
+            #                     "name": "$autocapture",
+            #                     "type": "events",
+            #                     "properties": [
+            #                         {
+            #                             "key": "$el_tag_name",
+            #                             "value": ["button"],
+            #                             "operator": "exact",
+            #                             "type": "event",
+            #                         }
+            #                     ],
+            #                 },
+            #                 {
+            #                     "id": "$autocapture",
+            #                     "name": "$autocapture",
+            #                     "type": "events",
+            #                     "properties": [
+            #                         {
+            #                             "key": "$el_tag_name",
+            #                             "value": ["form"],
+            #                             "operator": "exact",
+            #                             "type": "event",
+            #                         }
+            #                     ],
+            #                 },
+            #             ],
+            #         },
+            #         duration=[],
+            #         order=None,
+            #     ),
+            # ),
+        ],
+    )

--- a/ee/hogai/eval/eval_session_recording_filters.py
+++ b/ee/hogai/eval/eval_session_recording_filters.py
@@ -11,33 +11,88 @@ from posthog.schema import (
     RecordingDurationFilter,
     EventPropertyFilter,
     PersonPropertyFilter,
+    RecordingOrder,
 )
 from products.replay.backend.max_tools import SearchSessionRecordingsTool
+from braintrust_core.score import Scorer
 
 from ee.hogai.utils.types import AssistantState
 from .conftest import MaxEval
 import json
-from autoevals.partial import ScorerWithPartial
 from braintrust import Score
+from deepdiff import DeepDiff
 
 
-class FilterScorer(ScorerWithPartial):
+DUMMY_EXISTING_FILTERS = json.dumps(
+    MaxRecordingUniversalFilters(
+        date_from="-30d",
+        date_to=None,
+        filter_test_accounts=True,
+        duration=[
+            RecordingDurationFilter(
+                key=DurationType.DURATION,
+                operator=PropertyOperator.EXACT,
+                value=60.0,
+                type="recording",
+            )
+        ],
+        filter_group=MaxOuterUniversalFiltersGroup(
+            type=FilterLogicalOperator.AND_,
+            values=[
+                MaxInnerUniversalFiltersGroup(
+                    type=FilterLogicalOperator.AND_,
+                    values=[
+                        EventPropertyFilter(
+                            key="$level",
+                            value=["error"],
+                            operator=PropertyOperator.EXACT,
+                            type="event",
+                        )
+                    ],
+                )
+            ],
+        ),
+    ).model_dump_json()
+)
+
+
+class DidNotChangeExistingFilters(Scorer):
+    def _name(self):
+        return "did_not_change_existing_filters"
+
+    def _run_eval_sync(self, output, expected=None, **kwargs):
+        if expected is None:
+            return Score(name=self._name(), score=0, metadata={"description": "No expected value provided"})
+
+        return Score(name=self._name(), score=1, metadata={"description": "Did not change existing filters"})
+
+
+class FilterScorer(Scorer):
     def _name(self):
         return "recording_filter_scorer"
 
     def _run_eval_sync(self, output, expected=None, **kwargs):
         # Compare Pydantic models by their dictionary representation
-        if expected is None:
+        if expected is None or output is None:
             return Score(name=self._name(), score=0, metadata={"description": "No expected value provided"})
 
         # Convert both to dict for comparison, handling None cases
         output_dict = output.model_dump() if hasattr(output, "model_dump") else output
         expected_dict = expected.model_dump() if hasattr(expected, "model_dump") else expected
 
-        if output_dict == expected_dict:
-            return Score(name=self._name(), score=1, metadata={"description": "Filters are correct"})
+        diff = DeepDiff(
+            expected_dict,
+            output_dict,
+            ignore_order=True,
+            ignore_string_type_changes=True,
+            ignore_string_case=True,
+            ignore_numeric_type_changes=True,
+        )
+
+        if not diff:
+            return Score(name=self._name(), score=1, metadata={"description": "Filters are correct", "diff": diff})
         else:
-            return Score(name=self._name(), score=0, metadata={"description": "Filters are incorrect"})
+            return Score(name=self._name(), score=0, metadata={"description": "Filters are incorrect", "diff": diff})
 
 
 @pytest.fixture
@@ -45,40 +100,7 @@ def call_search_session_recordings(demo_org_team_user):
     def callable(change: str) -> MaxRecordingUniversalFilters:
         """Call the SearchSessionRecordingsTool and return the generated filters."""
         tool = SearchSessionRecordingsTool()
-        # Initialize required attributes manually since we're not using the proper constructor
-        tool._context = {
-            "current_filters": json.dumps(
-                MaxRecordingUniversalFilters(
-                    date_from="-30d",
-                    date_to=None,
-                    filter_test_accounts=True,
-                    duration=[
-                        RecordingDurationFilter(
-                            key=DurationType.DURATION,
-                            operator=PropertyOperator.EXACT,
-                            value=60.0,
-                            type="recording",
-                        )
-                    ],
-                    filter_group=MaxOuterUniversalFiltersGroup(
-                        type=FilterLogicalOperator.AND_,
-                        values=[
-                            MaxInnerUniversalFiltersGroup(
-                                type=FilterLogicalOperator.AND_,
-                                values=[
-                                    EventPropertyFilter(
-                                        key="$level",
-                                        value=["error"],
-                                        operator=PropertyOperator.EXACT,
-                                        type="event",
-                                    )
-                                ],
-                            )
-                        ],
-                    ),
-                ).model_dump_json()
-            )
-        }
+        tool._context = {"current_filters": DUMMY_EXISTING_FILTERS}
         tool._team = demo_org_team_user[1]
         tool._user = demo_org_team_user[2]
         tool._config = {}
@@ -124,7 +146,7 @@ async def eval_session_recording_filters(call_search_session_recordings):
                                     ),
                                     EventPropertyFilter(
                                         key="$ai_error",
-                                        value=["error"],
+                                        value=["true"],
                                         operator=PropertyOperator.EXACT,
                                         type="event",
                                     ),
@@ -146,7 +168,7 @@ async def eval_session_recording_filters(call_search_session_recordings):
                             type="recording",
                         )
                     ],
-                    order=None,
+                    order=RecordingOrder.START_TIME,
                 ),
             ),
             EvalCase(
@@ -196,312 +218,169 @@ async def eval_session_recording_filters(call_search_session_recordings):
                             type="recording",
                         )
                     ],
-                    order=None,
+                    order=RecordingOrder.START_TIME,
                 ),
             ),
-            # EvalCase(
-            #     input="Show recordings longer than 5 minutes",
-            #     expected=MaxRecordingUniversalFilters(
-            #         date_from="-30d",
-            #         date_to=None,
-            #         filter_test_accounts=True,
-            #         filter_group={
-            #             "type": "AND",
-            #             "values": [
-            #                 {
-            #                     "type": "AND",
-            #                     "values": [
-            #                         {
-            #                         }
-            #                     ],
-            #                 }
-            #             ],
-            #         },
-            #         duration=[
-            #             RecordingDurationFilter(
-            #                 key=DurationType.DURATION,
-            #                 operator=PropertyOperator.GT,
-            #                 value=300.0,
-            #                 type="recording",
-            #             )
-            #         ],
-            #         order=None,
-            #     ),
-            # ),
-            # EvalCase(
-            #     input="Find recordings where users visited the pricing page and are from the US",
-            #     expected=MaxRecordingUniversalFilters(
-            #         date_from="-30d",
-            #         date_to=None,
-            #         filter_test_accounts=True,
-            #         filter_group={
-            #             "type": "AND",
-            #             "values": [
-            #                 {
-            #                     "type": "AND",
-            #                     "values": [
-            #                         {
-            #                             "id": "$pageview",
-            #                             "name": "$pageview",
-            #                             "type": "events",
-            #                             "properties": [
-            #                                 {
-            #                                     "key": "$current_url",
-            #                                     "value": ["pricing"],
-            #                                     "operator": "icontains",
-            #                                     "type": "event",
-            #                                 }
-            #                             ],
-            #                         },
-            #                         {
-            #                             "key": "$geoip_country_code",
-            #                             "value": ["US"],
-            #                             "operator": "exact",
-            #                             "type": "person",
-            #                         },
-            #                     ],
-            #                 }
-            #             ],
-            #         },
-            #         duration=[],
-            #         order=None,
-            #     ),
-            # ),
-            # EvalCase(
-            #     input="Show recordings with rage clicks or console errors",
-            #     expected=MaxRecordingUniversalFilters(
-            #         date_from="-30d",
-            #         date_to=None,
-            #         filter_test_accounts=True,
-            #         filter_group={
-            #             "type": "OR",
-            #             "values": [
-            #                 {
-            #                     "id": "$rageclick",
-            #                     "name": "$rageclick",
-            #                     "type": "events",
-            #                 },
-            #                 {
-            #                     "key": "level",
-            #                     "value": ["error"],
-            #                     "operator": "exact",
-            #                     "type": "log_entry",
-            #                 },
-            #             ],
-            #         },
-            #         duration=[RecordingDurationFilter(
-            #             key=DurationType.ACTIVE_SECONDS,
-            #             operator=PropertyOperator.LT,
-            #             value=30,
-            #             type="recording",
-            #         )],
-            #         order=None,
-            #     ),
-            # ),
-            # EvalCase(
-            #     input="Find recordings from mobile users who signed up",
-            #     expected=MaxRecordingUniversalFilters(
-            #         date_from="-30d",
-            #         date_to=None,
-            #         filter_test_accounts=True,
-            #         filter_group={
-            #             "type": "AND",
-            #             "values": [
-            #                 {
-            #                     "type": "AND",
-            #                     "values": [
-            #                         {
-            #                             "id": "signed_up",
-            #                             "name": "signed_up",
-            #                             "type": "events",
-            #                         },
-            #                         {
-            #                             "key": "$device_type",
-            #                             "value": ["mobile"],
-            #                             "operator": "exact",
-            #                             "type": "person",
-            #                         },
-            #                     ],
-            #                 }
-            #             ],
-            #         },
-            #         duration=[RecordingDurationFilter(
-            #             key=DurationType.ACTIVE_SECONDS,
-            #             operator=PropertyOperator.LT,
-            #             value=30,
-            #             type="recording",
-            #         )],
-            #         order=None,
-            #     ),
-            # ),
-            # EvalCase(
-            #     input="Show recordings with console warnings containing 'deprecated'",
-            #     expected=MaxRecordingUniversalFilters(
-            #         date_from="-30d",
-            #         date_to=None,
-            #         filter_test_accounts=True,
-            #         filter_group={
-            #             "type": "AND",
-            #             "values": [
-            #                 {
-            #                     "type": "AND",
-            #                     "values": [
-            #                         {
-            #                             "key": "level",
-            #                             "value": ["warn"],
-            #                             "operator": "exact",
-            #                             "type": "log_entry",
-            #                         },
-            #                         {
-            #                             "key": "message",
-            #                             "value": ["deprecated"],
-            #                             "operator": "icontains",
-            #                             "type": "log_entry",
-            #                         },
-            #                     ],
-            #                 }
-            #             ],
-            #         },
-            #         duration=[RecordingDurationFilter(
-            #             key=DurationType.ACTIVE_SECONDS,
-            #             operator=PropertyOperator.LT,
-            #             value=30,
-            #             type="recording",
-            #         )],
-            #         order=None,
-            #     ),
-            # ),
-            # EvalCase(
-            #     input="Find recordings with active time less than 30 seconds",
-            #     expected=MaxRecordingUniversalFilters(
-            #         date_from="-30d",
-            #         date_to=None,
-            #         filter_test_accounts=True,
-            #         filter_group={
-            #             "type": "AND",
-            #             "values": [
-            #                 {
-            #                     "type": "AND",
-            #                     "values": [],
-            #                 }
-            #             ],
-            #         },
-            #         duration=[
-            #             {
-            #                 "key": "active_seconds",
-            #                 "operator": "lt",
-            #                 "value": 30,
-            #                 "type": "recording",
-            #             }
-            #         ],
-            #         order=None,
-            #     ),
-            # ),
-            # EvalCase(
-            #     input="Show recordings from users with email containing '@gmail.com' who visited the dashboard",
-            #     expected=MaxRecordingUniversalFilters(
-            #         date_from="-30d",
-            #         date_to=None,
-            #         filter_test_accounts=True,
-            #         filter_group={
-            #             "type": "AND",
-            #             "values": [
-            #                 {
-            #                     "type": "AND",
-            #                     "values": [
-            #                         {
-            #                             "id": "$pageview",
-            #                             "name": "$pageview",
-            #                             "type": "events",
-            #                             "properties": [
-            #                                 {
-            #                                     "key": "$current_url",
-            #                                     "value": ["dashboard"],
-            #                                     "operator": "icontains",
-            #                                     "type": "event",
-            #                                 }
-            #                             ],
-            #                         },
-            #                         {
-            #                             "key": "email",
-            #                             "value": ["@gmail.com"],
-            #                             "operator": "icontains",
-            #                             "type": "person",
-            #                         },
-            #                     ],
-            #                 }
-            #             ],
-            #         },
-            #         duration=[],
-            #         order=None,
-            #     ),
-            # ),
-            # EvalCase(
-            #     input="Find recordings from the last 7 days with more than 10 console logs",
-            #     expected=MaxRecordingUniversalFilters(
-            #         date_from="-7d",
-            #         date_to=None,
-            #         filter_test_accounts=True,
-            #         filter_group={
-            #             "type": "AND",
-            #             "values": [
-            #                 {
-            #                     "type": "AND",
-            #                     "values": [
-            #                         {
-            #                             "key": "console_log_count",
-            #                             "value": [10],
-            #                             "operator": "gt",
-            #                             "type": "recording",
-            #                         }
-            #                     ],
-            #                 }
-            #             ],
-            #         },
-            #         duration=[],
-            #         order=None,
-            #     ),
-            # ),
-            # EvalCase(
-            #     input="Show recordings where users either clicked a button or submitted a form",
-            #     expected=MaxRecordingUniversalFilters(
-            #         date_from="-30d",
-            #         date_to=None,
-            #         filter_test_accounts=True,
-            #         filter_group={
-            #             "type": "OR",
-            #             "values": [
-            #                 {
-            #                     "id": "$autocapture",
-            #                     "name": "$autocapture",
-            #                     "type": "events",
-            #                     "properties": [
-            #                         {
-            #                             "key": "$el_tag_name",
-            #                             "value": ["button"],
-            #                             "operator": "exact",
-            #                             "type": "event",
-            #                         }
-            #                     ],
-            #                 },
-            #                 {
-            #                     "id": "$autocapture",
-            #                     "name": "$autocapture",
-            #                     "type": "events",
-            #                     "properties": [
-            #                         {
-            #                             "key": "$el_tag_name",
-            #                             "value": ["form"],
-            #                             "operator": "exact",
-            #                             "type": "event",
-            #                         }
-            #                     ],
-            #                 },
-            #             ],
-            #         },
-            #         duration=[],
-            #         order=None,
-            #     ),
-            # ),
+            EvalCase(
+                input="Show recordings longer than 5 minutes",
+                expected=MaxRecordingUniversalFilters(
+                    date_from="-30d",
+                    date_to=None,
+                    filter_test_accounts=True,
+                    filter_group=MaxOuterUniversalFiltersGroup(
+                        type=FilterLogicalOperator.AND_,
+                        values=[
+                            MaxInnerUniversalFiltersGroup(
+                                type=FilterLogicalOperator.AND_,
+                                values=[
+                                    EventPropertyFilter(
+                                        key="$level",
+                                        value=["error"],
+                                        operator=PropertyOperator.EXACT,
+                                        type="event",
+                                    )
+                                ],
+                            )
+                        ],
+                    ),
+                    duration=[
+                        RecordingDurationFilter(
+                            key=DurationType.DURATION,
+                            operator=PropertyOperator.GT,
+                            value=300.0,
+                            type="recording",
+                        )
+                    ],
+                    order=RecordingOrder.START_TIME,
+                ),
+            ),
+            EvalCase(
+                input="Show recordings with rage clicks or console errors",
+                expected=MaxRecordingUniversalFilters(
+                    date_from="-30d",
+                    date_to=None,
+                    filter_test_accounts=True,
+                    filter_group=MaxOuterUniversalFiltersGroup(
+                        type=FilterLogicalOperator.OR_,
+                        values=[
+                            MaxInnerUniversalFiltersGroup(
+                                type=FilterLogicalOperator.AND_,
+                                values=[
+                                    EventPropertyFilter(
+                                        key="$level",
+                                        value=["error"],
+                                        operator=PropertyOperator.EXACT,
+                                        type="event",
+                                    ),
+                                ],
+                            ),
+                            MaxInnerUniversalFiltersGroup(
+                                type=FilterLogicalOperator.AND_,
+                                values=[
+                                    EventPropertyFilter(
+                                        key="$rageclick",
+                                        value=["true"],
+                                        operator=PropertyOperator.EXACT,
+                                        type="event",
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                    duration=[
+                        RecordingDurationFilter(
+                            key=DurationType.DURATION,
+                            operator=PropertyOperator.EXACT,
+                            value=60,
+                            type="recording",
+                        )
+                    ],
+                    order=RecordingOrder.START_TIME,
+                ),
+            ),
+            EvalCase(
+                input="Find recordings with active time less than 30 seconds",
+                expected=MaxRecordingUniversalFilters(
+                    date_from="-30d",
+                    date_to=None,
+                    filter_test_accounts=True,
+                    filter_group=MaxOuterUniversalFiltersGroup(
+                        type=FilterLogicalOperator.AND_,
+                        values=[
+                            MaxInnerUniversalFiltersGroup(
+                                type=FilterLogicalOperator.AND_,
+                                values=[
+                                    EventPropertyFilter(
+                                        key="$level",
+                                        value=["error"],
+                                        operator=PropertyOperator.EXACT,
+                                        type="event",
+                                    )
+                                ],
+                            )
+                        ],
+                    ),
+                    duration=[
+                        RecordingDurationFilter(
+                            key=DurationType.ACTIVE_SECONDS,
+                            operator=PropertyOperator.LT,
+                            value=30,
+                            type="recording",
+                        ),
+                        RecordingDurationFilter(
+                            key=DurationType.DURATION,
+                            operator=PropertyOperator.EXACT,
+                            value=60,
+                            type="recording",
+                        ),
+                    ],
+                    order=RecordingOrder.START_TIME,
+                ),
+            ),
+            EvalCase(
+                input="Find recordings from the last 7 days with more than 10 console logs and more than 1000ms of active time",
+                expected=MaxRecordingUniversalFilters(
+                    date_from="-7d",
+                    date_to=None,
+                    filter_test_accounts=True,
+                    filter_group=MaxOuterUniversalFiltersGroup(
+                        type=FilterLogicalOperator.AND_,
+                        values=[
+                            MaxInnerUniversalFiltersGroup(
+                                type=FilterLogicalOperator.AND_,
+                                values=[
+                                    EventPropertyFilter(
+                                        key="console_log_count",
+                                        value=[10],
+                                        operator=PropertyOperator.GT,
+                                        type="event",
+                                    ),
+                                    EventPropertyFilter(
+                                        key="$level",
+                                        value=["error"],
+                                        operator=PropertyOperator.EXACT,
+                                        type="event",
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                    duration=[
+                        RecordingDurationFilter(
+                            key=DurationType.DURATION,
+                            operator=PropertyOperator.EXACT,
+                            value=60,
+                            type="recording",
+                        ),
+                        RecordingDurationFilter(
+                            key=DurationType.ACTIVE_SECONDS,
+                            operator=PropertyOperator.GT,
+                            value=1,
+                            type="recording",
+                        ),
+                    ],
+                    order=RecordingOrder.START_TIME,
+                ),
+            ),
         ],
     )

--- a/frontend/bin/build-schema-json.mjs
+++ b/frontend/bin/build-schema-json.mjs
@@ -13,6 +13,8 @@ const config = {
     tsconfig: 'tsconfig.json',
     discriminatorType: 'open-api',
     skipTypeCheck: true,
+    jsDoc: 'extended', // Enable extended JSDoc processing
+    extraTags: ['@default'], // Include @default tags
 }
 
 const output_path = 'src/queries/schema.json'

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -14865,9 +14865,11 @@
             "additionalProperties": false,
             "properties": {
                 "type": {
-                    "$ref": "#/definitions/FilterLogicalOperator"
+                    "$ref": "#/definitions/FilterLogicalOperator",
+                    "description": "Defines how filters should be combined"
                 },
                 "values": {
+                    "description": "The filters and their values to be applied to the recordings",
                     "items": {
                         "$ref": "#/definitions/MaxUniversalFilterValue"
                     },
@@ -14904,9 +14906,11 @@
             "additionalProperties": false,
             "properties": {
                 "type": {
-                    "$ref": "#/definitions/FilterLogicalOperator"
+                    "$ref": "#/definitions/FilterLogicalOperator",
+                    "description": "Defines how filters should be combined"
                 },
                 "values": {
+                    "description": "The filter groups and their values to be applied to the recordings",
                     "items": {
                         "$ref": "#/definitions/MaxInnerUniversalFiltersGroup"
                     },
@@ -14920,26 +14924,34 @@
             "additionalProperties": false,
             "properties": {
                 "date_from": {
+                    "default": "-5d",
+                    "description": "The start date of the recording. If not provided, the default value is the last 5 days. Relative Date (Days): Use the format '-Nd' for the last N days (e.g., 'last 5 days' becomes '-5d') Relative Date (Hours): Use the format '-Nh' for the last N hours (e.g., 'last 5 hours' becomes '-5h') Custom Date: If a specific start date is provided, use the format ISO8601 date string",
                     "type": ["string", "null"]
                 },
                 "date_to": {
+                    "description": "ISO8601 date string. The end date of the recording. If not provided, the default value is today.",
                     "type": ["string", "null"]
                 },
                 "duration": {
+                    "default": [],
+                    "description": "The duration of the recording. If not provided, the default value is an empty list.",
                     "items": {
                         "$ref": "#/definitions/RecordingDurationFilter"
                     },
                     "type": "array"
                 },
                 "filter_group": {
-                    "$ref": "#/definitions/MaxOuterUniversalFiltersGroup"
+                    "$ref": "#/definitions/MaxOuterUniversalFiltersGroup",
+                    "description": "The filter group of the recording."
                 },
                 "filter_test_accounts": {
+                    "description": "Whether to filter test accounts.",
                     "type": "boolean"
                 },
                 "order": {
                     "$ref": "#/definitions/RecordingOrder",
-                    "default": "start_time"
+                    "default": "start_time",
+                    "description": "The order of the recordings"
                 }
             },
             "required": ["duration", "filter_group"],

--- a/frontend/src/queries/schema/schema-assistant-replay.ts
+++ b/frontend/src/queries/schema/schema-assistant-replay.ts
@@ -11,21 +11,40 @@ import { RecordingsQuery } from './schema-general'
 
 // Subset of RecordingUniversalFilters that is more tractable for the AI assistant
 export interface MaxRecordingUniversalFilters {
+    /** The start date of the recording. If not provided, the default value is the last 5 days.
+     * Relative Date (Days): Use the format '-Nd' for the last N days (e.g., 'last 5 days' becomes '-5d')
+     * Relative Date (Hours): Use the format '-Nh' for the last N hours (e.g., 'last 5 hours' becomes '-5h')
+     * Custom Date: If a specific start date is provided, use the format ISO8601 date string
+     * @default '-5d'
+     */
     date_from?: string | null
+    /** ISO8601 date string. The end date of the recording. If not provided, the default value is today. */
     date_to?: string | null
+    /** The duration of the recording. If not provided, the default value is an empty list.
+     * @default []
+     */
     duration: RecordingDurationFilter[]
+    /** Whether to filter test accounts. */
     filter_test_accounts?: boolean
+    /** The filter group of the recording. */
     filter_group: MaxOuterUniversalFiltersGroup
+    /** The order of the recordings
+     * @default 'start_time'
+     */
     order?: RecordingsQuery['order']
 }
 
 export type MaxOuterUniversalFiltersGroup = {
+    /** Defines how filters should be combined */
     type: FilterLogicalOperator
+    /** The filter groups and their values to be applied to the recordings */
     values: MaxInnerUniversalFiltersGroup[]
 }
 
 export type MaxInnerUniversalFiltersGroup = {
+    /** Defines how filters should be combined */
     type: FilterLogicalOperator
+    /** The filters and their values to be applied to the recordings */
     values: MaxUniversalFilterValue[]
 }
 

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -557,24 +557,21 @@ const RecordingsUniversalFilterGroup = (): JSX.Element => {
                     <UniversalFilters.Group key={index} index={index} group={filterOrGroup}>
                         <RecordingsUniversalFilterGroup />
 
-                        {/* Only show "Add filter" button if group has multiple filters */}
-                        {filterOrGroup.values.length > 1 && (
-                            <Popover
-                                overlay={<UniversalFilters.PureTaxonomicFilter fullWidth={false} />}
-                                placement="bottom"
-                                visible={isPopoverVisible}
-                                onClickOutside={() => setIsPopoverVisible(false)}
+                        <Popover
+                            overlay={<UniversalFilters.PureTaxonomicFilter fullWidth={false} />}
+                            placement="bottom"
+                            visible={isPopoverVisible}
+                            onClickOutside={() => setIsPopoverVisible(false)}
+                        >
+                            <LemonButton
+                                type="secondary"
+                                size="small"
+                                icon={<IconPlus />}
+                                onClick={() => setIsPopoverVisible(!isPopoverVisible)}
                             >
-                                <LemonButton
-                                    type="secondary"
-                                    size="small"
-                                    icon={<IconPlus />}
-                                    onClick={() => setIsPopoverVisible(!isPopoverVisible)}
-                                >
-                                    Add filter
-                                </LemonButton>
-                            </Popover>
-                        )}
+                                Add filter
+                            </LemonButton>
+                        </Popover>
                     </UniversalFilters.Group>
                 ) : (
                     <UniversalFilters.Value

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -557,21 +557,24 @@ const RecordingsUniversalFilterGroup = (): JSX.Element => {
                     <UniversalFilters.Group key={index} index={index} group={filterOrGroup}>
                         <RecordingsUniversalFilterGroup />
 
-                        <Popover
-                            overlay={<UniversalFilters.PureTaxonomicFilter fullWidth={false} />}
-                            placement="bottom"
-                            visible={isPopoverVisible}
-                            onClickOutside={() => setIsPopoverVisible(false)}
-                        >
-                            <LemonButton
-                                type="secondary"
-                                size="small"
-                                icon={<IconPlus />}
-                                onClick={() => setIsPopoverVisible(!isPopoverVisible)}
+                        {/* Only show "Add filter" button if group has multiple filters */}
+                        {filterOrGroup.values.length > 1 && (
+                            <Popover
+                                overlay={<UniversalFilters.PureTaxonomicFilter fullWidth={false} />}
+                                placement="bottom"
+                                visible={isPopoverVisible}
+                                onClickOutside={() => setIsPopoverVisible(false)}
                             >
-                                Add filter
-                            </LemonButton>
-                        </Popover>
+                                <LemonButton
+                                    type="secondary"
+                                    size="small"
+                                    icon={<IconPlus />}
+                                    onClick={() => setIsPopoverVisible(!isPopoverVisible)}
+                                >
+                                    Add filter
+                                </LemonButton>
+                            </Popover>
+                        )}
                     </UniversalFilters.Group>
                 ) : (
                     <UniversalFilters.Value

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1891,28 +1891,52 @@ class PropertyMathType(StrEnum):
 
 
 class PropertyOperator(StrEnum):
+    """The PropertyOperator specifies the operator to use for the comparison in a filter."""
+
     EXACT = "exact"
+    """Exact match"""
     IS_NOT = "is_not"
+    """Not equal to"""
     ICONTAINS = "icontains"
+    """Contains"""
     NOT_ICONTAINS = "not_icontains"
+    """Does not contain"""
     REGEX = "regex"
+    """Regex match"""
     NOT_REGEX = "not_regex"
+    """Not regex match"""
     GT = "gt"
+    """Greater than"""
     GTE = "gte"
+    """Greater than or equal to"""
     LT = "lt"
+    """Less than"""
     LTE = "lte"
+    """Less than or equal to"""
     IS_SET = "is_set"
+    """Is set"""
     IS_NOT_SET = "is_not_set"
+    """Is not set"""
     IS_DATE_EXACT = "is_date_exact"
+    """Is date exact"""
     IS_DATE_BEFORE = "is_date_before"
+    """Is date before"""
     IS_DATE_AFTER = "is_date_after"
+    """Is date after"""
     BETWEEN = "between"
+    """Between"""
     NOT_BETWEEN = "not_between"
+    """Not between"""
     MIN = "min"
+    """Minimum"""
     MAX = "max"
+    """Maximum"""
     IN_ = "in"
+    """In"""
     NOT_IN = "not_in"
+    """Not in"""
     IS_CLEANED_PATH_EXACT = "is_cleaned_path_exact"
+    """Is cleaned path exact"""
 
 
 class QueryIndexUsage(StrEnum):
@@ -2212,7 +2236,7 @@ class SessionPropertyFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    key: str
+    key: str = Field(description="The name of the session property, e.g. $start_timestamp, $entry_current_url")
     label: Optional[str] = None
     operator: PropertyOperator
     type: Literal["session"] = "session"
@@ -3277,7 +3301,7 @@ class EventPropertyFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    key: str
+    key: str = Field(description="The name of the event property")
     label: Optional[str] = None
     operator: Optional[PropertyOperator] = PropertyOperator.EXACT
     type: Literal["event"] = Field(default="event", description="Event properties")
@@ -3682,7 +3706,7 @@ class PersonPropertyFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    key: str
+    key: str = Field(description="The name of the person property, e.g. $browser, $device_type, email")
     label: Optional[str] = None
     operator: PropertyOperator
     type: Literal["person"] = Field(default="person", description="Person properties")
@@ -10611,7 +10635,9 @@ class MaxInnerUniversalFiltersGroup(BaseModel):
         extra="forbid",
     )
     type: FilterLogicalOperator = Field(description="Defines how filters should be combined")
-    values: list[Union[EventPropertyFilter, PersonPropertyFilter, SessionPropertyFilter, RecordingPropertyFilter]]
+    values: list[Union[EventPropertyFilter, PersonPropertyFilter, SessionPropertyFilter, RecordingPropertyFilter]] = (
+        Field(description="The filters and their values to be applied to the recordings")
+    )
 
 
 class MaxOuterUniversalFiltersGroup(BaseModel):
@@ -10626,19 +10652,25 @@ class MaxRecordingUniversalFilters(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    date_from: Optional[str] = Field(
+    date_from: str = Field(
         default="-5d",
-        description="The start date of the recording. If not provided, the default value is the last 5 days.",
+        description="The start date of the recording. If not provided, the default value is the last 5 days. "
+        + "\nRelative Date (Days): Use the format '-Nd' for the last N days (e.g., 'last 5 days' becomes '-5d')"
+        + "\nRelative Date (Hours): Use the format '-Nh' for the last N hours (e.g., 'last 5 hours' becomes '-5h')"
+        + "\nCustom Date: If a specific start date is provided, use the format ISO8601 date string",
     )
     date_to: Optional[str] = Field(
-        default=None, description="The end date of the recording. If not provided, the default value is today."
+        default=None,
+        description="ISO8601 date string. The end date of the recording. If not provided, the default value is today.",
     )
     duration: list[RecordingDurationFilter] = Field(
         default=[], description="The duration of the recording. If not provided, the default value is an empty list."
     )
     filter_group: MaxOuterUniversalFiltersGroup = Field(description="The filter group of the recording.")
     filter_test_accounts: Optional[bool] = Field(default=None, description="Whether to filter test accounts.")
-    order: Optional[RecordingOrder] = RecordingOrder.START_TIME
+    order: Optional[RecordingOrder] = Field(
+        default=RecordingOrder.START_TIME, description="The order of the recordings"
+    )
 
 
 class PropertyGroupFilter(BaseModel):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1840,23 +1840,42 @@ class PersonType(BaseModel):
 
 
 class PropertyFilterType(StrEnum):
+    """The PropertyFilterType specifies the type of property to filter on."""
+
     META = "meta"
+    """Filter by meta properties"""
     EVENT = "event"
+    """Filter by event properties"""
     EVENT_METADATA = "event_metadata"
+    """Filter by event metadata properties"""
     PERSON = "person"
+    """Filter by person properties"""
     ELEMENT = "element"
+    """Filter by element properties"""
     FEATURE = "feature"
+    """Filter by feature properties"""
     SESSION = "session"
+    """Filter by session properties"""
     COHORT = "cohort"
+    """Filter by cohort properties"""
     RECORDING = "recording"
+    """Filter by recording properties"""
     LOG_ENTRY = "log_entry"
+    """Filter by log entry properties"""
     GROUP = "group"
+    """Filter by group properties"""
     HOGQL = "hogql"
+    """Filter by HogQL properties"""
     DATA_WAREHOUSE = "data_warehouse"
+    """Filter by data warehouse properties"""
     DATA_WAREHOUSE_PERSON_PROPERTY = "data_warehouse_person_property"
+    """Filter by data warehouse person properties"""
     ERROR_TRACKING_ISSUE = "error_tracking_issue"
+    """Filter by error tracking issue properties"""
     REVENUE_ANALYTICS = "revenue_analytics"
+    """Filter by revenue analytics properties"""
     LOG = "log"
+    """Filter by log properties"""
 
 
 class PropertyMathType(StrEnum):
@@ -10591,7 +10610,7 @@ class MaxInnerUniversalFiltersGroup(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    type: FilterLogicalOperator
+    type: FilterLogicalOperator = Field(description="Defines how filters should be combined")
     values: list[Union[EventPropertyFilter, PersonPropertyFilter, SessionPropertyFilter, RecordingPropertyFilter]]
 
 
@@ -10599,7 +10618,7 @@ class MaxOuterUniversalFiltersGroup(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    type: FilterLogicalOperator
+    type: FilterLogicalOperator = Field(description="Defines how filters should be combined")
     values: list[MaxInnerUniversalFiltersGroup]
 
 
@@ -10607,11 +10626,18 @@ class MaxRecordingUniversalFilters(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    date_from: Optional[str] = None
-    date_to: Optional[str] = None
-    duration: list[RecordingDurationFilter]
-    filter_group: MaxOuterUniversalFiltersGroup
-    filter_test_accounts: Optional[bool] = None
+    date_from: Optional[str] = Field(
+        default="-5d",
+        description="The start date of the recording. If not provided, the default value is the last 5 days.",
+    )
+    date_to: Optional[str] = Field(
+        default=None, description="The end date of the recording. If not provided, the default value is today."
+    )
+    duration: list[RecordingDurationFilter] = Field(
+        default=[], description="The duration of the recording. If not provided, the default value is an empty list."
+    )
+    filter_group: MaxOuterUniversalFiltersGroup = Field(description="The filter group of the recording.")
+    filter_test_accounts: Optional[bool] = Field(default=None, description="Whether to filter test accounts.")
     order: Optional[RecordingOrder] = RecordingOrder.START_TIME
 
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1840,42 +1840,23 @@ class PersonType(BaseModel):
 
 
 class PropertyFilterType(StrEnum):
-    """The PropertyFilterType specifies the type of property to filter on."""
-
     META = "meta"
-    """Filter by meta properties"""
     EVENT = "event"
-    """Filter by event properties"""
     EVENT_METADATA = "event_metadata"
-    """Filter by event metadata properties"""
     PERSON = "person"
-    """Filter by person properties"""
     ELEMENT = "element"
-    """Filter by element properties"""
     FEATURE = "feature"
-    """Filter by feature properties"""
     SESSION = "session"
-    """Filter by session properties"""
     COHORT = "cohort"
-    """Filter by cohort properties"""
     RECORDING = "recording"
-    """Filter by recording properties"""
     LOG_ENTRY = "log_entry"
-    """Filter by log entry properties"""
     GROUP = "group"
-    """Filter by group properties"""
     HOGQL = "hogql"
-    """Filter by HogQL properties"""
     DATA_WAREHOUSE = "data_warehouse"
-    """Filter by data warehouse properties"""
     DATA_WAREHOUSE_PERSON_PROPERTY = "data_warehouse_person_property"
-    """Filter by data warehouse person properties"""
     ERROR_TRACKING_ISSUE = "error_tracking_issue"
-    """Filter by error tracking issue properties"""
     REVENUE_ANALYTICS = "revenue_analytics"
-    """Filter by revenue analytics properties"""
     LOG = "log"
-    """Filter by log properties"""
 
 
 class PropertyMathType(StrEnum):
@@ -1891,52 +1872,28 @@ class PropertyMathType(StrEnum):
 
 
 class PropertyOperator(StrEnum):
-    """The PropertyOperator specifies the operator to use for the comparison in a filter."""
-
     EXACT = "exact"
-    """Exact match"""
     IS_NOT = "is_not"
-    """Not equal to"""
     ICONTAINS = "icontains"
-    """Contains"""
     NOT_ICONTAINS = "not_icontains"
-    """Does not contain"""
     REGEX = "regex"
-    """Regex match"""
     NOT_REGEX = "not_regex"
-    """Not regex match"""
     GT = "gt"
-    """Greater than"""
     GTE = "gte"
-    """Greater than or equal to"""
     LT = "lt"
-    """Less than"""
     LTE = "lte"
-    """Less than or equal to"""
     IS_SET = "is_set"
-    """Is set"""
     IS_NOT_SET = "is_not_set"
-    """Is not set"""
     IS_DATE_EXACT = "is_date_exact"
-    """Is date exact"""
     IS_DATE_BEFORE = "is_date_before"
-    """Is date before"""
     IS_DATE_AFTER = "is_date_after"
-    """Is date after"""
     BETWEEN = "between"
-    """Between"""
     NOT_BETWEEN = "not_between"
-    """Not between"""
     MIN = "min"
-    """Minimum"""
     MAX = "max"
-    """Maximum"""
     IN_ = "in"
-    """In"""
     NOT_IN = "not_in"
-    """Not in"""
     IS_CLEANED_PATH_EXACT = "is_cleaned_path_exact"
-    """Is cleaned path exact"""
 
 
 class QueryIndexUsage(StrEnum):
@@ -2236,7 +2193,7 @@ class SessionPropertyFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    key: str = Field(description="The name of the session property, e.g. $start_timestamp, $entry_current_url")
+    key: str
     label: Optional[str] = None
     operator: PropertyOperator
     type: Literal["session"] = "session"
@@ -3301,7 +3258,7 @@ class EventPropertyFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    key: str = Field(description="The name of the event property")
+    key: str
     label: Optional[str] = None
     operator: Optional[PropertyOperator] = PropertyOperator.EXACT
     type: Literal["event"] = Field(default="event", description="Event properties")
@@ -3706,7 +3663,7 @@ class PersonPropertyFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    key: str = Field(description="The name of the person property, e.g. $browser, $device_type, email")
+    key: str
     label: Optional[str] = None
     operator: PropertyOperator
     type: Literal["person"] = Field(default="person", description="Person properties")
@@ -10634,9 +10591,9 @@ class MaxInnerUniversalFiltersGroup(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    type: FilterLogicalOperator = Field(description="Defines how filters should be combined")
+    type: FilterLogicalOperator = Field(..., description="Defines how filters should be combined")
     values: list[Union[EventPropertyFilter, PersonPropertyFilter, SessionPropertyFilter, RecordingPropertyFilter]] = (
-        Field(description="The filters and their values to be applied to the recordings")
+        Field(..., description="The filters and their values to be applied to the recordings")
     )
 
 
@@ -10644,29 +10601,33 @@ class MaxOuterUniversalFiltersGroup(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    type: FilterLogicalOperator = Field(description="Defines how filters should be combined")
-    values: list[MaxInnerUniversalFiltersGroup]
+    type: FilterLogicalOperator = Field(..., description="Defines how filters should be combined")
+    values: list[MaxInnerUniversalFiltersGroup] = Field(
+        ..., description="The filter groups and their values to be applied to the recordings"
+    )
 
 
 class MaxRecordingUniversalFilters(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    date_from: str = Field(
+    date_from: Optional[str] = Field(
         default="-5d",
-        description="The start date of the recording. If not provided, the default value is the last 5 days. "
-        + "\nRelative Date (Days): Use the format '-Nd' for the last N days (e.g., 'last 5 days' becomes '-5d')"
-        + "\nRelative Date (Hours): Use the format '-Nh' for the last N hours (e.g., 'last 5 hours' becomes '-5h')"
-        + "\nCustom Date: If a specific start date is provided, use the format ISO8601 date string",
+        description=(
+            "The start date of the recording. If not provided, the default value is the last 5 days. Relative Date"
+            " (Days): Use the format '-Nd' for the last N days (e.g., 'last 5 days' becomes '-5d') Relative Date"
+            " (Hours): Use the format '-Nh' for the last N hours (e.g., 'last 5 hours' becomes '-5h') Custom Date: If a"
+            " specific start date is provided, use the format ISO8601 date string"
+        ),
     )
     date_to: Optional[str] = Field(
         default=None,
         description="ISO8601 date string. The end date of the recording. If not provided, the default value is today.",
     )
-    duration: list[RecordingDurationFilter] = Field(
+    duration: Optional[list[RecordingDurationFilter]] = Field(
         default=[], description="The duration of the recording. If not provided, the default value is an empty list."
     )
-    filter_group: MaxOuterUniversalFiltersGroup = Field(description="The filter group of the recording.")
+    filter_group: MaxOuterUniversalFiltersGroup = Field(..., description="The filter group of the recording.")
     filter_test_accounts: Optional[bool] = Field(default=None, description="Whether to filter test accounts.")
     order: Optional[RecordingOrder] = Field(
         default=RecordingOrder.START_TIME, description="The order of the recordings"

--- a/products/replay/backend/max_tools.py
+++ b/products/replay/backend/max_tools.py
@@ -6,11 +6,16 @@ from .prompts import (
     AI_FILTER_INITIAL_PROMPT,
     AI_FILTER_PROPERTIES_PROMPT,
     AI_FILTER_REQUEST_PROMPT,
+    QuestionResponse,
 )
 from posthog.schema import MaxRecordingUniversalFilters
 from ee.hogai.tool import MaxTool
 import json
 from langchain_core.output_parsers import JsonOutputParser
+from langchain_core.exceptions import OutputParserException
+import structlog
+
+logger = structlog.getLogger(__name__)
 
 
 class SearchSessionRecordingsArgs(BaseModel):
@@ -20,10 +25,6 @@ class SearchSessionRecordingsArgs(BaseModel):
             "Include ALL relevant details that may or may not be needed, as the tool won't receive the history of this conversation."
         )
     )
-
-
-class QuestionResponse(BaseModel):
-    question: str = Field(description="The question that the user is asking.")
 
 
 class SearchSessionRecordingsTool(MaxTool):
@@ -56,128 +57,28 @@ class SearchSessionRecordingsTool(MaxTool):
         if "current_filters" not in self.context:
             raise ValueError("Context `current_filters` is required for the `search_session_recordings` tool")
 
-        and_filter_example = json.dumps(
-            MaxRecordingUniversalFilters(
-                **{
-                    "duration": [{"key": "duration", "type": "recording", "value": 60, "operator": "gte"}],
-                    "date_from": "-3d",
-                    "date_to": None,
-                    "filter_group": {
-                        "type": "AND",
-                        "values": [
-                            {
-                                "type": "AND",
-                                "values": [
-                                    {"key": "$browser", "type": "person", "value": ["Mobile"], "operator": "exact"}
-                                ],
-                            },
-                            {
-                                "type": "AND",
-                                "values": [
-                                    {"key": "$login_page", "type": "person", "value": ["true"], "operator": "exact"}
-                                ],
-                            },
-                        ],
-                    },
-                }
-            ).model_dump_json(indent=2)
-        )
-
-        or_filter_example = json.dumps(
-            MaxRecordingUniversalFilters(
-                **{
-                    "duration": [{"key": "duration", "type": "recording", "value": 60, "operator": "gte"}],
-                    "date_from": "-3d",
-                    "date_to": None,
-                    "filter_group": {  # Add them to the same filter group
-                        "type": "OR",  # type of the filter group, OR means at least one of the filters must be true
-                        "values": [
-                            {
-                                "type": "AND",
-                                "values": [
-                                    {"key": "$browser", "type": "person", "value": ["Mobile"], "operator": "exact"}
-                                ],
-                            },
-                            {
-                                "type": "AND",
-                                "values": [
-                                    {"key": "$login_page", "type": "person", "value": ["true"], "operator": "exact"}
-                                ],
-                            },
-                        ],
-                    },
-                }
-            ).model_dump_json(indent=2)
-        )
-
-        multiple_filters_example = MaxRecordingUniversalFilters(
-            **{
-                "duration": [{"key": "duration", "type": "recording", "value": 60, "operator": "exact"}],
-                "date_from": "-3d",
-                "date_to": None,
-                "filter_group": {
-                    "type": "AND",
-                    "values": [
-                        {
-                            "type": "AND",
-                            "values": [{"key": "$browser", "type": "person", "value": ["Mobile"], "operator": "exact"}],
-                        },
-                        {
-                            "type": "AND",
-                            "values": [{"key": "$login_page", "type": "event", "value": ["true"], "operator": "exact"}],
-                        },
-                        {
-                            "type": "OR",
-                            "values": [
-                                {"key": "$geo_ip_location", "type": "person", "value": ["Munich"], "operator": "exact"},
-                                {
-                                    "key": "$geo_ip_location",
-                                    "type": "person",
-                                    "value": ["Istanbul"],
-                                    "operator": "exact",
-                                },
-                            ],
-                        },
-                    ],
-                },
-            }
-        ).model_dump_json(indent=2)
-
-        default_filter_example = json.dumps(
-            MaxRecordingUniversalFilters(
-                **{
-                    "duration": [{"key": "duration", "type": "recording", "value": 60, "operator": "exact"}],
-                    "date_from": "-3d",
-                    "date_to": None,
-                    "filter_group": {"type": "AND", "values": [{"type": "AND", "values": []}]},
-                }
-            ).model_dump_json(indent=2)
-        )
-
         result = chain.invoke(
             {
                 "change": change,
                 **self.context,
                 "recording_filter_schema": json.dumps(MaxRecordingUniversalFilters.model_json_schema(), indent=2),
-                "and_filter_example": and_filter_example,
-                "or_filter_example": or_filter_example,
-                "multiple_filters_example": multiple_filters_example,
-                "default_filter_example": default_filter_example,
             }
         )
 
         parser = JsonOutputParser()
-        parsed_data = parser.parse(str(result.content))
-
-        if "question" in parsed_data:
-            question_response = QuestionResponse.model_validate(parsed_data)
-            return question_response.question, MaxRecordingUniversalFilters.model_validate_json(
-                self.context["current_filters"]
-            )
 
         try:
+            parsed_data = parser.parse(str(result.content))
+
+            if "question" in parsed_data:
+                question_response = QuestionResponse.model_validate(parsed_data)
+                return question_response.question, MaxRecordingUniversalFilters.model_validate_json(
+                    self.context["current_filters"]
+                )
+
             validated_data = MaxRecordingUniversalFilters.model_validate(parsed_data)
-        except ValidationError:
+        except (ValidationError, OutputParserException) as e:
+            logger.exception("Error generating filters", error=e)
             return "Could not generate filters. Please try again.", MaxRecordingUniversalFilters.model_validate_json(
                 self.context["current_filters"]
             )

--- a/products/replay/backend/max_tools.py
+++ b/products/replay/backend/max_tools.py
@@ -54,6 +54,7 @@ class SearchSessionRecordingsTool(MaxTool):
             raise ValueError("Context `current_filters` is required for the `search_session_recordings` tool")
 
         current_filters = self.context["current_filters"]
+
         if isinstance(current_filters, str):
             current_filters = json.loads(current_filters)
 
@@ -65,22 +66,19 @@ class SearchSessionRecordingsTool(MaxTool):
             }
         )
 
-        parser = JsonOutputParser()
-
         try:
+            parser = JsonOutputParser()
             parsed_data = parser.parse(str(result.content))
 
             if "question" in parsed_data:
                 question_response = QuestionResponse.model_validate(parsed_data)
-                return question_response.question, MaxRecordingUniversalFilters.model_validate_json(
-                    self.context["current_filters"]
-                )
+                return question_response.question, MaxRecordingUniversalFilters.model_validate_json(current_filters)
 
             validated_data = MaxRecordingUniversalFilters.model_validate(parsed_data)
         except (ValidationError, OutputParserException) as e:
             logger.exception("Error generating filters", error=e)
             return "Could not generate filters. Please try again.", MaxRecordingUniversalFilters.model_validate_json(
-                self.context["current_filters"]
+                current_filters
             )
 
         return "✅ Updated session recordings filters.", validated_data

--- a/products/replay/backend/max_tools.py
+++ b/products/replay/backend/max_tools.py
@@ -1,15 +1,16 @@
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from .prompts import (
     AI_FILTER_INITIAL_PROMPT,
     AI_FILTER_PROPERTIES_PROMPT,
     AI_FILTER_REQUEST_PROMPT,
 )
-from posthog.schema import MaxRecordingUniversalFilters, PropertyFilterType
+from posthog.schema import MaxRecordingUniversalFilters
 from ee.hogai.tool import MaxTool
 import json
+from langchain_core.output_parsers import JsonOutputParser
 
 
 class SearchSessionRecordingsArgs(BaseModel):
@@ -19,6 +20,10 @@ class SearchSessionRecordingsArgs(BaseModel):
             "Include ALL relevant details that may or may not be needed, as the tool won't receive the history of this conversation."
         )
     )
+
+
+class QuestionResponse(BaseModel):
+    question: str = Field(description="The question that the user is asking.")
 
 
 class SearchSessionRecordingsTool(MaxTool):
@@ -39,7 +44,8 @@ class SearchSessionRecordingsTool(MaxTool):
 
         prompt = ChatPromptTemplate(
             [
-                ("system", AI_FILTER_INITIAL_PROMPT + AI_FILTER_PROPERTIES_PROMPT),
+                ("system", AI_FILTER_INITIAL_PROMPT),
+                ("system", AI_FILTER_PROPERTIES_PROMPT),
                 ("human", AI_FILTER_REQUEST_PROMPT),
             ],
             template_format="mustache",
@@ -50,16 +56,130 @@ class SearchSessionRecordingsTool(MaxTool):
         if "current_filters" not in self.context:
             raise ValueError("Context `current_filters` is required for the `search_session_recordings` tool")
 
-        recording_filter_schema = MaxRecordingUniversalFilters.model_json_schema()
-        property_filter_schema = [e.value for e in PropertyFilterType]
+        and_filter_example = json.dumps(
+            MaxRecordingUniversalFilters(
+                **{
+                    "duration": [{"key": "duration", "type": "recording", "value": 60, "operator": "gte"}],
+                    "date_from": "-3d",
+                    "date_to": None,
+                    "filter_group": {
+                        "type": "AND",
+                        "values": [
+                            {
+                                "type": "AND",
+                                "values": [
+                                    {"key": "$browser", "type": "person", "value": ["Mobile"], "operator": "exact"}
+                                ],
+                            },
+                            {
+                                "type": "AND",
+                                "values": [
+                                    {"key": "$login_page", "type": "person", "value": ["true"], "operator": "exact"}
+                                ],
+                            },
+                        ],
+                    },
+                }
+            ).model_dump_json(indent=2)
+        )
+
+        or_filter_example = json.dumps(
+            MaxRecordingUniversalFilters(
+                **{
+                    "duration": [{"key": "duration", "type": "recording", "value": 60, "operator": "gte"}],
+                    "date_from": "-3d",
+                    "date_to": None,
+                    "filter_group": {  # Add them to the same filter group
+                        "type": "OR",  # type of the filter group, OR means at least one of the filters must be true
+                        "values": [
+                            {
+                                "type": "AND",
+                                "values": [
+                                    {"key": "$browser", "type": "person", "value": ["Mobile"], "operator": "exact"}
+                                ],
+                            },
+                            {
+                                "type": "AND",
+                                "values": [
+                                    {"key": "$login_page", "type": "person", "value": ["true"], "operator": "exact"}
+                                ],
+                            },
+                        ],
+                    },
+                }
+            ).model_dump_json(indent=2)
+        )
+
+        multiple_filters_example = MaxRecordingUniversalFilters(
+            **{
+                "duration": [{"key": "duration", "type": "recording", "value": 60, "operator": "exact"}],
+                "date_from": "-3d",
+                "date_to": None,
+                "filter_group": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [{"key": "$browser", "type": "person", "value": ["Mobile"], "operator": "exact"}],
+                        },
+                        {
+                            "type": "AND",
+                            "values": [{"key": "$login_page", "type": "event", "value": ["true"], "operator": "exact"}],
+                        },
+                        {
+                            "type": "OR",
+                            "values": [
+                                {"key": "$geo_ip_location", "type": "person", "value": ["Munich"], "operator": "exact"},
+                                {
+                                    "key": "$geo_ip_location",
+                                    "type": "person",
+                                    "value": ["Istanbul"],
+                                    "operator": "exact",
+                                },
+                            ],
+                        },
+                    ],
+                },
+            }
+        ).model_dump_json(indent=2)
+
+        default_filter_example = json.dumps(
+            MaxRecordingUniversalFilters(
+                **{
+                    "duration": [{"key": "duration", "type": "recording", "value": 60, "operator": "exact"}],
+                    "date_from": "-3d",
+                    "date_to": None,
+                    "filter_group": {"type": "AND", "values": [{"type": "AND", "values": []}]},
+                }
+            ).model_dump_json(indent=2)
+        )
+
         result = chain.invoke(
             {
                 "change": change,
                 **self.context,
-                "recording_filter_schema": json.dumps(recording_filter_schema, indent=2),
-                "property_filter_schema": json.dumps(property_filter_schema, indent=2),
+                "recording_filter_schema": json.dumps(MaxRecordingUniversalFilters.model_json_schema(), indent=2),
+                "and_filter_example": and_filter_example,
+                "or_filter_example": or_filter_example,
+                "multiple_filters_example": multiple_filters_example,
+                "default_filter_example": default_filter_example,
             }
         )
-        assert isinstance(result, MaxRecordingUniversalFilters)
 
-        return "✅ Updated session recordings filters.", result
+        parser = JsonOutputParser()
+        parsed_data = parser.parse(str(result.content))
+
+        if "question" in parsed_data:
+            question_response = QuestionResponse.model_validate(parsed_data)
+            return question_response.question, MaxRecordingUniversalFilters.model_validate_json(
+                self.context["current_filters"]
+            )
+
+        try:
+            validated_data = MaxRecordingUniversalFilters.model_validate(parsed_data)
+        except ValidationError:
+            return "Could not generate filters. Please try again.", MaxRecordingUniversalFilters.model_validate_json(
+                self.context["current_filters"]
+            )
+
+        return "✅ Updated session recordings filters.", validated_data

--- a/products/replay/backend/prompts.py
+++ b/products/replay/backend/prompts.py
@@ -159,7 +159,7 @@ DEFAULT_FILTER_EXAMPLE = MaxRecordingUniversalFilters(
             type="recording",
         )
     ],
-    date_from="-3d",
+    date_from="-5d",
     date_to=None,
     filter_group=MaxOuterUniversalFiltersGroup(
         type=FilterLogicalOperator.AND_,
@@ -229,7 +229,7 @@ When you need clarification or determines that additional information is require
 
 #### Clarification questions
 Here are some examples where you should ask clarification questions (return 'question' format):
-1.1.1 Page Specification Without URL: When a user says, "Show me recordings for the landing page" or "Show recordings for the sign-in page" without specifying the URL, the agent should ask: "Could you please provide the specific URL for the landing/sign-in page?"
+1.1.1. Page Specification Without URL: When a user says, "Show me recordings for the landing page" or "Show recordings for the sign-in page" without specifying the URL, the agent should ask: "Could you please provide the specific URL for the landing/sign-in page?"
 1.1.2. Ambiguous Date Ranges: If the user mentions a period like "recent sessions" without clear start and end dates, ask: "Could you specify the exact start and end dates for the period you are interested in?"
 1.1.3. Incomplete Filter Criteria: For queries such as "Show recordings with high session duration" where a threshold or comparison operator is missing, ask: "What value should be considered as 'high' for session duration?"
 
@@ -325,6 +325,7 @@ The <key> field represents the name of the property or event on which the filter
 {json.dumps(CORE_FILTER_DEFINITIONS_BY_GROUP, indent=2)}
 ```
 
+#### Full list of AVAILABLE CAMPAIGN PROPERTIES and their definitions:
 ```json
 {json.dumps(CAMPAIGN_PROPERTIES, indent=2)}
 ```
@@ -333,7 +334,9 @@ The <key> field represents the name of the property or event on which the filter
 
 AI_FILTER_REQUEST_PROMPT = """
 The current filters on this page are:
+```json
 {{{current_filters}}}
+```
 
 Put out an updated version based on the following ask:
 {{{change}}}

--- a/products/replay/backend/prompts.py
+++ b/products/replay/backend/prompts.py
@@ -2,6 +2,7 @@ from posthog.taxonomy.taxonomy import CORE_FILTER_DEFINITIONS_BY_GROUP, CAMPAIGN
 import json
 from datetime import datetime
 
+
 AI_FILTER_INITIAL_PROMPT = """
 PostHog (posthog.com) offers a Session Replay feature that supports various filters (refer to the attached documentation). Your task is to convert users' natural language queries into a precise set of filters that can be applied to the list of recordings. If a query is ambiguous, ask clarifying questions or make reasonable assumptions based on the available filter options.
 
@@ -34,29 +35,9 @@ When you need clarification or determines that additional information is require
 }
 2. Filter Response Format
 Once all necessary data is collected, the agent should return the filter in this structured format:
-{
-    "result": "filter",
-    "data": {
-        "date_from": "<date_from>",
-        "date_to": "<date_to>",
-        "filter_group": {
-            "type": "<FilterLogicalOperator>",
-            "values": [
-            {
-                "type": "<FilterLogicalOperator>",
-                "values": [
-                    {
-                        "key": "<key>",
-                        "type": "<PropertyFilterType>",
-                        "value": ["<value>"],
-                        "operator": "<PropertyOperator>"
-                    },
-                ],
-                ...
-            },
-        ]
-    }
-}
+
+{{{recording_filter_schema}}}
+
 3. Wrong Query Response Format
 If the query is not related to session replay, return with the following format:
 {
@@ -64,11 +45,6 @@ If the query is not related to session replay, return with the following format:
     "data": {
         "question": "Please ask questions only about Session Replay."
 }
-Notes:
-1. Replace <date_from> and <date_to> with valid date strings.
-2. <FilterLogicalOperator>, <PropertyFilterType>, and <PropertyOperator> should be replaced with their respective valid values defined in your system.
-3. The filter_group structure is nested. The inner "values": [] array can contain multiple items if more than one filter is needed.
-4. Ensure that the JSON output strictly follows these formats to maintain consistency and reliability in the session replay filtering process.
 
 Below is a refined description for the date fields and their types:
 
@@ -81,6 +57,8 @@ date_from:
 date_to:
 - Default Value: Set as null when the date range extends to today.
 - Custom Date: If a specific end date is required, use the format "YYYY-MM-DD".
+
+
 
 Filter Logical Operator
 - Definition: The FilterLogicalOperator defines how filters should be combined.

--- a/products/replay/backend/prompts.py
+++ b/products/replay/backend/prompts.py
@@ -2,7 +2,6 @@ from posthog.taxonomy.taxonomy import CORE_FILTER_DEFINITIONS_BY_GROUP, CAMPAIGN
 import json
 from datetime import datetime
 
-
 AI_FILTER_INITIAL_PROMPT = """
 PostHog (posthog.com) offers a Session Replay feature that supports various filters (refer to the attached documentation). Your task is to convert users' natural language queries into a precise set of filters that can be applied to the list of recordings. If a query is ambiguous, ask clarifying questions or make reasonable assumptions based on the available filter options.
 
@@ -24,245 +23,88 @@ Here are some examples where you should ask clarification questions (return 'que
 2. Ambiguous Date Ranges: If the user mentions a period like "recent sessions" without clear start and end dates, ask: "Could you specify the exact start and end dates for the period you are interested in?"
 3. Incomplete Filter Criteria: For queries such as "Show recordings with high session duration" where a threshold or comparison operator is missing, ask: "What value should be considered as 'high' for session duration?"
 
+Some knowledge about the schema:
+- Two concepts that are very important is FILTER and FILTER GROUP.
+- FILTER is a single filter that is applied to the recordings.
+- FILTER GROUP is a group of combined filters that are applied to the recordings using a logical operator 'AND' or 'OR'.
+- The 'type' field appears twice in the schema, once as a FilterLogicalOperator in the filter group object and once as a Literal in the property object. Make sure you are using it correctly.
+
 Formats of responses
 1. Question Response Format
 When you need clarification or determines that additional information is required, you should return a response in the following format:
+
+```json
 {
-    "result": "question",
-    "data": {
-        "question": "Your clarifying question here."
-    }
+"question": "Your clarifying question here."
 }
+```
 2. Filter Response Format
 Once all necessary data is collected, the agent should return the filter in this structured format:
 
+```json
 {{{recording_filter_schema}}}
+```
 
 3. Wrong Query Response Format
 If the query is not related to session replay, return with the following format:
+```json
 {
-    "result": "maxai",
-    "data": {
-        "question": "Please ask questions only about Session Replay."
+    "question": "Please ask questions only about Session Replay."
 }
+```
+4. Multiple Filters Response Format
+If the user asks for multiple filters for example "Show me recordings where people in Munich or Istanbul visit the login page and use a mobile phone", return a response with the following format:
 
-Below is a refined description for the date fields and their types:
+```json
+{{{multiple_filters_example}}}
+```
+CRITICAL: DO NOT create multiple filters if they can be combined with the same logical operator. Always optimise the number of filter groups to be as few as possible.
+Example: "show me recordings of people in Germany that had an ai error" - AND operator, both criteria should be matched, you put these filters in the same inner filter.
+ALWAYS MAKE SURE THE FILTERS ARE VALID AND MATCH THE SCHEMA.
 
-Date Fields and Types
-date_from:
-- Relative Date (Days): Use the format "-Nd" for the last N days (e.g., "last 5 days" becomes "-5d").
-- Relative Date (Hours): Use the format "-Nh" for the last N hours (e.g., "last 5 hours" becomes "-5h").
-- Custom Date: If a specific start date is provided, use the format "YYYY-MM-DD".
-- Default Behavior: If the user does not specify a date range, default to the last 5 days (i.e., use "-5d"). date_from MUST be set.
-date_to:
-- Default Value: Set as null when the date range extends to today.
-- Custom Date: If a specific end date is required, use the format "YYYY-MM-DD".
+IMPORTANT: The 'type' field appears twice in the schema, once as a FilterLogicalOperator in the filter group object and once as a Literal in the property object. Make sure you are using it correctly.
 
-
-
-Filter Logical Operator
-- Definition: The FilterLogicalOperator defines how filters should be combined.
-- Allowed Values: 'AND' or 'OR'
-- Usage: Use it as an enum. For example, use FilterLogicalOperator.AND when filters must all be met (logical AND) or FilterLogicalOperator.OR when any filter match is acceptable (logical OR).
-
-Property Filter Type
-- Definition: The PropertyFilterType specifies the type of property to filter on.
-- Allowed Values:
-    --meta: For event metadata and fields on the ClickHouse events table.
-    --event: For event properties.
-    --person: For person properties.
-    --element: For element properties.
-    --session: For session properties.
-    --cohort: For cohorts.
-    --recording: For recording properties.
-    --log_entry: For log entry properties.
-    --group: For group properties.
-    --hogql: For hogql properties.
-    --data_warehouse: For data warehouse properties.
-    --data_warehouse_person_property: For data warehouse person properties.
--Usage: Use the enum format, for example, PropertyFilterType.Person for filtering on person properties.
-
-Property Operator
-- Definition: The PropertyOperator defines the operator used for the comparison in a filter.
-- Allowed Values:
-    --Exact for 'exact'
-    --IsNot for 'is_not'
-    --IContains for 'icontains'
-    --NotIContains for 'not_icontains'
-    --Regex for 'regex'
-    --NotRegex for 'not_regex'
-    --GreaterThan for 'gt'
-    --GreaterThanOrEqual for 'gte'
-    --LessThan for 'lt'
-    --LessThanOrEqual for 'lte'
-    --IsSet     for 'is_set'
-    --IsNotSet for 'is_not_set'
-    --IsDateExact for 'is_date_exact'
-    --IsDateBefore for 'is_date_before'
-    --IsDateAfter for 'is_date_after'
-    --Between for 'between'
-    --NotBetween for 'not_between'
-    --Minimum for 'min'
-    --Maximum for 'max'
-    --In for 'in'
-    --NotIn for 'not_in'
-- Usage: Use it as an enum, for example, PropertyOperator.Exact for the exact match operator.
 
 ## Examples and Rules
 
-1. Combining Filters with the AND Operator
+1. Users can ask to create multiple filters at once.
+1.1. Combining Multiple Filters where ALL CONDITIONS MUST BE MET - use the "AND" operator
+Example: Show me recordings where people visit login page and use mobile phone
 
-If you need to combine multiple filter conditions using the AND operator, structure them as follows:
+```json
+{{{and_filter_example}}}
+```
 
-json
-{
-"result": "filter",
-"data": {
-    "date_from": "<date_from>",
-    "date_to": "<date_to>",
-    "filter_group": {
-    "type": FilterLogicalOperator.AND,
-    "values": [
-        {
-        "type": FilterLogicalOperator.AND,
-        "values": [
-            {
-            "key": "<key>",
-            "type": PropertyFilterType.<Type>,  // e.g., PropertyFilterType.Person
-            "value": ["<value>"],
-            "operator": PropertyOperator.<Operator>  // e.g., PropertyOperator.Exact or PropertyOperator.IContains
-            }
-        ]
-        }
-    ]
-    }
-}
-}
-Notes
-- Use FilterLogicalOperator.AND to ensure that all specified conditions must be met.
-- The inner "values": [] array can include multiple filter items if needed.
+1.2. Combining Multiple Filters where AT LEAST ONE CONDITION MUST BE MET - use the "OR" operator
+Example: Show me recordings where people visit login page or use mobile phone
 
-2. Combining Filters with the OR Operator
+```json
+{{{or_filter_example}}}
+```
 
-When multiple conditions are acceptable (i.e., at least one must match), use the OR operator. The structure is similar, but with multiple groups in the outer array:
+1.3. Show all recordings / clean filters:
+Return a default filter with default date range.
 
-json
-{
-"result": "filter",
-"data": {
-    "date_from": "<date_from>",
-    "date_to": "<date_to>",
-    "filter_group": {
-    "type": FilterLogicalOperator.OR,
-    "values": [
-        {
-        "type": FilterLogicalOperator.AND,
-        "values": [
-            {
-            "key": "<key>",
-            "type": PropertyFilterType.<Type>,
-            "value": ["<value>"],
-            "operator": PropertyOperator.<Operator>
-            }
-        ]
-        },
-        {
-        "type": FilterLogicalOperator.AND,
-        "values": [
-            {
-            "key": "<key>",
-            "type": PropertyFilterType.<Type>,
-            "value": ["<value>"],
-            "operator": PropertyOperator.<Operator>
-            }
-        ]
-        }
-    ]
-    }
-}
-}
-Notes:
-- The outer group uses FilterLogicalOperator.OR, while each nested group uses FilterLogicalOperator.AND for its individual conditions.
-- Multiple nested groups allow combining different filter criteria.
+```json
+{{{default_filter_example}}}
+```
 
-3. Operator Selection Guidelines
+2. Special Cases
 
-- Default Operators:
-In most cases, the operator can be either exact or contains:
-- For instance, if a user says, *"show me recordings where people visit login page"*, use the contains operator (PropertyOperator.IContains) since the URL may include parameters.
-- Exact Matching Example:
-If a user says, *"show me recordings where people use mobile phone"*, use the exact operator to target a specific device type. For example:
-
-json
-{
-    "result": "filter",
-    "data": {
-    "date_from": "<date_from>",
-    "date_to": "<date_to>",
-    "filter_group": {
-        "type": FilterLogicalOperator.AND,
-        "values": [
-        {
-            "type": FilterLogicalOperator.AND,
-            "values": [
-            {
-                "key": "$device_type",
-                "type": PropertyFilterType.Person,
-                "value": ["Mobile"],
-                "operator": PropertyOperator.Exact
-            }
-            ]
-        }
-        ]
-    }
-    }
-}
-
-4. Special Cases
-
-- Frustrated Users (Rageclicks):
+2.1. Frustrated Users (Rageclicks):
 If the query is to show recordings of people who are frustrated, filter for recordings containing a rageclick event. For example, use the event with:
 - "id": "$rageclick", "name": "$rageclick", and "type": "event"
 
-- Users Facing Bugs/Errors/Problems:
+2.2.Users Facing Bugs/Errors/Problems:
 For queries asking for recordings of users experiencing bugs or errors, target recordings with many console errors. An example filter might look like:
-- Key: "level", Type: PropertyFilterType.Log_entry, Value: ["error"], Operator: PropertyOperator.Exact.
+- Key: "level", "type": "log_entry", "value": ["error"], "operator": "exact"
 
-- Default Filter Group:
-The blank, default `filter_group` value you can use is:
+3. Prefer event over session properties, and session properties over person properties where it isn't clear.
+4. If a customer asks for recordings from a specific date but without a specific end date, set date_to to null.
+5. If a customer asks for recordings from a specific date but without specifying the year or month, use the current year and month.
 
-json
-{
-    "type": "AND",
-    "values": [
-        {
-            "type": "AND",
-            "values": []
-        }
-    ]
-}
 
-- Show all recordings / clean filters:
-Return a default filter with default date range and no duration.
-
-json
-{
-    "result": "filter",
-    "data":
-    {
-            "order": "start_time",
-            "date_to": "null",
-            "duration": [{"key": "duration", "type": "recording", "value": 60, "operator": "gt"}],
-            "date_from": "-3d",
-            "filter_group": {"type": "AND", "values": [{"type": "AND", "values": []}]},
-            "filter_test_accounts": "true",
-        }
-}
-
-5. Prefer event over session properties, and session properties over person properties where it isn't clear.
-
-6. If a customer asks for recordings from a specific date but without a specific end date, set date_to to null.
-7. If a customer asks for recordings from a specific date but without specifying the year or month, use the current year and month.
+CRITICAL: DO NOT REMOVE CURRENT FILTERS, ONLY APPLY THE NEW FILTERS COMING IN FROM THE USER.
 """
 
 day = datetime.now().day
@@ -270,61 +112,48 @@ today_date = datetime.now().strftime(f"{day} %B %Y")
 AI_FILTER_INITIAL_PROMPT += f"\nToday is {today_date}."
 
 AI_FILTER_PROPERTIES_PROMPT = f"""
-<key> Field
+The <key> field represents the name of the property or event on which the filter is applied.
 
-- Purpose:
-The <key> represents the name of the property on which the filter is applied.
+The <name> field represents the name of the source of the property or event.
+This is the list of sources of properties:
 
-- Source of Properties:
-- Person Properties:
-    Use the "name" field from the Person properties array (e.g., $browser, $device_type, email).
+1. Person Properties aka PersonPropertyFilter:
+    Use the "name" field from the PersonPropertyFilter array (e.g., $browser, $device_type, email).
     Example: If filtering on browser type, you might use the key $browser.
 
-- Session Properties:
+2. Session Properties aka SessionPropertyFilter:
     Use the "name" field from the Session properties array (e.g., $start_timestamp, $entry_current_url).
     Example: If filtering based on the session start time, you might use the key $start_timestamp.
 
-- Event Properties:
+3. Event Properties aka EventPropertyFilter:
     Use the "name" field from the Event properties array (e.g. $current_url).
     Example: For filtering on the user's browser, you might use the key $browser.
 
-- Events:
+4. Events aka EventFilter:
     In some cases, the filter might reference a predefined event name (e.g., "$rageclick", "recording viewed", etc.).
     The agent should match the event name from the provided events list if the query is about a specific event.
-- Type Determination:
-The expected data type can be inferred from the property_type field provided in each property object:
-- "String" indicates the value should be a string.
-- "Numeric" indicates a numeric value.
-- "Boolean" indicates a boolean value.
-- "DateTime", "Duration" and other types should follow their respective formats.
-- A null value for property_type means the type is flexible or unspecified; in such cases, rely on the property name's context.
 
-<value> Field
+5. Recording Properties aka RecordingPropertyFilter:
+    Use the "name" field from the Recording properties array (e.g. $duration).
 
-- Purpose:
 The <value> field is an array containing one or more values that the filter should match.
 
-- Data Type Matching:
+1. Data Type Matching:
 Ensure the values in this array match the expected type of the property identified by <key>. For example:
-- For a property with property_type "String", the value should be provided as a string (e.g., ["Mobile"]).
-- For a property with property_type "Numeric", the value should be a number (e.g., [10]).
-- For a property with property_type "Boolean", the value should be either true or false (e.g., [true]).
+- For a property with 'type' "String", the value should be quoted as a string (e.g., ["Mobile"]).
+- For a property with 'type' "Numeric", the value should be a number (e.g., [10]).
+- For a property with 'type' "Boolean", the value should be either true or false (e.g., 'true' or 'false' DO NOT USE 1 or 0).
+- For a property with 'type' "DateTime", the value should be a datetime string (e.g., ["2021-01-01"]).
+- For a property with 'type' "array", the value should be an array of elements (e.g., [["Mobile", "Desktop"]]).
+- A null value for type means the type is flexible or unspecified; in such cases, rely on the property name's context.
 
-- Multiple Values:
-The <value> array can contain multiple items when the filter should match any one of several potential values.
+2. Event Filtering:
+When the query references an event (such as a user action or system event) by name, verify that the <key> corresponds to an entry in the Event or the provided list of event names.
 
-Special Considerations and Examples
-
-- Guessing the Property Type:
-Use the property_type information to determine how to format the <value>. For instance, if the property is numeric, do not wrap the number in quotes.
-
-- Event Filtering:
-When the query references an event (such as a user action or system event) by name, verify that the <key> corresponds to an entry in the Event properties or the provided list of event names.
-
-Full list of available properties and their definitions:
+Full list of AVAILABLE PROPERTIES and their definitions:
 {json.dumps(CORE_FILTER_DEFINITIONS_BY_GROUP)}
 
-Campaign properties:
+CAMPAIGN_PROPERTIES:
 {json.dumps(CAMPAIGN_PROPERTIES)}
 """.strip()
 

--- a/products/replay/backend/prompts.py
+++ b/products/replay/backend/prompts.py
@@ -1,110 +1,276 @@
 from posthog.taxonomy.taxonomy import CORE_FILTER_DEFINITIONS_BY_GROUP, CAMPAIGN_PROPERTIES
 import json
 from datetime import datetime
+from posthog.schema import (
+    MaxRecordingUniversalFilters,
+    MaxOuterUniversalFiltersGroup,
+    MaxInnerUniversalFiltersGroup,
+    FilterLogicalOperator,
+    PersonPropertyFilter,
+    RecordingDurationFilter,
+    DurationType,
+)
+from posthog.schema import EventPropertyFilter, PropertyOperator
+from pydantic import BaseModel, Field
 
-AI_FILTER_INITIAL_PROMPT = """
+
+class QuestionResponse(BaseModel):
+    question: str = Field(description="The question that the user is asking.")
+
+
+# Filter examples for the AI prompts
+AND_FILTER_EXAMPLE = MaxRecordingUniversalFilters(
+    duration=[
+        RecordingDurationFilter(
+            key=DurationType.DURATION,
+            operator=PropertyOperator.GTE,
+            value=60,
+            type="recording",
+        )
+    ],
+    date_from="-3d",
+    date_to=None,
+    filter_group=MaxOuterUniversalFiltersGroup(
+        type=FilterLogicalOperator.AND_,
+        values=[
+            MaxInnerUniversalFiltersGroup(
+                type=FilterLogicalOperator.AND_,
+                values=[
+                    PersonPropertyFilter(
+                        key="$browser",
+                        type="person",
+                        value=["Mobile"],
+                        operator=PropertyOperator.EXACT,
+                    )
+                ],
+            ),
+            MaxInnerUniversalFiltersGroup(
+                type=FilterLogicalOperator.AND_,
+                values=[
+                    EventPropertyFilter(
+                        key="$login_page",
+                        type="event",
+                        value=["true"],
+                        operator=PropertyOperator.EXACT,
+                    )
+                ],
+            ),
+        ],
+    ),
+)
+
+OR_FILTER_EXAMPLE = MaxRecordingUniversalFilters(
+    duration=[
+        RecordingDurationFilter(
+            key=DurationType.DURATION,
+            operator=PropertyOperator.GTE,
+            value=60,
+            type="recording",
+        )
+    ],
+    date_from="-3d",
+    date_to=None,
+    filter_group=MaxOuterUniversalFiltersGroup(  # Add them to the same filter group
+        type=FilterLogicalOperator.OR_,
+        values=[
+            MaxInnerUniversalFiltersGroup(
+                type=FilterLogicalOperator.AND_,
+                values=[
+                    EventPropertyFilter(
+                        key="$browser",
+                        type="event",
+                        value=["Mobile"],
+                        operator=PropertyOperator.EXACT,
+                    )
+                ],
+            ),
+            MaxInnerUniversalFiltersGroup(
+                type=FilterLogicalOperator.AND_,
+                values=[
+                    EventPropertyFilter(
+                        key="$login_page",
+                        type="event",
+                        value=["true"],
+                        operator=PropertyOperator.EXACT,
+                    )
+                ],
+            ),
+        ],
+    ),
+)
+
+MULTIPLE_FILTERS_EXAMPLE = MaxRecordingUniversalFilters(
+    duration=[
+        RecordingDurationFilter(
+            key=DurationType.DURATION,
+            operator=PropertyOperator.EXACT,
+            value=60,
+            type="recording",
+        )
+    ],
+    date_from="-3d",
+    date_to=None,
+    filter_group=MaxOuterUniversalFiltersGroup(
+        type=FilterLogicalOperator.AND_,
+        values=[
+            MaxInnerUniversalFiltersGroup(
+                type=FilterLogicalOperator.AND_,
+                values=[
+                    PersonPropertyFilter(
+                        key="$browser",
+                        type="person",
+                        value=["Mobile"],
+                        operator=PropertyOperator.EXACT,
+                    )
+                ],
+            ),
+            MaxInnerUniversalFiltersGroup(
+                type=FilterLogicalOperator.AND_,
+                values=[
+                    EventPropertyFilter(
+                        key="$login_page",
+                        type="event",
+                        value=["true"],
+                        operator=PropertyOperator.EXACT,
+                    )
+                ],
+            ),
+            MaxInnerUniversalFiltersGroup(
+                type=FilterLogicalOperator.OR_,
+                values=[
+                    PersonPropertyFilter(
+                        key="$geo_ip_location",
+                        type="person",
+                        value=["Munich"],
+                        operator=PropertyOperator.EXACT,
+                    ),
+                ],
+            ),
+        ],
+    ),
+)
+
+DEFAULT_FILTER_EXAMPLE = MaxRecordingUniversalFilters(
+    duration=[
+        RecordingDurationFilter(
+            key=DurationType.DURATION,
+            operator=PropertyOperator.EXACT,
+            value=60,
+            type="recording",
+        )
+    ],
+    date_from="-3d",
+    date_to=None,
+    filter_group=MaxOuterUniversalFiltersGroup(
+        type=FilterLogicalOperator.AND_,
+        values=[MaxInnerUniversalFiltersGroup(type=FilterLogicalOperator.AND_, values=[])],
+    ),
+)
+
+AI_FILTER_INITIAL_PROMPT = f"""
 PostHog (posthog.com) offers a Session Replay feature that supports various filters (refer to the attached documentation). Your task is to convert users' natural language queries into a precise set of filters that can be applied to the list of recordings. If a query is ambiguous, ask clarifying questions or make reasonable assumptions based on the available filter options.
 
-Key Points:
+## Key Points:
 1. Purpose: Transform natural language queries related to session recordings into structured filters.
-2. Relevance Check: First, verify that the question is specifically related to session replay. If the question is off-topic—for example, asking about the weather, the AI model, or any subject not related to session replay—the agent should respond with a specific message result: 'maxai'.
+2. Relevance Check: First, verify that the question is specifically related to session replay. If the question is off-topic—for example, asking about the weather, the AI model, or any subject not related to session replay—the agent should respond with a specific message result: 'question'.
 3. Ambiguity Handling: If a query is ambiguous or missing details, ask clarifying questions or make reasonable assumptions based on the available filter options.
 
-Strictly follow this algorithm:
+## Strictly follow this algorithm:
 1. Verify Query Relevance: Confirm that the user's question is related to session recordings.
-2. Handle Irrelevant Queries: If the question is not related, return a response with result: 'maxai' that explains why the query is outside the scope.
-3. Identify Missing Information: If the question is relevant but lacks some required details, return a response with result: 'question' that asks clarifying questions to gather the missing information.
-4. Apply Default Values: If the user does not specify certain parameters, automatically use the default values from the provided 'default value' list.
-5. Iterative Clarification: Continue asking clarifying questions until you have all the necessary data to process the request.
-6. Return Structured Filter: Once all required data is collected, return a response with result: 'filter' containing the correctly structured answer as per the answer structure guidelines below.
+2. Identify Missing Information: If the question is relevant but lacks some required details, return a response with result: 'question' that asks clarifying questions to gather the missing information.
+3. Apply Default Values: If the user does not specify certain parameters, automatically use the default values from the provided 'default value' list.
+4. Iterative Clarification: Continue asking clarifying questions until you have all the necessary data to process the request.
+5. Return Structured Filter: Once all required data is collected, return a response containing the correctly structured answer using the formats below.
 
-Here are some examples where you should ask clarification questions (return 'question' format):
-1.Page Specification Without URL: When a user says, "Show me recordings for the landing page" or "Show recordings for the sign-in page" without specifying the URL, the agent should ask: "Could you please provide the specific URL for the landing/sign-in page?"
-2. Ambiguous Date Ranges: If the user mentions a period like "recent sessions" without clear start and end dates, ask: "Could you specify the exact start and end dates for the period you are interested in?"
-3. Incomplete Filter Criteria: For queries such as "Show recordings with high session duration" where a threshold or comparison operator is missing, ask: "What value should be considered as 'high' for session duration?"
+## Response format
 
-Some knowledge about the schema:
-- Two concepts that are very important is FILTER and FILTER GROUP.
+### Important concepts:
+- Two concepts that are very important are FILTER and FILTER GROUP.
 - FILTER is a single filter that is applied to the recordings.
 - FILTER GROUP is a group of combined filters that are applied to the recordings using a logical operator 'AND' or 'OR'.
-- The 'type' field appears twice in the schema, once as a FilterLogicalOperator in the filter group object and once as a Literal in the property object. Make sure you are using it correctly.
+- IMPORTANT: The 'type' field appears twice in the schema, once as a FilterLogicalOperator in the filter group object and once as a Literal in the property object. Make sure you are using it correctly.
+- For boolean properties, use the values 'true' or 'false' (DO NOT USE 1 or 0).
 
-Formats of responses
-1. Question Response Format
-When you need clarification or determines that additional information is required, you should return a response in the following format:
+### Accepted response formats:
 
-```json
-{
-"question": "Your clarifying question here."
-}
-```
-2. Filter Response Format
+#### Filter Response Format
 Once all necessary data is collected, the agent should return the filter in this structured format:
 
 ```json
-{{{recording_filter_schema}}}
+{json.dumps(MaxRecordingUniversalFilters.model_json_schema(), indent=2)}
 ```
 
-3. Wrong Query Response Format
-If the query is not related to session replay, return with the following format:
-```json
-{
-    "question": "Please ask questions only about Session Replay."
-}
-```
-4. Multiple Filters Response Format
+
+#### Multiple Filters Response Format
 If the user asks for multiple filters for example "Show me recordings where people in Munich or Istanbul visit the login page and use a mobile phone", return a response with the following format:
 
 ```json
-{{{multiple_filters_example}}}
+{MULTIPLE_FILTERS_EXAMPLE.model_dump_json(indent=2)}
 ```
-CRITICAL: DO NOT create multiple filters if they can be combined with the same logical operator. Always optimise the number of filter groups to be as few as possible.
+
+#### CRITICAL: DO NOT create multiple filters if they can be combined with the same logical operator. Always optimise the number of filter groups to be as few as possible.
 Example: "show me recordings of people in Germany that had an ai error" - AND operator, both criteria should be matched, you put these filters in the same inner filter.
+
 ALWAYS MAKE SURE THE FILTERS ARE VALID AND MATCH THE SCHEMA.
 
-IMPORTANT: The 'type' field appears twice in the schema, once as a FilterLogicalOperator in the filter group object and once as a Literal in the property object. Make sure you are using it correctly.
+#### Wrong Query Response Format
+If the query is not related to session replay, return with the following format:
 
+```json
+{json.dumps(QuestionResponse.model_json_schema(), indent=2)}
+```
+
+#### Question Response Format
+When you need clarification or determines that additional information is required, you should return a response in the following format:
+
+```json
+{json.dumps(QuestionResponse.model_json_schema(), indent=2)}
+```
+
+#### Clarification questions
+Here are some examples where you should ask clarification questions (return 'question' format):
+1.1.1 Page Specification Without URL: When a user says, "Show me recordings for the landing page" or "Show recordings for the sign-in page" without specifying the URL, the agent should ask: "Could you please provide the specific URL for the landing/sign-in page?"
+1.1.2. Ambiguous Date Ranges: If the user mentions a period like "recent sessions" without clear start and end dates, ask: "Could you specify the exact start and end dates for the period you are interested in?"
+1.1.3. Incomplete Filter Criteria: For queries such as "Show recordings with high session duration" where a threshold or comparison operator is missing, ask: "What value should be considered as 'high' for session duration?"
 
 ## Examples and Rules
 
-1. Users can ask to create multiple filters at once.
-1.1. Combining Multiple Filters where ALL CONDITIONS MUST BE MET - use the "AND" operator
+### Users can ask to create multiple filters at once.
+#### Combining Multiple Filters where ALL CONDITIONS MUST BE MET - use the "AND" operator
 Example: Show me recordings where people visit login page and use mobile phone
 
 ```json
-{{{and_filter_example}}}
+{AND_FILTER_EXAMPLE.model_dump_json(indent=2)}
 ```
 
-1.2. Combining Multiple Filters where AT LEAST ONE CONDITION MUST BE MET - use the "OR" operator
+#### Combining Multiple Filters where AT LEAST ONE CONDITION MUST BE MET - use the "OR" operator
 Example: Show me recordings where people visit login page or use mobile phone
 
 ```json
-{{{or_filter_example}}}
+{OR_FILTER_EXAMPLE.model_dump_json(indent=2)}
 ```
 
-1.3. Show all recordings / clean filters:
+#### Show all recordings / clean filters:
 Return a default filter with default date range.
 
 ```json
-{{{default_filter_example}}}
+{DEFAULT_FILTER_EXAMPLE.model_dump_json(indent=2)}
 ```
 
-2. Special Cases
+### Special Cases
 
-2.1. Frustrated Users (Rageclicks):
+#### Frustrated Users (Rageclicks):
 If the query is to show recordings of people who are frustrated, filter for recordings containing a rageclick event. For example, use the event with:
 - "id": "$rageclick", "name": "$rageclick", and "type": "event"
 
-2.2.Users Facing Bugs/Errors/Problems:
+#### Users Facing Bugs/Errors/Problems:
 For queries asking for recordings of users experiencing bugs or errors, target recordings with many console errors. An example filter might look like:
 - Key: "level", "type": "log_entry", "value": ["error"], "operator": "exact"
 
-3. Prefer event over session properties, and session properties over person properties where it isn't clear.
-4. If a customer asks for recordings from a specific date but without a specific end date, set date_to to null.
-5. If a customer asks for recordings from a specific date but without specifying the year or month, use the current year and month.
+#### Prefer event over session properties, and session properties over person properties where it isn't clear.
+#### If a customer asks for recordings from a specific date but without specifying the year or month, use the current year and month.
+#### VERY CRITICAL: DO NOT REMOVE CURRENT FILTERS, UNLESS THE USER ASKS FOR IT. APPLY THE CHANGE FROM THE USER ON TOP OF THE CURRENT FILTERS.
 
-
-CRITICAL: DO NOT REMOVE CURRENT FILTERS, ONLY APPLY THE NEW FILTERS COMING IN FROM THE USER.
 """
 
 day = datetime.now().day
@@ -112,33 +278,34 @@ today_date = datetime.now().strftime(f"{day} %B %Y")
 AI_FILTER_INITIAL_PROMPT += f"\nToday is {today_date}."
 
 AI_FILTER_PROPERTIES_PROMPT = f"""
-The <key> field represents the name of the property or event on which the filter is applied.
 
-The <name> field represents the name of the source of the property or event.
-This is the list of sources of properties:
+## Sources of properties
+
+The <type> field represents the type of the source of the property or event. e.g. person, session, event, recording, etc.
 
 1. Person Properties aka PersonPropertyFilter:
-    Use the "name" field from the PersonPropertyFilter array (e.g., $browser, $device_type, email).
-    Example: If filtering on browser type, you might use the key $browser.
+    Use the "type" field from the PersonPropertyFilter array
+    Example: If filtering on browser type, you might use the key $browser and the type "person"
 
 2. Session Properties aka SessionPropertyFilter:
-    Use the "name" field from the Session properties array (e.g., $start_timestamp, $entry_current_url).
-    Example: If filtering based on the session start time, you might use the key $start_timestamp.
+    Use the "type" field from the SessionPropertyFilter
+    Example: If filtering based on the session start time, you might use the key $start_timestamp and the type "session"
 
 3. Event Properties aka EventPropertyFilter:
-    Use the "name" field from the Event properties array (e.g. $current_url).
-    Example: For filtering on the user's browser, you might use the key $browser.
+    Use the "type" field from the EventPropertyFilter
+    Example: For filtering on the user's browser, you might use the key $browser and the type "event"
 
 4. Events aka EventFilter:
     In some cases, the filter might reference a predefined event name (e.g., "$rageclick", "recording viewed", etc.).
-    The agent should match the event name from the provided events list if the query is about a specific event.
+    The agent should match the event name from the provided events list if the query is about a specific event and the type "event"
 
 5. Recording Properties aka RecordingPropertyFilter:
-    Use the "name" field from the Recording properties array (e.g. $duration).
+    Use the "type" field from the RecordingPropertyFilter
+    Example: If filtering based on the recording duration, you might use the key $duration and the type "recording"
 
+### Property values
 The <value> field is an array containing one or more values that the filter should match.
-
-1. Data Type Matching:
+#### Data Type Matching:
 Ensure the values in this array match the expected type of the property identified by <key>. For example:
 - For a property with 'type' "String", the value should be quoted as a string (e.g., ["Mobile"]).
 - For a property with 'type' "Numeric", the value should be a number (e.g., [10]).
@@ -147,15 +314,22 @@ Ensure the values in this array match the expected type of the property identifi
 - For a property with 'type' "array", the value should be an array of elements (e.g., [["Mobile", "Desktop"]]).
 - A null value for type means the type is flexible or unspecified; in such cases, rely on the property name's context.
 
-2. Event Filtering:
+#### Event Filtering:
 When the query references an event (such as a user action or system event) by name, verify that the <key> corresponds to an entry in the Event or the provided list of event names.
 
-Full list of AVAILABLE PROPERTIES and their definitions:
-{json.dumps(CORE_FILTER_DEFINITIONS_BY_GROUP)}
+## Property names and event definitions
+The <key> field represents the name of the property or event on which the filter is applied. e.g. $browser, $device_type, email, $current_url, $rageclick, etc.
 
-CAMPAIGN_PROPERTIES:
-{json.dumps(CAMPAIGN_PROPERTIES)}
+#### Full list of AVAILABLE PROPERTIES and their definitions:
+```json
+{json.dumps(CORE_FILTER_DEFINITIONS_BY_GROUP, indent=2)}
+```
+
+```json
+{json.dumps(CAMPAIGN_PROPERTIES, indent=2)}
+```
 """.strip()
+
 
 AI_FILTER_REQUEST_PROMPT = """
 The current filters on this page are:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,6 +218,7 @@ dev = [
     "types-retry==0.9.9.4",
     "types-tzlocal~=5.1.0.1",
     "watchdog==5.0.3",
+    "deepdiff==8.5.0",
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -1207,6 +1207,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deepdiff"
+version = "8.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "orderly-set" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/0f/9cd2624f7dcd755cbf1fa21fb7234541f19a1be96a56f387ec9053ebe220/deepdiff-8.5.0.tar.gz", hash = "sha256:a4dd3529fa8d4cd5b9cbb6e3ea9c95997eaa919ba37dac3966c1b8f872dc1cd1", size = 538517, upload-time = "2025-05-09T18:44:10.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/3b/2e0797200c51531a6d8c97a8e4c9fa6fb56de7e6e2a15c1c067b6b10a0b0/deepdiff-8.5.0-py3-none-any.whl", hash = "sha256:d4599db637f36a1c285f5fdfc2cd8d38bde8d8be8636b65ab5e425b67c54df26", size = 85112, upload-time = "2025-05-09T18:44:07.784Z" },
+]
+
+[[package]]
 name = "defusedxml"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3527,6 +3539,15 @@ wheels = [
 ]
 
 [[package]]
+name = "orderly-set"
+version = "5.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/88/39c83c35d5e97cc203e9e77a4f93bf87ec89cf6a22ac4818fdcc65d66584/orderly_set-5.5.0.tar.gz", hash = "sha256:e87185c8e4d8afa64e7f8160ee2c542a475b738bc891dc3f58102e654125e6ce", size = 27414, upload-time = "2025-07-10T20:10:55.885Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl", hash = "sha256:46f0b801948e98f427b412fcabb831677194c05c3b699b80de260374baa0b1e7", size = 13068, upload-time = "2025-07-10T20:10:54.377Z" },
+]
+
+[[package]]
 name = "orjson"
 version = "3.10.15"
 source = { registry = "https://pypi.org/simple" }
@@ -3955,6 +3976,7 @@ dev = [
     { name = "braintrust" },
     { name = "braintrust-langchain" },
     { name = "datamodel-code-generator" },
+    { name = "deepdiff" },
     { name = "django-linear-migrations" },
     { name = "django-stubs" },
     { name = "djangorestframework-stubs" },
@@ -4172,6 +4194,7 @@ dev = [
     { name = "braintrust", specifier = "==0.1.1" },
     { name = "braintrust-langchain", specifier = "==0.0.2" },
     { name = "datamodel-code-generator", specifier = "==0.28.5" },
+    { name = "deepdiff", specifier = "==8.5.0" },
     { name = "django-linear-migrations", specifier = "==2.16.*" },
     { name = "django-stubs", specifier = "==5.0.4" },
     { name = "djangorestframework-stubs", specifier = "~=3.14.5" },


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
The session reply prompts include a lot of the hardcoded schemas. If the MaxSessionReplyFilters change, then the prompts would be outdated causing issues with the return type format. Also we are using both structured output and the direct format explanation in this case, only one should suffice. Also a lot of other issues with the FilterOperators and inconsistencies between the examples and the filter structure.

## Changes
1. Using now the Pydantic Schemas in the prompt instead of hardcoded response format
2. Using objects as examples to be able to maintain easily the prompts and examples if things change
3. Remove duplicate or redundant information about operators and data types
4. Help the llm get better at multiple complex filters.

## How did you test this code?
1. Evals and manual testing

## Did you write or update any docs for this change?
No
<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
