### PR TITLE
chore: count requests with api key in query param

### DIFF
--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -3,6 +3,7 @@ import re
 from datetime import timedelta
 from typing import Any, Optional, Union
 from urllib.parse import urlsplit
+from prometheus_client import Counter
 
 import jwt
 from django.apps import apps
@@ -24,8 +25,21 @@ from posthog.models.personal_api_key import (
 )
 from posthog.models.sharing_configuration import SharingConfiguration
 from posthog.models.user import User
+from posthog.metrics import LABEL_TEAM_ID
 from django.contrib.auth.models import AnonymousUser
 from zxcvbn import zxcvbn
+
+PERSONAL_API_KEY_QUERY_PARAM_COUNTER = Counter(
+    "api_auth_personal_api_key_query_param",
+    "Requests where the personal api key is specified in a query parameter",
+    labelnames=["user_uuid", "extra_data"],
+)
+
+PROJECT_SECRET_API_KEY_QUERY_PARAM_COUNTER = Counter(
+    "api_auth_project_secret_api_key_query_param",
+    "Requests where the project secret api key is specified in a query parameter",
+    labelnames=[LABEL_TEAM_ID],
+)
 
 
 class ZxcvbnValidator:
@@ -142,6 +156,11 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
             key_to_update.secure_value = hash_key_value(personal_api_key)
             key_to_update.save(update_fields=["secure_value"])
 
+        if source == "query string":
+            PERSONAL_API_KEY_QUERY_PARAM_COUNTER.labels(personal_api_key_object.user.uuid, False).inc()
+        elif source == "query string data":
+            PERSONAL_API_KEY_QUERY_PARAM_COUNTER.labels(personal_api_key_object.user.uuid, True).inc()
+
         return personal_api_key_object
 
     def authenticate(self, request: Union[HttpRequest, Request]) -> Optional[tuple[Any, None]]:
@@ -231,6 +250,9 @@ class ProjectSecretAPIKeyAuthentication(authentication.BaseAuthentication):
 
             if team is None:
                 return None
+
+            if source == "query":
+                PROJECT_SECRET_API_KEY_QUERY_PARAM_COUNTER.labels(team.id).inc()
 
             # Secret api keys are not associated with a user, so we create a ProjectSecretAPIKeyUser
             # and attach the team. The team is the important part here.


### PR DESCRIPTION
We currently support specifying Personal API Keys and Project Secret API Keys in a query param. This isn't desirable as query params are often logged by load balancers and other middleware. These prometheus counters will help us gauge how frequently this functionality is used so that we can deprecate it.

## How did you test this code?

Existing e2e tests verify the query param auth method is still functional. The prometheus counter is more difficult to test locally but is also non-critical.
