### PR TITLE
fix: safe async redis

### DIFF
--- a/ee/hogai/stream/test/test_redis_stream.py
+++ b/ee/hogai/stream/test/test_redis_stream.py
@@ -326,6 +326,7 @@ class TestRedisStream(BaseTest):
     @pytest.mark.asyncio
     async def test_write_to_stream_exception(self):
         with patch.object(self.redis_stream, "_redis_client") as mock_client:
+            mock_client.expire = AsyncMock()  # Allow expire to succeed
             mock_client.xadd = AsyncMock(side_effect=Exception("Redis error"))
 
             async def test_generator():
@@ -334,7 +335,7 @@ class TestRedisStream(BaseTest):
             with self.assertRaises(Exception):
                 await self.redis_stream.write_to_stream(test_generator())
 
-            self.assertEqual(mock_client.xadd.call_count, 1)
+            self.assertEqual(mock_client.xadd.call_count, 2)
 
     @pytest.mark.asyncio
     async def test_write_to_stream_empty_generator(self):

--- a/ee/hogai/stream/test/test_redis_stream.py
+++ b/ee/hogai/stream/test/test_redis_stream.py
@@ -334,8 +334,7 @@ class TestRedisStream(BaseTest):
             with self.assertRaises(Exception):
                 await self.redis_stream.write_to_stream(test_generator())
 
-            # Should call xadd twice: 1 failed data message + 1 error status
-            self.assertEqual(mock_client.xadd.call_count, 2)
+            self.assertEqual(mock_client.xadd.call_count, 1)
 
     @pytest.mark.asyncio
     async def test_write_to_stream_empty_generator(self):

--- a/posthog/redis.py
+++ b/posthog/redis.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, Optional
 
 import asyncio
 import weakref
-import fakeredis
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -23,6 +22,9 @@ def get_client(redis_url: Optional[str] = None) -> redis.Redis:
 
     if not _client_map.get(redis_url):
         if settings.TEST:
+            # This import is only used in tests, we don't want to import it in production
+            import fakeredis
+
             client: Any = fakeredis.FakeRedis()
         elif redis_url:
             client = redis.from_url(redis_url, db=0)
@@ -104,6 +106,8 @@ def get_async_client(redis_url: Optional[str] = None):
         # For tests, use simple caching without per-loop complexity
         # since FakeAsyncRedis doesn't have the same event loop restrictions
         if redis_url not in _client_map:
+            import fakeredis
+
             _client_map[redis_url] = fakeredis.FakeAsyncRedis()
         return _client_map[redis_url]
     else:

--- a/posthog/redis.py
+++ b/posthog/redis.py
@@ -1,31 +1,37 @@
 # flake8: noqa
-from typing import Any, Dict, Optional, TypeVar, Union, overload
+from typing import Any, Dict, Optional
 
-import redis
-from redis import asyncio as aioredis
+import asyncio
+import weakref
+
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+import redis
+
 
 _client_map: Dict[str, Any] = {}
-_async_client_map: Dict[str, Any] = {}
 
 
 def get_client(redis_url: Optional[str] = None) -> redis.Redis:
-    redis_url = redis_url or settings.REDIS_URL
+    """Return a *synchronous* Redis client (singleton per redis_url)."""
 
-    global _client_map
+    redis_url = redis_url or settings.REDIS_URL
+    if redis_url is None:
+        raise ImproperlyConfigured("REDIS_URL is not configured")
 
     if not _client_map.get(redis_url):
-        client: Any = None
-
         if settings.TEST:
             import fakeredis
 
-            client = fakeredis.FakeRedis()
+            client: Any = fakeredis.FakeRedis()
         elif redis_url:
-            client = redis.from_url(redis_url, db=0)
+            import redis  # local import to avoid the heavy dependency at startup if unused
 
-        if not client:
+            client = redis.from_url(redis_url, db=0)
+        else:
+            client = None
+
+        if client is None:
             raise ImproperlyConfigured("Redis not configured!")
 
         _client_map[redis_url] = client
