### PR TITLE
fix(experiments): fix waiting for experiment to start msg

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -105,7 +105,7 @@ export function MetricRowGroup({
                     }`}
                     style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}
                 >
-                    {isLoading ? (
+                    {isLoading && experiment.start_date ? (
                         <ChartLoadingState height={CELL_HEIGHT} />
                     ) : (
                         <ChartEmptyState

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -105,7 +105,7 @@ export function MetricRowGroup({
                     }`}
                     style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}
                 >
-                    {isLoading && experiment.start_date ? (
+                    {isLoading ? (
                         <ChartLoadingState height={CELL_HEIGHT} />
                     ) : (
                         <ChartEmptyState

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx
@@ -73,10 +73,7 @@ export function MetricsTable({
                         const result = results[metricIndex]
                         const error = errors[metricIndex]
 
-                        const hasResult = !!result
-                        const hasError = !!error
-                        const hasExperimentStarted = !!experiment.start_date
-                        const isLoading = !hasResult && !hasError && hasExperimentStarted
+                        const isLoading = !result && !error && !!experiment.start_date
 
                         return (
                             <MetricRowGroup

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx
@@ -72,7 +72,11 @@ export function MetricsTable({
                     {metrics.map((metric, metricIndex) => {
                         const result = results[metricIndex]
                         const error = errors[metricIndex]
-                        const isLoading = !result && !error
+
+                        const hasResult = !!result
+                        const hasError = !!error
+                        const hasExperimentStarted = !!experiment.start_date
+                        const isLoading = !hasResult && !hasError && hasExperimentStarted
 
                         return (
                             <MetricRowGroup


### PR DESCRIPTION
## Problem

In the new metrics table, before the experiment starts, metrics are showing "Loading results ..." when in fact, results are not loading.

## Changes
Fix the `isLoading` condition such that we show the "Waiting for experiment to start ..." message when the experiment has not started yet.

## How did you test this code?
* 👀 
