### PR TITLE
feat: Track activity attempts in batch exports interceptor

### DIFF
--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -13,12 +13,12 @@ from products.batch_exports.backend.temporal.metrics import BatchExportsMetricsI
 
 logger = structlog.get_logger(__name__)
 
-BATCH_EXPORTS_HISTOGRAM_METRICS = (
+BATCH_EXPORTS_LATENCY_HISTOGRAM_METRICS = (
     "batch_exports_activity_execution_latency",
     "batch_exports_activity_interval_execution_latency",
     "batch_exports_workflow_interval_execution_latency",
 )
-BATCH_EXPORTS_HISTOGRAM_BUCKETS = [
+BATCH_EXPORTS_LATENCY_HISTOGRAM_BUCKETS = [
     1_000.0,
     30_000.0,  # 30 seconds
     60_000.0,  # 1 minute
@@ -82,8 +82,12 @@ async def create_worker(
                 # given that the `duration_as_seconds` is `False`.
                 # But in Python we still need to pass floats due to type hints.
                 histogram_bucket_overrides=dict(
-                    zip(BATCH_EXPORTS_HISTOGRAM_METRICS, itertools.repeat(BATCH_EXPORTS_HISTOGRAM_BUCKETS))
-                ),
+                    zip(
+                        BATCH_EXPORTS_LATENCY_HISTOGRAM_METRICS,
+                        itertools.repeat(BATCH_EXPORTS_LATENCY_HISTOGRAM_BUCKETS),
+                    )
+                )
+                | {"batch_exports_activity_attempt": [1.0, 5.0, 10.0]},
             ),
         )
     )

--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -87,7 +87,7 @@ async def create_worker(
                         itertools.repeat(BATCH_EXPORTS_LATENCY_HISTOGRAM_BUCKETS),
                     )
                 )
-                | {"batch_exports_activity_attempt": [1.0, 5.0, 10.0]},
+                | {"batch_exports_activity_attempt": [1.0, 5.0, 10.0, 100.0]},
             ),
         )
     )

--- a/products/batch_exports/backend/temporal/metrics.py
+++ b/products/batch_exports/backend/temporal/metrics.py
@@ -4,7 +4,7 @@ import typing
 
 import structlog
 from temporalio import activity, workflow
-from temporalio.common import MetricCounter
+from temporalio.common import MetricCounter, MetricMeter
 from temporalio.worker import (
     ActivityInboundInterceptor,
     ExecuteActivityInput,
@@ -41,8 +41,6 @@ def get_export_finished_metric(status: str) -> MetricCounter:
     )
 
 
