### PR TITLE
feat(admin): Add Django admin tooling for managing PersonalAPIKey

### DIFF
--- a/posthog/admin/__init__.py
+++ b/posthog/admin/__init__.py
@@ -27,6 +27,7 @@ from posthog.admin.admins import (
     EventIngestionRestrictionConfigAdmin,
     LinkAdmin,
     BatchImportAdmin,
+    PersonalAPIKeyAdmin,
 )
 from posthog.models import (
     Organization,
@@ -55,6 +56,7 @@ from posthog.models import (
     EventIngestionRestrictionConfig,
     Link,
     BatchImport,
+    PersonalAPIKey,
 )
 
 admin.site.register(Organization, OrganizationAdmin)
@@ -89,3 +91,5 @@ admin.site.register(HogFunction, HogFunctionAdmin)
 admin.site.register(EventIngestionRestrictionConfig, EventIngestionRestrictionConfigAdmin)
 admin.site.register(Link, LinkAdmin)
 admin.site.register(BatchImport, BatchImportAdmin)
+
+admin.site.register(PersonalAPIKey, PersonalAPIKeyAdmin)

--- a/posthog/admin/admins/__init__.py
+++ b/posthog/admin/admins/__init__.py
@@ -24,3 +24,4 @@ from .user_admin import UserAdmin
 from .project_admin import ProjectAdmin
 from .hog_function_admin import HogFunctionAdmin
 from .event_ingestion_restriction_config import EventIngestionRestrictionConfigAdmin
+from .personal_api_key_admin import PersonalAPIKeyAdmin

--- a/posthog/admin/admins/personal_api_key_admin.py
+++ b/posthog/admin/admins/personal_api_key_admin.py
@@ -1,0 +1,30 @@
+from django.contrib import admin
+from django.utils.html import format_html
+from django.urls import reverse
+
+from posthog.models import PersonalAPIKey
+
+
+class PersonalAPIKeyAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "label",
+        "mask_value",
+        "user_link",
+        "created_at",
+        "last_used_at",
+        "scopes",
+    )
+    list_display_links = ("id", "label")
+    list_select_related = ("user",)
+    search_fields = ("id", "user__email", "scopes")
+    autocomplete_fields = ("user",)
+    ordering = ("-created_at",)
+
+    @admin.display(description="User")
+    def user_link(self, key: PersonalAPIKey):
+        return format_html(
+            '<a href="{}">{}</a>',
+            reverse("admin:posthog_user_change", args=[key.user.pk]),
+            key.user.email,
+        )

--- a/posthog/templates/api_key_search/values.html
+++ b/posthog/templates/api_key_search/values.html
@@ -64,8 +64,8 @@
                     </thead>
                     <tbody>
                         <tr>
-                            <td>Personal API Key ({{ personal_api_key_hash_mode }})</td>
-                            <td>{{ personal_api_key_object.label }}</td>
+                            <td><a href="/admin/posthog/personalapikey/{{ personal_api_key_object.id }}/change/">Personal API Key ({{ personal_api_key_hash_mode }})</a></td>
+                            <td><a href="/admin/posthog/personalapikey/{{ personal_api_key_object.id }}/change/">{{ personal_api_key_object.label }}</a></td>
                             <td><a href="/admin/posthog/user/{{ personal_api_key_object.user.id }}/change/">{{ personal_api_key_object.user.email }}</a></td>
                             <td>{{ personal_api_key_object.scopes }}</td>
                             <td>


### PR DESCRIPTION
This allows us to list all `PersonalAPIKey`s and manually revoke. All raw keys are hashed and so are never made accessible (we couldn't even if we wanted).

## Problem

We are currently unable to revoke a `PersonalAPIKey` that a user accidentally exposed.

## Did you write or update any docs for this change?

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change