@@ -33,32 +39,104 @@ def get_client(redis_url: Optional[str] = None) -> redis.Redis:
     return _client_map[redis_url]
 
 
-def get_async_client(redis_url: Optional[str] = None) -> aioredis.Redis:
+_loop_clients: "weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, Dict[str, Any]]" = weakref.WeakKeyDictionary()
+
+
+def _close_pools(pool_map: Dict[str, Any]) -> None:
+    """Close all Redis pools that belonged to a dead event-loop."""
+
+    import asyncio
+
+    for client in pool_map.values():
+        try:
+            # For async clients, close() returns a coroutine
+            close_method = getattr(client, "close", None)
+            if close_method:
+                result = close_method(close_connection_pool=True)
+                # If it's a coroutine, we need to run it in an event loop
+                if asyncio.iscoroutine(result):
+                    try:
+                        loop = asyncio.new_event_loop()
+                        loop.run_until_complete(result)
+                        loop.close()
+                    except Exception:
+                        pass
+        except Exception:  # close shouldn't fail, but be safe
+            pass
+
+
+def get_async_client(redis_url: Optional[str] = None):
+    """Return an *async* Redis client bound to *this* event-loop.
+
+    This is safe when multiple :pyclass:`asyncio.AbstractEventLoop` objects exist in the
+    same Python process (that happens anytime someone calls
+    :pyfunc:`asyncio.run`, which we unfortunately do in a few endpoints and
+    management commands).
+    It does not leak file-descriptors or memory when those short-lived event-loops
+    disappear.
+
+    The synchronous helper (`get_client`) is trivial – we can keep a single process-wide
+    singleton.  The asynchronous side is trickier because an ``aioredis.Redis``
+    instance is bound to the event-loop in which it was created. Using the same
+    client from another loop raises
+
+    ``RuntimeError: Task ... got Future attached to a different loop``.
+
+    To make this bullet-proof we cache one Redis instance
+    per (event-loop, redis_url) pair and keep that cache in a
+    ``weakref.WeakKeyDictionary``. When a loop is garbage-collected (which happens
+    immediately after ``asyncio.run`` returns) its entry in the weak dict
+    disappears and we close all the connection pools via a ``weakref.finalize``.
+
+    This gives us:
+
+    * zero cross-loop accidents (each pool is only ever used by the loop that
+      created it),
+    * zero leaks (pools are closed as soon as their loop dies),
+    * no behavioural change for callers (they still just call
+      :pyfunc:`get_async_client`).
+
+    If you *really* need to bypass the cache, just call ``aioredis.from_url``
+    directly; but in 99 % of cases you want the cached client.
+    """
+
+    from redis import asyncio as aioredis  # local import to avoid unnecessary dependency for sync paths
+
     redis_url = redis_url or settings.REDIS_URL
+    if redis_url is None:
+        raise ImproperlyConfigured("REDIS_URL is not configured")
 
-    global _async_client_map
+    # When tests use fakeredis we *still* want the per-loop safety guarantees.
+    if settings.TEST:
+        import fakeredis
 
-    if not _async_client_map.get(redis_url):
-        client: Any = None
+        ClientCls = fakeredis.FakeAsyncRedis
+    else:
+        ClientCls = aioredis.from_url
 
+    loop = asyncio.get_running_loop()
+
+    # Get (or create) the per-loop sub-map
+    pool_map = _loop_clients.get(loop)
+    if pool_map is None:
+        pool_map = {}
+        _loop_clients[loop] = pool_map
+        # As soon as loop is garbage collected call _close_pools(pool_map)
+        weakref.finalize(loop, _close_pools, pool_map)
+
+    # Get (or create) the Redis instance for redis_url
+    client = pool_map.get(redis_url)
+    if client is None:
         if settings.TEST:
-            import fakeredis
+            client = ClientCls()
+        else:
+            client = ClientCls(redis_url, db=0)
+        pool_map[redis_url] = client
 
-            client = fakeredis.FakeAsyncRedis()
-        elif redis_url:
-            client = aioredis.from_url(redis_url, db=0)
-
-        if not client:
-            raise ImproperlyConfigured("Redis not configured!")
-
-        _async_client_map[redis_url] = client
-
-    return _async_client_map[redis_url]
+    return client
 
 
 def TEST_clear_clients():
