### PR TITLE
fix(experiments): fix getMathProperties to work with all math types

### DIFF
--- a/frontend/src/scenes/experiments/metricQueryUtils.test.ts
+++ b/frontend/src/scenes/experiments/metricQueryUtils.test.ts
@@ -17,7 +17,7 @@ import {
     PropertyOperator,
 } from '~/types'
 
-import { getFilter, getQuery } from './metricQueryUtils'
+import { getFilter, getMathProperties, getQuery } from './metricQueryUtils'
 
 describe('getFilter', () => {
     it('returns the correct filter for an event', () => {
@@ -654,6 +654,123 @@ describe('Data Warehouse Support', () => {
                 math_hogql: 'sum(conversion_value)',
                 kind: NodeKind.ExperimentDataWarehouseNode,
             })
+        })
+    })
+})
+
+describe('getMathProperties', () => {
+    it('returns TotalCount math properties when no math is specified', () => {
+        const source = {
+            kind: NodeKind.EventsNode,
+            event: '$pageview',
+        } as EventsNode
+
+        const result = getMathProperties(source)
+        expect(result).toEqual({
+            math: ExperimentMetricMathType.TotalCount,
+            math_property: undefined,
+        })
+    })
+
+    it('returns TotalCount math properties when math is explicitly TotalCount', () => {
+        const source = {
+            kind: NodeKind.EventsNode,
+            event: '$pageview',
+            math: ExperimentMetricMathType.TotalCount,
+        } as EventsNode
+
+        const result = getMathProperties(source)
+        expect(result).toEqual({
+            math: ExperimentMetricMathType.TotalCount,
+            math_property: undefined,
+        })
+    })
+
+    it('returns UniqueSessions math properties without math_property', () => {
+        const source = {
+            kind: NodeKind.EventsNode,
+            event: '$pageview',
+            math: ExperimentMetricMathType.UniqueSessions,
+        } as EventsNode
+
+        const result = getMathProperties(source)
+        expect(result).toEqual({
+            math: ExperimentMetricMathType.UniqueSessions,
+        })
+    })
+
+    it('returns Sum math properties with math_property', () => {
+        const source = {
+            kind: NodeKind.EventsNode,
+            event: 'purchase',
+            math: ExperimentMetricMathType.Sum,
+            math_property: 'price',
+        } as EventsNode
+
+        const result = getMathProperties(source)
+        expect(result).toEqual({
+            math: ExperimentMetricMathType.Sum,
+            math_property: 'price',
+        })
+    })
+
+    it('returns Avg math properties with math_property', () => {
+        const source = {
+            kind: NodeKind.EventsNode,
+            event: 'session_duration',
+            math: ExperimentMetricMathType.Avg,
+            math_property: 'duration',
+        } as EventsNode
+
+        const result = getMathProperties(source)
+        expect(result).toEqual({
+            math: ExperimentMetricMathType.Avg,
+            math_property: 'duration',
+        })
+    })
+
+    it('returns Min math properties with math_property', () => {
+        const source = {
+            kind: NodeKind.EventsNode,
+            event: 'purchase',
+            math: ExperimentMetricMathType.Min,
+            math_property: 'price',
+        } as EventsNode
+
+        const result = getMathProperties(source)
+        expect(result).toEqual({
+            math: ExperimentMetricMathType.Min,
+            math_property: 'price',
+        })
+    })
+
+    it('returns Max math properties with math_property', () => {
+        const source = {
+            kind: NodeKind.EventsNode,
+            event: 'purchase',
+            math: ExperimentMetricMathType.Max,
+            math_property: 'price',
+        } as EventsNode
+
+        const result = getMathProperties(source)
+        expect(result).toEqual({
+            math: ExperimentMetricMathType.Max,
+            math_property: 'price',
+        })
+    })
+
+    it('preserves undefined math_property for property-based math types', () => {
+        const source = {
+            kind: NodeKind.EventsNode,
+            event: 'purchase',
+            math: ExperimentMetricMathType.Avg,
+            math_property: undefined,
+        } as EventsNode
+
+        const result = getMathProperties(source)
+        expect(result).toEqual({
+            math: ExperimentMetricMathType.Avg,
+            math_property: undefined,
         })
     })
 })

--- a/frontend/src/scenes/experiments/metricQueryUtils.ts
+++ b/frontend/src/scenes/experiments/metricQueryUtils.ts
@@ -88,14 +88,18 @@ export const getExperimentDateRange = (experiment: Experiment): DateRange => {
 /**
  * returns the math properties for the source
  */
-export const getMathProperties = (source: ExperimentMetricSource): MathProperties =>
-    match(source)
-        .with({ math: ExperimentMetricMathType.Sum }, ({ math, math_property }) => ({
-            math,
-            math_property,
-        }))
-        .with({ math: ExperimentMetricMathType.UniqueSessions }, ({ math }) => ({ math }))
-        .otherwise(() => ({ math: ExperimentMetricMathType.TotalCount, math_property: undefined }))
+export const getMathProperties = (source: ExperimentMetricSource): MathProperties => {
+    if (!source.math || source.math === ExperimentMetricMathType.TotalCount) {
+        return { math: ExperimentMetricMathType.TotalCount, math_property: undefined }
+    }
+
+    if (source.math === ExperimentMetricMathType.UniqueSessions) {
+        return { math: source.math }
+    }
+
+    // For Sum, Avg, Min, Max - all require math_property
+    return { math: source.math, math_property: source.math_property }
+}
 
 type GetQueryOptions = {
     breakdownFilter: BreakdownFilter


### PR DESCRIPTION
## Problem
> property value average is being ignored and the query is being as math type total which just returns a count of events

From ticket https://posthoghelp.zendesk.com/agent/tickets/33512 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/36559)

Only an issue in the preview, not the actual experiment metric evaluation.

## Changes
Handle all supported math types

## How did you test this code?
- added unit tests for all math types