### PR TITLE
fix(experiments): reduce metric table cell height

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -155,7 +155,7 @@ export function MetricRowGroup({
 
                 {/* Variant name */}
                 <td
-                    className={`w-20 p-3 text-xs font-semibold text-left whitespace-nowrap overflow-hidden ${
+                    className={`w-20 pt-1 pl-3 pr-3 pb-1 text-xs font-semibold text-left whitespace-nowrap overflow-hidden ${
                         isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                     } ${variantResults.length === 0 ? 'border-b' : ''}`}
                     style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}
@@ -165,7 +165,7 @@ export function MetricRowGroup({
 
                 {/* Value */}
                 <td
-                    className={`w-24 p-3 text-left whitespace-nowrap overflow-hidden ${
+                    className={`w-24 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${
                         isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                     } ${variantResults.length === 0 ? 'border-b' : ''}`}
                     style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}
@@ -181,7 +181,7 @@ export function MetricRowGroup({
 
                 {/* Change (empty for baseline) */}
                 <td
-                    className={`w-20 p-3 text-left whitespace-nowrap overflow-hidden ${
+                    className={`w-20 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${
                         isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                     } ${variantResults.length === 0 ? 'border-b' : ''}`}
                     style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}
@@ -260,7 +260,7 @@ export function MetricRowGroup({
                     >
                         {/* Variant name */}
                         <td
-                            className={`w-20 p-3 text-left whitespace-nowrap overflow-hidden ${
+                            className={`w-20 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${
                                 isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                             } ${isLastRow ? 'border-b' : ''}`}
                             style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}
@@ -270,7 +270,7 @@ export function MetricRowGroup({
 
                         {/* Value */}
                         <td
-                            className={`w-24 p-3 text-left whitespace-nowrap overflow-hidden ${
+                            className={`w-24 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${
                                 isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                             } ${isLastRow ? 'border-b' : ''}`}
                             style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}
@@ -286,7 +286,7 @@ export function MetricRowGroup({
 
                         {/* Change */}
                         <td
-                            className={`w-20 p-3 text-left whitespace-nowrap overflow-hidden ${
+                            className={`w-20 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${
                                 isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                             } ${isLastRow ? 'border-b' : ''}`}
                             style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}

--- a/frontend/src/scenes/experiments/MetricsView/new/constants.ts
+++ b/frontend/src/scenes/experiments/MetricsView/new/constants.ts
@@ -7,7 +7,7 @@ export const BAR_SPACING = 12
 // ChartCell
 export const CHART_CELL_VIEW_BOX_HEIGHT = 51
 export const CHART_CELL_BAR_HEIGHT_PERCENT = 15
-export const CELL_HEIGHT = 61
+export const CELL_HEIGHT = 51
 export const CHART_BAR_OPACITY = 0.9
 export const GRID_LINES_OPACITY = 0.8
 


### PR DESCRIPTION
## Problem
It's a little too much vertical space between variants

<img width="1425" height="657" alt="Screenshot 2025-07-22 at 10 30 45" src="https://github.com/user-attachments/assets/f348ee3a-2dee-4dfd-aad6-a53908286d03" />


## Changes
Reduce the cell height a little
<img width="1426" height="567" alt="Screenshot 2025-07-22 at 10 31 11" src="https://github.com/user-attachments/assets/1b550233-a3e0-47a8-83c7-853fe0d6f578" />

## How did you test this code?
- 👀 