### PR TITLE
fix: Produce Ingestion Warning when flush message too large

### DIFF
--- a/plugin-server/src/worker/ingestion/groups/batch-writing-group-store.ts
+++ b/plugin-server/src/worker/ingestion/groups/batch-writing-group-store.ts
@@ -2,7 +2,6 @@ import { Properties } from '@posthog/plugin-scaffold'
 import { DateTime } from 'luxon'
 import pLimit from 'p-limit'
 
-import { TopicMessage } from '../../../kafka/producer'
 import { GroupTypeIndex, TeamId } from '../../../types'
 import { DB } from '../../../utils/db/db'
 import { MessageSizeTooLarge } from '../../../utils/db/error'
@@ -10,6 +9,7 @@ import { PostgresUse } from '../../../utils/db/postgres'
 import { logger } from '../../../utils/logger'
 import { promiseRetry } from '../../../utils/retries'
 import { RaceConditionError } from '../../../utils/utils'
+import { FlushResult } from '../persons/persons-store-for-batch'
 import { captureIngestionWarning } from '../utils'
 import { logMissingRow, logVersionMismatch } from './group-logging'
 import { GroupStore } from './group-store'
@@ -146,7 +146,7 @@ export class BatchWritingGroupStoreForBatch implements GroupStoreForBatch {
         return this.groupCache
     }
 
