### PR TITLE
fix(web-analytics): pathname filter not working on pre-agg stats

### DIFF
--- a/posthog/hogql_queries/web_analytics/pre_aggregated/query_builder.py
+++ b/posthog/hogql_queries/web_analytics/pre_aggregated/query_builder.py
@@ -63,7 +63,7 @@ class WebAnalyticsPreAggregatedQueryBuilder:
             timings=self.runner.timings,
         )
 
-    def _get_filters(self, table_name: str):
+    def _get_filters(self, table_name: str, exclude_pathname: bool = False):
         filter_exprs: list[ast.Expr] = [
             ast.CompareOperation(
                 op=ast.CompareOperationOp.GtEq,
@@ -89,6 +89,8 @@ class WebAnalyticsPreAggregatedQueryBuilder:
 
             for prop in self.runner.query.properties:
                 if hasattr(prop, "key") and prop.key in self.supported_props_filters:
+                    if exclude_pathname and prop.key == "$pathname":
+                        continue
                     if self.supported_props_filters[prop.key] is None:
                         virtual_properties.append(prop)
                     else:

--- a/posthog/hogql_queries/web_analytics/stats_table_pre_aggregated.py
+++ b/posthog/hogql_queries/web_analytics/stats_table_pre_aggregated.py
@@ -119,12 +119,15 @@ class StatsTablePreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder)
                     "bounce_rate_tuple": self._bounce_rate_calculation_tuple(
                         current_period_filter, previous_period_filter
                     ),
-                    "filters": self._get_filters(table_name="web_bounces_combined"),
+                    "filters": self._get_bounce_rate_filters(),
                 },
             ),
         )
 
         return query
+
+    def _get_bounce_rate_filters(self) -> ast.Expr:
+        return self._get_filters(table_name="web_bounces_combined", exclude_pathname=True)
 
     def _path_query(self) -> ast.SelectQuery:
         previous_period_filter, current_period_filter = self.get_date_ranges(table_name="web_stats_combined")

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_pre_aggregated.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_pre_aggregated.ambr
@@ -381,6 +381,37 @@
                     allow_experimental_join_condition=1
   '''
 # ---
+# name: TestWebStatsPreAggregated.test_page_breakdown_with_pathname_filter
+  '''
+  SELECT nullIf(web_stats_combined.pathname, '') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+         any(bounces.`context.columns.bounce_rate`) AS `context.columns.bounce_rate`
+  FROM web_stats_combined
+  LEFT JOIN
+    (SELECT nullIf(web_bounces_combined.entry_pathname, '') AS `context.columns.breakdown_value`,
+            tuple(uniqMergeIf(web_bounces_combined.persons_uniq_state, and(greaterOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+            tuple(sumMergeIf(web_bounces_combined.pageviews_count_state, and(greaterOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+            tuple(divide(sumMergeIf(web_bounces_combined.bounces_count_state, and(greaterOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), nullIf(uniqMergeIf(web_bounces_combined.sessions_uniq_state, and(greaterOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), 0)), NULL) AS `context.columns.bounce_rate`
+     FROM web_bounces_combined
+     WHERE and(equals(web_bounces_combined.team_id, 99999), and(and(greaterOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC'))), isNotNull(nullIf(web_bounces_combined.entry_pathname, ''))))
+     GROUP BY `context.columns.breakdown_value`) AS bounces ON equals(web_stats_combined.pathname, bounces.`context.columns.breakdown_value`)
+  WHERE and(equals(web_stats_combined.team_id, 99999), and(and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')), ifNull(equals(web_stats_combined.pathname, '/landing'), 0)), isNotNull(nullIf(web_stats_combined.pathname, ''))))
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.views` DESC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1
+  '''
+# ---
 # name: TestWebStatsPreAggregated.test_property_filtering
   '''
   SELECT nullIf(nullIf(web_stats_combined.device_type, ''), 'null') AS `context.columns.breakdown_value`,

--- a/posthog/hogql_queries/web_analytics/test/test_web_stats_pre_aggregated.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_stats_pre_aggregated.py
@@ -373,6 +373,18 @@ class TestWebStatsPreAggregated(WebAnalyticsPreAggregatedTestBase):
 
         assert response.results == expected_results
 
+    def test_page_breakdown_with_pathname_filter(self):
+        properties = [EventPropertyFilter(key="$pathname", value="/landing", operator=PropertyOperator.EXACT)]
+        response = self._calculate_breakdown_query(WebStatsBreakdown.PAGE, use_preagg=True, properties=properties)
+
+        # Only /landing should be returned since we're filtering by pathname
+        expected_results = [
+            ["/landing", (2.0, None), (2.0, None), (1.0, None), ""],  # user_0, user_2
+        ]
+
+        assert response.results == expected_results
+        assert response.usedPreAggregatedTables
+
     def test_breakdown_consistency_preagg_vs_regular(self):
         # Note: PAGE and VIEWPORT breakdowns are excluded. I will add them back in later.
         breakdowns_to_test = [


### PR DESCRIPTION
## Problem

This is a regression after the change to support virtual props like channel type: https://github.com/PostHog/posthog/pull/35222

## Changes

- Do not include `pathname` on the bounce filters as it doesn't exist on pre-agg (just `$entry_pathname`)

## How did you test this code?

- Integration test + manually

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
