### PR TITLE
feat: Revamp groups list table

### DIFF
--- a/frontend/src/queries/nodes/DataTable/renderColumn.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumn.tsx
@@ -303,13 +303,14 @@ export function renderColumn(
     } else if (
         isGroupsQuery(query.source) &&
         key.startsWith('properties.') &&
-        context?.columns?.[key.split('.')[1].trim()]?.render
+        context?.columns?.[trimQuotes(key.substring(11))]?.render
     ) {
-        const Component = context?.columns?.[key.split('.')[1].trim()].render
+        const propertyName = trimQuotes(key.substring(11))
+        const Component = context?.columns?.[propertyName].render
         return Component ? (
             <Component
                 record={record}
-                columnName={key.split('.')[1].trim()}
+                columnName={propertyName}
                 value={value}
                 query={query}
                 recordIndex={recordIndex}

--- a/frontend/src/queries/nodes/DataTable/renderColumn.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumn.tsx
@@ -48,6 +48,10 @@ export function renderColumn(
 ): JSX.Element | string {
     const queryContextColumnName = key.startsWith('context.columns.') ? trimQuotes(key.substring(16)) : undefined
     const queryContextColumn = queryContextColumnName ? context?.columns?.[queryContextColumnName] : undefined
+    const keySplit = key.split('--')
+    if (keySplit.length > 1 && isGroupsQuery(query.source)) {
+        key = keySplit[1].trim()
+    }
     key = key.split('--')[0].trim()
 
     if (value === loadingColumn) {
@@ -288,6 +292,24 @@ export function renderColumn(
             <Component
                 record={record}
                 columnName={columnName}
+                value={value}
+                query={query}
+                recordIndex={recordIndex}
+                rowCount={rowCount}
+            />
+        ) : (
+            String(value)
+        )
+    } else if (
+        isGroupsQuery(query.source) &&
+        key.startsWith('properties.') &&
+        context?.columns?.[key.split('.')[1].trim()]?.render
+    ) {
+        const Component = context?.columns?.[key.split('.')[1].trim()].render
+        return Component ? (
+            <Component
+                record={record}
+                columnName={key.split('.')[1].trim()}
                 value={value}
                 query={query}
                 recordIndex={recordIndex}

--- a/frontend/src/queries/nodes/DataTable/renderColumnMeta.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumnMeta.tsx
@@ -6,7 +6,7 @@ import { getQueryFeatures, QueryFeature } from '~/queries/nodes/DataTable/queryF
 import { extractExpressionComment, removeExpressionComment } from '~/queries/nodes/DataTable/utils'
 import { DataTableNode, DataVisualizationNode, EventsQuery } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
-import { isDataTableNode, isHogQLQuery, trimQuotes } from '~/queries/utils'
+import { isDataTableNode, isGroupsQuery, isHogQLQuery, trimQuotes } from '~/queries/utils'
 
 export interface ColumnMeta {
     title?: JSX.Element | string
@@ -28,6 +28,8 @@ export function renderColumnMeta<T extends DataVisualizationNode | DataTableNode
     const queryContextColumn =
         (queryContextColumnName ? context?.columns?.[queryContextColumnName] : undefined) ?? context?.columns?.[key]
 
+    const propertyName = key.startsWith('properties.') ? trimQuotes(key.substring(11)) : undefined
+
     if (queryContextColumnName && queryContextColumn && (queryContextColumn.title || queryContextColumn.renderTitle)) {
         const Component = queryContextColumn.renderTitle
         title = Component ? <Component columnName={queryContextColumnName} query={query} /> : queryContextColumn.title
@@ -41,6 +43,9 @@ export function renderColumnMeta<T extends DataVisualizationNode | DataTableNode
             title =
                 tagName === '__hx_obj' ? 'Object' : tagName === 'RecordingButton' ? 'Recording' : '<' + tagName + ' />'
         }
+    } else if (propertyName && isGroupsQuery(query.source)) {
+        const splitPropertyName = propertyName.split('--')
+        title = splitPropertyName.length > 1 ? splitPropertyName[1].trim() : propertyName
     } else if (key === 'timestamp') {
         title = 'Time'
     } else if (key === 'created_at') {

--- a/frontend/src/scenes/groups/Groups.tsx
+++ b/frontend/src/scenes/groups/Groups.tsx
@@ -9,11 +9,17 @@ import { GroupTypeIndex } from '~/types'
 
 import { groupsListLogic } from './groupsListLogic'
 import { groupsSceneLogic } from './groupsSceneLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { QueryContext } from '~/queries/types'
+import { getCRMColumns } from './crm/utils'
+
 export function Groups({ groupTypeIndex }: { groupTypeIndex: GroupTypeIndex }): JSX.Element {
     const { groupTypeName, groupTypeNamePlural } = useValues(groupsSceneLogic)
     const { query, queryWasModified } = useValues(groupsListLogic({ groupTypeIndex }))
     const { setQuery } = useActions(groupsListLogic({ groupTypeIndex }))
     const { groupsAccessStatus } = useValues(groupsAccessLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     if (groupTypeIndex === undefined) {
         throw new Error('groupTypeIndex is undefined')
@@ -29,6 +35,15 @@ export function Groups({ groupTypeIndex }: { groupTypeIndex: GroupTypeIndex }): 
                 <GroupsIntroduction />
             </>
         )
+    }
+
+    let columns = {
+        group_name: {
+            title: groupTypeName,
+        },
+    } as QueryContext['columns']
+    if (featureFlags[FEATURE_FLAGS.CRM_ITERATION_ONE]) {
+        columns = getCRMColumns(groupTypeName, groupTypeIndex)
     }
 
     return (
@@ -51,11 +66,7 @@ export function Groups({ groupTypeIndex }: { groupTypeIndex: GroupTypeIndex }): 
                         to learn what needs to be done
                     </>
                 ),
-                columns: {
-                    group_name: {
-                        title: groupTypeName,
-                    },
-                },
+                columns,
                 groupTypeLabel: groupTypeNamePlural,
             }}
             dataAttr="groups-table"

--- a/frontend/src/scenes/groups/Groups.tsx
+++ b/frontend/src/scenes/groups/Groups.tsx
@@ -44,6 +44,7 @@ export function Groups({ groupTypeIndex }: { groupTypeIndex: GroupTypeIndex }): 
     } as QueryContext['columns']
     if (featureFlags[FEATURE_FLAGS.CRM_ITERATION_ONE]) {
         columns = getCRMColumns(groupTypeName, groupTypeIndex)
+        query['hiddenColumns'] = ['key']
     }
 
     return (

--- a/frontend/src/scenes/groups/Groups.tsx
+++ b/frontend/src/scenes/groups/Groups.tsx
@@ -42,14 +42,15 @@ export function Groups({ groupTypeIndex }: { groupTypeIndex: GroupTypeIndex }): 
             title: groupTypeName,
         },
     } as QueryContext['columns']
+    let hiddenColumns = [] as string[]
     if (featureFlags[FEATURE_FLAGS.CRM_ITERATION_ONE]) {
         columns = getCRMColumns(groupTypeName, groupTypeIndex)
-        query['hiddenColumns'] = ['key']
+        hiddenColumns.push('key')
     }
 
     return (
         <Query
-            query={query}
+            query={{ ...query, hiddenColumns }}
             setQuery={setQuery}
             context={{
                 refresh: 'blocking',

--- a/frontend/src/scenes/groups/crm/utils.tsx
+++ b/frontend/src/scenes/groups/crm/utils.tsx
@@ -115,7 +115,7 @@ function renderLink({ value, columnName }: { value: unknown; columnName: string 
         case 'events':
             return (
                 <div className="min-w-30">
-                    <LemonTableLink to={urls.sqlEditor()} title={value as string} description="in the last 7d" />
+                    <LemonTableLink to={urls.activity()} title={value as string} description="in the last 7d" />
                 </div>
             )
         default:

--- a/frontend/src/scenes/groups/crm/utils.tsx
+++ b/frontend/src/scenes/groups/crm/utils.tsx
@@ -1,0 +1,124 @@
+import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
+import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
+import stringWithWBR from 'lib/utils/stringWithWBR'
+import { currencyFormatter } from 'scenes/billing/billing-utils'
+import { PersonDisplay } from 'scenes/persons/PersonDisplay'
+import { urls } from 'scenes/urls'
+import { GroupsQuery } from '~/queries/schema/schema-general'
+import { QueryContext } from '~/queries/types'
+import { GroupTypeIndex } from '~/types'
+
+export function getCRMColumns(groupTypeName: string, groupTypeIndex: GroupTypeIndex): QueryContext['columns'] {
+    return {
+        group_name: {
+            title: groupTypeName,
+            render: function renderGroupName({ query, record, value }) {
+                const sourceQuery = query.source as GroupsQuery
+                const keyIndex = sourceQuery?.select?.indexOf('key') ?? -1
+                const groupKey = (record as string[])[keyIndex]
+                return (
+                    <div className="min-w-40">
+                        <LemonTableLink to={urls.group(groupTypeIndex, groupKey)} title={value as string} />
+                        <CopyToClipboardInline
+                            explicitValue={groupKey}
+                            iconStyle={{ color: 'var(--accent)' }}
+                            description="group id"
+                        >
+                            {stringWithWBR(groupKey, 100)}
+                        </CopyToClipboardInline>
+                    </div>
+                )
+            },
+        },
+        arr: {
+            render: renderCurrency,
+        },
+        mrr: {
+            render: renderCurrency,
+        },
+        forecasted_mrr: {
+            render: renderCurrency,
+        },
+        owner_name: {
+            render: renderPerson,
+        },
+        'survey responses': {
+            render: renderLink,
+        },
+        'feature flags': {
+            render: renderLink,
+        },
+        'mobile recordings': {
+            render: renderLink,
+        },
+        'data warehouse': {
+            render: renderLink,
+        },
+        events: {
+            render: renderLink,
+        },
+    }
+}
+
+function renderCurrency({ value }: { value: unknown }): JSX.Element {
+    if (!value || isNaN(Number(value))) {
+        return <>—</>
+    }
+    return <LemonTableLink to={urls.revenueAnalytics()} title={currencyFormatter(value as number)} />
+}
+
+function renderPerson({ value }: { value: unknown }): JSX.Element {
+    if (!value || typeof value !== 'string') {
+        return <>—</>
+    }
+    return <PersonDisplay withIcon displayName={value as string} />
+}
+
+function renderLink({ value, columnName }: { value: unknown; columnName: string }): JSX.Element {
+    if (!value || isNaN(Number(value))) {
+        return <>—</>
+    }
+    switch (columnName) {
+        case 'survey responses':
+            return (
+                <div className="min-w-30">
+                    <LemonTableLink to={urls.surveys()} title={value as string} description="in the last 7d" />
+                </div>
+            )
+
+        case 'feature flags':
+            return (
+                <div className="min-w-30">
+                    <LemonTableLink
+                        to={urls.featureFlags()}
+                        title={value as string}
+                        description="evals in the last 7d"
+                    />
+                </div>
+            )
+        case 'mobile recordings':
+            return (
+                <div className="min-w-30">
+                    <LemonTableLink to={urls.replay()} title={value as string} description="in the last 7d" />
+                </div>
+            )
+        case 'data warehouse':
+            return (
+                <div className="min-w-30">
+                    <LemonTableLink
+                        to={urls.sqlEditor()}
+                        title={value as string}
+                        description="rows synced in the last 7d"
+                    />
+                </div>
+            )
+        case 'events':
+            return (
+                <div className="min-w-30">
+                    <LemonTableLink to={urls.sqlEditor()} title={value as string} description="in the last 7d" />
+                </div>
+            )
+        default:
+            return <>—</>
+    }
+}

--- a/frontend/src/scenes/groups/crm/utils.tsx
+++ b/frontend/src/scenes/groups/crm/utils.tsx
@@ -36,10 +36,10 @@ export function getCRMColumns(groupTypeName: string, groupTypeIndex: GroupTypeIn
         mrr: {
             render: renderCurrency,
         },
-        forecasted_mrr: {
+        'forecasted mrr': {
             render: renderCurrency,
         },
-        owner_name: {
+        owner: {
             render: renderPerson,
         },
         'survey responses': {


### PR DESCRIPTION
## Problem
Related to https://github.com/PostHog/posthog/issues/35390
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
**_Almost_ all changes are gated by `crm-iteration-one` feature flag**
- Pass in custom `columns` object with special types for certain column names
	- The column names are hardcoded for now.
	- The hardcoded values are the ones we intend to display internally in our group list page as a PoC

The only exception is the change in `renderColumnMeta.tsx`, which is applied for all columns derived from properties.
### Before
<img width="4064" height="2334" alt="image" src="https://github.com/user-attachments/assets/8ad967b0-a462-4a3e-aadf-2cb6dc654b37" />

### After
<img width="4064" height="2334" alt="image" src="https://github.com/user-attachments/assets/059cf99d-dcdd-40f7-9dd3-f9d3ab90281d" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Follow up work
- A natural next step is to have the hardcoded custom columns configurable.
	- Create a few column types: Person, Currency, Link, default to Plain and allow user to pick what type to show for each column.
## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
