### PR TITLE
feat(dashboards): refresh only stale insights

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -204,7 +204,6 @@ function InsightCardInternal(
                             refreshEnabled={refreshEnabled}
                             loadingQueued={loadingQueued}
                             loading={loading}
-                            hasResults={hasResults}
                             rename={rename}
                             duplicate={duplicate}
                             moveToDashboard={moveToDashboard}

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx'
 import { lemonToast } from '@posthog/lemon-ui'
 import { useValues } from 'kea'
 import { CardMeta } from 'lib/components/Cards/CardMeta'

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -52,7 +52,6 @@ interface InsightMetaProps
     > {
     insight: QueryBasedInsightModel
     areDetailsShown?: boolean
-    hasResults?: boolean
     setAreDetailsShown?: React.Dispatch<React.SetStateAction<boolean>>
 }
 
@@ -68,7 +67,6 @@ export function InsightMeta({
     refreshEnabled,
     loading,
     loadingQueued,
-    hasResults,
     rename,
     duplicate,
     moveToDashboard,
@@ -114,7 +112,6 @@ export function InsightMeta({
                     description={insight.description}
                     loading={loading}
                     loadingQueued={loadingQueued}
-                    hasResults={hasResults}
                     tags={insight.tags}
                 />
             }
@@ -309,7 +306,6 @@ export function InsightMetaContent({
     link,
     loading,
     loadingQueued,
-    hasResults,
     tags,
 }: {
     title: string
@@ -318,43 +314,21 @@ export function InsightMetaContent({
     link?: string
     loading?: boolean
     loadingQueued?: boolean
-    hasResults?: boolean
     tags?: string[]
 }): JSX.Element {
     let titleEl: JSX.Element = (
         <h4 title={title} data-attr="insight-card-title">
             {title || <i>{fallbackTitle || 'Untitled'}</i>}
             {(loading || loadingQueued) && (
-                <>
-                    {hasResults ? (
-                        <Tooltip
-                            title={
-                                loading
-                                    ? 'This insight is checking for newer results.'
-                                    : 'This insight is waiting to check for newer results.'
-                            }
-                            placement="top-end"
-                        >
-                            <span className="text-muted text-sm font-medium ml-1.5">
-                                <Spinner className="mr-1.5 text-base" textColored />
-                            </span>
-                        </Tooltip>
-                    ) : (
-                        <Tooltip
-                            title={
-                                loading
-                                    ? 'This insight is loading results.'
-                                    : 'This insight is waiting to load results.'
-                            }
-                            placement="top-end"
-                        >
-                            <span className="text-accent text-sm font-medium ml-1.5">
-                                <Spinner className="mr-1.5 text-base" textColored />
-                                {loading ? 'Loading' : 'Waiting to load'}
-                            </span>
-                        </Tooltip>
-                    )}
-                </>
+                <Tooltip
+                    title={loading ? 'This insight is loading results.' : 'This insight is waiting to load results.'}
+                    placement="top-end"
+                >
+                    <span className="text-accent text-sm font-medium ml-1.5">
+                        <Spinner className="mr-1.5 text-base" textColored />
+                        {loading ? 'Loading' : 'Waiting to load'}
+                    </span>
+                </Tooltip>
             )}
         </h4>
     )
@@ -371,7 +345,7 @@ export function InsightMetaContent({
                 </LemonMarkdown>
             )}
             {tags && tags.length > 0 && <ObjectTags tags={tags} staticOnly />}
-            <LemonTableLoader loading={loading && !hasResults} />
+            <LemonTableLoader loading={loading} />
         </>
     )
 }

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -324,7 +324,7 @@ export function InsightMetaContent({
                     title={loading ? 'This insight is loading results.' : 'This insight is waiting to load results.'}
                     placement="top-end"
                 >
-                    <span className="text-accent text-sm font-medium ml-1.5">
+                    <span className={clsx('text-sm font-medium ml-1.5', loading ? 'text-accent' : 'text-muted')}>
                         <Spinner className="mr-1.5 text-base" textColored />
                         {loading ? 'Loading' : 'Waiting to load'}
                     </span>

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1404,7 +1404,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 .map((t) => t.insight)
                 .filter((i): i is QueryBasedInsightModel => !!i)
                 // only refresh stale insights
-                .filter((i) => !i.cache_target_age || dayjs(i.cache_target_age).isBefore(dayjs()))
+                .filter(
+                    (i) => manualDashboardRefresh || !i.cache_target_age || dayjs(i.cache_target_age).isBefore(dayjs())
+                )
 
             const insightsToRefresh = sortedInsights
             if (insightsToRefresh.length > 0) {

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1403,6 +1403,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
                 .map((t) => t.insight)
                 .filter((i): i is QueryBasedInsightModel => !!i)
+                // only refresh stale insights
+                .filter((i) => !i.cache_target_age || dayjs(i.cache_target_age).isBefore(dayjs()))
 
             const insightsToRefresh = sortedInsights
             if (insightsToRefresh.length > 0) {


### PR DESCRIPTION
## Problem

When navigating to a dashboard, we issue a separate api call for each insight to recompute it, if it would be stale. We can use the `cache_target_age` property to only issue the call for insights that are stale.

<img width="1369" height="362" alt="Screenshot 2025-07-22 at 15 52 58" src="https://github.com/user-attachments/assets/d42e49f1-9233-4487-ba13-f4a1ef41b207" />

## Changes

- Does not refresh insights that are not stale
- Removes the "checking for latest data" loading state
- Bases the color of the spinner and wether the loading bar is shown on wether the insight is actually loading or merely being queued for loading

## How did you test this code?

Tried locally and adapted a test