### PR TITLE
chore(batch-exports): Separate user vs internal errors

### DIFF
--- a/posthog/api/test/batch_exports/conftest.py
+++ b/posthog/api/test/batch_exports/conftest.py
@@ -99,7 +99,7 @@ def start_test_worker(temporal: TemporalClient):
         client=temporal,
         task_queue=constants.BATCH_EXPORTS_TASK_QUEUE,
         workflows=WORKFLOWS,
-        activities=ACTIVITIES,  # type: ignore
+        activities=ACTIVITIES,
         workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
         graceful_shutdown_timeout=dt.timedelta(seconds=5),
     ).run_in_thread():

--- a/products/batch_exports/backend/temporal/batch_exports.py
+++ b/products/batch_exports/backend/temporal/batch_exports.py
@@ -707,8 +707,6 @@ async def update_batch_export_backfill_model_status(inputs: UpdateBatchExportBac
         )
 
 
-# TODO - remove this
-RecordsCompleted = int
 BatchExportActivity = collections.abc.Callable[..., collections.abc.Awaitable[BatchExportResult]]
 
 

--- a/products/batch_exports/backend/temporal/batch_exports.py
+++ b/products/batch_exports/backend/temporal/batch_exports.py
@@ -772,8 +772,8 @@ async def execute_batch_export_insert_activity(
         )
         finish_inputs.records_completed = result.records_completed
         finish_inputs.bytes_exported = result.bytes_exported
-        if result.error:
-            finish_inputs.latest_error = result.error
+        if result.error_repr:
+            finish_inputs.latest_error = result.error_repr
             finish_inputs.status = BatchExportRun.Status.FAILED
 
     except exceptions.ActivityError as e:

--- a/products/batch_exports/backend/temporal/batch_exports.py
+++ b/products/batch_exports/backend/temporal/batch_exports.py
@@ -14,6 +14,7 @@ from posthog.batch_exports.models import BatchExportBackfill, BatchExportRun
 from posthog.batch_exports.service import (
     BackfillDetails,
     BatchExportField,
+    BatchExportInsertInputs,
     acount_failed_batch_export_runs,
     apause_batch_export,
     cancel_running_batch_export_backfill,
@@ -36,6 +37,7 @@ from products.batch_exports.backend.temporal.metrics import (
     get_export_finished_metric,
     get_export_started_metric,
 )
+from products.batch_exports.backend.temporal.pipeline.types import BatchExportResult
 from products.batch_exports.backend.temporal.spmc import (
     use_distributed_events_recent_table,
 )
@@ -705,14 +707,14 @@ async def update_batch_export_backfill_model_status(inputs: UpdateBatchExportBac
         )
 
 
+# TODO - remove this
 RecordsCompleted = int
-BatchExportActivity = collections.abc.Callable[..., collections.abc.Awaitable[RecordsCompleted]]
+BatchExportActivity = collections.abc.Callable[..., collections.abc.Awaitable[BatchExportResult]]
 
 
 async def execute_batch_export_insert_activity(
     activity: BatchExportActivity,
-    inputs,
-    non_retryable_error_types: list[str],
+    inputs: BatchExportInsertInputs,
     finish_inputs: FinishBatchExportRunInputs,
     interval: str,
     heartbeat_timeout_seconds: int | None = 180,
@@ -729,7 +731,6 @@ async def execute_batch_export_insert_activity(
     Args:
         activity: The 'insert_into_*' activity function to execute.
         inputs: The inputs to the activity.
-        non_retryable_error_types: A list of errors to not retry on when executing the activity.
         finish_inputs: Inputs to the 'finish_batch_export_run' to run at the end.
         interval: The interval of the batch export used to set the start to close timeout.
         maximum_attempts: Maximum number of retries for the 'insert_into_*' activity function.
@@ -761,26 +762,27 @@ async def execute_batch_export_insert_activity(
         initial_interval=dt.timedelta(seconds=initial_retry_interval_seconds),
         maximum_interval=dt.timedelta(seconds=maximum_retry_interval_seconds),
         maximum_attempts=maximum_attempts,
-        non_retryable_error_types=non_retryable_error_types,
     )
 
     try:
-        records_completed = await workflow.execute_activity(
+        result = await workflow.execute_activity(
             activity,
             inputs,
             start_to_close_timeout=start_to_close_timeout,
             heartbeat_timeout=dt.timedelta(seconds=heartbeat_timeout_seconds) if heartbeat_timeout_seconds else None,
             retry_policy=retry_policy,
         )
-        finish_inputs.records_completed = records_completed
+        finish_inputs.records_completed = result.records_completed
+        finish_inputs.bytes_exported = result.bytes_exported
+        if result.error:
+            finish_inputs.latest_error = result.error
+            finish_inputs.status = BatchExportRun.Status.FAILED
 
     except exceptions.ActivityError as e:
         if isinstance(e.cause, exceptions.CancelledError):
             finish_inputs.status = BatchExportRun.Status.CANCELLED
-        elif isinstance(e.cause, exceptions.ApplicationError) and e.cause.type not in non_retryable_error_types:
-            finish_inputs.status = BatchExportRun.Status.FAILED_RETRYABLE
         else:
-            finish_inputs.status = BatchExportRun.Status.FAILED
+            finish_inputs.status = BatchExportRun.Status.FAILED_RETRYABLE
 
         finish_inputs.latest_error = str(e.cause)
         raise

--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -30,7 +30,6 @@ from posthog.temporal.common.logger import (
 )
 from products.batch_exports.backend.temporal.batch_exports import (
     FinishBatchExportRunInputs,
-    RecordsCompleted,
     StartBatchExportRunInputs,
     default_fields,
     execute_batch_export_insert_activity,
@@ -42,6 +41,7 @@ from products.batch_exports.backend.temporal.heartbeat import (
     DateRange,
     should_resume_from_activity_heartbeat,
 )
+from products.batch_exports.backend.temporal.pipeline.types import BatchExportResult
 from products.batch_exports.backend.temporal.record_batch_model import resolve_batch_exports_model
 from products.batch_exports.backend.temporal.spmc import (
     Consumer,
@@ -651,212 +651,221 @@ class BigQueryConsumer(Consumer):
 
 
 @activity.defn
-async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> RecordsCompleted:
+async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> BatchExportResult:
     """Activity streams data from ClickHouse to BigQuery."""
-    bind_contextvars(
-        team_id=inputs.team_id,
-        destination="BigQuery",
-        data_interval_start=inputs.data_interval_start,
-        data_interval_end=inputs.data_interval_end,
-    )
-    external_logger = EXTERNAL_LOGGER.bind()
-
-    external_logger.info(
-        "Batch exporting range %s - %s to BigQuery: %s.%s.%s",
-        inputs.data_interval_start or "START",
-        inputs.data_interval_end or "END",
-        inputs.project_id,
-        inputs.dataset_id,
-        inputs.table_id,
-    )
-
-    async with (
-        Heartbeater() as heartbeater,
-        set_status_to_running_task(run_id=inputs.run_id),
-    ):
-        is_orderless = str(inputs.team_id) in settings.BATCH_EXPORT_ORDERLESS_TEAM_IDS
-
-        _, details = await should_resume_from_activity_heartbeat(activity, BigQueryHeartbeatDetails)
-        if details is None or is_orderless:
-            details = BigQueryHeartbeatDetails()
-
-        done_ranges: list[DateRange] = details.done_ranges
-
-        model, record_batch_model, model_name, fields, filters, extra_query_parameters = resolve_batch_exports_model(
-            inputs.team_id, inputs.batch_export_model, inputs.batch_export_schema
-        )
-        data_interval_start = (
-            dt.datetime.fromisoformat(inputs.data_interval_start) if inputs.data_interval_start else None
-        )
-        data_interval_end = dt.datetime.fromisoformat(inputs.data_interval_end)
-        full_range = (data_interval_start, data_interval_end)
-
-        queue = RecordBatchQueue(max_size_bytes=settings.BATCH_EXPORT_BIGQUERY_RECORD_BATCH_QUEUE_MAX_SIZE_BYTES)
-        producer = Producer(record_batch_model)
-        producer_task = await producer.start(
-            queue=queue,
-            model_name=model_name,
-            is_backfill=inputs.get_is_backfill(),
-            backfill_details=inputs.backfill_details,
+    try:
+        bind_contextvars(
             team_id=inputs.team_id,
-            full_range=full_range,
-            done_ranges=done_ranges,
-            fields=fields,
-            filters=filters,
-            destination_default_fields=bigquery_default_fields(),
-            exclude_events=inputs.exclude_events,
-            include_events=inputs.include_events,
-            extra_query_parameters=extra_query_parameters,
+            destination="BigQuery",
+            data_interval_start=inputs.data_interval_start,
+            data_interval_end=inputs.data_interval_end,
+        )
+        external_logger = EXTERNAL_LOGGER.bind()
+
+        external_logger.info(
+            "Batch exporting range %s - %s to BigQuery: %s.%s.%s",
+            inputs.data_interval_start or "START",
+            inputs.data_interval_end or "END",
+            inputs.project_id,
+            inputs.dataset_id,
+            inputs.table_id,
         )
 
-        record_batch_schema = await wait_for_schema_or_producer(queue, producer_task)
-        if record_batch_schema is None:
-            external_logger.info(
-                "Batch export will finish early as there is no data matching specified filters in range %s - %s",
-                inputs.data_interval_start or "START",
-                inputs.data_interval_end or "END",
+        async with (
+            Heartbeater() as heartbeater,
+            set_status_to_running_task(run_id=inputs.run_id),
+        ):
+            is_orderless = str(inputs.team_id) in settings.BATCH_EXPORT_ORDERLESS_TEAM_IDS
+
+            _, details = await should_resume_from_activity_heartbeat(activity, BigQueryHeartbeatDetails)
+            if details is None or is_orderless:
+                details = BigQueryHeartbeatDetails()
+
+            done_ranges: list[DateRange] = details.done_ranges
+
+            model, record_batch_model, model_name, fields, filters, extra_query_parameters = (
+                resolve_batch_exports_model(inputs.team_id, inputs.batch_export_model, inputs.batch_export_schema)
+            )
+            data_interval_start = (
+                dt.datetime.fromisoformat(inputs.data_interval_start) if inputs.data_interval_start else None
+            )
+            data_interval_end = dt.datetime.fromisoformat(inputs.data_interval_end)
+            full_range = (data_interval_start, data_interval_end)
+
+            queue = RecordBatchQueue(max_size_bytes=settings.BATCH_EXPORT_BIGQUERY_RECORD_BATCH_QUEUE_MAX_SIZE_BYTES)
+            producer = Producer(record_batch_model)
+            producer_task = await producer.start(
+                queue=queue,
+                model_name=model_name,
+                is_backfill=inputs.get_is_backfill(),
+                backfill_details=inputs.backfill_details,
+                team_id=inputs.team_id,
+                full_range=full_range,
+                done_ranges=done_ranges,
+                fields=fields,
+                filters=filters,
+                destination_default_fields=bigquery_default_fields(),
+                exclude_events=inputs.exclude_events,
+                include_events=inputs.include_events,
+                extra_query_parameters=extra_query_parameters,
             )
 
-            return details.records_completed
+            record_batch_schema = await wait_for_schema_or_producer(queue, producer_task)
+            if record_batch_schema is None:
+                external_logger.info(
+                    "Batch export will finish early as there is no data matching specified filters in range %s - %s",
+                    inputs.data_interval_start or "START",
+                    inputs.data_interval_end or "END",
+                )
 
-        record_batch_schema = pa.schema(
-            # NOTE: For some reason, some batches set non-nullable fields as non-nullable, whereas other
-            # record batches have them as nullable.
-            # Until we figure it out, we set all fields to nullable. There are some fields we know
-            # are not nullable, but I'm opting for the more flexible option until we out why schemas differ
-            # between batches.
-            [field.with_nullable(True) for field in record_batch_schema if field.name != "_inserted_at"]
-        )
-        if inputs.use_json_type is True:
-            json_type = "JSON"
-            json_columns = ["properties", "set", "set_once", "person_properties"]
-        else:
-            json_type = "STRING"
-            json_columns = []
+                return BatchExportResult(records_completed=details.records_completed)
 
-        if model is None or (isinstance(model, BatchExportModel) and model.name == "events"):
-            schema = [
-                bigquery.SchemaField("uuid", "STRING"),
-                bigquery.SchemaField("event", "STRING"),
-                bigquery.SchemaField("properties", json_type),
-                bigquery.SchemaField("elements", "STRING"),
-                bigquery.SchemaField("set", json_type),
-                bigquery.SchemaField("set_once", json_type),
-                bigquery.SchemaField("distinct_id", "STRING"),
-                bigquery.SchemaField("team_id", "INT64"),
-                bigquery.SchemaField("ip", "STRING"),
-                bigquery.SchemaField("site_url", "STRING"),
-                bigquery.SchemaField("timestamp", "TIMESTAMP"),
-                bigquery.SchemaField("bq_ingested_timestamp", "TIMESTAMP"),
-            ]
-        else:
-            schema = get_bigquery_fields_from_record_schema(record_batch_schema, known_json_columns=json_columns)
+            record_batch_schema = pa.schema(
+                # NOTE: For some reason, some batches set non-nullable fields as non-nullable, whereas other
+                # record batches have them as nullable.
+                # Until we figure it out, we set all fields to nullable. There are some fields we know
+                # are not nullable, but I'm opting for the more flexible option until we out why schemas differ
+                # between batches.
+                [field.with_nullable(True) for field in record_batch_schema if field.name != "_inserted_at"]
+            )
+            if inputs.use_json_type is True:
+                json_type = "JSON"
+                json_columns = ["properties", "set", "set_once", "person_properties"]
+            else:
+                json_type = "STRING"
+                json_columns = []
 
-        stage_schema = [
-            bigquery.SchemaField(field.name, "STRING") if field.name in json_columns else field for field in schema
-        ]
-
-        mutable = False
-        merge_key = None
-        update_key = None
-        if isinstance(inputs.batch_export_model, BatchExportModel):
-            if inputs.batch_export_model.name == "persons":
-                mutable = True
-                merge_key = (
-                    bigquery.SchemaField("team_id", "INT64"),
+            if model is None or (isinstance(model, BatchExportModel) and model.name == "events"):
+                schema = [
+                    bigquery.SchemaField("uuid", "STRING"),
+                    bigquery.SchemaField("event", "STRING"),
+                    bigquery.SchemaField("properties", json_type),
+                    bigquery.SchemaField("elements", "STRING"),
+                    bigquery.SchemaField("set", json_type),
+                    bigquery.SchemaField("set_once", json_type),
                     bigquery.SchemaField("distinct_id", "STRING"),
-                )
-
-                update_key = ["person_version", "person_distinct_id_version"]
-            elif inputs.batch_export_model.name == "sessions":
-                mutable = True
-                merge_key = (
                     bigquery.SchemaField("team_id", "INT64"),
-                    bigquery.SchemaField("session_id", "STRING"),
-                )
-                update_key = ["end_timestamp"]
+                    bigquery.SchemaField("ip", "STRING"),
+                    bigquery.SchemaField("site_url", "STRING"),
+                    bigquery.SchemaField("timestamp", "TIMESTAMP"),
+                    bigquery.SchemaField("bq_ingested_timestamp", "TIMESTAMP"),
+                ]
+            else:
+                schema = get_bigquery_fields_from_record_schema(record_batch_schema, known_json_columns=json_columns)
 
-        data_interval_end_str = dt.datetime.fromisoformat(inputs.data_interval_end).strftime("%Y-%m-%d_%H-%M-%S")
-        stage_table_name = f"stage_{inputs.table_id}_{data_interval_end_str}_{inputs.team_id}"
+            stage_schema = [
+                bigquery.SchemaField(field.name, "STRING") if field.name in json_columns else field for field in schema
+            ]
 
-        with bigquery_client(inputs) as bq_client:
-            async with bq_client.managed_table(
-                project_id=inputs.project_id,
-                dataset_id=inputs.dataset_id,
-                table_id=inputs.table_id,
-                table_schema=schema,
-                delete=False,
-            ) as bigquery_table:
-                can_perform_merge = await bq_client.acheck_for_query_permissions_on_table(bigquery_table)
-
-                if not can_perform_merge:
-                    if model_name == "persons":
-                        raise MissingRequiredPermissionsError()
-
-                    external_logger.warning(
-                        "Missing query permissions on BigQuery table required for merging, will attempt direct load into final table"
+            mutable = False
+            merge_key = None
+            update_key = None
+            if isinstance(inputs.batch_export_model, BatchExportModel):
+                if inputs.batch_export_model.name == "persons":
+                    mutable = True
+                    merge_key = (
+                        bigquery.SchemaField("team_id", "INT64"),
+                        bigquery.SchemaField("distinct_id", "STRING"),
                     )
 
+                    update_key = ["person_version", "person_distinct_id_version"]
+                elif inputs.batch_export_model.name == "sessions":
+                    mutable = True
+                    merge_key = (
+                        bigquery.SchemaField("team_id", "INT64"),
+                        bigquery.SchemaField("session_id", "STRING"),
+                    )
+                    update_key = ["end_timestamp"]
+
+            data_interval_end_str = dt.datetime.fromisoformat(inputs.data_interval_end).strftime("%Y-%m-%d_%H-%M-%S")
+            stage_table_name = f"stage_{inputs.table_id}_{data_interval_end_str}_{inputs.team_id}"
+
+            with bigquery_client(inputs) as bq_client:
                 async with bq_client.managed_table(
                     project_id=inputs.project_id,
                     dataset_id=inputs.dataset_id,
-                    table_id=stage_table_name if can_perform_merge else inputs.table_id,
-                    table_schema=stage_schema,
-                    create=can_perform_merge,
-                    delete=can_perform_merge,
-                ) as bigquery_stage_table:
-                    consumer = BigQueryConsumer(
-                        heartbeater=heartbeater,
-                        heartbeat_details=details,
-                        data_interval_end=data_interval_end,
-                        data_interval_start=data_interval_start,
-                        writer_format=WriterFormat.PARQUET if can_perform_merge else WriterFormat.JSONL,
-                        bigquery_client=bq_client,
-                        bigquery_table=bigquery_stage_table if can_perform_merge else bigquery_table,
-                        table_schema=stage_schema if can_perform_merge else schema,
-                    )
+                    table_id=inputs.table_id,
+                    table_schema=schema,
+                    delete=False,
+                ) as bigquery_table:
+                    can_perform_merge = await bq_client.acheck_for_query_permissions_on_table(bigquery_table)
 
-                    try:
-                        await run_consumer(
-                            consumer=consumer,
-                            queue=queue,
-                            producer_task=producer_task,
-                            schema=record_batch_schema,
-                            max_bytes=settings.BATCH_EXPORT_BIGQUERY_UPLOAD_CHUNK_SIZE_BYTES,
-                            json_columns=() if can_perform_merge else json_columns,
-                            writer_file_kwargs={"compression": "zstd"} if can_perform_merge else {},
-                            multiple_files=True,
+                    if not can_perform_merge:
+                        if model_name == "persons":
+                            raise MissingRequiredPermissionsError()
+
+                        external_logger.warning(
+                            "Missing query permissions on BigQuery table required for merging, will attempt direct load into final table"
                         )
 
-                    except Exception:
-                        # Ensure we always write data to final table,  even if
-                        # we fail halfway through, as if we resume from a
-                        # heartbeat, we can continue without losing data
-                        # However, orderless batch exports should not merge
-                        # partial data as they will resume from the beginning.
-                        if can_perform_merge and not is_orderless:
-                            await bq_client.amerge_tables(
-                                final_table=bigquery_table,
-                                stage_table=bigquery_stage_table,
-                                mutable=mutable,
-                                merge_key=merge_key,
-                                update_key=update_key,
-                                stage_fields_cast_to_json=json_columns,
-                            )
-                        raise
+                    async with bq_client.managed_table(
+                        project_id=inputs.project_id,
+                        dataset_id=inputs.dataset_id,
+                        table_id=stage_table_name if can_perform_merge else inputs.table_id,
+                        table_schema=stage_schema,
+                        create=can_perform_merge,
+                        delete=can_perform_merge,
+                    ) as bigquery_stage_table:
+                        consumer = BigQueryConsumer(
+                            heartbeater=heartbeater,
+                            heartbeat_details=details,
+                            data_interval_end=data_interval_end,
+                            data_interval_start=data_interval_start,
+                            writer_format=WriterFormat.PARQUET if can_perform_merge else WriterFormat.JSONL,
+                            bigquery_client=bq_client,
+                            bigquery_table=bigquery_stage_table if can_perform_merge else bigquery_table,
+                            table_schema=stage_schema if can_perform_merge else schema,
+                        )
 
-                    else:
-                        if can_perform_merge:
-                            await bq_client.amerge_tables(
-                                final_table=bigquery_table,
-                                stage_table=bigquery_stage_table,
-                                mutable=mutable,
-                                merge_key=merge_key,
-                                update_key=update_key,
-                                stage_fields_cast_to_json=json_columns,
+                        try:
+                            await run_consumer(
+                                consumer=consumer,
+                                queue=queue,
+                                producer_task=producer_task,
+                                schema=record_batch_schema,
+                                max_bytes=settings.BATCH_EXPORT_BIGQUERY_UPLOAD_CHUNK_SIZE_BYTES,
+                                json_columns=() if can_perform_merge else json_columns,
+                                writer_file_kwargs={"compression": "zstd"} if can_perform_merge else {},
+                                multiple_files=True,
                             )
 
-        return details.records_completed
+                        except Exception:
+                            # Ensure we always write data to final table,  even if
+                            # we fail halfway through, as if we resume from a
+                            # heartbeat, we can continue without losing data
+                            # However, orderless batch exports should not merge
+                            # partial data as they will resume from the beginning.
+                            if can_perform_merge and not is_orderless:
+                                await bq_client.amerge_tables(
+                                    final_table=bigquery_table,
+                                    stage_table=bigquery_stage_table,
+                                    mutable=mutable,
+                                    merge_key=merge_key,
+                                    update_key=update_key,
+                                    stage_fields_cast_to_json=json_columns,
+                                )
+                            raise
+
+                        else:
+                            if can_perform_merge:
+                                await bq_client.amerge_tables(
+                                    final_table=bigquery_table,
+                                    stage_table=bigquery_stage_table,
+                                    mutable=mutable,
+                                    merge_key=merge_key,
+                                    update_key=update_key,
+                                    stage_fields_cast_to_json=json_columns,
+                                )
+
+            return BatchExportResult(records_completed=details.records_completed)
+    except Exception as e:
+        # If we catch an error at any point during this activity, we check if it's a non-retryable error.
+        # If it is, we return a BatchExportResult with the error.
+        # If it's not, we re-raise the error.
+        # TODO: Use actual exception classes instead of strings.
+        if e.__class__.__name__ in NON_RETRYABLE_ERROR_TYPES:
+            return BatchExportResult.from_exception(e)
+        raise
 
 
 @workflow.defn(name="bigquery-export", failure_exception_types=[workflow.NondeterminismError])
@@ -938,7 +947,6 @@ class BigQueryBatchExportWorkflow(PostHogWorkflow):
             insert_into_bigquery_activity,
             insert_inputs,
             interval=inputs.interval,
-            non_retryable_error_types=NON_RETRYABLE_ERROR_TYPES,
             finish_inputs=finish_inputs,
             maximum_retry_interval_seconds=240,
         )

--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -651,8 +651,8 @@ class BigQueryConsumer(Consumer):
         self.heartbeat_details.track_done_range(last_date_range, self.data_interval_start)
 
 
-@handle_non_retryable_errors(NON_RETRYABLE_ERROR_TYPES)
 @activity.defn
+@handle_non_retryable_errors(NON_RETRYABLE_ERROR_TYPES)
 async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> BatchExportResult:
     """Activity streams data from ClickHouse to BigQuery."""
     bind_contextvars(

--- a/products/batch_exports/backend/temporal/destinations/http_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/http_batch_export.py
@@ -155,8 +155,8 @@ async def post_json_file_to_url(url, batch_file, session: aiohttp.ClientSession)
     return response
 
 
-@handle_non_retryable_errors(NON_RETRYABLE_ERROR_TYPES)
 @activity.defn
+@handle_non_retryable_errors(NON_RETRYABLE_ERROR_TYPES)
 async def insert_into_http_activity(inputs: HttpInsertInputs) -> BatchExportResult:
     """Activity streams data from ClickHouse to an HTTP Endpoint."""
     logger = await bind_temporal_worker_logger(team_id=inputs.team_id, destination="HTTP")

--- a/products/batch_exports/backend/temporal/destinations/http_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/http_batch_export.py
@@ -206,7 +206,7 @@ async def insert_into_http_activity(inputs: HttpInsertInputs) -> BatchExportResu
                 if last_uploaded_timestamp is None:
                     # Don't heartbeat if worker shuts down before we could even send anything
                     # Just start from the beginning again.
-                    return BatchExportResult(records_completed=0)
+                    return
 
                 activity.heartbeat(last_uploaded_timestamp)
 

--- a/products/batch_exports/backend/temporal/destinations/http_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/http_batch_export.py
@@ -20,7 +20,6 @@ from posthog.temporal.common.clickhouse import get_client
 from posthog.temporal.common.logger import bind_temporal_worker_logger
 from products.batch_exports.backend.temporal.batch_exports import (
     FinishBatchExportRunInputs,
-    RecordsCompleted,
     StartBatchExportRunInputs,
     execute_batch_export_insert_activity,
     get_data_interval,
@@ -31,10 +30,15 @@ from products.batch_exports.backend.temporal.metrics import (
     get_bytes_exported_metric,
     get_rows_exported_metric,
 )
+from products.batch_exports.backend.temporal.pipeline.types import BatchExportResult
 from products.batch_exports.backend.temporal.temporary_file import (
     BatchExportTemporaryFile,
     json_dumps_bytes,
 )
+
+NON_RETRYABLE_ERROR_TYPES = [
+    "NonRetryableResponseError",
+]
 
 
 class RetryableResponseError(Exception):
@@ -153,144 +157,153 @@ async def post_json_file_to_url(url, batch_file, session: aiohttp.ClientSession)
 
 
 @activity.defn
-async def insert_into_http_activity(inputs: HttpInsertInputs) -> RecordsCompleted:
+async def insert_into_http_activity(inputs: HttpInsertInputs) -> BatchExportResult:
     """Activity streams data from ClickHouse to an HTTP Endpoint."""
-    logger = await bind_temporal_worker_logger(team_id=inputs.team_id, destination="HTTP")
-    logger.info(
-        "Batch exporting range %s - %s to HTTP endpoint: %s",
-        inputs.data_interval_start or "START",
-        inputs.data_interval_end or "END",
-        inputs.url,
-    )
-
-    async with get_client(team_id=inputs.team_id) as client:
-        if not await client.is_alive():
-            raise ConnectionError("Cannot establish connection to ClickHouse")
-
-        if inputs.batch_export_schema is not None:
-            raise NotImplementedError("Batch export schema is not supported for HTTP export")
-
-        fields = http_default_fields()
-        columns = [field["alias"] for field in fields]
-
-        interval_start = await maybe_resume_from_heartbeat(inputs)
-
-        is_backfill = inputs.get_is_backfill()
-
-        record_iterator = iter_records(
-            client=client,
-            team_id=inputs.team_id,
-            interval_start=interval_start,
-            interval_end=inputs.data_interval_end,
-            exclude_events=inputs.exclude_events,
-            include_events=inputs.include_events,
-            fields=fields,
-            extra_query_parameters=None,
-            backfill_details=inputs.backfill_details,
-            is_backfill=is_backfill,
+    try:
+        logger = await bind_temporal_worker_logger(team_id=inputs.team_id, destination="HTTP")
+        logger.info(
+            "Batch exporting range %s - %s to HTTP endpoint: %s",
+            inputs.data_interval_start or "START",
+            inputs.data_interval_end or "END",
+            inputs.url,
         )
 
-        last_uploaded_timestamp: str | None = None
+        async with get_client(team_id=inputs.team_id) as client:
+            if not await client.is_alive():
+                raise ConnectionError("Cannot establish connection to ClickHouse")
 
-        async def worker_shutdown_handler():
-            """Handle the Worker shutting down by heart-beating our latest status."""
-            await activity.wait_for_worker_shutdown()
-            logger.warn(
-                f"Worker shutting down! Reporting back latest exported part {last_uploaded_timestamp}",
+            if inputs.batch_export_schema is not None:
+                raise NotImplementedError("Batch export schema is not supported for HTTP export")
+
+            fields = http_default_fields()
+            columns = [field["alias"] for field in fields]
+
+            interval_start = await maybe_resume_from_heartbeat(inputs)
+
+            is_backfill = inputs.get_is_backfill()
+
+            record_iterator = iter_records(
+                client=client,
+                team_id=inputs.team_id,
+                interval_start=interval_start,
+                interval_end=inputs.data_interval_end,
+                exclude_events=inputs.exclude_events,
+                include_events=inputs.include_events,
+                fields=fields,
+                extra_query_parameters=None,
+                backfill_details=inputs.backfill_details,
+                is_backfill=is_backfill,
             )
-            if last_uploaded_timestamp is None:
-                # Don't heartbeat if worker shuts down before we could even send anything
-                # Just start from the beginning again.
-                return
 
-            activity.heartbeat(last_uploaded_timestamp)
+            last_uploaded_timestamp: str | None = None
 
-        asyncio.create_task(worker_shutdown_handler())
-
-        rows_exported = get_rows_exported_metric()
-        bytes_exported = get_bytes_exported_metric()
-
-        # The HTTP destination currently only supports the PostHog batch capture endpoint. In the
-        # future we may support other endpoints, but we'll need a way to template the request body,
-        # headers, etc.
-        #
-        # For now, we write the batch out in PostHog capture format, which means each Batch Export
-        # temporary file starts with a header and ends with a footer.
-        #
-        # For example:
-        #
-        #   Header written when temp file is opened: {"api_key": "api-key-from-inputs","batch": [
-        #   Each record is written out as an object:   {"event": "foo", ...},
-        #   Finally, a footer is written out:        ]}
-        #
-        # Why write to a file at all? Because we need to serialize the data anyway, and it's the
-        # safest way to stay within batch endpoint payload limits and not waste process memory.
-        posthog_batch_header = """{{"api_key": "{}","historical_migration":true,"batch": [""".format(inputs.token)
-        posthog_batch_footer = "]}"
-
-        with BatchExportTemporaryFile() as batch_file:
-
-            def write_event_to_batch(event):
-                if batch_file.records_since_last_reset == 0:
-                    batch_file.write(posthog_batch_header)
-                else:
-                    batch_file.write(",")
-
-                batch_file.write_record_as_bytes(json_dumps_bytes(event))
-
-            async def flush_batch_to_http_endpoint(last_uploaded_timestamp: str, session: aiohttp.ClientSession):
-                logger.debug(
-                    "Sending %s records of size %s bytes",
-                    batch_file.records_since_last_reset,
-                    batch_file.bytes_since_last_reset,
+            async def worker_shutdown_handler():
+                """Handle the Worker shutting down by heart-beating our latest status."""
+                await activity.wait_for_worker_shutdown()
+                logger.warn(
+                    f"Worker shutting down! Reporting back latest exported part {last_uploaded_timestamp}",
                 )
-
-                batch_file.write(posthog_batch_footer)
-
-                await post_json_file_to_url(inputs.url, batch_file, session)
-
-                rows_exported.add(batch_file.records_since_last_reset)
-                bytes_exported.add(batch_file.bytes_since_last_reset)
+                if last_uploaded_timestamp is None:
+                    # Don't heartbeat if worker shuts down before we could even send anything
+                    # Just start from the beginning again.
+                    return BatchExportResult(records_completed=0)
 
                 activity.heartbeat(last_uploaded_timestamp)
 
-            async with aiohttp.ClientSession() as session:
-                for record_batch in record_iterator:
-                    for row in record_batch.select(columns).to_pylist():
-                        # Format result row as PostHog event, write JSON to the batch file.
+            asyncio.create_task(worker_shutdown_handler())
 
-                        properties = row["properties"]
-                        properties = json.loads(properties) if properties else {}
-                        properties["$geoip_disable"] = True
+            rows_exported = get_rows_exported_metric()
+            bytes_exported = get_bytes_exported_metric()
 
-                        if row["event"] == "$autocapture" and row["elements_chain"] is not None:
-                            properties["$elements_chain"] = row["elements_chain"]
+            # The HTTP destination currently only supports the PostHog batch capture endpoint. In the
+            # future we may support other endpoints, but we'll need a way to template the request body,
+            # headers, etc.
+            #
+            # For now, we write the batch out in PostHog capture format, which means each Batch Export
+            # temporary file starts with a header and ends with a footer.
+            #
+            # For example:
+            #
+            #   Header written when temp file is opened: {"api_key": "api-key-from-inputs","batch": [
+            #   Each record is written out as an object:   {"event": "foo", ...},
+            #   Finally, a footer is written out:        ]}
+            #
+            # Why write to a file at all? Because we need to serialize the data anyway, and it's the
+            # safest way to stay within batch endpoint payload limits and not waste process memory.
+            posthog_batch_header = """{{"api_key": "{}","historical_migration":true,"batch": [""".format(inputs.token)
+            posthog_batch_footer = "]}"
 
-                        capture_event = {
-                            "uuid": row["uuid"],
-                            "distinct_id": row["distinct_id"],
-                            "timestamp": row["timestamp"],
-                            "event": row["event"],
-                            "properties": properties,
-                        }
+            with BatchExportTemporaryFile() as batch_file:
 
-                        inserted_at = row.pop("_inserted_at")
+                def write_event_to_batch(event):
+                    if batch_file.records_since_last_reset == 0:
+                        batch_file.write(posthog_batch_header)
+                    else:
+                        batch_file.write(",")
 
-                        write_event_to_batch(capture_event)
+                    batch_file.write_record_as_bytes(json_dumps_bytes(event))
 
-                        if (
-                            batch_file.tell() > settings.BATCH_EXPORT_HTTP_UPLOAD_CHUNK_SIZE_BYTES
-                            or batch_file.records_since_last_reset >= settings.BATCH_EXPORT_HTTP_BATCH_SIZE
-                        ):
-                            last_uploaded_timestamp = str(inserted_at)
-                            await flush_batch_to_http_endpoint(last_uploaded_timestamp, session)
-                            batch_file.reset()
+                async def flush_batch_to_http_endpoint(last_uploaded_timestamp: str, session: aiohttp.ClientSession):
+                    logger.debug(
+                        "Sending %s records of size %s bytes",
+                        batch_file.records_since_last_reset,
+                        batch_file.bytes_since_last_reset,
+                    )
 
-                if batch_file.tell() > 0:
-                    last_uploaded_timestamp = str(inserted_at)
-                    await flush_batch_to_http_endpoint(last_uploaded_timestamp, session)
+                    batch_file.write(posthog_batch_footer)
 
-            return batch_file.records_total
+                    await post_json_file_to_url(inputs.url, batch_file, session)
+
+                    rows_exported.add(batch_file.records_since_last_reset)
+                    bytes_exported.add(batch_file.bytes_since_last_reset)
+
+                    activity.heartbeat(last_uploaded_timestamp)
+
+                async with aiohttp.ClientSession() as session:
+                    for record_batch in record_iterator:
+                        for row in record_batch.select(columns).to_pylist():
+                            # Format result row as PostHog event, write JSON to the batch file.
+
+                            properties = row["properties"]
+                            properties = json.loads(properties) if properties else {}
+                            properties["$geoip_disable"] = True
+
+                            if row["event"] == "$autocapture" and row["elements_chain"] is not None:
+                                properties["$elements_chain"] = row["elements_chain"]
+
+                            capture_event = {
+                                "uuid": row["uuid"],
+                                "distinct_id": row["distinct_id"],
+                                "timestamp": row["timestamp"],
+                                "event": row["event"],
+                                "properties": properties,
+                            }
+
+                            inserted_at = row.pop("_inserted_at")
+
+                            write_event_to_batch(capture_event)
+
+                            if (
+                                batch_file.tell() > settings.BATCH_EXPORT_HTTP_UPLOAD_CHUNK_SIZE_BYTES
+                                or batch_file.records_since_last_reset >= settings.BATCH_EXPORT_HTTP_BATCH_SIZE
+                            ):
+                                last_uploaded_timestamp = str(inserted_at)
+                                await flush_batch_to_http_endpoint(last_uploaded_timestamp, session)
+                                batch_file.reset()
+
+                    if batch_file.tell() > 0:
+                        last_uploaded_timestamp = str(inserted_at)
+                        await flush_batch_to_http_endpoint(last_uploaded_timestamp, session)
+
+                return BatchExportResult(records_completed=batch_file.records_total)
+    except Exception as e:
+        # If we catch an error at any point during this activity, we check if it's a non-retryable error.
+        # If it is, we return a BatchExportResult with the error.
+        # If it's not, we re-raise the error.
+        # TODO: Use actual exception classes instead of strings.
+        if e.__class__.__name__ in NON_RETRYABLE_ERROR_TYPES:
+            return BatchExportResult.from_exception(e)
+        raise
 
 
 @workflow.defn(name="http-export")
@@ -364,9 +377,6 @@ class HttpBatchExportWorkflow(PostHogWorkflow):
             insert_into_http_activity,
             insert_inputs,
             interval=inputs.interval,
-            non_retryable_error_types=[
-                "NonRetryableResponseError",
-            ],
             finish_inputs=finish_inputs,
             # Disable heartbeat timeout until we add heartbeat support.
             heartbeat_timeout_seconds=None,

--- a/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
@@ -57,6 +57,7 @@ from products.batch_exports.backend.temporal.temporary_file import (
 )
 from products.batch_exports.backend.temporal.utils import (
     JsonType,
+    handle_non_retryable_errors,
     make_retryable_with_exponential_backoff,
     set_status_to_running_task,
 )
@@ -76,7 +77,7 @@ UNPAIRED_SURROGATE_PATTERN_2 = re.compile(
 LOGGER = get_logger(__name__)
 EXTERNAL_LOGGER = get_external_logger()
 
-NON_RETRYABLE_ERROR_TYPES = [
+NON_RETRYABLE_ERROR_TYPES = (
     # Raised on errors that are related to database operation.
     # For example: unexpected disconnect, database or other object not found.
     "OperationalError",
@@ -116,7 +117,7 @@ NON_RETRYABLE_ERROR_TYPES = [
     "DatatypeMismatch",
     # Exceeded limits for indexes that we do not maintain.
     "ProgramLimitExceeded",
-]
+)
 
 
 class PostgreSQLConnectionError(Exception):
@@ -641,218 +642,210 @@ class PostgreSQLConsumer(Consumer):
         self.heartbeat_details.track_done_range(last_date_range, self.data_interval_start)
 
 
+@handle_non_retryable_errors(NON_RETRYABLE_ERROR_TYPES)
 @activity.defn
 async def insert_into_postgres_activity(inputs: PostgresInsertInputs) -> BatchExportResult:
     """Activity streams data from ClickHouse to Postgres."""
-    try:
-        bind_contextvars(
+    bind_contextvars(
+        team_id=inputs.team_id,
+        destination="PostgreSQL",
+        data_interval_start=inputs.data_interval_start,
+        data_interval_end=inputs.data_interval_end,
+    )
+    external_logger = EXTERNAL_LOGGER.bind()
+
+    external_logger.info(
+        "Batch exporting range %s - %s to PostgreSQL: %s.%s.%s",
+        inputs.data_interval_start or "START",
+        inputs.data_interval_end or "END",
+        inputs.database,
+        inputs.schema,
+        inputs.table_name,
+    )
+
+    async with (
+        Heartbeater() as heartbeater,
+        set_status_to_running_task(run_id=inputs.run_id),
+    ):
+        _, details = await should_resume_from_activity_heartbeat(activity, PostgreSQLHeartbeatDetails)
+        if details is None:
+            details = PostgreSQLHeartbeatDetails()
+
+        done_ranges: list[DateRange] = details.done_ranges
+
+        model, record_batch_model, model_name, fields, filters, extra_query_parameters = resolve_batch_exports_model(
+            inputs.team_id, inputs.batch_export_model, inputs.batch_export_schema
+        )
+
+        data_interval_start = (
+            dt.datetime.fromisoformat(inputs.data_interval_start) if inputs.data_interval_start else None
+        )
+        data_interval_end = dt.datetime.fromisoformat(inputs.data_interval_end)
+        full_range = (data_interval_start, data_interval_end)
+
+        queue = RecordBatchQueue(max_size_bytes=settings.BATCH_EXPORT_POSTGRES_RECORD_BATCH_QUEUE_MAX_SIZE_BYTES)
+        producer = Producer(record_batch_model)
+        producer_task = await producer.start(
+            queue=queue,
+            model_name=model_name,
+            is_backfill=inputs.get_is_backfill(),
+            backfill_details=inputs.backfill_details,
             team_id=inputs.team_id,
-            destination="PostgreSQL",
-            data_interval_start=inputs.data_interval_start,
-            data_interval_end=inputs.data_interval_end,
-        )
-        external_logger = EXTERNAL_LOGGER.bind()
-
-        external_logger.info(
-            "Batch exporting range %s - %s to PostgreSQL: %s.%s.%s",
-            inputs.data_interval_start or "START",
-            inputs.data_interval_end or "END",
-            inputs.database,
-            inputs.schema,
-            inputs.table_name,
+            full_range=full_range,
+            done_ranges=done_ranges,
+            fields=fields,
+            filters=filters,
+            destination_default_fields=postgres_default_fields(),
+            exclude_events=inputs.exclude_events,
+            include_events=inputs.include_events,
+            extra_query_parameters=extra_query_parameters,
         )
 
-        async with (
-            Heartbeater() as heartbeater,
-            set_status_to_running_task(run_id=inputs.run_id),
-        ):
-            _, details = await should_resume_from_activity_heartbeat(activity, PostgreSQLHeartbeatDetails)
-            if details is None:
-                details = PostgreSQLHeartbeatDetails()
-
-            done_ranges: list[DateRange] = details.done_ranges
-
-            model, record_batch_model, model_name, fields, filters, extra_query_parameters = (
-                resolve_batch_exports_model(inputs.team_id, inputs.batch_export_model, inputs.batch_export_schema)
+        record_batch_schema = await wait_for_schema_or_producer(queue, producer_task)
+        if record_batch_schema is None:
+            external_logger.info(
+                "Batch export will finish early as there is no data matching specified filters in range %s - %s",
+                inputs.data_interval_start or "START",
+                inputs.data_interval_end or "END",
             )
 
-            data_interval_start = (
-                dt.datetime.fromisoformat(inputs.data_interval_start) if inputs.data_interval_start else None
-            )
-            data_interval_end = dt.datetime.fromisoformat(inputs.data_interval_end)
-            full_range = (data_interval_start, data_interval_end)
+            return BatchExportResult(records_completed=details.records_completed)
 
-            queue = RecordBatchQueue(max_size_bytes=settings.BATCH_EXPORT_POSTGRES_RECORD_BATCH_QUEUE_MAX_SIZE_BYTES)
-            producer = Producer(record_batch_model)
-            producer_task = await producer.start(
-                queue=queue,
-                model_name=model_name,
-                is_backfill=inputs.get_is_backfill(),
-                backfill_details=inputs.backfill_details,
-                team_id=inputs.team_id,
-                full_range=full_range,
-                done_ranges=done_ranges,
-                fields=fields,
-                filters=filters,
-                destination_default_fields=postgres_default_fields(),
-                exclude_events=inputs.exclude_events,
-                include_events=inputs.include_events,
-                extra_query_parameters=extra_query_parameters,
+        record_batch_schema = pa.schema(
+            [field.with_nullable(True) for field in record_batch_schema if field.name != "_inserted_at"]
+        )
+
+        if model is None or (isinstance(model, BatchExportModel) and model.name == "events"):
+            table_fields: Fields = [
+                ("uuid", "VARCHAR(200)"),
+                ("event", "VARCHAR(200)"),
+                ("properties", "JSONB"),
+                ("elements", "JSONB"),
+                ("set", "JSONB"),
+                ("set_once", "JSONB"),
+                ("distinct_id", "VARCHAR(200)"),
+                ("team_id", "INTEGER"),
+                ("ip", "VARCHAR(200)"),
+                ("site_url", "VARCHAR(200)"),
+                ("timestamp", "TIMESTAMP WITH TIME ZONE"),
+            ]
+
+        else:
+            table_fields = get_postgres_fields_from_record_schema(
+                record_batch_schema,
+                known_json_columns=["properties", "set", "set_once", "person_properties"],
             )
 
-            record_batch_schema = await wait_for_schema_or_producer(queue, producer_task)
-            if record_batch_schema is None:
-                external_logger.info(
-                    "Batch export will finish early as there is no data matching specified filters in range %s - %s",
-                    inputs.data_interval_start or "START",
-                    inputs.data_interval_end or "END",
+        requires_merge = False
+        merge_key: Fields = []
+        update_key: Fields = []
+        primary_key: Fields | None = None
+        if isinstance(inputs.batch_export_model, BatchExportModel):
+            if inputs.batch_export_model.name == "persons":
+                requires_merge = True
+                merge_key = [
+                    ("team_id", "INT"),
+                    ("distinct_id", "TEXT"),
+                ]
+                update_key = [
+                    ("person_version", "INT"),
+                    ("person_distinct_id_version", "INT"),
+                ]
+                primary_key = (("team_id", "INTEGER"), ("distinct_id", "VARCHAR(200)"))
+
+            elif inputs.batch_export_model.name == "sessions":
+                requires_merge = True
+                merge_key = [
+                    ("team_id", "INT"),
+                    ("session_id", "TEXT"),
+                ]
+                update_key = [
+                    ("end_timestamp", "TIMESTAMP"),
+                ]
+                primary_key = (("team_id", "INTEGER"), ("session_id", "TEXT"))
+
+        data_interval_end_str = dt.datetime.fromisoformat(inputs.data_interval_end).strftime("%Y-%m-%d_%H-%M-%S")
+        # NOTE: PostgreSQL has a 63 byte limit on identifiers.
+        # With a 6 digit `team_id`, this leaves 30 bytes for a table name input.
+        # TODO: That should be enough, but we should add a proper check and alert on larger inputs.
+        stagle_table_name = (
+            f"stage_{inputs.table_name}_{data_interval_end_str}_{inputs.team_id}"
+            if requires_merge
+            else inputs.table_name
+        )[:63]
+
+        async with PostgreSQLClient.from_inputs(inputs).connect() as pg_client:
+            # handle the case where the final table doesn't contain all the fields present in the record batch schema
+            try:
+                columns = await pg_client.aget_table_columns(inputs.schema, inputs.table_name)
+                table_fields = [field for field in table_fields if field[0] in columns]
+            except psycopg.errors.InsufficientPrivilege:
+                external_logger.warning(
+                    "Insufficient privileges to get table columns for table '%s.%s'; "
+                    "will assume all columns are present. If this results in an error, please grant SELECT "
+                    "permissions on this table or ensure the destination table is using the latest schema "
+                    "as described in the docs: https://posthog.com/docs/cdp/batch-exports/postgres",
+                    inputs.schema,
+                    inputs.table_name,
                 )
+            except psycopg.errors.UndefinedTable:
+                # this can happen if the table doesn't exist yet
+                pass
+
+            schema_columns = [field[0] for field in table_fields]
+
+            async with (
+                pg_client.managed_table(
+                    inputs.schema, inputs.table_name, table_fields, delete=False, primary_key=primary_key
+                ) as pg_table,
+                pg_client.managed_table(
+                    inputs.schema,
+                    stagle_table_name,
+                    table_fields,
+                    create=requires_merge,
+                    delete=requires_merge,
+                    primary_key=primary_key,
+                ) as pg_stage_table,
+            ):
+                consumer = PostgreSQLConsumer(
+                    heartbeater=heartbeater,
+                    heartbeat_details=details,
+                    data_interval_end=data_interval_end,
+                    data_interval_start=data_interval_start,
+                    writer_format=WriterFormat.CSV,
+                    postgresql_client=pg_client,
+                    postgresql_table=pg_stage_table if requires_merge else pg_table,
+                    postgresql_table_schema=inputs.schema,
+                    postgresql_table_fields=schema_columns,
+                )
+                try:
+                    _ = await run_consumer(
+                        consumer=consumer,
+                        queue=queue,
+                        producer_task=producer_task,
+                        schema=record_batch_schema,
+                        max_bytes=settings.BATCH_EXPORT_POSTGRES_UPLOAD_CHUNK_SIZE_BYTES,
+                        json_columns=(),
+                        writer_file_kwargs={
+                            "delimiter": "\t",
+                            "quoting": csv.QUOTE_MINIMAL,
+                            "escape_char": None,
+                            "field_names": schema_columns,
+                        },
+                        multiple_files=True,
+                    )
+                finally:
+                    if requires_merge:
+                        await pg_client.amerge_mutable_tables(
+                            final_table_name=pg_table,
+                            stage_table_name=pg_stage_table,
+                            schema=inputs.schema,
+                            update_when_matched=table_fields,
+                            merge_key=merge_key,
+                            update_key=update_key,
+                        )
 
                 return BatchExportResult(records_completed=details.records_completed)
-
-            record_batch_schema = pa.schema(
-                [field.with_nullable(True) for field in record_batch_schema if field.name != "_inserted_at"]
-            )
-
-            if model is None or (isinstance(model, BatchExportModel) and model.name == "events"):
-                table_fields: Fields = [
-                    ("uuid", "VARCHAR(200)"),
-                    ("event", "VARCHAR(200)"),
-                    ("properties", "JSONB"),
-                    ("elements", "JSONB"),
-                    ("set", "JSONB"),
-                    ("set_once", "JSONB"),
-                    ("distinct_id", "VARCHAR(200)"),
-                    ("team_id", "INTEGER"),
-                    ("ip", "VARCHAR(200)"),
-                    ("site_url", "VARCHAR(200)"),
-                    ("timestamp", "TIMESTAMP WITH TIME ZONE"),
-                ]
-
-            else:
-                table_fields = get_postgres_fields_from_record_schema(
-                    record_batch_schema,
-                    known_json_columns=["properties", "set", "set_once", "person_properties"],
-                )
-
-            requires_merge = False
-            merge_key: Fields = []
-            update_key: Fields = []
-            primary_key: Fields | None = None
-            if isinstance(inputs.batch_export_model, BatchExportModel):
-                if inputs.batch_export_model.name == "persons":
-                    requires_merge = True
-                    merge_key = [
-                        ("team_id", "INT"),
-                        ("distinct_id", "TEXT"),
-                    ]
-                    update_key = [
-                        ("person_version", "INT"),
-                        ("person_distinct_id_version", "INT"),
-                    ]
-                    primary_key = (("team_id", "INTEGER"), ("distinct_id", "VARCHAR(200)"))
-
-                elif inputs.batch_export_model.name == "sessions":
-                    requires_merge = True
-                    merge_key = [
-                        ("team_id", "INT"),
-                        ("session_id", "TEXT"),
-                    ]
-                    update_key = [
-                        ("end_timestamp", "TIMESTAMP"),
-                    ]
-                    primary_key = (("team_id", "INTEGER"), ("session_id", "TEXT"))
-
-            data_interval_end_str = dt.datetime.fromisoformat(inputs.data_interval_end).strftime("%Y-%m-%d_%H-%M-%S")
-            # NOTE: PostgreSQL has a 63 byte limit on identifiers.
-            # With a 6 digit `team_id`, this leaves 30 bytes for a table name input.
-            # TODO: That should be enough, but we should add a proper check and alert on larger inputs.
-            stagle_table_name = (
-                f"stage_{inputs.table_name}_{data_interval_end_str}_{inputs.team_id}"
-                if requires_merge
-                else inputs.table_name
-            )[:63]
-
-            async with PostgreSQLClient.from_inputs(inputs).connect() as pg_client:
-                # handle the case where the final table doesn't contain all the fields present in the record batch schema
-                try:
-                    columns = await pg_client.aget_table_columns(inputs.schema, inputs.table_name)
-                    table_fields = [field for field in table_fields if field[0] in columns]
-                except psycopg.errors.InsufficientPrivilege:
-                    external_logger.warning(
-                        "Insufficient privileges to get table columns for table '%s.%s'; "
-                        "will assume all columns are present. If this results in an error, please grant SELECT "
-                        "permissions on this table or ensure the destination table is using the latest schema "
-                        "as described in the docs: https://posthog.com/docs/cdp/batch-exports/postgres",
-                        inputs.schema,
-                        inputs.table_name,
-                    )
-                except psycopg.errors.UndefinedTable:
-                    # this can happen if the table doesn't exist yet
-                    pass
-
-                schema_columns = [field[0] for field in table_fields]
-
-                async with (
-                    pg_client.managed_table(
-                        inputs.schema, inputs.table_name, table_fields, delete=False, primary_key=primary_key
-                    ) as pg_table,
-                    pg_client.managed_table(
-                        inputs.schema,
-                        stagle_table_name,
-                        table_fields,
-                        create=requires_merge,
-                        delete=requires_merge,
-                        primary_key=primary_key,
-                    ) as pg_stage_table,
-                ):
-                    consumer = PostgreSQLConsumer(
-                        heartbeater=heartbeater,
-                        heartbeat_details=details,
-                        data_interval_end=data_interval_end,
-                        data_interval_start=data_interval_start,
-                        writer_format=WriterFormat.CSV,
-                        postgresql_client=pg_client,
-                        postgresql_table=pg_stage_table if requires_merge else pg_table,
-                        postgresql_table_schema=inputs.schema,
-                        postgresql_table_fields=schema_columns,
-                    )
-                    try:
-                        _ = await run_consumer(
-                            consumer=consumer,
-                            queue=queue,
-                            producer_task=producer_task,
-                            schema=record_batch_schema,
-                            max_bytes=settings.BATCH_EXPORT_POSTGRES_UPLOAD_CHUNK_SIZE_BYTES,
-                            json_columns=(),
-                            writer_file_kwargs={
-                                "delimiter": "\t",
-                                "quoting": csv.QUOTE_MINIMAL,
-                                "escape_char": None,
-                                "field_names": schema_columns,
-                            },
-                            multiple_files=True,
-                        )
-                    finally:
-                        if requires_merge:
-                            await pg_client.amerge_mutable_tables(
-                                final_table_name=pg_table,
-                                stage_table_name=pg_stage_table,
-                                schema=inputs.schema,
-                                update_when_matched=table_fields,
-                                merge_key=merge_key,
-                                update_key=update_key,
-                            )
-
-                    return BatchExportResult(records_completed=details.records_completed)
-    except Exception as e:
-        # If we catch an error at any point during this activity, we check if it's a non-retryable error.
-        # If it is, we return a BatchExportResult with the error.
-        # If it's not, we re-raise the error.
-        # TODO: Use actual exception classes instead of strings.
-        if e.__class__.__name__ in NON_RETRYABLE_ERROR_TYPES:
-            return BatchExportResult.from_exception(e)
-        raise
 
 
 @workflow.defn(name="postgres-export", failure_exception_types=[workflow.NondeterminismError])

--- a/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
@@ -642,8 +642,8 @@ class PostgreSQLConsumer(Consumer):
         self.heartbeat_details.track_done_range(last_date_range, self.data_interval_start)
 
 
-@handle_non_retryable_errors(NON_RETRYABLE_ERROR_TYPES)
 @activity.defn
+@handle_non_retryable_errors(NON_RETRYABLE_ERROR_TYPES)
 async def insert_into_postgres_activity(inputs: PostgresInsertInputs) -> BatchExportResult:
     """Activity streams data from ClickHouse to Postgres."""
     bind_contextvars(

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -58,6 +58,7 @@ from products.batch_exports.backend.temporal.temporary_file import (
 )
 from products.batch_exports.backend.temporal.utils import (
     JsonType,
+    handle_non_retryable_errors,
     set_status_to_running_task,
 )
 
@@ -65,7 +66,7 @@ LOGGER = get_logger(__name__)
 EXTERNAL_LOGGER = get_external_logger()
 
 
-NON_RETRYABLE_ERROR_TYPES = [
+NON_RETRYABLE_ERROR_TYPES = (
     # Raised on errors that are related to database operation.
     # For example: unexpected disconnect, database or other object not found.
     "OperationalError",
@@ -84,7 +85,7 @@ NON_RETRYABLE_ERROR_TYPES = [
     # This can also happen when merging tables with a different number of columns:
     # "Target relation and source relation must have the same number of columns"
     "FeatureNotSupported",
-]
+)
 
 
 class RedshiftClient(PostgreSQLClient):
@@ -365,6 +366,7 @@ class RedshiftInsertInputs(PostgresInsertInputs):
     properties_data_type: str = "varchar"
 
 
+@handle_non_retryable_errors(NON_RETRYABLE_ERROR_TYPES)
 @activity.defn
 async def insert_into_redshift_activity(inputs: RedshiftInsertInputs) -> BatchExportResult:
     """Activity to insert data from ClickHouse to Redshift.
@@ -382,206 +384,197 @@ async def insert_into_redshift_activity(inputs: RedshiftInsertInputs) -> BatchEx
             the Redshift-specific properties_data_type to indicate the type of JSON-like
             fields.
     """
-    try:
-        bind_contextvars(
+    bind_contextvars(
+        team_id=inputs.team_id,
+        destination="Redshift",
+        data_interval_start=inputs.data_interval_start,
+        data_interval_end=inputs.data_interval_end,
+    )
+    external_logger = EXTERNAL_LOGGER.bind()
+
+    external_logger.info(
+        "Batch exporting range %s - %s to Redshift: %s.%s.%s",
+        inputs.data_interval_start or "START",
+        inputs.data_interval_end or "END",
+        inputs.database,
+        inputs.schema,
+        inputs.table_name,
+    )
+
+    async with (
+        Heartbeater() as heartbeater,
+        set_status_to_running_task(run_id=inputs.run_id),
+    ):
+        _, details = await should_resume_from_activity_heartbeat(activity, RedshiftHeartbeatDetails)
+        if details is None:
+            details = RedshiftHeartbeatDetails()
+
+        done_ranges: list[DateRange] = details.done_ranges
+
+        model, record_batch_model, model_name, fields, filters, extra_query_parameters = resolve_batch_exports_model(
+            inputs.team_id, inputs.batch_export_model, inputs.batch_export_schema
+        )
+
+        data_interval_start = (
+            dt.datetime.fromisoformat(inputs.data_interval_start) if inputs.data_interval_start else None
+        )
+        data_interval_end = dt.datetime.fromisoformat(inputs.data_interval_end)
+        full_range = (data_interval_start, data_interval_end)
+
+        queue = RecordBatchQueue(max_size_bytes=settings.BATCH_EXPORT_REDSHIFT_RECORD_BATCH_QUEUE_MAX_SIZE_BYTES)
+        producer = Producer(record_batch_model)
+        producer_task = await producer.start(
+            queue=queue,
+            model_name=model_name,
+            is_backfill=inputs.get_is_backfill(),
+            backfill_details=inputs.backfill_details,
             team_id=inputs.team_id,
-            destination="Redshift",
-            data_interval_start=inputs.data_interval_start,
-            data_interval_end=inputs.data_interval_end,
-        )
-        external_logger = EXTERNAL_LOGGER.bind()
-
-        external_logger.info(
-            "Batch exporting range %s - %s to Redshift: %s.%s.%s",
-            inputs.data_interval_start or "START",
-            inputs.data_interval_end or "END",
-            inputs.database,
-            inputs.schema,
-            inputs.table_name,
+            full_range=full_range,
+            done_ranges=done_ranges,
+            fields=fields,
+            filters=filters,
+            destination_default_fields=redshift_default_fields(),
+            exclude_events=inputs.exclude_events,
+            include_events=inputs.include_events,
+            extra_query_parameters=extra_query_parameters,
+            max_record_batch_size_bytes=1024 * 1024 * 2,  # 2MB
         )
 
-        async with (
-            Heartbeater() as heartbeater,
-            set_status_to_running_task(run_id=inputs.run_id),
-        ):
-            _, details = await should_resume_from_activity_heartbeat(activity, RedshiftHeartbeatDetails)
-            if details is None:
-                details = RedshiftHeartbeatDetails()
-
-            done_ranges: list[DateRange] = details.done_ranges
-
-            model, record_batch_model, model_name, fields, filters, extra_query_parameters = (
-                resolve_batch_exports_model(inputs.team_id, inputs.batch_export_model, inputs.batch_export_schema)
+        record_batch_schema = await wait_for_schema_or_producer(queue, producer_task)
+        if record_batch_schema is None:
+            external_logger.info(
+                "Batch export will finish early as there is no data matching specified filters in range %s - %s",
+                inputs.data_interval_start or "START",
+                inputs.data_interval_end or "END",
             )
 
-            data_interval_start = (
-                dt.datetime.fromisoformat(inputs.data_interval_start) if inputs.data_interval_start else None
+            return BatchExportResult(records_completed=details.records_completed)
+
+        record_batch_schema = pa.schema(
+            [field.with_nullable(True) for field in record_batch_schema if field.name != "_inserted_at"]
+        )
+        known_super_columns = ["properties", "set", "set_once", "person_properties"]
+        if inputs.properties_data_type != "varchar":
+            properties_type = "SUPER"
+
+        else:
+            properties_type = "VARCHAR(65535)"
+
+        if model is None or (isinstance(model, BatchExportModel) and model.name == "events"):
+            table_fields: Fields = [
+                ("uuid", "VARCHAR(200)"),
+                ("event", "VARCHAR(200)"),
+                ("properties", properties_type),
+                ("elements", "VARCHAR(65535)"),
+                ("set", properties_type),
+                ("set_once", properties_type),
+                ("distinct_id", "VARCHAR(200)"),
+                ("team_id", "INTEGER"),
+                ("ip", "VARCHAR(200)"),
+                ("site_url", "VARCHAR(200)"),
+                ("timestamp", "TIMESTAMP WITH TIME ZONE"),
+            ]
+        else:
+            table_fields = get_redshift_fields_from_record_schema(
+                record_batch_schema, known_super_columns=known_super_columns, use_super=properties_type == "SUPER"
             )
-            data_interval_end = dt.datetime.fromisoformat(inputs.data_interval_end)
-            full_range = (data_interval_start, data_interval_end)
 
-            queue = RecordBatchQueue(max_size_bytes=settings.BATCH_EXPORT_REDSHIFT_RECORD_BATCH_QUEUE_MAX_SIZE_BYTES)
-            producer = Producer(record_batch_model)
-            producer_task = await producer.start(
-                queue=queue,
-                model_name=model_name,
-                is_backfill=inputs.get_is_backfill(),
-                backfill_details=inputs.backfill_details,
-                team_id=inputs.team_id,
-                full_range=full_range,
-                done_ranges=done_ranges,
-                fields=fields,
-                filters=filters,
-                destination_default_fields=redshift_default_fields(),
-                exclude_events=inputs.exclude_events,
-                include_events=inputs.include_events,
-                extra_query_parameters=extra_query_parameters,
-                max_record_batch_size_bytes=1024 * 1024 * 2,  # 2MB
-            )
-
-            record_batch_schema = await wait_for_schema_or_producer(queue, producer_task)
-            if record_batch_schema is None:
-                external_logger.info(
-                    "Batch export will finish early as there is no data matching specified filters in range %s - %s",
-                    inputs.data_interval_start or "START",
-                    inputs.data_interval_end or "END",
-                )
-
-                return BatchExportResult(records_completed=details.records_completed)
-
-            record_batch_schema = pa.schema(
-                [field.with_nullable(True) for field in record_batch_schema if field.name != "_inserted_at"]
-            )
-            known_super_columns = ["properties", "set", "set_once", "person_properties"]
-            if inputs.properties_data_type != "varchar":
-                properties_type = "SUPER"
-
-            else:
-                properties_type = "VARCHAR(65535)"
-
-            if model is None or (isinstance(model, BatchExportModel) and model.name == "events"):
-                table_fields: Fields = [
-                    ("uuid", "VARCHAR(200)"),
-                    ("event", "VARCHAR(200)"),
-                    ("properties", properties_type),
-                    ("elements", "VARCHAR(65535)"),
-                    ("set", properties_type),
-                    ("set_once", properties_type),
-                    ("distinct_id", "VARCHAR(200)"),
-                    ("team_id", "INTEGER"),
-                    ("ip", "VARCHAR(200)"),
-                    ("site_url", "VARCHAR(200)"),
-                    ("timestamp", "TIMESTAMP WITH TIME ZONE"),
+        requires_merge = False
+        merge_key: Fields = []
+        update_key: Fields = []
+        primary_key: Fields | None = None
+        if isinstance(inputs.batch_export_model, BatchExportModel):
+            if inputs.batch_export_model.name == "persons":
+                requires_merge = True
+                merge_key = [
+                    ("team_id", "INT"),
+                    ("distinct_id", "TEXT"),
                 ]
-            else:
-                table_fields = get_redshift_fields_from_record_schema(
-                    record_batch_schema, known_super_columns=known_super_columns, use_super=properties_type == "SUPER"
+                update_key = [
+                    ("person_version", "INT"),
+                    ("person_distinct_id_version", "INT"),
+                ]
+                primary_key = (("team_id", "INTEGER"), ("distinct_id", "VARCHAR(200)"))
+
+            elif inputs.batch_export_model.name == "sessions":
+                requires_merge = True
+                merge_key = [
+                    ("team_id", "INT"),
+                    ("session_id", "TEXT"),
+                ]
+                update_key = [
+                    ("end_timestamp", "TIMESTAMP"),
+                ]
+                primary_key = (("team_id", "INTEGER"), ("session_id", "TEXT"))
+
+        data_interval_end_str = dt.datetime.fromisoformat(inputs.data_interval_end).strftime("%Y-%m-%d_%H-%M-%S")
+        stagle_table_name = (
+            f"stage_{inputs.table_name}_{data_interval_end_str}_{inputs.team_id}"
+            if requires_merge
+            else inputs.table_name
+        )
+
+        async with RedshiftClient.from_inputs(inputs).connect() as redshift_client:
+            # filter out fields that are not in the destination table
+            try:
+                columns = await redshift_client.aget_table_columns(inputs.schema, inputs.table_name)
+                table_fields = [field for field in table_fields if field[0] in columns]
+            except psycopg.errors.UndefinedTable:
+                pass
+
+            async with (
+                redshift_client.managed_table(
+                    inputs.schema, inputs.table_name, table_fields, delete=False, primary_key=primary_key
+                ) as redshift_table,
+                redshift_client.managed_table(
+                    inputs.schema,
+                    stagle_table_name,
+                    table_fields,
+                    create=requires_merge,
+                    delete=requires_merge,
+                    primary_key=primary_key,
+                ) as redshift_stage_table,
+            ):
+                schema_columns = {field[0] for field in table_fields}
+
+                consumer = RedshiftConsumer(
+                    heartbeater=heartbeater,
+                    heartbeat_details=details,
+                    data_interval_end=data_interval_end,
+                    data_interval_start=data_interval_start,
+                    redshift_client=redshift_client,
+                    redshift_table=redshift_stage_table if requires_merge else redshift_table,
                 )
-
-            requires_merge = False
-            merge_key: Fields = []
-            update_key: Fields = []
-            primary_key: Fields | None = None
-            if isinstance(inputs.batch_export_model, BatchExportModel):
-                if inputs.batch_export_model.name == "persons":
-                    requires_merge = True
-                    merge_key = [
-                        ("team_id", "INT"),
-                        ("distinct_id", "TEXT"),
-                    ]
-                    update_key = [
-                        ("person_version", "INT"),
-                        ("person_distinct_id_version", "INT"),
-                    ]
-                    primary_key = (("team_id", "INTEGER"), ("distinct_id", "VARCHAR(200)"))
-
-                elif inputs.batch_export_model.name == "sessions":
-                    requires_merge = True
-                    merge_key = [
-                        ("team_id", "INT"),
-                        ("session_id", "TEXT"),
-                    ]
-                    update_key = [
-                        ("end_timestamp", "TIMESTAMP"),
-                    ]
-                    primary_key = (("team_id", "INTEGER"), ("session_id", "TEXT"))
-
-            data_interval_end_str = dt.datetime.fromisoformat(inputs.data_interval_end).strftime("%Y-%m-%d_%H-%M-%S")
-            stagle_table_name = (
-                f"stage_{inputs.table_name}_{data_interval_end_str}_{inputs.team_id}"
-                if requires_merge
-                else inputs.table_name
-            )
-
-            async with RedshiftClient.from_inputs(inputs).connect() as redshift_client:
-                # filter out fields that are not in the destination table
                 try:
-                    columns = await redshift_client.aget_table_columns(inputs.schema, inputs.table_name)
-                    table_fields = [field for field in table_fields if field[0] in columns]
-                except psycopg.errors.UndefinedTable:
-                    pass
-
-                async with (
-                    redshift_client.managed_table(
-                        inputs.schema, inputs.table_name, table_fields, delete=False, primary_key=primary_key
-                    ) as redshift_table,
-                    redshift_client.managed_table(
-                        inputs.schema,
-                        stagle_table_name,
-                        table_fields,
-                        create=requires_merge,
-                        delete=requires_merge,
-                        primary_key=primary_key,
-                    ) as redshift_stage_table,
-                ):
-                    schema_columns = {field[0] for field in table_fields}
-
-                    consumer = RedshiftConsumer(
-                        heartbeater=heartbeater,
-                        heartbeat_details=details,
-                        data_interval_end=data_interval_end,
-                        data_interval_start=data_interval_start,
-                        redshift_client=redshift_client,
-                        redshift_table=redshift_stage_table if requires_merge else redshift_table,
+                    _ = await run_consumer(
+                        consumer=consumer,
+                        queue=queue,
+                        producer_task=producer_task,
+                        schema=record_batch_schema,
+                        max_bytes=settings.BATCH_EXPORT_REDSHIFT_UPLOAD_CHUNK_SIZE_BYTES,
+                        json_columns=known_super_columns,
+                        writer_file_kwargs={
+                            "redshift_table": redshift_stage_table if requires_merge else redshift_table,
+                            "redshift_schema": inputs.schema,
+                            "table_columns": schema_columns,
+                            "known_json_columns": set(known_super_columns),
+                            "use_super": properties_type == "SUPER",
+                            "redshift_client": redshift_client,
+                        },
+                        multiple_files=True,
                     )
-                    try:
-                        _ = await run_consumer(
-                            consumer=consumer,
-                            queue=queue,
-                            producer_task=producer_task,
-                            schema=record_batch_schema,
-                            max_bytes=settings.BATCH_EXPORT_REDSHIFT_UPLOAD_CHUNK_SIZE_BYTES,
-                            json_columns=known_super_columns,
-                            writer_file_kwargs={
-                                "redshift_table": redshift_stage_table if requires_merge else redshift_table,
-                                "redshift_schema": inputs.schema,
-                                "table_columns": schema_columns,
-                                "known_json_columns": set(known_super_columns),
-                                "use_super": properties_type == "SUPER",
-                                "redshift_client": redshift_client,
-                            },
-                            multiple_files=True,
+
+                finally:
+                    if requires_merge:
+                        await redshift_client.amerge_mutable_tables(
+                            final_table_name=redshift_table,
+                            stage_table_name=redshift_stage_table,
+                            schema=inputs.schema,
+                            merge_key=merge_key,
+                            update_key=update_key,
                         )
 
-                    finally:
-                        if requires_merge:
-                            await redshift_client.amerge_mutable_tables(
-                                final_table_name=redshift_table,
-                                stage_table_name=redshift_stage_table,
-                                schema=inputs.schema,
-                                merge_key=merge_key,
-                                update_key=update_key,
-                            )
-
-                    return BatchExportResult(records_completed=details.records_completed)
-    except Exception as e:
-        # If we catch an error at any point during this activity, we check if it's a non-retryable error.
-        # If it is, we return a BatchExportResult with the error.
-        # If it's not, we re-raise the error.
-        # TODO: Use actual exception classes instead of strings.
-        if e.__class__.__name__ in NON_RETRYABLE_ERROR_TYPES:
-            return BatchExportResult.from_exception(e)
-        raise
+                return BatchExportResult(records_completed=details.records_completed)
 
 
 @workflow.defn(name="redshift-export", failure_exception_types=[workflow.NondeterminismError])

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -366,8 +366,8 @@ class RedshiftInsertInputs(PostgresInsertInputs):
     properties_data_type: str = "varchar"
 
 
-@handle_non_retryable_errors(NON_RETRYABLE_ERROR_TYPES)
 @activity.defn
+@handle_non_retryable_errors(NON_RETRYABLE_ERROR_TYPES)
 async def insert_into_redshift_activity(inputs: RedshiftInsertInputs) -> BatchExportResult:
     """Activity to insert data from ClickHouse to Redshift.
 

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -333,8 +333,8 @@ class S3BatchExportWorkflow(PostHogWorkflow):
         return
 
 
-@handle_non_retryable_errors(NON_RETRYABLE_ERROR_TYPES)
 @activity.defn
+@handle_non_retryable_errors(NON_RETRYABLE_ERROR_TYPES)
 async def insert_into_s3_activity_from_stage(inputs: S3InsertInputs) -> BatchExportResult:
     """Activity to batch export data to a customer's S3.
 

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -71,8 +71,6 @@ NON_RETRYABLE_ERROR_TYPES = [
     "EndpointConnectionError",
     # User provided an invalid S3 key
     "InvalidS3Key",
-    # All consumers failed with non-retryable errors.
-    "RecordBatchConsumerNonRetryableExceptionGroup",
     # Invalid S3 endpoint URL
     "InvalidS3EndpointError",
     # Invalid file_format input

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -324,7 +324,6 @@ class S3BatchExportWorkflow(PostHogWorkflow):
             insert_into_s3_activity_from_stage,
             insert_inputs,
             interval=inputs.interval,
-            non_retryable_error_types=NON_RETRYABLE_ERROR_TYPES,
         )
         return
 
@@ -344,79 +343,88 @@ async def insert_into_s3_activity_from_stage(inputs: S3InsertInputs) -> BatchExp
     it will be used by other destinations, not just S3. Our S3 batch exports also support customising the max S3 file
     size, different file formats, compression, etc, which ClickHouse's S3 functions may not support.
     """
-    bind_contextvars(
-        team_id=inputs.team_id,
-        destination="S3",
-        data_interval_start=inputs.data_interval_start,
-        data_interval_end=inputs.data_interval_end,
-    )
-    external_logger = EXTERNAL_LOGGER.bind()
-
-    external_logger.info(
-        "Batch exporting range %s - %s to S3: %s",
-        inputs.data_interval_start or "START",
-        inputs.data_interval_end or "END",
-        get_s3_key(inputs),
-    )
-
-    async with Heartbeater():
-        # NOTE: we don't support resuming from heartbeats for this activity for 2 reasons:
-        # - resuming from old heartbeats doesn't play nicely with S3 multipart uploads
-        # - we don't order the events in the query to ClickHouse
-        data_interval_start = (
-            dt.datetime.fromisoformat(inputs.data_interval_start) if inputs.data_interval_start else None
-        )
-        data_interval_end = dt.datetime.fromisoformat(inputs.data_interval_end)
-
-        queue = RecordBatchQueue(max_size_bytes=settings.BATCH_EXPORT_S3_RECORD_BATCH_QUEUE_MAX_SIZE_BYTES)
-        producer = ProducerFromInternalStage()
-        assert inputs.batch_export_id is not None
-        producer_task = await producer.start(
-            queue=queue,
-            batch_export_id=inputs.batch_export_id,
+    try:
+        bind_contextvars(
+            team_id=inputs.team_id,
+            destination="S3",
             data_interval_start=inputs.data_interval_start,
             data_interval_end=inputs.data_interval_end,
-            max_record_batch_size_bytes=1024 * 1024 * 60,  # 60MB
+        )
+        external_logger = EXTERNAL_LOGGER.bind()
+
+        external_logger.info(
+            "Batch exporting range %s - %s to S3: %s",
+            inputs.data_interval_start or "START",
+            inputs.data_interval_end or "END",
+            get_s3_key(inputs),
         )
 
-        record_batch_schema = await wait_for_schema_or_producer(queue, producer_task)
-        if record_batch_schema is None:
-            external_logger.info(
-                "Batch export will finish early as there is no data matching specified filters in range %s - %s",
-                inputs.data_interval_start or "START",
-                inputs.data_interval_end or "END",
+        async with Heartbeater():
+            # NOTE: we don't support resuming from heartbeats for this activity for 2 reasons:
+            # - resuming from old heartbeats doesn't play nicely with S3 multipart uploads
+            # - we don't order the events in the query to ClickHouse
+            data_interval_start = (
+                dt.datetime.fromisoformat(inputs.data_interval_start) if inputs.data_interval_start else None
+            )
+            data_interval_end = dt.datetime.fromisoformat(inputs.data_interval_end)
+
+            queue = RecordBatchQueue(max_size_bytes=settings.BATCH_EXPORT_S3_RECORD_BATCH_QUEUE_MAX_SIZE_BYTES)
+            producer = ProducerFromInternalStage()
+            assert inputs.batch_export_id is not None
+            producer_task = await producer.start(
+                queue=queue,
+                batch_export_id=inputs.batch_export_id,
+                data_interval_start=inputs.data_interval_start,
+                data_interval_end=inputs.data_interval_end,
+                max_record_batch_size_bytes=1024 * 1024 * 60,  # 60MB
             )
 
-            return BatchExportResult(records_completed=0, bytes_exported=0)
+            record_batch_schema = await wait_for_schema_or_producer(queue, producer_task)
+            if record_batch_schema is None:
+                external_logger.info(
+                    "Batch export will finish early as there is no data matching specified filters in range %s - %s",
+                    inputs.data_interval_start or "START",
+                    inputs.data_interval_end or "END",
+                )
 
-        record_batch_schema = pa.schema(
-            # NOTE: For some reason, some batches set non-nullable fields as non-nullable, whereas other
-            # record batches have them as nullable.
-            # Until we figure it out, we set all fields to nullable. There are some fields we know
-            # are not nullable, but I'm opting for the more flexible option until we out why schemas differ
-            # between batches.
-            [field.with_nullable(True) for field in record_batch_schema]
-        )
+                return BatchExportResult(records_completed=0, bytes_exported=0)
 
-        consumer = ConcurrentS3Consumer(
-            data_interval_start=data_interval_start,
-            data_interval_end=data_interval_end,
-            s3_inputs=inputs,
-            part_size=settings.BATCH_EXPORT_S3_UPLOAD_CHUNK_SIZE_BYTES,
-            max_concurrent_uploads=settings.BATCH_EXPORT_S3_MAX_CONCURRENT_UPLOADS,
-        )
+            record_batch_schema = pa.schema(
+                # NOTE: For some reason, some batches set non-nullable fields as non-nullable, whereas other
+                # record batches have them as nullable.
+                # Until we figure it out, we set all fields to nullable. There are some fields we know
+                # are not nullable, but I'm opting for the more flexible option until we out why schemas differ
+                # between batches.
+                [field.with_nullable(True) for field in record_batch_schema]
+            )
 
-        return await run_consumer_from_stage(
-            queue=queue,
-            consumer=consumer,
-            producer_task=producer_task,
-            schema=record_batch_schema,
-            file_format=inputs.file_format,
-            compression=inputs.compression,
-            include_inserted_at=True,
-            max_file_size_bytes=inputs.max_file_size_mb * 1024 * 1024 if inputs.max_file_size_mb else 0,
-            json_columns=("properties", "person_properties", "set", "set_once"),
-        )
+            consumer = ConcurrentS3Consumer(
+                data_interval_start=data_interval_start,
+                data_interval_end=data_interval_end,
+                s3_inputs=inputs,
+                part_size=settings.BATCH_EXPORT_S3_UPLOAD_CHUNK_SIZE_BYTES,
+                max_concurrent_uploads=settings.BATCH_EXPORT_S3_MAX_CONCURRENT_UPLOADS,
+            )
+
+            return await run_consumer_from_stage(
+                queue=queue,
+                consumer=consumer,
+                producer_task=producer_task,
+                schema=record_batch_schema,
+                file_format=inputs.file_format,
+                compression=inputs.compression,
+                include_inserted_at=True,
+                max_file_size_bytes=inputs.max_file_size_mb * 1024 * 1024 if inputs.max_file_size_mb else 0,
+                json_columns=("properties", "person_properties", "set", "set_once"),
+            )
+    except Exception as e:
+        # If we catch an error at any point during this activity, we check if it's a non-retryable error.
+        # If it is, we return a BatchExportResult with the error.
+        # If it's not, we re-raise the error.
+        # TODO: Use actual exception classes instead of strings.
+        if e.__class__.__name__ in NON_RETRYABLE_ERROR_TYPES:
+            return BatchExportResult.from_exception(e)
+        raise
 
 
 class ConcurrentS3Consumer(ConsumerFromStage):

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -56,9 +56,6 @@ from products.batch_exports.backend.temporal.spmc import (
     RecordBatchQueue,
     wait_for_schema_or_producer,
 )
-from products.batch_exports.backend.temporal.temporary_file import (
-    UnsupportedFileFormatError,
-)
 
 NON_RETRYABLE_ERROR_TYPES = [
     # S3 parameter validation failed.
@@ -97,6 +94,13 @@ SUPPORTED_COMPRESSIONS = {
 
 LOGGER = get_logger(__name__)
 EXTERNAL_LOGGER = get_external_logger()
+
+
+class UnsupportedFileFormatError(Exception):
+    """Raised when an unsupported file format is requested."""
+
+    def __init__(self, file_format: str):
+        super().__init__(f"'{file_format}' is not a supported format for S3 batch exports.")
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -150,7 +154,7 @@ def get_s3_key(inputs: S3InsertInputs, file_number: int = 0) -> str:
     try:
         file_extension = FILE_FORMAT_EXTENSIONS[inputs.file_format]
     except KeyError:
-        raise UnsupportedFileFormatError(inputs.file_format, "S3")
+        raise UnsupportedFileFormatError(inputs.file_format)
 
     base_file_name = f"{inputs.data_interval_start}-{inputs.data_interval_end}"
     # to maintain backwards compatibility with the old file naming scheme

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -785,8 +785,8 @@ def get_snowflake_fields_from_record_schema(
     return snowflake_schema
 
 
-@handle_non_retryable_errors(NON_RETRYABLE_ERROR_TYPES)
 @activity.defn
+@handle_non_retryable_errors(NON_RETRYABLE_ERROR_TYPES)
 async def insert_into_snowflake_activity(inputs: SnowflakeInsertInputs) -> BatchExportResult:
     """Activity streams data from ClickHouse to Snowflake.
 

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -62,6 +62,7 @@ from products.batch_exports.backend.temporal.temporary_file import (
 )
 from products.batch_exports.backend.temporal.utils import (
     JsonType,
+    handle_non_retryable_errors,
     set_status_to_running_task,
 )
 
@@ -71,7 +72,7 @@ EXTERNAL_LOGGER = get_external_logger()
 # One batch export allowed to connect at a time (in theory) per worker.
 CONNECTION_SEMAPHORE = asyncio.Semaphore(value=1)
 
-NON_RETRYABLE_ERROR_TYPES = [
+NON_RETRYABLE_ERROR_TYPES = (
     # Raised when we cannot connect to Snowflake.
     "DatabaseError",
     # Raised by Snowflake when a query cannot be compiled.
@@ -87,7 +88,7 @@ NON_RETRYABLE_ERROR_TYPES = [
     "InvalidPrivateKeyError",
     # Raised when a valid authentication method is not provided.
     "SnowflakeAuthenticationError",
-]
+)
 
 
 class SnowflakeFileNotUploadedError(Exception):
@@ -784,197 +785,187 @@ def get_snowflake_fields_from_record_schema(
     return snowflake_schema
 
 
+@handle_non_retryable_errors(NON_RETRYABLE_ERROR_TYPES)
 @activity.defn
 async def insert_into_snowflake_activity(inputs: SnowflakeInsertInputs) -> BatchExportResult:
     """Activity streams data from ClickHouse to Snowflake.
 
     TODO: We're using JSON here, it's not the most efficient way to do this.
     """
-    try:
-        bind_contextvars(
+    bind_contextvars(
+        team_id=inputs.team_id,
+        destination="Snowflake",
+        data_interval_start=inputs.data_interval_start,
+        data_interval_end=inputs.data_interval_end,
+    )
+    external_logger = EXTERNAL_LOGGER.bind()
+
+    external_logger.info(
+        "Batch exporting range %s - %s to Snowflake: %s.%s.%s",
+        inputs.data_interval_start or "START",
+        inputs.data_interval_end or "END",
+        inputs.database,
+        inputs.schema,
+        inputs.table_name,
+    )
+
+    async with (
+        Heartbeater() as heartbeater,
+        set_status_to_running_task(run_id=inputs.run_id),
+    ):
+        _, details = await should_resume_from_activity_heartbeat(activity, SnowflakeHeartbeatDetails)
+        if details is None or str(inputs.team_id) in settings.BATCH_EXPORT_ORDERLESS_TEAM_IDS:
+            details = SnowflakeHeartbeatDetails()
+
+        done_ranges: list[DateRange] = details.done_ranges
+
+        model, record_batch_model, model_name, fields, filters, extra_query_parameters = resolve_batch_exports_model(
+            inputs.team_id, inputs.batch_export_model, inputs.batch_export_schema
+        )
+
+        data_interval_start = (
+            dt.datetime.fromisoformat(inputs.data_interval_start) if inputs.data_interval_start else None
+        )
+        data_interval_end = dt.datetime.fromisoformat(inputs.data_interval_end)
+        full_range = (data_interval_start, data_interval_end)
+
+        queue = RecordBatchQueue(max_size_bytes=settings.BATCH_EXPORT_SNOWFLAKE_RECORD_BATCH_QUEUE_MAX_SIZE_BYTES)
+        producer = Producer(record_batch_model)
+        producer_task = await producer.start(
+            queue=queue,
+            model_name=model_name,
+            is_backfill=inputs.get_is_backfill(),
+            backfill_details=inputs.backfill_details,
             team_id=inputs.team_id,
-            destination="Snowflake",
-            data_interval_start=inputs.data_interval_start,
-            data_interval_end=inputs.data_interval_end,
-        )
-        external_logger = EXTERNAL_LOGGER.bind()
-
-        external_logger.info(
-            "Batch exporting range %s - %s to Snowflake: %s.%s.%s",
-            inputs.data_interval_start or "START",
-            inputs.data_interval_end or "END",
-            inputs.database,
-            inputs.schema,
-            inputs.table_name,
+            full_range=full_range,
+            done_ranges=done_ranges,
+            fields=fields,
+            filters=filters,
+            destination_default_fields=snowflake_default_fields(),
+            exclude_events=inputs.exclude_events,
+            include_events=inputs.include_events,
+            extra_query_parameters=extra_query_parameters,
         )
 
-        async with (
-            Heartbeater() as heartbeater,
-            set_status_to_running_task(run_id=inputs.run_id),
-        ):
-            _, details = await should_resume_from_activity_heartbeat(activity, SnowflakeHeartbeatDetails)
-            if details is None or str(inputs.team_id) in settings.BATCH_EXPORT_ORDERLESS_TEAM_IDS:
-                details = SnowflakeHeartbeatDetails()
-
-            done_ranges: list[DateRange] = details.done_ranges
-
-            model, record_batch_model, model_name, fields, filters, extra_query_parameters = (
-                resolve_batch_exports_model(inputs.team_id, inputs.batch_export_model, inputs.batch_export_schema)
+        record_batch_schema = await wait_for_schema_or_producer(queue, producer_task)
+        if record_batch_schema is None:
+            external_logger.info(
+                "Batch export will finish early as there is no data matching specified filters in range %s - %s",
+                inputs.data_interval_start or "START",
+                inputs.data_interval_end or "END",
             )
 
-            data_interval_start = (
-                dt.datetime.fromisoformat(inputs.data_interval_start) if inputs.data_interval_start else None
-            )
-            data_interval_end = dt.datetime.fromisoformat(inputs.data_interval_end)
-            full_range = (data_interval_start, data_interval_end)
+            return BatchExportResult(records_completed=details.records_completed)
 
-            queue = RecordBatchQueue(max_size_bytes=settings.BATCH_EXPORT_SNOWFLAKE_RECORD_BATCH_QUEUE_MAX_SIZE_BYTES)
-            producer = Producer(record_batch_model)
-            producer_task = await producer.start(
-                queue=queue,
-                model_name=model_name,
-                is_backfill=inputs.get_is_backfill(),
-                backfill_details=inputs.backfill_details,
-                team_id=inputs.team_id,
-                full_range=full_range,
-                done_ranges=done_ranges,
-                fields=fields,
-                filters=filters,
-                destination_default_fields=snowflake_default_fields(),
-                exclude_events=inputs.exclude_events,
-                include_events=inputs.include_events,
-                extra_query_parameters=extra_query_parameters,
-            )
+        record_batch_schema = pa.schema(
+            # NOTE: For some reason, some batches set non-nullable fields as non-nullable, whereas other
+            # record batches have them as nullable.
+            # Until we figure it out, we set all fields to nullable. There are some fields we know
+            # are not nullable, but I'm opting for the more flexible option until we out why schemas differ
+            # between batches.
+            [field.with_nullable(True) for field in record_batch_schema if field.name != "_inserted_at"]
+        )
 
-            record_batch_schema = await wait_for_schema_or_producer(queue, producer_task)
-            if record_batch_schema is None:
-                external_logger.info(
-                    "Batch export will finish early as there is no data matching specified filters in range %s - %s",
-                    inputs.data_interval_start or "START",
-                    inputs.data_interval_end or "END",
-                )
+        known_variant_columns = ["properties", "people_set", "people_set_once", "person_properties"]
 
-                return BatchExportResult(records_completed=details.records_completed)
+        if model is None or (isinstance(model, BatchExportModel) and model.name == "events"):
+            table_fields = [
+                ("uuid", "STRING"),
+                ("event", "STRING"),
+                ("properties", "VARIANT"),
+                ("elements", "VARIANT"),
+                ("people_set", "VARIANT"),
+                ("people_set_once", "VARIANT"),
+                ("distinct_id", "STRING"),
+                ("team_id", "INTEGER"),
+                ("ip", "STRING"),
+                ("site_url", "STRING"),
+                ("timestamp", "TIMESTAMP"),
+            ]
 
-            record_batch_schema = pa.schema(
-                # NOTE: For some reason, some batches set non-nullable fields as non-nullable, whereas other
-                # record batches have them as nullable.
-                # Until we figure it out, we set all fields to nullable. There are some fields we know
-                # are not nullable, but I'm opting for the more flexible option until we out why schemas differ
-                # between batches.
-                [field.with_nullable(True) for field in record_batch_schema if field.name != "_inserted_at"]
+        else:
+            table_fields = get_snowflake_fields_from_record_schema(
+                record_batch_schema,
+                known_variant_columns=known_variant_columns,
             )
 
-            known_variant_columns = ["properties", "people_set", "people_set_once", "person_properties"]
-
-            if model is None or (isinstance(model, BatchExportModel) and model.name == "events"):
-                table_fields = [
-                    ("uuid", "STRING"),
-                    ("event", "STRING"),
-                    ("properties", "VARIANT"),
-                    ("elements", "VARIANT"),
-                    ("people_set", "VARIANT"),
-                    ("people_set_once", "VARIANT"),
+        requires_merge = False
+        merge_key = []
+        update_key = []
+        if isinstance(inputs.batch_export_model, BatchExportModel):
+            if inputs.batch_export_model.name == "persons":
+                requires_merge = True
+                merge_key = [
+                    ("team_id", "INT64"),
                     ("distinct_id", "STRING"),
-                    ("team_id", "INTEGER"),
-                    ("ip", "STRING"),
-                    ("site_url", "STRING"),
-                    ("timestamp", "TIMESTAMP"),
+                ]
+                update_key = ["person_version", "person_distinct_id_version"]
+
+            elif inputs.batch_export_model.name == "sessions":
+                requires_merge = True
+                merge_key = [("team_id", "INT64"), ("session_id", "STRING")]
+                update_key = [
+                    "end_timestamp",
                 ]
 
-            else:
-                table_fields = get_snowflake_fields_from_record_schema(
-                    record_batch_schema,
-                    known_variant_columns=known_variant_columns,
+        data_interval_end_str = dt.datetime.fromisoformat(inputs.data_interval_end).strftime("%Y-%m-%d_%H-%M-%S")
+        stagle_table_name = (
+            f"stage_{inputs.table_name}_{data_interval_end_str}_{inputs.team_id}"
+            if requires_merge
+            else inputs.table_name
+        )
+
+        async with SnowflakeClient.from_inputs(inputs).connect() as snow_client:
+            async with (
+                snow_client.managed_table(
+                    inputs.table_name, data_interval_end_str, table_fields, delete=False
+                ) as snow_table,
+                snow_client.managed_table(
+                    stagle_table_name,
+                    data_interval_end_str,
+                    table_fields,
+                    create=requires_merge,
+                    delete=requires_merge,
+                ) as snow_stage_table,
+            ):
+                consumer = SnowflakeConsumer(
+                    heartbeater=heartbeater,
+                    heartbeat_details=details,
+                    data_interval_end=data_interval_end,
+                    data_interval_start=data_interval_start,
+                    writer_format=WriterFormat.JSONL,
+                    snowflake_client=snow_client,
+                    snowflake_table=snow_stage_table if requires_merge else snow_table,
+                    snowflake_table_stage_prefix=data_interval_end_str,
                 )
-
-            requires_merge = False
-            merge_key = []
-            update_key = []
-            if isinstance(inputs.batch_export_model, BatchExportModel):
-                if inputs.batch_export_model.name == "persons":
-                    requires_merge = True
-                    merge_key = [
-                        ("team_id", "INT64"),
-                        ("distinct_id", "STRING"),
-                    ]
-                    update_key = ["person_version", "person_distinct_id_version"]
-
-                elif inputs.batch_export_model.name == "sessions":
-                    requires_merge = True
-                    merge_key = [("team_id", "INT64"), ("session_id", "STRING")]
-                    update_key = [
-                        "end_timestamp",
-                    ]
-
-            data_interval_end_str = dt.datetime.fromisoformat(inputs.data_interval_end).strftime("%Y-%m-%d_%H-%M-%S")
-            stagle_table_name = (
-                f"stage_{inputs.table_name}_{data_interval_end_str}_{inputs.team_id}"
-                if requires_merge
-                else inputs.table_name
-            )
-
-            async with SnowflakeClient.from_inputs(inputs).connect() as snow_client:
-                async with (
-                    snow_client.managed_table(
-                        inputs.table_name, data_interval_end_str, table_fields, delete=False
-                    ) as snow_table,
-                    snow_client.managed_table(
-                        stagle_table_name,
-                        data_interval_end_str,
-                        table_fields,
-                        create=requires_merge,
-                        delete=requires_merge,
-                    ) as snow_stage_table,
-                ):
-                    consumer = SnowflakeConsumer(
-                        heartbeater=heartbeater,
-                        heartbeat_details=details,
-                        data_interval_end=data_interval_end,
-                        data_interval_start=data_interval_start,
-                        writer_format=WriterFormat.JSONL,
-                        snowflake_client=snow_client,
-                        snowflake_table=snow_stage_table if requires_merge else snow_table,
-                        snowflake_table_stage_prefix=data_interval_end_str,
+                try:
+                    await run_consumer(
+                        consumer=consumer,
+                        queue=queue,
+                        producer_task=producer_task,
+                        schema=record_batch_schema,
+                        max_bytes=settings.BATCH_EXPORT_SNOWFLAKE_UPLOAD_CHUNK_SIZE_BYTES,
+                        json_columns=known_variant_columns,
+                        multiple_files=True,
                     )
-                    try:
-                        await run_consumer(
-                            consumer=consumer,
-                            queue=queue,
-                            producer_task=producer_task,
-                            schema=record_batch_schema,
-                            max_bytes=settings.BATCH_EXPORT_SNOWFLAKE_UPLOAD_CHUNK_SIZE_BYTES,
-                            json_columns=known_variant_columns,
-                            multiple_files=True,
+
+                # ensure we always write data to final table, even if we fail halfway through, as if we resume from
+                # a heartbeat, we can continue without losing data
+                finally:
+                    await snow_client.copy_loaded_files_to_snowflake_table(
+                        snow_stage_table if requires_merge else snow_table, data_interval_end_str
+                    )
+
+                    if requires_merge:
+                        await snow_client.amerge_mutable_tables(
+                            final_table=snow_table,
+                            stage_table=snow_stage_table,
+                            update_when_matched=table_fields,
+                            merge_key=merge_key,
+                            update_key=update_key,
                         )
 
-                    # ensure we always write data to final table, even if we fail halfway through, as if we resume from
-                    # a heartbeat, we can continue without losing data
-                    finally:
-                        await snow_client.copy_loaded_files_to_snowflake_table(
-                            snow_stage_table if requires_merge else snow_table, data_interval_end_str
-                        )
-
-                        if requires_merge:
-                            await snow_client.amerge_mutable_tables(
-                                final_table=snow_table,
-                                stage_table=snow_stage_table,
-                                update_when_matched=table_fields,
-                                merge_key=merge_key,
-                                update_key=update_key,
-                            )
-
-            return BatchExportResult(
-                records_completed=details.records_completed,
-            )
-    except Exception as e:
-        # If we catch an error at any point during this activity, we check if it's a non-retryable error.
-        # If it is, we return a BatchExportResult with the error.
-        # If it's not, we re-raise the error.
-        # TODO: Use actual exception classes instead of strings.
-        if e.__class__.__name__ in NON_RETRYABLE_ERROR_TYPES:
-            return BatchExportResult.from_exception(e)
-        raise
+        return BatchExportResult(records_completed=details.records_completed)
 
 
 @workflow.defn(name="snowflake-export", failure_exception_types=[workflow.NondeterminismError])

--- a/products/batch_exports/backend/temporal/pipeline/consumer.py
+++ b/products/batch_exports/backend/temporal/pipeline/consumer.py
@@ -14,11 +14,11 @@ from products.batch_exports.backend.temporal.metrics import (
 from products.batch_exports.backend.temporal.pipeline.transformer import (
     get_stream_transformer,
 )
+from products.batch_exports.backend.temporal.pipeline.types import BatchExportResult
 from products.batch_exports.backend.temporal.spmc import (
     RecordBatchQueue,
     raise_on_task_failure,
 )
-from products.batch_exports.backend.temporal.pipeline.types import BatchExportResult
 from products.batch_exports.backend.temporal.utils import (
     cast_record_batch_json_columns,
     cast_record_batch_schema_json_columns,
@@ -87,10 +87,12 @@ class Consumer:
         multiple files that must each individually be valid.
 
         Returns:
-            BatchExportResult (A tuple containing):
-                - The total number of records in all consumed record batches.
+            BatchExportResult:
+                - The total number of records in all consumed record batches. If an error occurs, this will be None.
                 - The total number of bytes exported (this is the size of the actual data exported, which takes into
-                    account the file type and compression).
+                    account the file type and compression). If an error occurs, this will be None.
+                - The error that occurred, if any. If no error occurred, this will be None. If an error occurs, this
+                    will be a string representation of the error.
         """
 
         schema = cast_record_batch_schema_json_columns(schema, json_columns=json_columns)

--- a/products/batch_exports/backend/temporal/pipeline/entrypoint.py
+++ b/products/batch_exports/backend/temporal/pipeline/entrypoint.py
@@ -129,8 +129,8 @@ async def execute_batch_export_using_internal_stage(
         )
         finish_inputs.records_completed = result.records_completed
         finish_inputs.bytes_exported = result.bytes_exported
-        if result.error:
-            finish_inputs.latest_error = result.error
+        if result.error_repr:
+            finish_inputs.latest_error = result.error_repr
             finish_inputs.status = BatchExportRun.Status.FAILED
 
     except exceptions.ActivityError as e:

--- a/products/batch_exports/backend/temporal/pipeline/types.py
+++ b/products/batch_exports/backend/temporal/pipeline/types.py
@@ -1,10 +1,17 @@
-import typing
+from dataclasses import dataclass
 
 
-class BatchExportResult(typing.NamedTuple):
+@dataclass
+class BatchExportResult:
     # This is the total number of records that were successfully exported
     # (not the number of record batches, but the number of records in all record batches)
-    records_completed: int
+    records_completed: int | None = None
     # This is the number of bytes of data exported (i.e. not the number of bytes in ClickHouse or the internal stage)
     # and therefore takes into account things like the file type and compression
-    bytes_exported: int
+    bytes_exported: int | None = None
+    # This is the error that occurred, if any
+    error: str | None = None
+
+    @classmethod
+    def from_exception(cls, e: Exception) -> "BatchExportResult":
+        return cls(error=f"{e.__class__.__name__}: {e}")

--- a/products/batch_exports/backend/temporal/pipeline/types.py
+++ b/products/batch_exports/backend/temporal/pipeline/types.py
@@ -2,6 +2,12 @@ from dataclasses import dataclass
 
 
 @dataclass
+class BatchExportError:
+    type: str
+    message: str
+
+
+@dataclass
 class BatchExportResult:
     # This is the total number of records that were successfully exported
     # (not the number of record batches, but the number of records in all record batches)
@@ -10,8 +16,14 @@ class BatchExportResult:
     # and therefore takes into account things like the file type and compression
     bytes_exported: int | None = None
     # This is the error that occurred, if any
-    error: str | None = None
+    error: BatchExportError | None = None
+
+    @property
+    def error_repr(self) -> str | None:
+        if self.error:
+            return f"{self.error.type}: {self.error.message}"
+        return None
 
     @classmethod
     def from_exception(cls, e: Exception) -> "BatchExportResult":
-        return cls(error=f"{e.__class__.__name__}: {e}")
+        return cls(error=BatchExportError(type=e.__class__.__name__, message=str(e)))

--- a/products/batch_exports/backend/temporal/utils.py
+++ b/products/batch_exports/backend/temporal/utils.py
@@ -295,8 +295,8 @@ def handle_non_retryable_errors(non_retryable_error_types: typing.Sequence[str])
         A decorator function that handles exceptions according to the retry policy.
 
     Example:
-        @handle_non_retryable_errors(("ClientError", "ParamValidationError"))
         @activity.defn
+        @handle_non_retryable_errors(("ClientError", "ParamValidationError"))
         async def insert_into_s3_activity(inputs: S3InsertInputs) -> BatchExportResult:
             # Activity implementation here
             return BatchExportResult(records_completed=100)

--- a/products/batch_exports/backend/tests/temporal/README.md
+++ b/products/batch_exports/backend/tests/temporal/README.md
@@ -19,7 +19,7 @@ Then, a [key](https://cloud.google.com/iam/docs/keys-create-delete#creating) can
 Tests for BigQuery batch exports can be then run from the root of the `posthog` repo:
 
 ```bash
-DEBUG=1 GOOGLE_APPLICATION_CREDENTIALS=/path/to/my/project-credentials.json pytest products/batch_exports/backend/tests/temporal/test_bigquery_batch_export_workflow.py
+DEBUG=1 GOOGLE_APPLICATION_CREDENTIALS=/path/to/my/project-credentials.json pytest products/batch_exports/backend/tests/temporal/destinations/test_bigquery_batch_export_workflow.py
 ```
 
 ## Testing Redshift batch exports
@@ -38,7 +38,7 @@ To enable testing for Redshift batch exports, we require:
 For PostHog employees, check the password manager as a set of development credentials should already be available. You will also need to use the `dev` exit node in Tailscale and be added to the `group:engineering` group in the tailnet policy. With these credentials, and Tailscale setup, we can run the tests from the root of the `posthog` repo with:
 
 ```bash
-DEBUG=1 REDSHIFT_HOST=workgroup.111222333.region.redshift-serverless.amazonaws.com REDSHIFT_USER=test_user REDSHIFT_PASSWORD=test_password pytest products/batch_exports/backend/tests/temporal/test_redshift_batch_export_workflow.py
+DEBUG=1 REDSHIFT_HOST=workgroup.111222333.region.redshift-serverless.amazonaws.com REDSHIFT_USER=test_user REDSHIFT_PASSWORD=test_password pytest products/batch_exports/backend/tests/temporal/destinations/test_redshift_batch_export_workflow.py
 ```
 
 Replace the `REDSHIFT_*` environment variables with the values obtained from the setup steps.
@@ -58,7 +58,7 @@ S3 batch exports are tested against a MinIO bucket available in the local develo
 With these setup steps done, we can run all tests (MinIO and S3 bucket) from the root of the `posthog` repo with:
 
 ```bash
-DEBUG=1 S3_TEST_KMS_KEY_ID='1111111-2222-3333-4444-55555555555' S3_TEST_BUCKET='your-test-bucket' pytest products/batch_exports/backend/tests/temporal/test_s3_batch_export_workflow.py
+DEBUG=1 S3_TEST_KMS_KEY_ID='1111111-2222-3333-4444-55555555555' S3_TEST_BUCKET='your-test-bucket' pytest products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
 ```
 
 Replace the `S3_*` environment variables with the values obtained from the setup steps.
@@ -85,7 +85,7 @@ We currently support 2 types of authentication for Snowflake batch exports:
 For password authentication, you can run the tests from the root of the `posthog` repo with:
 
 ```bash
-DEBUG=1 SNOWFLAKE_WAREHOUSE='your-warehouse' SNOWFLAKE_USERNAME='your-username' SNOWFLAKE_PASSWORD='your-password' SNOWFLAKE_ACCOUNT='your-account' SNOWFLAKE_ROLE='your-role' pytest products/batch_exports/backend/tests/temporal/test_snowflake_batch_export_workflow.py
+DEBUG=1 SNOWFLAKE_WAREHOUSE='your-warehouse' SNOWFLAKE_USERNAME='your-username' SNOWFLAKE_PASSWORD='your-password' SNOWFLAKE_ACCOUNT='your-account' SNOWFLAKE_ROLE='your-role' pytest products/batch_exports/backend/tests/temporal/destinations/test_snowflake_batch_export_workflow.py
 ```
 
 Replace the `SNOWFLAKE_*` environment variables with the values obtained from the setup steps.
@@ -97,7 +97,7 @@ For key pair authentication, you will first need to generate a key pair. You can
 Once you have generated the key pair, you can run the tests from the root of the `posthog` repo with:
 
 ```bash
-DEBUG=1 SNOWFLAKE_WAREHOUSE='your-warehouse' SNOWFLAKE_USERNAME='your-username' SNOWFLAKE_PRIVATE_KEY='your-private-key' SNOWFLAKE_PRIVATE_KEY_PASSPHRASE='your-passphrase' SNOWFLAKE_ACCOUNT='your-account' SNOWFLAKE_ROLE='your-role' pytest products/batch_exports/backend/tests/temporal/test_snowflake_batch_export_workflow.py
+DEBUG=1 SNOWFLAKE_WAREHOUSE='your-warehouse' SNOWFLAKE_USERNAME='your-username' SNOWFLAKE_PRIVATE_KEY='your-private-key' SNOWFLAKE_PRIVATE_KEY_PASSPHRASE='your-passphrase' SNOWFLAKE_ACCOUNT='your-account' SNOWFLAKE_ROLE='your-role' pytest products/batch_exports/backend/tests/temporal/destinations/test_snowflake_batch_export_workflow.py
 ```
 
 Replace the `SNOWFLAKE_*` environment variables with the values obtained from the setup steps.

--- a/products/batch_exports/backend/tests/temporal/destinations/test_bigquery_batch_export_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/test_bigquery_batch_export_workflow.py
@@ -517,9 +517,10 @@ async def test_insert_into_bigquery_activity_inserts_sessions_data_into_bigquery
     sort_key = "session_id"
 
     with override_settings(BATCH_EXPORT_BIGQUERY_UPLOAD_CHUNK_SIZE_BYTES=1):
-        records_completed = await activity_environment.run(insert_into_bigquery_activity, insert_inputs)
+        result = await activity_environment.run(insert_into_bigquery_activity, insert_inputs)
 
-        assert records_completed == 1
+        assert result.records_completed == 1
+        assert result.error is None
 
         await assert_clickhouse_records_in_bigquery(
             bigquery_client=bigquery_client,
@@ -835,9 +836,10 @@ async def test_insert_into_bigquery_activity_merges_sessions_data_in_follow_up_r
         **bigquery_config,
     )
 
-    records_completed = await activity_environment.run(insert_into_bigquery_activity, insert_inputs)
+    result = await activity_environment.run(insert_into_bigquery_activity, insert_inputs)
 
-    assert records_completed == 1
+    assert result.records_completed == 1
+    assert result.error is None
 
     await assert_clickhouse_records_in_bigquery(
         bigquery_client=bigquery_client,
@@ -877,9 +879,10 @@ async def test_insert_into_bigquery_activity_merges_sessions_data_in_follow_up_r
     insert_inputs.data_interval_start = new_data_interval_start.isoformat()
     insert_inputs.data_interval_end = new_data_interval_end.isoformat()
 
-    records_completed = await activity_environment.run(insert_into_bigquery_activity, insert_inputs)
+    result = await activity_environment.run(insert_into_bigquery_activity, insert_inputs)
 
-    assert records_completed == 1
+    assert result.records_completed == 1
+    assert result.error is None
 
     await assert_clickhouse_records_in_bigquery(
         bigquery_client=bigquery_client,
@@ -1608,8 +1611,16 @@ async def test_bigquery_export_workflow_backfill_earliest_persons(
     )
 
 
-async def test_bigquery_export_workflow_handles_insert_activity_errors(ateam, bigquery_batch_export, interval):
-    """Test that BigQuery Export Workflow can gracefully handle errors when inserting BigQuery data."""
+async def test_bigquery_export_workflow_handles_unexpected_insert_activity_errors(
+    ateam, bigquery_batch_export, interval
+):
+    """Test that BigQuery Export Workflow can gracefully handle unexpected errors when inserting BigQuery data.
+
+    This means we do the right updates to the BatchExportRun model and ensure the workflow fails (since we
+    treat this as an unexpected internal error).
+
+    To simulate an unexpected error, we mock the `Producer.start` activity.
+    """
     data_interval_end = dt.datetime.fromisoformat("2023-04-25T14:30:00.000000+00:00")
 
     workflow_id = str(uuid.uuid4())
@@ -1621,10 +1632,6 @@ async def test_bigquery_export_workflow_handles_insert_activity_errors(ateam, bi
         **bigquery_batch_export.destination.config,
     )
 
-    @activity.defn(name="insert_into_bigquery_activity")
-    async def insert_into_bigquery_activity_mocked(_: BigQueryInsertInputs) -> str:
-        raise ValueError("A useful error message")
-
     async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
         async with Worker(
             activity_environment.client,
@@ -1632,33 +1639,43 @@ async def test_bigquery_export_workflow_handles_insert_activity_errors(ateam, bi
             workflows=[BigQueryBatchExportWorkflow],
             activities=[
                 mocked_start_batch_export_run,
-                insert_into_bigquery_activity_mocked,
+                insert_into_bigquery_activity,
                 finish_batch_export_run,
             ],
             workflow_runner=UnsandboxedWorkflowRunner(),
         ):
-            with pytest.raises(WorkflowFailureError):
-                await activity_environment.client.execute_workflow(
-                    BigQueryBatchExportWorkflow.run,
-                    inputs,
-                    id=workflow_id,
-                    task_queue=BATCH_EXPORTS_TASK_QUEUE,
-                    retry_policy=RetryPolicy(maximum_attempts=1),
-                    execution_timeout=dt.timedelta(seconds=20),
-                )
+            with unittest.mock.patch(
+                "products.batch_exports.backend.temporal.destinations.bigquery_batch_export.Producer.start",
+                side_effect=RuntimeError("A useful error message"),
+            ):
+                with pytest.raises(WorkflowFailureError):
+                    await activity_environment.client.execute_workflow(
+                        BigQueryBatchExportWorkflow.run,
+                        inputs,
+                        id=workflow_id,
+                        task_queue=BATCH_EXPORTS_TASK_QUEUE,
+                        retry_policy=RetryPolicy(maximum_attempts=1),
+                        execution_timeout=dt.timedelta(seconds=20),
+                    )
 
     runs = await afetch_batch_export_runs(batch_export_id=bigquery_batch_export.id)
     assert len(runs) == 1
 
     run = runs[0]
-    assert run.status == "Failed"
-    assert run.latest_error == "ValueError: A useful error message"
+    assert run.status == "FailedRetryable"
+    assert run.latest_error == "RuntimeError: A useful error message"
 
 
 async def test_bigquery_export_workflow_handles_insert_activity_non_retryable_errors(
     ateam, bigquery_batch_export, interval
 ):
-    """Test that BigQuery Export Workflow can gracefully handle non-retryable errors when inserting BigQuery data."""
+    """Test that BigQuery Export Workflow can gracefully handle non-retryable errors when inserting BigQuery data.
+
+    This means we do the right updates to the BatchExportRun model and ensure the workflow succeeds (since we
+    treat this as a user error).
+
+    To simulate a user error, we mock the `Producer.start` activity.
+    """
     data_interval_end = dt.datetime.fromisoformat("2023-04-25T14:30:00.000000+00:00")
 
     workflow_id = str(uuid.uuid4())
@@ -1670,12 +1687,8 @@ async def test_bigquery_export_workflow_handles_insert_activity_non_retryable_er
         **bigquery_batch_export.destination.config,
     )
 
-    @activity.defn(name="insert_into_bigquery_activity")
-    async def insert_into_bigquery_activity_mocked(_: BigQueryInsertInputs) -> str:
-        class RefreshError(Exception):
-            pass
-
-        raise RefreshError("A useful error message")
+    class RefreshError(Exception):
+        pass
 
     async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
         async with Worker(
@@ -1684,12 +1697,15 @@ async def test_bigquery_export_workflow_handles_insert_activity_non_retryable_er
             workflows=[BigQueryBatchExportWorkflow],
             activities=[
                 mocked_start_batch_export_run,
-                insert_into_bigquery_activity_mocked,
+                insert_into_bigquery_activity,
                 finish_batch_export_run,
             ],
             workflow_runner=UnsandboxedWorkflowRunner(),
         ):
-            with pytest.raises(WorkflowFailureError):
+            with unittest.mock.patch(
+                "products.batch_exports.backend.temporal.destinations.bigquery_batch_export.Producer.start",
+                side_effect=RefreshError("A useful error message"),
+            ):
                 await activity_environment.client.execute_workflow(
                     BigQueryBatchExportWorkflow.run,
                     inputs,

--- a/products/batch_exports/backend/tests/temporal/destinations/test_http_batch_export_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/test_http_batch_export_workflow.py
@@ -268,8 +268,11 @@ async def test_insert_into_http_activity_throws_on_bad_http_status(
         m.post(TEST_URL, status=400, body="A useful error message", repeat=True)
         result = await activity_environment.run(insert_into_http_activity, insert_inputs)
         assert result.error is not None
+        assert result.error.type == "NonRetryableResponseError"
+        assert result.error.message == "NonRetryableResponseError (status: 400): A useful error message"
         assert (
-            result.error == "NonRetryableResponseError: NonRetryableResponseError (status: 400): A useful error message"
+            result.error_repr
+            == "NonRetryableResponseError: NonRetryableResponseError (status: 400): A useful error message"
         )
 
     with (

--- a/products/batch_exports/backend/tests/temporal/destinations/test_postgres_batch_export_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/test_postgres_batch_export_workflow.py
@@ -720,7 +720,8 @@ async def test_insert_into_postgres_activity_inserts_fails_on_missing_primary_ke
     with override_settings(BATCH_EXPORT_POSTGRES_UPLOAD_CHUNK_SIZE_BYTES=5 * 1024**2):
         result = await activity_environment.run(insert_into_postgres_activity, insert_inputs)
         assert result.error is not None
-        assert result.error.startswith("MissingPrimaryKeyError: An operation could not be completed as")
+        assert result.error.type == "MissingPrimaryKeyError"
+        assert result.error.message.startswith("An operation could not be completed as")
 
 
 @pytest_asyncio.fixture

--- a/products/batch_exports/backend/tests/temporal/destinations/test_postgres_batch_export_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/test_postgres_batch_export_workflow.py
@@ -42,7 +42,6 @@ from products.batch_exports.backend.temporal.batch_exports import (
     start_batch_export_run,
 )
 from products.batch_exports.backend.temporal.destinations.postgres_batch_export import (
-    MissingPrimaryKeyError,
     PostgresBatchExportInputs,
     PostgresBatchExportWorkflow,
     PostgresInsertInputs,
@@ -718,9 +717,10 @@ async def test_insert_into_postgres_activity_inserts_fails_on_missing_primary_ke
         **postgres_config,
     )
 
-    with pytest.raises(MissingPrimaryKeyError):
-        with override_settings(BATCH_EXPORT_POSTGRES_UPLOAD_CHUNK_SIZE_BYTES=5 * 1024**2):
-            await activity_environment.run(insert_into_postgres_activity, insert_inputs)
+    with override_settings(BATCH_EXPORT_POSTGRES_UPLOAD_CHUNK_SIZE_BYTES=5 * 1024**2):
+        result = await activity_environment.run(insert_into_postgres_activity, insert_inputs)
+        assert result.error is not None
+        assert result.error.startswith("MissingPrimaryKeyError: An operation could not be completed as")
 
 
 @pytest_asyncio.fixture
@@ -1021,8 +1021,16 @@ async def test_postgres_export_workflow_backfill_earliest_persons(
     )
 
 
-async def test_postgres_export_workflow_handles_insert_activity_errors(ateam, postgres_batch_export, interval):
-    """Test that Postgres Export Workflow can gracefully handle errors when inserting Postgres data."""
+async def test_postgres_export_workflow_handles_unexpected_insert_activity_errors(
+    ateam, postgres_batch_export, interval
+):
+    """Test that Postgres Export Workflow can gracefully handle unexpected errors when inserting Postgres data.
+
+    This means we do the right updates to the BatchExportRun model and ensure the workflow fails (since we
+    treat this as an unexpected internal error).
+
+    To simulate an unexpected error, we mock the `Producer.start` activity.
+    """
     data_interval_end = dt.datetime.fromisoformat("2023-04-25T14:30:00.000000+00:00")
 
     workflow_id = str(uuid.uuid4())
@@ -1034,10 +1042,6 @@ async def test_postgres_export_workflow_handles_insert_activity_errors(ateam, po
         **postgres_batch_export.destination.config,
     )
 
-    @activity.defn(name="insert_into_postgres_activity")
-    async def insert_into_postgres_activity_mocked(_: PostgresInsertInputs) -> str:
-        raise ValueError("A useful error message")
-
     async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
         async with Worker(
             activity_environment.client,
@@ -1045,19 +1049,23 @@ async def test_postgres_export_workflow_handles_insert_activity_errors(ateam, po
             workflows=[PostgresBatchExportWorkflow],
             activities=[
                 mocked_start_batch_export_run,
-                insert_into_postgres_activity_mocked,
+                insert_into_postgres_activity,
                 finish_batch_export_run,
             ],
             workflow_runner=UnsandboxedWorkflowRunner(),
         ):
-            with pytest.raises(WorkflowFailureError):
-                await activity_environment.client.execute_workflow(
-                    PostgresBatchExportWorkflow.run,
-                    inputs,
-                    id=workflow_id,
-                    task_queue=constants.BATCH_EXPORTS_TASK_QUEUE,
-                    retry_policy=RetryPolicy(maximum_attempts=1),
-                )
+            with unittest.mock.patch(
+                "products.batch_exports.backend.temporal.destinations.postgres_batch_export.Producer.start",
+                side_effect=ValueError("A useful error message"),
+            ):
+                with pytest.raises(WorkflowFailureError):
+                    await activity_environment.client.execute_workflow(
+                        PostgresBatchExportWorkflow.run,
+                        inputs,
+                        id=workflow_id,
+                        task_queue=constants.BATCH_EXPORTS_TASK_QUEUE,
+                        retry_policy=RetryPolicy(maximum_attempts=1),
+                    )
 
     runs = await afetch_batch_export_runs(batch_export_id=postgres_batch_export.id)
     assert len(runs) == 1
@@ -1071,7 +1079,13 @@ async def test_postgres_export_workflow_handles_insert_activity_errors(ateam, po
 async def test_postgres_export_workflow_handles_insert_activity_non_retryable_errors(
     ateam, postgres_batch_export, interval
 ):
-    """Test that Postgres Export Workflow can gracefully handle non-retryable errors when inserting Postgres data."""
+    """Test that Postgres Export Workflow can gracefully handle non-retryable errors when inserting Postgres data.
+
+    This means we do the right updates to the BatchExportRun model and ensure the workflow succeeds (since we
+    treat this as a user error).
+
+    To simulate a user error, we mock the `Producer.start` activity.
+    """
     data_interval_end = dt.datetime.fromisoformat("2023-04-25T14:30:00.000000+00:00")
 
     workflow_id = str(uuid.uuid4())
@@ -1083,12 +1097,8 @@ async def test_postgres_export_workflow_handles_insert_activity_non_retryable_er
         **postgres_batch_export.destination.config,
     )
 
-    @activity.defn(name="insert_into_postgres_activity")
-    async def insert_into_postgres_activity_mocked(_: PostgresInsertInputs) -> str:
-        class InsufficientPrivilege(Exception):
-            pass
-
-        raise InsufficientPrivilege("A useful error message")
+    class InsufficientPrivilege(Exception):
+        pass
 
     async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
         async with Worker(
@@ -1097,12 +1107,15 @@ async def test_postgres_export_workflow_handles_insert_activity_non_retryable_er
             workflows=[PostgresBatchExportWorkflow],
             activities=[
                 mocked_start_batch_export_run,
-                insert_into_postgres_activity_mocked,
+                insert_into_postgres_activity,
                 finish_batch_export_run,
             ],
             workflow_runner=UnsandboxedWorkflowRunner(),
         ):
-            with pytest.raises(WorkflowFailureError):
+            with unittest.mock.patch(
+                "products.batch_exports.backend.temporal.destinations.postgres_batch_export.Producer.start",
+                side_effect=InsufficientPrivilege("A useful error message"),
+            ):
                 await activity_environment.client.execute_workflow(
                     PostgresBatchExportWorkflow.run,
                     inputs,

--- a/products/batch_exports/backend/tests/temporal/destinations/test_redshift_batch_export_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/test_redshift_batch_export_workflow.py
@@ -779,7 +779,7 @@ async def test_redshift_export_workflow(
                     id=workflow_id,
                     task_queue=constants.BATCH_EXPORTS_TASK_QUEUE,
                     retry_policy=RetryPolicy(maximum_attempts=1),
-                    execution_timeout=dt.timedelta(seconds=10),
+                    execution_timeout=dt.timedelta(seconds=20),
                 )
 
     runs = await afetch_batch_export_runs(batch_export_id=redshift_batch_export.id)

--- a/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
@@ -762,7 +762,12 @@ class TestInsertIntoS3ActivityFromStage:
 
         result = await self._run_activity(activity_environment, insert_inputs)
         assert result.error is not None
-        assert result.error == "UnsupportedFileFormatError: 'invalid' is not a supported format for S3 batch exports."
+        assert result.error.type == "UnsupportedFileFormatError"
+        assert result.error.message == "'invalid' is not a supported format for S3 batch exports."
+        assert result.error_repr is not None  # this is the error that will be returned to the user
+        assert (
+            result.error_repr == "UnsupportedFileFormatError: 'invalid' is not a supported format for S3 batch exports."
+        )
 
 
 @pytest_asyncio.fixture

--- a/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
@@ -1331,10 +1331,15 @@ class RetryableTestException(Exception):
 
 
 class TestErrorHandling:
-    async def test_s3_export_workflow_handles_insert_activity_errors(self, ateam, s3_batch_export, interval):
-        """Test S3BatchExport Workflow can handle errors from executing the insert into S3 activity.
+    async def test_s3_export_workflow_handles_unexpected_insert_activity_errors(self, ateam, s3_batch_export, interval):
+        """Test S3BatchExport Workflow can handle unexpected errors from executing the insert into S3 activity.
 
-        Currently, this only means we do the right updates to the BatchExportRun model.
+        This means we do the right updates to the BatchExportRun model and ensure the workflow fails (since we
+        treat this as an unexpected internal error).
+
+        To simulate an unexpected error, we mock the `ProducerFromInternalStage.start` activity. It doesn't matter where
+        the exception is raised, but since the insert into stage activity doesn't actually generate any data, we need to
+        raise it before the activity completes early.
         """
         data_interval_end = dt.datetime.fromisoformat("2023-04-25T14:30:00.000000+00:00")
 
@@ -1347,13 +1352,9 @@ class TestErrorHandling:
             **s3_batch_export.destination.config,
         )
 
-        @activity.defn(name="insert_into_s3_activity")
-        async def insert_into_s3_activity_mocked(_: S3InsertInputs) -> str:
-            raise RetryableTestException("A useful error message")
-
-        @activity.defn(name="insert_into_s3_activity_from_stage")
-        async def insert_into_s3_activity_from_stage_mocked(_: S3InsertInputs) -> str:
-            raise RetryableTestException("A useful error message")
+        @activity.defn(name="insert_into_internal_stage_activity")
+        async def insert_into_internal_stage_activity_mocked(_: BatchExportInsertIntoInternalStageInputs):
+            return
 
         async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
             async with Worker(
@@ -1362,21 +1363,24 @@ class TestErrorHandling:
                 workflows=[S3BatchExportWorkflow],
                 activities=[
                     mocked_start_batch_export_run,
-                    insert_into_s3_activity_mocked,
-                    insert_into_internal_stage_activity,
-                    insert_into_s3_activity_from_stage_mocked,
+                    insert_into_internal_stage_activity_mocked,
+                    insert_into_s3_activity_from_stage,
                     finish_batch_export_run,
                 ],
                 workflow_runner=UnsandboxedWorkflowRunner(),
             ):
-                with pytest.raises(WorkflowFailureError):
-                    await activity_environment.client.execute_workflow(
-                        S3BatchExportWorkflow.run,
-                        inputs,
-                        id=workflow_id,
-                        task_queue=constants.BATCH_EXPORTS_TASK_QUEUE,
-                        retry_policy=RetryPolicy(maximum_attempts=1),
-                    )
+                with mock.patch(
+                    "products.batch_exports.backend.temporal.destinations.s3_batch_export.ProducerFromInternalStage.start",
+                    side_effect=RetryableTestException("A useful error message"),
+                ):
+                    with pytest.raises(WorkflowFailureError):
+                        await activity_environment.client.execute_workflow(
+                            S3BatchExportWorkflow.run,
+                            inputs,
+                            id=workflow_id,
+                            task_queue=constants.BATCH_EXPORTS_TASK_QUEUE,
+                            retry_policy=RetryPolicy(maximum_attempts=1),
+                        )
 
         runs = await afetch_batch_export_runs(batch_export_id=s3_batch_export.id)
         assert len(runs) == 1
@@ -1392,7 +1396,12 @@ class TestErrorHandling:
     ):
         """Test S3BatchExport Workflow can handle non-retryable errors from executing the insert into S3 activity.
 
-        Currently, this only means we do the right updates to the BatchExportRun model.
+        This means we do the right updates to the BatchExportRun model and ensure the workflow succeeds (since we
+        treat this as a user error).
+
+        To simulate a user error, we mock the `ProducerFromInternalStage.start` activity. It doesn't matter where
+        the exception is raised, but since the insert into stage activity doesn't actually generate any data, we need to
+        raise it before the activity completes early.
         """
         data_interval_end = dt.datetime.fromisoformat("2023-04-25T14:30:00.000000+00:00")
 
@@ -1408,9 +1417,9 @@ class TestErrorHandling:
         class ParamValidationError(Exception):
             pass
 
-        @activity.defn(name="insert_into_s3_activity_from_stage")
-        async def insert_into_s3_activity_from_stage_mocked(_: S3InsertInputs) -> str:
-            raise ParamValidationError("A useful error message")
+        @activity.defn(name="insert_into_internal_stage_activity")
+        async def insert_into_internal_stage_activity_mocked(_: BatchExportInsertIntoInternalStageInputs):
+            return
 
         async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
             async with Worker(
@@ -1419,13 +1428,16 @@ class TestErrorHandling:
                 workflows=[S3BatchExportWorkflow],
                 activities=[
                     mocked_start_batch_export_run,
-                    insert_into_internal_stage_activity,
-                    insert_into_s3_activity_from_stage_mocked,
+                    insert_into_internal_stage_activity_mocked,
+                    insert_into_s3_activity_from_stage,
                     finish_batch_export_run,
                 ],
                 workflow_runner=UnsandboxedWorkflowRunner(),
             ):
-                with pytest.raises(WorkflowFailureError):
+                with mock.patch(
+                    "products.batch_exports.backend.temporal.destinations.s3_batch_export.ProducerFromInternalStage.start",
+                    side_effect=ParamValidationError("A useful error message"),
+                ):
                     await activity_environment.client.execute_workflow(
                         S3BatchExportWorkflow.run,
                         inputs,

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_entrypoint.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_entrypoint.py
@@ -1,0 +1,232 @@
+import datetime as dt
+import json
+import uuid
+from dataclasses import dataclass
+
+import pytest
+import pytest_asyncio
+from temporalio import activity, workflow
+from temporalio.client import WorkflowFailureError
+from temporalio.common import RetryPolicy
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+
+from posthog import constants
+from posthog.batch_exports.service import (
+    BaseBatchExportInputs,
+    BatchExportInsertInputs,
+    BatchExportModel,
+)
+from posthog.models import (
+    BatchExport,
+    BatchExportDestination,
+)
+from posthog.temporal.common.base import PostHogWorkflow
+from posthog.temporal.tests.utils.models import (
+    afetch_batch_export_runs,
+)
+from products.batch_exports.backend.temporal.batch_exports import (
+    StartBatchExportRunInputs,
+    finish_batch_export_run,
+    get_data_interval,
+    start_batch_export_run,
+)
+from products.batch_exports.backend.temporal.pipeline.entrypoint import execute_batch_export_using_internal_stage
+from products.batch_exports.backend.temporal.pipeline.internal_stage import (
+    insert_into_internal_stage_activity,
+)
+from products.batch_exports.backend.temporal.pipeline.types import BatchExportResult
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
+
+
+@pytest_asyncio.fixture
+async def batch_export(
+    ateam,
+    # temporal_client,
+):
+    """Provide a batch export for tests, not intended to be used."""
+    destination_data = {"type": "Dummy", "config": {}}
+
+    destination = await BatchExportDestination.objects.acreate(**destination_data)
+
+    batch_export = await BatchExport.objects.acreate(
+        team=ateam,
+        name="test-batch-export",
+        destination=destination,
+        interval="hour",
+    )
+
+    yield batch_export
+
+    await batch_export.adelete()
+    await destination.adelete()
+
+
+class DummyNonRetryableError(Exception):
+    def __init__(self, message: str = "This is a non-retryable error"):
+        super().__init__(message)
+
+
+class DummyRetryableError(Exception):
+    def __init__(self, message: str = "This is a retryable error"):
+        super().__init__(message)
+
+
+NON_RETRYABLE_ERROR_TYPES = ["DummyNonRetryableError"]
+
+
+@dataclass(kw_only=True)
+class DummyExportInputs(BaseBatchExportInputs):
+    """Inputs for the Dummy export workflow."""
+
+    exception_to_raise: str | None = None
+
+
+@dataclass(kw_only=True)
+class DummyInsertInputs(BatchExportInsertInputs):
+    """Inputs for the Dummy insert activity."""
+
+    exception_to_raise: str | None = None
+
+
+@workflow.defn(name="dummy-export", failure_exception_types=[workflow.NondeterminismError])
+class DummyExportWorkflow(PostHogWorkflow):
+    """A Temporal Workflow for testing the batch export entrypoint."""
+
+    @staticmethod
+    def parse_inputs(inputs: list[str]) -> DummyExportInputs:
+        """Parse inputs from the management command CLI."""
+        loaded = json.loads(inputs[0])
+        return DummyExportInputs(**loaded)
+
+    @workflow.run
+    async def run(self, inputs: DummyExportInputs):
+        """Workflow implementation to test the batch export entrypoint."""
+        is_backfill = inputs.get_is_backfill()
+        is_earliest_backfill = inputs.get_is_earliest_backfill()
+        data_interval_start, data_interval_end = get_data_interval(inputs.interval, inputs.data_interval_end)
+        should_backfill_from_beginning = is_backfill and is_earliest_backfill
+
+        start_batch_export_run_inputs = StartBatchExportRunInputs(
+            team_id=inputs.team_id,
+            batch_export_id=inputs.batch_export_id,
+            data_interval_start=data_interval_start.isoformat() if not should_backfill_from_beginning else None,
+            data_interval_end=data_interval_end.isoformat(),
+            exclude_events=inputs.exclude_events,
+            include_events=inputs.include_events,
+            backfill_id=inputs.backfill_details.backfill_id if inputs.backfill_details else None,
+        )
+        run_id = await workflow.execute_activity(
+            start_batch_export_run,
+            start_batch_export_run_inputs,
+            start_to_close_timeout=dt.timedelta(minutes=5),
+            retry_policy=RetryPolicy(
+                initial_interval=dt.timedelta(seconds=10),
+                maximum_interval=dt.timedelta(seconds=60),
+                maximum_attempts=0,
+                non_retryable_error_types=["NotNullViolation", "IntegrityError"],
+            ),
+        )
+
+        insert_inputs = DummyInsertInputs(
+            team_id=inputs.team_id,
+            data_interval_start=data_interval_start.isoformat() if not should_backfill_from_beginning else None,
+            data_interval_end=data_interval_end.isoformat(),
+            exclude_events=inputs.exclude_events,
+            include_events=inputs.include_events,
+            run_id=run_id,
+            backfill_details=inputs.backfill_details,
+            is_backfill=is_backfill,
+            batch_export_model=inputs.batch_export_model,
+            # TODO: Remove after updating existing batch exports.
+            batch_export_schema=inputs.batch_export_schema,
+            batch_export_id=inputs.batch_export_id,
+            destination_default_fields=None,
+            exception_to_raise=inputs.exception_to_raise,
+        )
+
+        await execute_batch_export_using_internal_stage(
+            insert_into_dummy_activity_from_stage,
+            insert_inputs,
+            interval=inputs.interval,
+            non_retryable_error_types=NON_RETRYABLE_ERROR_TYPES,
+        )
+        return
+
+
+@activity.defn(name="insert_into_dummy_activity_from_stage")
+async def insert_into_dummy_activity_from_stage(inputs: DummyInsertInputs) -> BatchExportResult:
+    """A mock activity to test the batch export entrypoint."""
+    if inputs.exception_to_raise:
+        # get the exception class from the string
+        exception_cls = globals()[inputs.exception_to_raise]
+        raise exception_cls()
+    return BatchExportResult(records_completed=100, bytes_exported=100)
+
+
+class TestErrorHandling:
+    async def _run_workflow(self, inputs: DummyExportInputs):
+        workflow_id = str(uuid.uuid4())
+
+        async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
+            async with Worker(
+                activity_environment.client,
+                task_queue=constants.BATCH_EXPORTS_TASK_QUEUE,
+                workflows=[DummyExportWorkflow],
+                activities=[
+                    start_batch_export_run,
+                    finish_batch_export_run,
+                    insert_into_internal_stage_activity,
+                    insert_into_dummy_activity_from_stage,
+                ],
+                workflow_runner=UnsandboxedWorkflowRunner(),
+            ):
+                # we expect the workflow to fail because of the non-retryable error
+                with pytest.raises(WorkflowFailureError):
+                    await activity_environment.client.execute_workflow(
+                        DummyExportWorkflow.run,
+                        inputs,
+                        id=workflow_id,
+                        task_queue=constants.BATCH_EXPORTS_TASK_QUEUE,
+                        retry_policy=RetryPolicy(maximum_attempts=1),
+                        execution_timeout=dt.timedelta(minutes=1),
+                    )
+
+        # Ensure the run is marked as failed
+        runs = await afetch_batch_export_runs(batch_export_id=uuid.UUID(inputs.batch_export_id))
+        assert len(runs) == 1
+        run = runs[0]
+        return run
+
+    async def test_handling_of_non_retryable_errors(self, batch_export):
+        """A non-retryable error raised by an 'insert-into-destination' activity should result in a failed batch export
+        run and a failed Temporal activity.
+        """
+        inputs = DummyExportInputs(
+            team_id=batch_export.team_id,
+            batch_export_id=str(batch_export.id),
+            interval="hour",
+            data_interval_end=dt.datetime(2025, 7, 21, 13, 0, 0, tzinfo=dt.UTC).isoformat(),
+            batch_export_model=BatchExportModel(name="events", schema=None),
+            exception_to_raise="DummyNonRetryableError",
+        )
+        run = await self._run_workflow(inputs)
+        assert run.status == "Failed"
+        assert run.latest_error == "DummyNonRetryableError: This is a non-retryable error"
+
+    async def test_handling_of_retryable_errors(self, batch_export):
+        """A retryable error raised by an 'insert-into-destination' activity should result in a failed batch export
+        run and a failed Temporal activity.
+        """
+        inputs = DummyExportInputs(
+            team_id=batch_export.team_id,
+            batch_export_id=str(batch_export.id),
+            interval="hour",
+            data_interval_end=dt.datetime(2025, 7, 21, 13, 0, 0, tzinfo=dt.UTC).isoformat(),
+            batch_export_model=BatchExportModel(name="events", schema=None),
+            exception_to_raise="DummyRetryableError",
+        )
+        run = await self._run_workflow(inputs)
+        assert run.status == "FailedRetryable"
+        assert run.latest_error == "DummyRetryableError: This is a retryable error"

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_entrypoint.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_entrypoint.py
@@ -205,7 +205,6 @@ class TestErrorHandling:
                         execution_timeout=dt.timedelta(minutes=1),
                     )
 
-        # Ensure the run is marked as failed
         runs = await afetch_batch_export_runs(batch_export_id=uuid.UUID(inputs.batch_export_id))
         assert len(runs) == 1
         run = runs[0]

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_entrypoint.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_entrypoint.py
@@ -157,8 +157,8 @@ class DummyExportWorkflow(PostHogWorkflow):
         return
 
 
-@handle_non_retryable_errors(NON_RETRYABLE_ERROR_TYPES)
 @activity.defn(name="insert_into_dummy_activity_from_stage")
+@handle_non_retryable_errors(NON_RETRYABLE_ERROR_TYPES)
 async def insert_into_dummy_activity_from_stage(inputs: DummyInsertInputs) -> BatchExportResult:
     """A mock activity to test the batch export entrypoint."""
     if inputs.exception_to_raise:


### PR DESCRIPTION
## Problem

At the moment we treat all errors raised during a batch export in a similar manner in terms of alerting, which makes it difficult to differentiate between internal errors and 'expected' user errors.

## Changes

- For non-retryable (i.e. user) errors, mark the Temporal activity as successful but mark the run as failed
    - We do this by wrapping the main activity in a try/except and checking if the exception is in the list of non-retryable errors. For now I'm comparing the exception string, which is what Temporal does, just to minimise the changes (it will also take a while to figure out where each exception is defined and import it).
    - We add a new `error` field to the `BatchExportResult` which we use to determine whether to mark the run as failed or not.
- Keep current behaviour for unexpected errors.

The changes to the destination code looks larger than they are - I'm basically just wrapping the main activity code in a try/except block that handles the retryable/non-retryable error handling logic.

## How did you test this code?

- Added new tests for the entrypoint code
- Updated existing tests for the various destinations to ensure behaviour is as expected

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
