### PR TITLE
chore: remove unnecessary ORDER BY in background delete task

### DIFF
--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -909,7 +909,6 @@ def background_delete_model_task(
                     f"""
                     SELECT id FROM {model._meta.db_table}
                     WHERE {team_field} = %s
-                    ORDER BY id
                     LIMIT %s
                     """,
                     [team_id, current_batch_size],


### PR DESCRIPTION
Eliminated the ORDER BY clause from the SQL query in background_delete_model_task, as it was not required for batch deletion - it's slowing it down too much.