### PR TITLE
chore: turn on tracing headers

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -92,6 +92,7 @@ export function loadPostHogJS(): void {
             person_profiles: 'always',
             __preview_remote_config: true,
             __preview_flags_v2: true,
+            __add_tracing_headers: true,
         })
 
         posthog.onFeatureFlags((_flags, _variants, context) => {


### PR DESCRIPTION
turn these on because then we'll get session id and distinct id automagically on our python events

locally I can see this picking up session id for python events with the django integration but not LLM events

<img width="904" height="813" alt="Screenshot 2025-07-21 at 20 42 45" src="https://github.com/user-attachments/assets/32f513bc-36c1-45bb-94f2-3fa133a38113" />
