### PR TITLE
fix(max): shared attributes between nodes and tools

### DIFF
--- a/ee/hogai/assistant.py
+++ b/ee/hogai/assistant.py
@@ -397,7 +397,7 @@ class Assistant:
                 # when the tool has been removed from the backend since the user's frontent was loaded
                 ToolClass = CONTEXTUAL_TOOL_NAME_TO_TOOL.get(tool_call.name)  # type: ignore
                 return ReasoningMessage(
-                    content=ToolClass(self._team, self._user).thinking_message
+                    content=ToolClass(team=self._team, user=self._user).thinking_message
                     if ToolClass
                     else f"Running tool {tool_call.name}"
                 )

--- a/ee/hogai/assistant.py
+++ b/ee/hogai/assistant.py
@@ -27,6 +27,7 @@ from ee.hogai.graph import (
     TrendsGeneratorNode,
 )
 from ee.hogai.graph.base import AssistantNode
+from ee.hogai.graph.filter_options.types import FilterOptionsNodeName
 from ee.hogai.tool import CONTEXTUAL_TOOL_NAME_TO_TOOL
 from ee.hogai.utils.exceptions import GenerationCanceled
 from ee.hogai.utils.helpers import find_last_ui_context, should_output_assistant_message
@@ -50,7 +51,6 @@ from ee.hogai.utils.types import (
     AssistantState,
     PartialAssistantState,
 )
-from ee.hogai.graph.filter_options.types import FilterOptionsNodeName
 from ee.models import Conversation
 from posthog.event_usage import report_user_action
 from posthog.models import Action, Team, User
@@ -397,7 +397,9 @@ class Assistant:
                 # when the tool has been removed from the backend since the user's frontent was loaded
                 ToolClass = CONTEXTUAL_TOOL_NAME_TO_TOOL.get(tool_call.name)  # type: ignore
                 return ReasoningMessage(
-                    content=ToolClass().thinking_message if ToolClass else f"Running tool {tool_call.name}"
+                    content=ToolClass(self._team, self._user).thinking_message
+                    if ToolClass
+                    else f"Running tool {tool_call.name}"
                 )
             case AssistantNodeName.ROOT:
                 ui_context = find_last_ui_context(input.messages)

--- a/ee/hogai/eval/eval_surveys.py
+++ b/ee/hogai/eval/eval_surveys.py
@@ -16,7 +16,7 @@ def call_surveys_max_tool(demo_org_team_user):
     # Extract team and user from the demo fixture
     _, team, user = demo_org_team_user
 
-    max_tool = CreateSurveyTool(team, user)
+    max_tool = CreateSurveyTool(team=team, user=user)
     max_tool._context = {"user_id": str(user.uuid)}  # Additional context
 
     async def call_max_tool(instructions: str) -> dict:

--- a/ee/hogai/eval/eval_surveys.py
+++ b/ee/hogai/eval/eval_surveys.py
@@ -1,7 +1,7 @@
 import pytest
+from autoevals.llm import LLMClassifier
 from braintrust import EvalCase, Score
 from braintrust_core.score import Scorer
-from autoevals.llm import LLMClassifier
 
 from products.surveys.backend.max_tools import CreateSurveyTool
 
@@ -16,11 +16,7 @@ def call_surveys_max_tool(demo_org_team_user):
     # Extract team and user from the demo fixture
     _, team, user = demo_org_team_user
 
-    max_tool = CreateSurveyTool()
-
-    # Set up the required attributes that the tool expects
-    max_tool._team = team  # Team context for survey creation
-    max_tool._user = user  # User who is creating the survey
+    max_tool = CreateSurveyTool(team, user)
     max_tool._context = {"user_id": str(user.uuid)}  # Additional context
 
     async def call_max_tool(instructions: str) -> dict:

--- a/ee/hogai/eval/max_tools/eval_hogql_generator_tool.py
+++ b/ee/hogai/eval/max_tools/eval_hogql_generator_tool.py
@@ -30,7 +30,7 @@ def call_generate_hogql_query(demo_org_team_user):
 
     async def callable(inputs: EvalInput, *args, **kwargs) -> str:
         # Initial state for the graph
-        tool = HogQLGeneratorTool(state=AssistantState(messages=[]))
+        tool = HogQLGeneratorTool(team=team, user=user, state=AssistantState(messages=[]))
 
         if inputs.apply_patch:
             inputs.apply_patch(tool)

