### PR TITLE
chore: deletion command improvements

### DIFF
--- a/posthog/management/commands/test/test_background_delete_model.py
+++ b/posthog/management/commands/test/test_background_delete_model.py
@@ -169,3 +169,35 @@ class TestBackgroundDeleteModel(BaseTest):
         mock_task.assert_called_once_with(model_name="posthog.Person", team_id=self.team.id, batch_size=10000)
         # Verify .delay() was not called
         mock_task.delay.assert_not_called()
+
+    @patch("posthog.management.commands.background_delete_model.background_delete_model_task")
+    @patch("builtins.input", return_value="DELETE 2 RECORDS")
+    def test_only_deletes_from_specified_team(self, mock_input, mock_task):
+        """Test that only records from the specified team are deleted"""
+        mock_task.delay.return_value = MagicMock(id="test-task-id")
+
+        # Create a second team
+        from posthog.models.team.team import Team
+
+        team2 = Team.objects.create(organization=self.organization, name="Team 2")
+
+        # Create persons across multiple teams
+        Person.objects.create(team=self.team, properties={})  # Team 1
+        Person.objects.create(team=self.team, properties={})  # Team 1
+        Person.objects.create(team=team2, properties={})  # Team 2
+        Person.objects.create(team=team2, properties={})  # Team 2
+        Person.objects.create(team=team2, properties={})  # Team 2
+
+        # Verify initial counts
+        self.assertEqual(Person.objects.filter(team=self.team).count(), 2)
+        self.assertEqual(Person.objects.filter(team=team2).count(), 3)
+
+        # Run command for team 1 only
+        self.command.handle("posthog.Person", team_id=self.team.id)
+
+        # Verify task was called with correct team_id
+        mock_task.delay.assert_called_once_with(model_name="posthog.Person", team_id=self.team.id, batch_size=10000)
+
+        # Verify counts haven't changed (since we're just testing the command, not the actual deletion)
+        self.assertEqual(Person.objects.filter(team=self.team).count(), 2)
+        self.assertEqual(Person.objects.filter(team=team2).count(), 3)

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -850,14 +850,7 @@ def environments_rollback_migration(organization_id: int, environment_mappings: 
     environments_rollback_migration(organization_id, environment_mappings, user_id)
 
 
-@shared_task(
-    ignore_result=True,
-    queue=CeleryQueue.LONG_RUNNING.value,
-    autoretry_for=(Exception,),
-    retry_backoff=60,
-    retry_backoff_max=300,
-    max_retries=3,
-)
+@shared_task(ignore_result=True, queue=CeleryQueue.LONG_RUNNING.value)
 def background_delete_model_task(model_name: str, team_id: int, batch_size: int = 10000) -> None:
     """
     Background task to delete records from a model in batches.

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -912,6 +912,8 @@ def background_delete_model_task(model_name: str, team_id: int, batch_size: int 
             if len(batch_ids) < batch_size:
                 break
 
+            time.sleep(0.2)  # Sleep to avoid overwhelming the database
+
         logger.info(
             f"Completed background deletion for {model_name}, " f"team_id={team_id}, total_deleted={deleted_count}"
         )


### PR DESCRIPTION
## Changes

Follow up to https://github.com/PostHog/posthog/pull/35215

Few improvements to the deletion command
- small sleep between batch runs
- sync option to run in toolbox
- few extra tests
- remove retry logic for task decorator, shouldn't auto retry 

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
