### PR TITLE
fix: tailwind classes break selectors in autocapture

### DIFF
--- a/posthog/hogql/test/test_action_to_expr.py
+++ b/posthog/hogql/test/test_action_to_expr.py
@@ -40,7 +40,7 @@ class TestActionToExpr(BaseTest):
                                 "elements_chain =~ {regex}",
                                 {
                                     "regex": ast.Constant(
-                                        value='(^|;)a.*?\\.active\\..*?nav\\-link([-_a-zA-Z0-9\\.:"= ]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
+                                        value='(^|;)a.*?\\.active\\..*?nav\\-link([-_a-zA-Z0-9\\.:"= \\[\\]\\(\\),]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
                                     )
                                 },
                             ),

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -625,7 +625,7 @@ class TestProperty(BaseTest):
             self._selector_to_expr(".sm:[max-width:640px]"),
             clear_locations(
                 elements_chain_match(
-                    '(^|;).*?\\.sm:\\[max\\-width:640px\\]([-_a-zA-Z0-9\\.:"= \\[\\]\\(\\),]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
+                    '(^|;)sm:\\[max\\-width:640px\\]([-_a-zA-Z0-9\\.:"= \\[\\]\\(\\),]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
                 )
             ),
         )
@@ -635,7 +635,7 @@ class TestProperty(BaseTest):
             self._selector_to_expr(".w-[calc(100%-2rem)]"),
             clear_locations(
                 elements_chain_match(
-                    '(^|;).*?\\.w\\-\\[calc\\(100%\\-2rem\\)\\]([-_a-zA-Z0-9\\.:"= \\[\\]\\(\\),]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
+                    '(^|;)w\\-\\[calc\\(100%\\-2rem\\)\\]([-_a-zA-Z0-9\\.:"= \\[\\]\\(\\),]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
                 )
             ),
         )
@@ -645,7 +645,7 @@ class TestProperty(BaseTest):
             self._selector_to_expr(".shadow-[0_4px_6px_rgba(0,0,0,0.1)]"),
             clear_locations(
                 elements_chain_match(
-                    '(^|;).*?\\.1\\)\\]\\..*?shadow\\-\\[0_4px_6px_rgba\\(0,0,0,0([-_a-zA-Z0-9\\.:"= \\[\\]\\(\\),]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
+                    '(^|;)shadow\\-\\[0_4px_6px_rgba\\(0,0,0,0\\.1\\)\\]([-_a-zA-Z0-9\\.:"= \\[\\]\\(\\),]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
                 )
             ),
         )

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -625,7 +625,7 @@ class TestProperty(BaseTest):
             self._selector_to_expr(".sm:[max-width:640px]"),
             clear_locations(
                 elements_chain_match(
-                    '(^|;)sm:\\[max\\-width:640px\\]([-_a-zA-Z0-9\\.:"= \\[\\]\\(\\),]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
+                    '(^|;).*?\\.sm:\\[max\\-width:640px\\]([-_a-zA-Z0-9\\.:"= \\[\\]\\(\\),]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
                 )
             ),
         )
@@ -635,7 +635,7 @@ class TestProperty(BaseTest):
             self._selector_to_expr(".w-[calc(100%-2rem)]"),
             clear_locations(
                 elements_chain_match(
-                    '(^|;)w\\-\\[calc\\(100%\\-2rem\\)\\]([-_a-zA-Z0-9\\.:"= \\[\\]\\(\\),]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
+                    '(^|;).*?\\.w\\-\\[calc\\(100%\\-2rem\\)\\]([-_a-zA-Z0-9\\.:"= \\[\\]\\(\\),]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
                 )
             ),
         )
