### PR TITLE
feat: add onDataPointClick for cost per user graph in LLMO

### DIFF
--- a/products/llm_observability/frontend/llmObservabilityLogic.tsx
+++ b/products/llm_observability/frontend/llmObservabilityLogic.tsx
@@ -231,6 +231,7 @@ export const llmObservabilityLogic = kea<llmObservabilityLogicType>([
                         onDataPointClick: (series) => {
                             if (typeof series.day === 'string') {
                                 const dayStart = dayjs(series.day).startOf('day')
+
                                 router.actions.push(urls.llmObservabilityUsers(), {
                                     ...router.values.searchParams,
                                     date_from: dayStart.format('YYYY-MM-DD[T]HH:mm:ss'),
@@ -312,6 +313,20 @@ export const llmObservabilityLogic = kea<llmObservabilityLogicType>([
                     context: {
                         insightProps: {
                             dashboardItemId: `new-cost-per-user-query`,
+                        },
+                        onDataPointClick: (series) => {
+                            if (typeof series.day === 'string') {
+                                const dayStart = dayjs(series.day).startOf('day')
+
+                                router.actions.push(urls.llmObservabilityUsers(), {
+                                    ...router.values.searchParams,
+                                    date_from: dayStart.format('YYYY-MM-DD[T]HH:mm:ss'),
+                                    date_to: dayStart
+                                        .add(1, 'day')
+                                        .subtract(1, 'second')
+                                        .format('YYYY-MM-DD[T]HH:mm:ss'),
+                                })
+                            }
                         },
                     },
                 },


### PR DESCRIPTION
## Problem

In the LLM Observability dashboard, the Cost per User graph's datapoint click did not show the LLM users for that day, but rather a list of identified users on the platform.

## Changes

This adds a `onDataPointClick` for the Cost per User graph, mimicking the behaviour from the Generative AI users graph.

## How did you test this code?

- Visit the LLM Observability dashboard
- Click on a data point inside the Cost per User graph
- You should be redirected to the Users tab, showing all the LLM users for that day

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
