### PR TITLE
chore: do not use `.env.local` in PostHog.run.xml

### DIFF
--- a/.run/PostHog.run.xml
+++ b/.run/PostHog.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="PostHog" type="Python.DjangoServer" factoryName="Django server">
     <module name="posthog" />
-    <option name="ENV_FILES" value="$PROJECT_DIR$/.env.local" />
+    <option name="ENV_FILES" value="" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>


### PR DESCRIPTION
## Problem


<!-- Who are we building for, what are their needs, why is this important? -->
Reverts [this change](https://github.com/PostHog/posthog/pull/35380/files#diff-3d27847d080f1459bdf19c7d378fabebd64f0fefb9ce803b70b748f2f99a8709R4) in #35380 , which was accidentally committed. Right now, devs are required to have a `.env.local` present when running the `PostHog` configuration in IntelliJ which is undesirable. We have yet to agree on a standard on how to use (local) environment variables. 


<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We now don't enforce `.env.local` anymore in the PostHog IntelliJ Run/Debug Configuration.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
