### PR TITLE
fix(batch-exports): Set snowflake logger to info

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -318,7 +318,7 @@ class SnowflakeClient:
         self._connection = connection
 
         # Call this again in case level was reset.
-        self.ensure_snowflake_logger_level("DEBUG")
+        self.ensure_snowflake_logger_level("INFO")
 
         await self.use_namespace()
         await self.execute_async_query("SET ABORT_DETACHED_QUERY = FALSE", fetch_results=False)


### PR DESCRIPTION
## Problem

Snowflake is too noisy. I originally tried to set this level to info, but I missed there was another call setting the logger back to debug level.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

There are some bigger changes coming to allow us to control log levels for external libraries, but for now this just sets the level to info as intended by me in #34571
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._