### PR TITLE
chore: Reduce which dags are used in local dev to only web analytics

### DIFF
--- a/.dagster_home/workspace.yaml
+++ b/.dagster_home/workspace.yaml
@@ -1,9 +1,11 @@
 # Local dev only, see dags/README.md for more info
 
 load_from:
-    - python_module: dags.locations.clickhouse
-    - python_module: dags.locations.error_tracking
-    - python_module: dags.locations.growth
-    - python_module: dags.locations.revenue_analytics
-    - python_module: dags.locations.shared
+    ## Most dags are not loaded in local dev, but feel free to edit this list
+    #    - python_module: dags.locations.clickhouse
+    #    - python_module: dags.locations.error_tracking
+    #    - python_module: dags.locations.growth
+    #    - python_module: dags.locations.revenue_analytics
+    #    - python_module: dags.locations.shared
+    # These dags are loaded in local dev
     - python_module: dags.locations.web_analytics


### PR DESCRIPTION
## Problem

We run many dags in local dev that eat CPU and aren't necessary, only the pre-aggregation dags are useful because these tables are used by some queries

## Changes
Reduce local dev dags

## How did you test this code?
Ran dagster locally, saw that there were fewer runs present