-    global _client_map, _async_client_map
+    global _client_map
     for key in list(_client_map.keys()):
         del _client_map[key]
-    for key in list(_async_client_map.keys()):
-        del _async_client_map[key]

--- a/posthog/redis.py
+++ b/posthog/redis.py
@@ -136,5 +136,5 @@ def TEST_clear_clients():
     for key in list(_client_map.keys()):
         del _client_map[key]
     global _loop_clients
-    for key in list(_loop_clients.keys()):
-        del _loop_clients[key]
+    for loop in list(_loop_clients.keys()):
+        del _loop_clients[loop]

--- a/posthog/test/test_redis.py
+++ b/posthog/test/test_redis.py
@@ -1,4 +1,4 @@
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, patch, AsyncMock
 
 from posthog.redis import TEST_clear_clients, get_client, get_async_client, _client_map, _loop_clients
 
@@ -50,51 +50,67 @@ class TestRedis(TestCase):
                 assert get_client("redis://other:6379")
                 spy_fakeredis.assert_called_once()
 
-    def test_async_redis_client_is_cached_between_calls(self):
-        # Test async client caching
-        async def runner():
-            with patch("fakeredis.FakeAsyncRedis", wraps=fakeredis.FakeAsyncRedis) as spy_fakeasyncredis:
-                with self.settings(REDIS_URL="redis://mocked:6379"):
-                    # Ask for the client, none cached, create one
-                    assert get_async_client()
-                    spy_fakeasyncredis.assert_called_once()
-                    spy_fakeasyncredis.reset_mock()
-                    # Ask once more, for the same URL, get cached one
-                    assert get_async_client()
-                    spy_fakeasyncredis.assert_not_called()
-                    # Ask for a different URL, create a new one
-                    assert get_async_client("redis://other:6379")
-                    spy_fakeasyncredis.assert_called_once()
+    def test_async_redis_client_is_cached_between_calls_test_mode(self):
+        # Test async client caching in test mode (simple caching)
+        with self.settings(REDIS_URL="redis://mocked:6379"):
+            # Ask for the client, none cached, create one
+            client1 = get_async_client()
+            assert client1 is not None
 
-        asyncio.run(runner())
+            # Ask once more, for the same URL, get cached one (should be same instance)
+            client2 = get_async_client()
+            assert client2 is client1  # Should be same instance due to caching
 
-    def test_same_loop_returns_cached_client(self):
-        """Calling get_async_client twice inside the same event-loop must return the identical object."""
+            # Ask for a different URL, create a new one
+            client3 = get_async_client("redis://other:6379")
+            assert client3 is not client1  # Should be different instance
+
+    def test_async_redis_client_production_behavior(self):
+        # Test the production behavior with per-loop caching
+        with patch("redis.asyncio.from_url") as mock_from_url:
+            # Return different mock objects for each call
+            mock_client1 = AsyncMock()
+            mock_client2 = AsyncMock()
+            mock_from_url.side_effect = [mock_client1, mock_client2]
+
+            with self.settings(TEST=False, REDIS_URL="redis://mocked:6379"):
+
+                async def runner():
+                    # Within the same loop, should get same instance
+                    c1 = get_async_client()
+                    c2 = get_async_client()
+                    self.assertIs(c1, c2)
+                    return c1
+
+                # Run in two different event loops
+                client1 = asyncio.run(runner())
+                client2 = asyncio.run(runner())
+
+                # Different loops should get different client instances
+                self.assertIsNot(client1, client2)
+                # Should have been called twice (once per loop)
+                self.assertEqual(mock_from_url.call_count, 2)
+                # Verify the calls were made with correct parameters
+                mock_from_url.assert_any_call("redis://mocked:6379", db=0)
+
+    def test_same_loop_returns_cached_client_test_mode(self):
+        """In test mode, calling get_async_client twice returns the same cached instance."""
 
         async def runner():
             c1 = get_async_client("redis://mocked:6379")
             c2 = get_async_client("redis://mocked:6379")
             self.assertIs(c1, c2)
 
