### PR TITLE
refactor(max): Use team taxonomy for events

### DIFF
--- a/ee/hogai/eval/eval_tool_filter_generation.py
+++ b/ee/hogai/eval/eval_tool_filter_generation.py
@@ -21,6 +21,7 @@ from products.replay.backend.max_tools import (
     PRODUCT_DESCRIPTION_PROMPT,
     SESSION_REPLAY_RESPONSE_FORMATS_PROMPT,
     SESSION_REPLAY_EXAMPLES_PROMPT,
+    MULTIPLE_FILTERS_PROMPT,
 )
 
 logger = logging.getLogger(__name__)
@@ -46,6 +47,7 @@ def call_search_session_recordings(demo_org_team_user):
         "product_description_prompt": PRODUCT_DESCRIPTION_PROMPT,
         "response_formats_prompt": SESSION_REPLAY_RESPONSE_FORMATS_PROMPT,
         "examples_prompt": SESSION_REPLAY_EXAMPLES_PROMPT,
+        "multiple_filters_prompt": MULTIPLE_FILTERS_PROMPT,
     }
     graph = FilterOptionsGraph(
         demo_org_team_user[1], demo_org_team_user[2], injected_prompts=injected_prompts
@@ -151,7 +153,7 @@ async def eval_tool_search_session_recordings(call_search_session_recordings):
                 input="show me recordings of users that were using a mobile device",
                 expected=MaxRecordingUniversalFilters(
                     **{
-                        "date_from": "-3d",
+                        "date_from": "-7d",
                         "date_to": None,
                         "duration": [{"key": "duration", "type": "recording", "value": 60, "operator": "gt"}],
                         "filter_group": {
@@ -179,7 +181,7 @@ async def eval_tool_search_session_recordings(call_search_session_recordings):
                 input="show me recordings of users who signed up on mobile",
                 expected=MaxRecordingUniversalFilters(
                     **{
-                        "date_from": "-3d",
+                        "date_from": "-7d",
                         "date_to": None,
                         "duration": [{"key": "duration", "type": "recording", "value": 60, "operator": "gt"}],
                         "filter_group": {

--- a/ee/hogai/eval/eval_tool_filter_generation.py
+++ b/ee/hogai/eval/eval_tool_filter_generation.py
@@ -148,7 +148,35 @@ async def eval_tool_search_session_recordings(call_search_session_recordings):
         data=[
             # Test basic filter generation for mobile devices
             EvalCase(
-                input="show me the last 3 days for users that were using a mobile device",
+                input="show me recordings of users that were using a mobile device",
+                expected=MaxRecordingUniversalFilters(
+                    **{
+                        "date_from": "-3d",
+                        "date_to": None,
+                        "duration": [{"key": "duration", "type": "recording", "value": 60, "operator": "gt"}],
+                        "filter_group": {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "type": "AND",
+                                    "values": [
+                                        {
+                                            "key": "$device_type",
+                                            "type": "event",
+                                            "value": ["Mobile"],
+                                            "operator": "exact",
+                                        }
+                                    ],
+                                }
+                            ],
+                        },
+                        "filter_test_accounts": True,
+                        "order": "start_time",
+                    }
+                ),
+            ),
+            EvalCase(
+                input="show me recordings of users who signed up on mobile",
                 expected=MaxRecordingUniversalFilters(
                     **{
                         "date_from": "-3d",

--- a/ee/hogai/eval/eval_tool_filter_generation.py
+++ b/ee/hogai/eval/eval_tool_filter_generation.py
@@ -148,10 +148,10 @@ async def eval_tool_search_session_recordings(call_search_session_recordings):
         data=[
             # Test basic filter generation for mobile devices
             EvalCase(
-                input="Show me recordings from mobile devices",
+                input="show me the last 3 days for users that were using a mobile device",
                 expected=MaxRecordingUniversalFilters(
                     **{
-                        "date_from": "-7d",
+                        "date_from": "-3d",
                         "date_to": None,
                         "duration": [{"key": "duration", "type": "recording", "value": 60, "operator": "gt"}],
                         "filter_group": {
@@ -177,8 +177,8 @@ async def eval_tool_search_session_recordings(call_search_session_recordings):
             ),
             # Test date range filtering
             EvalCase(
-                input="Show recordings from the last 24 hours",
-                expected=MaxRecordingUniversalFilters(**{**DUMMY_CURRENT_FILTERS, "date_from": "-1d"}),
+                input="Show recordings from the last 2 hours",
+                expected=MaxRecordingUniversalFilters(**{**DUMMY_CURRENT_FILTERS, "date_from": "-2h"}),
             ),
             # Test location filtering
             EvalCase(
@@ -207,7 +207,7 @@ async def eval_tool_search_session_recordings(call_search_session_recordings):
             ),
             # Test browser-specific filtering
             EvalCase(
-                input="Show recordings from Chrome users",
+                input="Show recordings from users that were using a browser in English",
                 expected=MaxRecordingUniversalFilters(
                     **{
                         **DUMMY_CURRENT_FILTERS,
@@ -217,7 +217,12 @@ async def eval_tool_search_session_recordings(call_search_session_recordings):
                                 {
                                     "type": "AND",
                                     "values": [
-                                        {"key": "$browser", "type": "event", "value": ["Chrome"], "operator": "exact"}
+                                        {
+                                            "key": "$browser_language",
+                                            "type": "person",
+                                            "value": ["EN-en"],
+                                            "operator": "exact",
+                                        }
                                     ],
                                 }
                             ],

--- a/ee/hogai/graph/filter_options/nodes.py
+++ b/ee/hogai/graph/filter_options/nodes.py
@@ -31,7 +31,6 @@ from .prompts import (
     DATE_FIELDS_PROMPT,
     TOOL_USAGE_PROMPT,
     EXAMPLES_PROMPT,
-    EVENT_DEFINITIONS_PROMPT,
 )
 from posthog.models.group_type_mapping import GroupTypeMapping
 from .toolkit import EntityType, FilterOptionsTool, FilterOptionsToolkit, ask_user_for_help, final_answer
@@ -104,7 +103,6 @@ class FilterOptionsNode(FilterOptionsBaseNode):
         system_messages = [
             ("system", dynamic_filter_prompt),  # Use dynamic prompt instead of static
             ("system", self._get_react_property_filters_prompt()),
-            ("system", EVENT_DEFINITIONS_PROMPT),
             ("system", HUMAN_IN_THE_LOOP_PROMPT),
         ]
 

--- a/ee/hogai/graph/filter_options/nodes.py
+++ b/ee/hogai/graph/filter_options/nodes.py
@@ -31,6 +31,7 @@ from .prompts import (
     DATE_FIELDS_PROMPT,
     TOOL_USAGE_PROMPT,
     EXAMPLES_PROMPT,
+    EVENT_DEFINITIONS_PROMPT,
 )
 from posthog.models.group_type_mapping import GroupTypeMapping
 from .toolkit import EntityType, FilterOptionsTool, FilterOptionsToolkit, ask_user_for_help, final_answer
@@ -44,6 +45,7 @@ from .prompts import (
     FILTER_OPTIONS_ITERATION_LIMIT_PROMPT,
 )
 from ee.hogai.llm import MaxChatOpenAI
+from ee.hogai.utils.helpers import format_events_prompt
 
 
 class FilterOptionsNode(FilterOptionsBaseNode):
@@ -102,19 +104,16 @@ class FilterOptionsNode(FilterOptionsBaseNode):
         system_messages = [
             ("system", dynamic_filter_prompt),  # Use dynamic prompt instead of static
             ("system", self._get_react_property_filters_prompt()),
+            ("system", EVENT_DEFINITIONS_PROMPT),
             ("system", HUMAN_IN_THE_LOOP_PROMPT),
         ]
 
-        messages = [*system_messages, ("human", USER_FILTER_OPTIONS_PROMPT)]
+        progress_messages = getattr(state, "tool_progress_messages", [])
 
-        # Add any existing tool messages from state
-        conversation = ChatPromptTemplate(messages, template_format="mustache")
-
-        progress_messages = list(getattr(state, "tool_progress_messages", []))
-        all_messages = [*conversation.messages, *progress_messages]
-
-        full_conversation = ChatPromptTemplate(all_messages, template_format="mustache")
-
+        full_conversation = ChatPromptTemplate(
+            [*system_messages, ("human", USER_FILTER_OPTIONS_PROMPT), *progress_messages],
+            template_format="mustache",
+        )
         return full_conversation
 
     def _get_filter_generation_prompt(self, injected_prompts: dict) -> str:
@@ -156,6 +155,10 @@ class FilterOptionsNode(FilterOptionsBaseNode):
         if not change.strip():
             change = "Show me all session recordings with default filters"
 
+        events_in_context = []
+        if ui_context := self._get_ui_context(state):
+            events_in_context = ui_context.events if ui_context.events else []
+
         # Use injected prompts if available, otherwise fall back to default prompts
         output_message = chain.invoke(
             {
@@ -163,6 +166,7 @@ class FilterOptionsNode(FilterOptionsBaseNode):
                 "groups": self._all_entities,
                 "change": change,
                 "current_filters": current_filters,
+                "events": format_events_prompt(events_in_context, self._team),
             },
             config,
         )
@@ -207,7 +211,6 @@ class FilterOptionsToolsNode(FilterOptionsBaseNode, ABC):
         else:
             # First check if we've reached the terminal stage and return the filter options
             if input.name == "final_answer":
-                # Extract the full response structure
                 full_response = {
                     "data": input.arguments.data,  # type: ignore
                 }

--- a/ee/hogai/graph/filter_options/prompts.py
+++ b/ee/hogai/graph/filter_options/prompts.py
@@ -1,65 +1,42 @@
 from datetime import datetime
 
-RESPONSE_FORMATS_PROMPT = """
-<response_formats>
-Formats of responses
-1. Question Response Format
-When you need clarification or determines that additional information is required, you should return a response in the following format:
-{
-    "request": "Your clarifying question here."
-}
-2. Filter Response Format
-Once all necessary data is collected, the agent should return the filter in this structured format:
-{
-    "data": {
-        "date_from": "<date_from>",
-        "date_to": "<date_to>",
-        "duration": [{"key": "duration", "type": "recording", "value": <duration>, "operator": "gt"}],  // Use "gt", "lt", "gte", "lte"
-        "filter_group": {
-            "type": "<FilterLogicalOperator>",
-            "values": [
-            {
-                "type": "<FilterLogicalOperator>",
-                "values": [
-                    {
-                        "key": "<key>",
-                        "type": "<PropertyFilterType>",
-                        "value": ["<value>"],
-                        "operator": "<PropertyOperator>"
-                    },
-                ],
-                ...
-            },
-        ]
-    }
-}
+FILTER_INITIAL_PROMPT = """
 
-Notes:
-1. Replace <date_from> and <date_to> with valid date strings.
-2. <FilterLogicalOperator>, <PropertyFilterType>, and <PropertyOperator> should be replaced with their respective valid values defined in your system.
-3. The filter_group structure is nested. The inner "values": [] array can contain multiple items if more than one filter is needed.
-4. Ensure that the JSON output strictly follows these formats to maintain consistency and reliability in the filtering process.
+{{{product_description_prompt}}}
 
-WHEN GENERATING A FILTER BASED ON MORE THAN ONE PROPERTY ALWAYS MAKE SURE TO KEEP THE OLD FILTERS. NEVER REMOVE ANY FILTERS.
-</response_formats>
+{{{group_property_filter_types_prompt}}}
+
+{{{multiple_filters_prompt}}}
+
+{{{response_formats_prompt}}}
+
+{{{date_fields_prompt}}}
+
+{{{filter_logical_operators_prompt}}}
+
+{{{examples_prompt}}}
+
+{{{tool_usage_prompt}}}
 
 """.strip()
 
-TOOL_USAGE_PROMPT = """
+day = datetime.now().day
+today_date = datetime.now().strftime(f"{day} %B %Y")
+FILTER_INITIAL_PROMPT += f"\nToday is {today_date}."
 
+
+TOOL_USAGE_PROMPT = """
+<tool_usage>
 ## Tool Usage Rules
 1. **Property Discovery Required**: Use tools to find properties.
-2. Users can be looking for properties related to PERSON, SESSION, ORGANIZATION, or EVENT. EVENTS ARE NOT ENTITIES. THEY HAVE THEIR OWN PROPERTIES AND VALUES.
+2. **CRITICAL DISTINCTION**: EVENTS ARE NOT ENTITIES. THEY HAVE THEIR OWN PROPERTIES AND VALUES.
 
-2. **Tool Workflow**:
-   - Infer if the user is asking for a person, session, organization, or event property.
-   - Use `retrieve_entity_properties` to discover available properties for an entity such as person, session, organization, etc.
-   - Use `retrieve_entity_property_values` to get possible values for a specific property related to person, session, organization, etc.
-   - Use `retrieve_event_properties` to discover available properties for an event
-   - Use `retrieve_event_property_values` to get possible values for a specific property related to event.
+3. **Tool Workflow**:
+   - **For ENTITY properties** (person, session, organization, groups): Use `retrieve_entity_properties` and `retrieve_entity_property_values`
+   - **For EVENT properties** (properties of specific events like pageview, signup, etc.): Use `retrieve_event_properties` and `retrieve_event_property_values`
    - Use `ask_user_for_help` when you need clarification
    - Use `final_answer` only when you have complete filter information
-   - *CRITICAL*: Call the event tools if you have found a property related to event, do not call the entity tools.
+   - *CRITICAL*: NEVER use entity tools for event properties. NEVER use event tools for entity properties.
    - *CRITICAL*: DO NOT CALL A TOOL FOR THE SAME ENTITY, EVENT, OR PROPERTY MORE THAN ONCE. IF YOU HAVE NOT FOUND A MATCH YOU MUST TRY WITH THE NEXT BEST MATCH.
 
 3. **When to Ask for Help**:
@@ -70,71 +47,69 @@ TOOL_USAGE_PROMPT = """
 
 4. **Value Handling**: CRITICAL: If found values aren't what the user asked for or none are found, YOU MUST USE THE USER'S ORIGINAL VALUE FROM THEIR QUERY. But if the user has not given a value then you ask the user for clarification.
 
-5. **Multi-Filter Example**: If user mentions "mobile users who completed signup":
-   - Filter 1: Infer entity type "person" for "mobile" → find $device_type property → get values → use "Mobile"
-   - Filter 2: Infer entity type "event" for "signup" → find $signup_event → get event properties if needed
-   - Combine both filters with AND logic
-   - Use `final_answer` only when ALL filters are processed
-
-6. Use the output of the tools to build the filter. Merge the results for each filter component into a single filter.
-
+5. **Tool Selection Decision Tree**:
+   - If the user mentions a property that belongs to a person (browser, device, location, etc.) → use entity tools with entity="person"
+   - If the user mentions a property that belongs to a session (duration, start time, etc.) → use entity tools with entity="session"
+   - If the user mentions a property that belongs to a group (organization, account, etc.) → use entity tools with entity="[group_name]"
+   - If the user mentions an action or event (signup, purchase, pageview, etc.) → use event tools with event_name="[event_name]"
+</tool_usage>
 """.strip()
 
-ALGORITHM_PROMPT = """
-<algorithm>
-Strictly follow this algorithm:
-1. Verify Query Relevance: Confirm that the user's question is related to filter generation.
-2. Handle Irrelevant Queries: If the question is not related, return a response that explains why the query is outside the scope.
-3. **MULTI-FILTER ANALYSIS**: Identify ALL filter components in the user's request. Don't stop at the first filter - look for additional conditions using words like "and", "also", "who", "where", "with", etc.
-4. **ENTITY TYPE INFERENCE**: For EACH filter component identified, infer the appropriate entity type (person, event, session, etc.). Multiple filters can target different entity types.
-5. **PROPERTY DISCOVERY**: For EACH entity type and filter component, use `retrieve_entity_properties` or `retrieve_event_properties` to discover relevant properties. Don't skip any filter component.
-6. **VALUE DISCOVERY**: For EACH property you need to filter on, use `retrieve_entity_property_values` or `retrieve_event_property_values` to discover possible values.
-7. **SOME FILTERS MAY BE MISSING**: If you can only partially find the filter components, return what you found and ask clarification for the other filters.
-8. **FALLBACK TO USER VALUES**: If you found no property values or they don't match what the user asked, use the value that the user provided in their query.
-9. **COMBINE FILTERS**: Structure all filters using appropriate logical operators (AND/OR) based on user intent. Use nested filter groups for complex combinations.
-10. Return Structured Filter: Once all required data is collected, return a response with result containing the correctly structured answer as per the answer structure guidelines below.
-</algorithm>
-
-""".strip()
 
 GROUP_PROPERTY_FILTER_TYPES_PROMPT = """
+<property_filter_types>
 PostHog users can filter their data using various properties and values.
 Properties are classified into groups based on the source of the property or a user defined group. Each project has its own set of custom property groups, but there are also some core property groups that are available to all projects.
-For example, properties can of events, persons, actions, cohorts, sessions properties and more custom groups.
 
-Properties can orginate from the following sources:
+**CRITICAL**: There are two main categories of properties - ENTITY properties and EVENT properties. They use different tools.
 
+<entity>
+**ENTITY PROPERTIES** (use `retrieve_entity_properties` and `retrieve_entity_property_values`):
+
+<person>
 - Person Properties:
     Are associated with a person. For example, $browser, email, name, is_signed_up etc.
     Use the "name" field from the Person properties array (e.g., $browser, $device_type, email).
     Example: If filtering on browser type, you might use the key $browser.
-    Use `retrieve_entity_properties` to get the list of all available person properties.
+    Use `retrieve_entity_properties` with entity="person" to get the list of all available person properties.
+</person>
 
+<session>
 - Session Properties:
     Are associated with a session. For example, $start_timestamp, $entry_current_url, session duration etc.
     Use the "name" field from the Session properties array (e.g., $start_timestamp, $entry_current_url).
     Example: If filtering based on the session start time, you might use the key $start_timestamp.
-    Use `retrieve_entity_properties` to get the list of all available session properties.
+    Use `retrieve_entity_properties` with entity="session" to get the list of all available session properties.
+</session>
 
+<group>
+- Group Properties:
+    PostHog users can group these events into custom groups. For example organisation, instance, account etc.
+    This is the list of all the groups that this user can generate filters for:
+    {{#groups}}{{.}}{{^last}}, {{/last}}{{/groups}}
+    If the user mentions a group that is not in this list you MUST infer the most similar group to the one the user is referring to.
+    Use `retrieve_entity_properties` with entity="[group_name]" to get the list of all available group properties.
+</group>
+</entity>
+<events>
+**EVENT PROPERTIES** (use `retrieve_event_properties` and `retrieve_event_property_values`):
 - Event Properties:
-    Properties of an event. For example, $current_url, $browser, $ai_error etc
-    Use the "name" field from the Event properties array (e.g. $current_url).
-    Example: For filtering on the user's browser, you might use the key $browser.
+    Properties of specific events. For example, if someone says "users who completed signup", you need to find the "signup" event and then get its properties.
+    Use `retrieve_event_properties` with event_name="signup" to get properties of the signup event.
+    Example: For filtering on the user's browser during signup, you might use the key $browser from the signup event.
 
-PostHog users can group these events into custom groups. For example organisation, instance, account etc.
+Here is a non-exhaustive list of known event names:
+{{{events}}}
 
-These groups are also used for filtering.
-This is the list of all the groups that this user can generate filters for:
-{{#groups}}, {{.}}{{/groups}}
-If the user mentions a group that is not in this list you MUST infer the most similar group to the one the user is referring to.
-
+If you find the event name the user is asking for in the list, use it to retrieve the event properties.
+</events>
+</property_filter_types>
 """.strip()
 
 FILTER_LOGICAL_OPERATORS_PROMPT = """
 <filter_logical_operator>
 - Definition: The FilterLogicalOperator defines how filters should be combined.
 - Allowed Values: 'AND' or 'OR'
-- Usage: Use it as an enum. For example, use FilterLogicalOperator.AND when filters must all be met (logical AND) or FilterLogicalOperator.OR when any filter match is acceptable (logical OR).
 
 Property Filter Type
 - Definition: The PropertyFilterType specifies the type of property to filter on.
@@ -195,6 +170,153 @@ date_to:
 - Default Value: Set as null when the date range extends to today.
 - Custom Date: If a specific end date is required, use the format "YYYY-MM-DD".
 </date_fields>
+""".strip()
+
+FILTER_FIELDS_TAXONOMY_PROMPT = """
+<filter_fields_taxonomy>
+Below you will find information on how to correctly discover the taxonomy of the user's data.
+
+<key> Field
+
+- Purpose:
+The <key> represents the name of the property on which the filter is applied.
+
+- Type Determination:
+The expected data type can be inferred from the property_type field provided in each property object:
+- "String" indicates the value should be a string.
+- "Numeric" indicates a numeric value.
+- "Boolean" indicates a boolean value.
+- "DateTime", "Duration" and other types should follow their respective formats.
+- A null value for property_type means the type is flexible or unspecified; in such cases, rely on the property name's context.
+</key>
+
+<value> Field
+
+- Purpose:
+The <value> field is an array containing one or more values that the filter should match.
+
+- Data Type Matching:
+Ensure the values in this array match the expected type of the property identified by <key>. For example:
+- For a property with property_type "String", the value should be provided as a string (e.g., ["Mobile"]).
+- For a property with property_type "Numeric", the value should be a number (e.g., [10]).
+- For a property with property_type "Boolean", the value should be either true or false (e.g., [true]).
+
+- Multiple Values:
+The <value> array can contain multiple items when the filter should match any one of several potential values.
+
+
+<supported_operators>
+Supported operators for the String or Numeric types are:
+- equals
+- doesn't equal
+- contains
+- doesn't contain
+- matches regex
+- doesn't match regex
+- is set
+- is not set
+
+Supported operators for the DateTime type are:
+- equals
+- doesn't equal
+- greater than
+- less than
+- is set
+- is not set
+
+Supported operators for the Boolean type are:
+- equals
+- doesn't equal
+- is set
+- is not set
+
+All operators take a single value except for `equals` and `doesn't equal` which can take one or more values.
+</supported_operators>
+
+</filter_fields_taxonomy>
+
+""".strip()
+
+
+HUMAN_IN_THE_LOOP_PROMPT = """
+<human_in_the_loop>
+
+Ask the user for clarification if:
+- The user's question is ambiguous.
+- You can't find matching events or properties.
+- You can't find matching property values.
+- You're unable to build a filter that effectively answers the user's question.
+- Use the `ask_user_for_help` tool to ask the user for clarification.
+
+</human_in_the_loop>
+""".strip()
+
+FILTER_OPTIONS_ITERATION_LIMIT_PROMPT = """I've tried several approaches but haven't been able to find the right filtering options. Could you please be more specific about what kind of filters you're looking for? For example:
+- What type of events or actions are you interested in?
+- What properties do you want to filter on?
+- Are you looking for specific values or ranges?"""
+
+REACT_PYDANTIC_VALIDATION_EXCEPTION_PROMPT = """I encountered an error while validating the tool input. Here's what went wrong:
+{{{exception}}}
+
+Please help me understand what you're looking for more clearly, and I'll try again.""".strip()
+
+
+USER_FILTER_OPTIONS_PROMPT = """
+Goal: {{{change}}}
+
+Current filters: {{{current_filters}}}
+
+DO NOT CHANGE THE FIELDS THAT ARE NOT MENTIONED IN THE USER'S QUERY. UPDATE ONLY THE FIELDS THAT ARE MENTIONED IN THE USER'S QUERY.
+
+""".strip()
+
+
+## Default response formats and examples
+
+RESPONSE_FORMATS_PROMPT = """
+<response_formats>
+Formats of responses
+1. Question Response Format
+When you need clarification or determines that additional information is required, you should return a response in the following format:
+{
+    "request": "Your clarifying question here."
+}
+2. Filter Response Format
+Once all necessary data is collected, the agent should return the filter in this structured format:
+{
+    "data": {
+        "date_from": "<date_from>",
+        "date_to": "<date_to>",
+        "duration": [{"key": "duration", "type": "recording", "value": <duration>, "operator": "gt"}],  // Use "gt", "lt", "gte", "lte"
+        "filter_group": {
+            "type": "<FilterLogicalOperator>",
+            "values": [
+            {
+                "type": "<FilterLogicalOperator>",
+                "values": [
+                    {
+                        "key": "<key>",
+                        "type": "<PropertyFilterType>",
+                        "value": ["<value>"],
+                        "operator": "<PropertyOperator>"
+                    },
+                ],
+                ...
+            },
+        ]
+    }
+}
+
+Notes:
+1. Replace <date_from> and <date_to> with valid date strings.
+2. <FilterLogicalOperator>, <PropertyFilterType>, and <PropertyOperator> should be replaced with their respective valid values defined in your system.
+3. The filter_group structure is nested. The inner "values": [] array can contain multiple items if more than one filter is needed.
+4. Ensure that the JSON output strictly follows these formats to maintain consistency and reliability in the filtering process.
+
+WHEN GENERATING A FILTER BASED ON MORE THAN ONE PROPERTY ALWAYS MAKE SURE TO KEEP THE OLD FILTERS. NEVER REMOVE ANY FILTERS.
+</response_formats>
+
 """.strip()
 
 EXAMPLES_PROMPT = """
@@ -374,135 +496,4 @@ json
 PRODUCT_DESCRIPTION_PROMPT = """
 You are an expert at creating filters for PostHog products. Your job is to understand what users want to see in their data and translate that into precise filter configurations.
 Transform natural language requests like "show me users from mobile devices who completed signup" into structured filter objects that will find exactly what they're looking for.
-""".strip()
-
-FILTER_INITIAL_PROMPT = """
-
-{{{product_description_prompt}}}
-
-{{{group_property_filter_types_prompt}}}
-
-{{{multiple_filters_prompt}}}
-
-{{{response_formats_prompt}}}
-
-{{{date_fields_prompt}}}
-
-{{{filter_logical_operators_prompt}}}
-
-{{{examples_prompt}}}
-
-{{{tool_usage_prompt}}}
-
-""".strip()
-
-day = datetime.now().day
-today_date = datetime.now().strftime(f"{day} %B %Y")
-FILTER_INITIAL_PROMPT += f"\nToday is {today_date}."
-
-FILTER_FIELDS_TAXONOMY_PROMPT = """
-<taxonomy_info>
-Below you will find information on how to correctly discover the taxonomy of the user's data.
-
-<key> Field
-
-- Purpose:
-The <key> represents the name of the property on which the filter is applied.
-
-- Type Determination:
-The expected data type can be inferred from the property_type field provided in each property object:
-- "String" indicates the value should be a string.
-- "Numeric" indicates a numeric value.
-- "Boolean" indicates a boolean value.
-- "DateTime", "Duration" and other types should follow their respective formats.
-- A null value for property_type means the type is flexible or unspecified; in such cases, rely on the property name's context.
-</key>
-
-<value> Field
-
-- Purpose:
-The <value> field is an array containing one or more values that the filter should match.
-
-- Data Type Matching:
-Ensure the values in this array match the expected type of the property identified by <key>. For example:
-- For a property with property_type "String", the value should be provided as a string (e.g., ["Mobile"]).
-- For a property with property_type "Numeric", the value should be a number (e.g., [10]).
-- For a property with property_type "Boolean", the value should be either true or false (e.g., [true]).
-
-- Multiple Values:
-The <value> array can contain multiple items when the filter should match any one of several potential values.
-
-
-<supported_operators>
-Supported operators for the String or Numeric types are:
-- equals
-- doesn't equal
-- contains
-- doesn't contain
-- matches regex
-- doesn't match regex
-- is set
-- is not set
-
-Supported operators for the DateTime type are:
-- equals
-- doesn't equal
-- greater than
-- less than
-- is set
-- is not set
-
-Supported operators for the Boolean type are:
-- equals
-- doesn't equal
-- is set
-- is not set
-
-All operators take a single value except for `equals` and `doesn't equal` which can take one or more values.
-</supported_operators>
-
-</taxonomy_info>
-
-""".strip()
-
-EVENT_DEFINITIONS_PROMPT = """
-Here is a non-exhaustive list of known event names:
-{{{events}}}
-
-If you find the event name the user is asking for in the list, use it without calling the tool.
-If you cannot find the event name in the list, call the tool to get the list of events.
-""".strip()
-
-HUMAN_IN_THE_LOOP_PROMPT = """
-<human_in_the_loop>
-
-Ask the user for clarification if:
-- The user's question is ambiguous.
-- You can't find matching events or properties.
-- You can't find matching property values.
-- You're unable to build a filter that effectively answers the user's question.
-- Use the `ask_user_for_help` tool to ask the user for clarification.
-
-</human_in_the_loop>
-""".strip()
-
-FILTER_OPTIONS_ITERATION_LIMIT_PROMPT = """I've tried several approaches but haven't been able to find the right filtering options. Could you please be more specific about what kind of filters you're looking for? For example:
-- What type of events or actions are you interested in?
-- What properties do you want to filter on?
-- Are you looking for specific values or ranges?"""
-
-REACT_PYDANTIC_VALIDATION_EXCEPTION_PROMPT = """I encountered an error while validating the tool input. Here's what went wrong:
-{{{exception}}}
-
-Please help me understand what you're looking for more clearly, and I'll try again.""".strip()
-
-
-USER_FILTER_OPTIONS_PROMPT = """
-Goal: {{{change}}}
-
-Current filters: {{{current_filters}}}
-
-DO NOT CHANGE THE CURRENT FILTERS. ONLY ADD NEW FILTERS or update the existing filters.
-
-CRITICAL: Always use the enum format. For example PropertyOperator.Exact or directly 'exact'. DO NOT USE 'Exact' THE FILTER WILL FAIL IF YOU DO.
 """.strip()

--- a/ee/hogai/graph/filter_options/prompts.py
+++ b/ee/hogai/graph/filter_options/prompts.py
@@ -59,7 +59,7 @@ TOOL_USAGE_PROMPT = """
 GROUP_PROPERTY_FILTER_TYPES_PROMPT = """
 <property_filter_types>
 PostHog users can filter their data using various properties and values.
-Properties are classified into groups based on the source of the property or a user defined group. Each project has its own set of custom property groups, but there are also some core property groups that are available to all projects.
+Properties are always associated with an event or entity. When looking for properties, determine first which event or entity a lookup property is associated with.
 
 **CRITICAL**: There are two main categories of properties - ENTITY properties and EVENT properties. They use different tools.
 
@@ -341,7 +341,7 @@ json
                 "values": [
                     {
                         "key": "$device_type",
-                        "type": "person",
+                        "type": "event",
                         "value": ["Mobile"],
                         "operator": "exact"
                     },
@@ -362,41 +362,12 @@ json
 
 User: "Show me recordings of users who are either mobile OR desktop"
 
-json
-{
-"data": {
-    "date_from": "-5d",
-    "date_to": null,
-    "duration": [{"key": "duration", "type": "recording", "value": 60, "operator": "gt"}],
-    "filter_group": {
-        "type": "OR",
-        "values": [
-            {
-                "type": "AND",
-                "values": [
-                    {
-                        "key": "$device_type",
-                        "type": "person",
-                        "value": ["Mobile"],
-                        "operator": "exact"
-                    }
-                ]
-            },
-            {
-                "type": "AND",
-                "values": [
-                    {
-                        "key": "$device_type",
-                        "type": "person",
-                        "value": ["Desktop"],
-                        "operator": "exact"
-                    }
-                ]
-            }
-        ]
-    }
-}
-}
+```json
+{"data":{"date_from":"-5d","date_to":null,"duration":[{"key":"duration","type":"recording","value":60,"operator":"gt"}],"filter_group":{"type":"OR","values":[{"type":"AND","values":[{"key":"$device_type","type":"person","value":["Mobile"],"operator":"exact"}]},{"type":"AND","values":[{"key":"$device_type","type":"person","value":["Desktop"],"operator":"exact"}]}]}}}
+```
+
+Note: Some default properties, starting with the $ sign, are present in events and entities. For example, `$device_type` can be found under `person` properties and under the `$pageview` (or similar) event.
+
 
 3. **Complex Multi-Filter Example**
 
@@ -496,4 +467,8 @@ json
 PRODUCT_DESCRIPTION_PROMPT = """
 You are an expert at creating filters for PostHog products. Your job is to understand what users want to see in their data and translate that into precise filter configurations.
 Transform natural language requests like "show me users from mobile devices who completed signup" into structured filter objects that will find exactly what they're looking for.
+
+<session_replay_details>
+A session recording is a timeline of many events along with related entities a user has interacted with (directly or indirectly). When you apply a filter using an event property, the system returns any recording that contains at least one event matching that property/value pair.
+</session_replay_details>
 """.strip()

--- a/ee/hogai/graph/filter_options/prompts.py
+++ b/ee/hogai/graph/filter_options/prompts.py
@@ -1,6 +1,4 @@
 from datetime import datetime
-import json
-from posthog.taxonomy.taxonomy import CORE_FILTER_DEFINITIONS_BY_GROUP, CAMPAIGN_PROPERTIES
 
 RESPONSE_FORMATS_PROMPT = """
 <response_formats>
@@ -382,21 +380,15 @@ FILTER_INITIAL_PROMPT = """
 
 {{{product_description_prompt}}}
 
-
 {{{group_property_filter_types_prompt}}}
-
 
 {{{multiple_filters_prompt}}}
 
-
 {{{response_formats_prompt}}}
-
 
 {{{date_fields_prompt}}}
 
-
 {{{filter_logical_operators_prompt}}}
-
 
 {{{examples_prompt}}}
 
@@ -408,7 +400,7 @@ day = datetime.now().day
 today_date = datetime.now().strftime(f"{day} %B %Y")
 FILTER_INITIAL_PROMPT += f"\nToday is {today_date}."
 
-FILTER_FIELDS_TAXONOMY_PROMPT = f"""
+FILTER_FIELDS_TAXONOMY_PROMPT = """
 <taxonomy_info>
 Below you will find information on how to correctly discover the taxonomy of the user's data.
 
@@ -469,27 +461,16 @@ Supported operators for the Boolean type are:
 All operators take a single value except for `equals` and `doesn't equal` which can take one or more values.
 </supported_operators>
 
-
-<list_of_property_and_event_names>
-The following is a list of property names, event names and their definitions.
-If you find the property name the user is asking for in the list, use it without calling a tool.
-If you cannot find the property name in the list, call the tool to get the list of properties for the entity or event.
-
-
-SOME OF THE AVAILABLE PROPERTIES, EVENTS and their definitions:
-```json
-{json.dumps(CORE_FILTER_DEFINITIONS_BY_GROUP, indent=2)}
-```
-#### SOME OF THE AVAILABLE CAMPAIGN PROPERTIES and their definitions:
-
-```json
-{json.dumps(CAMPAIGN_PROPERTIES, indent=2)}
-```
-
-</list_of_property_and_event_names>
-
 </taxonomy_info>
 
+""".strip()
+
+EVENT_DEFINITIONS_PROMPT = """
+Here is a non-exhaustive list of known event names:
+{{{events}}}
+
+If you find the event name the user is asking for in the list, use it without calling the tool.
+If you cannot find the event name in the list, call the tool to get the list of events.
 """.strip()
 
 HUMAN_IN_THE_LOOP_PROMPT = """

--- a/ee/hogai/graph/filter_options/toolkit.py
+++ b/ee/hogai/graph/filter_options/toolkit.py
@@ -9,7 +9,6 @@ from ee.hogai.graph.query_planner.toolkit import (
     retrieve_event_properties,
     retrieve_event_property_values,
 )
-from posthog.models.property_definition import PropertyDefinition
 from posthog.schema import MaxRecordingUniversalFilters
 import yaml
 
@@ -64,8 +63,8 @@ class FilterOptionsTool(BaseModel):
 class FilterOptionsToolkit(TaxonomyAgentToolkit):
     @cached_property
     def _entity_names(self) -> list[str]:
-        """Override to include event type."""
-        return [*super()._entity_names, EntityType.EVENT.value]
+        """Override to use only actual entity types, not events."""
+        return super()._entity_names
 
     def _generate_properties_output(self, props: list[tuple[str, str | None, str | None]]) -> str:
         """
@@ -95,24 +94,13 @@ class FilterOptionsToolkit(TaxonomyAgentToolkit):
 
     def retrieve_entity_properties(self, entity: str, max_properties: int = 500) -> str:
         """
-        Retrieve properties for an entitiy like person, session, or one of the groups.
+        Retrieve properties for an entity like person, session, or one of the groups.
+        Events should use retrieve_event_properties instead.
         """
         if entity not in self._entity_names:
             return f"Entity '{entity}' does not exist. Available entities are: {', '.join(self._entity_names)}. Try one of these other entities."
 
-        if entity == EntityType.EVENT.value or entity == EntityType.ACTION.value:
-            qs = PropertyDefinition.objects.filter(team=self._team, type=PropertyDefinition.Type.EVENT).values_list(
-                "name", "property_type"
-            )[:max_properties]
-            props = self._enrich_props_with_descriptions("event", qs)
-            if not props:
-                return f"Properties do not exist in the taxonomy for the entity {entity}. Try one of these other entities: {', '.join(self._entity_names)}."
-
-            return self._generate_properties_output(props)
-        else:
-            result = super().retrieve_entity_properties(entity)
-
-        return result
+        return super().retrieve_entity_properties(entity)
 
     def handle_incorrect_response(self, response: BaseModel) -> str:
         """

--- a/ee/hogai/graph/filter_options/types.py
+++ b/ee/hogai/graph/filter_options/types.py
@@ -8,9 +8,9 @@ from pydantic import Field
 from ee.hogai.utils.types import BaseState
 
 
-class FilterOptionsState(BaseState):
+class PartialFilterOptionsState(BaseState):
     """
-    State class specifically for filter options functionality.
+    Partial state class for filter options functionality.
     Only includes fields relevant to filter options generation.
     """
 
@@ -40,9 +40,9 @@ class FilterOptionsState(BaseState):
     """
 
 
-class PartialFilterOptionsState(BaseState):
+class FilterOptionsState(PartialFilterOptionsState):
     """
-    Partial state class for filter options functionality.
+    State class specifically for filter options functionality.
     Only includes fields relevant to filter options generation.
     """
 

--- a/ee/hogai/graph/filter_options/types.py
+++ b/ee/hogai/graph/filter_options/types.py
@@ -46,30 +46,7 @@ class FilterOptionsState(PartialFilterOptionsState):
     Only includes fields relevant to filter options generation.
     """
 
-    intermediate_steps: Optional[list[tuple[AgentAction, Optional[str]]]] = Field(default=None)
-    """
-    Actions taken by the ReAct agent.
-    """
-
-    generated_filter_options: Optional[dict] = Field(default=None)
-    """
-    The filter options to apply to the product.
-    """
-
-    change: Optional[str] = Field(default=None)
-    """
-    The change requested for the filters.
-    """
-
-    current_filters: Optional[dict] = Field(default=None)
-    """
-    The current filters applied to the product.
-    """
-
-    tool_progress_messages: list[LangchainBaseMessage] = Field(default=[])
-    """
-    The messages with tool calls to collect tool progress.
-    """
+    pass
 
 
 class FilterOptionsNodeName(StrEnum):

--- a/ee/hogai/graph/query_planner/nodes.py
+++ b/ee/hogai/graph/query_planner/nodes.py
@@ -1,4 +1,3 @@
-import xml.etree.ElementTree as ET
 from abc import ABC
 from functools import cached_property
 from typing import Literal, cast
@@ -15,25 +14,19 @@ from pydantic import Field, ValidationError, create_model
 
 from ee.hogai.graph.root.prompts import ROOT_INSIGHT_DESCRIPTION_PROMPT
 from ee.hogai.graph.shared_prompts import CORE_MEMORY_PROMPT, PROJECT_ORG_USER_CONTEXT_PROMPT
-from ee.hogai.utils.helpers import dereference_schema, remove_line_breaks
+from ee.hogai.utils.helpers import dereference_schema, format_events_prompt
 from ee.hogai.utils.types import AssistantState, PartialAssistantState
 from posthog.hogql.ai import SCHEMA_MESSAGE
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import create_hogql_database, serialize_database
-from posthog.hogql_queries.ai.team_taxonomy_query_runner import TeamTaxonomyQueryRunner
-from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.schema import (
     AssistantFunnelsQuery,
     AssistantRetentionQuery,
     AssistantToolCallMessage,
     AssistantTrendsQuery,
-    CachedTeamTaxonomyQueryResponse,
-    MaxEventContext,
-    TeamTaxonomyQuery,
     VisualizationMessage,
 )
-from posthog.taxonomy.taxonomy import CORE_FILTER_DEFINITIONS_BY_GROUP
 
 from ..base import AssistantNode
 from .prompts import (
@@ -112,7 +105,7 @@ class QueryPlannerNode(AssistantNode):
                 "react_property_filters": self._get_react_property_filters_prompt(),
                 "react_human_in_the_loop": HUMAN_IN_THE_LOOP_PROMPT,
                 "groups": self._team_group_types,
-                "events": self._format_events_prompt(events_in_context),
+                "events": format_events_prompt(events_in_context, self._team),
                 "project_datetime": self.project_now,
                 "project_timezone": self.project_timezone,
                 "project_name": self._team.name,
@@ -174,56 +167,6 @@ class QueryPlannerNode(AssistantNode):
             .format_messages(groups=self._team_group_types)[0]
             .content,
         )
-
-    def _format_events_prompt(self, events_in_context: list[MaxEventContext]) -> str:
-        response = TeamTaxonomyQueryRunner(TeamTaxonomyQuery(), self._team).run(
-            ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS
-        )
-
-        if not isinstance(response, CachedTeamTaxonomyQueryResponse):
-            raise ValueError("Failed to generate events prompt.")
-
-        events: list[str] = [
-            # Add "All events" to the mapping
-            "All events",
-        ]
-        for item in response.results:
-            if len(response.results) > 25 and item.count <= 3:
-                continue
-            events.append(item.event)
-        event_to_description: dict[str, str] = {}
-        for event in events_in_context:
-            if event.name and event.name not in events:
-                events.append(event.name)
-                if event.description:
-                    event_to_description[event.name] = event.description
-
-        # Create a set of event names from context for efficient lookup
-        context_event_names = {event.name for event in events_in_context if event.name}
-
-        root = ET.Element("defined_events")
-        for event_name in events:
-            event_tag = ET.SubElement(root, "event")
-            name_tag = ET.SubElement(event_tag, "name")
-            name_tag.text = event_name
-
-            if event_core_definition := CORE_FILTER_DEFINITIONS_BY_GROUP["events"].get(event_name):
-                if event_name not in context_event_names and (
-                    event_core_definition.get("system") or event_core_definition.get("ignored_in_assistant")
-                ):
-                    continue  # Skip irrelevant events but keep events the user has added to the context
-                if description := event_core_definition.get("description"):
-                    desc_tag = ET.SubElement(event_tag, "description")
-                    if label := event_core_definition.get("label_llm") or event_core_definition.get("label"):
-                        desc_tag.text = f"{label}. {description}"
-                    else:
-                        desc_tag.text = description
-                    desc_tag.text = remove_line_breaks(desc_tag.text)
-            elif event_name in event_to_description:
-                desc_tag = ET.SubElement(event_tag, "description")
-                desc_tag.text = event_to_description[event_name]
-                desc_tag.text = remove_line_breaks(desc_tag.text)
-        return ET.tostring(root, encoding="unicode")
 
     @cached_property
     def _team_group_types(self) -> list[str]:

--- a/ee/hogai/graph/query_planner/test/test_nodes.py
+++ b/ee/hogai/graph/query_planner/test/test_nodes.py
@@ -181,10 +181,6 @@ class TestQueryPlannerNode(ClickhouseTestMixin, APIBaseTest):
         self.assertIn("Final Question", final_msg.prompt.template)
 
 
-# Removed all the tests testing the old format_events_prompt function as it is no longer in the query planner node
-# as it is now handled in the utils.helpers.format_events_prompt function
-
-
 @override_settings(IN_UNIT_TESTING=True)
 class TestTaxonomyAgentPlannerToolsNode(ClickhouseTestMixin, APIBaseTest):
     def _get_node(self):

--- a/ee/hogai/graph/query_planner/test/test_nodes.py
+++ b/ee/hogai/graph/query_planner/test/test_nodes.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 from django.test import override_settings
 from langchain_core.agents import AgentAction
 from langchain_core.prompts import AIMessagePromptTemplate, HumanMessagePromptTemplate
@@ -14,10 +12,9 @@ from posthog.schema import (
     AssistantTrendsQuery,
     FailureMessage,
     HumanMessage,
-    MaxEventContext,
     VisualizationMessage,
 )
-from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, _create_person
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 
 
 class DummyToolkit(TaxonomyAgentToolkit):
@@ -112,34 +109,8 @@ class TestQueryPlannerNode(ClickhouseTestMixin, APIBaseTest):
         self.assertIsInstance(history[5], HumanMessagePromptTemplate)
         self.assertIn("Question 3", history[5].prompt.template)
 
-    def test_agent_filters_out_low_count_events(self):
-        _create_person(distinct_ids=["test"], team=self.team)
-        for i in range(26):
-            _create_event(event=f"event{i}", distinct_id="test", team=self.team)
-            _create_event(event="distinctevent", distinct_id="test", team=self.team)
-        node = self._get_node()
-        self.assertEqual(
-            node._format_events_prompt([]),
-            "<defined_events><event><name>All events</name><description>All events. This is a wildcard that matches all events.</description></event><event><name>distinctevent</name></event></defined_events>",
-        )
-
-    def test_agent_preserves_low_count_events_for_smaller_teams(self):
-        _create_person(distinct_ids=["test"], team=self.team)
-        _create_event(event="distinctevent", distinct_id="test", team=self.team)
-        node = self._get_node()
-        self.assertIn("distinctevent", node._format_events_prompt([]))
-        self.assertIn("all events", node._format_events_prompt([]))
-
     # Removed test_agent_handles_output_without_tool_call as this functionality
     # is now handled differently and the test was testing legacy behavior
-
-    def test_node_outputs_all_events_prompt(self):
-        node = self._get_node()
-        self.assertIn("All events", node._format_events_prompt([]))
-        self.assertIn(
-            "<event><name>All events</name><description>All events. This is a wildcard that matches all events.</description></event>",
-            node._format_events_prompt([]),
-        )
 
     # Removed test_format_prompt as _get_react_format_prompt method no longer exists
     # The current implementation uses a different approach for prompt formatting
@@ -209,93 +180,9 @@ class TestQueryPlannerNode(ClickhouseTestMixin, APIBaseTest):
         self.assertIsInstance(final_msg, HumanMessagePromptTemplate)
         self.assertIn("Final Question", final_msg.prompt.template)
 
-    def test_events_in_context_adds_events_to_prompt(self):
-        """Test that events from context are added to the events list"""
-        _create_person(distinct_ids=["test"], team=self.team)
-        _create_event(event="existing_event", distinct_id="test", team=self.team)
 
-        node = self._get_node()
-        events_in_context = [
-            MaxEventContext(id="1", name="context_event", description="Event from context"),
-            MaxEventContext(id="2", name="another_context_event", description=None),
-        ]
-
-        prompt = node._format_events_prompt(events_in_context)
-
-        self.assertIn("context_event", prompt)
-        self.assertIn("another_context_event", prompt)
-        self.assertIn("Event from context", prompt)
-
-    def test_events_in_context_overwrites_system_event_filtering(self):
-        """Test that system events are not filtered out if they're in context"""
-        node = self._get_node()
-
-        # Test with a system event that would normally be filtered
-        # (we'll mock the core filter definitions to include a system event)
-        with patch("ee.hogai.graph.query_planner.nodes.CORE_FILTER_DEFINITIONS_BY_GROUP") as mock_definitions:
-            mock_definitions.__getitem__.return_value = {
-                "test_system_event": {
-                    "system": True,
-                    "description": "System event that should be filtered",
-                    "ignored_in_assistant": True,
-                }
-            }
-
-            events_in_context = [
-                MaxEventContext(id="1", name="test_system_event", description="System event from context"),
-            ]
-
-            prompt = node._format_events_prompt(events_in_context)
-
-            # Should include the system event because it's in context
-            self.assertIn("test_system_event", prompt)
-
-    def test_events_in_context_duplicates_are_handled(self):
-        """Test that duplicate events between context and taxonomy are handled correctly"""
-        _create_person(distinct_ids=["test"], team=self.team)
-        _create_event(event="duplicate_event", distinct_id="test", team=self.team)
-
-        node = self._get_node()
-        events_in_context = [
-            MaxEventContext(id="1", name="duplicate_event", description="Context description"),
-        ]
-
-        prompt = node._format_events_prompt(events_in_context)
-
-        # Should only appear once in the prompt
-        event_count = prompt.count("<name>duplicate_event</name>")
-        self.assertEqual(event_count, 1)
-
-    def test_events_in_context_mixed_with_core_definitions(self):
-        """Test events from context mixed with core event definitions"""
-        node = self._get_node()
-
-        with patch("ee.hogai.graph.query_planner.nodes.CORE_FILTER_DEFINITIONS_BY_GROUP") as mock_definitions:
-            mock_definitions.__getitem__.return_value = {
-                "core_event": {
-                    "description": "Core event description",
-                    "label": "Core Event",
-                }
-            }
-
-            events_in_context = [
-                MaxEventContext(id="1", name="core_event", description="Context description"),
-                MaxEventContext(id="2", name="context_only_event", description="Only in context"),
-            ]
-
-            prompt = node._format_events_prompt(events_in_context)
-
-            # Should include both events
-            self.assertIn("core_event", prompt)
-            self.assertIn("context_only_event", prompt)
-
-            # For core_event, should use core definition, not context description
-            # because core definitions take precedence
-            self.assertIn("Core Event. Core event description", prompt)
-            self.assertNotIn("Context description", prompt)
-
-            # For context-only event, should use context description
-            self.assertIn("Only in context", prompt)
+# Removed all the tests testing the old format_events_prompt function as it is no longer in the query planner node
+# as it is now handled in the utils.helpers.format_events_prompt function
 
 
 @override_settings(IN_UNIT_TESTING=True)

--- a/ee/hogai/utils/helpers.py
+++ b/ee/hogai/utils/helpers.py
@@ -15,6 +15,12 @@ from posthog.schema import (
     MaxUIContext,
     VisualizationMessage,
 )
+from posthog.schema import MaxEventContext, TeamTaxonomyQuery, CachedTeamTaxonomyQueryResponse
+from posthog.taxonomy.taxonomy import CORE_FILTER_DEFINITIONS_BY_GROUP
+from posthog.models import Team
+from posthog.hogql_queries.query_runner import ExecutionMode
+from posthog.hogql_queries.ai.team_taxonomy_query_runner import TeamTaxonomyQueryRunner
+import xml.etree.ElementTree as ET
 
 
 def remove_line_breaks(line: str) -> str:
@@ -107,3 +113,54 @@ def find_last_ui_context(messages: Sequence[AssistantMessageUnion]) -> MaxUICont
         if isinstance(message, HumanMessage) and message.ui_context is not None:
             return message.ui_context
     return None
+
+
+def format_events_prompt(events_in_context: list[MaxEventContext], team: Team) -> str:
+    response = TeamTaxonomyQueryRunner(TeamTaxonomyQuery(), team).run(
+        ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS
+    )
+
+    if not isinstance(response, CachedTeamTaxonomyQueryResponse):
+        raise ValueError("Failed to generate events prompt.")
+
+    events: list[str] = [
+        # Add "All events" to the mapping
+        "All events",
+    ]
+    for item in response.results:
+        if len(response.results) > 25 and item.count <= 3:
+            continue
+        events.append(item.event)
+    event_to_description: dict[str, str] = {}
+    for event in events_in_context:
+        if event.name and event.name not in events:
+            events.append(event.name)
+            if event.description:
+                event_to_description[event.name] = event.description
+
+    # Create a set of event names from context for efficient lookup
+    context_event_names = {event.name for event in events_in_context if event.name}
+
+    root = ET.Element("defined_events")
+    for event_name in events:
+        event_tag = ET.SubElement(root, "event")
+        name_tag = ET.SubElement(event_tag, "name")
+        name_tag.text = event_name
+
+        if event_core_definition := CORE_FILTER_DEFINITIONS_BY_GROUP["events"].get(event_name):
+            if event_name not in context_event_names and (
+                event_core_definition.get("system") or event_core_definition.get("ignored_in_assistant")
+            ):
+                continue  # Skip irrelevant events but keep events the user has added to the context
+            if description := event_core_definition.get("description"):
+                desc_tag = ET.SubElement(event_tag, "description")
+                if label := event_core_definition.get("label_llm") or event_core_definition.get("label"):
+                    desc_tag.text = f"{label}. {description}"
+                else:
+                    desc_tag.text = description
+                desc_tag.text = remove_line_breaks(desc_tag.text)
+        elif event_name in event_to_description:
+            desc_tag = ET.SubElement(event_tag, "description")
+            desc_tag.text = event_to_description[event_name]
+            desc_tag.text = remove_line_breaks(desc_tag.text)
+    return ET.tostring(root, encoding="unicode")

--- a/ee/hogai/utils/test/test_format_events_prompt.py
+++ b/ee/hogai/utils/test/test_format_events_prompt.py
@@ -41,7 +41,6 @@ MOCK_CORE_FILTER_DEFINITIONS = {
 class TestFormatEventsPrompt(BaseTest):
     def setUp(self):
         super().setUp()
-        self.team = self.team
         # Mock CORE_FILTER_DEFINITIONS_BY_GROUP
         self.core_definitions_patcher = patch(
             "posthog.taxonomy.taxonomy.CORE_FILTER_DEFINITIONS_BY_GROUP", MOCK_CORE_FILTER_DEFINITIONS

--- a/ee/hogai/utils/test/test_format_events_prompt.py
+++ b/ee/hogai/utils/test/test_format_events_prompt.py
@@ -1,0 +1,407 @@
+from unittest.mock import Mock, patch
+import xml.etree.ElementTree as ET
+
+from posthog.schema import MaxEventContext, TeamTaxonomyItem, CachedTeamTaxonomyQueryResponse, TeamTaxonomyQuery
+from posthog.test.base import BaseTest
+from posthog.hogql_queries.query_runner import ExecutionMode
+
+from ee.hogai.utils.helpers import format_events_prompt
+import datetime
+
+
+# Mock CORE_FILTER_DEFINITIONS_BY_GROUP for consistent testing
+MOCK_CORE_FILTER_DEFINITIONS = {
+    "events": {
+        "All events": {
+            "label": "All events",
+            "description": "This is a wildcard that matches all events.",
+        },
+        "$pageview": {
+            "label": "Pageview",
+            "description": "When a user loads (or reloads) a page.",
+        },
+        "$autocapture": {
+            "label": "Autocapture",
+            "description": "User interactions that were automatically captured.",
+            "ignored_in_assistant": True,
+        },
+        "$pageleave": {
+            "label": "Pageleave",
+            "description": "When a user leaves a page.",
+            "ignored_in_assistant": True,
+        },
+        "custom_event": {
+            "label": "Custom Event",
+            "description": "A custom event defined by the user.",
+        },
+    }
+}
+
+
+class TestFormatEventsPrompt(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.team = self.team
+        # Mock CORE_FILTER_DEFINITIONS_BY_GROUP
+        self.core_definitions_patcher = patch(
+            "posthog.taxonomy.taxonomy.CORE_FILTER_DEFINITIONS_BY_GROUP", MOCK_CORE_FILTER_DEFINITIONS
+        )
+        self.mock_core_definitions = self.core_definitions_patcher.start()
+
+    def tearDown(self):
+        self.core_definitions_patcher.stop()
+        super().tearDown()
+
+    def _create_mock_response(self, results=None):
+        """Helper to create a mock CachedTeamTaxonomyQueryResponse."""
+        if results is None:
+            results = []
+        return CachedTeamTaxonomyQueryResponse(
+            cache_key="test_key",
+            is_cached=True,
+            last_refresh=datetime.datetime(2023, 1, 1, 0, 0, 0),
+            next_allowed_client_refresh=datetime.datetime(2023, 1, 1, 1, 0, 0),
+            timezone="UTC",
+            results=results,
+        )
+
+    def _create_taxonomy_items(self, events_with_counts):
+        """Helper to create TeamTaxonomyItem list from event name and count pairs."""
+        return [TeamTaxonomyItem(event=event, count=count) for event, count in events_with_counts]
+
+    def _create_context_events(self, events_with_descriptions):
+        """Helper to create MaxEventContext list from event name and description pairs."""
+        return [
+            MaxEventContext(id=str(i), name=event, description=description, type="event")
+            for i, (event, description) in enumerate(events_with_descriptions, 1)
+        ]
+
+    def _get_event_names_from_xml(self, xml_string):
+        """Helper to extract event names from XML result."""
+        root = ET.fromstring(xml_string)
+        event_names = []
+        for event in root.findall("event"):
+            name_elem = event.find("name")
+            if name_elem is not None and name_elem.text is not None:
+                event_names.append(name_elem.text)
+        return event_names
+
+    def _get_event_description(self, xml_string, event_name):
+        """Helper to get description for a specific event from XML."""
+        root = ET.fromstring(xml_string)
+        event = root.find(f".//event[name='{event_name}']")
+        if event is not None:
+            description = event.find("description")
+            return description.text if description is not None else None
+        return None
+
+    def _setup_mock_runner(self, mock_runner_class, results=None):
+        """Helper to setup mock runner with given results."""
+        mock_runner = Mock()
+        mock_response = self._create_mock_response(results)
+        mock_runner.run.return_value = mock_response
+        mock_runner_class.return_value = mock_runner
+        return mock_runner
+
+    @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")
+    def test_format_events_prompt_basic(self, mock_runner_class):
+        """Test basic functionality with core events and context events."""
+        # Setup mock with taxonomy results
+        taxonomy_items = self._create_taxonomy_items(
+            [
+                ("$pageview", 100),
+                ("custom_event", 25),
+            ]
+        )
+        self._setup_mock_runner(mock_runner_class, taxonomy_items)
+
+        # Test data
+        events_in_context = self._create_context_events(
+            [
+                ("custom_event", "A custom event"),
+                ("another_event", "Another event"),
+            ]
+        )
+
+        result = format_events_prompt(events_in_context, self.team)
+
+        # Verify the XML structure
+        root = ET.fromstring(result)
+        self.assertEqual(root.tag, "defined_events")
+
+        # Should contain "All events" and the events from taxonomy and context
+        event_names = self._get_event_names_from_xml(result)
+        expected_events = ["All events", "$pageview", "custom_event", "another_event"]
+        self.assertEqual(set(event_names), set(expected_events))
+
+        # Verify descriptions are present
+        descriptions = [
+            event.find("description").text for event in root.findall("event") if event.find("description") is not None
+        ]
+        self.assertGreater(len(descriptions), 0)
+
+    @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")
+    def test_format_events_prompt_filters_low_count_events(self, mock_runner_class):
+        """Test that events with count <= 3 are filtered out when there are more than 25 results."""
+        # Create 30 results with some low count events
+        taxonomy_items = self._create_taxonomy_items(
+            [
+                ("high_count_event", 100),
+                ("low_count_event", 2),  # Should be filtered out
+                ("medium_count_event", 10),
+            ]
+            * 10
+        )  # Create 30 results total
+        self._setup_mock_runner(mock_runner_class, taxonomy_items)
+
+        events_in_context = []
+        result = format_events_prompt(events_in_context, self.team)
+
+        event_names = self._get_event_names_from_xml(result)
+
+        # Should not contain the low count event
+        self.assertNotIn("low_count_event", event_names)
+        self.assertIn("high_count_event", event_names)
+        self.assertIn("medium_count_event", event_names)
+
+    @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")
+    def test_format_events_prompt_keeps_low_count_events_when_few_results(self, mock_runner_class):
+        """Test that low count events are kept when there are 25 or fewer results."""
+        taxonomy_items = self._create_taxonomy_items(
+            [
+                ("high_count_event", 100),
+                ("low_count_event", 2),  # Should be kept
+                ("medium_count_event", 10),
+            ]
+        )
+        self._setup_mock_runner(mock_runner_class, taxonomy_items)
+
+        events_in_context = []
+        result = format_events_prompt(events_in_context, self.team)
+
+        event_names = self._get_event_names_from_xml(result)
+
+        # Should contain the low count event when there are few results
+        self.assertIn("low_count_event", event_names)
+
+    @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")
+    def test_format_events_prompt_skips_ignored_events(self, mock_runner_class):
+        """Test that events marked as ignored_in_assistant are skipped."""
+        taxonomy_items = self._create_taxonomy_items(
+            [
+                ("$autocapture", 50),  # This is ignored_in_assistant
+            ]
+        )
+        self._setup_mock_runner(mock_runner_class, taxonomy_items)
+
+        events_in_context = []
+        result = format_events_prompt(events_in_context, self.team)
+
+        event_names = self._get_event_names_from_xml(result)
+
+        # Should not contain ignored events that are not in the context
+        self.assertNotIn("$autocapture", event_names)
+
+    @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")
+    def test_format_events_prompt_keeps_ignored_events_in_context(self, mock_runner_class):
+        """Test that ignored events are kept if they're in the context."""
+        taxonomy_items = self._create_taxonomy_items(
+            [
+                ("$pageview", 100),
+                ("$autocapture", 50),
+            ]
+        )
+        self._setup_mock_runner(mock_runner_class, taxonomy_items)
+
+        # Add ignored event to context
+        events_in_context = self._create_context_events(
+            [
+                ("$autocapture", "User interactions"),
+            ]
+        )
+
+        result = format_events_prompt(events_in_context, self.team)
+
+        event_names = self._get_event_names_from_xml(result)
+
+        # Should contain the ignored event because it's in context
+        self.assertIn("$autocapture", event_names)
+
+    @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")
+    def test_format_events_prompt_uses_context_descriptions(self, mock_runner_class):
+        """Test that context event descriptions are used when available."""
+        taxonomy_items = self._create_taxonomy_items(
+            [
+                ("custom_event", 100),
+            ]
+        )
+        self._setup_mock_runner(mock_runner_class, taxonomy_items)
+
+        events_in_context = self._create_context_events(
+            [
+                ("custom_event", "Custom event description"),
+            ]
+        )
+
+        result = format_events_prompt(events_in_context, self.team)
+
+        description = self._get_event_description(result, "custom_event")
+        self.assertEqual(description, "Custom event description")
+
+    @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")
+    def test_format_events_prompt_removes_line_breaks(self, mock_runner_class):
+        """Test that line breaks are removed from descriptions."""
+        self._setup_mock_runner(mock_runner_class, [])
+
+        events_in_context = self._create_context_events(
+            [
+                ("test_event", "Line 1\nLine 2\nLine 3"),
+            ]
+        )
+
+        result = format_events_prompt(events_in_context, self.team)
+
+        description = self._get_event_description(result, "test_event")
+        self.assertEqual(description, "Line 1 Line 2 Line 3")
+
+    @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")
+    def test_format_events_prompt_handles_empty_context(self, mock_runner_class):
+        """Test with empty events context."""
+        taxonomy_items = self._create_taxonomy_items(
+            [
+                ("$pageview", 100),
+            ]
+        )
+        self._setup_mock_runner(mock_runner_class, taxonomy_items)
+
+        events_in_context = []
+        result = format_events_prompt(events_in_context, self.team)
+
+        event_names = self._get_event_names_from_xml(result)
+        self.assertEqual(set(event_names), {"All events", "$pageview"})
+
+    @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")
+    def test_format_events_prompt_handles_none_description(self, mock_runner_class):
+        """Test handling of events with None description."""
+        self._setup_mock_runner(mock_runner_class, [])
+
+        events_in_context = self._create_context_events(
+            [
+                ("test_event", None),
+            ]
+        )
+
+        result = format_events_prompt(events_in_context, self.team)
+
+        root = ET.fromstring(result)
+        test_event = root.find(".//event[name='test_event']")
+        description = test_event.find("description")
+
+        # Should not have a description tag
+        self.assertIsNone(description)
+
+    @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")
+    def test_format_events_prompt_handles_empty_description(self, mock_runner_class):
+        """Test handling of events with empty description."""
+        self._setup_mock_runner(mock_runner_class, [])
+
+        events_in_context = self._create_context_events(
+            [
+                ("test_event", ""),
+            ]
+        )
+
+        result = format_events_prompt(events_in_context, self.team)
+
+        root = ET.fromstring(result)
+        test_event = root.find(".//event[name='test_event']")
+        description = test_event.find("description")
+        # Empty string descriptions should not create a description tag
+        self.assertIsNone(description)
+
+    @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")
+    def test_format_events_prompt_handles_duplicate_events(self, mock_runner_class):
+        """Test handling of duplicate events between taxonomy and context."""
+        taxonomy_items = self._create_taxonomy_items(
+            [
+                ("duplicate_event", 100),
+            ]
+        )
+        self._setup_mock_runner(mock_runner_class, taxonomy_items)
+
+        events_in_context = self._create_context_events(
+            [
+                ("duplicate_event", "Context description"),
+            ]
+        )
+
+        result = format_events_prompt(events_in_context, self.team)
+
+        event_names = self._get_event_names_from_xml(result)
+
+        # Should only appear once
+        self.assertEqual(event_names.count("duplicate_event"), 1)
+
+    @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")
+    def test_format_events_prompt_handles_non_cached_response(self, mock_runner_class):
+        """Test handling when response is not a CachedTeamTaxonomyQueryResponse."""
+        mock_runner = Mock()
+        mock_runner.run.return_value = "not a cached response"
+        mock_runner_class.return_value = mock_runner
+
+        events_in_context = []
+
+        with self.assertRaises(ValueError, msg="Failed to generate events prompt."):
+            format_events_prompt(events_in_context, self.team)
+
+    @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")
+    def test_format_events_prompt_uses_label_llm_when_available(self, mock_runner_class):
+        """Test that label_llm is used when available in core definitions."""
+        taxonomy_items = self._create_taxonomy_items(
+            [
+                ("$pageview", 100),
+            ]
+        )
+        self._setup_mock_runner(mock_runner_class, taxonomy_items)
+
+        events_in_context = []
+        result = format_events_prompt(events_in_context, self.team)
+
+        description = self._get_event_description(result, "$pageview")
+
+        # Should use label_llm if available, otherwise label
+        self.assertIsNotNone(description)
+        # The actual content depends on the core definitions, but it should contain the label
+        if description is not None:
+            self.assertIn("Pageview", description)
+
+    @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")
+    def test_format_events_prompt_handles_events_without_names(self, mock_runner_class):
+        """Test handling of context events without names."""
+        self._setup_mock_runner(mock_runner_class, [])
+
+        events_in_context = [
+            MaxEventContext(id="1", name=None, description="No name event", type="event"),
+            MaxEventContext(id="2", name="", description="Empty name event", type="event"),
+        ]
+
+        result = format_events_prompt(events_in_context, self.team)
+
+        event_names = self._get_event_names_from_xml(result)
+
+        # Should only contain "All events" since context events have no names
+        self.assertEqual(set(event_names), {"All events"})
+
+    @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")
+    def test_format_events_prompt_calls_runner_with_correct_parameters(self, mock_runner_class):
+        """Test that TeamTaxonomyQueryRunner is called with correct parameters."""
+        self._setup_mock_runner(mock_runner_class, [])
+
+        events_in_context = []
+        format_events_prompt(events_in_context, self.team)
+
+        # Verify TeamTaxonomyQueryRunner was called correctly
+        mock_runner_class.assert_called_once_with(TeamTaxonomyQuery(), self.team)
+        mock_runner_class.return_value.run.assert_called_once_with(
+            ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS
+        )

--- a/products/replay/backend/prompts.py
+++ b/products/replay/backend/prompts.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 SESSION_REPLAY_RESPONSE_FORMATS_PROMPT = """
 <response_formats>
 Formats of responses
@@ -8,6 +6,13 @@ When you need clarification or determines that additional information is require
 {
     "request": "Your clarifying question here."
 }
+
+Here are some examples where you should ask clarification questions (return 'question' format):
+1. Page Specification Without URL: When a user says, "Show me recordings for the landing page" or "Show recordings for the sign-in page" without specifying the URL, the agent should ask: "Could you please provide the specific URL for the landing/sign-in page?"
+2. Ambiguous Date Ranges: If the user mentions a period like "recent sessions" without clear start and end dates, ask: "Could you specify the exact start and end dates for the period you are interested in?"
+3. Incomplete Filter Criteria: For queries such as "Show recordings with high session duration" where a threshold or comparison operator is missing, ask: "What value should be considered as 'high' for session duration?"
+
+
 2. Filter Response Format
 Once all necessary data is collected, the agent should return the filter in this structured format:
 {
@@ -40,7 +45,8 @@ Notes:
 3. The filter_group structure is nested. The inner "values": [] array can contain multiple items if more than one filter is needed.
 4. Ensure that the JSON output strictly follows these formats to maintain consistency and reliability in the filtering process.
 
-WHEN GENERATING A FILTER BASED ON MORE THAN ONE PROPERTY ALWAYS MAKE SURE TO KEEP THE OLD FILTERS. NEVER REMOVE ANY FILTERS.
+
+WHEN GENERATING A FILTER ALWAYS MAKE SURE TO KEEP THE STATE OF THE FILTERS. NEVER REMOVE ANY FILTERS UNLESS THE USER ASKS FOR IT.
 </response_formats>
 
 """.strip()
@@ -210,330 +216,6 @@ PRODUCT_DESCRIPTION_PROMPT = """
 PostHog (posthog.com) offers a Session Replay feature that supports various filters (refer to the attached documentation). Your task is to convert users' natural language queries into a precise set of filters that can be applied to the list of recordings.
 """.strip()
 
-
-AI_FILTER_INITIAL_PROMPT = """
-Key Points:
-1. Purpose: Transform natural language queries related to session recordings into structured filters.
-2. Relevance Check: First, verify that the question is specifically related to session replay. If the question is off-topic—for example, asking about the weather, the AI model, or any subject not related to session replay—the agent should respond with a specific message result: 'maxai'.
-3. Ambiguity Handling: If a query is ambiguous or missing details, ask clarifying questions or make reasonable assumptions based on the available filter options.
-
-Strictly follow this algorithm:
-1. Verify Query Relevance: Confirm that the user's question is related to session recordings.
-2. Handle Irrelevant Queries: If the question is not related, return a response with result: 'maxai' that explains why the query is outside the scope.
-3. **MULTI-FILTER ANALYSIS**: Identify ALL filter components in the user's request. Look for multiple conditions using words like "and", "also", "who", "where", "with", "from", "that", etc. Don't stop after finding the first filter.
-4. **ENTITY TYPE INFERENCE**: For EACH filter component identified, determine the appropriate entity type (person, event, session, etc.). Multiple filters can target different entity types.
-5. **PROPERTY DISCOVERY**: For EACH entity type and filter component, discover relevant properties. Don't skip any filter component.
-6. **VALUE DISCOVERY**: For EACH property you need to filter on, discover possible values.
-7. **COMBINE FILTERS**: Structure all filters using appropriate logical operators (AND/OR) based on user intent.
-8. Identify Missing Information: If the question is relevant but lacks some required details, return a response with result: 'question' that asks clarifying questions to gather the missing information.
-9. Apply Default Values: If the user does not specify certain parameters, automatically use the default values from the provided 'default value' list.
-10. Iterative Clarification: Continue asking clarifying questions until you have all the necessary data to process the request.
-11. Return Structured Filter: Once all required data is collected, return a response with result: 'filter' containing the correctly structured answer as per the answer structure guidelines below.
-
-Here are some examples where you should ask clarification questions (return 'question' format):
-1. Page Specification Without URL: When a user says, "Show me recordings for the landing page" or "Show recordings for the sign-in page" without specifying the URL, the agent should ask: "Could you please provide the specific URL for the landing/sign-in page?"
-2. Ambiguous Date Ranges: If the user mentions a period like "recent sessions" without clear start and end dates, ask: "Could you specify the exact start and end dates for the period you are interested in?"
-3. Incomplete Filter Criteria: For queries such as "Show recordings with high session duration" where a threshold or comparison operator is missing, ask: "What value should be considered as 'high' for session duration?"
-4. **Multi-Filter Ambiguity**: If a user mentions multiple conditions but it's unclear how they should be combined (AND vs OR), ask for clarification. For example, "users from mobile OR desktop who signed up" vs "mobile users who signed up AND visited pricing page".
-
-Formats of responses
-1. Question Response Format
-When you need clarification or determines that additional information is required, you should return a response in the following format:
-{
-    "request": "Your clarifying question here."
-}
-2. Filter Response Format
-Once all necessary data is collected, the agent should return the filter in this structured format:
-{
-    "data": {
-        "date_from": "<date_from>",
-        "date_to": "<date_to>",
-        "filter_group": {
-            "type": "<FilterLogicalOperator>",
-            "values": [
-            {
-                "type": "<FilterLogicalOperator>",
-                "values": [
-                    {
-                        "key": "<key>",
-                        "type": "<PropertyFilterType>",
-                        "value": ["<value>"],
-                        "operator": "<PropertyOperator>"
-                    },
-                ],
-                ...
-            },
-        ]
-    }
-}
-3. Wrong Query Response Format
-If the query is not related to session replay, return with the following format:
-{
-    "request": "Please ask questions only about Session Replay."
-}
-Notes:
-1. Replace <date_from> and <date_to> with valid date strings.
-2. <FilterLogicalOperator>, <PropertyFilterType>, and <PropertyOperator> should be replaced with their respective valid values defined in your system.
-3. The filter_group structure is nested. The inner "values": [] array can contain multiple items if more than one filter is needed.
-4. Ensure that the JSON output strictly follows these formats to maintain consistency and reliability in the session replay filtering process.
-
-Below is a refined description for the date fields and their types:
-
-Date Fields and Types
-date_from:
-- Relative Date (Days): Use the format "-Nd" for the last N days (e.g., "last 5 days" becomes "-5d").
-- Relative Date (Hours): Use the format "-Nh" for the last N hours (e.g., "last 5 hours" becomes "-5h").
-- Custom Date: If a specific start date is provided, use the format "YYYY-MM-DD".
-- Default Behavior: If the user does not specify a date range, default to the last 5 days (i.e., use "-5d"). date_from MUST be set.
-date_to:
-- Default Value: Set as null when the date range extends to today.
-- Custom Date: If a specific end date is required, use the format "YYYY-MM-DD".
-
-Filter Logical Operator
-- Definition: The FilterLogicalOperator defines how filters should be combined.
-- Allowed Values: 'AND' or 'OR'
-- Usage: Use it as an enum. For example, use FilterLogicalOperator.AND when filters must all be met (logical AND) or FilterLogicalOperator.OR when any filter match is acceptable (logical OR).
-
-Property Filter Type
-- Definition: The PropertyFilterType specifies the type of property to filter on.
-- Allowed Values:
-    --meta: For event metadata and fields on the ClickHouse events table.
-    --event: For event properties.
-    --person: For person properties.
-    --element: For element properties.
-    --session: For session properties.
-    --cohort: For cohorts.
-    --recording: For recording properties.
-    --log_entry: For log entry properties.
-    --group: For group properties.
-    --hogql: For hogql properties.
-    --data_warehouse: For data warehouse properties.
-    --data_warehouse_person_property: For data warehouse person properties.
--Usage: Use the enum format, for example, PropertyFilterType.Person for filtering on person properties.
-
-Property Operator
-- Definition: The PropertyOperator defines the operator used for the comparison in a filter.
-- Allowed Values:
-    --Exact for 'exact'
-    --IsNot for 'is_not'
-    --IContains for 'icontains'
-    --NotIContains for 'not_icontains'
-    --Regex for 'regex'
-    --NotRegex for 'not_regex'
-    --GreaterThan for 'gt'
-    --GreaterThanOrEqual for 'gte'
-    --LessThan for 'lt'
-    --LessThanOrEqual for 'lte'
-    --IsSet     for 'is_set'
-    --IsNotSet for 'is_not_set'
-    --IsDateExact for 'is_date_exact'
-    --IsDateBefore for 'is_date_before'
-    --IsDateAfter for 'is_date_after'
-    --Between for 'between'
-    --NotBetween for 'not_between'
-    --Minimum for 'min'
-    --Maximum for 'max'
-    --In for 'in'
-    --NotIn for 'not_in'
-- Usage: Use it as an enum, for example, PropertyOperator.Exact for the exact match operator.
-
-## Examples and Rules
-
-1. **Multi-Filter Example with AND Logic**
-
-User: "Show me recordings of mobile users who completed signup"
-
-json
-{
-"data": {
-    "date_from": "-5d",
-    "date_to": null,
-    "duration": [{"key": "duration", "type": "recording", "value": 60, "operator": "gt"}],
-    "filter_group": {
-        "type": "AND",
-        "values": [
-            {
-                "type": "AND",
-                "values": [
-                    {
-                        "key": "$device_type",
-                        "type": "person",
-                        "value": ["Mobile"],
-                        "operator": "exact"
-                    },
-                    {
-                        "key": "signup",
-                        "type": "event",
-                        "value": ["signup"],
-                        "operator": "exact"
-                    }
-                ]
-            }
-        ]
-    }
-}
-}
-
-**Process**:
-- Identified 2 filter components: "mobile" (person property) + "completed signup" (event)
-- Combined with AND logic since user implied both conditions must be met
-
-2. **Multi-Filter Example with OR Logic**
-
-User: "Show me recordings of users who are either mobile OR desktop"
-
-json
-{
-"data": {
-    "date_from": "-5d",
-    "date_to": null,
-    "duration": [{"key": "duration", "type": "recording", "value": 60, "operator": "gt"}],
-    "filter_group": {
-        "type": "OR",
-        "values": [
-            {
-                "type": "AND",
-                "values": [
-                    {
-                        "key": "$device_type",
-                        "type": "person",
-                        "value": ["Mobile"],
-                        "operator": "exact"
-                    }
-                ]
-            },
-            {
-                "type": "AND",
-                "values": [
-                    {
-                        "key": "$device_type",
-                        "type": "person",
-                        "value": ["Desktop"],
-                        "operator": "exact"
-                    }
-                ]
-            }
-        ]
-    }
-}
-}
-
-**Process**:
-- Identified 2 filter components: "mobile" + "desktop" (both person properties)
-- Combined with OR logic since user said "either... OR..."
-
-3. **Complex Multi-Filter Example**
-
-User: "Show me recordings from last week of users from US who visited pricing page and made a purchase"
-
-json
-{
-"data": {
-    "date_from": "-7d",
-    "date_to": null,
-    "duration": [{"key": "duration", "type": "recording", "value": 60, "operator": "gt"}],
-    "filter_group": {
-        "type": "AND",
-        "values": [
-            {
-                "type": "AND",
-                "values": [
-                    {
-                        "key": "$geoip_country_code",
-                        "type": "person",
-                        "value": ["US"],
-                        "operator": "exact"
-                    },
-                    {
-                        "key": "pricing_page_viewed",
-                        "type": "event",
-                        "value": ["pricing_page_viewed"],
-                        "operator": "exact"
-                    },
-                    {
-                        "key": "purchase_completed",
-                        "type": "event",
-                        "value": ["purchase_completed"],
-                        "operator": "exact"
-                    }
-                ]
-            }
-        ]
-    }
-}
-}
-
-**Process**:
-- Identified 4 filter components: "last week" (date) + "US" (person property) + "pricing page" (event) + "purchase" (event)
-- Combined with AND logic since user implied all conditions must be met
-
-4. **Operator Selection Guidelines**
-
-- Default Operators:
-In most cases, the operator can be either exact or contains:
-- For instance, if a user says, *"show me recordings where people visit login page"*, use the contains operator ("icontains") since the URL may include parameters.
-
-- Exact Matching Example:
-If a user says, *"show me recordings where people use mobile phone"*, use the exact operator to target a specific device type.
-
-5. **Special Cases**
-
-- Frustrated Users (Rageclicks):
-If the query is to show recordings of people who are frustrated, filter for recordings containing a rageclick event. For example, use the event with:
-- "id": "$rageclick", "name": "$rageclick", and "type": "event"
-
-- Users Facing Bugs/Errors/Problems:
-For queries asking for recordings of users experiencing bugs or errors, target recordings with many console errors. An example filter might look like:
-- Key: "level", Type: "log_entry", Value: ["error"], Operator: "exact".
-
-- Default Filter Group:
-The blank, default `filter_group` value you can use is:
-
-json
-{
-    "type": "AND",
-    "values": [
-        {
-            "type": "AND",
-            "values": []
-        }
-    ]
-}
-
-- Show all recordings / clean filters:
-Return a default filter with default date range and no duration.
-
-json
-{
-    "data":
-    {
-            "order": "start_time",
-            "date_to": "null",
-            "duration": [{"key": "duration", "type": "recording", "value": 60, "operator": "gt"}],
-            "date_from": "-3d",
-            "filter_group": {"type": "AND", "values": [{"type": "AND", "values": []}]},
-            "filter_test_accounts": "true",
-        }
-}
-
-6. **Multi-Filter Best Practices**:
-   - Always look for multiple filter components in user requests
-   - Common patterns: "users who [condition1] AND [condition2]", "recordings where [property1] is [value1] and [property2] is [value2]"
-   - Different entity types can be combined: person properties + event properties + session properties
-   - Use AND logic when user implies all conditions must be met
-   - Use OR logic when user says "either... OR..." or "mobile OR desktop"
-
-7. Prefer event over session properties, and session properties over person properties where it isn't clear.
-
-8. If a customer asks for recordings from a specific date but without a specific end date, set date_to to null.
-9. If a customer asks for recordings from a specific date but without specifying the year or month, use the current year and month.
-"""
-
-day = datetime.now().day
-today_date = datetime.now().strftime(f"{day} %B %Y")
-AI_FILTER_INITIAL_PROMPT += f"\nToday is {today_date}."
-
-
 MULTIPLE_FILTERS_PROMPT = """
 <multiple_filters_handling>
 When a user requests multiple filters simultaneously, follow these guidelines:
@@ -550,11 +232,8 @@ When a user requests multiple filters simultaneously, follow these guidelines:
    - Example: "users from mobile devices who completed signup" = person property ($device_type) + event property (signup event)
 
 3. **Property Discovery for Each Filter**:
-   - Use `retrieve_entity_properties` for EACH entity type mentioned
-   - Use `retrieve_entity_property_values` for EACH property you need to filter on
-   - Use `retrieve_event_properties` to discover available properties for an event
-   - Use `retrieve_event_property_values` to get possible values for a specific event property
-   - Don't skip property discovery for any filter component
+   - Use `retrieve_entity_properties` or `retrieve_event_properties` for EACH entity type or event mentioned
+   - Use `retrieve_entity_property_values` or `retrieve_event_property_values` for EACH property you need to filter on
 
 4. **Combining Multiple Filters**:
    - Use "AND" to combine all filters when user implies "AND" logic
@@ -564,26 +243,19 @@ When a user requests multiple filters simultaneously, follow these guidelines:
 5. **Example Multi-Filter Request**:
    User: "Show me recordings of mobile users who completed signup in the last week"
    Process:
-   - Filter 1: Person property $device_type = "Mobile"
+   - Filter 1: Property $device_type = "Mobile"
    - Filter 2: Event property for signup event
    - Date filter: last 7 days
    - Combine with AND logic
 
-6. **Validation Checklist**:
-   - Have I identified ALL filter criteria in the user's request?
-   - Have I discovered properties for EACH entity type mentioned?
-   - Have I retrieved values for EACH property I'm filtering on?
-   - Have I structured the filter_group to properly combine all conditions?
-   - Am I using the correct logical operators (AND/OR) based on user intent?
-
-7. **Common Multi-Filter Patterns**:
+6. **Common Multi-Filter Patterns**:
    - Device + Action: "mobile users who signed up"
    - Location + Behavior: "users from US who made a purchase"
    - Time + Property: "recordings from last week where users were frustrated"
    - Multiple Properties: "users with email domain @company.com who visited pricing page"
    - Complex: "mobile users from US who visited pricing page and made a purchase last week"
 
-8. **Logical Operator Examples**:
+7. **Logical Operator Examples**:
    - AND: "mobile users who signed up" (both conditions must be met)
    - OR: "users who are either mobile OR desktop" (either condition is acceptable)
    - Mixed: "mobile users who either signed up OR made a purchase" (mobile AND (signup OR purchase))


### PR DESCRIPTION
## Problem
Use the formatted team allowed events in the filter options generation
## Changes
1. added the `format_events_prompt` to the utils
2. added tests
3. fixed an issue with the current `format_events_prompt` overriding descriptions form the ui context, also, avoid adding tags for ignored events
4. added an inheritance between filter options partial to filters

## How did you test this code?
1. unittests
2. evals

## Did you write or update any docs for this change?
- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
