### PR TITLE
fix(experiments): UI fixes

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExposureCriteria.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExposureCriteria.tsx
@@ -132,50 +132,52 @@ export function ExposureCriteriaModal(): JSX.Element {
                     />
                 </div>
             )}
-            <div className="mb-4">
-                <label className="block text-sm font-medium text-default mb-2">Multiple variant handling</label>
-                <LemonSelect
-                    value={experiment.exposure_criteria?.multiple_variant_handling || 'exclude'}
-                    onChange={(value) => {
+            <div className="w-[405px]">
+                <div className="mb-4">
+                    <label className="block text-sm font-medium text-default mb-2">Multiple variant handling</label>
+                    <LemonSelect
+                        value={experiment.exposure_criteria?.multiple_variant_handling || 'exclude'}
+                        onChange={(value) => {
+                            setExposureCriteria({
+                                multiple_variant_handling: value as 'exclude' | 'first_seen',
+                            })
+                        }}
+                        options={[
+                            {
+                                value: 'exclude',
+                                label: 'Exclude from analysis',
+                                'data-attr': 'multiple-handling-exclude',
+                            },
+                            {
+                                value: 'first_seen',
+                                label: 'Use first seen variant',
+                                'data-attr': 'multiple-handling-first-seen',
+                            },
+                        ]}
+                        placeholder="Select handling method"
+                        fullWidth
+                    />
+                    <div className="text-xs text-muted mt-1">
+                        {experiment.exposure_criteria?.multiple_variant_handling === 'first_seen' &&
+                            'Users exposed to multiple variants will be analyzed using their first seen variant.'}
+                        {(!experiment.exposure_criteria?.multiple_variant_handling ||
+                            experiment.exposure_criteria?.multiple_variant_handling === 'exclude') &&
+                            'Users exposed to multiple variants will be excluded from the analysis (recommended).'}
+                    </div>
+                </div>
+                <TestAccountFilterSwitch
+                    checked={(() => {
+                        const val = experiment.exposure_criteria?.filterTestAccounts
+                        return hasFilters ? !!val : false
+                    })()}
+                    onChange={(checked: boolean) => {
                         setExposureCriteria({
-                            multiple_variant_handling: value as 'exclude' | 'first_seen',
+                            filterTestAccounts: checked,
                         })
                     }}
-                    options={[
-                        {
-                            value: 'exclude',
-                            label: 'Exclude from analysis',
-                            'data-attr': 'multiple-handling-exclude',
-                        },
-                        {
-                            value: 'first_seen',
-                            label: 'Use first seen variant',
-                            'data-attr': 'multiple-handling-first-seen',
-                        },
-                    ]}
-                    placeholder="Select handling method"
                     fullWidth
                 />
-                <div className="text-xs text-muted mt-1">
-                    {experiment.exposure_criteria?.multiple_variant_handling === 'first_seen' &&
-                        'Users exposed to multiple variants will be analyzed using their first seen variant.'}
-                    {(!experiment.exposure_criteria?.multiple_variant_handling ||
-                        experiment.exposure_criteria?.multiple_variant_handling === 'exclude') &&
-                        'Users exposed to multiple variants will be excluded from the analysis (recommended).'}
-                </div>
             </div>
-            <TestAccountFilterSwitch
-                checked={(() => {
-                    const val = experiment.exposure_criteria?.filterTestAccounts
-                    return hasFilters ? !!val : false
-                })()}
-                onChange={(checked: boolean) => {
-                    setExposureCriteria({
-                        filterTestAccounts: checked,
-                    })
-                }}
-                fullWidth
-            />
         </LemonModal>
     )
 }

--- a/frontend/src/scenes/experiments/ExperimentView/Info.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Info.tsx
@@ -215,7 +215,7 @@ export function Info(): JSX.Element {
                                 className="w-full"
                                 value={tempDescription}
                                 onChange={(value) => setTempDescription(value)}
-                                placeholder="Add your hypothesis for this test (optional)"
+                                placeholder="Add your hypothesis for this test"
                                 minRows={6}
                                 maxLength={400}
                             />

--- a/frontend/src/scenes/experiments/MetricsView/shared/MetricTitle.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/MetricTitle.tsx
@@ -24,14 +24,9 @@ export const MetricTitle = ({ metric, metricType }: { metric: any; metricType?: 
         return element
     }
 
-    if (metric.name) {
-        const element = <span className={getTextClassName(metric.name)}>{metric.name}</span>
-        return wrapWithTooltip(metric.name, element)
-    }
-
     if (metric.kind === NodeKind.ExperimentMetric) {
-        const title = getDefaultMetricTitle(metric)
-        const element = <span className={getTextClassName(title)}>{title}</span>
+        const title = metric.name || getDefaultMetricTitle(metric)
+        const element = <span className={`max-h-[34px] overflow-hidden ${getTextClassName(title)}`}>{title}</span>
         return wrapWithTooltip(title, element)
     }
 


### PR DESCRIPTION
## Changes
1. Reduce width of the form elements in the custom exposure modal
2. Prevent overflow of long multi-line metric titles (a band aid for now, the new results view will solve this better)
3. Remove unnecessary "optional" in the hypothesis input

## How did you test this code?
1.
|Before|After|
|----|----|
|<img width="868" height="500" alt="image" src="https://github.com/user-attachments/assets/4459adab-3879-4b4a-8edd-8474210be626" />|<img width="863" height="513" alt="image" src="https://github.com/user-attachments/assets/12eec0eb-c1cb-4fcb-9ab4-9813f70fd855" />|

2.
|Before|After|
|----|----|
|<img width="219" height="125" alt="image" src="https://github.com/user-attachments/assets/5f078321-09ba-41d6-8d6c-96206e1b13a1" />|<img width="222" height="80" alt="image" src="https://github.com/user-attachments/assets/20fda07a-c26a-4188-8d71-a9e337db5674" />|

3.
|Before|After|
|----|----|
|<img width="419" height="164" alt="image" src="https://github.com/user-attachments/assets/40d65e5c-98ae-4b39-9173-ae58efbff8ef" />|<img width="422" height="167" alt="image" src="https://github.com/user-attachments/assets/bf17edd3-f1d7-4e33-9506-5736ba1048a1" />|