### PR TITLE
fix(cdp): fix json key input in legacy pubsub destination

### DIFF
--- a/plugin-server/src/cdp/legacy-plugins/_destinations/pubsub/index.ts
+++ b/plugin-server/src/cdp/legacy-plugins/_destinations/pubsub/index.ts
@@ -2,7 +2,6 @@ import { PubSub, Topic } from '@google-cloud/pubsub'
 import { ProcessedPluginEvent } from '@posthog/plugin-scaffold'
 import { RetryError } from '@posthog/plugin-scaffold'
 
-import { parseJSON } from '../../../../utils/json-parse'
 import { LegacyDestinationPluginMeta } from '../../types'
 
 type PubSubMeta = LegacyDestinationPluginMeta & {
@@ -12,13 +11,25 @@ type PubSubMeta = LegacyDestinationPluginMeta & {
     }
     config: {
         topicId: string
+        googleCloudKeyJson: {
+            type: string
+            project_id: string
+            private_key_id: string
+            private_key: string
+            client_email: string
+            client_id: string
+            auth_uri: string
+            token_uri: string
+            auth_provider_x509_cert_url: string
+            client_x509_cert_url: string
+            universe_domain: string
+        }
     }
-    attachments: any
 }
 
 export const setupPlugin = async (meta: PubSubMeta): Promise<void> => {
-    const { global, attachments, config, logger } = meta
-    if (!attachments.googleCloudKeyJson) {
+    const { global, config, logger } = meta
+    if (!config.googleCloudKeyJson) {
         throw new Error('JSON config not provided!')
     }
     if (!config.topicId) {
@@ -26,10 +37,9 @@ export const setupPlugin = async (meta: PubSubMeta): Promise<void> => {
     }
 
     try {
-        const credentials = parseJSON(attachments.googleCloudKeyJson.contents.toString())
         global.pubSubClient = new PubSub({
-            projectId: credentials['project_id'],
-            credentials,
+            projectId: config.googleCloudKeyJson.project_id,
+            credentials: config.googleCloudKeyJson,
         })
         global.pubSubTopic = global.pubSubClient.topic(config.topicId)
 

--- a/plugin-server/src/cdp/services/__snapshots__/legacy-plugin-executor.service.test.ts.snap
+++ b/plugin-server/src/cdp/services/__snapshots__/legacy-plugin-executor.service.test.ts.snap
@@ -72,7 +72,7 @@ exports[`LegacyPluginExecutorService smoke tests should run the destination plug
 
 exports[`LegacyPluginExecutorService smoke tests should run the destination plugin: { name: 'plugin-pubsub-plugin', plugin: [Object] } 1`] = `
 [
-  "Plugin execution failed: Plugin plugin-pubsub-plugin setup failed: Cannot read properties of undefined (reading 'googleCloudKeyJson')",
+  "Plugin execution failed: Plugin plugin-pubsub-plugin setup failed: JSON config not provided!",
 ]
 `;
 


### PR DESCRIPTION
## Problem

The legacy pubsub destination was never working in the first place because we switched from JSON attachments to JSON inputs at some point. Fixing it in this PR.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Tested it manually

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
