### PR TITLE
chore: retry assertion not test to banish a flake

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -508,6 +508,192 @@
                                                                                                             join_algorithm = 'auto'
   '''
 # ---
+# name: TestCohortQuery.test_cohort_filter_with_extra.6
+  '''
+  /* cohort_calculation: */ (
+                               (SELECT persons.id AS id
+                                FROM
+                                  (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', ''), person.version) AS properties___name,
+                                          person.id AS id
+                                   FROM person
+                                   WHERE and(equals(person.team_id, 99999), in(id,
+                                                                                 (SELECT where_optimization.id AS id
+                                                                                  FROM person AS where_optimization
+                                                                                  WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, 'name'), ''), 'null'), '^"|"$', ''), 'test'), 0)))))
+                                   GROUP BY person.id
+                                   HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
+                                WHERE ifNull(equals(persons.properties___name, 'test'), 0)
+                                ORDER BY persons.id ASC
+                                LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
+                                                          join_algorithm='auto'))
+  UNION DISTINCT (
+                    (SELECT source.id AS id
+                     FROM
+                       (SELECT actor_id AS actor_id,
+                               count() AS event_count,
+                               groupUniqArray(distinct_id) AS event_distinct_ids,
+                               actor_id AS id
+                        FROM
+                          (SELECT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,
+                                  toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                                  e.uuid AS uuid,
+                                  e.distinct_id AS distinct_id
+                           FROM events AS e
+                           LEFT OUTER JOIN
+                             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                                     person_distinct_id_overrides.distinct_id AS distinct_id
+                              FROM person_distinct_id_overrides
+                              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                              GROUP BY person_distinct_id_overrides.distinct_id
+                              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+                        GROUP BY actor_id) AS source
+                     ORDER BY source.id ASC
+                     LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
+                                               join_algorithm='auto')) SETTINGS readonly=2,
+                                                                                max_execution_time=600,
+                                                                                allow_experimental_object_type=1,
+                                                                                format_csv_allow_double_quotes=0,
+                                                                                max_ast_elements=4000000,
+                                                                                max_expanded_ast_elements=4000000,
+                                                                                max_bytes_before_external_group_by=0,
+                                                                                transform_null_in=1,
+                                                                                optimize_min_equality_disjunction_chain_length=4294967295,
+                                                                                allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestCohortQuery.test_cohort_filter_with_extra.7
+  '''
+  /* cohort_calculation: */
+  SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
+  FROM
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+            countIf(timestamp > now() - INTERVAL 1 week
+                    AND timestamp < now()
+                    AND event = '$pageview'
+                    AND 1=1) > 0 AS performed_event_condition_None_level_level_0_level_1_level_0_0
+     FROM events e
+     LEFT OUTER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 99999
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+     WHERE team_id = 99999
+       AND event IN ['$pageview']
+       AND timestamp <= now()
+       AND timestamp >= now() - INTERVAL 1 week
+     GROUP BY person_id) behavior_query
+  FULL OUTER JOIN
+    (SELECT *,
+            id AS person_id
+     FROM
+       (SELECT id,
+               argMax(properties, version) as person_props
+        FROM person
+        WHERE team_id = 99999
+        GROUP BY id
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = behavior_query.person_id
+  WHERE 1 = 1
+    AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', ''))))
+          OR ((coalesce(performed_event_condition_None_level_level_0_level_1_level_0_0, false))))) SETTINGS optimize_aggregation_in_order = 1,
+                                                                                                            join_algorithm = 'auto'
+  '''
+# ---
+# name: TestCohortQuery.test_cohort_filter_with_extra.8
+  '''
+  /* cohort_calculation: */ (
+                               (SELECT persons.id AS id
+                                FROM
+                                  (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', ''), person.version) AS properties___name,
+                                          person.id AS id
+                                   FROM person
+                                   WHERE and(equals(person.team_id, 99999), in(id,
+                                                                                 (SELECT where_optimization.id AS id
+                                                                                  FROM person AS where_optimization
+                                                                                  WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, 'name'), ''), 'null'), '^"|"$', ''), 'test'), 0)))))
+                                   GROUP BY person.id
+                                   HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
+                                WHERE ifNull(equals(persons.properties___name, 'test'), 0)
+                                ORDER BY persons.id ASC
+                                LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
+                                                          join_algorithm='auto'))
+  UNION DISTINCT (
+                    (SELECT source.id AS id
+                     FROM
+                       (SELECT actor_id AS actor_id,
+                               count() AS event_count,
+                               groupUniqArray(distinct_id) AS event_distinct_ids,
+                               actor_id AS id
+                        FROM
+                          (SELECT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,
+                                  toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                                  e.uuid AS uuid,
+                                  e.distinct_id AS distinct_id
+                           FROM events AS e
+                           LEFT OUTER JOIN
+                             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                                     person_distinct_id_overrides.distinct_id AS distinct_id
+                              FROM person_distinct_id_overrides
+                              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                              GROUP BY person_distinct_id_overrides.distinct_id
+                              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+                        GROUP BY actor_id) AS source
+                     ORDER BY source.id ASC
+                     LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
+                                               join_algorithm='auto')) SETTINGS readonly=2,
+                                                                                max_execution_time=600,
+                                                                                allow_experimental_object_type=1,
+                                                                                format_csv_allow_double_quotes=0,
+                                                                                max_ast_elements=4000000,
+                                                                                max_expanded_ast_elements=4000000,
+                                                                                max_bytes_before_external_group_by=0,
+                                                                                transform_null_in=1,
+                                                                                optimize_min_equality_disjunction_chain_length=4294967295,
+                                                                                allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestCohortQuery.test_cohort_filter_with_extra.9
+  '''
+  /* cohort_calculation: */
+  SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
+  FROM
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+            countIf(timestamp > now() - INTERVAL 1 week
+                    AND timestamp < now()
+                    AND event = '$pageview'
+                    AND 1=1) > 0 AS performed_event_condition_None_level_level_0_level_1_level_0_0
+     FROM events e
+     LEFT OUTER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 99999
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+     WHERE team_id = 99999
+       AND event IN ['$pageview']
+       AND timestamp <= now()
+       AND timestamp >= now() - INTERVAL 1 week
+     GROUP BY person_id) behavior_query
+  FULL OUTER JOIN
+    (SELECT *,
+            id AS person_id
+     FROM
+       (SELECT id,
+               argMax(properties, version) as person_props
+        FROM person
+        WHERE team_id = 99999
+        GROUP BY id
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = behavior_query.person_id
+  WHERE 1 = 1
+    AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', ''))))
+          OR ((coalesce(performed_event_condition_None_level_level_0_level_1_level_0_0, false))))) SETTINGS optimize_aggregation_in_order = 1,
+                                                                                                            join_algorithm = 'auto'
+  '''
+# ---
 # name: TestCohortQuery.test_performed_event_poe_override
   '''
   

