### PR TITLE
feat: Add new batch exports metrics interceptors

### DIFF
--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -8,6 +8,7 @@ from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
 from posthog.temporal.common.client import connect
 from posthog.temporal.common.posthog_client import PostHogClientInterceptor
+from products.batch_exports.backend.temporal.metrics import BatchExportsMetricsInterceptor
 
 logger = structlog.get_logger(__name__)
 
@@ -95,7 +96,7 @@ async def create_worker(
         activities=activities,
         workflow_runner=UnsandboxedWorkflowRunner(),
         graceful_shutdown_timeout=graceful_shutdown_timeout or dt.timedelta(minutes=5),
-        interceptors=[PostHogClientInterceptor()],
+        interceptors=[PostHogClientInterceptor(), BatchExportsMetricsInterceptor()],
         activity_executor=ThreadPoolExecutor(max_workers=max_concurrent_activities or 50),
         max_concurrent_activities=max_concurrent_activities or 50,
         max_concurrent_workflow_tasks=max_concurrent_workflow_tasks,

--- a/products/batch_exports/backend/tests/temporal/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/conftest.py
@@ -15,15 +15,16 @@ from temporalio.testing import ActivityEnvironment
 from posthog import constants
 from posthog.models import Organization, Team
 from posthog.models.utils import uuid7
+from posthog.otel_instrumentation import initialize_otel
 from posthog.temporal.common.clickhouse import ClickHouseClient
 from posthog.temporal.common.client import connect
 from posthog.temporal.common.logger import configure_logger_async
-from posthog.otel_instrumentation import initialize_otel
 from posthog.temporal.tests.utils.events import generate_test_events_in_clickhouse
 from posthog.temporal.tests.utils.persons import (
     generate_test_person_distinct_id2_in_clickhouse,
     generate_test_persons_in_clickhouse,
 )
+from products.batch_exports.backend.temporal.metrics import BatchExportsMetricsInterceptor
 
 
 @pytest.fixture
@@ -306,6 +307,7 @@ async def temporal_worker(temporal_client, workflows, activities):
         task_queue=constants.BATCH_EXPORTS_TASK_QUEUE,
         workflows=workflows,
         activities=activities,
+        interceptors=[BatchExportsMetricsInterceptor()],
         workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
     )
 

