### PR TITLE
fix: Remove team_id from duplicate breakdown metric

### DIFF
--- a/plugin-server/src/ingestion/deduplication/events.test.ts
+++ b/plugin-server/src/ingestion/deduplication/events.test.ts
@@ -79,14 +79,12 @@ describe('deduplicateEvents', () => {
         expect(metrics.duplicateBreakdownTotal.inc).toHaveBeenCalledTimes(2)
         expect(metrics.duplicateBreakdownTotal.inc).toHaveBeenCalledWith(
             {
-                team_id: 123,
                 source: 'web',
             },
             1
         )
         expect(metrics.duplicateBreakdownTotal.inc).toHaveBeenCalledWith(
             {
-                team_id: 456,
                 source: 'python',
             },
             1

--- a/plugin-server/src/ingestion/deduplication/metrics.ts
+++ b/plugin-server/src/ingestion/deduplication/metrics.ts
@@ -24,8 +24,8 @@ export const eventsProcessedTotal = new Counter({
 // Duplicate breakdown by team and source
 export const duplicateBreakdownTotal = new Counter({
     name: 'deduplication_duplicates_breakdown_total',
-    help: 'Total number of duplicate events broken down by team_id and source',
-    labelNames: ['team_id', 'source'],
+    help: 'Total number of duplicate events broken down by source',
+    labelNames: ['source'],
 })
 
 // Deduplication operation duration


### PR DESCRIPTION
## Problem

Metric is not being shown, maybe team_id has too much cardinality?

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
