### PR TITLE
chore: Add duplicate metrics breakdown by team and source

### DIFF
--- a/plugin-server/src/ingestion/deduplication/events.test.ts
+++ b/plugin-server/src/ingestion/deduplication/events.test.ts
@@ -3,7 +3,15 @@ import { Message } from 'node-rdkafka'
 import { IncomingEvent, PipelineEvent } from '~/types'
 
 import { deduplicateEvents } from './events'
+import * as metrics from './metrics'
 import { DeduplicationRedis } from './redis-client'
+
+// Mock the metrics
+jest.mock('./metrics', () => ({
+    duplicateBreakdownTotal: {
+        inc: jest.fn(),
+    },
+}))
 
 describe('deduplicateEvents', () => {
     let deduplicationRedis: DeduplicationRedis
@@ -12,10 +20,14 @@ describe('deduplicateEvents', () => {
         // Mock DeduplicationRedis
         deduplicationRedis = {
             deduplicate: jest.fn(),
+            deduplicateIds: jest.fn(),
         } as unknown as DeduplicationRedis
+
+        // Clear all metrics mocks
+        jest.clearAllMocks()
     })
 
-    it('should call redis deduplicate with the correct hashed keys', async () => {
+    it('should call redis deduplicate with the correct hashed keys and publish metrics for duplicates', async () => {
         const messages = [
             {
                 message: {} as unknown as Message,
@@ -25,6 +37,8 @@ describe('deduplicateEvents', () => {
                     distinct_id: 'test',
                     timestamp: '2021-01-01',
                     token: 'token',
+                    team_id: 123,
+                    properties: { $lib: 'web' },
                 } as unknown as PipelineEvent,
             },
             {
@@ -35,21 +49,51 @@ describe('deduplicateEvents', () => {
                     distinct_id: 'test',
                     timestamp: '2021-01-03',
                     token: 'token',
+                    team_id: 456,
+                    properties: { $lib: 'python' },
                 } as unknown as PipelineEvent,
             },
         ]
 
+        // Mock deduplicateIds to return duplicates
+        const duplicateKeys = new Set([
+            '7a184cabe9cce485b181a9b8113845fededc36f56d7d4eff4fbebca53abd55f7',
+            'd0eafb964a9b3a603d44cea8376f5434e24fec80760e0bed1cd5b76ee5869796',
+        ])
+        deduplicationRedis.deduplicateIds = jest.fn().mockResolvedValue({
+            duplicates: duplicateKeys,
+            processed: 2,
+        })
+
         await deduplicateEvents(deduplicationRedis, messages)
 
-        expect(deduplicationRedis.deduplicate).toHaveBeenCalledWith({
+        expect(deduplicationRedis.deduplicateIds).toHaveBeenCalledWith({
             keys: [
                 '7a184cabe9cce485b181a9b8113845fededc36f56d7d4eff4fbebca53abd55f7',
                 'd0eafb964a9b3a603d44cea8376f5434e24fec80760e0bed1cd5b76ee5869796',
             ],
         })
+        expect(deduplicationRedis.deduplicate).not.toHaveBeenCalled()
+
+        // Verify metrics were published with correct counts
+        expect(metrics.duplicateBreakdownTotal.inc).toHaveBeenCalledTimes(2)
+        expect(metrics.duplicateBreakdownTotal.inc).toHaveBeenCalledWith(
+            {
+                team_id: 123,
+                source: 'web',
+            },
+            1
+        )
+        expect(metrics.duplicateBreakdownTotal.inc).toHaveBeenCalledWith(
+            {
+                team_id: 456,
+                source: 'python',
+            },
+            1
+        )
     })
 
-    it('should resolve same event to same key', async () => {
+    it('should resolve same event to same key and not publish metrics when no duplicates', async () => {
         const messages = [
             {
                 message: {} as unknown as Message,
@@ -59,6 +103,8 @@ describe('deduplicateEvents', () => {
                     distinct_id: 'test',
                     timestamp: '2021-01-01',
                     token: 'token',
+                    team_id: 123,
+                    properties: { $lib: 'web' },
                 } as unknown as PipelineEvent,
             },
             {
@@ -69,20 +115,34 @@ describe('deduplicateEvents', () => {
                     distinct_id: 'test',
                     timestamp: '2021-01-01',
                     token: 'token',
+                    team_id: 123,
+                    properties: { $lib: 'web' },
                 } as unknown as PipelineEvent,
             },
         ]
 
+        // Mock deduplicateIds to return no duplicates
+        deduplicationRedis.deduplicateIds = jest.fn().mockResolvedValue({
+            duplicates: new Set(),
+            processed: 1,
+        })
+
         await deduplicateEvents(deduplicationRedis, messages)
 
-        expect(deduplicationRedis.deduplicate).toHaveBeenCalledWith({
+        expect(deduplicationRedis.deduplicateIds).toHaveBeenCalledWith({
             keys: ['7a184cabe9cce485b181a9b8113845fededc36f56d7d4eff4fbebca53abd55f7'],
         })
+        expect(deduplicationRedis.deduplicate).not.toHaveBeenCalled()
+
+        // Verify no metrics were published when no duplicates found
+        expect(metrics.duplicateBreakdownTotal.inc).not.toHaveBeenCalled()
     })
 
     it('should handle empty messages', async () => {
         const messages: IncomingEvent[] = []
         await deduplicateEvents(deduplicationRedis, messages)
+        expect(deduplicationRedis.deduplicateIds).not.toHaveBeenCalled()
         expect(deduplicationRedis.deduplicate).not.toHaveBeenCalled()
+        expect(metrics.duplicateBreakdownTotal.inc).not.toHaveBeenCalled()
     })
 })

--- a/plugin-server/src/ingestion/deduplication/events.ts
+++ b/plugin-server/src/ingestion/deduplication/events.ts
@@ -3,7 +3,13 @@ import crypto from 'crypto'
 import { IncomingEvent } from '~/types'
 import { logger } from '~/utils/logger'
 
-import { DeduplicationRedis } from './redis-client'
+import { duplicateBreakdownTotal } from './metrics'
+import { DeduplicationIdsResult, DeduplicationRedis } from './redis-client'
+
+interface KeyMetricData {
+    team_id: number
+    source: string
+}
 
 export async function deduplicateEvents(
     deduplicationRedis: DeduplicationRedis,
@@ -14,29 +20,65 @@ export async function deduplicateEvents(
             return
         }
 
-        // Extract event deduplication keys for deduplication
-        const deduplicationKeys = extractDeduplicationKeys(messages)
+        // Extract event deduplication keys and create mapping to messages
+        const { keys: deduplicationKeys, keyToMetricDataMap } = extractDeduplicationKeysWithMapping(messages)
 
         if (!deduplicationKeys.length) {
             return
         }
 
         // Perform fire-and-forget deduplication
-        await deduplicationRedis.deduplicate({
+        const result: DeduplicationIdsResult = await deduplicationRedis.deduplicateIds({
             keys: deduplicationKeys,
         })
+
+        if (result.duplicates.size > 0) {
+            duplicateReport(result.duplicates, keyToMetricDataMap)
+        }
     } catch (error) {
         // Log error but don't fail the batch processing
         logger.warn('Failed to deduplicate events', { error, eventsCount: messages.length })
     }
 }
 
-function extractDeduplicationKeys(messages: IncomingEvent[]): string[] {
+function duplicateReport(duplicates: Set<string>, keyToMetricDataMap: Map<string, KeyMetricData>): void {
+    // Group duplicates by team_id and source to batch metric increments
+    const metricCounts = new Map<string, { labels: { team_id: number; source: string }; count: number }>()
+
+    duplicates.forEach((duplicateKey) => {
+        const metricData = keyToMetricDataMap.get(duplicateKey)
+        if (metricData) {
+            const key = `${metricData.team_id}:${metricData.source}`
+            const existing = metricCounts.get(key)
+
+            if (existing) {
+                existing.count++
+            } else {
+                metricCounts.set(key, {
+                    labels: { team_id: metricData.team_id, source: metricData.source },
+                    count: 1,
+                })
+            }
+        }
+    })
+
+    // Batch increment metrics - one call per unique team_id/source combination
+    metricCounts.forEach(({ labels, count }) => {
+        duplicateBreakdownTotal.inc(labels, count)
+    })
+}
+
+function extractDeduplicationKeysWithMapping(messages: IncomingEvent[]): {
+    keys: string[]
+    keyToMetricDataMap: Map<string, KeyMetricData>
+} {
     const keys = new Set<string>()
+    const keyToMetricDataMap = new Map<string, KeyMetricData>()
     messages.forEach(({ event }) => {
         // Create a robust deduplication key using (event_name, distinct_id, timestamp, uuid)
         // This prevents gaming the system when SDKs have bugs or apply naive retry strategies
-        const { token, event: eventName, distinct_id, timestamp } = event
+        const { token, event: eventName, distinct_id, timestamp, team_id, properties } = event
+        const source = properties?.$lib ?? 'unknown'
 
         // Only create a key if we have all required fields
         if (!token || !eventName || !distinct_id || !timestamp) {
@@ -49,6 +91,11 @@ function extractDeduplicationKeys(messages: IncomingEvent[]): string[] {
         // Hash the key to prevent it from being too long
         const hashedKey = crypto.createHash('sha256').update(key).digest('hex')
         keys.add(hashedKey)
+        keyToMetricDataMap.set(hashedKey, { team_id: team_id ?? 0, source })
     })
-    return Array.from(keys)
+
+    return {
+        keys: Array.from(keys),
+        keyToMetricDataMap,
+    }
 }

--- a/plugin-server/src/ingestion/deduplication/metrics.ts
+++ b/plugin-server/src/ingestion/deduplication/metrics.ts
@@ -21,6 +21,13 @@ export const eventsProcessedTotal = new Counter({
     labelNames: ['operation'],
 })
 
+// Duplicate breakdown by team and source
+export const duplicateBreakdownTotal = new Counter({
+    name: 'deduplication_duplicates_breakdown_total',
+    help: 'Total number of duplicate events broken down by team_id and source',
+    labelNames: ['team_id', 'source'],
+})
+
 // Deduplication operation duration
 export const deduplicationOperationDurationMs = new Summary({
     name: 'deduplication_operation_duration_ms',

--- a/plugin-server/src/ingestion/deduplication/redis-client.test.ts
+++ b/plugin-server/src/ingestion/deduplication/redis-client.test.ts
@@ -50,7 +50,7 @@ describe('DeduplicationRedis Integration Tests', () => {
             })
 
             expect(idsResult.processed).toBe(2)
-            expect(idsResult.duplicates).toEqual([])
+            expect(idsResult.duplicates).toEqual(new Set())
         } finally {
             await deduplicationRedis.destroy()
         }
@@ -515,8 +515,8 @@ describe('DeduplicationRedis Integration Tests', () => {
                     const result = await deduplicationRedis.deduplicateIds(options)
 
                     expect(result.processed).toBe(3)
-                    expect(result.duplicates).toEqual([])
-                    expect(result.duplicates.length).toBe(0)
+                    expect(result.duplicates).toEqual(new Set())
+                    expect(result.duplicates.size).toBe(0)
                 } finally {
                     await deduplicationRedis.destroy()
                 }
@@ -537,13 +537,13 @@ describe('DeduplicationRedis Integration Tests', () => {
                     // First call - should be all new
                     const firstResult = await deduplicationRedis.deduplicateIds(options)
                     expect(firstResult.processed).toBe(2)
-                    expect(firstResult.duplicates).toEqual([])
+                    expect(firstResult.duplicates).toEqual(new Set())
 
                     // Second call - should return the duplicate IDs
                     const secondResult = await deduplicationRedis.deduplicateIds(options)
                     expect(secondResult.processed).toBe(2)
-                    expect(secondResult.duplicates).toEqual(deduplicationRedis.prefixKeys(keys))
-                    expect(secondResult.duplicates.length).toBe(2)
+                    expect(secondResult.duplicates).toEqual(new Set(deduplicationRedis.prefixKeys(keys)))
+                    expect(secondResult.duplicates.size).toBe(2)
                 } finally {
                     await deduplicationRedis.destroy()
                 }
@@ -568,8 +568,8 @@ describe('DeduplicationRedis Integration Tests', () => {
                     // Test with mixed keys
                     const result = await deduplicationRedis.deduplicateIds({ keys: mixedKeys, ttl: 60 })
                     expect(result.processed).toBe(2)
-                    expect(result.duplicates).toEqual(deduplicationRedis.prefixKeys([`${testId}:ids:mixed:1`]))
-                    expect(result.duplicates.length).toBe(1)
+                    expect(result.duplicates).toEqual(new Set(deduplicationRedis.prefixKeys([`${testId}:ids:mixed:1`])))
+                    expect(result.duplicates.size).toBe(1)
                 } finally {
                     await deduplicationRedis.destroy()
                 }
@@ -585,7 +585,7 @@ describe('DeduplicationRedis Integration Tests', () => {
                 try {
                     const result = await deduplicationRedis.deduplicateIds({ keys: [], ttl: 60 })
                     expect(result.processed).toBe(0)
-                    expect(result.duplicates).toEqual([])
+                    expect(result.duplicates).toEqual(new Set())
                 } finally {
                     await deduplicationRedis.destroy()
                 }
@@ -606,18 +606,18 @@ describe('DeduplicationRedis Integration Tests', () => {
 
                     // First call - should be new
                     const firstResult = await deduplicationRedis.deduplicateIds(options)
-                    expect(firstResult.duplicates).toEqual([])
+                    expect(firstResult.duplicates).toEqual(new Set())
 
                     // Second call - should be duplicate
                     const secondResult = await deduplicationRedis.deduplicateIds(options)
-                    expect(secondResult.duplicates).toEqual(prefixedKeys)
+                    expect(secondResult.duplicates).toEqual(new Set(prefixedKeys))
 
                     // Wait for TTL to expire with buffer time
                     await new Promise((resolve) => setTimeout(resolve, 2500))
 
                     // Third call after TTL expiration - should be new again
                     const thirdResult = await deduplicationRedis.deduplicateIds(options)
-                    expect(thirdResult.duplicates).toEqual([])
+                    expect(thirdResult.duplicates).toEqual(new Set())
                 } finally {
                     await deduplicationRedis.destroy()
                 }
@@ -732,8 +732,8 @@ describe('DeduplicationRedis Integration Tests', () => {
 
                     const result = await deduplicationRedis.deduplicateIds(options)
                     expect(result.processed).toBe(500)
-                    expect(result.duplicates).toEqual([])
-                    expect(result.duplicates.length).toBe(0)
+                    expect(result.duplicates).toEqual(new Set())
+                    expect(result.duplicates.size).toBe(0)
                 } finally {
                     await deduplicationRedis.destroy()
                 }
@@ -755,13 +755,13 @@ describe('DeduplicationRedis Integration Tests', () => {
                     // First call - set up the keys
                     const firstResult = await deduplicationRedis.deduplicateIds(options)
                     expect(firstResult.processed).toBe(500)
-                    expect(firstResult.duplicates).toEqual([])
+                    expect(firstResult.duplicates).toEqual(new Set())
 
                     // Second call - should return all 500 keys as duplicates
                     const secondResult = await deduplicationRedis.deduplicateIds(options)
                     expect(secondResult.processed).toBe(500)
-                    expect(secondResult.duplicates).toEqual(prefixedKeys)
-                    expect(secondResult.duplicates.length).toBe(500)
+                    expect(secondResult.duplicates).toEqual(new Set(prefixedKeys))
+                    expect(secondResult.duplicates.size).toBe(500)
                 } finally {
                     await deduplicationRedis.destroy()
                 }
@@ -814,8 +814,8 @@ describe('DeduplicationRedis Integration Tests', () => {
                     // Test with deduplicateIds method
                     const idsResult = await deduplicationRedis.deduplicateIds({ keys: mixedKeys, ttl: 60 })
                     expect(idsResult.processed).toBe(500)
-                    expect(idsResult.duplicates).toEqual(prefixedKeys)
-                    expect(idsResult.duplicates.length).toBe(250)
+                    expect(idsResult.duplicates).toEqual(new Set(prefixedKeys))
+                    expect(idsResult.duplicates.size).toBe(250)
                 } finally {
                     await deduplicationRedis.destroy()
                 }
@@ -874,8 +874,8 @@ describe('DeduplicationRedis Integration Tests', () => {
                     ])
 
                     expect(countResult.processed).toBe(idsResult.processed)
-                    expect(countResult.duplicates).toBe(idsResult.duplicates.length)
-                    expect(idsResult.duplicates).toEqual(prefixedKeys)
+                    expect(countResult.duplicates).toBe(idsResult.duplicates.size)
+                    expect(idsResult.duplicates).toEqual(new Set(prefixedKeys))
                 } finally {
                     await deduplicationRedis.destroy()
                 }


### PR DESCRIPTION
## Problem

Deduplicate ids went pretty well, let's now add a second step where we log some information around team_id and sources to identify some outliers

## Changes

- Use deduplicateIds, which return a list of duplicates
- Log metrics for duplicate list with event data

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
