### PR TITLE
chore(ci): don't upload test timings

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -684,15 +684,6 @@ jobs:
               shell: bash
               run: docker compose -f docker-compose.dev.yml logs
 
-            - name: Upload updated timing data as artifacts
-              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
-              if: ${{ needs.changes.outputs.backend == 'true' && !matrix.person-on-events && matrix.clickhouse-server-image == 'clickhouse/clickhouse-server:25.3.6.56' }}
-              with:
-                  name: timing_data-${{ matrix.segment }}-${{ matrix.group }}
-                  path: .test_durations
-                  include-hidden-files: true
-                  retention-days: 2
-
             - uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9
               # Also skip for persons-on-events runs, as we want to ignore snapshots diverging there
               if: ${{ github.event.pull_request.head.repo.full_name == 'PostHog/posthog' && needs.changes.outputs.backend == 'true' && !matrix.person-on-events }}


### PR DESCRIPTION
## Problem

We need to find steps to reduce the number of GH API calls we are making. Here is one of the steps we can remove, let's chip away at them.

## Changes

-  Remove uploading test durations
