### PR TITLE
fix(e2e): fix flaky insight variables test

### DIFF
--- a/playwright/e2e/product-analytics/insight-variables.spec.ts
+++ b/playwright/e2e/product-analytics/insight-variables.spec.ts
@@ -1,34 +1,34 @@
-import { expect, test } from '../../utils/playwright-test-base'
+// import { expect, test } from '../../utils/playwright-test-base'
 
-test.describe('insight variables', () => {
-    test('show correctly on dashboards', async ({ page }) => {
-        // Go to "Insight variables" dashboard.
-        await page.goToMenuItem('dashboards')
-        await page.getByText('Insight variables').click()
+// test.describe('insight variables', () => {
+//     test('show correctly on dashboards', async ({ page }) => {
+//         // Go to "Insight variables" dashboard.
+//         await page.goToMenuItem('dashboards')
+//         await page.getByText('Insight variables').click()
 
-        // Add a temporary override
-        await page.goto(page.url() + '?query_variables=%7B"variable_4"%3A40%7D%20')
+//         // Add a temporary override
+//         await page.goto(page.url() + '?query_variables=%7B"variable_4"%3A40%7D%20')
 
-        const cardForDefaultVariable = page
-            .getByText('Variable default')
-            .locator('xpath=ancestor::*[contains(@class, "InsightCard")]')
-        await expect(cardForDefaultVariable.locator('.BoldNumber')).toHaveText('10')
+//         const cardForDefaultVariable = page
+//             .getByText('Variable default')
+//             .locator('xpath=ancestor::*[contains(@class, "InsightCard")]')
+//         await expect(cardForDefaultVariable.locator('.BoldNumber')).toHaveText('10')
 
-        // :FIXME: This override gets cancelled out when setting a temporary override.
-        // const cardForDashboardOverride = page
-        //     .getByText('Dashboard override')
-        //     .locator('xpath=ancestor::*[contains(@class, "InsightCard")]')
-        // await cardForDashboardOverride.highlight()
-        // await expect(cardForDashboardOverride.locator('.BoldNumber')).toHaveText('20')
+//         // :FIXME: This override gets cancelled out when setting a temporary override.
+//         // const cardForDashboardOverride = page
+//         //     .getByText('Dashboard override')
+//         //     .locator('xpath=ancestor::*[contains(@class, "InsightCard")]')
+//         // await cardForDashboardOverride.highlight()
+//         // await expect(cardForDashboardOverride.locator('.BoldNumber')).toHaveText('20')
 
-        const cardForInsightOverride = page
-            .getByText('Insight override')
-            .locator('xpath=ancestor::*[contains(@class, "InsightCard")]')
-        await expect(cardForInsightOverride.locator('.BoldNumber')).toHaveText('30')
+//         const cardForInsightOverride = page
+//             .getByText('Insight override')
+//             .locator('xpath=ancestor::*[contains(@class, "InsightCard")]')
+//         await expect(cardForInsightOverride.locator('.BoldNumber')).toHaveText('30')
 
-        const cardForURLOverride = page
-            .getByText('Temporary override')
-            .locator('xpath=ancestor::*[contains(@class, "InsightCard")]')
-        await expect(cardForURLOverride.locator('.BoldNumber')).toHaveText('40')
-    })
-})
+//         const cardForURLOverride = page
+//             .getByText('Temporary override')
+//             .locator('xpath=ancestor::*[contains(@class, "InsightCard")]')
+//         await expect(cardForURLOverride.locator('.BoldNumber')).toHaveText('40')
+//     })
+// })

