### PR TITLE
fix(experiments): add exposure event series also to trend queries

### DIFF
--- a/frontend/src/scenes/experiments/metricQueryUtils.ts
+++ b/frontend/src/scenes/experiments/metricQueryUtils.ts
@@ -428,7 +428,10 @@ export const addExposureToQuery =
                       ...query,
                       series: [exposureEvent, ...query.series],
                   }
-                : query // Don't add exposure to TrendsQuery
+                : {
+                      ...query,
+                      series: [exposureEvent, ...query.series],
+                  }
             : undefined
 
 type InsightVizNodeOptions = {


### PR DESCRIPTION
## Problem
The MDE calculator is currently broken for trend queries as the exposure event series is not added to the query.

See slack thread [here](https://posthog.slack.com/archives/C07PXH2GTGV/p1753090621851239)

## Changes
Add the exposure event to trend queries also.

## How did you test this code?
* tested locally and confirm that it now works
