### PR TITLE
fix(experiments): Increase query timeout to 10 minutes

### DIFF
--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -91,6 +91,9 @@ from posthog.schema import (
 logger = structlog.get_logger(__name__)
 
 
+MAX_EXECUTION_TIME = 600
+
+
 class ExperimentQueryRunner(QueryRunner):
     query: ExperimentQuery
     response: ExperimentQueryResponse
@@ -611,7 +614,7 @@ class ExperimentQueryRunner(QueryRunner):
                 team=self.team,
                 timings=self.timings,
                 modifiers=create_default_modifiers_for_team(self.team),
-                settings=HogQLGlobalSettings(max_execution_time=180),
+                settings=HogQLGlobalSettings(max_execution_time=MAX_EXECUTION_TIME),
             )
         except InternalHogQLError as e:
             # Log essential context for debugging (no PII/secrets)

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_base.ambr
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_base.ambr
@@ -56,7 +56,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -103,7 +103,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -150,7 +150,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -218,7 +218,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -286,7 +286,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -354,7 +354,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -422,7 +422,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -490,7 +490,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -558,7 +558,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -626,7 +626,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -694,7 +694,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -762,7 +762,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -830,7 +830,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -898,7 +898,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -966,7 +966,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1064,7 +1064,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1132,7 +1132,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1200,7 +1200,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1268,7 +1268,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1336,7 +1336,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1404,7 +1404,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1490,7 +1490,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1558,7 +1558,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1646,7 +1646,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1715,7 +1715,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1807,7 +1807,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1875,7 +1875,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1943,7 +1943,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -2011,7 +2011,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -2079,7 +2079,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -2147,7 +2147,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -2215,7 +2215,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -2283,7 +2283,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -2351,7 +2351,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -2419,7 +2419,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_data_warehouse_metric.ambr
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_data_warehouse_metric.ambr
@@ -54,7 +54,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -120,7 +120,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -186,7 +186,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -252,7 +252,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -318,7 +318,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -384,7 +384,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -450,7 +450,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -516,7 +516,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -582,7 +582,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -634,7 +634,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -720,7 +720,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -786,7 +786,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -852,7 +852,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -918,7 +918,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -984,7 +984,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1050,7 +1050,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1131,7 +1131,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1197,7 +1197,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1280,7 +1280,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1347,7 +1347,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1429,7 +1429,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1495,7 +1495,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1561,7 +1561,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1627,7 +1627,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1717,7 +1717,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_frequentist_method.ambr
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_frequentist_method.ambr
@@ -56,7 +56,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_funnel_metric.ambr
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_funnel_metric.ambr
@@ -59,7 +59,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -130,7 +130,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -201,7 +201,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -272,7 +272,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -343,7 +343,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -414,7 +414,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -485,7 +485,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -560,7 +560,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -632,7 +632,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -703,7 +703,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -774,7 +774,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -844,7 +844,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -893,7 +893,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -972,7 +972,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1051,7 +1051,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1130,7 +1130,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1239,7 +1239,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1348,7 +1348,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1457,7 +1457,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1515,7 +1515,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1573,7 +1573,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -1631,7 +1631,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_mean_metric.ambr
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_mean_metric.ambr
@@ -112,7 +112,7 @@
                     exposures.entity_id) AS metric_events) AS percentiles) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -236,7 +236,7 @@
                     exposures.entity_id) AS metric_events) AS percentiles) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -304,7 +304,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -372,7 +372,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -440,7 +440,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -508,7 +508,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,
@@ -576,7 +576,7 @@
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=180,
+                     max_execution_time=600,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=4000000,


### PR DESCRIPTION
## Problem
Some customers with a lot of data do sometimes hit the current 3 min query timeout.

## Changes
For now, increase the query timeout to 10 minutes.

We might need to look into leveraging materialized views more for experiment queries for better performance when there is large amounts of data. Something to research.