### PR TITLE
fix: bulk operation menu can be empty and show an empty dropdown on menu click

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
@@ -197,14 +197,17 @@ export function SessionRecordingsPlaylistTopSettings({
 
         menuItems.push({
             label: 'Add to collection',
-            items: playlistsLoading ? (
-                <Spinner textColored={true} />
-            ) : (
-                collections.map((playlist) => ({
-                    label: <span className="truncate">{playlist.name || playlist.derived_name || 'Unnamed'}</span>,
-                    onClick: () => handleBulkAddToPlaylist(playlist.short_id),
-                }))
-            ),
+            items: playlistsLoading
+                ? [
+                      {
+                          label: <Spinner textColored={true} />,
+                          onClick: () => {},
+                      },
+                  ]
+                : collections.map((playlist) => ({
+                      label: <span className="truncate">{playlist.name || playlist.derived_name || 'Unnamed'}</span>,
+                      onClick: () => handleBulkAddToPlaylist(playlist.short_id),
+                  })),
             disabledReason:
                 collections.length === 0
                     ? 'There are no collections. You have to make a collection before you can bulk add recordings to it'

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
@@ -190,23 +190,25 @@ export function SessionRecordingsPlaylistTopSettings({
     const getActionsMenuItems = (): LemonMenuItem[] => {
         const menuItems = []
 
-        if (!playlistsLoading) {
-            const collections =
-                type === 'collection' && shortId
-                    ? playlists.results.filter((playlist) => playlist.short_id !== shortId)
-                    : playlists.results
+        const collections =
+            type === 'collection' && shortId
+                ? playlists.results.filter((playlist) => playlist.short_id !== shortId)
+                : playlists.results
 
-            if (collections.length > 0) {
-                menuItems.push({
-                    label: 'Add to collection',
-                    items: collections.map((playlist) => ({
-                        label: <span className="truncate">{playlist.name || playlist.derived_name || 'Unnamed'}</span>,
-                        onClick: () => handleBulkAddToPlaylist(playlist.short_id),
-                    })),
-                    'data-attr': 'add-to-collection',
-                })
-            }
-        }
+        menuItems.push({
+            label: 'Add to collection',
+            items: playlistsLoading
+                ? []
+                : collections.map((playlist) => ({
+                      label: <span className="truncate">{playlist.name || playlist.derived_name || 'Unnamed'}</span>,
+                      onClick: () => handleBulkAddToPlaylist(playlist.short_id),
+                  })),
+            disabledReason:
+                collections.length === 0
+                    ? 'There are no collections. You have to make a collection before you can bulk add recordings to it'
+                    : undefined,
+            'data-attr': 'add-to-collection',
+        })
 
         if (type === 'collection' && shortId) {
             menuItems.push({
@@ -256,6 +258,7 @@ export function SessionRecordingsPlaylistTopSettings({
                     <SettingsMenu
                         items={getActionsMenuItems()}
                         label={<LemonBadge content={selectedRecordingsIds.length.toString()} size="small" />}
+                        data-attr="bulk-action-menu"
                     />
                 )}
                 <SettingsMenu

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
@@ -10,7 +10,7 @@ import {
 } from './sessionRecordingsPlaylistLogic'
 import { savedSessionRecordingPlaylistsLogic } from 'scenes/session-recordings/saved-playlists/savedSessionRecordingPlaylistsLogic'
 import { ReplayTabs } from '~/types'
-import { LemonBadge, LemonButton, LemonCheckbox, LemonInput, LemonModal } from '@posthog/lemon-ui'
+import { LemonBadge, LemonButton, LemonCheckbox, LemonInput, LemonModal, Spinner } from '@posthog/lemon-ui'
 import { LemonMenuItem } from 'lib/lemon-ui/LemonMenu/LemonMenu'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -197,12 +197,14 @@ export function SessionRecordingsPlaylistTopSettings({
 
         menuItems.push({
             label: 'Add to collection',
-            items: playlistsLoading
-                ? []
-                : collections.map((playlist) => ({
-                      label: <span className="truncate">{playlist.name || playlist.derived_name || 'Unnamed'}</span>,
-                      onClick: () => handleBulkAddToPlaylist(playlist.short_id),
-                  })),
+            items: playlistsLoading ? (
+                <Spinner textColored={true} />
+            ) : (
+                collections.map((playlist) => ({
+                    label: <span className="truncate">{playlist.name || playlist.derived_name || 'Unnamed'}</span>,
+                    onClick: () => handleBulkAddToPlaylist(playlist.short_id),
+                }))
+            ),
             disabledReason:
                 collections.length === 0
                     ? 'There are no collections. You have to make a collection before you can bulk add recordings to it'


### PR DESCRIPTION
this is a good example of why we should prefer to disable UI elements over hiding them

fixes https://github.com/PostHog/posthog/issues/35238

|before|after|
|-|-|
|<img width="272" height="76" alt="Screenshot 2025-07-21 at 13 12 59" src="https://github.com/user-attachments/assets/5f3fece0-16d1-4d5e-8a40-591e0a5bf7fc" />|<img width="611" height="150" alt="Screenshot 2025-07-21 at 13 08 14" src="https://github.com/user-attachments/assets/ea7c8502-5be8-436e-99ed-e873fc3fce55" />|

in the case where `playlistsLoading` was true or there were no playlists
we would not add "add to collection" to the menu

in the case where we were not looking at a collection
we would not add "remove from collection" to the menu

in the case where the bulk delete feature flag is false
we would not add "delete" to the menu

which meant it was possible for the menu to be empty

ideally we would let you create a new collection when bulk adding, but for the sake of getting a fix out for confusing behaviour

we should always add "add to collection" and disable it if it is not available for interaction
this way the menu is never empty (even though its contents do vary)

## when still loading

<img width="334" height="91" alt="Screenshot 2025-07-21 at 13 18 33" src="https://github.com/user-attachments/assets/b472dbc0-c9fd-4196-8dde-09ec5044855d" />
