### PR TITLE
chore(capture-rs): remove bug detection observability sampler

### DIFF
--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -93,7 +93,6 @@ pub struct Config {
     #[envconfig(default = "info")]
     pub log_level: Level,
 
-    // temporary: gates some chatty debug logging
     #[envconfig(default = "0.0")]
     pub verbose_sample_percent: f32,
 }

--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -95,7 +95,7 @@ pub struct Config {
 
     // temporary: gates some chatty debug logging
     #[envconfig(default = "0.0")]
-    pub base64_detect_percent: f32,
+    pub verbose_sample_percent: f32,
 }
 
 #[derive(Envconfig, Clone)]

--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -36,7 +36,7 @@ pub struct State {
     pub event_size_limit: usize,
     pub historical_cfg: HistoricalConfig,
     pub is_mirror_deploy: bool,
-    pub base64_detect_percent: f32,
+    pub verbose_sample_percent: f32,
 }
 
 #[derive(Clone)]
@@ -111,7 +111,7 @@ pub fn router<
     historical_rerouting_threshold_days: i64,
     historical_tokens_keys: Option<String>,
     is_mirror_deploy: bool,
-    base64_detect_percent: f32,
+    verbose_sample_percent: f32,
 ) -> Router {
     let state = State {
         sink: Arc::new(sink),
@@ -126,7 +126,7 @@ pub fn router<
             historical_tokens_keys,
         ),
         is_mirror_deploy,
-        base64_detect_percent,
+        verbose_sample_percent,
     };
 
     // Very permissive CORS policy, as old SDK versions

--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -186,7 +186,7 @@ where
         config.historical_rerouting_threshold_days,
         config.historical_tokens_keys,
         config.is_mirror_deploy,
-        config.base64_detect_percent,
+        config.verbose_sample_percent,
     );
 
     // run our app with hyper

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -1,4 +1,3 @@
-use std::cell::RefCell;
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -13,11 +12,9 @@ use chrono::{DateTime, Duration, Utc};
 use common_types::{CapturedEvent, RawEvent};
 use limiters::token_dropper::TokenDropper;
 use metrics::counter;
-use rand::Rng;
-use rand::{rngs::ThreadRng, thread_rng};
 use serde_json::json;
 use serde_json::Value;
-use tracing::{debug, error, info, instrument, warn, Span};
+use tracing::{debug, error, instrument, warn, Span};
 
 use crate::prometheus::{report_dropped_events, report_internal_error_metrics};
 use crate::v0_request::{
@@ -34,10 +31,9 @@ use crate::{
     v0_request::{EventFormData, EventQuery},
 };
 
-// TEMPORARY: used to trigger sampling of chatty log line
-thread_local! {
-    static RNG: RefCell<ThreadRng> = RefCell::new(thread_rng());
-}
+// EXAMPLE: use verbose_sample_percent env var to capture extra logging/metric details of interest
+// let roll = thread_rng().with_borrow_mut(|rng| rng.gen_range(0.0..100.0));
+// if roll < verbose_sample_percent { ... }
 
 /// handle_legacy owns the /e, /capture, /track, and /engage capture endpoints
 #[instrument(
@@ -217,13 +213,6 @@ async fn handle_legacy(
         }
     };
     Span::current().record("token", &token);
-
-    // TEMPORARY: conditionally sample targeted event submissions
-    let roll = RNG.with_borrow_mut(|rng| rng.gen_range(0.0..100.0));
-    if compression == Compression::Base64 && roll < state.base64_detect_percent {
-        // API token, req path etc. should be logged here by tracing lib
-        info!("handle_legacy: candidate team for base64 issue")
-    }
 
     counter!("capture_events_received_total", &[("legacy", "true")]).increment(events.len() as u64);
 

--- a/rust/capture/tests/common.rs
+++ b/rust/capture/tests/common.rs
@@ -45,7 +45,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     historical_tokens_keys: None,
     is_mirror_deploy: false,
     log_level: Level::INFO,
-    base64_detect_percent: 0.0_f32,
+    verbose_sample_percent: 0.0_f32,
     kafka: KafkaConfig {
         kafka_producer_linger_ms: 0, // Send messages as soon as possible
         kafka_producer_queue_mib: 10,


### PR DESCRIPTION
## Problem
I implemented a sampling verbose logger/metrics publish trigger I could adjust in deployments in realtime to address a previous `capture-rs` bug. I'd like to get rid of this while keeping a bit of the plumbing around for future uses, it was quite handy.

## Changes
Change config env var name to something more general for future uses. Add small sample code snip for usage instructions.

## How did you test this code?
Locally and in CI. Previously in deploy usage in US and EU

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

---
