### PR TITLE
chore: add CSP reporting to Admin

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -644,3 +644,20 @@ class Fix204Middleware:
                 response.headers.pop(h, None)
 
         return response
+
+
+# Add CSP to Admin tooling
+class AdminCSPMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        if request.path.startswith("/admin/"):
+            response.headers["Reporting-Endpoints"] = (
+                'posthog="https://us.i.posthog.com/report/?token=sTMFPsFhdP1Ssg&v=1"'
+            )
+            response.headers["Content-Security-Policy-Report-Only"] = (
+                "default-src 'self'; worker-src 'none'; child-src 'none'; object-src 'none'; frame-ancestors 'none'; manifest-src 'none'; report-uri https://us.i.posthog.com/report/?token=sTMFPsFhdP1Ssg&v=1; report-to posthog"
+            )
+        return response

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -98,7 +98,6 @@ MIDDLEWARE = [
     "posthog.middleware.CHQueries",
     "django_prometheus.middleware.PrometheusAfterMiddleware",
     "posthog.middleware.PostHogTokenCookieMiddleware",
-    "posthog.middleware.Fix204Middleware",
     "posthog.middleware.AdminCSPMiddleware",
     "posthoganalytics.integrations.django.PosthogContextMiddleware",
 ]

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -99,6 +99,7 @@ MIDDLEWARE = [
     "django_prometheus.middleware.PrometheusAfterMiddleware",
     "posthog.middleware.PostHogTokenCookieMiddleware",
     "posthog.middleware.Fix204Middleware",
+    "posthog.middleware.AdminCSPMiddleware",
     "posthoganalytics.integrations.django.PosthogContextMiddleware",
 ]
 


### PR DESCRIPTION
This will help us determine how strict of a CSP we can apply to Admin. The ultimate goal is protecting against XSS and exfiltration of cookies not declared HttpOnly.

This makes use of [CSP Tracking](https://posthog.com/docs/csp-tracking).