### PR TITLE
fix(max): do not run onboarding if no messages in AssistantState

### DIFF
--- a/ee/hogai/graph/memory/nodes.py
+++ b/ee/hogai/graph/memory/nodes.py
@@ -86,12 +86,16 @@ class MemoryOnboardingShouldRunMixin(AssistantNode):
     def should_run_onboarding_at_start(self, state: AssistantState) -> Literal["continue", "memory_onboarding"]:
         """
         If another user has already started the onboarding process, or it has already been completed, do not trigger it again.
+        If no messages are to be found in the AssistantState, do not run onboarding.
         If the conversation starts with the onboarding initial message, start the onboarding process.
         """
         core_memory = self.core_memory
 
         if core_memory and (core_memory.is_scraping_pending or core_memory.is_scraping_finished):
             # a user has already started the onboarding, we don't allow other users to start it concurrently until timeout is reached
+            return "continue"
+
+        if not state.messages:
             return "continue"
 
         last_message = state.messages[-1]

--- a/ee/hogai/graph/memory/test/test_nodes.py
+++ b/ee/hogai/graph/memory/test/test_nodes.py
@@ -163,6 +163,10 @@ class TestMemoryOnboardingNode(ClickhouseTestMixin, BaseTest):
             node.should_run_onboarding_at_start(AssistantState(messages=[HumanMessage(content="Hello")])), "continue"
         )
 
+    def test_should_run_with_empty_messages(self):
+        node = MemoryOnboardingNode(team=self.team, user=self.user)
+        self.assertEqual(node.should_run_onboarding_at_start(AssistantState(messages=[])), "continue")
+
     def test_router(self):
         node = MemoryOnboardingNode(team=self.team, user=self.user)
         self.assertEqual(node.router(AssistantState(messages=[HumanMessage(content="Hello")])), "initialize_memory")


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Max Onboarding might fail due to the [AssistantState](https://github.com/PostHog/posthog/blob/3807ca7449e5117e56e7968c19327f9714b96037/ee/hogai/utils/types.py#L166) not containing messages.

We [observed _125_ exceptions](https://us.posthog.com/project/2/error_tracking/0197e9b1-4b3a-7120-9e62-afc82d349f73?searchQuery=IndexError&dateRange=%7B%22date_from%22:%222025-07-05%22,%22date_to%22:null%7D) in the last executions in `production`.

<img width="3022" height="434" alt="" src="https://github.com/user-attachments/assets/14bfb01e-2aed-4d7c-9b0a-501e1042fa2d" />


## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

* Setting `continue` to the root note once no state messages are to be found

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

- [x] unit test

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [x] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
