### PR TITLE
fix(experiments): only show error on failing metrics

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -23,7 +23,7 @@ import { MetricsViewLegacy } from '../MetricsView/legacy/MetricsViewLegacy'
 import { VariantDeltaTimeseries } from '../MetricsView/legacy/VariantDeltaTimeseries'
 import { Metrics } from '../MetricsView/new/Metrics'
 import { RunningTimeCalculatorModal } from '../RunningTimeCalculator/RunningTimeCalculatorModal'
-import { isLegacyExperimentQuery } from '../utils'
+import { isLegacyExperiment, isLegacyExperimentQuery } from '../utils'
 import {
     EditConclusionModal,
     LegacyExploreButton,
@@ -80,7 +80,7 @@ const ResultsTab = (): JSX.Element => {
             {/**
              *  check if we should render the legacy metrics view or the new one
              */}
-            {legacyPrimaryMetricsResults.length > 0 ? (
+            {isLegacyExperiment(experiment) ? (
                 <>
                     <MetricsViewLegacy isSecondary={false} />
                     {/**

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -23,7 +23,6 @@ import { MetricsViewLegacy } from '../MetricsView/legacy/MetricsViewLegacy'
 import { VariantDeltaTimeseries } from '../MetricsView/legacy/VariantDeltaTimeseries'
 import { Metrics } from '../MetricsView/new/Metrics'
 import { RunningTimeCalculatorModal } from '../RunningTimeCalculator/RunningTimeCalculatorModal'
-import { isLegacyExperiment, isLegacyExperimentQuery } from '../utils'
 import {
     EditConclusionModal,
     LegacyExploreButton,
@@ -40,6 +39,7 @@ import { LegacyExperimentHeader } from './LegacyExperimentHeader'
 import { Overview } from './Overview'
 import { ReleaseConditionsModal, ReleaseConditionsTable } from './ReleaseConditionsTable'
 import { SummaryTable } from './SummaryTable'
+import { isLegacyExperiment, isLegacyExperimentQuery } from '../utils'
 
 const ResultsTab = (): JSX.Element => {
     const {
@@ -59,6 +59,8 @@ const ResultsTab = (): JSX.Element => {
     const hasSinglePrimaryMetric = primaryMetricsLengthWithSharedMetrics === 1
 
     const firstPrimaryMetricResult = legacyPrimaryMetricsResults?.[0]
+
+    const hasLegacyResults = legacyPrimaryMetricsResults.some((result) => result != null)
 
     return (
         <>
@@ -80,7 +82,7 @@ const ResultsTab = (): JSX.Element => {
             {/**
              *  check if we should render the legacy metrics view or the new one
              */}
-            {isLegacyExperiment(experiment) ? (
+            {isLegacyExperiment(experiment) || hasLegacyResults ? (
                 <>
                     <MetricsViewLegacy isSecondary={false} />
                     {/**


### PR DESCRIPTION
## Problem
Due to a bug, we are showing "Error" on all metrics if a single metric fails for the new metrics UI.

## Changes
Make the check more robust by filtering out `null` values in the `legacyPrimaryMetricsResults`. Also include an `isLegacyExperiment` check as we know we should render the old UI then.

A tricky thing now on the new engine, is that when loading results we don't know yet if the results are on the old or new format. So it does cause some unnecessary UI flickering until all experiments on the new engine is flipped over on the new format.

## How did you test this code?
👀 
