### PR TITLE
fix(funnel): fix types failing typescript:check

### DIFF
--- a/frontend/src/scenes/insights/views/Funnels/FunnelStepsTable.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelStepsTable.tsx
@@ -381,7 +381,10 @@ export function FunnelStepsTable(): JSX.Element | null {
                 const findColumnByKey = (
                     columns: LemonTableColumnGroup<FlattenedFunnelStepByBreakdown>[],
                     key: string
-                ): LemonTableColumnGroup<FlattenedFunnelStepByBreakdown> | null => {
+                ): LemonTableColumn<
+                    FlattenedFunnelStepByBreakdown,
+                    keyof FlattenedFunnelStepByBreakdown | undefined
+                > | null => {
                     for (const group of columns) {
                         for (const col of group.children) {
                             if (col.key === key || col.dataIndex === key) {


### PR DESCRIPTION
## Problem

Frontend checks are failing in CI.

## Changes

Fixes types.

## How did you test this code?

Re-generated types and ran `pnpm --filter=@posthog/frontend typescript:check`