### PR TITLE
fix: turn tracing headers on for calls home

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -92,6 +92,7 @@ export function loadPostHogJS(): void {
             person_profiles: 'always',
             __preview_remote_config: true,
             __preview_flags_v2: true,
+            __add_tracing_headers: ['eu.posthog.com', 'us.posthog.com'],
         })
 
         posthog.onFeatureFlags((_flags, _variants, context) => {


### PR DESCRIPTION
we've changed the tracing headers preview to work off an allowlist

let's test that in our dog with its food