### PR TITLE
fix(msg): fix toggle logic for pipeline errors

### DIFF
--- a/frontend/src/scenes/settings/user/UpdateEmailPreferences.tsx
+++ b/frontend/src/scenes/settings/user/UpdateEmailPreferences.tsx
@@ -12,7 +12,7 @@ export function UpdateEmailPreferences(): JSX.Element {
 
     const weeklyDigestEnabled = !user?.notification_settings?.all_weekly_digest_disabled
     const [weeklyDigestProjectsExpanded, setWeeklyDigestProjectsExpanded] = useState(weeklyDigestEnabled)
-    const pipelineErrorsEnabled = !(user?.notification_settings?.plugin_disabled || false)
+    const pipelineErrorsEnabled = !user?.notification_settings?.plugin_disabled
 
     const updateWeeklyDigestForProject = (teamId: number, enabled: boolean): void => {
         if (!user?.notification_settings) {


### PR DESCRIPTION
## Problem

Our logic treats undefined (when the field doesn't exist) as enabled, but the onChange handler toggles the plugin_disabled field. So if someone never set this preference before, it shows as "on" in the UI,
but when they toggle it, it sets plugin_disabled: true, which turns it off.

Backend code

```
  if not membership.user.notification_settings.get(notification_setting, True):
      continue
```

This means that if plugin_disabled is not set in notification_settings, it defaults to True (notifications are enabled). But if plugin_disabled is True, then notifications are disabled.

The frontend logic should be consistent with this. The issue is that the current frontend code doesn't handle the undefined case properly.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

  - When plugin_disabled is undefined (never set), !undefined evaluates to true, so notifications are enabled by default
  - When plugin_disabled is false, !false evaluates to true, so notifications are enabled
  - When plugin_disabled is true, !true evaluates to false, so notifications are disabled

This matches the backend logic where notification_settings.get(notification_setting, True) defaults to True when the setting doesn't exist, and the email is sent unless plugin_disabled is True.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- local dev

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