--- a/ee/clickhouse/queries/test/test_cohort_query.py
+++ b/ee/clickhouse/queries/test/test_cohort_query.py
@@ -199,9 +199,9 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         res, q, params = execute(filter, self.team)
 
         # Since all props should be pushed down here, there should be no full outer join!
-        self.assertTrue("FULL OUTER JOIN" not in q)
+        assert "FULL OUTER JOIN" not in q
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        assert [p1.uuid] == [r[0] for r in res]
 
         # This addition to the test returns the wrong result with current cohort queries
         # Uncomment after porting
@@ -219,9 +219,9 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         res, q, params = execute(filter, self.team)
 
         # No push down because of the person property in an OR
-        self.assertTrue("FULL OUTER JOIN" in q)
+        assert "FULL OUTER JOIN" in q
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        assert [p1.uuid] == [r[0] for r in res]
         """
 
     def test_performed_event(self):
@@ -271,7 +271,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        assert [p1.uuid] == [r[0] for r in res]
 
     @snapshot_clickhouse_queries
     def test_performed_event_poe_override(self):
@@ -323,7 +323,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        assert [p1.uuid] == [r[0] for r in res]
         assert "if(not(empty(overrides.distinct_id)), overrides.person_id, e.person_id) AS person_id" in q
 
     @snapshot_clickhouse_queries
@@ -389,7 +389,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        assert [p1.uuid] == [r[0] for r in res]
 
     def test_performed_event_multiple(self):
         p1 = _create_person(
@@ -449,7 +449,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        assert [p1.uuid] == [r[0] for r in res]
 
     def test_performed_event_multiple_with_event_filters(self):
         p1 = _create_person(
@@ -520,7 +520,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        assert [p1.uuid] == [r[0] for r in res]
 
     def test_performed_event_lte_1_times(self):
         _create_person(
@@ -585,7 +585,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertEqual({p2.uuid}, {r[0] for r in res})
+        assert {p2.uuid} == {r[0] for r in res}
 
     def test_can_handle_many_performed_multiple_filters(self):
         p1 = _create_person(
@@ -667,7 +667,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertEqual({p1.uuid, p2.uuid, p3.uuid}, {r[0] for r in res})
+        assert {p1.uuid, p2.uuid, p3.uuid} == {r[0] for r in res}
 
     def test_performed_event_zero_times_(self):
         filter = Filter(
@@ -689,7 +689,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
                 }
             }
         )
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             CohortQuery(filter=filter, team=self.team).get_query()
 
     def test_stopped_performing_event(self):
@@ -742,7 +742,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        assert [p1.uuid] == [r[0] for r in res]
 
     def test_stopped_performing_event_raises_if_seq_date_later_than_date(self):
         filter = Filter(
@@ -765,7 +765,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             }
         )
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             CohortQuery(filter=filter, team=self.team).get_query()
 
     def test_restarted_performing_event(self):
@@ -856,7 +856,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        assert [p1.uuid] == [r[0] for r in res]
 
     def test_restarted_performing_event_raises_if_seq_date_later_than_date(self):
         filter = Filter(
@@ -879,7 +879,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             }
         )
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             CohortQuery(filter=filter, team=self.team).get_query()
 
     def test_performed_event_first_time(self):
@@ -934,7 +934,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertEqual([p2.uuid], [r[0] for r in res])
+        assert [p2.uuid] == [r[0] for r in res]
 
     def test_performed_event_regularly(self):
         p1 = _create_person(
@@ -972,7 +972,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        assert [p1.uuid] == [r[0] for r in res]
 
     def test_performed_event_regularly_month(self):
         p1 = _create_person(
@@ -1010,7 +1010,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        assert [p1.uuid] == [r[0] for r in res]
 
     @unittest.skip(
         "flaky in west coast afternoons because we're comparing a clickhouse query using now() and something is wrong with the freezetime / test setup"
@@ -1063,11 +1063,11 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             filter = Filter(data=data)
 
             res, q, params = execute(filter, self.team)
-            self.assertCountEqual([p1.uuid, p2.uuid, p3.uuid], [r[0] for r in res])
+            assert sorted([p1.uuid, p2.uuid, p3.uuid]) == sorted([r[0] for r in res])
 
             data["properties"]["values"][0] |= {"time_value": 2, "total_periods": 3, "min_periods": 3}
             res, q, params = execute(filter, self.team)
-            self.assertCountEqual([p1.uuid, p2.uuid], [r[0] for r in res])
+            assert sorted([p1.uuid, p2.uuid]) == sorted([r[0] for r in res])
 
     def test_performed_event_regularly_with_variable_event_counts_in_each_period(self):
         p1 = _create_person(
@@ -1111,7 +1111,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         )
 
         res, q, params = execute(filter, self.team)
-        self.assertEqual([p2.uuid], [r[0] for r in res])
+        assert [p2.uuid] == [r[0] for r in res]
         flush_persons_and_events()
 
         # Filter for:
@@ -1140,7 +1140,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         )
 
         res, q, params = execute(filter, self.team)
-        self.assertCountEqual([p1.uuid, p2.uuid], [r[0] for r in res])
+        assert sorted([p1.uuid, p2.uuid]) == sorted([r[0] for r in res])
 
     @snapshot_clickhouse_queries
     def test_person_props_only(self):
@@ -1205,9 +1205,9 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         res, q, params = execute(filter, self.team)
 
         # Since all props should be pushed down here, there should be no full outer join!
-        self.assertTrue("FULL OUTER JOIN" not in q)
+        assert "FULL OUTER JOIN" not in q
 
-        self.assertCountEqual([p1.uuid, p2.uuid, p3.uuid], [r[0] for r in res])
+        assert sorted([p1.uuid, p2.uuid, p3.uuid]) == sorted([r[0] for r in res])
 
     @snapshot_clickhouse_queries
     def test_person_properties_with_pushdowns(self):
@@ -1336,7 +1336,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertCountEqual([p1.uuid, p3.uuid], [r[0] for r in res])
+        assert sorted([p1.uuid, p3.uuid]) == sorted([r[0] for r in res])
 
     @also_test_with_materialized_columns(person_properties=["$sample_field"])
     @snapshot_clickhouse_queries
@@ -1373,7 +1373,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        assert [p1.uuid] == [r[0] for r in res]
 
     def test_earliest_date_clause(self):
         filter = Filter(
@@ -1435,7 +1435,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertTrue("timestamp >= now() - INTERVAL 9 week" in (q % params))
+        assert "timestamp >= now() - INTERVAL 9 week" in (q % params)
 
     def test_earliest_date_clause_removed_for_started_at_query(self):
         filter = Filter(
@@ -1469,7 +1469,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         )
         query_class = CohortQuery(filter=filter, team=self.team)
         q, params = query_class.get_query()
-        self.assertFalse(query_class._restrict_event_query_by_time)
+        assert not query_class._restrict_event_query_by_time
         res, q, params = execute(filter, self.team)
 
     def test_negation_raises(self):
@@ -1519,7 +1519,8 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             }
         )
 
-        self.assertRaises(ValueError, lambda: CohortQuery(filter=filter, team=self.team))
+        with pytest.raises(ValueError):
+            CohortQuery(filter=filter, team=self.team)
 
     def test_negation_with_simplify_filters(self):
         _create_person(
@@ -1592,7 +1593,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         )
 
         res, q, params = execute(filter, self.team)
-        self.assertCountEqual([p3.uuid], [r[0] for r in res])
+        assert sorted([p3.uuid]) == sorted([r[0] for r in res])
 
     def test_negation_dynamic_time_bound_with_performed_event(self):
         # invalid dude because $pageview happened too early
@@ -1697,7 +1698,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertCountEqual([p3.uuid, p4.uuid], [r[0] for r in res])
+        assert sorted([p3.uuid, p4.uuid]) == sorted([r[0] for r in res])
 
     def test_negation_dynamic_time_bound_with_performed_event_sequence(self):
         # invalid dude because $pageview sequence happened too early
@@ -1836,7 +1837,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         )
 
         res, q, params = execute(filter, self.team)
-        self.assertCountEqual([p3.uuid, p4.uuid, p5.uuid, p6.uuid], [r[0] for r in res])
+        assert sorted([p3.uuid, p4.uuid, p5.uuid, p6.uuid]) == sorted([r[0] for r in res])
 
     def test_cohort_filter(self):
         p1 = _create_person(
@@ -1864,7 +1865,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        assert [p1.uuid] == [r[0] for r in res]
 
     def test_faulty_type(self):
         cohort = _create_cohort(
@@ -1884,25 +1885,22 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             ],
         )
 
-        self.assertEqual(
-            cohort.properties.to_dict(),
-            {
-                "type": "OR",
-                "values": [
-                    {
-                        "type": "AND",
-                        "values": [
-                            {
-                                "key": "email",
-                                "value": ["fake@test.com"],
-                                "operator": "exact",
-                                "type": "person",
-                            }
-                        ],
-                    }
-                ],
-            },
-        )
+        assert cohort.properties.to_dict() == {
+            "type": "OR",
+            "values": [
+                {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "key": "email",
+                            "value": ["fake@test.com"],
+                            "operator": "exact",
+                            "type": "person",
+                        }
+                    ],
+                }
+            ],
+        }
 
     def test_missing_type(self):
         cohort = _create_cohort(
@@ -1921,25 +1919,22 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             ],
         )
 
-        self.assertEqual(
-            cohort.properties.to_dict(),
-            {
-                "type": "OR",
-                "values": [
-                    {
-                        "type": "AND",
-                        "values": [
-                            {
-                                "key": "email",
-                                "value": ["fake@test.com"],
-                                "operator": "exact",
-                                "type": "person",
-                            }
-                        ],
-                    }
-                ],
-            },
-        )
+        assert cohort.properties.to_dict() == {
+            "type": "OR",
+            "values": [
+                {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "key": "email",
+                            "value": ["fake@test.com"],
+                            "operator": "exact",
+                            "type": "person",
+                        }
+                    ],
+                }
+            ],
+        }
 
     def test_old_old_style_properties(self):
         cohort = _create_cohort(
@@ -1959,32 +1954,29 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             ],
         )
 
-        self.assertEqual(
-            cohort.properties.to_dict(),
-            {
-                "type": "OR",
-                "values": [
-                    {
-                        "type": "AND",
-                        "values": [
-                            {
-                                "key": "email",
-                                "value": ["fake@test.com"],
-                                "operator": "exact",
-                                "type": "person",
-                            }
-                        ],
-                    },
-                    {
-                        "type": "AND",
-                        "values": [
-                            {"key": "abra", "value": "cadabra", "type": "person"},
-                            {"key": "name", "value": "alakazam", "type": "person"},
-                        ],
-                    },
-                ],
-            },
-        )
+        assert cohort.properties.to_dict() == {
+            "type": "OR",
+            "values": [
+                {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "key": "email",
+                            "value": ["fake@test.com"],
+                            "operator": "exact",
+                            "type": "person",
+                        }
+                    ],
+                },
+                {
+                    "type": "AND",
+                    "values": [
+                        {"key": "abra", "value": "cadabra", "type": "person"},
+                        {"key": "name", "value": "alakazam", "type": "person"},
+                    ],
+                },
+            ],
+        }
 
     def test_precalculated_cohort_filter(self):
         p1 = _create_person(
@@ -2022,7 +2014,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             # since we want cohort calculation with cohort properties to not be out of sync
             res, q, params = execute(filter, self.team)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        assert [p1.uuid] == [r[0] for r in res]
 
     @snapshot_clickhouse_queries
     def test_precalculated_cohort_filter_with_extra_filters(self):
@@ -2061,7 +2053,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             q, params = CohortQuery(filter=filter, team=self.team).get_query()
             res, q, params = execute(filter, self.team)
 
-        self.assertCountEqual([p1.uuid, p2.uuid], [r[0] for r in res])
+        assert sorted([p1.uuid, p2.uuid]) == sorted([r[0] for r in res])
 
     @snapshot_clickhouse_queries
     @pytest.mark.flaky(max_runs=2)
@@ -2235,7 +2227,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         cohort.calculate_people_ch(pending_version=0)
         res, q, params = execute(filter, self.team)
 
-        self.assertEqual([p2.uuid], [r[0] for r in res])
+        assert [p2.uuid] == [r[0] for r in res]
 
     @snapshot_clickhouse_queries
     def test_static_cohort_filter(self):
@@ -2259,7 +2251,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        assert [p1.uuid] == [r[0] for r in res]
 
     @snapshot_clickhouse_queries
     def test_static_cohort_filter_with_extra(self):
@@ -2306,7 +2298,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertEqual([p2.uuid], [r[0] for r in res])
+        assert [p2.uuid] == [r[0] for r in res]
 
         filter = Filter(
             data={
@@ -2330,7 +2322,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertCountEqual([p1.uuid, p2.uuid], [r[0] for r in res])
+        assert sorted([p1.uuid, p2.uuid]) == sorted([r[0] for r in res])
 
     @snapshot_clickhouse_queries
     def test_performed_event_sequence(self):
@@ -2381,7 +2373,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        assert [p1.uuid] == [r[0] for r in res]
 
     @also_test_with_materialized_columns(event_properties=["$current_url"])
     def test_performed_event_sequence_with_action(self):
@@ -2450,7 +2442,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        assert [p1.uuid] == [r[0] for r in res]
 
     def test_performed_event_sequence_with_restarted(self):
         p1 = _create_person(
@@ -2517,7 +2509,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertEqual(sorted([p1.uuid, p2.uuid]), sorted([r[0] for r in res]))
+        assert sorted([p1.uuid, p2.uuid]) == sorted([r[0] for r in res])
 
     def test_performed_event_sequence_with_extra_conditions(self):
         p1 = _create_person(
@@ -2593,7 +2585,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        assert [p1.uuid] == [r[0] for r in res]
 
     @snapshot_clickhouse_queries
     def test_performed_event_sequence_with_person_properties(self):
@@ -2700,7 +2692,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        assert [p1.uuid] == [r[0] for r in res]
 
     def test_multiple_performed_event_sequence(self):
         p1 = _create_person(
@@ -2786,7 +2778,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        assert [p1.uuid] == [r[0] for r in res]
 
     @snapshot_clickhouse_queries
     def test_performed_event_sequence_and_clause_with_additional_event(self):
@@ -2861,7 +2853,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertEqual({p1.uuid, p2.uuid}, {r[0] for r in res})
+        assert {p1.uuid, p2.uuid} == {r[0] for r in res}
 
     @snapshot_clickhouse_queries
     def test_unwrapping_static_cohort_filter_hidden_in_layers_of_cohorts(self):
@@ -2962,7 +2954,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         other_cohort.calculate_people_ch(pending_version=0)
         res, q, params = execute(filter, self.team)
 
-        self.assertCountEqual([p2.uuid, p3.uuid], [r[0] for r in res])
+        assert sorted([p2.uuid, p3.uuid]) == sorted([r[0] for r in res])
 
     def test_unwrap_with_negated_cohort(self):
         _create_person(
@@ -3081,7 +3073,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         cohort2.calculate_people_ch(pending_version=0)
         res, q, params = execute(filter, self.team)
 
-        self.assertCountEqual([p2.uuid], [r[0] for r in res])
+        assert sorted([p2.uuid]) == sorted([r[0] for r in res])
 
     def test_unwrap_multiple_levels(self):
         _create_person(
@@ -3232,7 +3224,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         res, q, params = execute(filter, self.team)
 
-        self.assertCountEqual([p4.uuid], [r[0] for r in res])
+        assert sorted([p4.uuid]) == sorted([r[0] for r in res])
 
     def test_performed_event_regularly_years_interval(self):
         # Person 1: Matches the condition - has 2 "Application Opened" events per year
@@ -3354,10 +3346,10 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         res, q, params = execute(filter, self.team)
 
         # Only person 1 should match
-        self.assertEqual(len(res), 1)
-        self.assertEqual(res[0][0], p1.uuid)
-        self.assertNotIn(p2.uuid, [r[0] for r in res])
-        self.assertNotIn(p3.uuid, [r[0] for r in res])
+        assert len(res) == 1
+        assert res[0][0] == p1.uuid
+        assert p2.uuid not in [r[0] for r in res]
+        assert p3.uuid not in [r[0] for r in res]
 
     def test_person_property_with_value_list(self):
         # Create people with different email values
@@ -3418,11 +3410,11 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         res, q, params = execute(filter, self.team)
 
         # Person 1 and 2 should match because their emails are in the list
-        self.assertEqual(len(res), 2)
+        assert len(res) == 2
         result_uuids = [r[0] for r in res]
-        self.assertIn(p1.uuid, result_uuids)
-        self.assertIn(p2.uuid, result_uuids)
-        self.assertNotIn(p3.uuid, result_uuids)
+        assert p1.uuid in result_uuids
+        assert p2.uuid in result_uuids
+        assert p3.uuid not in result_uuids
 
 
 class TestCohortNegationValidation(BaseTest):
@@ -3436,8 +3428,8 @@ class TestCohortNegationValidation(BaseTest):
         )
 
         has_pending_neg, has_reg = check_negation_clause(property_group)
-        self.assertEqual(has_pending_neg, False)
-        self.assertEqual(has_reg, True)
+        assert has_pending_neg is False
+        assert has_reg is True
 
     def test_valid_negation_tree_with_extra_layers(self):
         property_group = PropertyGroup(
@@ -3471,8 +3463,8 @@ class TestCohortNegationValidation(BaseTest):
         )
 
         has_pending_neg, has_reg = check_negation_clause(property_group)
-        self.assertEqual(has_pending_neg, False)
-        self.assertEqual(has_reg, True)
+        assert has_pending_neg is False
+        assert has_reg is True
 
     def test_invalid_negation_tree_with_extra_layers(self):
         property_group = PropertyGroup(
@@ -3513,8 +3505,8 @@ class TestCohortNegationValidation(BaseTest):
         )
 
         has_pending_neg, has_reg = check_negation_clause(property_group)
-        self.assertEqual(has_pending_neg, True)
-        self.assertEqual(has_reg, True)
+        assert has_pending_neg is True
+        assert has_reg is True
 
     def test_valid_negation_tree_with_extra_layers_recombining_at_top(self):
         property_group = PropertyGroup(
@@ -3555,8 +3547,8 @@ class TestCohortNegationValidation(BaseTest):
         )
 
         has_pending_neg, has_reg = check_negation_clause(property_group)
-        self.assertEqual(has_pending_neg, False)
-        self.assertEqual(has_reg, True)
+        assert has_pending_neg is False
+        assert has_reg is True
 
     def test_invalid_negation_tree_no_positive_filter(self):
         property_group = PropertyGroup(
@@ -3597,15 +3589,15 @@ class TestCohortNegationValidation(BaseTest):
         )
 
         has_pending_neg, has_reg = check_negation_clause(property_group)
-        self.assertEqual(has_pending_neg, True)
-        self.assertEqual(has_reg, False)
+        assert has_pending_neg is True
+        assert has_reg is False
 
     def test_empty_property_group(self):
         property_group = PropertyGroup(type=PropertyOperatorType.AND, values=[])  # type: ignore
 
         has_pending_neg, has_reg = check_negation_clause(property_group)
-        self.assertEqual(has_pending_neg, False)
-        self.assertEqual(has_reg, False)
+        assert has_pending_neg is False
+        assert has_reg is False
 
     def test_basic_invalid_negation_tree(self):
         property_group = PropertyGroup(
@@ -3614,8 +3606,8 @@ class TestCohortNegationValidation(BaseTest):
         )
 
         has_pending_neg, has_reg = check_negation_clause(property_group)
-        self.assertEqual(has_pending_neg, True)
-        self.assertEqual(has_reg, False)
+        assert has_pending_neg is True
+        assert has_reg is False
 
     def test_basic_valid_negation_tree_with_no_negations(self):
         property_group = PropertyGroup(
@@ -3624,8 +3616,8 @@ class TestCohortNegationValidation(BaseTest):
         )
 
         has_pending_neg, has_reg = check_negation_clause(property_group)
-        self.assertEqual(has_pending_neg, False)
-        self.assertEqual(has_reg, True)
+        assert has_pending_neg is False
+        assert has_reg is True
 
     def test_type_misalignment(self):
         PropertyDefinition.objects.create(


### PR DESCRIPTION
i think this test was flaking because the cohort needed to finish calculating

so instead of re-running the test and maybe there's enough time between calculating and asserting

we now retry the assertion a few times

(also switched assert style while i was in the file)