-MAIN_ACTIVITY_EXECUTION_LATENCY_HISTOGRAM_NAME = "batch_exports_main_activity_execution_latency"
-STAGE_ACTIVITY_EXECUTION_LATENCY_HISTOGRAM_NAME = "batch_exports_stage_activity_execution_latency"
 BATCH_EXPORT_ACTIVITY_TYPES = {
     "insert_into_s3_activity_from_stage",
     "insert_into_snowflake_activity",
@@ -95,6 +93,11 @@ class _BatchExportsMetricsActivityInboundInterceptor(ActivityInboundInterceptor)
         histogram_attributes: Attributes = {
             "interval": interval,
         }
+
+        activity_attempt = activity_info.attempt
+        meter = get_metric_meter(histogram_attributes)
+        hist = meter.create_histogram("batch_exports_activity_attempt")
+        hist.record(activity_attempt)
 
         with ExecutionTimeRecorder(
             "batch_exports_activity_interval_execution_latency", histogram_attributes=histogram_attributes, log=False
@@ -183,7 +186,8 @@ class ExecutionTimeRecorder:
         delta_milli_seconds = int((end_counter - start_counter) * 1000)
         delta = dt.timedelta(milliseconds=delta_milli_seconds)
 
-        attributes = get_attributes(self.histogram_attributes)
+        attributes = self.histogram_attributes or {}
+
         if exc_value is not None:
             attributes["status"] = "FAILED"
             attributes["exception"] = str(exc_value)
@@ -225,18 +229,18 @@ class ExecutionTimeRecorder:
         self.bytes_processed = None
 
 
-def get_metric_meter(additional_attributes: Attributes | None = None):
+def get_metric_meter(additional_attributes: Attributes | None = None) -> MetricMeter:
     """Return a meter depending on in which context we are."""
+    attributes = get_attributes(additional_attributes)
+
     if activity.in_activity():
         meter = activity.metric_meter()
+    elif workflow.in_workflow():
+        meter = workflow.metric_meter()
     else:
-        try:
-            meter = workflow.metric_meter()
-        except Exception:
-            raise RuntimeError("Not within workflow or activity context")
+        raise RuntimeError("Not within workflow or activity context")
 
-    if additional_attributes:
-        meter = meter.with_additional_attributes(additional_attributes)
+    meter = meter.with_additional_attributes(attributes)
 
     return meter
 
@@ -245,11 +249,10 @@ def get_attributes(additional_attributes: Attributes | None = None) -> Attribute
     """Return attributes depending on in which context we are."""
     if activity.in_activity():
         attributes = get_activity_attributes()
+    elif workflow.in_workflow():
+        attributes = get_workflow_attributes()
     else:
-        try:
-            attributes = get_workflow_attributes()
-        except Exception:
-            attributes = {}
+        attributes = {}
 
     if additional_attributes:
         attributes = {**attributes, **additional_attributes}
@@ -258,7 +261,7 @@ def get_attributes(additional_attributes: Attributes | None = None) -> Attribute
 
 
 def get_activity_attributes() -> Attributes:
-    """Return basic Temporal.io activity attributes."""
+    """Return basic Temporal activity attributes."""
     info = activity.info()
 
     return {
@@ -269,7 +272,7 @@ def get_activity_attributes() -> Attributes:
 
 
 def get_workflow_attributes() -> Attributes:
-    """Return basic Temporal.io workflow attributes."""
+    """Return basic Temporal workflow attributes."""
     info = workflow.info()
 
     return {

--- a/products/batch_exports/backend/temporal/metrics.py
+++ b/products/batch_exports/backend/temporal/metrics.py
@@ -96,11 +96,17 @@ class _BatchExportsMetricsActivityInboundInterceptor(ActivityInboundInterceptor)
 
         activity_attempt = activity_info.attempt
         meter = get_metric_meter(histogram_attributes)
-        hist = meter.create_histogram("batch_exports_activity_attempt")
+        hist = meter.create_histogram(
+            name="batch_exports_activity_attempt",
+            description="Histogram tracking attempts made by critical batch export activities",
+        )
         hist.record(activity_attempt)
 
         with ExecutionTimeRecorder(
-            "batch_exports_activity_interval_execution_latency", histogram_attributes=histogram_attributes, log=False
+            "batch_exports_activity_interval_execution_latency",
+            description="Histogram tracking execution latency for critical batch export activities by interval",
+            histogram_attributes=histogram_attributes,
+            log=False,
         ):
             return await super().execute_activity(input)
 
@@ -119,7 +125,10 @@ class _BatchExportsMetricsWorkflowInterceptor(WorkflowInboundInterceptor):
         histogram_attributes: Attributes = {"interval": interval}
 
         with ExecutionTimeRecorder(
-            "batch_exports_workflow_interval_execution_latency", histogram_attributes=histogram_attributes, log=False
+            "batch_exports_workflow_interval_execution_latency",
+            description="Histogram tracking execution latency for batch export workflows by interval",
+            histogram_attributes=histogram_attributes,
+            log=False,
         ):
             return await super().execute_workflow(input)
 

--- a/products/batch_exports/backend/tests/temporal/test_metrics.py
+++ b/products/batch_exports/backend/tests/temporal/test_metrics.py
@@ -115,29 +115,25 @@ async def test_interceptor_calls_histogram_metrics(
 
         mocked_meter.assert_any_call(
             {
-                "workflow_namespace": "default",
-                "workflow_type": "postgres-export",
-                "activity_type": "insert_into_postgres_activity",
-                "interval": "hour",
-                "status": "COMPLETED",
-                "exception": "",
-            }
-        )
-        mocked_meter.assert_any_call(
-            {
-                "workflow_namespace": "default",
-                "workflow_type": "postgres-export",
                 "interval": "hour",
                 "status": "COMPLETED",
                 "exception": "",
             }
         )
 
-        mocked_meter.return_value.create_histogram_timedelta.assert_any_call(
-            name="batch_exports_activity_interval_execution_latency", description=None, unit="ms"
+        mocked_meter.return_value.create_histogram.assert_any_call(
+            name="batch_exports_activity_attempt",
+            description="Histogram tracking attempts made by critical batch export activities",
         )
         mocked_meter.return_value.create_histogram_timedelta.assert_any_call(
-            name="batch_exports_workflow_interval_execution_latency", description=None, unit="ms"
+            name="batch_exports_activity_interval_execution_latency",
+            description="Histogram tracking execution latency for critical batch export activities separated by interval",
+            unit="ms",
+        )
+        mocked_meter.return_value.create_histogram_timedelta.assert_any_call(
+            name="batch_exports_workflow_interval_execution_latency",
+            description="Histogram tracking execution latency for batch export workflows by interval",
+            unit="ms",
         )
 
         number_of_record_calls = len(
@@ -146,3 +142,5 @@ async def test_interceptor_calls_histogram_metrics(
         assert (
             number_of_record_calls == 2
         ), f"expected to have recorded two metrics: for workflow and activity execution latency, but only found {number_of_record_calls}"
+
+        mocked_meter.return_value.create_histogram.return_value.record.assert_called_once_with(1)

--- a/products/batch_exports/backend/tests/temporal/test_metrics.py
+++ b/products/batch_exports/backend/tests/temporal/test_metrics.py
@@ -126,13 +126,13 @@ async def test_interceptor_calls_histogram_metrics(
             description="Histogram tracking attempts made by critical batch export activities",
         )
         mocked_meter.return_value.create_histogram_timedelta.assert_any_call(
-            name="batch_exports_activity_interval_execution_latency",
-            description="Histogram tracking execution latency for critical batch export activities separated by interval",
+            name="batch_exports_workflow_interval_execution_latency",
+            description="Histogram tracking execution latency for batch export workflows by interval",
             unit="ms",
         )
         mocked_meter.return_value.create_histogram_timedelta.assert_any_call(
-            name="batch_exports_workflow_interval_execution_latency",
-            description="Histogram tracking execution latency for batch export workflows by interval",
+            name="batch_exports_activity_interval_execution_latency",
+            description="Histogram tracking execution latency for critical batch export activities by interval",
             unit="ms",
         )
 


### PR DESCRIPTION
## Problem

We want to make sure we catch as many retryable errors as possible, so we are pretty generous with our retry policy in batch exports: We assume all errors are retryable, unless we have determined they are not. However, this means that we will occasionally have retryable errors that should be non-retryable. In these cases, we end up with batch exports using up lots of attempts, which can be hard to miss unless you are looking at the Temporal UI.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Start tracking activity attempts to detect retryable errors that should actually be non-retryable. Most of these should be 1, if we ever see the number shoot up: there is likely something going on that is worth taking a look.

Added missing descriptions to histograms.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
