### PR TITLE
feat: Update Prom metrics for batch exports

### DIFF
--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -88,6 +88,10 @@ ACTIVITIES_DICT = {
     TEST_TASK_QUEUE: TEST_ACTIVITIES,
 }
 
+TASK_QUEUE_METRIC_PREFIXES = {
+    BATCH_EXPORTS_TASK_QUEUE: "batch_exports_",
+}
+
 LOGGER = get_logger(__name__)
 
 
@@ -231,6 +235,7 @@ class Command(BaseCommand):
                     else None,
                     max_concurrent_workflow_tasks=max_concurrent_workflow_tasks,
                     max_concurrent_activities=max_concurrent_activities,
+                    metric_prefix=TASK_QUEUE_METRIC_PREFIXES.get(task_queue, None),
                 )
             )
 

--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -64,6 +64,7 @@ async def create_worker(
                 histogram_bucket_overrides={
                     "batch_exports_activity_execution_latency": [
                         1_000.0,
+                        30_000.0,  # 30 seconds
                         60_000.0,  # 1 minute
                         300_000.0,  # 5 minutes
                         900_000.0,  # 15 minutes

--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -57,6 +57,23 @@ async def create_worker(
             metric_prefix=metric_prefix,
             metrics=PrometheusConfig(
                 bind_address=f"0.0.0.0:{metrics_port:d}",
+                durations_as_seconds=False,
+                # Units are u64 milliseconds in sdk-core,
+                # given that the `duration_as_seconds` is `False`.
+                # But in Python we still need to pass floats due to type hints.
+                histogram_bucket_overrides={
+                    "batch_exports_activity_execution_latency": [
+                        1_000.0,
+                        60_000.0,  # 1 minute
+                        300_000.0,  # 5 minutes
+                        900_000.0,  # 15 minutes
+                        1_800_000.0,  # 30 minutes
+                        3_600_000.0,  # 1 hour
+                        21_600_000.0,  # 6 hours
+                        43_200_000.0,  # 12 hours
+                        86_400_000.0,  # 24 hours
+                    ],
+                },
             ),
         )
     )

--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -26,6 +26,7 @@ async def create_worker(
     graceful_shutdown_timeout: dt.timedelta | None = None,
     max_concurrent_workflow_tasks: int | None = None,
     max_concurrent_activities: int | None = None,
+    metric_prefix: str | None = None,
 ) -> Worker:
     """Connect to Temporal server and return a Worker.
 
@@ -47,9 +48,18 @@ async def create_worker(
             the worker can handle. Defaults to 50.
         max_concurrent_activities: Maximum number of concurrent activity tasks the
             worker can handle. Defaults to 50.
+        metric_prefix: Prefix to apply to metrics emitted by this worker, if
+            left unset (`None`) Temporal will default to "temporal_".
     """
 
-    runtime = Runtime(telemetry=TelemetryConfig(metrics=PrometheusConfig(bind_address=f"0.0.0.0:{metrics_port:d}")))
+    runtime = Runtime(
+        telemetry=TelemetryConfig(
+            metric_prefix=metric_prefix,
+            metrics=PrometheusConfig(
+                bind_address=f"0.0.0.0:{metrics_port:d}",
+            ),
+        )
+    )
     client = await connect(
         host,
         port,


### PR DESCRIPTION
## Problem

Batch exports prom metrics emitted by the worker look the same as metrics emitted by all other workers, we should have our own (and so should other teams). Moreover, the latency buckets used in the activity execution latency metric don't line up with batch export frequencies.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Configure `metric_prefix` to `batch_exports_` when the worker is running the batch exports queue.

Configure activity execution latency buckets to closely match supported batch exports frequencies (5min, 1 hour, 1 day).

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
