### PR TITLE
feat: Add custom property types and validation

### DIFF
--- a/frontend/src/scenes/groups/GroupsNew.tsx
+++ b/frontend/src/scenes/groups/GroupsNew.tsx
@@ -5,7 +5,7 @@ import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 import { groupsNewLogic } from 'scenes/groups/groupsNewLogic'
 import { useActions, useValues } from 'kea'
-import { Form } from 'kea-forms'
+import { Form, Group } from 'kea-forms'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { IconPlus, IconTrash } from '@posthog/icons'
 
@@ -22,8 +22,8 @@ export const scene: SceneExport = {
 }
 
 export function GroupsNew(): JSX.Element {
-    const { logicProps, customProperties } = useValues(groupsNewLogic)
-    const { addProperty, removeProperty, updateProperty } = useActions(groupsNewLogic)
+    const { logicProps, group } = useValues(groupsNewLogic)
+    const { addFormProperty, removeFormProperty } = useActions(groupsNewLogic)
 
     return (
         <div className="groups-new">
@@ -65,7 +65,7 @@ export function GroupsNew(): JSX.Element {
                     <div className="mt-4">
                         <h3 className="text-md font-medium mb-2">Properties</h3>
 
-                        {customProperties && customProperties.length > 0 && (
+                        {group.customProperties && group.customProperties.length > 0 && (
                             <div className="flex gap-4 mb-2 text-s font-medium">
                                 <div className="flex-1">Name</div>
                                 <div className="flex-1">Value</div>
@@ -73,38 +73,36 @@ export function GroupsNew(): JSX.Element {
                             </div>
                         )}
 
-                        {customProperties &&
-                            customProperties.map((property, index) => (
-                                <div key={index} className="flex gap-4 mb-2 items-start">
-                                    <div className="flex-1">
-                                        <LemonInput
-                                            value={property.name}
-                                            onChange={(value) => updateProperty(index, 'name', value)}
-                                            placeholder="e.g., company"
+                        {group.customProperties &&
+                            group.customProperties.map((_, index: number) => (
+                                <Group key={index} name={['customProperties', index]}>
+                                    <div className="flex gap-4 mb-2 items-start">
+                                        <div className="flex-1">
+                                            <LemonField name="name">
+                                                <LemonInput placeholder="e.g. is_subscribed" />
+                                            </LemonField>
+                                        </div>
+                                        <div className="flex-1">
+                                            <LemonField name="value">
+                                                <LemonInput placeholder="e.g. true" />
+                                            </LemonField>
+                                        </div>
+                                        <LemonButton
+                                            icon={<IconTrash />}
+                                            size="small"
+                                            type="secondary"
+                                            status="danger"
+                                            onClick={() => removeFormProperty(index)}
+                                            data-attr={`remove-property-${index}`}
                                         />
                                     </div>
-                                    <div className="flex-1">
-                                        <LemonInput
-                                            value={property.value}
-                                            onChange={(value) => updateProperty(index, 'value', value)}
-                                            placeholder="e.g., PostHog"
-                                        />
-                                    </div>
-                                    <LemonButton
-                                        icon={<IconTrash />}
-                                        size="small"
-                                        type="secondary"
-                                        status="danger"
-                                        onClick={() => removeProperty(index)}
-                                        data-attr={`remove-property-${index}`}
-                                    />
-                                </div>
+                                </Group>
                             ))}
 
                         <LemonButton
                             icon={<IconPlus />}
                             type="secondary"
-                            onClick={addProperty}
+                            onClick={addFormProperty}
                             data-attr="add-property"
                         >
                             Add property

--- a/frontend/src/scenes/groups/GroupsNew.tsx
+++ b/frontend/src/scenes/groups/GroupsNew.tsx
@@ -1,4 +1,4 @@
-import { LemonButton, LemonDivider, LemonInput } from '@posthog/lemon-ui'
+import { LemonButton, LemonDivider, LemonInput, LemonSegmentedButton } from '@posthog/lemon-ui'
 import { router } from 'kea-router'
 import { PageHeader } from 'lib/components/PageHeader'
 import { SceneExport } from 'scenes/sceneTypes'
@@ -23,7 +23,7 @@ export const scene: SceneExport = {
 
 export function GroupsNew(): JSX.Element {
     const { logicProps, group } = useValues(groupsNewLogic)
-    const { addFormProperty, removeFormProperty } = useActions(groupsNewLogic)
+    const { addFormProperty, removeFormProperty, setGroupValue } = useActions(groupsNewLogic)
 
     return (
         <div className="groups-new">
@@ -68,6 +68,7 @@ export function GroupsNew(): JSX.Element {
                         {group.customProperties && group.customProperties.length > 0 && (
                             <div className="flex gap-4 mb-2 text-s font-medium">
                                 <div className="flex-1">Name</div>
+                                <div className="flex-1">Type</div>
                                 <div className="flex-1">Value</div>
                                 <div className="w-8" /> {/* Space for trash button */}
                             </div>
@@ -83,8 +84,67 @@ export function GroupsNew(): JSX.Element {
                                             </LemonField>
                                         </div>
                                         <div className="flex-1">
+                                            <LemonField name="type">
+                                                <LemonSegmentedButton
+                                                    onChange={(value: 'string' | 'boolean') => {
+                                                        const currentProperties = group.customProperties || []
+                                                        const updatedProperties = currentProperties.map((prop, i) =>
+                                                            i === index
+                                                                ? {
+                                                                      ...prop,
+                                                                      type: value,
+                                                                      value: value === 'string' ? '' : 'true',
+                                                                  }
+                                                                : prop
+                                                        )
+                                                        setGroupValue('customProperties', updatedProperties)
+                                                    }}
+                                                    value={group.customProperties?.[index]?.type || 'string'}
+                                                    options={[
+                                                        {
+                                                            value: 'string',
+                                                            label: 'Text or Number',
+                                                        },
+                                                        {
+                                                            value: 'boolean',
+                                                            label: 'Boolean or Null',
+                                                        },
+                                                    ]}
+                                                    size="small"
+                                                />
+                                            </LemonField>
+                                        </div>
+                                        <div className="flex-1">
                                             <LemonField name="value">
-                                                <LemonInput placeholder="e.g. true" />
+                                                {group.customProperties?.[index]?.type === 'boolean' ? (
+                                                    <LemonSegmentedButton
+                                                        onChange={(value: string) => {
+                                                            const currentProperties = group.customProperties || []
+                                                            const updatedProperties = currentProperties.map((prop, i) =>
+                                                                i === index ? { ...prop, value } : prop
+                                                            )
+                                                            setGroupValue('customProperties', updatedProperties)
+                                                        }}
+                                                        value={group.customProperties?.[index]?.value || 'true'}
+                                                        options={[
+                                                            {
+                                                                value: 'true',
+                                                                label: 'True',
+                                                            },
+                                                            {
+                                                                value: 'false',
+                                                                label: 'False',
+                                                            },
+                                                            {
+                                                                value: 'null',
+                                                                label: 'Null',
+                                                            },
+                                                        ]}
+                                                        size="small"
+                                                    />
+                                                ) : (
+                                                    <LemonInput placeholder="e.g. subscription_tier" />
+                                                )}
                                             </LemonField>
                                         </div>
                                         <LemonButton

--- a/frontend/src/scenes/groups/groupsNewLogic.test.ts
+++ b/frontend/src/scenes/groups/groupsNewLogic.test.ts
@@ -1,15 +1,7 @@
 import { initKeaTests } from '~/test/init'
-import { CreateGroupParams, GroupTypeIndex } from '~/types'
+import {} from '~/types'
 
 import { flattenProperties, groupsNewLogic, GroupsNewLogicProps } from './groupsNewLogic'
-
-const MOCK_CREATE_PARAMS: CreateGroupParams = {
-    group_key: 'test-group-key',
-    group_type_index: 0 as GroupTypeIndex,
-    group_properties: {
-        name: 'Test Group',
-    },
-}
 
 describe('groupsNewLogic', () => {
     let logic: ReturnType<typeof groupsNewLogic.build>
@@ -30,7 +22,6 @@ describe('groupsNewLogic', () => {
 
             expect(logic.values.logicProps).toEqual(props)
             expect(logic.values.createdGroup).toBeNull()
-            expect(logic.values.customProperties).toEqual([])
             expect(logic.values.group).toEqual({})
         })
 
@@ -48,40 +39,22 @@ describe('groupsNewLogic', () => {
         })
     })
 
-    describe('form management', () => {
+    describe('form logic', () => {
         beforeEach(() => {
-            logic = groupsNewLogic({ groupTypeIndex: 0 })
+            const props: GroupsNewLogicProps = { groupTypeIndex: 1 }
+            logic = groupsNewLogic(props)
             logic.mount()
         })
 
-        it('validates required fields correctly', () => {
-            logic.actions.setGroupValue('name', '')
-            logic.actions.setGroupValue('group_key', '')
-
-            expect(logic.values.groupHasErrors).toBe(true)
-
-            logic.actions.submitGroup()
-
-            expect(logic.values.groupErrors.name).toBe('Group name cannot be empty')
-            expect(logic.values.groupErrors.group_key).toBe('Group key cannot be empty')
-        })
-
-        it('validates whitespace-only values as invalid', () => {
-            logic.actions.setGroupValue('name', '   ')
-            logic.actions.setGroupValue('group_key', '\t\n  ')
-
+        it('handles form validation correctly', () => {
             logic.actions.submitGroup()
 
             expect(logic.values.groupHasErrors).toBe(true)
             expect(logic.values.groupErrors.name).toBe('Group name cannot be empty')
             expect(logic.values.groupErrors.group_key).toBe('Group key cannot be empty')
-        })
 
-        it('accepts valid form data', () => {
             logic.actions.setGroupValue('name', 'Valid Name')
             logic.actions.setGroupValue('group_key', 'valid-key')
-
-            logic.actions.submitGroup()
 
             expect(logic.values.groupHasErrors).toBe(false)
             expect(logic.values.groupErrors).toEqual({})
@@ -89,243 +62,207 @@ describe('groupsNewLogic', () => {
 
         it('resets form state', () => {
             logic.actions.setGroupValue('name', 'Test Name')
-            logic.actions.addProperty()
+            logic.actions.addFormProperty()
 
             expect(logic.values.group.name).toBe('Test Name')
-            expect(logic.values.customProperties).toHaveLength(1)
+            expect(logic.values.group.customProperties).toHaveLength(1)
 
             logic.actions.resetGroup()
 
             expect(logic.values.createdGroup).toBeNull()
-            expect(logic.values.customProperties).toEqual([])
+            expect(logic.values.group.customProperties).toBe(undefined)
         })
     })
 
     describe('custom properties management', () => {
         beforeEach(() => {
-            logic = groupsNewLogic({ groupTypeIndex: 0 })
+            const props: GroupsNewLogicProps = { groupTypeIndex: 1 }
+            logic = groupsNewLogic(props)
             logic.mount()
         })
 
-        it('adds properties correctly', () => {
-            expect(logic.values.customProperties).toEqual([])
+        it('should add a new property', () => {
+            expect(logic.values.group.customProperties).toBe(undefined)
 
-            logic.actions.addProperty()
-            expect(logic.values.customProperties).toEqual([{ name: '', value: '' }])
+            logic.actions.addFormProperty()
 
-            logic.actions.addProperty()
-            expect(logic.values.customProperties).toEqual([
-                { name: '', value: '' },
-                { name: '', value: '' },
+            expect(logic.values.group.customProperties).toEqual([{ name: '', type: 'string', value: '' }])
+        })
+
+        it('should add multiple properties', () => {
+            logic.actions.addFormProperty()
+
+            expect(logic.values.group.customProperties).toEqual([{ name: '', type: 'string', value: '' }])
+
+            logic.actions.addFormProperty()
+
+            expect(logic.values.group.customProperties).toEqual([
+                { name: '', type: 'string', value: '' },
+                { name: '', type: 'string', value: '' },
             ])
         })
 
-        it('updates property name and value', () => {
-            logic.actions.addProperty()
+        it('should update property name and value', () => {
+            logic.actions.addFormProperty()
 
-            logic.actions.updateProperty(0, 'name', 'test-property')
-            expect(logic.values.customProperties[0]).toEqual({ name: 'test-property', value: '' })
+            logic.actions.setGroupValue('customProperties', [{ name: 'test-property', type: 'string', value: '' }])
 
-            logic.actions.updateProperty(0, 'value', 'test-value')
-            expect(logic.values.customProperties[0]).toEqual({ name: 'test-property', value: 'test-value' })
-        })
+            expect(logic.values.group.customProperties[0]).toMatchObject({
+                name: 'test-property',
+                type: 'string',
+                value: '',
+            })
 
-        it('removes properties by index', () => {
-            logic.actions.addProperty()
-            logic.actions.addProperty()
-            logic.actions.addProperty()
-            logic.actions.updateProperty(0, 'name', 'zero')
-            logic.actions.updateProperty(1, 'name', 'one')
-            logic.actions.updateProperty(2, 'name', 'two')
-
-            logic.actions.removeProperty(1)
-            expect(logic.values.customProperties).toEqual([
-                { name: 'zero', value: '' },
-                { name: 'two', value: '' },
+            logic.actions.setGroupValue('customProperties', [
+                { name: 'test-property', type: 'string', value: 'test-value' },
             ])
 
-            logic.actions.removeProperty(0)
-            expect(logic.values.customProperties).toEqual([{ name: 'two', value: '' }])
-        })
-
-        it('handles out-of-bounds removal gracefully', () => {
-            logic.actions.addProperty()
-
-            logic.actions.removeProperty(5)
-            expect(logic.values.customProperties).toHaveLength(1)
-
-            logic.actions.removeProperty(-1)
-            expect(logic.values.customProperties).toHaveLength(1)
-        })
-
-        it('handles invalid property updates gracefully', () => {
-            logic.actions.addProperty()
-            const originalProperties = [...logic.values.customProperties]
-
-            logic.actions.updateProperty(5, 'name', 'test')
-            expect(logic.values.customProperties).toEqual(originalProperties)
-
-            logic.actions.updateProperty(-1, 'value', 'test')
-            expect(logic.values.customProperties).toEqual(originalProperties)
-        })
-    })
-
-    describe('action dispatch and state management', () => {
-        beforeEach(() => {
-            logic = groupsNewLogic({ groupTypeIndex: 1 })
-            logic.mount()
-        })
-
-        it('dispatches saveGroup action correctly', () => {
-            expect(() => {
-                logic.actions.saveGroup(MOCK_CREATE_PARAMS)
-            }).not.toThrow()
-        })
-
-        it('initializes with correct loading states', () => {
-            expect(logic.values.createdGroupLoading).toBe(false)
-            expect(logic.values.createdGroup).toBeNull()
-        })
-    })
-
-    describe('form validation and submission', () => {
-        beforeEach(() => {
-            logic = groupsNewLogic({ groupTypeIndex: 0 })
-            logic.mount()
-        })
-
-        it('prevents submission with validation errors', () => {
-            logic.actions.setGroupValue('name', '')
-            logic.actions.setGroupValue('group_key', '')
-
-            logic.actions.submitGroup()
-
-            expect(logic.values.groupHasErrors).toBe(true)
-        })
-
-        it('accepts valid form data for submission', () => {
-            logic.actions.setGroupValue('name', 'Valid Group')
-            logic.actions.setGroupValue('group_key', 'valid-group')
-
-            expect(logic.values.groupHasErrors).toBe(false)
-            expect(logic.values.group.name).toBe('Valid Group')
-            expect(logic.values.group.group_key).toBe('valid-group')
-        })
-
-        it('validates custom property names are not empty', () => {
-            logic.actions.setGroupValue('name', 'Valid Name')
-            logic.actions.setGroupValue('group_key', 'valid-key')
-            logic.actions.addProperty()
-
-            logic.actions.submitGroup()
-
-            expect(logic.values.groupHasErrors).toBe(true)
-            expect(logic.values.groupErrors.customProperties[0].name).toBe('Property name cannot be empty')
-        })
-
-        it('validates custom property names are unique', () => {
-            logic.actions.setGroupValue('name', 'Valid Name')
-            logic.actions.setGroupValue('group_key', 'valid-key')
-            logic.actions.addProperty()
-            logic.actions.addProperty()
-            logic.actions.updateProperty(0, 'name', 'duplicate')
-            logic.actions.updateProperty(1, 'name', 'duplicate')
-
-            logic.actions.submitGroup()
-
-            expect(logic.values.groupHasErrors).toBe(true)
-            expect(logic.values.groupErrors.customProperties[0].name).toBe('Property name must be unique')
-            expect(logic.values.groupErrors.customProperties[1].name).toBe('Property name must be unique')
-        })
-
-        it('validates custom property names are not reserved', () => {
-            logic.actions.setGroupValue('name', 'Valid Name')
-            logic.actions.setGroupValue('group_key', 'valid-key')
-            logic.actions.addProperty()
-            logic.actions.updateProperty(0, 'name', 'name')
-
-            logic.actions.submitGroup()
-
-            expect(logic.values.groupHasErrors).toBe(true)
-            expect(logic.values.groupErrors.customProperties[0].name).toBe('Property name "name" is reserved')
-        })
-
-        it('accepts valid custom properties', () => {
-            logic.actions.setGroupValue('name', 'Valid Name')
-            logic.actions.setGroupValue('group_key', 'valid-key')
-            logic.actions.addProperty()
-            logic.actions.addProperty()
-            logic.actions.updateProperty(0, 'name', 'company')
-            logic.actions.updateProperty(0, 'value', 'PostHog')
-            logic.actions.updateProperty(1, 'name', 'industry')
-            logic.actions.updateProperty(1, 'value', 'Analytics')
-
-            logic.actions.submitGroup()
-
-            expect(logic.values.groupHasErrors).toBe(false)
-            expect(logic.values.groupErrors).toEqual({})
-        })
-    })
-
-    describe('cleanup and lifecycle', () => {
-        it('resets state on unmount', () => {
-            logic = groupsNewLogic({ groupTypeIndex: 0 })
-            logic.mount()
-
-            logic.actions.setGroupValue('name', 'Test')
-            logic.actions.addProperty()
-
-            expect(logic.values.group.name).toBe('Test')
-            expect(logic.values.customProperties).toHaveLength(1)
-
-            logic.unmount()
-            logic.mount()
-
-            expect(logic.values.createdGroup).toBeNull()
-            expect(logic.values.customProperties).toEqual([])
-        })
-
-        it('resets custom properties when resetGroup is called', () => {
-            logic = groupsNewLogic({ groupTypeIndex: 0 })
-            logic.mount()
-
-            logic.actions.setGroupValue('name', 'Test Group')
-            logic.actions.addProperty()
-            logic.actions.updateProperty(0, 'name', 'test-prop')
-
-            expect(logic.values.customProperties).toHaveLength(1)
-            expect(logic.values.customProperties[0].name).toBe('test-prop')
-
-            logic.actions.resetGroup()
-
-            expect(logic.values.customProperties).toEqual([])
-            expect(logic.values.createdGroup).toBeNull()
-        })
-    })
-
-    describe('edge cases and error scenarios', () => {
-        beforeEach(() => {
-            logic = groupsNewLogic({ groupTypeIndex: 0 })
-            logic.mount()
-        })
-
-        it('handles special characters in property names and values', () => {
-            logic.actions.addProperty()
-            logic.actions.updateProperty(0, 'name', 'special-chars!@#$%')
-            logic.actions.updateProperty(0, 'value', 'value with spaces & symbols')
-
-            expect(logic.values.customProperties[0]).toEqual({
-                name: 'special-chars!@#$%',
-                value: 'value with spaces & symbols',
+            expect(logic.values.group.customProperties[0]).toMatchObject({
+                name: 'test-property',
+                type: 'string',
+                value: 'test-value',
             })
         })
 
-        it('handles unicode characters in form fields', () => {
-            logic.actions.setGroupValue('name', 'Group with émojis 🎉')
-            logic.actions.setGroupValue('group_key', 'group-key-with-dashes')
+        it('should handle multiple properties with updates', () => {
+            logic.actions.setGroupValue('customProperties', [
+                { name: 'zero', type: 'string', value: '' },
+                { name: 'one', type: 'string', value: '' },
+                { name: 'two', type: 'string', value: '' },
+            ])
 
-            expect(logic.values.group.name).toBe('Group with émojis 🎉')
-            expect(logic.values.group.group_key).toBe('group-key-with-dashes')
+            expect(logic.values.group.customProperties).toEqual([
+                { name: 'zero', type: 'string', value: '' },
+                { name: 'one', type: 'string', value: '' },
+                { name: 'two', type: 'string', value: '' },
+            ])
+        })
+
+        it('should remove a property', () => {
+            // Add some properties first
+            logic.actions.setGroupValue('customProperties', [
+                { name: 'prop1', type: 'string', value: 'value1' },
+                { name: 'prop2', type: 'string', value: 'value2' },
+            ])
+
+            expect(logic.values.group.customProperties).toHaveLength(2)
+
+            // Remove the first property
+            logic.actions.removeFormProperty(0)
+
+            expect(logic.values.group.customProperties).toEqual([{ name: 'prop2', type: 'string', value: 'value2' }])
+        })
+
+        it('should handle edge cases for property updates gracefully', () => {
+            logic.actions.addFormProperty()
+            // Test bounds - trying to update non-existent property
+            const currentProps = logic.values.group.customProperties || []
+            logic.actions.setGroupValue('customProperties', currentProps)
+            expect(logic.values.group.customProperties?.[5]).toBeUndefined()
+        })
+    })
+
+    describe('form validation', () => {
+        beforeEach(() => {
+            const props: GroupsNewLogicProps = { groupTypeIndex: 1 }
+            logic = groupsNewLogic(props)
+            logic.mount()
+        })
+
+        it('should validate empty custom property names', () => {
+            logic.actions.setGroupValue('name', 'Valid Name')
+            logic.actions.setGroupValue('group_key', 'valid-key')
+            logic.actions.addFormProperty()
+
+            logic.actions.submitGroup()
+
+            expect(logic.values.groupHasErrors).toBe(true)
+            expect(logic.values.groupErrors?.customProperties?.[0]?.name).toBe('Property name cannot be empty')
+        })
+
+        it('should validate duplicate custom property names', () => {
+            logic.actions.setGroupValue('name', 'Valid Name')
+            logic.actions.setGroupValue('group_key', 'valid-key')
+            logic.actions.setGroupValue('customProperties', [
+                { name: 'duplicate', type: 'string', value: '' },
+                { name: 'duplicate', type: 'string', value: '' },
+            ])
+
+            logic.actions.submitGroup()
+
+            expect(logic.values.groupHasErrors).toBe(true)
+            expect(logic.values.groupErrors?.customProperties?.[0]?.name).toBe('Property name must be unique')
+            expect(logic.values.groupErrors?.customProperties?.[1]?.name).toBe('Property name must be unique')
+        })
+
+        it('should validate reserved property name "name"', () => {
+            logic.actions.setGroupValue('name', 'Valid Name')
+            logic.actions.setGroupValue('group_key', 'valid-key')
+            logic.actions.setGroupValue('customProperties', [{ name: 'name', type: 'string', value: '' }])
+
+            logic.actions.submitGroup()
+
+            expect(logic.values.groupHasErrors).toBe(true)
+            expect(logic.values.groupErrors?.customProperties?.[0]?.name).toBe('Property name "name" is reserved')
+        })
+
+        it('should pass validation with valid custom properties', () => {
+            logic.actions.setGroupValue('name', 'Valid Name')
+            logic.actions.setGroupValue('group_key', 'valid-key')
+            logic.actions.setGroupValue('customProperties', [
+                { name: 'company', type: 'string', value: 'PostHog' },
+                { name: 'industry', type: 'string', value: 'Analytics' },
+            ])
+
+            expect(logic.values.groupHasErrors).toBe(false)
+            expect(logic.values.groupErrors?.customProperties).toBeUndefined()
+        })
+    })
+
+    describe('form submission', () => {
+        beforeEach(() => {
+            const props: GroupsNewLogicProps = { groupTypeIndex: 1 }
+            logic = groupsNewLogic(props)
+            logic.mount()
+        })
+
+        it('should submit form with custom properties', () => {
+            const saveGroupSpy = jest.spyOn(logic.actions, 'saveGroup')
+
+            logic.actions.setGroupValue('name', 'Test Group')
+            logic.actions.setGroupValue('group_key', 'test-key')
+            logic.actions.setGroupValue('customProperties', [{ name: 'test-prop', type: 'string', value: '' }])
+
+            logic.actions.submitGroup()
+
+            expect(saveGroupSpy).toHaveBeenCalledWith({
+                group_key: 'test-key',
+                group_type_index: 1,
+                group_properties: {
+                    name: 'Test Group',
+                },
+            })
+        })
+    })
+
+    describe('property handling edge cases', () => {
+        beforeEach(() => {
+            const props: GroupsNewLogicProps = { groupTypeIndex: 1 }
+            logic = groupsNewLogic(props)
+            logic.mount()
+        })
+
+        it('should handle special characters in property names and values', () => {
+            logic.actions.setGroupValue('customProperties', [
+                { name: 'special-chars!@#$%', type: 'string', value: 'value with spaces & symbols' },
+            ])
+
+            const customProperties = logic.values.group.customProperties
+            expect(customProperties?.[0]).toEqual({
+                name: 'special-chars!@#$%',
+                type: 'string',
+                value: 'value with spaces & symbols',
+            })
         })
     })
 })
@@ -333,16 +270,49 @@ describe('groupsNewLogic', () => {
 describe('flattenProperties', () => {
     it('filters out empty properties during form submission', () => {
         const rawProperties = [
-            { name: '', value: '' },
-            { name: '  ', value: '' },
-            { name: 'my value is a whitespace', value: ' ' },
-            { name: 'empty-value-prop', value: '' },
-            { name: 'valid-prop', value: 'valid-value' },
-            { name: ' another-valid-prop', value: 'valid-value ' },
+            { name: '', type: 'string' as const, value: '' },
+            { name: ' ', type: 'string' as const, value: ' ' },
+            { name: 'valid-prop', type: 'string' as const, value: 'valid-value' },
+            { name: 'another-valid-prop', type: 'string' as const, value: 'valid-value ' },
+            { name: '', type: 'string' as const, value: 'orphaned-value' },
         ]
 
         const flattenedProperties = flattenProperties(rawProperties)
 
         expect(flattenedProperties).toEqual({ 'valid-prop': 'valid-value', 'another-valid-prop': 'valid-value ' })
+    })
+
+    it('handles boolean properties correctly', () => {
+        const rawProperties = [
+            { name: 'is_active', type: 'boolean' as const, value: 'true' },
+            { name: 'has_subscription', type: 'boolean' as const, value: 'false' },
+            { name: 'is_null', type: 'boolean' as const, value: 'null' },
+        ]
+
+        const flattenedProperties = flattenProperties(rawProperties)
+
+        expect(flattenedProperties).toEqual({
+            is_active: true,
+            has_subscription: false,
+            is_null: null,
+        })
+    })
+
+    it('converts numeric strings to numbers for string type properties', () => {
+        const rawProperties = [
+            { name: 'count', type: 'string' as const, value: '42' },
+            { name: 'price', type: 'string' as const, value: '19.99' },
+            { name: 'name', type: 'string' as const, value: 'PostHog' },
+            { name: 'zero', type: 'string' as const, value: '0' },
+        ]
+
+        const flattenedProperties = flattenProperties(rawProperties)
+
+        expect(flattenedProperties).toEqual({
+            count: 42,
+            price: 19.99,
+            name: 'PostHog',
+            zero: 0,
+        })
     })
 })

--- a/frontend/src/scenes/groups/groupsNewLogic.test.ts
+++ b/frontend/src/scenes/groups/groupsNewLogic.test.ts
@@ -211,6 +211,60 @@ describe('groupsNewLogic', () => {
             expect(logic.values.group.name).toBe('Valid Group')
             expect(logic.values.group.group_key).toBe('valid-group')
         })
+
+        it('validates custom property names are not empty', () => {
+            logic.actions.setGroupValue('name', 'Valid Name')
+            logic.actions.setGroupValue('group_key', 'valid-key')
+            logic.actions.addProperty()
+
+            logic.actions.submitGroup()
+
+            expect(logic.values.groupHasErrors).toBe(true)
+            expect(logic.values.groupErrors.customProperties[0].name).toBe('Property name cannot be empty')
+        })
+
+        it('validates custom property names are unique', () => {
+            logic.actions.setGroupValue('name', 'Valid Name')
+            logic.actions.setGroupValue('group_key', 'valid-key')
+            logic.actions.addProperty()
+            logic.actions.addProperty()
+            logic.actions.updateProperty(0, 'name', 'duplicate')
+            logic.actions.updateProperty(1, 'name', 'duplicate')
+
+            logic.actions.submitGroup()
+
+            expect(logic.values.groupHasErrors).toBe(true)
+            expect(logic.values.groupErrors.customProperties[0].name).toBe('Property name must be unique')
+            expect(logic.values.groupErrors.customProperties[1].name).toBe('Property name must be unique')
+        })
+
+        it('validates custom property names are not reserved', () => {
+            logic.actions.setGroupValue('name', 'Valid Name')
+            logic.actions.setGroupValue('group_key', 'valid-key')
+            logic.actions.addProperty()
+            logic.actions.updateProperty(0, 'name', 'name')
+
+            logic.actions.submitGroup()
+
+            expect(logic.values.groupHasErrors).toBe(true)
+            expect(logic.values.groupErrors.customProperties[0].name).toBe('Property name "name" is reserved')
+        })
+
+        it('accepts valid custom properties', () => {
+            logic.actions.setGroupValue('name', 'Valid Name')
+            logic.actions.setGroupValue('group_key', 'valid-key')
+            logic.actions.addProperty()
+            logic.actions.addProperty()
+            logic.actions.updateProperty(0, 'name', 'company')
+            logic.actions.updateProperty(0, 'value', 'PostHog')
+            logic.actions.updateProperty(1, 'name', 'industry')
+            logic.actions.updateProperty(1, 'value', 'Analytics')
+
+            logic.actions.submitGroup()
+
+            expect(logic.values.groupHasErrors).toBe(false)
+            expect(logic.values.groupErrors).toEqual({})
+        })
     })
 
     describe('cleanup and lifecycle', () => {

--- a/frontend/src/scenes/groups/groupsNewLogic.ts
+++ b/frontend/src/scenes/groups/groupsNewLogic.ts
@@ -23,12 +23,12 @@ export interface NewGroupFormData {
     name: string
     group_key: string
     group_type_index: number
-    properties: Record<string, any>
     customProperties: GroupProperty[]
 }
 
 export interface GroupProperty {
     name: string
+    type: 'string' | 'boolean'
     value: string
 }
 
@@ -91,7 +91,7 @@ export const groupsNewLogic = kea<groupsNewLogicType>([
         customProperties: [
             [] as GroupProperty[],
             {
-                addProperty: (state) => [...state, { name: '', value: '' }],
+                addProperty: (state) => [...state, { name: '', type: 'string' as const, value: '' }],
                 removeProperty: (state, { index }) => state.filter((_, i) => i !== index),
                 updateProperty: (state, { index, field, value }) =>
                     state.map((prop, i) => (i === index ? { ...prop, [field]: value } : prop)),
@@ -104,7 +104,7 @@ export const groupsNewLogic = kea<groupsNewLogicType>([
         group: {
             defaults: NEW_GROUP,
             errors: ({ group_key, name, customProperties }: NewGroupFormData) => {
-                const errors: any = {
+                const errors: Record<string, string | object | undefined> = {
                     name: !name?.trim() ? 'Group name cannot be empty' : undefined,
                     group_key: !group_key?.trim() ? 'Group key cannot be empty' : undefined,
                 }
@@ -189,7 +189,10 @@ export const groupsNewLogic = kea<groupsNewLogicType>([
         saveGroupSuccess: () => actions.resetGroup(),
         addFormProperty: () => {
             const currentProperties = values.group.customProperties || []
-            actions.setGroupValue('customProperties', [...currentProperties, { name: '', value: '' }])
+            actions.setGroupValue('customProperties', [
+                ...currentProperties,
+                { name: '', type: 'string' as const, value: '' },
+            ])
         },
         removeFormProperty: ({ index }) => {
             const currentProperties = values.group.customProperties || []
@@ -214,11 +217,31 @@ export const groupsNewLogic = kea<groupsNewLogicType>([
     beforeUnmount(({ actions }) => actions.resetGroup()),
 ])
 
-export function flattenProperties(properties: GroupProperty[]): Record<string, string> {
+export function flattenProperties(properties: GroupProperty[]): Record<string, any> {
     return properties
         .filter((prop) => prop.name.trim() && prop.value.trim())
         .reduce((acc, prop) => {
-            acc[prop.name.trim()] = prop.value
+            const key = prop.name.trim()
+            let value: any = prop.value
+
+            // Convert boolean type values to proper types
+            if (prop.type === 'boolean') {
+                if (value === 'true') {
+                    value = true
+                } else if (value === 'false') {
+                    value = false
+                } else if (value === 'null') {
+                    value = null
+                }
+            } else if (prop.type === 'string') {
+                // Convert numeric strings to numbers
+                const numericValue = Number(value)
+                if (!isNaN(numericValue) && isFinite(numericValue) && value.trim() !== '') {
+                    value = numericValue
+                }
+            }
+
+            acc[key] = value
             return acc
-        }, {} as Record<string, string>)
+        }, {} as Record<string, any>)
 }


### PR DESCRIPTION
## Problem
- There is no validation for custom properties when creating a new group
- All properties are stored as string
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Closes https://github.com/PostHog/posthog/issues/35270
Closes https://github.com/PostHog/posthog/issues/35272
## Changes
- Add form validation for custom properties
	- prop name must not be empty
	- prop name must not be repeated
	- prop name must not equal `name`, as it is a protectec prop name
- Add type selector for props
	- Similar to what is in place when adding a new group prop 
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Manually via UI and unit tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
