### PR TITLE
chore: remove use of dangerouslySetInnerHTML

### DIFF
--- a/frontend/src/scenes/billing/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.tsx
@@ -337,7 +337,7 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
 
                     {product.price_description ? (
                         <LemonBanner type="info">
-                            <span dangerouslySetInnerHTML={{ __html: product.price_description }} />
+                            <span>{product.price_description}</span>
                         </LemonBanner>
                     ) : null}
 


### PR DESCRIPTION
`dangerouslySetInnerHTML` allows for injecting HTML, but presents the risk of introduxing XSS. None of the descriptions in the billing repo appear to use HTML so we should be safe to remove this.

I've tested this on the billing page though this code is fairly foreign to me, so please verify I'm not breaking all the things.