-    async flush(): Promise<TopicMessage[]> {
+    async flush(): Promise<FlushResult[]> {
         const pendingUpdates = Array.from(this.groupCache.entries()).filter((entry): entry is [string, GroupUpdate] => {
             const [_, update] = entry
             return update !== null && update.needsWrite

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -35,7 +35,7 @@ import {
 } from './metrics'
 import { fromInternalPerson, PersonUpdate, toInternalPerson } from './person-update-batch'
 import { PersonsStore } from './persons-store'
-import { PersonsStoreForBatch } from './persons-store-for-batch'
+import { FlushResult, PersonsStoreForBatch } from './persons-store-for-batch'
 
 type MethodName =
     | 'fetchForChecking'
@@ -140,7 +140,7 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         }
     }
 
-    async flush(): Promise<TopicMessage[]> {
+    async flush(): Promise<FlushResult[]> {
         const flushStartTime = performance.now()
         const updateEntries = Array.from(this.personUpdateCache.entries()).filter(
             (entry): entry is [string, PersonUpdate] => {
@@ -163,7 +163,7 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         try {
             const results = await Promise.all(
                 updateEntries.map(([cacheKey, update]) =>
-                    limit(async (): Promise<TopicMessage[]> => {
+                    limit(async (): Promise<FlushResult[]> => {
                         try {
                             personWriteMethodAttemptCounter.inc({
                                 db_write_mode: this.options.dbWriteMode,
@@ -171,7 +171,7 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
                                 outcome: 'attempt',
                             })
 
-                            let kafkaMessages: TopicMessage[] = []
+                            let kafkaMessages: FlushResult[] = []
                             switch (this.options.dbWriteMode) {
                                 case 'NO_ASSERT': {
                                     const result = await this.withMergeRetry(
@@ -181,7 +181,12 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
                                         this.options.maxOptimisticUpdateRetries,
                                         this.options.optimisticUpdateRetryInterval
                                     )
-                                    kafkaMessages = result.messages
+                                    kafkaMessages = result.messages.map((message) => ({
+                                        topicMessage: message,
+                                        teamId: update.team_id,
+                                        uuid: update.uuid,
+                                        distinctId: update.distinct_id,
+                                    }))
                                     break
                                 }
                                 case 'ASSERT_VERSION': {
@@ -192,7 +197,12 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
                                         this.options.maxOptimisticUpdateRetries,
                                         this.options.optimisticUpdateRetryInterval
                                     )
-                                    kafkaMessages = result.messages
+                                    kafkaMessages = result.messages.map((message) => ({
+                                        topicMessage: message,
+                                        teamId: update.team_id,
+                                        uuid: update.uuid,
+                                        distinctId: update.distinct_id,
+                                    }))
                                     break
                                 }
                             }
@@ -246,7 +256,12 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
                                     outcome: 'success',
                                 })
 
-                                return fallbackMessages
+                                return fallbackMessages.map((message) => ({
+                                    topicMessage: message,
+                                    teamId: error.latestPersonUpdate.team_id,
+                                    uuid: error.latestPersonUpdate.uuid,
+                                    distinctId: error.latestPersonUpdate.distinct_id,
+                                }))
                             }
 
                             // Re-throw any other errors

--- a/plugin-server/src/worker/ingestion/persons/measuring-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/measuring-person-store.ts
@@ -16,7 +16,7 @@ import {
 } from './metrics'
 import { applyEventPropertyUpdates } from './person-update'
 import { PersonsStore } from './persons-store'
-import { PersonsStoreForBatch } from './persons-store-for-batch'
+import { FlushResult, PersonsStoreForBatch } from './persons-store-for-batch'
 
 type MethodName =
     | 'fetchForChecking'
@@ -100,7 +100,7 @@ export class MeasuringPersonsStoreForBatch implements PersonsStoreForBatch {
         }
     }
 
-    flush(): Promise<TopicMessage[]> {
+    flush(): Promise<FlushResult[]> {
         return Promise.resolve([])
     }
 

--- a/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-store-manager.ts
@@ -10,7 +10,7 @@ import { BatchWritingPersonsStore, BatchWritingPersonsStoreForBatch } from './ba
 import { MeasuringPersonsStore, MeasuringPersonsStoreForBatch } from './measuring-person-store'
 import { personShadowModeComparisonCounter, personShadowModeReturnIntermediateOutcomeCounter } from './metrics'
 import { fromInternalPerson, toInternalPerson } from './person-update-batch'
-import { PersonsStoreForBatch } from './persons-store-for-batch'
+import { FlushResult, PersonsStoreForBatch } from './persons-store-for-batch'
 
 interface FinalStateEntry {
     person: InternalPerson
@@ -505,7 +505,7 @@ export class PersonStoreManagerForBatch implements PersonsStoreForBatch {
         }
     }
 
-    async flush(): Promise<TopicMessage[]> {
+    async flush(): Promise<FlushResult[]> {
         await Promise.resolve(this.compareFinalStates())
         return []
     }

--- a/plugin-server/src/worker/ingestion/persons/persons-store-for-batch.ts
+++ b/plugin-server/src/worker/ingestion/persons/persons-store-for-batch.ts
@@ -7,6 +7,13 @@ import { MoveDistinctIdsResult } from '../../../utils/db/db'
 import { TransactionClient } from '../../../utils/db/postgres'
 import { BatchWritingStore } from '../stores/batch-writing-store'
 
+export type FlushResult = {
+    topicMessage: TopicMessage
+    teamId: number
+    distinctId?: string
+    uuid?: string
+}
+
 export interface PersonsStoreForBatch extends BatchWritingStore {
     /**
      * Executes a function within a transaction
@@ -124,5 +131,5 @@ export interface PersonsStoreForBatch extends BatchWritingStore {
     /**
      * Flushes the batch
      */
-    flush(): Promise<TopicMessage[]>
+    flush(): Promise<FlushResult[]>
 }

--- a/plugin-server/src/worker/ingestion/stores/batch-writing-store.ts
+++ b/plugin-server/src/worker/ingestion/stores/batch-writing-store.ts
@@ -1,9 +1,9 @@
-import { TopicMessage } from '../../../kafka/producer'
+import { FlushResult } from '../persons/persons-store-for-batch'
 
 export interface BatchWritingStore {
     /*
      * Flushes all batch data that needs to be written
      * Returns Kafka messages that need to be sent
      */
-    flush(): Promise<TopicMessage[]>
+    flush(): Promise<FlushResult[]>
 }

--- a/plugin-server/tests/worker/ingestion/person-state-batch.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state-batch.test.ts
@@ -71,7 +71,7 @@ async function createPerson(
 
 async function flushPersonStoreToKafka(hub: Hub, personStore: PersonsStoreForBatch, kafkaAcks: Promise<void>) {
     const kafkaMessages = await (personStore as BatchWritingPersonsStoreForBatch).flush()
-    await hub.db.kafkaProducer.queueMessages(kafkaMessages)
+    await hub.db.kafkaProducer.queueMessages(kafkaMessages.map((message) => message.topicMessage))
     await hub.db.kafkaProducer.flush()
     await kafkaAcks
     return kafkaMessages


### PR DESCRIPTION
## Problem

We were not producing Ingestion Warnings because `flush` was not returning relevant information, this PR addresses that

## Changes

- Add return type FlushResult that wraps TopicMessage and  contains relevant data for the Ingestion Warning

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