--- a/ee/hogai/graph/base.py
+++ b/ee/hogai/graph/base.py
@@ -25,8 +25,8 @@ from ..utils.types import (
 
 class BaseAssistantNode(Generic[StateType, PartialStateType], AssistantContextMixin):
     def __init__(self, team: Team, user: User):
-        self.__internal_team = team
-        self.__internal_user = user
+        self._team = team
+        self._user = user
 
     async def __call__(self, state: StateType, config: RunnableConfig) -> PartialStateType | None:
         """
@@ -47,14 +47,6 @@ class BaseAssistantNode(Generic[StateType, PartialStateType], AssistantContextMi
 
     async def arun(self, state: StateType, config: RunnableConfig) -> PartialStateType | None:
         raise NotImplementedError
-
-    @property
-    def _team(self) -> Team:
-        return self.__internal_team
-
-    @property
-    def _user(self) -> User:
-        return self.__internal_user
 
     async def _is_conversation_cancelled(self, conversation_id: UUID) -> bool:
         conversation = await self._aget_conversation(conversation_id)

--- a/ee/hogai/graph/mixins.py
+++ b/ee/hogai/graph/mixins.py
@@ -1,5 +1,5 @@
 import datetime
-from abc import ABC, abstractmethod
+from abc import ABC
 from uuid import UUID
 
 from django.utils import timezone
@@ -10,13 +10,8 @@ from posthog.models.user import User
 
 
 class AssistantContextMixin(ABC):
-    @property
-    @abstractmethod
-    def _team(self) -> Team: ...
-
-    @property
-    @abstractmethod
-    def _user(self) -> User: ...
+    _team: Team
+    _user: User
 
     async def _aget_core_memory(self) -> CoreMemory | None:
         try:

--- a/ee/hogai/graph/root/nodes.py
+++ b/ee/hogai/graph/root/nodes.py
@@ -12,13 +12,13 @@ from langchain_core.messages import (
 )
 from langchain_core.prompts import ChatPromptTemplate, PromptTemplate
 from langchain_core.runnables import RunnableConfig
-from ee.hogai.llm import MaxChatOpenAI
 from langgraph.errors import NodeInterrupt
 from posthoganalytics import capture_exception
 from pydantic import BaseModel
 
-from ee.hogai.graph.shared_prompts import CORE_MEMORY_PROMPT
 from ee.hogai.graph.query_executor.query_executor import AssistantQueryExecutor, SupportedQueryTypes
+from ee.hogai.graph.shared_prompts import CORE_MEMORY_PROMPT
+from ee.hogai.llm import MaxChatOpenAI
 
 # Import moved inside functions to avoid circular imports
 from ee.hogai.utils.types import AssistantState, PartialAssistantState
@@ -35,8 +35,8 @@ from posthog.schema import (
     FunnelsQuery,
     HogQLQuery,
     HumanMessage,
-    MaxUIContext,
     MaxInsightContext,
+    MaxUIContext,
     RetentionQuery,
     TrendsQuery,
 )
@@ -533,7 +533,7 @@ class RootNodeTools(AssistantNode):
                 root_tool_calls_count=tool_call_count + 1,
             )
         elif ToolClass := get_contextual_tool_class(tool_call.name):
-            tool_class = ToolClass(state)
+            tool_class = ToolClass(self._team, self._user, state)
             result = await tool_class.ainvoke(tool_call.model_dump(), config)
             if not isinstance(result, LangchainToolMessage):
                 raise TypeError(f"Expected a {LangchainToolMessage}, got {type(result)}")

--- a/ee/hogai/graph/root/nodes.py
+++ b/ee/hogai/graph/root/nodes.py
@@ -304,7 +304,7 @@ class RootNode(RootNodeUIContextMixin):
                         (
                             "system",
                             f"<{tool_name}>\n"
-                            f"{get_contextual_tool_class(tool_name)(self._team, self._user).format_system_prompt_injection(tool_context)}\n"  # type: ignore
+                            f"{get_contextual_tool_class(tool_name)(team=self._team, user=self._user).format_system_prompt_injection(tool_context)}\n"  # type: ignore
                             f"</{tool_name}>",
                         )
                         for tool_name, tool_context in self._get_contextual_tools(config).items()
@@ -386,7 +386,7 @@ class RootNode(RootNodeUIContextMixin):
             ToolClass = get_contextual_tool_class(tool_name)
             if ToolClass is None:
                 continue  # Ignoring a tool that the backend doesn't know about - might be a deployment mismatch
-            available_tools.append(ToolClass(self._team, self._user))  # type: ignore
+            available_tools.append(ToolClass(team=self._team, user=self._user))  # type: ignore
         return base_model.bind_tools(available_tools, strict=True, parallel_tool_calls=False)
 
     def _get_assistant_messages_in_window(self, state: AssistantState) -> list[RootMessageUnion]:
@@ -533,7 +533,7 @@ class RootNodeTools(AssistantNode):
                 root_tool_calls_count=tool_call_count + 1,
             )
         elif ToolClass := get_contextual_tool_class(tool_call.name):
-            tool_class = ToolClass(self._team, self._user, state)
+            tool_class = ToolClass(team=self._team, user=self._user, state=state)
             result = await tool_class.ainvoke(tool_call.model_dump(), config)
             if not isinstance(result, LangchainToolMessage):
                 raise TypeError(f"Expected a {LangchainToolMessage}, got {type(result)}")

--- a/ee/hogai/graph/root/nodes.py
+++ b/ee/hogai/graph/root/nodes.py
@@ -304,7 +304,7 @@ class RootNode(RootNodeUIContextMixin):
                         (
                             "system",
                             f"<{tool_name}>\n"
-                            f"{get_contextual_tool_class(tool_name)().format_system_prompt_injection(tool_context)}\n"  # type: ignore
+                            f"{get_contextual_tool_class(tool_name)(self._team, self._user).format_system_prompt_injection(tool_context)}\n"  # type: ignore
                             f"</{tool_name}>",
                         )
                         for tool_name, tool_context in self._get_contextual_tools(config).items()
@@ -386,7 +386,7 @@ class RootNode(RootNodeUIContextMixin):
             ToolClass = get_contextual_tool_class(tool_name)
             if ToolClass is None:
                 continue  # Ignoring a tool that the backend doesn't know about - might be a deployment mismatch
-            available_tools.append(ToolClass())  # type: ignore
+            available_tools.append(ToolClass(self._team, self._user))  # type: ignore
         return base_model.bind_tools(available_tools, strict=True, parallel_tool_calls=False)
 
     def _get_assistant_messages_in_window(self, state: AssistantState) -> list[RootMessageUnion]:

--- a/ee/hogai/graph/root/test/test_nodes.py
+++ b/ee/hogai/graph/root/test/test_nodes.py
@@ -1,13 +1,13 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from langchain_core.outputs import ChatResult, ChatGeneration
-from langchain_core.messages import AIMessage
 from langchain_core.messages import (
+    AIMessage,
     AIMessage as LangchainAIMessage,
     HumanMessage as LangchainHumanMessage,
     SystemMessage,
     ToolMessage as LangchainToolMessage,
 )
+from langchain_core.outputs import ChatGeneration, ChatResult
 from langgraph.errors import NodeInterrupt
 from parameterized import parameterized
 
@@ -26,10 +26,10 @@ from posthog.schema import (
     HumanMessage,
     LifecycleQuery,
     MaxActionContext,
-    MaxUIContext,
     MaxDashboardContext,
     MaxEventContext,
     MaxInsightContext,
+    MaxUIContext,
     RetentionEntity,
     RetentionFilter,
     RetentionQuery,
@@ -722,7 +722,7 @@ class TestRootNodeTools(BaseTest):
             mock_navigate_tool.ainvoke.return_value = LangchainToolMessage(
                 content="XXX", tool_call_id="nav-123", artifact={"page_key": "insights"}
             )
-            mock_tools.return_value = lambda _: mock_navigate_tool
+            mock_tools.return_value = lambda *args: mock_navigate_tool
 
             # The navigate tool call should raise NodeInterrupt
             with self.assertRaises(NodeInterrupt) as cm:
@@ -761,7 +761,7 @@ class TestRootNodeTools(BaseTest):
             mock_search_session_recordings.ainvoke.return_value = LangchainToolMessage(
                 content="YYYY", tool_call_id="nav-123", artifact={"filters": {}}
             )
-            mock_tools.return_value = lambda _: mock_search_session_recordings
+            mock_tools.return_value = lambda *args: mock_search_session_recordings
 
             # This should not raise NodeInterrupt
             result = await node.arun(

--- a/ee/hogai/graph/root/test/test_nodes.py
+++ b/ee/hogai/graph/root/test/test_nodes.py
@@ -722,7 +722,7 @@ class TestRootNodeTools(BaseTest):
             mock_navigate_tool.ainvoke.return_value = LangchainToolMessage(
                 content="XXX", tool_call_id="nav-123", artifact={"page_key": "insights"}
             )
-            mock_tools.return_value = lambda *args: mock_navigate_tool
+            mock_tools.return_value = lambda *args, **kwargs: mock_navigate_tool
 
             # The navigate tool call should raise NodeInterrupt
             with self.assertRaises(NodeInterrupt) as cm:
@@ -761,7 +761,7 @@ class TestRootNodeTools(BaseTest):
             mock_search_session_recordings.ainvoke.return_value = LangchainToolMessage(
                 content="YYYY", tool_call_id="nav-123", artifact={"filters": {}}
             )
-            mock_tools.return_value = lambda *args: mock_search_session_recordings
+            mock_tools.return_value = lambda *args, **kwargs: mock_search_session_recordings
 
             # This should not raise NodeInterrupt
             result = await node.arun(

--- a/ee/hogai/graph/test/test_mixins.py
+++ b/ee/hogai/graph/test/test_mixins.py
@@ -9,16 +9,8 @@ class TestAssistantNodeMixin(BaseTest):
 
         class TestNode(AssistantContextMixin):
             def __init__(self, team, user):
-                self.__team = team
-                self.__user = user
-
-            @property
-            def _team(self):
-                return self.__team
-
-            @property
-            def _user(self):
-                return self.__user
+                self._team = team
+                self._user = user
 
         self.node = TestNode(self.team, self.user)
 

--- a/ee/hogai/tool.py
+++ b/ee/hogai/tool.py
@@ -1,7 +1,7 @@
 import importlib
 import json
 import pkgutil
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal
 
 from asgiref.sync import async_to_sync
 from langchain_core.runnables import RunnableConfig
@@ -104,8 +104,8 @@ class MaxTool(AssistantContextMixin, BaseTool):
     """
 
     _context: dict[str, Any]
-    __internal_team: Optional["Team"]
-    __internal_user: Optional["User"]
+    _team: "Team"
+    _user: "User"
     _config: RunnableConfig
     _state: AssistantState
 
@@ -118,8 +118,10 @@ class MaxTool(AssistantContextMixin, BaseTool):
         """Tool execution, which should return a tuple of (content, artifact)"""
         raise NotImplementedError
 
-    def __init__(self, state: AssistantState | None = None):
-        super().__init__()
+    def __init__(self, team: "Team", user: "User", *, state: AssistantState | None = None, **kwargs):
+        super().__init__(**kwargs)
+        self._team = team
+        self._user = user
         self._state = state if state else AssistantState(messages=[])
 
     def __init_subclass__(cls, **kwargs):
@@ -135,18 +137,6 @@ class MaxTool(AssistantContextMixin, BaseTool):
         CONTEXTUAL_TOOL_NAME_TO_TOOL[accepted_name] = cls
         if not getattr(cls, "thinking_message", None):
             raise ValueError("You must set `thinking_message` on the tool, so that we can show the tool kicking off")
-
-    @property
-    def _team(self) -> "Team":
-        if not self.__internal_team:
-            raise ValueError("Team not set")
-        return self.__internal_team
-
-    @property
-    def _user(self) -> "User":
-        if not self.__internal_user:
-            raise ValueError("User not set")
-        return self.__internal_user
 
     def _run(self, *args, config: RunnableConfig, **kwargs):
         self._init_run(config)
@@ -164,8 +154,8 @@ class MaxTool(AssistantContextMixin, BaseTool):
 
     def _init_run(self, config: RunnableConfig):
         self._context = config["configurable"].get("contextual_tools", {}).get(self.get_name(), {})
-        self.__internal_team = config["configurable"]["team"]
-        self.__internal_user = config["configurable"]["user"]
+        self._team = config["configurable"]["team"]
+        self._user = config["configurable"]["user"]
         self._config = {
             "recursion_limit": 48,
             "callbacks": config.get("callbacks", []),

--- a/ee/hogai/tool.py
+++ b/ee/hogai/tool.py
@@ -1,7 +1,7 @@
 import importlib
 import json
 import pkgutil
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 from asgiref.sync import async_to_sync
 from langchain_core.runnables import RunnableConfig
@@ -11,10 +11,8 @@ from pydantic import BaseModel, Field
 import products
 from ee.hogai.graph.mixins import AssistantContextMixin
 from ee.hogai.utils.types import AssistantState
+from posthog.models import Team, User
 from posthog.schema import AssistantContextualTool, AssistantNavigateUrls
-
-if TYPE_CHECKING:
-    from posthog.models import Team, User
 
 
 # Lower casing matters here. Do not change it.
@@ -118,7 +116,7 @@ class MaxTool(AssistantContextMixin, BaseTool):
         """Tool execution, which should return a tuple of (content, artifact)"""
         raise NotImplementedError
 
-    def __init__(self, team: "Team", user: "User", state: AssistantState | None = None, **kwargs):
+    def __init__(self, *, team: Team, user: User, state: AssistantState | None = None, **kwargs):
         super().__init__(**kwargs)
         self._team = team
         self._user = user

--- a/ee/hogai/tool.py
+++ b/ee/hogai/tool.py
@@ -118,7 +118,7 @@ class MaxTool(AssistantContextMixin, BaseTool):
         """Tool execution, which should return a tuple of (content, artifact)"""
         raise NotImplementedError
 
-    def __init__(self, team: "Team", user: "User", *, state: AssistantState | None = None, **kwargs):
+    def __init__(self, team: "Team", user: "User", state: AssistantState | None = None, **kwargs):
         super().__init__(**kwargs)
         self._team = team
         self._user = user

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -34,6 +34,7 @@ ee/billing/test/test_billing_manager.py:0: error: Module "django.utils.timezone"
 ee/billing/test/test_billing_manager.py:0: error: Module "django.utils.timezone" does not explicitly export attribute "datetime"  [attr-defined]
 ee/billing/test/test_billing_manager.py:0: error: Module "django.utils.timezone" does not explicitly export attribute "datetime"  [attr-defined]
 ee/clickhouse/queries/funnels/funnel_correlation.py:0: error: Statement is unreachable  [unreachable]
+ee/hogai/graph/root/nodes.py:0: error: Too many positional arguments for "MaxTool"  [misc]
 ee/models/explicit_team_membership.py:0: error: Incompatible return value type (got "int", expected "Level")  [return-value]
 ee/models/license.py:0: error: "_T" has no attribute "plan"  [attr-defined]
 ee/models/license.py:0: error: Cannot use a covariant type variable as a parameter  [misc]
@@ -457,4 +458,4 @@ posthog/warehouse/models/table.py:0: error: Item "None" of "DataWarehouseCredent
 posthog/warehouse/models/table.py:0: error: Item "None" of "DataWarehouseCredential | None" has no attribute "access_secret"  [union-attr]
 posthog/warehouse/models/table.py:0: error: Item "None" of "DataWarehouseCredential | None" has no attribute "access_secret"  [union-attr]
 posthog/warehouse/models/table.py:0: error: Subclass of "list[tuple[str, ...]]" and "int" cannot exist: would have incompatible method signatures  [unreachable]
-products/data_warehouse/backend/api/fix_hogql.py:0: error: Unused "type: ignore" comment  [unused-ignore]
+products/data_warehouse/backend/api/fix_hogql.py:0: error: Too many positional arguments for "HogQLQueryFixerTool"  [misc]

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -34,7 +34,6 @@ ee/billing/test/test_billing_manager.py:0: error: Module "django.utils.timezone"
 ee/billing/test/test_billing_manager.py:0: error: Module "django.utils.timezone" does not explicitly export attribute "datetime"  [attr-defined]
 ee/billing/test/test_billing_manager.py:0: error: Module "django.utils.timezone" does not explicitly export attribute "datetime"  [attr-defined]
 ee/clickhouse/queries/funnels/funnel_correlation.py:0: error: Statement is unreachable  [unreachable]
-ee/hogai/graph/root/nodes.py:0: error: Too many positional arguments for "MaxTool"  [misc]
 ee/models/explicit_team_membership.py:0: error: Incompatible return value type (got "int", expected "Level")  [return-value]
 ee/models/license.py:0: error: "_T" has no attribute "plan"  [attr-defined]
 ee/models/license.py:0: error: Cannot use a covariant type variable as a parameter  [misc]

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -457,4 +457,3 @@ posthog/warehouse/models/table.py:0: error: Item "None" of "DataWarehouseCredent
 posthog/warehouse/models/table.py:0: error: Item "None" of "DataWarehouseCredential | None" has no attribute "access_secret"  [union-attr]
 posthog/warehouse/models/table.py:0: error: Item "None" of "DataWarehouseCredential | None" has no attribute "access_secret"  [union-attr]
 posthog/warehouse/models/table.py:0: error: Subclass of "list[tuple[str, ...]]" and "int" cannot exist: would have incompatible method signatures  [unreachable]
-products/data_warehouse/backend/api/fix_hogql.py:0: error: Too many positional arguments for "HogQLQueryFixerTool"  [misc]

--- a/products/data_warehouse/backend/api/fix_hogql.py
+++ b/products/data_warehouse/backend/api/fix_hogql.py
@@ -50,7 +50,7 @@ class FixHogQLViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             ),
         }
 