--- a/products/batch_exports/backend/tests/temporal/test_metrics.py
+++ b/products/batch_exports/backend/tests/temporal/test_metrics.py
@@ -1,0 +1,145 @@
+import datetime as dt
+import uuid
+from unittest import mock
+
+import psycopg
+import pytest
+import pytest_asyncio
+import temporalio.client
+from django.conf import settings
+from temporalio.common import RetryPolicy
+
+from posthog.batch_exports.service import (
+    BatchExportModel,
+)
+from posthog.constants import BATCH_EXPORTS_TASK_QUEUE
+from posthog.temporal.tests.utils.models import (
+    acreate_batch_export,
+    adelete_batch_export,
+)
+from products.batch_exports.backend.temporal.destinations.postgres_batch_export import (
+    PostgresBatchExportInputs,
+)
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
+
+
+@pytest.fixture
+def table_name(ateam, interval):
+    return f"test_table_{ateam.pk}_{interval}"
+
+
+@pytest.fixture
+def postgres_config():
+    return {
+        "user": settings.PG_USER,
+        "password": settings.PG_PASSWORD,
+        "database": "exports_test_database",
+        "schema": "exports_test_schema",
+        "host": settings.PG_HOST,
+        "port": int(settings.PG_PORT),
+    }
+
+
+@pytest_asyncio.fixture
+async def postgres_connection(postgres_config, setup_postgres_test_db):
+    connection = await psycopg.AsyncConnection.connect(
+        user=postgres_config["user"],
+        password=postgres_config["password"],
+        dbname=postgres_config["database"],
+        host=postgres_config["host"],
+        port=postgres_config["port"],
+        autocommit=True,
+    )
+
+    yield connection
+
+    await connection.close()
+
+
+@pytest_asyncio.fixture
+async def postgres_batch_export(ateam, table_name, postgres_config, interval, exclude_events, temporal_client):
+    destination_data = {
+        "type": "Postgres",
+        "config": {**postgres_config, "table_name": table_name, "exclude_events": exclude_events},
+    }
+    batch_export_data = {
+        "name": "my-production-postgres-export",
+        "destination": destination_data,
+        "interval": interval,
+    }
+
+    batch_export = await acreate_batch_export(
+        team_id=ateam.pk,
+        name=batch_export_data["name"],
+        destination_data=batch_export_data["destination"],
+        interval=batch_export_data["interval"],
+    )
+
+    yield batch_export
+
+    await adelete_batch_export(batch_export, temporal_client)
+
+
+async def test_interceptor_calls_histogram_metrics(
+    ateam,
+    data_interval_end,
+    interval,
+    postgres_batch_export,
+    temporal_client: temporalio.client.Client,
+    temporal_worker,
+):
+    """Test metrics interceptor calls mocked histogram metrics."""
+
+    workflow_id = str(uuid.uuid4())
+    inputs = PostgresBatchExportInputs(
+        team_id=ateam.pk,
+        batch_export_id=str(postgres_batch_export.id),
+        data_interval_end=data_interval_end.isoformat(),
+        interval=interval,
+        batch_export_model=BatchExportModel(name="events", schema=None),
+        **postgres_batch_export.destination.config,
+    )
+
+    with mock.patch(
+        "products.batch_exports.backend.temporal.metrics.get_metric_meter", mock.MagicMock()
+    ) as mocked_meter:
+        await temporal_client.execute_workflow(
+            "postgres-export",
+            inputs,
+            id=workflow_id,
+            task_queue=BATCH_EXPORTS_TASK_QUEUE,
+            execution_timeout=dt.timedelta(seconds=10),
+            retry_policy=RetryPolicy(maximum_attempts=1),
+        )
+
+        mocked_meter.assert_any_call(
+            {
+                "workflow_namespace": "default",
+                "workflow_type": "postgres-export",
+                "activity_type": "insert_into_postgres_activity",
+                "interval": "hour",
+                "status": "COMPLETED",
+                "exception": "",
+            }
+        )
+        mocked_meter.assert_any_call(
+            {
+                "workflow_namespace": "default",
+                "workflow_type": "postgres-export",
+                "interval": "hour",
+                "status": "COMPLETED",
+                "exception": "",
+            }
+        )
+
+        mocked_meter.return_value.create_histogram_timedelta.assert_any_call(
+            name="batch_exports_activity_interval_execution_latency", description=None, unit="ms"
+        )
+        mocked_meter.return_value.create_histogram_timedelta.assert_any_call(
+            name="batch_exports_workflow_interval_execution_latency", description=None, unit="ms"
+        )
+
+        assert (
+            len(mocked_meter.return_value.create_histogram_timedelta.return_value.record.mock_calls) == 2
+        ), "expected to have recorded two metrics: for workflow and activity execution latency"

--- a/products/batch_exports/backend/tests/temporal/test_metrics.py
+++ b/products/batch_exports/backend/tests/temporal/test_metrics.py
@@ -140,6 +140,9 @@ async def test_interceptor_calls_histogram_metrics(
             name="batch_exports_workflow_interval_execution_latency", description=None, unit="ms"
         )
 
+        number_of_record_calls = len(
+            mocked_meter.return_value.create_histogram_timedelta.return_value.record.mock_calls
+        )
         assert (
-            len(mocked_meter.return_value.create_histogram_timedelta.return_value.record.mock_calls) == 2
-        ), "expected to have recorded two metrics: for workflow and activity execution latency"
+            number_of_record_calls == 2
+        ), f"expected to have recorded two metrics: for workflow and activity execution latency, but only found {number_of_record_calls}"


### PR DESCRIPTION
## Problem

Metrics from temporal are not enough for batch exports, mainly because we are not able to separate metrics by batch export interval.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

This adds a new interceptor that captures execution duration for batch export workflows and activities with the interval as a tag on the metric. Later, this may be extended to capture other metrics, like retries per activity.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
