### PR TITLE
feat: add last name searching for access control and roles

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/AccessControlObject.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/AccessControlObject.tsx
@@ -29,6 +29,7 @@ import {
     AccessControlTypeRole,
     AvailableFeature,
     OrganizationMemberType,
+    RoleMemberType,
     RoleType,
 } from '~/types'
 
@@ -286,7 +287,7 @@ function AccessControlObjectRoles(): JSX.Element | null {
                 return (
                     <ProfileBubbles
                         people={
-                            rolesById[role]?.members?.map((member: OrganizationMemberType) => ({
+                            rolesById[role]?.members?.map((member: RoleMemberType) => ({
                                 email: member.user.email,
                                 name: fullName(member.user),
                                 title: `${fullName(member.user)} <${member.user.email}>`,

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/AccessControlObject.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/AccessControlObject.tsx
@@ -17,7 +17,7 @@ import { UserSelectItem } from 'lib/components/UserSelectItem'
 import { LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { ProfileBubbles, ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
-import { capitalizeFirstLetter } from 'lib/utils'
+import { capitalizeFirstLetter, fullName } from 'lib/utils'
 import { useEffect, useState } from 'react'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
@@ -29,6 +29,7 @@ import {
     AccessControlTypeRole,
     AvailableFeature,
     OrganizationMemberType,
+    RoleType,
 } from '~/types'
 
 import { accessControlLogic, AccessControlLogicProps } from './accessControlLogic'
@@ -139,7 +140,7 @@ function AccessControlObjectUsers(): JSX.Element | null {
                             people={(ac as AccessControlTypeOrganizationAdmins)?.organization_admin_members?.map(
                                 (member) => ({
                                     email: membersById[member]?.user.email,
-                                    name: membersById[member]?.user.first_name,
+                                    name: fullName(membersById[member]?.user),
                                 })
                             )}
                         />
@@ -155,16 +156,16 @@ function AccessControlObjectUsers(): JSX.Element | null {
                         <div>
                             <p className="font-medium mb-0">
                                 {member(ac as AccessControlTypeMember)?.user.uuid == user.uuid
-                                    ? `${member(ac as AccessControlTypeMember)?.user.first_name} (you)`
-                                    : member(ac as AccessControlTypeMember)?.user.first_name}
+                                    ? `${fullName(member(ac as AccessControlTypeMember)?.user)} (you)`
+                                    : fullName(member(ac as AccessControlTypeMember)?.user)}
                             </p>
                             <p className="text-secondary mb-0">{member(ac as AccessControlTypeMember)?.user.email}</p>
                         </div>
                     </div>
                 ),
             sorter: (a, b) =>
-                member(a as AccessControlTypeMember)?.user.first_name.localeCompare(
-                    member(b as AccessControlTypeMember)?.user.first_name
+                fullName(member(a as AccessControlTypeMember)?.user).localeCompare(
+                    fullName(member(b as AccessControlTypeMember)?.user)
                 ),
         },
         {
@@ -240,9 +241,9 @@ function AccessControlObjectUsers(): JSX.Element | null {
                         setModelOpen(false)
                     }
                 }}
-                options={addableMembers.map((member) => ({
+                options={addableMembers.map((member: OrganizationMemberType) => ({
                     key: member.id,
-                    label: `${member.user.first_name} ${member.user.email}`,
+                    label: `${fullName(member.user)} ${member.user.email}`,
                     labelComponent: <UserSelectItem user={member.user} />,
                 }))}
             />
@@ -285,10 +286,10 @@ function AccessControlObjectRoles(): JSX.Element | null {
                 return (
                     <ProfileBubbles
                         people={
-                            rolesById[role]?.members?.map((member) => ({
+                            rolesById[role]?.members?.map((member: OrganizationMemberType) => ({
                                 email: member.user.email,
-                                name: member.user.first_name,
-                                title: `${member.user.first_name} <${member.user.email}>`,
+                                name: fullName(member.user),
+                                title: `${fullName(member.user)} <${member.user.email}>`,
                             })) ?? []
                         }
                     />
@@ -353,7 +354,7 @@ function AccessControlObjectRoles(): JSX.Element | null {
                         setModelOpen(false)
                     }
                 }}
-                options={addableRoles.map((role) => ({
+                options={addableRoles.map((role: RoleType) => ({
                     key: role.id,
                     label: role.name,
                 }))}

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/RolesAccessControls.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/RolesAccessControls.tsx
@@ -53,11 +53,13 @@ export function RolesAccessControls(): JSX.Element {
                 return role ? (
                     role.members.length ? (
                         <ProfileBubbles
-                            people={role.members.map((member) => ({
-                                email: member.user.email,
-                                name: member.user.first_name,
-                                title: `${member.user.first_name} <${member.user.email}>`,
-                            }))}
+                            people={
+                                role?.members?.map((member) => ({
+                                    email: member.user.email,
+                                    name: fullName(member.user),
+                                    title: `${fullName(member.user)} <${member.user.email}>`,
+                                })) ?? []
+                            }
                             onClick={() => (role.id === selectedRoleId ? selectRoleId(null) : selectRoleId(role.id))}
                         />
                     ) : (

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/resourcesAccessControlLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/resourcesAccessControlLogic.ts
@@ -9,6 +9,7 @@ import {
     AccessControlResourceType,
     AccessControlResponseType,
     AccessControlType,
+    AccessControlLevel,
     AccessControlTypeRole,
     AccessControlUpdateType,
     APIScopeObject,
@@ -72,7 +73,7 @@ export const resourcesAccessControlLogic = kea<resourcesAccessControlLogicType>(
     selectors({
         availableLevels: [
             (s) => [s.resourceAccessControls],
-            (resourceAccessControls): string[] => {
+            (resourceAccessControls): AccessControlLevel[] => {
                 return resourceAccessControls?.available_access_levels ?? []
             },
         ],

--- a/frontend/src/lib/components/UserSelectItem.tsx
+++ b/frontend/src/lib/components/UserSelectItem.tsx
@@ -1,5 +1,6 @@
 import { LemonInputSelectOption } from 'lib/lemon-ui/LemonInputSelect'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
+import { fullName } from 'lib/utils'
 
 import { UserBasicType, UserType } from '~/types'
 
@@ -12,7 +13,7 @@ export function UserSelectItem({ user }: UserSelectItemProps): JSX.Element {
         <span className="flex gap-2 items-center">
             <ProfilePicture user={user} size="sm" />
             <span>
-                {user.first_name} <b>{`<${user.email}>`}</b>
+                {fullName(user)} <b>{`<${user.email}>`}</b>
             </span>
         </span>
     )
@@ -24,7 +25,7 @@ export function usersLemonSelectOptions(
 ): LemonInputSelectOption[] {
     return users.map((user) => ({
         key: user[key],
-        label: `${user.first_name} ${user.email}`,
+        label: `${fullName(user)} ${user.email}`,
         labelComponent: <UserSelectItem user={user} />,
     }))
 }


### PR DESCRIPTION
Add last name when searching members for roles and access control #35301

## Problem

Sometimes the first name + email in the access control and role components doesn't make it clear enough to identify who the user is. Especially in large organizations.

Closes #35301 

## Changes

Changed user.first_name to fullName(user) in access control components
Now showing full name (first + last)

<img width="969" height="252" alt="Screenshot 2025-07-22 at 15 26 17" src="https://github.com/user-attachments/assets/19f338c8-9f6a-464a-9597-15300be9cc12" />

<img width="961" height="373" alt="Screenshot 2025-07-22 at 15 36 00" src="https://github.com/user-attachments/assets/9bb1999d-e4db-4cb4-b4f9-8d9b18ebd694" />

## How did you test this code?

Manual testing in local PostHog environment:
1. Send an invite to a new user via the “Members” settings page.
2. Accept the invite as that user and add a Last name in the account settings.
3. Log back in as admin and go to Settings → Members. Searched for the user using their last name in the “Search for members” input, verify correct appearance. 
4. Navigate to Settings → Roles, create a new role. Use the member search input to find the user by last name - verify correct appearance. 

## Did you write or update any docs for this change?

No docs needed for this change