### PR TITLE
feat(web-analytics): Support count(DISTINCT person_id) in ast-to-ast transformation

### DIFF
--- a/posthog/hogql/transforms/preaggregated_table_transformation.py
+++ b/posthog/hogql/transforms/preaggregated_table_transformation.py
@@ -166,6 +166,9 @@ def _is_count_pageviews_call(call: ast.Call) -> bool:
     if call.name != "count":
         return False
 
+    if call.distinct:
+        return False
+
     if len(call.args) == 0:
         # count() - valid
         return True
@@ -177,11 +180,11 @@ def _is_count_pageviews_call(call: ast.Call) -> bool:
 
 
 def _is_uniq_persons_call(call: ast.Call) -> bool:
-    """Check if a call is uniq(person_id) or similar for person counting."""
-    if call.name != "uniq":
+    """Check if a call is uniq(person_id), count(DISTINCT person_id), or similar for person counting."""
+    if len(call.args) != 1:
         return False
 
-    if len(call.args) == 1:
+    if call.name == "uniq" or (call.name == "count" and call.distinct):
         arg = call.args[0]
         if isinstance(arg, ast.Field):
             return _is_person_id_field(arg)
@@ -190,11 +193,11 @@ def _is_uniq_persons_call(call: ast.Call) -> bool:
 
 
 def _is_uniq_sessions_call(call: ast.Call) -> bool:
-    """Check if a call is uniq(session.id) or similar for session counting."""
-    if call.name != "uniq":
+    """Check if a call is uniq(session.id), count(DISTINCT session.id) or similar for session counting."""
+    if len(call.args) != 1:
         return False
 
-    if len(call.args) == 1:
+    if call.name == "uniq" or (call.name == "count" and call.distinct):
         arg = call.args[0]
         if isinstance(arg, ast.Field):
             return _is_session_id_field(arg)

--- a/posthog/hogql/transforms/test/__snapshots__/test_preaggregated_table_transformation.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_preaggregated_table_transformation.ambr
@@ -277,6 +277,13 @@
      ORDER BY c DESC)
   '''
 # ---
+# name: TestPreaggregatedTableTransformation.test_preaggregation_tables
+  '''
+  sql
+    (SELECT sumMerge(pageviews_count_state), sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state), uniqMerge(persons_uniq_state), uniqMerge(persons_uniq_state), uniqMerge(persons_uniq_state), uniqMerge(persons_uniq_state), uniqMerge(sessions_uniq_state), uniqMerge(sessions_uniq_state), uniqMerge(sessions_uniq_state), uniqMerge(sessions_uniq_state), uniqMerge(sessions_uniq_state)
+     FROM web_stats_daily)
+  '''
+# ---
 # name: TestPreaggregatedTableTransformation.test_preaggregation_tables_group_by_session_property
   '''
   sql
@@ -457,6 +464,35 @@
                      transform_null_in=1,
                      optimize_min_equality_disjunction_chain_length=4294967295,
                      allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestPreaggregatedTableTransformationIntegration.test_trends_line_dau_query
+  '''
+  SELECT arrayMap(number -> plus(toStartOfInterval(assumeNotNull(toDateTime('2024-11-22 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(number)), range(0, plus(coalesce(dateDiff('day', toStartOfInterval(assumeNotNull(toDateTime('2024-11-22 00:00:00', 'UTC')), toIntervalDay(1)), toStartOfInterval(assumeNotNull(toDateTime('2024-11-26 23:59:59', 'UTC')), toIntervalDay(1)))), 1))) AS date,
+         arrayMap(_match_date -> arraySum(arraySlice(groupArray(ifNull(count, 0)), indexOf(groupArray(day_start) AS _days_for_count, _match_date) AS _index, plus(minus(arrayLastIndex(x -> ifNull(equals(x, _match_date), isNull(x)
+                                                                                                                                                                                                   and isNull(_match_date)), _days_for_count), _index), 1))), date) AS total
+  FROM
+    (SELECT sum(total) AS count,
+            day_start AS day_start
+     FROM
+       (SELECT uniqMerge(e.persons_uniq_state) AS total,
+               toStartOfDay(toTimeZone(e.period_bucket, 'UTC')) AS day_start
+        FROM web_stats_daily AS e
+        WHERE and(equals(e.team_id, 99999), ifNull(greaterOrEquals(toTimeZone(e.period_bucket, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2024-11-22 00:00:00', 'UTC')), toIntervalDay(1))), 0), ifNull(lessOrEquals(toTimeZone(e.period_bucket, 'UTC'), assumeNotNull(toDateTime('2024-11-26 23:59:59', 'UTC'))), 0))
+        GROUP BY day_start)
+     GROUP BY day_start
+     ORDER BY day_start ASC)
+  ORDER BY arraySum(total) DESC
+  LIMIT 50000 SETTINGS readonly=2,
+                       max_execution_time=60,
+                       allow_experimental_object_type=1,
+                       format_csv_allow_double_quotes=0,
+                       max_ast_elements=4000000,
+                       max_expanded_ast_elements=4000000,
+                       max_bytes_before_external_group_by=0,
+                       transform_null_in=1,
+                       optimize_min_equality_disjunction_chain_length=4294967295,
+                       allow_experimental_join_condition=1
   '''
 # ---
 # name: TestPreaggregatedTableTransformationIntegration.test_trends_query


### PR DESCRIPTION
## Problem

We didn't support transforming `count(DISTINCT person_id)`, but Trends use this for DAU, so we do need it.

## Changes

Add support for it. We will lose some accuracy here as clickhouse will use `uniqExact` for count DISTINCT, whereas the pre-aggregated tables use `uniq`. Read more in the clickhouse docs https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/count

## How did you test this code?

Added a test for a SQL query that uses this form, and a Trends query object

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
