### PR TITLE
fix(flags): Ensure properties are not `None` before getting `len`

### DIFF
--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -427,7 +427,8 @@ class FeatureFlagMatcher:
         self, feature_flag: FeatureFlag, condition: dict, condition_index: int
     ) -> tuple[bool, FeatureFlagMatchReason]:
         rollout_percentage = condition.get("rollout_percentage")
-        if len(condition.get("properties", [])) > 0:
+        properties = condition.get("properties")
+        if properties and len(properties) > 0:
             properties = Filter(data=condition).property_groups.flat
             if self.can_compute_locally(properties, feature_flag.aggregation_group_type_index):
                 # :TRICKY: If overrides are enough to determine if a condition is a match,
@@ -559,7 +560,8 @@ class FeatureFlagMatcher:
                     property_list, self.cohorts_cache, self.project_id
                 )
 
-                if len(condition.get("properties", {})) > 0:
+                properties = condition.get("properties")
+                if properties and len(properties) > 0:
                     # Feature Flags don't support OR filtering yet
                     target_properties = self.property_value_overrides
                     if feature_flag.aggregation_group_type_index is not None:


### PR DESCRIPTION
It's possible that `condition.get("properties", {})` returns `None` if the value of the `properties` key is `None`. We need to guard against that.

## Problem

Seeing a type error pop up a bunch in error tracking with `object of type 'NoneType' has no len()` in prod.

https://us.posthog.com/project/2/error_tracking/0197a831-a131-7931-a85b-5778cc7dda99
https://us.posthog.com/project/2/error_tracking/0197a831-a217-73e1-a7df-2de6190ea515
https://us.posthog.com/project/2/error_tracking/0196b4d7-ba77-79e3-ad04-1d8399fedc51

## Changes

Check if `condition.get("properties")` is not None before getting length.

## How did you test this code?

Unit tests

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

---

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