-        with patch("fakeredis.FakeAsyncRedis") as mocked:
-            mock_instance = object()
-            mocked.return_value = mock_instance
-            asyncio.run(runner())
-            # FakeAsyncRedis called only once – second call was served from cache
-            mocked.assert_called_once()
+        asyncio.run(runner())
 
-    def test_different_loops_get_distinct_clients(self):
-        """Each event-loop gets its own cached client – separate loops ⇒ separate objects."""
+    def test_different_loops_get_same_cached_client_test_mode(self):
+        """In test mode, different event-loops get the same cached client for simplicity."""
 
         async def get_client():
             return get_async_client("redis://mocked:6379")
 
-        with patch("fakeredis.FakeAsyncRedis") as mocked:
-            # Return different objects for each call
-            mocked.side_effect = [object(), object()]
-            c1 = asyncio.run(get_client())
-            c2 = asyncio.run(get_client())
+        c1 = asyncio.run(get_client())
+        c2 = asyncio.run(get_client())
 
-            self.assertIsNot(c1, c2)
-            # called twice because two distinct loops instantiated their own pool
-            self.assertEqual(mocked.call_count, 2)
+        # In test mode with simple caching, same URL returns same instance
+        self.assertIs(c1, c2)

--- a/posthog/test/test_redis.py
+++ b/posthog/test/test_redis.py
@@ -1,28 +1,31 @@
 from unittest.mock import ANY, patch
-from posthog.redis import TEST_clear_clients, get_client, get_async_client, _client_map
-import posthog.redis
+
+from posthog.redis import TEST_clear_clients, get_client, get_async_client, _client_map, _loop_clients
 
 from django.test.testcases import TestCase
+import asyncio
+import fakeredis
 
 
 class TestRedis(TestCase):
     def setUp(self) -> None:
         super().setUp()
-
         TEST_clear_clients()
+        _loop_clients.clear()
 
-    @patch("posthog.redis.redis")
-    def test_redis_client_is_created(self, mock_redis):
-        mock_redis.from_url.return_value = "test"
+    @patch("fakeredis.FakeRedis")
+    def test_redis_client_is_created(self, mock_fakeredis):
+        mock_instance = "test"
+        mock_fakeredis.return_value = mock_instance
 
-        with self.settings(REDIS_URL="redis://mocked:6379", TEST=False):
+        with self.settings(REDIS_URL="redis://mocked:6379"):
             client = get_client()
 
-        assert client
+        assert client == mock_instance
         assert _client_map == {
-            "redis://mocked:6379": "test",
+            "redis://mocked:6379": mock_instance,
         }
-        mock_redis.from_url.assert_called_once_with("redis://mocked:6379", db=0)
+        mock_fakeredis.assert_called_once()
 
     def test_redis_client_uses_given_url(self):
         with self.settings(REDIS_URL="redis://mocked:6379"):
@@ -33,23 +36,65 @@ class TestRedis(TestCase):
         }
 
     def test_redis_client_is_cached_between_calls(self):
