### PR TITLE
chore: log dropped event tokens

### DIFF
--- a/rust/cymbal/src/pipeline/billing.rs
+++ b/rust/cymbal/src/pipeline/billing.rs
@@ -1,4 +1,5 @@
 use metrics::counter;
+use tracing::info;
 
 use crate::{app_context::AppContext, error::PipelineFailure, metric_consts::DROPPED_EVENTS};
 
@@ -21,6 +22,7 @@ pub async fn apply_billing_limits(
         };
 
         if context.billing_limiter.is_limited(&e.token).await {
+            info!("Dropped event for {}", &e.token);
             continue;
         }
         out.push(IncomingEvent::Captured(e));


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/34761 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/37163)

We should temporarily log which tokens events are being dropped for so I can investigate if the rate limiter is working correctly