### PR TITLE
fix: Do not consume logs if not running loop

### DIFF
--- a/products/batch_exports/backend/tests/temporal/test_logger.py
+++ b/products/batch_exports/backend/tests/temporal/test_logger.py
@@ -148,7 +148,11 @@ async def configure(configure_logger, log_capture, queue, producer):
         # We override settings as otherwise we'll get console logs which
         # are not JSON
         configure_logger_async(
-            extra_processors=[log_capture], queue=queue, producer=producer, cache_logger_on_first_use=False
+            extra_processors=[log_capture],
+            queue=queue,
+            producer=producer,
+            cache_logger_on_first_use=False,
+            loop=asyncio.get_running_loop(),
         )
 
     yield


### PR DESCRIPTION
## Problem

For whatever reason, if we ever try to call `configure_logging_async` without an asyncio event loop, we should not run the async parts, meaning the log producer pipeline.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Skip log producer creation if not passing an asyncio loop. This shouldn't change anything when starting a worker normally, as we always pass the loop in `start_temopral_worker`. Otherwise nothing will ever get produced. But sometimes when running tests I find myself in the strange situation where a producer doesn't fail to get started, yet nothing is consumed from the log queue. Since the point of the tests that failed was not to test logging (Those are passing fine always), I say we shouldn't care much for now.

So, all in all, this just means that we won't consume logs in tests. Everywhere else should be the same.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