@@ -645,7 +645,7 @@ class TestProperty(BaseTest):
             self._selector_to_expr(".shadow-[0_4px_6px_rgba(0,0,0,0.1)]"),
             clear_locations(
                 elements_chain_match(
-                    '(^|;)shadow\\-\\[0_4px_6px_rgba\\(0,0,0,0\\.1\\)\\]([-_a-zA-Z0-9\\.:"= \\[\\]\\(\\),]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
+                    '(^|;).*?\\.shadow\\-\\[0_4px_6px_rgba\\(0,0,0,0\\.1\\)\\]([-_a-zA-Z0-9\\.:"= \\[\\]\\(\\),]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
                 )
             ),
         )

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -540,13 +540,15 @@ class TestProperty(BaseTest):
     def test_selector_to_expr(self):
         self.assertEqual(
             self._selector_to_expr("div"),
-            clear_locations(elements_chain_match('(^|;)div([-_a-zA-Z0-9\\.:"= ]*?)?($|;|:([^;^\\s]*(;|$|\\s)))')),
+            clear_locations(
+                elements_chain_match('(^|;)div([-_a-zA-Z0-9\\.:"= \\[\\]\\(\\),]*?)?($|;|:([^;^\\s]*(;|$|\\s)))')
+            ),
         )
         self.assertEqual(
             self._selector_to_expr("div > div"),
             clear_locations(
                 elements_chain_match(
-                    '(^|;)div([-_a-zA-Z0-9\\.:"= ]*?)?($|;|:([^;^\\s]*(;|$|\\s)))div([-_a-zA-Z0-9\\.:"= ]*?)?($|;|:([^;^\\s]*(;|$|\\s))).*'
+                    '(^|;)div([-_a-zA-Z0-9\\.:"= \\[\\]\\(\\),]*?)?($|;|:([^;^\\s]*(;|$|\\s)))div([-_a-zA-Z0-9\\.:"= \\[\\]\\(\\),]*?)?($|;|:([^;^\\s]*(;|$|\\s))).*'
                 )
             ),
         )
@@ -557,7 +559,7 @@ class TestProperty(BaseTest):
                     "{regex} and arrayCount(x -> x IN ['a'], elements_chain_elements) > 0",
                     {
                         "regex": elements_chain_match(
-                            '(^|;)a.*?href="boo".*?([-_a-zA-Z0-9\\.:"= ]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
+                            '(^|;)a.*?href="boo".*?([-_a-zA-Z0-9\\.:"= \\[\\]\\(\\),]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
                         )
                     },
                 )
@@ -566,7 +568,9 @@ class TestProperty(BaseTest):
         self.assertEqual(
             self._selector_to_expr(".class"),
             clear_locations(
-                elements_chain_match('(^|;).*?\\.class([-_a-zA-Z0-9\\.:"= ]*?)?($|;|:([^;^\\s]*(;|$|\\s)))')
+                elements_chain_match(
+                    '(^|;).*?\\.class([-_a-zA-Z0-9\\.:"= \\[\\]\\(\\),]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
+                )
             ),
         )
         self.assertEqual(
@@ -576,7 +580,7 @@ class TestProperty(BaseTest):
                     """{regex} and indexOf(elements_chain_ids, 'withid') > 0 and arrayCount(x -> x IN ['a'], elements_chain_elements) > 0""",
                     {
                         "regex": elements_chain_match(
-                            '(^|;)a.*?attr_id="withid".*?([-_a-zA-Z0-9\\.:"= ]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
+                            '(^|;)a.*?attr_id="withid".*?([-_a-zA-Z0-9\\.:"= \\[\\]\\(\\),]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
                         )
                     },
                 )
@@ -590,7 +594,7 @@ class TestProperty(BaseTest):
                     """{regex} and indexOf(elements_chain_ids, 'with-dashed-id') > 0 and arrayCount(x -> x IN ['a'], elements_chain_elements) > 0""",
                     {
                         "regex": elements_chain_match(
-                            '(^|;)a.*?attr_id="with\\-dashed\\-id".*?([-_a-zA-Z0-9\\.:"= ]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
+                            '(^|;)a.*?attr_id="with\\-dashed\\-id".*?([-_a-zA-Z0-9\\.:"= \\[\\]\\(\\),]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
                         )
                     },
                 )
@@ -610,6 +614,38 @@ class TestProperty(BaseTest):
             clear_locations(
                 parse_expr(
                     "indexOf(elements_chain_ids, 'with\\\\slashed\\\\id') > 0",
+                )
+            ),
+        )
+
+    def test_selector_to_expr_tailwind_classes(self):
+        """Test that selectors work with Tailwind classes that include brackets, parentheses, and commas"""
+        # Test Tailwind class with brackets (responsive design)
+        self.assertEqual(
+            self._selector_to_expr(".sm:[max-width:640px]"),
+            clear_locations(
+                elements_chain_match(
+                    '(^|;).*?\\.sm:\\[max\\-width:640px\\]([-_a-zA-Z0-9\\.:"= \\[\\]\\(\\),]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
+                )
+            ),
+        )
+
+        # Test Tailwind class with parentheses and commas (calc functions)
+        self.assertEqual(
+            self._selector_to_expr(".w-[calc(100%-2rem)]"),
+            clear_locations(
+                elements_chain_match(
+                    '(^|;).*?\\.w\\-\\[calc\\(100%\\-2rem\\)\\]([-_a-zA-Z0-9\\.:"= \\[\\]\\(\\),]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
+                )
+            ),
+        )
+
+        # Test Tailwind class with complex values including commas
+        self.assertEqual(
+            self._selector_to_expr(".shadow-[0_4px_6px_rgba(0,0,0,0.1)]"),
+            clear_locations(
+                elements_chain_match(
+                    '(^|;).*?\\.1\\)\\]\\..*?shadow\\-\\[0_4px_6px_rgba\\(0,0,0,0([-_a-zA-Z0-9\\.:"= \\[\\]\\(\\),]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
                 )
             ),
         )

