### PR TITLE
fix: Put async logs with tasks

### DIFF
--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -355,6 +355,7 @@ class PutInLogQueueProcessor:
 
     def __init__(self, queue: asyncio.Queue | sync_queue.Queue):
         self.queue = queue
+        self.put_tasks = []
 
     def __call__(
         self, logger: logging.Logger, method_name: str, event_dict: structlog.types.EventDict
@@ -382,7 +383,7 @@ class PutInLogQueueProcessor:
             # This could be because we are running outside an Activity/Workflow context.
             return event_dict
 
-        self.queue.put_nowait(json.dumps(message_dict).encode("utf-8"))
+        self.put_tasks.append(asyncio.create_task(self.queue.put(json.dumps(message_dict).encode("utf-8"))))
 
         return event_dict
 


### PR DESCRIPTION
## Problem

We now have a queue limit, so we could fail if our external log throughput ever exceeds that limit.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Use tasks to put the logs, thus the tasks can wait for the queue to clear up.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