-        result = HogQLQueryFixerTool(self.team, user).invoke({}, config)  # type: ignore
+        result = HogQLQueryFixerTool(team=self.team, user=user).invoke({}, config)
 
         if result is None or (isinstance(result, str) and len(result) == 0):
             return Response({"trace_id": trace_id, "error": "Could not fix the query"}, status=400)

--- a/products/data_warehouse/backend/api/fix_hogql.py
+++ b/products/data_warehouse/backend/api/fix_hogql.py
@@ -50,7 +50,7 @@ class FixHogQLViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             ),
         }
 
-        result = HogQLQueryFixerTool(self.team, user).invoke({}, config)
+        result = HogQLQueryFixerTool(self.team, user).invoke({}, config)  # type: ignore
 
         if result is None or (isinstance(result, str) and len(result) == 0):
             return Response({"trace_id": trace_id, "error": "Could not fix the query"}, status=400)

--- a/products/data_warehouse/backend/api/fix_hogql.py
+++ b/products/data_warehouse/backend/api/fix_hogql.py
@@ -1,15 +1,14 @@
-from typing import cast
 import uuid
+from typing import cast
 
 import posthoganalytics
+from langchain_core.runnables import RunnableConfig
 from posthoganalytics.ai.langchain.callbacks import CallbackHandler