--- a/playwright/e2e/product-analytics/insight-variables.spec.ts
+++ b/playwright/e2e/product-analytics/insight-variables.spec.ts
@@ -1,8 +1,7 @@
 import { expect, test } from '../../utils/playwright-test-base'
 
 test.describe('insight variables', () => {
-    // :FIXME: This test is flaky on CI.
-    test.skip('show correctly on dashboards', async ({ page }) => {
+    test('show correctly on dashboards', async ({ page }) => {
         // Go to "Insight variables" dashboard.
         await page.goToMenuItem('dashboards')
         await page.getByText('Insight variables').click()
@@ -13,23 +12,26 @@ test.describe('insight variables', () => {
         const cardForDefaultVariable = page
             .getByText('Variable default')
             .locator('xpath=ancestor::*[contains(@class, "InsightCard")]')
+        await cardForDefaultVariable.scrollIntoViewIfNeeded()
         await expect(cardForDefaultVariable.locator('.BoldNumber')).toHaveText('10')
 
-        // :FIXME: This override gets cancelled out when setting a temporary override.
+        // // :FIXME: This override gets cancelled out when setting a temporary override.
         // const cardForDashboardOverride = page
         //     .getByText('Dashboard override')
         //     .locator('xpath=ancestor::*[contains(@class, "InsightCard")]')
-        // await cardForDashboardOverride.highlight()
+        // await cardForDashboardOverride.scrollIntoViewIfNeeded()
         // await expect(cardForDashboardOverride.locator('.BoldNumber')).toHaveText('20')
 
         const cardForInsightOverride = page
             .getByText('Insight override')
             .locator('xpath=ancestor::*[contains(@class, "InsightCard")]')
+        await cardForInsightOverride.scrollIntoViewIfNeeded()
         await expect(cardForInsightOverride.locator('.BoldNumber')).toHaveText('30')
 
         const cardForURLOverride = page
             .getByText('Temporary override')
             .locator('xpath=ancestor::*[contains(@class, "InsightCard")]')
+        await cardForURLOverride.scrollIntoViewIfNeeded()
         await expect(cardForURLOverride.locator('.BoldNumber')).toHaveText('40')
     })
 })

--- a/playwright/e2e/product-analytics/insight-variables.spec.ts
+++ b/playwright/e2e/product-analytics/insight-variables.spec.ts
@@ -1,34 +1,35 @@
-// import { expect, test } from '../../utils/playwright-test-base'
+import { expect, test } from '../../utils/playwright-test-base'
 
-// test.describe('insight variables', () => {
-//     test('show correctly on dashboards', async ({ page }) => {
-//         // Go to "Insight variables" dashboard.
-//         await page.goToMenuItem('dashboards')
-//         await page.getByText('Insight variables').click()
+test.describe('insight variables', () => {
+    // :FIXME: This test is flaky on CI.
+    test.skip('show correctly on dashboards', async ({ page }) => {
+        // Go to "Insight variables" dashboard.
+        await page.goToMenuItem('dashboards')
+        await page.getByText('Insight variables').click()
 
-//         // Add a temporary override
-//         await page.goto(page.url() + '?query_variables=%7B"variable_4"%3A40%7D%20')
+        // Add a temporary override
+        await page.goto(page.url() + '?query_variables=%7B"variable_4"%3A40%7D%20')
 
-//         const cardForDefaultVariable = page
-//             .getByText('Variable default')
-//             .locator('xpath=ancestor::*[contains(@class, "InsightCard")]')
-//         await expect(cardForDefaultVariable.locator('.BoldNumber')).toHaveText('10')
+        const cardForDefaultVariable = page
+            .getByText('Variable default')
+            .locator('xpath=ancestor::*[contains(@class, "InsightCard")]')
+        await expect(cardForDefaultVariable.locator('.BoldNumber')).toHaveText('10')
 
-//         // :FIXME: This override gets cancelled out when setting a temporary override.
-//         // const cardForDashboardOverride = page
-//         //     .getByText('Dashboard override')
-//         //     .locator('xpath=ancestor::*[contains(@class, "InsightCard")]')
-//         // await cardForDashboardOverride.highlight()
-//         // await expect(cardForDashboardOverride.locator('.BoldNumber')).toHaveText('20')
+        // :FIXME: This override gets cancelled out when setting a temporary override.
+        // const cardForDashboardOverride = page
+        //     .getByText('Dashboard override')
+        //     .locator('xpath=ancestor::*[contains(@class, "InsightCard")]')
+        // await cardForDashboardOverride.highlight()
+        // await expect(cardForDashboardOverride.locator('.BoldNumber')).toHaveText('20')
 
-//         const cardForInsightOverride = page
-//             .getByText('Insight override')
-//             .locator('xpath=ancestor::*[contains(@class, "InsightCard")]')
-//         await expect(cardForInsightOverride.locator('.BoldNumber')).toHaveText('30')
+        const cardForInsightOverride = page
+            .getByText('Insight override')
+            .locator('xpath=ancestor::*[contains(@class, "InsightCard")]')
+        await expect(cardForInsightOverride.locator('.BoldNumber')).toHaveText('30')
 
-//         const cardForURLOverride = page
-//             .getByText('Temporary override')
-//             .locator('xpath=ancestor::*[contains(@class, "InsightCard")]')
-//         await expect(cardForURLOverride.locator('.BoldNumber')).toHaveText('40')
-//     })
-// })
+        const cardForURLOverride = page
+            .getByText('Temporary override')
+            .locator('xpath=ancestor::*[contains(@class, "InsightCard")]')
+        await expect(cardForURLOverride.locator('.BoldNumber')).toHaveText('40')
+    })
+})


### PR DESCRIPTION
## Problem

The e2e test was flaking in CI, see https://posthog.slack.com/archives/C0368RPHLQH/p1753124200191519.

## Changes

Unfortunately the erroring part is not visible in the playwright report, as the card is not in view. I therefore added a scroll command to help debugging, but now I can't get the playwright test to fail even when repeatedly re-running the CI step. This makes me think scrolling into view fixed the issue? No sure what else I could do other than write a script to re-run the step many times.

## How did you test this code?

Re-running the CI step, repeatedley