### PR TITLE
refactor: Separate consumer from S3 multi part upload

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -1050,7 +1050,9 @@ class ConcurrentS3Consumer(ConsumerFromStage):
     #     self.current_file_size = 0
 
 
-async def upload_manifest_file(inputs: S3InsertInputs, files_uploaded: list[str], manifest_key: str):
+async def upload_manifest_file(
+    inputs: S3InsertInputs, files_uploaded: collections.abc.Sequence[str], manifest_key: str
+):
     session = aioboto3.Session()
     async with session.client(
         "s3",
@@ -1062,5 +1064,5 @@ async def upload_manifest_file(inputs: S3InsertInputs, files_uploaded: list[str]
         await client.put_object(
             Bucket=inputs.bucket_name,
             Key=manifest_key,
-            Body=json.dumps({"files": files_uploaded}),
+            Body=json.dumps({"files": sorted(files_uploaded, key=lambda file_key: (len(file_key), file_key))}),
         )

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -918,7 +918,7 @@ class ConcurrentS3Consumer(ConsumerFromStage):
             await self._finalize_current_file()
 
         try:
-            await asyncio.wait([active.task for active in self._pending_multipart_uploads.values()])
+            await asyncio.gather(*(active.task for active in self._pending_multipart_uploads.values()))
         finally:
             self._finalized = True
 

--- a/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
@@ -1626,7 +1626,7 @@ class TestErrorHandling:
         assert run.bytes_exported is None
         assert (
             run.latest_error
-            == "IntermittentUploadPartTimeoutError: An intermittent `RequestTimeout` was raised while attempting to upload part 1"
+            == "IntermittentUploadPartTimeoutError: A client error occurred while uploading part 1: Upload part request timed out"
         )
 
         run = runs[1]

--- a/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
@@ -47,9 +47,9 @@ from products.batch_exports.backend.temporal.destinations.s3_batch_export import
     COMPRESSION_EXTENSIONS,
     FILE_FORMAT_EXTENSIONS,
     SUPPORTED_COMPRESSIONS,
-    ConcurrentS3Consumer,
     S3BatchExportWorkflow,
     S3InsertInputs,
+    S3UploadRetryConfiguration,
     get_s3_key,
     insert_into_s3_activity_from_stage,
     s3_default_fields,
@@ -1603,7 +1603,7 @@ class TestErrorHandling:
                     "products.batch_exports.backend.temporal.destinations.s3_batch_export.aioboto3.Session",
                     FakeSession,
                 ),
-                mock.patch.object(ConcurrentS3Consumer, "MAX_RETRY_DELAY", 0.01),
+                mock.patch.object(S3UploadRetryConfiguration, "max_delay", 0.01),
             ):
                 await activity_environment.client.execute_workflow(
                     S3BatchExportWorkflow.run,


### PR DESCRIPTION
## Problem

`ConcurrentS3Consumer` does too much: It tracks file splits, maintains s3 multipart upload state, defines s3 upload part retry logic, and handles the actual chunk consuming logic. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Move s3 multipart upload state and individual part retry logic to its own class: `S3MultipartUpload`. This class now handles everything related to S3, but there are a couple of things still leaking:
* S3 client. Since we want to share this for performance, it has to be somewhere outside the multipart upload. I don't think the consumer is the best place to hold this, but I didn't get to write a better solution, and the PR was growing a bit too large.
* The file index. The multipart upload shouldn't care about file index, but we log it, so I've kept it as an attribute.

The move means that:
* We are guaranteed to cancel any pending uploads when one fails thanks to `asyncio.TaskGroup` semantics.
* We can run multiple multipart uploads in parallel, although this is currently not exploited beyond starting one immediately after one finishes, rather than waiting for the upload to finish.
* We can unit test the multipart upload parts separate from any consumer code.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