--- a/posthog/models/event/event.py
+++ b/posthog/models/event/event.py
@@ -44,7 +44,14 @@ class SelectorPart:
             self.ch_attributes["nth-child"] = self.data["nth_child"]
             tag = parts[0]
         if "." in tag:
-            parts = self._split_css_classes(tag)
+            # Regex pattern that matches dots that are NOT inside square brackets
+            # Uses negative lookahead to ensure the dot is not followed by content ending with ]
+            # without an opening [ in between
+            # Handles Tailwind arbitrary values with square brackets properly.
+            # Example: 'div.shadow-[0_4px_6px_rgba(0,0,0,0.1)].text-blue-500'
+            # Returns: ['div', 'shadow-[0_4px_6px_rgba(0,0,0,0.1)]', 'text-blue-500']
+            pattern = r"\.(?![^\[]*\])"
+            parts = re.split(pattern, tag)
             # Strip all slashes that are not followed by another slash
             self.data["attr_class__contains"] = [self._unescape_class(p) if escape_slashes else p for p in parts[1:]]
             tag = parts[0]
@@ -75,46 +82,6 @@ class SelectorPart:
     def _unescape_class(self, class_name):
         r"""Separate all double slashes "\\" (replace them with "\") and remove all single slashes between them."""
         return "\\".join([p.replace("\\", "") for p in class_name.split("\\\\")])
-
-    def _split_css_classes(self, tag: str) -> list[str]:
-        """
-        Splits a tag string into its base name and CSS classes.
-        Handles Tailwind arbitrary values with square brackets properly.
-
-        Example: 'div.shadow-[0_4px_6px_rgba(0,0,0,0.1)].text-blue-500'
-        Returns: ['div', 'shadow-[0_4px_6px_rgba(0,0,0,0.1)]', 'text-blue-500']
-        """
-        if "." not in tag:
-            return [tag]
-
-        parts = []
-        current_part = ""
-        bracket_depth = 0
-        i = 0
-
-        while i < len(tag):
-            char = tag[i]
-
-            if char == "[":
-                bracket_depth += 1
-                current_part += char
-            elif char == "]":
-                bracket_depth -= 1
-                current_part += char
-            elif char == "." and bracket_depth == 0:
-                # Only split on dots when we're not inside brackets
-                if current_part:
-                    parts.append(current_part)
-                current_part = ""
-            else:
-                current_part += char
-
-            i += 1
-
-        if current_part:
-            parts.append(current_part)
-
-        return parts
 
 
 class Selector:

--- a/posthog/models/property/util.py
+++ b/posthog/models/property/util.py
@@ -833,7 +833,7 @@ def build_selector_regex(selector: Selector) -> str:
             regex += r".*?"
             for key, value in sorted(tag.ch_attributes.items()):
                 regex += rf'{re.escape(key)}="{re.escape(str(value))}".*?'
-        regex += r'([-_a-zA-Z0-9\.:"= ]*?)?($|;|:([^;^\s]*(;|$|\s)))'
+        regex += r'([-_a-zA-Z0-9\.:"= \[\]\(\),]*?)?($|;|:([^;^\s]*(;|$|\s)))'
         if tag.direct_descendant:
             regex += r".*"
     if regex:


### PR DESCRIPTION
## Problem
a customer has a really complex elements chain that includes tailwind classes that have brackets and parentheses. This is breaking our regex and causing "create action from event" to not work. 
https://posthoghelp.zendesk.com/agent/tickets/33812 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/36275)

## Changes
Fix it.

## How did you test this code?
Wrote a test

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