-
-from posthog.api.routing import TeamAndOrgViewSetMixin
 from rest_framework import status, viewsets
 from rest_framework.request import Request
 from rest_framework.response import Response
-from langchain_core.runnables import RunnableConfig
 
+from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.models.user import User
 
 
@@ -51,7 +50,7 @@ class FixHogQLViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             ),
         }
 
-        result = HogQLQueryFixerTool().invoke({}, config)  # type: ignore
+        result = HogQLQueryFixerTool(self.team, user).invoke({}, config)
 
         if result is None or (isinstance(result, str) and len(result) == 0):
             return Response({"trace_id": trace_id, "error": "Could not fix the query"}, status=400)

--- a/products/data_warehouse/backend/test/test_max_tools.py
+++ b/products/data_warehouse/backend/test/test_max_tools.py
@@ -20,7 +20,7 @@ class TestDataWarehouseMaxTools(NonAtomicBaseTest):
             "products.data_warehouse.backend.max_tools.HogQLGeneratorTool._model",
             return_value={"query": "SELECT AVG(properties.$session_length) FROM events"},
         ):
-            tool = HogQLGeneratorTool(AssistantState(messages=[]))
+            tool = HogQLGeneratorTool(team=self.team, user=self.user, state=AssistantState(messages=[]))
             tool_call = AssistantToolCall(
                 id="1",
                 name="generate_hogql_query",

--- a/products/surveys/backend/test_max_tools.py
+++ b/products/surveys/backend/test_max_tools.py
@@ -41,7 +41,7 @@ class TestSurveyCreatorTool(BaseTest):
 
     def _setup_tool(self):
         """Helper to create a SurveyCreatorTool instance with mocked dependencies"""
-        tool = CreateSurveyTool(self.team, self.user)
+        tool = CreateSurveyTool(team=self.team, user=self.user)
 
         # Mock the internal state required by MaxTool
         tool._init_run(self._config)

--- a/products/surveys/backend/test_max_tools.py
+++ b/products/surveys/backend/test_max_tools.py
@@ -41,7 +41,7 @@ class TestSurveyCreatorTool(BaseTest):
 
     def _setup_tool(self):
         """Helper to create a SurveyCreatorTool instance with mocked dependencies"""
-        tool = CreateSurveyTool()
+        tool = CreateSurveyTool(self.team, self.user)
 
         # Mock the internal state required by MaxTool
         tool._init_run(self._config)


### PR DESCRIPTION
## Problem

I've merged a new mixin for nodes and tools in #35426, but as @Twixes correctly pointed out, Pydantic excludes private fields from validation. Checked the implementation without mypy cache, and it worked well...

## Changes

Replace getters with class attributes in the Max mixin.

## How did you test this code?

Unit tests
