### PR TITLE
chore(aggregations): rename first time math

### DIFF
--- a/frontend/src/lib/components/InsightLabel/index.tsx
+++ b/frontend/src/lib/components/InsightLabel/index.tsx
@@ -69,7 +69,7 @@ function MathTag({ math, mathProperty, mathHogQL, mathGroupTypeIndex }: MathTagP
     if (math && ['sum', 'avg', 'min', 'max', 'median', 'p75', 'p90', 'p95', 'p99'].includes(math)) {
         return (
             <>
-                <LemonTag>{mathDefinitions[math]?.name || capitalizeFirstLetter(math)}</LemonTag>
+                <LemonTag>{(mathDefinitions as any)[math]?.name || capitalizeFirstLetter(math)}</LemonTag>
                 {mathProperty && (
                     <>
                         <span>of</span>
@@ -82,7 +82,8 @@ function MathTag({ math, mathProperty, mathHogQL, mathGroupTypeIndex }: MathTagP
     if (math === 'hogql') {
         return <LemonTag className="max-w-60 text-ellipsis overflow-hidden">{String(mathHogQL) || 'SQL'}</LemonTag>
     }
-    return <LemonTag>{capitalizeFirstLetter(math)}</LemonTag>
+    // Use mathDefinitions first, then fall back to capitalizing the math string
+    return <LemonTag>{(mathDefinitions as any)[math]?.name || capitalizeFirstLetter(math)}</LemonTag>
 }
 
 export function InsightLabel({

--- a/frontend/src/scenes/insights/EditorFilters/RetentionCondition.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/RetentionCondition.tsx
@@ -54,18 +54,23 @@ export function RetentionCondition({ insightProps }: EditorFilterProps): JSX.Ele
             />
             <LemonSelect
                 options={Object.entries(retentionOptions).map(([key, value]) => ({
-                    label: value,
                     value: key,
-                    element: (
-                        <>
-                            {value}
-                            <Tooltip placement="right" title={retentionOptionDescriptions[key]}>
-                                <IconInfo className="info-indicator" />
+                    label: value,
+                    labelInMenu: (
+                        <div className="flex items-center justify-between w-full">
+                            <Tooltip
+                                placement="right"
+                                title={retentionOptionDescriptions[key as keyof typeof retentionOptionDescriptions]}
+                            >
+                                <div className="flex items-center gap-1">
+                                    <span>{value}</span>
+                                    <IconInfo className="info-indicator" />
+                                </div>
                             </Tooltip>
-                        </>
+                        </div>
                     ),
                 }))}
-                value={retentionType ? retentionOptions[retentionType] : undefined}
+                value={retentionType}
                 onChange={(value): void => updateInsightFilter({ retentionType: value as RetentionType })}
                 dropdownMatchSelectWidth={false}
             />

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -399,7 +399,7 @@ export function SlowQuerySuggestions({
         ) : null,
         slowQueryPossibilities.includes('first_time_for_user') ? (
             <li key="first_time_for_user">
-                When possible, avoid <CodeWrapper>First time for user</CodeWrapper> metric types.
+                When possible, avoid <CodeWrapper>First-ever occurrence</CodeWrapper> metric types.
             </li>
         ) : null,
         slowQueryPossibilities.includes('strict_funnel') ? (

--- a/frontend/src/scenes/retention/constants.ts
+++ b/frontend/src/scenes/retention/constants.ts
@@ -3,12 +3,7 @@ import { OpUnitType } from 'lib/dayjs'
 
 import { RetentionPeriod } from '~/types'
 
-export const dateOptions: RetentionPeriod[] = [
-    RetentionPeriod.Hour,
-    RetentionPeriod.Day,
-    RetentionPeriod.Week,
-    RetentionPeriod.Month,
-]
+export const dateOptions: RetentionPeriod[] = [RetentionPeriod.Day, RetentionPeriod.Week, RetentionPeriod.Month]
 
 // https://day.js.org/docs/en/durations/creating#list-of-all-available-units
 export const dateOptionToTimeIntervalMap: Record<RetentionPeriod, OpUnitType> = {
@@ -25,13 +20,14 @@ export const dateOptionPlurals: Record<RetentionPeriod, string> = {
     Month: 'months',
 }
 
-export const retentionOptions = {
-    [RETENTION_FIRST_TIME]: 'for the first time',
-    [RETENTION_RECURRING]: 'recurringly',
+export const retentionOptions: Record<string, string> = {
+    [`${RETENTION_FIRST_TIME}`]: 'for the first time',
+    [`${RETENTION_RECURRING}`]: 'recurringly',
 }
 
 export const retentionOptionDescriptions = {
-    [`${RETENTION_RECURRING}`]: 'A user will belong to any cohort where they have performed the event in its Period 0.',
+    [`${RETENTION_RECURRING}`]:
+        "A user is counted in a cohort for each period in which they perform the action matching the specified filters. A user can belong to multiple cohorts. Example: For a daily insight filtering by 'Browser = Chrome', a user who logs in from Chrome on Monday and Wednesday will be part of both cohorts.",
     [`${RETENTION_FIRST_TIME}`]:
-        'A user will only belong to the cohort for which they performed the event for the first time.',
+        "A user is counted only in the cohort of the first time they performed the action matching the specified filters. This is based on the user's lifetime history. Example: For a monthly insight filtering by 'Browser = Chrome', if a user's first-ever login from Chrome was in April, they will not be included in the cohort for May.",
 }

--- a/frontend/src/scenes/trends/mathsLogic.tsx
+++ b/frontend/src/scenes/trends/mathsLogic.tsx
@@ -40,36 +40,36 @@ export const FUNNEL_MATH_DEFINITIONS: Record<FunnelMathType, MathDefinition> = {
         category: MathCategory.EventCount,
     },
     [FunnelMathType.FirstTimeForUser]: {
-        name: 'First event for user',
+        // renamed on 2025-07-24, used to 'First time for user'
+        name: 'First-ever occurrence',
         shortName: 'first event',
         description: (
             <>
-                Matches only the first time the user performed this event type. If this event does not match the event
-                filters, or is outside the selected date range, the user will be excluded from the funnel.
+                Finds the user's very first occurrence of this event type, then checks if it matches your filters. If
+                the first-ever event doesn't match your filters, the user is excluded from the funnel.
                 <br />
                 <br />
                 <i>
-                    Example: If the we are looking for pageview events to posthog.com/about, but the user's first
-                    pageview was on posthog.com, it will not match, even if they went to posthog.com/about afterwards.
+                    Example: If you're filtering for pageview events to posthog.com/about, but the user's first pageview
+                    was to posthog.com, it will not match (even if they went to posthog.com/about later).
                 </i>
             </>
         ),
         category: MathCategory.EventCount,
     },
     [FunnelMathType.FirstTimeForUserWithFilters]: {
-        name: 'First matching event for user',
+        // renamed on 2025-07-24, used to 'First matching event for user'
+        name: 'First occurrence matching filters',
         shortName: 'first matching event',
         description: (
             <>
-                Matches only the first time the user performed this event type with the selected filters. If this event
-                is outside the selected date range, or the user never performed the event with the selected filters, the
-                user will be excluded from the funnel.
+                Finds the first time the user performed this event type that also matches your filters. Previous events
+                that don't match are ignored.
                 <br />
                 <br />
                 <i>
-                    Example: If the we are looking for pageview events to posthog.com/about, and the user's first
-                    pageview was on posthog.com but then they navigated to posthog.com/about, it will match the pageview
-                    event from posthog.com/about
+                    Example: If you're filtering for pageview events to posthog.com/about, and the user first viewed
+                    posthog.com then later posthog.com/about, it will match the posthog.com/about pageview.
                 </i>
             </>
         ),
@@ -188,36 +188,36 @@ export const BASE_MATH_DEFINITIONS: Record<BaseMathType, MathDefinition> = {
         category: MathCategory.SessionCount,
     },
     [BaseMathType.FirstTimeForUser]: {
-        name: 'First time for user',
+        // renamed on 2025-07-24, used to 'First time for user'
+        name: 'First-ever occurrence',
         shortName: 'first time',
         description: (
             <>
-                Matches only the first time the user performed this event type. If this event does not match the event
-                filters, or is outside the selected date range, the user will be excluded from the insight.
+                Finds the user's very first occurrence of this event type, then checks if it matches your filters. If
+                the first-ever event doesn't match your filters, the user is excluded.
                 <br />
                 <br />
                 <i>
-                    Example: If the we are looking for pageview events to posthog.com/about, but the user's first
-                    pageview was on posthog.com, it will not match, even if they went to posthog.com/about afterwards.
+                    Example: If you're filtering for pageview events to posthog.com/about, but the user's first pageview
+                    was to posthog.com, it will not match (even if they went to posthog.com/about later).
                 </i>
             </>
         ),
         category: MathCategory.EventCount,
     },
     [BaseMathType.FirstMatchingEventForUser]: {
-        name: 'First matching event for user',
+        // renamed on 2025-07-24, used to 'First matching event for user'
+        name: 'First occurrence matching filters',
         shortName: 'first matching event',
         description: (
             <>
-                Matches only the first time the user performed this event type with the selected filters. If this event
-                is outside the selected date range, or the user never performed the event with the selected filters, the
-                user will be excluded from the insight.
+                Finds the first time the user performed this event type that also matches your filters. Previous events
+                that don't match are ignored.
                 <br />
                 <br />
                 <i>
-                    Example: If the we are looking for pageview events to posthog.com/about, and the user's first
-                    pageview was on posthog.com but then they navigated to posthog.com/about, it will match the pageview
-                    event from posthog.com/about
+                    Example: If you're filtering for pageview events to posthog.com/about, and the user first viewed
+                    posthog.com then later posthog.com/about, it will match the posthog.com/about pageview.
                 </i>
             </>
         ),


### PR DESCRIPTION
## Problem
Currently the first time filters on the UI are hard to understand
<img width="227" height="69" alt="image" src="https://github.com/user-attachments/assets/83830814-e340-4d9a-af10-3b1818933212" />
+ the 'first time' filter on retention insights is actually doing 'first time matching filters' but doesn't say matching filters (according to other places on the UI)

## Changes
- Renames then with better tooltips
<img width="648" height="222" alt="image" src="https://github.com/user-attachments/assets/6fb8f2e1-07db-48bb-826d-ad275e270212" />
<img width="641" height="199" alt="image" src="https://github.com/user-attachments/assets/047b2c45-8d8a-4f9d-97a1-7b042273e7a8" />

- also fixes their display in the insight tooltip (uses the formatted name now)
<img width="299" height="150" alt="image" src="https://github.com/user-attachments/assets/27e7dfc9-6418-4881-92ac-dc0b6a8fa793" />

- Fixed tooltip rendering on retention insights (also improved the tooltips)
<img width="557" height="196" alt="image" src="https://github.com/user-attachments/assets/7600706a-87a6-4a1b-baf0-dd8be3d108a1" />
<img width="538" height="250" alt="image" src="https://github.com/user-attachments/assets/fee2ba4b-95a4-408f-94e1-74dd319337ba" />


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Existing test suite + checking UI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
