### PR TITLE
chore(max): Make AI evals baseline clearer

### DIFF
--- a/.github/workflows/ci-ai.yml
+++ b/.github/workflows/ci-ai.yml
@@ -100,9 +100,7 @@ jobs:
                                   if (result.comparison_experiment_name?.startsWith("master-")) {
                                       baselineComparison = `${diffHighlight}${value.diff > 0 ? "+" : value.diff < 0 ? "" : "±"}${(
                                           value.diff * 100
-                                      ).toFixed(2)}%${diffHighlight} versus [baseline (master)](${result.project_url}/experiments/${
-                                          result.comparison_experiment_name
-                                      }) (improvements: ${value.improvements}, regressions: ${value.regressions})`
+                                      ).toFixed(2)}%${diffHighlight} (improvements: ${value.improvements}, regressions: ${value.regressions})`
                                       diffEmoji = value.diff > 0.01 ? "🟢" : value.diff < -0.01 ? "🔴" : "🔵"
                                   }
                                   return `${diffEmoji} **${key}**: **${score}**${baselineComparison ? `, ${baselineComparison}` : ""}`
@@ -115,11 +113,16 @@ jobs:
                           const totalTokens = metrics.total_tokens ? `🔢 ${Math.floor(metrics.total_tokens.metric)} tokens` : null
                           const cost = metrics.estimated_cost ? `💵 $${metrics.estimated_cost.metric.toFixed(4)} in tokens` : null
                           const metricsText = [duration, totalTokens, cost].filter(Boolean).join(", ")
+                          const baselineLink = `[${result.comparison_experiment_name}](${result.project_url}/experiments/${result.comparison_experiment_name})`
 
                           // Create concise experiment summary with header only showing experiment name
                           const experimentName = result.project_name.replace(/^max-ai-/, "")
 
-                          return `### [${experimentName}](${result.experiment_url})\n\n${scoresList}\n\nAvg. case performance: ${metricsText}`
+                          return [
+                              `### [${experimentName}](${result.experiment_url})`,
+                              scoresList,
+                              `Baseline: ${baselineLink} • Avg. case performance: ${metricsText}`,
+                          ].join("\n\n")
                       })
 
                       const totalExperiments = evalResults.length


### PR DESCRIPTION
## Changes

We were pointlessly repeating the same baseline link:

> <img width="745" height="179" alt="before" src="https://github.com/user-attachments/assets/2d7c0f76-bd44-47d8-a26b-2e99bb79aea7" />

This should be clearer:

> <img width="706" height="174" alt="Screenshot 2025-07-24 at 13 13 06" src="https://github.com/user-attachments/assets/bfabb9a7-86f1-4110-951c-3da716d8738c" />