-        test_cases = [
-            (get_client, "posthog.redis.redis.from_url", posthog.redis.redis.from_url),
-            (get_async_client, "posthog.redis.aioredis.from_url", posthog.redis.aioredis.from_url),
-        ]
-        # Test both sync and async clients
-        for client_func, patch_path, original_func in test_cases:
-            # Isolate test cases
-            with self.subTest(client_func=client_func.__name__):
-                with patch(patch_path, wraps=original_func) as spy_from_url:
-                    with self.settings(REDIS_URL="redis://mocked:6379", TEST=False):
-                        # Ask for the client, none cached, create one
-                        assert client_func()
-                        spy_from_url.assert_called_once_with("redis://mocked:6379", db=0)
-                        spy_from_url.reset_mock()
-                        # Ask once more, for the same URL, get cached one
-                        assert client_func()
-                        spy_from_url.assert_not_called()
-                        # Ask for a different URL, create a new one
-                        assert client_func("redis://other:6379")
-                        spy_from_url.assert_called_once_with("redis://other:6379", db=0)
+        # Test sync client caching
+        with patch("fakeredis.FakeRedis", wraps=fakeredis.FakeRedis) as spy_fakeredis:
+            with self.settings(REDIS_URL="redis://mocked:6379"):
+                # Ask for the client, none cached, create one
+                assert get_client()
+                spy_fakeredis.assert_called_once()
+                spy_fakeredis.reset_mock()
+                # Ask once more, for the same URL, get cached one
+                assert get_client()
+                spy_fakeredis.assert_not_called()
+                # Ask for a different URL, create a new one
+                assert get_client("redis://other:6379")
+                spy_fakeredis.assert_called_once()
+
+    def test_async_redis_client_is_cached_between_calls(self):
+        # Test async client caching
+        async def runner():
+            with patch("fakeredis.FakeAsyncRedis", wraps=fakeredis.FakeAsyncRedis) as spy_fakeasyncredis:
+                with self.settings(REDIS_URL="redis://mocked:6379"):
+                    # Ask for the client, none cached, create one
+                    assert get_async_client()
+                    spy_fakeasyncredis.assert_called_once()
+                    spy_fakeasyncredis.reset_mock()
+                    # Ask once more, for the same URL, get cached one
+                    assert get_async_client()
+                    spy_fakeasyncredis.assert_not_called()
+                    # Ask for a different URL, create a new one
+                    assert get_async_client("redis://other:6379")
+                    spy_fakeasyncredis.assert_called_once()
+
+        asyncio.run(runner())
+
+    def test_same_loop_returns_cached_client(self):
+        """Calling get_async_client twice inside the same event-loop must return the identical object."""
+
+        async def runner():
+            c1 = get_async_client("redis://mocked:6379")
+            c2 = get_async_client("redis://mocked:6379")
+            self.assertIs(c1, c2)
+
+        with patch("fakeredis.FakeAsyncRedis") as mocked:
+            mock_instance = object()
+            mocked.return_value = mock_instance
+            asyncio.run(runner())
+            # FakeAsyncRedis called only once – second call was served from cache
+            mocked.assert_called_once()
+
+    def test_different_loops_get_distinct_clients(self):
+        """Each event-loop gets its own cached client – separate loops ⇒ separate objects."""
+
+        async def get_client():
+            return get_async_client("redis://mocked:6379")
+
+        with patch("fakeredis.FakeAsyncRedis") as mocked:
+            # Return different objects for each call
+            mocked.side_effect = [object(), object()]
+            c1 = asyncio.run(get_client())
+            c2 = asyncio.run(get_client())
+
+            self.assertIsNot(c1, c2)
+            # called twice because two distinct loops instantiated their own pool
+            self.assertEqual(mocked.call_count, 2)

--- a/posthog/test/test_redis.py
+++ b/posthog/test/test_redis.py
@@ -15,7 +15,9 @@ class TestRedis(TestCase):
 
     @patch("fakeredis.FakeRedis")
     def test_redis_client_is_created(self, mock_fakeredis):
-        mock_instance = "test"
+        from unittest.mock import Mock
+
+        mock_instance = Mock()
         mock_fakeredis.return_value = mock_instance
 
         with self.settings(REDIS_URL="redis://mocked:6379"):


### PR DESCRIPTION
## Problem
When releasing the new architecture for Max AI, we introduced a global map for async Redis clients, in the same fashion as the existing sync one.

We [discovered](https://posthog.slack.com/archives/C06NZEZ7V3Q/p1753358515179149?thread_ts=1753358501.911089&cid=C06NZEZ7V3Q) that this can throw errors when accessing the Redis client, because the async Redis client was instantiated in a loop, but then used from another, raising:

```
RuntimeError: Task … got Future attached to a different loop
```

With this PR, we replace the global singleton with a per-loop cache held in a WeakKeyDictionary.
Now every loop gets its own connection-pool and when a short-lived loop dies (common with asyncio.run()), its pool is automatically closed and removed, avoiding cross-loop crashes

## Changes
- New per-event-loop async client cache

## How did you test this code?
Added tests