### PR TITLE
feat(err): show last seen exception

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -9453,6 +9453,22 @@
                 "id": {
                     "type": "string"
                 },
+                "last_event": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "properties": {
+                            "type": "string"
+                        },
+                        "timestamp": {
+                            "type": "string"
+                        },
+                        "uuid": {
+                            "type": "string"
+                        }
+                    },
+                    "required": ["uuid", "timestamp", "properties"],
+                    "type": "object"
+                },
                 "last_seen": {
                     "format": "date-time",
                     "type": "string"
@@ -9608,6 +9624,9 @@
                     "type": "boolean"
                 },
                 "withFirstEvent": {
+                    "type": "boolean"
+                },
+                "withLastEvent": {
                     "type": "boolean"
                 }
             },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2055,6 +2055,7 @@ export interface ErrorTrackingQuery extends DataNode<ErrorTrackingQueryResponse>
     volumeResolution: integer
     withAggregations?: boolean
     withFirstEvent?: boolean
+    withLastEvent?: boolean
     limit?: integer
     offset?: integer
 }
@@ -2102,6 +2103,11 @@ export type ErrorTrackingIssue = ErrorTrackingRelationalIssue & {
     /**  @format date-time */
     last_seen: string
     first_event?: {
+        uuid: string
+        timestamp: string
+        properties: string
+    }
+    last_event?: {
         uuid: string
         timestamp: string
         properties: string

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1003,6 +1003,15 @@ class FirstEvent(BaseModel):
     uuid: str
 
 
+class LastEvent(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    properties: str
+    timestamp: str
+    uuid: str
+
+
 class Status(StrEnum):
     ARCHIVED = "archived"
     ACTIVE = "active"
@@ -7268,6 +7277,7 @@ class ErrorTrackingIssue(BaseModel):
     first_event: Optional[FirstEvent] = None
     first_seen: datetime
     id: str
+    last_event: Optional[LastEvent] = None
     last_seen: datetime
     library: Optional[str] = None
     name: Optional[str] = None
@@ -11093,6 +11103,7 @@ class ErrorTrackingQuery(BaseModel):
     volumeResolution: int
     withAggregations: Optional[bool] = None
     withFirstEvent: Optional[bool] = None
+    withLastEvent: Optional[bool] = None
 
 
 class ExperimentFunnelMetric(BaseModel):

--- a/products/error_tracking/frontend/ErrorTrackingIssueScene.tsx
+++ b/products/error_tracking/frontend/ErrorTrackingIssueScene.tsx
@@ -3,7 +3,7 @@ import './ErrorTracking.scss'
 import { LemonButton } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { PageHeader } from 'lib/components/PageHeader'
-import { useEffect } from 'react'
+
 import { SceneExport } from 'scenes/sceneTypes'
 
 import { ErrorTrackingIssue } from '~/queries/schema/schema-general'
@@ -25,14 +25,15 @@ import { SidePanelDiscussionIcon } from '~/layout/navigation-3000/sidepanel/pane
 import { ConnectIssueButton } from './components/ErrorTrackingExternalReference'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useErrorTagRenderer } from './hooks/use-error-tag-renderer'
+import { EventsTable } from './components/EventsTable/EventsTable'
 
 export const scene: SceneExport = {
     component: ErrorTrackingIssueScene,
     logic: errorTrackingIssueSceneLogic,
     paramsToProps: ({
         params: { id },
-        searchParams: { fingerprint },
-    }): (typeof errorTrackingIssueSceneLogic)['props'] => ({ id, fingerprint }),
+        searchParams: { fingerprint, timestamp },
+    }): (typeof errorTrackingIssueSceneLogic)['props'] => ({ id, fingerprint, timestamp }),
 }
 
 export const STATUS_LABEL: Record<ErrorTrackingIssue['status'], string> = {
@@ -44,18 +45,13 @@ export const STATUS_LABEL: Record<ErrorTrackingIssue['status'], string> = {
 }
 
 export function ErrorTrackingIssueScene(): JSX.Element {
-    const { issue, issueId, issueLoading, selectedEvent, firstSeenEventLoading } =
-        useValues(errorTrackingIssueSceneLogic)
-    const { loadIssue } = useActions(errorTrackingIssueSceneLogic)
+    const { issue, issueId, issueLoading, selectedEvent, initialEventLoading } = useValues(errorTrackingIssueSceneLogic)
+    const { selectEvent } = useActions(errorTrackingIssueSceneLogic)
     const { updateIssueAssignee, updateIssueStatus } = useActions(issueActionsLogic)
     const tagRenderer = useErrorTagRenderer()
     const hasDiscussions = useFeatureFlag('DISCUSSIONS')
     const { openSidePanel } = useActions(sidePanelLogic)
     const hasIntegrations = useFeatureFlag('ERROR_TRACKING_INTEGRATIONS')
-
-    useEffect(() => {
-        loadIssue()
-    }, [loadIssue])
 
     return (
         <ErrorTrackingSetupPrompt>
@@ -107,7 +103,7 @@ export function ErrorTrackingIssueScene(): JSX.Element {
                     issue={issue ?? undefined}
                     issueLoading={issueLoading}
                     event={selectedEvent ?? undefined}
-                    eventLoading={firstSeenEventLoading}
+                    eventLoading={initialEventLoading}
                     label={tagRenderer(selectedEvent)}
                 />
                 <ErrorFilters.Root>
@@ -115,7 +111,13 @@ export function ErrorTrackingIssueScene(): JSX.Element {
                     <ErrorFilters.FilterGroup />
                     <ErrorFilters.InternalAccounts />
                 </ErrorFilters.Root>
-                <Metadata />
+                <Metadata>
+                    <EventsTable
+                        issueId={issueId}
+                        selectedEvent={selectedEvent}
+                        onEventSelect={(selectedEvent) => (selectedEvent ? selectEvent(selectedEvent) : null)}
+                    />
+                </Metadata>
             </div>
         </ErrorTrackingSetupPrompt>
     )

--- a/products/error_tracking/frontend/ErrorTrackingScene.tsx
+++ b/products/error_tracking/frontend/ErrorTrackingScene.tsx
@@ -164,9 +164,9 @@ const CustomGroupTitleColumn: QueryContextColumnComponent = (props) => {
             <div className="flex flex-col gap-[2px]">
                 <Link
                     className="flex-1 pr-12"
-                    to={urls.errorTrackingIssue(record.id)}
+                    to={urls.errorTrackingIssue(record.id, { timestamp: record.last_seen })}
                     onClick={() => {
-                        const issueLogic = errorTrackingIssueSceneLogic({ id: record.id })
+                        const issueLogic = errorTrackingIssueSceneLogic({ id: record.id, timestamp: record.last_seen })
                         issueLogic.mount()
                         issueLogic.actions.setIssue(record)
                     }}

--- a/products/error_tracking/frontend/errorTrackingActivityDescriber.tsx
+++ b/products/error_tracking/frontend/errorTrackingActivityDescriber.tsx
@@ -116,6 +116,7 @@ const errorTrackingIssueActionsMapping: Record<
     first_seen: () => null,
     last_seen: () => null,
     first_event: () => null,
+    last_event: () => null,
     library: () => null,
     external_issues: () => null,
 }

--- a/products/error_tracking/frontend/errorTrackingIssueSceneLogic.ts
+++ b/products/error_tracking/frontend/errorTrackingIssueSceneLogic.ts
@@ -1,4 +1,4 @@
-import { actions, connect, defaults, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, connect, defaults, events, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { router } from 'kea-router'
 import api from 'lib/api'
@@ -21,10 +21,12 @@ import { issueActionsLogic } from './components/IssueActions/issueActionsLogic'
 import type { errorTrackingIssueSceneLogicType } from './errorTrackingIssueSceneLogicType'
 import { errorTrackingIssueQuery } from './queries'
 import { ERROR_TRACKING_DETAILS_RESOLUTION } from './utils'
+import { subscriptions } from 'kea-subscriptions'
 
 export interface ErrorTrackingIssueSceneLogicProps {
     id: ErrorTrackingIssue['id']
     fingerprint?: string
+    timestamp?: string
 }
 
 export type ErrorTrackingIssueStatus = ErrorTrackingIssue['status']
@@ -51,7 +53,8 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
     actions({
         loadIssue: true,
         loadSummary: true,
-        loadFirstSeenEvent: (timestamp: string) => ({ timestamp }),
+        loadInitialEvent: (timestamp: string) => ({ timestamp }),
+        setInitialEventTimestamp: (timestamp: string | null) => ({ timestamp }),
         setIssue: (issue: ErrorTrackingRelationalIssue) => ({ issue }),
         setLastSeen: (lastSeen: Dayjs) => ({ lastSeen }),
         selectEvent: (event: ErrorEventType | null) => ({
@@ -68,8 +71,10 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
         summary: null as ErrorTrackingIssueSummary | null,
         properties: null as ErrorEventProperties | null,
         lastSeen: null as Dayjs | null,
-        firstSeenEvent: null as ErrorEventType | null,
+        initialEvent: null as ErrorEventType | null,
         selectedEvent: null as ErrorEventType | null,
+        initialEventTimestamp: null as string | null,
+        initialEventLoading: true as boolean,
     }),
 
     reducers(({ values }) => ({
@@ -100,10 +105,18 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
                 return prevLastSeen
             },
         },
+        initialEventTimestamp: {
+            setInitialEventTimestamp: (state, { timestamp }) => {
+                if (!state && timestamp) {
+                    return timestamp
+                }
+                return state
+            },
+        },
         selectedEvent: {
             selectEvent: (_, { event }) => {
-                if (!event && values.firstSeenEvent) {
-                    return values.firstSeenEvent
+                if (!event && values.initialEvent) {
+                    return values.initialEvent
                 }
                 return event
             },
@@ -122,33 +135,36 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
                 return null
             },
         },
-        firstSeenEvent: {
-            loadFirstSeenEvent: async ({ timestamp }) => {
+        initialEvent: {
+            loadInitialEvent: async ({ timestamp }) => {
                 const response = await api.query(
                     errorTrackingIssueQuery({
                         issueId: props.id,
                         dateRange: getNarrowDateRange(timestamp),
                         filterTestAccounts: false,
                         withAggregations: false,
-                        withFirstEvent: true,
+                        withFirstEvent: false,
+                        withLastEvent: true,
                     }),
                     { refresh: 'blocking' }
                 )
                 const issue = response.results[0]
-                if (!issue.first_event) {
+                let positionEvent = null
+                if (issue.last_event) {
+                    positionEvent = issue.last_event
+                } else {
                     return null
                 }
-                const first_event_properties = JSON.parse(issue.first_event.properties)
-                const firstSeenEvent: ErrorEventType = {
-                    uuid: issue.first_event.uuid,
-                    timestamp: issue.first_event.timestamp,
+                const initialEvent: ErrorEventType = {
+                    uuid: positionEvent.uuid,
+                    timestamp: positionEvent.timestamp,
                     person: { distinct_ids: [], properties: {} },
-                    properties: first_event_properties,
+                    properties: JSON.parse(positionEvent.properties),
                 }
                 if (!values.selectedEvent) {
-                    actions.selectEvent(firstSeenEvent)
+                    actions.selectEvent(initialEvent)
                 }
-                return firstSeenEvent
+                return initialEvent
             },
         },
         summary: {
@@ -163,13 +179,17 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
                         volumeResolution: ERROR_TRACKING_DETAILS_RESOLUTION,
                         withAggregations: true,
                         withFirstEvent: false,
+                        withLastEvent: false,
                     }),
                     { refresh: 'blocking' }
                 )
                 if (!response.results.length) {
                     return null
                 }
-                actions.setLastSeen(dayjs(response.results[0].last_seen))
+                if (response.results[0] && response.results[0].last_seen) {
+                    actions.setLastSeen(dayjs(response.results[0].last_seen))
+                    actions.setInitialEventTimestamp(response.results[0].last_seen)
+                }
                 const summary = response.results[0]
                 if (!summary.aggregations) {
                     return null
@@ -213,6 +233,7 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
             },
         ],
         issueId: [(_, p) => [p.id], (id: string) => id],
+
         firstSeen: [
             (s) => [s.issue],
             (issue: ErrorTrackingRelationalIssue | null) => (issue ? dayjs(issue.first_seen) : null),
@@ -221,21 +242,47 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
         aggregations: [(s) => [s.summary], (summary: ErrorTrackingIssueSummary | null) => summary?.aggregations],
     })),
 
+    subscriptions(({ actions }) => ({
+        initialEventTimestamp: (value: string | null, oldValue: string | null) => {
+            if (!oldValue && value) {
+                actions.loadInitialEvent(value)
+            }
+        },
+    })),
+
     listeners(({ actions }) => {
         return {
             setDateRange: actions.loadSummary,
             setFilterGroup: actions.loadSummary,
             setFilterTestAccounts: actions.loadSummary,
             setSearchQuery: actions.loadSummary,
-            loadIssue: actions.loadSummary,
-            loadIssueSuccess: [({ issue }) => actions.loadFirstSeenEvent(issue.first_seen)],
             loadIssueFailure: ({ errorObject: { status, data } }) => {
                 if (status == 308 && 'issue_id' in data) {
                     router.actions.replace(urls.errorTrackingIssue(data.issue_id))
                 }
             },
+            selectEvent: ({ event }) => {
+                if (event) {
+                    router.actions.replace(
+                        router.values.currentLocation.pathname,
+                        {
+                            ...router.values.searchParams,
+                            timestamp: event.timestamp,
+                        },
+                        router.values.hashParams
+                    )
+                }
+            },
         }
     }),
+
+    events(({ props, actions }) => ({
+        afterMount: () => {
+            actions.loadIssue()
+            actions.setInitialEventTimestamp(props.timestamp ?? null)
+            actions.loadSummary()
+        },
+    })),
 ])
 
 function getNarrowDateRange(timestamp: Dayjs | string): DateRange {

--- a/products/error_tracking/frontend/hooks/use-error-tag-renderer.tsx
+++ b/products/error_tracking/frontend/hooks/use-error-tag-renderer.tsx
@@ -7,7 +7,7 @@ import { ErrorTag } from '../components/ErrorTag'
 import { errorTrackingIssueSceneLogic } from '../errorTrackingIssueSceneLogic'
 
 export function useErrorTagRenderer(): (evt: ErrorEventType | null) => JSX.Element {
-    const { lastSeen, firstSeenEvent, selectedEvent } = useValues(errorTrackingIssueSceneLogic)
+    const { lastSeen, firstSeen, selectedEvent } = useValues(errorTrackingIssueSceneLogic)
     return useCallback(
         (evt: ErrorEventType | null) => {
             if (!evt) {
@@ -16,7 +16,7 @@ export function useErrorTagRenderer(): (evt: ErrorEventType | null) => JSX.Eleme
             if (lastSeen && evt.timestamp && dayjs(evt.timestamp).isSame(lastSeen)) {
                 return <ErrorTag color="red" label="Last Seen" />
             }
-            if (firstSeenEvent && firstSeenEvent.uuid == evt.uuid) {
+            if (firstSeen && evt.timestamp && dayjs(evt.timestamp).isSame(firstSeen)) {
                 return <ErrorTag color="blue" label="First Seen" />
             }
             if (selectedEvent && selectedEvent.uuid == evt.uuid) {
@@ -24,6 +24,6 @@ export function useErrorTagRenderer(): (evt: ErrorEventType | null) => JSX.Eleme
             }
             return <></>
         },
-        [lastSeen, firstSeenEvent, selectedEvent]
+        [lastSeen, firstSeen, selectedEvent]
     )
 }

--- a/products/error_tracking/frontend/hooks/use-sparkline-events.tsx
+++ b/products/error_tracking/frontend/hooks/use-sparkline-events.tsx
@@ -7,7 +7,7 @@ import { SparklineEvent } from '../components/SparklineChart/SparklineChart'
 import { errorTrackingIssueSceneLogic } from '../errorTrackingIssueSceneLogic'
 
 export function useSparklineEvents(): SparklineEvent<string>[] {
-    const { firstSeen, firstSeenEvent, lastSeen, selectedEvent } = useValues(errorTrackingIssueSceneLogic)
+    const { firstSeen, lastSeen, selectedEvent } = useValues(errorTrackingIssueSceneLogic)
     return useMemo(() => {
         const events = []
         if (firstSeen) {
@@ -19,7 +19,7 @@ export function useSparklineEvents(): SparklineEvent<string>[] {
                 radius: 6,
             })
         }
-        if (selectedEvent && !isFirstOrLastEvent(firstSeenEvent, lastSeen, selectedEvent)) {
+        if (selectedEvent && !isFirstOrLastEvent(firstSeen, lastSeen, selectedEvent)) {
             events.push({
                 id: 'current',
                 date: new Date(selectedEvent.timestamp),
@@ -38,15 +38,15 @@ export function useSparklineEvents(): SparklineEvent<string>[] {
             })
         }
         return events
-    }, [firstSeen, firstSeenEvent, lastSeen, selectedEvent])
+    }, [firstSeen, lastSeen, selectedEvent])
 }
 
 function isFirstOrLastEvent(
-    firstSeenEvent: ErrorEventType | null,
+    firstSeen: Dayjs | null,
     lastSeen: Dayjs | null,
     selectedEvent: ErrorEventType | null
 ): boolean {
-    if (selectedEvent && firstSeenEvent && firstSeenEvent.uuid == selectedEvent.uuid) {
+    if (selectedEvent && firstSeen?.isSame(selectedEvent.timestamp)) {
         return true
     }
     if (selectedEvent && lastSeen?.isSame(selectedEvent.timestamp)) {

--- a/products/error_tracking/frontend/issue/Metadata.tsx
+++ b/products/error_tracking/frontend/issue/Metadata.tsx
@@ -1,5 +1,5 @@
 import { LemonCard, LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
-import { useActions, useValues } from 'kea'
+import { useValues } from 'kea'
 import { dayjs } from 'lib/dayjs'
 import { IconChevronRight } from 'lib/lemon-ui/icons'
 import { humanFriendlyLargeNumber } from 'lib/utils'
@@ -8,7 +8,6 @@ import { match } from 'ts-pattern'
 
 import { ErrorTrackingIssueAggregations } from '~/queries/schema/schema-general'
 
-import { EventsTable } from '../components/EventsTable/EventsTable'
 import { SparklineChart, SparklineDatum, SparklineEvent } from '../components/SparklineChart/SparklineChart'
 import { TimeBoundary } from '../components/TimeBoundary'
 import { errorTrackingIssueSceneLogic } from '../errorTrackingIssueSceneLogic'
@@ -28,10 +27,8 @@ type SelectedDataType =
       }
     | null
 
-export const Metadata = (): JSX.Element => {
-    const { aggregations, issueId, selectedEvent, firstSeenEvent, summaryLoading, issueLoading, firstSeen, lastSeen } =
-        useValues(errorTrackingIssueSceneLogic)
-    const { selectEvent } = useActions(errorTrackingIssueSceneLogic)
+export const Metadata = ({ children }: { children: React.ReactNode }): JSX.Element => {
+    const { aggregations, summaryLoading, issueLoading, firstSeen, lastSeen } = useValues(errorTrackingIssueSceneLogic)
     const [hoveredDatum, setHoveredDatum] = useState<SelectedDataType>(null)
     const sparklineData = useSparklineDataIssueScene()
     const sparklineEvents = useSparklineEvents()
@@ -107,13 +104,7 @@ export const Metadata = (): JSX.Element => {
                     className="h-full pt-0"
                 />
             </div>
-            <EventsTable
-                issueId={issueId}
-                selectedEvent={selectedEvent}
-                onEventSelect={(selectedEvent) =>
-                    selectedEvent ? selectEvent(selectedEvent) : selectEvent(firstSeenEvent)
-                }
-            />
+            {children}
         </LemonCard>
     )
 }

--- a/products/error_tracking/frontend/queries.ts
+++ b/products/error_tracking/frontend/queries.ts
@@ -72,6 +72,7 @@ export const errorTrackingIssueQuery = ({
     searchQuery,
     volumeResolution = 0,
     withFirstEvent = false,
+    withLastEvent = false,
     withAggregations = false,
 }: {
     issueId: string
@@ -81,6 +82,7 @@ export const errorTrackingIssueQuery = ({
     searchQuery?: string
     volumeResolution?: number
     withFirstEvent?: boolean
+    withLastEvent?: boolean
     withAggregations?: boolean
 }): ErrorTrackingQuery => {
     return setLatestVersionsOnQuery<ErrorTrackingQuery>({
@@ -93,6 +95,7 @@ export const errorTrackingIssueQuery = ({
         volumeResolution,
         withFirstEvent,
         withAggregations,
+        withLastEvent,
         tags: {
             productKey: ProductKey.ERROR_TRACKING,
         },

--- a/products/error_tracking/manifest.tsx
+++ b/products/error_tracking/manifest.tsx
@@ -35,8 +35,8 @@ export const manifest: ProductManifest = {
         errorTracking: (params = {}): string => combineUrl('/error_tracking', params).url,
         errorTrackingConfiguration: (params = {}): string => combineUrl('/error_tracking/configuration', params).url,
         /** @param id A UUID or 'new'. ':id' for routing. */
-        errorTrackingIssue: (id: string, fingerprint?: string): string =>
-            combineUrl(`/error_tracking/${id}`, { fingerprint }).url,
+        errorTrackingIssue: (id: string, params: { timestamp?: string; fingerprint?: string } = {}): string =>
+            combineUrl(`/error_tracking/${id}`, params).url,
         errorTrackingAlert: (id: string): string => `/error_tracking/alerts/${id}`,
         errorTrackingAlertNew: (templateId: string): string => `/error_tracking/alerts/new/${templateId}`,
     },


### PR DESCRIPTION
## Problem

- When displaying issue page, first event si shown. This event doesn't necessarily contain all the context information.

## Changes

- Add lastEvent option in ErrorTrackingQuery
- Add optional timestamp in url params to optimize fetching
- Fallback to last_seen field from aggregation query