### PR TITLE
feat(experiments): shared metrics activity logging.

### DIFF
--- a/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
@@ -46,6 +46,13 @@ const UnknownAction = ({ logItem }: { logItem: ActivityLogItem }): JSX.Element =
 }
 
 export const experimentActivityDescriber = (logItem: ActivityLogItem): HumanizedChange => {
+    //bail for shared metrics
+    if (logItem.detail.type === 'shared_metric') {
+        return {
+            description: null,
+        }
+    }
+
     return match(logItem.activity)
         .with('created', () => {
             /**

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -42,6 +42,7 @@ ActivityScope = Literal[
     "Dashboard",
     "Replay",
     "Experiment",
+    "ExperimentSavedMetric",
     "Survey",
     "EarlyAccessFeature",
     "SessionRecordingPlaylist",
@@ -198,6 +199,10 @@ field_exclusions: dict[ActivityScope, list[str]] = {
         "exposure_cohort",
         "holdout",
         "saved_metrics",
+        "experimenttosavedmetric_set",
+    ],
+    "ExperimentSavedMetric": [
+        "experiments",
         "experimenttosavedmetric_set",
     ],
     "Person": [

--- a/posthog/models/experiment.py
+++ b/posthog/models/experiment.py
@@ -126,7 +126,7 @@ class ExperimentHoldout(RootTeamMixin, models.Model):
     updated_at = models.DateTimeField(auto_now=True)
 
 
-class ExperimentSavedMetric(RootTeamMixin, models.Model):
+class ExperimentSavedMetric(ModelActivityMixin, RootTeamMixin, models.Model):
     name = models.CharField(max_length=400)
     description = models.CharField(max_length=400, null=True, blank=True)
     team = models.ForeignKey("Team", on_delete=models.CASCADE)


### PR DESCRIPTION
## Problem

The _Experiments_ activity log wasn't logging changes on _Shared Metrics_.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We are adding logging support to the _Shared Metrics_ model in the backend, allowing us to log changes within the same scope.
This only covers backend changes and instructs the frontend to filter out shared metric activity from the log. The frontend part will be implemented in a future PR.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/cd68480e-124b-4ceb-9053-c3c70ebb8a91)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
