### PR TITLE
feat: Add button to create group

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -60,6 +60,7 @@ import {
     CommentType,
     ConversationDetail,
     CoreMemory,
+    CreateGroupParams,
     CyclotronJobFiltersType,
     CyclotronJobTestInvocationResult,
     DashboardCollaboratorType,
@@ -2229,6 +2230,9 @@ const api = {
     groups: {
         async list(params: GroupListParams): Promise<CountedPaginatedResponse<Group>> {
             return await new ApiRequest().groups().withQueryString(toParams(params, true)).get()
+        },
+        async create(data: CreateGroupParams): Promise<Group> {
+            return await new ApiRequest().groups().create({ data })
         },
         async updateProperty(index: number, key: string, property: string, value: any): Promise<void> {
             return new ApiRequest()

--- a/frontend/src/scenes/appScenes.ts
+++ b/frontend/src/scenes/appScenes.ts
@@ -33,6 +33,7 @@ export const appScenes: Record<Scene | string, () => any> = {
     [Scene.Pipeline]: () => import('./pipeline/Pipeline'),
     [Scene.PipelineNode]: () => import('./pipeline/PipelineNode'),
     [Scene.Groups]: () => import('./groups/Groups'),
+    [Scene.GroupsNew]: () => import('./groups/GroupsNew'),
     [Scene.Group]: () => import('./groups/Group'),
     [Scene.Action]: () => import('./actions/Action'),
     [Scene.Experiments]: () => import('./experiments/Experiments'),

--- a/frontend/src/scenes/groups/GroupsNew.tsx
+++ b/frontend/src/scenes/groups/GroupsNew.tsx
@@ -1,10 +1,13 @@
-import { LemonButton } from '@posthog/lemon-ui'
+import { LemonButton, LemonDivider, LemonInput } from '@posthog/lemon-ui'
 import { router } from 'kea-router'
 import { PageHeader } from 'lib/components/PageHeader'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 import { groupsNewLogic } from 'scenes/groups/groupsNewLogic'
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
+import { Form } from 'kea-forms'
+import { LemonField } from 'lib/lemon-ui/LemonField'
+import { IconPlus, IconTrash } from '@posthog/icons'
 
 interface GroupsNewSceneProps {
     groupTypeIndex?: string
@@ -19,28 +22,96 @@ export const scene: SceneExport = {
 }
 
 export function GroupsNew(): JSX.Element {
-    const { logicProps } = useValues(groupsNewLogic)
+    const { logicProps, customProperties } = useValues(groupsNewLogic)
+    const { addProperty, removeProperty, updateProperty } = useActions(groupsNewLogic)
 
     return (
         <div className="groups-new">
-            <PageHeader
-                buttons={
-                    <div className="flex items-center gap-2">
+            <Form id="group" logic={groupsNewLogic} props={logicProps} formKey="group" enableFormOnSubmit>
+                <PageHeader
+                    buttons={
+                        <div className="flex items-center gap-2">
+                            <LemonButton
+                                data-attr="cancel-group"
+                                type="secondary"
+                                onClick={() => {
+                                    router.actions.push(urls.groups(logicProps.groupTypeIndex))
+                                }}
+                            >
+                                Cancel
+                            </LemonButton>
+                            <LemonButton type="primary" data-attr="save-group" htmlType="submit" form="group">
+                                Save
+                            </LemonButton>
+                        </div>
+                    }
+                />
+                <div className="deprecated-space-y-2 max-w-200 gap-4">
+                    <div className="flex gap-4 flex-wrap">
+                        <div className="flex-1">
+                            <LemonField name="name" label="Name">
+                                <LemonInput data-attr="group-name" />
+                            </LemonField>
+                        </div>
+                        <div className="flex-1">
+                            <LemonField name="group_key" label="ID">
+                                <LemonInput data-attr="group-key" />
+                            </LemonField>
+                        </div>
+                    </div>
+                    <LemonDivider className="my-4" />
+                </div>
+                <div className="deprecated-space-y-2 max-w-214 gap-4">
+                    <div className="mt-4">
+                        <h3 className="text-md font-medium mb-2">Properties</h3>
+
+                        {customProperties && customProperties.length > 0 && (
+                            <div className="flex gap-4 mb-2 text-s font-medium">
+                                <div className="flex-1">Name</div>
+                                <div className="flex-1">Value</div>
+                                <div className="w-8" /> {/* Space for trash button */}
+                            </div>
+                        )}
+
+                        {customProperties &&
+                            customProperties.map((property, index) => (
+                                <div key={index} className="flex gap-4 mb-2 items-start">
+                                    <div className="flex-1">
+                                        <LemonInput
+                                            value={property.name}
+                                            onChange={(value) => updateProperty(index, 'name', value)}
+                                            placeholder="e.g., company"
+                                        />
+                                    </div>
+                                    <div className="flex-1">
+                                        <LemonInput
+                                            value={property.value}
+                                            onChange={(value) => updateProperty(index, 'value', value)}
+                                            placeholder="e.g., PostHog"
+                                        />
+                                    </div>
+                                    <LemonButton
+                                        icon={<IconTrash />}
+                                        size="small"
+                                        type="secondary"
+                                        status="danger"
+                                        onClick={() => removeProperty(index)}
+                                        data-attr={`remove-property-${index}`}
+                                    />
+                                </div>
+                            ))}
+
                         <LemonButton
-                            data-attr="cancel-group"
+                            icon={<IconPlus />}
                             type="secondary"
-                            onClick={() => {
-                                router.actions.push(urls.groups(logicProps.groupTypeIndex))
-                            }}
+                            onClick={addProperty}
+                            data-attr="add-property"
                         >
-                            Cancel
-                        </LemonButton>
-                        <LemonButton type="primary" data-attr="save-group" htmlType="submit" form="group">
-                            Save
+                            Add property
                         </LemonButton>
                     </div>
-                }
-            />
+                </div>
+            </Form>
         </div>
     )
 }

--- a/frontend/src/scenes/groups/GroupsNew.tsx
+++ b/frontend/src/scenes/groups/GroupsNew.tsx
@@ -1,0 +1,46 @@
+import { LemonButton } from '@posthog/lemon-ui'
+import { router } from 'kea-router'
+import { PageHeader } from 'lib/components/PageHeader'
+import { SceneExport } from 'scenes/sceneTypes'
+import { urls } from 'scenes/urls'
+import { groupsNewLogic } from 'scenes/groups/groupsNewLogic'
+import { useValues } from 'kea'
+
+interface GroupsNewSceneProps {
+    groupTypeIndex?: string
+}
+
+export const scene: SceneExport = {
+    component: GroupsNew,
+    logic: groupsNewLogic,
+    paramsToProps: ({ params: { groupTypeIndex } }: { params: GroupsNewSceneProps }) => ({
+        groupTypeIndex: parseInt(groupTypeIndex ?? '0'),
+    }),
+}
+
+export function GroupsNew(): JSX.Element {
+    const { logicProps } = useValues(groupsNewLogic)
+
+    return (
+        <div className="groups-new">
+            <PageHeader
+                buttons={
+                    <div className="flex items-center gap-2">
+                        <LemonButton
+                            data-attr="cancel-group"
+                            type="secondary"
+                            onClick={() => {
+                                router.actions.push(urls.groups(logicProps.groupTypeIndex))
+                            }}
+                        >
+                            Cancel
+                        </LemonButton>
+                        <LemonButton type="primary" data-attr="save-group" htmlType="submit" form="group">
+                            Save
+                        </LemonButton>
+                    </div>
+                }
+            />
+        </div>
+    )
+}

--- a/frontend/src/scenes/groups/groupsNewLogic.test.ts
+++ b/frontend/src/scenes/groups/groupsNewLogic.test.ts
@@ -1,0 +1,294 @@
+import { initKeaTests } from '~/test/init'
+import { CreateGroupParams, GroupTypeIndex } from '~/types'
+
+import { flattenProperties, groupsNewLogic, GroupsNewLogicProps } from './groupsNewLogic'
+
+const MOCK_CREATE_PARAMS: CreateGroupParams = {
+    group_key: 'test-group-key',
+    group_type_index: 0 as GroupTypeIndex,
+    group_properties: {
+        name: 'Test Group',
+    },
+}
+
+describe('groupsNewLogic', () => {
+    let logic: ReturnType<typeof groupsNewLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+    })
+
+    describe('initial state and props', () => {
+        it('initializes with correct default state', () => {
+            const props: GroupsNewLogicProps = { groupTypeIndex: 1 }
+            logic = groupsNewLogic(props)
+            logic.mount()
+
+            expect(logic.values.logicProps).toEqual(props)
+            expect(logic.values.createdGroup).toBeNull()
+            expect(logic.values.customProperties).toEqual([])
+            expect(logic.values.group).toEqual({})
+        })
+
+        it('handles different groupTypeIndex values', () => {
+            const testCases = [0, 1, 2, 4]
+
+            testCases.forEach((groupTypeIndex) => {
+                const testLogic = groupsNewLogic({ groupTypeIndex })
+                testLogic.mount()
+
+                expect(testLogic.values.logicProps.groupTypeIndex).toBe(groupTypeIndex)
+
+                testLogic.unmount()
+            })
+        })
+    })
+
+    describe('form management', () => {
+        beforeEach(() => {
+            logic = groupsNewLogic({ groupTypeIndex: 0 })
+            logic.mount()
+        })
+
+        it('validates required fields correctly', () => {
+            logic.actions.setGroupValue('name', '')
+            logic.actions.setGroupValue('group_key', '')
+
+            expect(logic.values.groupHasErrors).toBe(true)
+
+            logic.actions.submitGroup()
+
+            expect(logic.values.groupErrors.name).toBe('Group name cannot be empty')
+            expect(logic.values.groupErrors.group_key).toBe('Group key cannot be empty')
+        })
+
+        it('validates whitespace-only values as invalid', () => {
+            logic.actions.setGroupValue('name', '   ')
+            logic.actions.setGroupValue('group_key', '\t\n  ')
+
+            logic.actions.submitGroup()
+
+            expect(logic.values.groupHasErrors).toBe(true)
+            expect(logic.values.groupErrors.name).toBe('Group name cannot be empty')
+            expect(logic.values.groupErrors.group_key).toBe('Group key cannot be empty')
+        })
+
+        it('accepts valid form data', () => {
+            logic.actions.setGroupValue('name', 'Valid Name')
+            logic.actions.setGroupValue('group_key', 'valid-key')
+
+            logic.actions.submitGroup()
+
+            expect(logic.values.groupHasErrors).toBe(false)
+            expect(logic.values.groupErrors).toEqual({})
+        })
+
+        it('resets form state', () => {
+            logic.actions.setGroupValue('name', 'Test Name')
+            logic.actions.addProperty()
+
+            expect(logic.values.group.name).toBe('Test Name')
+            expect(logic.values.customProperties).toHaveLength(1)
+
+            logic.actions.resetGroup()
+
+            expect(logic.values.createdGroup).toBeNull()
+            expect(logic.values.customProperties).toEqual([])
+        })
+    })
+
+    describe('custom properties management', () => {
+        beforeEach(() => {
+            logic = groupsNewLogic({ groupTypeIndex: 0 })
+            logic.mount()
+        })
+
+        it('adds properties correctly', () => {
+            expect(logic.values.customProperties).toEqual([])
+
+            logic.actions.addProperty()
+            expect(logic.values.customProperties).toEqual([{ name: '', value: '' }])
+
+            logic.actions.addProperty()
+            expect(logic.values.customProperties).toEqual([
+                { name: '', value: '' },
+                { name: '', value: '' },
+            ])
+        })
+
+        it('updates property name and value', () => {
+            logic.actions.addProperty()
+
+            logic.actions.updateProperty(0, 'name', 'test-property')
+            expect(logic.values.customProperties[0]).toEqual({ name: 'test-property', value: '' })
+
+            logic.actions.updateProperty(0, 'value', 'test-value')
+            expect(logic.values.customProperties[0]).toEqual({ name: 'test-property', value: 'test-value' })
+        })
+
+        it('removes properties by index', () => {
+            logic.actions.addProperty()
+            logic.actions.addProperty()
+            logic.actions.addProperty()
+            logic.actions.updateProperty(0, 'name', 'zero')
+            logic.actions.updateProperty(1, 'name', 'one')
+            logic.actions.updateProperty(2, 'name', 'two')
+
+            logic.actions.removeProperty(1)
+            expect(logic.values.customProperties).toEqual([
+                { name: 'zero', value: '' },
+                { name: 'two', value: '' },
+            ])
+
+            logic.actions.removeProperty(0)
+            expect(logic.values.customProperties).toEqual([{ name: 'two', value: '' }])
+        })
+
+        it('handles out-of-bounds removal gracefully', () => {
+            logic.actions.addProperty()
+
+            logic.actions.removeProperty(5)
+            expect(logic.values.customProperties).toHaveLength(1)
+
+            logic.actions.removeProperty(-1)
+            expect(logic.values.customProperties).toHaveLength(1)
+        })
+
+        it('handles invalid property updates gracefully', () => {
+            logic.actions.addProperty()
+            const originalProperties = [...logic.values.customProperties]
+
+            logic.actions.updateProperty(5, 'name', 'test')
+            expect(logic.values.customProperties).toEqual(originalProperties)
+
+            logic.actions.updateProperty(-1, 'value', 'test')
+            expect(logic.values.customProperties).toEqual(originalProperties)
+        })
+    })
+
+    describe('action dispatch and state management', () => {
+        beforeEach(() => {
+            logic = groupsNewLogic({ groupTypeIndex: 1 })
+            logic.mount()
+        })
+
+        it('dispatches saveGroup action correctly', () => {
+            expect(() => {
+                logic.actions.saveGroup(MOCK_CREATE_PARAMS)
+            }).not.toThrow()
+        })
+
+        it('initializes with correct loading states', () => {
+            expect(logic.values.createdGroupLoading).toBe(false)
+            expect(logic.values.createdGroup).toBeNull()
+        })
+    })
+
+    describe('form validation and submission', () => {
+        beforeEach(() => {
+            logic = groupsNewLogic({ groupTypeIndex: 0 })
+            logic.mount()
+        })
+
+        it('prevents submission with validation errors', () => {
+            logic.actions.setGroupValue('name', '')
+            logic.actions.setGroupValue('group_key', '')
+
+            logic.actions.submitGroup()
+
+            expect(logic.values.groupHasErrors).toBe(true)
+        })
+
+        it('accepts valid form data for submission', () => {
+            logic.actions.setGroupValue('name', 'Valid Group')
+            logic.actions.setGroupValue('group_key', 'valid-group')
+
+            expect(logic.values.groupHasErrors).toBe(false)
+            expect(logic.values.group.name).toBe('Valid Group')
+            expect(logic.values.group.group_key).toBe('valid-group')
+        })
+    })
+
+    describe('cleanup and lifecycle', () => {
+        it('resets state on unmount', () => {
+            logic = groupsNewLogic({ groupTypeIndex: 0 })
+            logic.mount()
+
+            logic.actions.setGroupValue('name', 'Test')
+            logic.actions.addProperty()
+
+            expect(logic.values.group.name).toBe('Test')
+            expect(logic.values.customProperties).toHaveLength(1)
+
+            logic.unmount()
+            logic.mount()
+
+            expect(logic.values.createdGroup).toBeNull()
+            expect(logic.values.customProperties).toEqual([])
+        })
+
+        it('resets custom properties when resetGroup is called', () => {
+            logic = groupsNewLogic({ groupTypeIndex: 0 })
+            logic.mount()
+
+            logic.actions.setGroupValue('name', 'Test Group')
+            logic.actions.addProperty()
+            logic.actions.updateProperty(0, 'name', 'test-prop')
+
+            expect(logic.values.customProperties).toHaveLength(1)
+            expect(logic.values.customProperties[0].name).toBe('test-prop')
+
+            logic.actions.resetGroup()
+
+            expect(logic.values.customProperties).toEqual([])
+            expect(logic.values.createdGroup).toBeNull()
+        })
+    })
+
+    describe('edge cases and error scenarios', () => {
+        beforeEach(() => {
+            logic = groupsNewLogic({ groupTypeIndex: 0 })
+            logic.mount()
+        })
+
+        it('handles special characters in property names and values', () => {
+            logic.actions.addProperty()
+            logic.actions.updateProperty(0, 'name', 'special-chars!@#$%')
+            logic.actions.updateProperty(0, 'value', 'value with spaces & symbols')
+
+            expect(logic.values.customProperties[0]).toEqual({
+                name: 'special-chars!@#$%',
+                value: 'value with spaces & symbols',
+            })
+        })
+
+        it('handles unicode characters in form fields', () => {
+            logic.actions.setGroupValue('name', 'Group with émojis 🎉')
+            logic.actions.setGroupValue('group_key', 'group-key-with-dashes')
+
+            expect(logic.values.group.name).toBe('Group with émojis 🎉')
+            expect(logic.values.group.group_key).toBe('group-key-with-dashes')
+        })
+    })
+})
+
+describe('flattenProperties', () => {
+    it('filters out empty properties during form submission', () => {
+        const rawProperties = [
+            { name: '', value: '' },
+            { name: '  ', value: '' },
+            { name: 'my value is a whitespace', value: ' ' },
+            { name: 'empty-value-prop', value: '' },
+            { name: 'valid-prop', value: 'valid-value' },
+            { name: ' another-valid-prop', value: 'valid-value ' },
+        ]
+
+        const flattenedProperties = flattenProperties(rawProperties)
+
+        expect(flattenedProperties).toEqual({ 'valid-prop': 'valid-value', 'another-valid-prop': 'valid-value ' })
+    })
+})

--- a/frontend/src/scenes/groups/groupsNewLogic.ts
+++ b/frontend/src/scenes/groups/groupsNewLogic.ts
@@ -1,26 +1,132 @@
-import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, beforeUnmount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
-import { urlToAction } from 'kea-router'
-// import api from 'lib/api'
+import { actionToUrl } from 'kea-router'
+import api from 'lib/api'
 
 import type { groupsNewLogicType } from './groupsNewLogicType'
+import { forms } from 'kea-forms'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { CreateGroupParams, Group, GroupTypeIndex } from '~/types'
+import { urls } from 'scenes/urls'
+import { groupsModel } from '~/models/groupsModel'
 
 export type GroupsNewLogicProps = {
     groupTypeIndex: number
 }
 
+export interface NewGroupFormData {
+    name: string
+    group_key: string
+    group_type_index: number
+    properties: Record<string, any>
+}
+
+export interface GroupProperty {
+    name: string
+    value: string
+}
+
+const NEW_GROUP = {} as NewGroupFormData
+
 export const groupsNewLogic = kea<groupsNewLogicType>([
     props({} as GroupsNewLogicProps),
     key((props) => `${props.groupTypeIndex}-new`),
     path((key) => ['scenes', 'groupsNew', 'groupsNewLogic', key]),
-    connect(() => ({})),
-    actions(() => ({})),
-    loaders(() => ({})),
-    listeners(() => ({})),
-    reducers({}),
+
+    connect(() => ({ values: [groupsModel, ['aggregationLabel']] })),
+
     selectors({
         logicProps: [() => [(_, props) => props], (props): GroupsNewLogicProps => props],
     }),
-    urlToAction(() => ({})),
-    afterMount(() => {}),
+
+    actions({
+        saveGroup: (groupParams: CreateGroupParams) => ({ groupParams }),
+        addProperty: () => ({}),
+        removeProperty: (index: number) => ({ index }),
+        updateProperty: (index: number, field: 'name' | 'value', value: string) => ({ index, field, value }),
+    }),
+
+    reducers({
+        createdGroup: [
+            null as Group | null,
+            {
+                saveGroupSuccess: (_, { createdGroup }) => createdGroup,
+                resetGroup: () => null,
+            },
+        ],
+        customProperties: [
+            [] as GroupProperty[],
+            {
+                addProperty: (state) => [...state, { name: '', value: '' }],
+                removeProperty: (state, { index }) => state.filter((_, i) => i !== index),
+                updateProperty: (state, { index, field, value }) =>
+                    state.map((prop, i) => (i === index ? { ...prop, [field]: value } : prop)),
+                resetGroup: () => [],
+            },
+        ],
+    }),
+
+    forms(({ actions, props, values }) => ({
+        group: {
+            defaults: NEW_GROUP,
+            errors: ({ group_key, name }: NewGroupFormData) => {
+                return {
+                    name: !name ? 'Group name cannot be empty' : undefined,
+                    group_key: !group_key ? 'Group key cannot be empty' : undefined,
+                }
+            },
+            submit: (formData: NewGroupFormData) => {
+                const flattenedCustomProperties = values.customProperties
+                    .filter((prop) => prop.name.trim() && prop.value.trim())
+                    .reduce((acc, prop) => {
+                        acc[prop.name] = prop.value
+                        return acc
+                    }, {} as Record<string, string>)
+                const group_properties = {
+                    name: formData.name,
+                    ...flattenedCustomProperties,
+                }
+
+                const groupData: CreateGroupParams = {
+                    group_key: formData.group_key,
+                    group_type_index: props.groupTypeIndex as GroupTypeIndex,
+                    group_properties,
+                }
+                actions.saveGroup(groupData)
+            },
+        },
+    })),
+
+    loaders(() => ({
+        createdGroup: [
+            null as Group | null,
+            {
+                saveGroup: async ({ groupParams }): Promise<Group> => {
+                    try {
+                        const newGroup = await api.groups.create(groupParams)
+                        lemonToast.success('Group saved')
+                        return newGroup
+                    } catch (error) {
+                        lemonToast.error('Failed to save group')
+                        throw error
+                    }
+                },
+            },
+        ],
+    })),
+
+    listeners(({ actions, values }) => ({
+        submitGroup: () => {
+            if (values.groupHasErrors) {
+                lemonToast.error('There was an error submitting this group. Make sure all fields are filled correctly.')
+            }
+        },
+        saveGroupSuccess: () => actions.resetGroup(),
+    })),
+
+    actionToUrl(({ values }) => ({
+        saveGroupSuccess: () => urls.groups(values.logicProps.groupTypeIndex),
+    })),
+
+    beforeUnmount(({ actions }) => actions.resetGroup()),
 ])

--- a/frontend/src/scenes/groups/groupsNewLogic.ts
+++ b/frontend/src/scenes/groups/groupsNewLogic.ts
@@ -1,0 +1,26 @@
+import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+import { urlToAction } from 'kea-router'
+// import api from 'lib/api'
+
+import type { groupsNewLogicType } from './groupsNewLogicType'
+
+export type GroupsNewLogicProps = {
+    groupTypeIndex: number
+}
+
+export const groupsNewLogic = kea<groupsNewLogicType>([
+    props({} as GroupsNewLogicProps),
+    key((props) => `${props.groupTypeIndex}-new`),
+    path((key) => ['scenes', 'groupsNew', 'groupsNewLogic', key]),
+    connect(() => ({})),
+    actions(() => ({})),
+    loaders(() => ({})),
+    listeners(() => ({})),
+    reducers({}),
+    selectors({
+        logicProps: [() => [(_, props) => props], (props): GroupsNewLogicProps => props],
+    }),
+    urlToAction(() => ({})),
+    afterMount(() => {}),
+])

--- a/frontend/src/scenes/groups/groupsNewLogic.ts
+++ b/frontend/src/scenes/groups/groupsNewLogic.ts
@@ -71,17 +71,12 @@ export const groupsNewLogic = kea<groupsNewLogicType>([
             defaults: NEW_GROUP,
             errors: ({ group_key, name }: NewGroupFormData) => {
                 return {
-                    name: !name ? 'Group name cannot be empty' : undefined,
-                    group_key: !group_key ? 'Group key cannot be empty' : undefined,
+                    name: !name?.trim() ? 'Group name cannot be empty' : undefined,
+                    group_key: !group_key?.trim() ? 'Group key cannot be empty' : undefined,
                 }
             },
             submit: (formData: NewGroupFormData) => {
-                const flattenedCustomProperties = values.customProperties
-                    .filter((prop) => prop.name.trim() && prop.value.trim())
-                    .reduce((acc, prop) => {
-                        acc[prop.name] = prop.value
-                        return acc
-                    }, {} as Record<string, string>)
+                const flattenedCustomProperties = flattenProperties(values.customProperties)
                 const group_properties = {
                     name: formData.name,
                     ...flattenedCustomProperties,
@@ -130,3 +125,12 @@ export const groupsNewLogic = kea<groupsNewLogicType>([
 
     beforeUnmount(({ actions }) => actions.resetGroup()),
 ])
+
+export function flattenProperties(properties: GroupProperty[]): Record<string, string> {
+    return properties
+        .filter((prop) => prop.name.trim() && prop.value.trim())
+        .reduce((acc, prop) => {
+            acc[prop.name.trim()] = prop.value
+            return acc
+        }, {} as Record<string, string>)
+}

--- a/frontend/src/scenes/groups/groupsNewLogic.ts
+++ b/frontend/src/scenes/groups/groupsNewLogic.ts
@@ -6,9 +6,11 @@ import api from 'lib/api'
 import type { groupsNewLogicType } from './groupsNewLogicType'
 import { forms } from 'kea-forms'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
-import { CreateGroupParams, Group, GroupTypeIndex } from '~/types'
+import { CreateGroupParams, Group, GroupTypeIndex, Breadcrumb } from '~/types'
 import { urls } from 'scenes/urls'
 import { groupsModel } from '~/models/groupsModel'
+import { Scene } from 'scenes/sceneTypes'
+import { capitalizeFirstLetter } from 'lib/utils'
 
 export type GroupsNewLogicProps = {
     groupTypeIndex: number
@@ -37,6 +39,33 @@ export const groupsNewLogic = kea<groupsNewLogicType>([
 
     selectors({
         logicProps: [() => [(_, props) => props], (props): GroupsNewLogicProps => props],
+        groupTypeName: [
+            (s) => [s.aggregationLabel, s.logicProps],
+            (aggregationLabel, logicProps): string => {
+                return aggregationLabel(logicProps.groupTypeIndex).singular
+            },
+        ],
+        breadcrumbs: [
+            (s) => [s.logicProps, s.groupTypeName],
+            (logicProps, groupTypeName): Breadcrumb[] => {
+                return [
+                    {
+                        key: Scene.PersonsManagement,
+                        name: 'People',
+                        path: urls.persons(),
+                    },
+                    {
+                        key: Scene.Groups,
+                        name: capitalizeFirstLetter(groupTypeName),
+                        path: urls.groups(logicProps.groupTypeIndex),
+                    },
+                    {
+                        key: Scene.GroupsNew,
+                        name: `Create ${groupTypeName}`,
+                    },
+                ]
+            },
+        ],
     }),
 
     actions({

--- a/frontend/src/scenes/persons-management/personsManagementSceneLogic.tsx
+++ b/frontend/src/scenes/persons-management/personsManagementSceneLogic.tsx
@@ -15,6 +15,8 @@ import { Breadcrumb } from '~/types'
 
 import type { personsManagementSceneLogicType } from './personsManagementSceneLogicType'
 import { Persons } from './tabs/Persons'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 
 export type PersonsManagementTab = {
     key: string
@@ -34,7 +36,12 @@ export const personsManagementSceneLogic = kea<personsManagementSceneLogicType>(
     path(['scenes', 'persons-management', 'personsManagementSceneLogic']),
     connect(() => ({
         actions: [groupsSceneLogic, ['setGroupTypeIndex']],
-        values: [groupsModel, ['aggregationLabel', 'groupTypes', 'groupTypesLoading', 'groupsAccessStatus']],
+        values: [
+            groupsModel,
+            ['aggregationLabel', 'groupTypes', 'groupTypesLoading', 'groupsAccessStatus'],
+            featureFlagLogic,
+            ['featureFlags'],
+        ],
     })),
     actions({
         setTabKey: (tabKey: string) => ({ tabKey }),
@@ -85,10 +92,10 @@ export const personsManagementSceneLogic = kea<personsManagementSceneLogicType>(
                 return tabs.find((x) => x.key === tabKey) ?? null
             },
         ],
-
+        crmFeatureFlag: [(s) => [s.featureFlags], (featureFlags) => featureFlags[FEATURE_FLAGS.CRM_ITERATION_ONE]],
         groupTabs: [
-            (s) => [s.groupTypes, s.groupsAccessStatus, s.aggregationLabel],
-            (groupTypes, groupsAccessStatus, aggregationLabel): PersonsManagementTab[] => {
+            (s) => [s.groupTypes, s.groupsAccessStatus, s.aggregationLabel, s.crmFeatureFlag],
+            (groupTypes, groupsAccessStatus, aggregationLabel, crmFeatureFlag): PersonsManagementTab[] => {
                 const showGroupsIntroductionPage = [
                     GroupsAccessStatus.HasAccess,
                     GroupsAccessStatus.HasGroupTypes,
@@ -104,11 +111,20 @@ export const personsManagementSceneLogic = kea<personsManagementSceneLogicType>(
                               content: <Groups groupTypeIndex={0} />,
                           },
                       ]
-                    : Array.from(groupTypes.values()).map((groupType) => ({
-                          key: `groups-${groupType.group_type_index}`,
-                          label: capitalizeFirstLetter(aggregationLabel(groupType.group_type_index).plural),
-                          url: urls.groups(groupType.group_type_index),
-                          content: <Groups groupTypeIndex={groupType.group_type_index} />,
+                    : Array.from(groupTypes.values()).map(({ group_type_index }) => ({
+                          key: `groups-${group_type_index}`,
+                          label: capitalizeFirstLetter(aggregationLabel(group_type_index).plural),
+                          url: urls.groups(group_type_index),
+                          content: <Groups groupTypeIndex={group_type_index} />,
+                          buttons: crmFeatureFlag ? (
+                              <LemonButton
+                                  type="primary"
+                                  data-attr={`new-group-${group_type_index}`}
+                                  onClick={() => router.actions.push(urls.group(group_type_index, 'new', false))}
+                              >
+                                  New {aggregationLabel(group_type_index).singular}
+                              </LemonButton>
+                          ) : null,
                       }))
 
                 return groupTabs

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -42,6 +42,7 @@ export enum Scene {
     Pipeline = 'Pipeline',
     PipelineNode = 'PipelineNode',
     Groups = 'Groups',
+    GroupsNew = 'GroupsNew',
     Group = 'Group',
     Action = 'Action',
     EarlyAccessFeatures = 'EarlyAccessFeatures',

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -203,6 +203,11 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
         name: 'Groups',
         defaultDocsPath: '/docs/product-analytics/group-analytics',
     },
+    [Scene.GroupsNew]: {
+        projectBased: true,
+        name: 'GroupsNew',
+        defaultDocsPath: '/docs/product-analytics/group-analytics',
+    },
     [Scene.Group]: {
         projectBased: true,
         name: 'People & groups',
@@ -630,6 +635,7 @@ export const routes: Record<string, [Scene | string, string]> = {
     [urls.pipelineNode(':stage', ':id')]: [Scene.PipelineNode, 'pipelineNodeWithId'],
     [urls.customCss()]: [Scene.CustomCss, 'customCss'],
     [urls.groups(':groupTypeIndex')]: [Scene.PersonsManagement, 'groups'],
+    [urls.groupsNew(':groupTypeIndex')]: [Scene.GroupsNew, 'groupsNew'],
     [urls.group(':groupTypeIndex', ':groupKey', false)]: [Scene.Group, 'group'],
     [urls.group(':groupTypeIndex', ':groupKey', false, ':groupTab')]: [Scene.Group, 'groupWithTab'],
     [urls.cohort(':id')]: [Scene.Cohort, 'cohort'],

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -205,7 +205,6 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
     },
     [Scene.GroupsNew]: {
         projectBased: true,
-        name: 'Create Group',
         defaultDocsPath: '/docs/product-analytics/group-analytics',
     },
     [Scene.Group]: {

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -205,7 +205,7 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
     },
     [Scene.GroupsNew]: {
         projectBased: true,
-        name: 'GroupsNew',
+        name: 'Create Group',
         defaultDocsPath: '/docs/product-analytics/group-analytics',
     },
     [Scene.Group]: {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1357,6 +1357,12 @@ export type SearchResponse = {
 
 export type GroupListParams = { group_type_index: GroupTypeIndex; search: string }
 
+export type CreateGroupParams = {
+    group_type_index: GroupTypeIndex
+    group_key: string
+    group_properties?: Record<string, any>
+}
+
 export interface MatchedRecordingEvent {
     uuid: string
 }

--- a/products/groups/manifest.tsx
+++ b/products/groups/manifest.tsx
@@ -4,6 +4,7 @@ export const manifest: ProductManifest = {
     name: 'Groups',
     urls: {
         groups: (groupTypeIndex: string | number): string => `/groups/${groupTypeIndex}`,
+        groupsNew: (groupTypeIndex: string | number): string => `/groups/${groupTypeIndex}/new`,
         // :TRICKY: Note that groupKey is provided by user. We need to override urlPatternOptions for kea-router.
         group: (
             groupTypeIndex: string | number,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Closes https://github.com/PostHog/posthog/issues/35304
Closes https://github.com/PostHog/posthog/issues/35273
Closes https://github.com/PostHog/posthog/issues/35274
## Changes
**Everything is gated by `crm-iteration-one` feature flag**
- Add a button to create new group in group list view
- Create new scene to handle group creation with basic form
- Integrates with #35306
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Manually in the UI and through unit tests
https://www.loom.com/share/6ccab942c82a41caa3047bcbd3b7e9ac?sid=3ebaf9d2-6a36-4785-9ba7-dca3d5e51a4c
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
