### PR TITLE
fix(devex): pencil icon breadcrumbs for feature offramp

### DIFF
--- a/frontend/src/layout/scenes/SceneHeader.tsx
+++ b/frontend/src/layout/scenes/SceneHeader.tsx
@@ -100,14 +100,15 @@ interface BreadcrumbProps {
 }
 
 function Breadcrumb({ breadcrumb, here, isOnboarding }: BreadcrumbProps): JSX.Element {
+    const [popoverShown, setPopoverShown] = useState(false)
+    const [isEditing, setIsEditing] = useState(false)
+
     const { assureVisibility } = useActions(projectTreeLogic({ key: PROJECT_TREE_KEY }))
     const { showLayoutPanel, setActivePanelIdentifier } = useActions(panelLayoutLogic)
-    const [popoverShown, setPopoverShown] = useState(false)
     const { scenePanelOpen, scenePanelIsPresent } = useValues(sceneLayoutLogic)
     const { setScenePanelOpen } = useActions(sceneLayoutLogic)
     const { renameState } = useValues(breadcrumbsLogic)
     const { tentativelyRename, finishRenaming } = useActions(breadcrumbsLogic)
-    const [editing, setEditing] = useState(false)
 
     const joinedKey = joinBreadcrumbKey(breadcrumb.key)
 
@@ -168,7 +169,7 @@ function Breadcrumb({ breadcrumb, here, isOnboarding }: BreadcrumbProps): JSX.El
             {/* if renaming exists, show a button to rename */}
             {'onRename' in breadcrumb && breadcrumb.onRename ? (
                 <>
-                    {editing ? (
+                    {isEditing ? (
                         <EditableField
                             name="item-name-small"
                             value={renameState && renameState[0] === joinedKey ? renameState[1] : breadcrumbName}
@@ -184,7 +185,7 @@ function Breadcrumb({ breadcrumb, here, isOnboarding }: BreadcrumbProps): JSX.El
                                     finishRenaming()
                                 }
                                 setPopoverShown(false)
-                                setEditing(false)
+                                setIsEditing(false)
                             }}
                             autoFocus
                             placeholder="Unnamed"
@@ -200,7 +201,7 @@ function Breadcrumb({ breadcrumb, here, isOnboarding }: BreadcrumbProps): JSX.El
                                     if (scenePanelIsPresent) {
                                         setScenePanelOpen(!scenePanelOpen)
                                     } else {
-                                        setEditing(!editing)
+                                        setIsEditing(!isEditing)
                                     }
                                 }}
                                 className="ml-1"

--- a/frontend/src/layout/scenes/SceneHeader.tsx
+++ b/frontend/src/layout/scenes/SceneHeader.tsx
@@ -1,4 +1,4 @@
-import { IconChevronDown, IconGear, IconInfo, IconX } from '@posthog/icons'
+import { IconChevronDown, IconGear, IconInfo, IconPencil, IconX } from '@posthog/icons'
 import { LemonButton, LemonTag } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { IconMenu, IconSlash } from 'lib/lemon-ui/icons'
@@ -6,8 +6,10 @@ import { Link } from 'lib/lemon-ui/Link'
 import { cn } from 'lib/utils/css-classes'
 import React, { useState } from 'react'
 
+import { EditableField } from 'lib/components/EditableField/EditableField'
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
 import { TopBarSettingsButton } from 'lib/components/TopBarSettingsButton/TopBarSettingsButton'
+import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { ErrorBoundary } from '~/layout/ErrorBoundary'
 import { breadcrumbsLogic } from '~/layout/navigation/Breadcrumbs/breadcrumbsLogic'
 import { navigationLogic } from '~/layout/navigation/navigationLogic'
@@ -50,7 +52,7 @@ export function SceneHeader({ className }: { className?: string }): JSX.Element 
                         <ScrollableShadows
                             direction="horizontal"
                             styledScrollbars
-                            className="h-[var(--scene-layout-header-height)] pr-2"
+                            className="h-[var(--scene-layout-header-height)] pr-2 flex-1"
                             innerClassName="flex gap-0 flex-1 items-center overflow-x-auto show-scrollbar-on-hover h-full"
                         >
                             {breadcrumbs.map((breadcrumb, index) => (
@@ -101,6 +103,11 @@ function Breadcrumb({ breadcrumb, here, isOnboarding }: BreadcrumbProps): JSX.El
     const { assureVisibility } = useActions(projectTreeLogic({ key: PROJECT_TREE_KEY }))
     const { showLayoutPanel, setActivePanelIdentifier } = useActions(panelLayoutLogic)
     const [popoverShown, setPopoverShown] = useState(false)
+    const { scenePanelOpen, scenePanelIsPresent } = useValues(sceneLayoutLogic)
+    const { setScenePanelOpen } = useActions(sceneLayoutLogic)
+    const { renameState } = useValues(breadcrumbsLogic)
+    const { tentativelyRename, finishRenaming } = useActions(breadcrumbsLogic)
+    const [editing, setEditing] = useState(false)
 
     const joinedKey = joinBreadcrumbKey(breadcrumb.key)
 
@@ -111,7 +118,7 @@ function Breadcrumb({ breadcrumb, here, isOnboarding }: BreadcrumbProps): JSX.El
         nameElement = breadcrumb.symbol
     } else {
         nameElement = (
-            <span className={cn('flex items-center gap-1.5 inline-block whitespace-nowrap')}>
+            <span className={cn('items-center gap-1.5 inline-block whitespace-nowrap')}>
                 {breadcrumbName === '' ? <em>Unnamed</em> : breadcrumbName}
                 {'tag' in breadcrumb && breadcrumb.tag && <LemonTag size="small">{breadcrumb.tag}</LemonTag>}
             </span>
@@ -155,7 +162,60 @@ function Breadcrumb({ breadcrumb, here, isOnboarding }: BreadcrumbProps): JSX.El
         )
     }
 
-    return <ErrorBoundary>{breadcrumbContent}</ErrorBoundary>
+    return (
+        <ErrorBoundary>
+            {/* if renaming exists, show a button to rename */}
+            {/* if renaming exists, show a button to rename */}
+            {'onRename' in breadcrumb && breadcrumb.onRename ? (
+                <>
+                    {editing ? (
+                        <EditableField
+                            name="item-name-small"
+                            value={renameState && renameState[0] === joinedKey ? renameState[1] : breadcrumbName}
+                            onChange={(newName) => tentativelyRename(joinedKey, newName)}
+                            onSave={(newName) => {
+                                void breadcrumb.onRename?.(newName)
+                            }}
+                            mode="edit"
+                            onModeToggle={(newMode) => {
+                                if (newMode === 'edit') {
+                                    tentativelyRename(joinedKey, breadcrumbName)
+                                } else {
+                                    finishRenaming()
+                                }
+                                setPopoverShown(false)
+                                setEditing(false)
+                            }}
+                            autoFocus
+                            placeholder="Unnamed"
+                            compactButtons="xsmall"
+                            editingIndication="underlined"
+                        />
+                    ) : (
+                        <>
+                            {breadcrumbContent}
+                            <ButtonPrimitive
+                                iconOnly
+                                onClick={() => {
+                                    if (scenePanelIsPresent) {
+                                        setScenePanelOpen(!scenePanelOpen)
+                                    } else {
+                                        setEditing(!editing)
+                                    }
+                                }}
+                                className="ml-1"
+                                tooltip={scenePanelIsPresent ? 'Editing has moved to the info panel' : 'Rename'}
+                            >
+                                <IconPencil className="text-primary" />
+                            </ButtonPrimitive>
+                        </>
+                    )}
+                </>
+            ) : (
+                breadcrumbContent
+            )}
+        </ErrorBoundary>
+    )
 }
 
 function joinBreadcrumbKey(key: IBreadcrumb['key']): string {


### PR DESCRIPTION
## Problem
* People didn't know how to use the new scene panel
* If new scene layout flag was active, but didn't have the scene panel you couldn't rename something!

## Changes
Re-add a pencil icon button to breadcrumbs
* If scene panel is available, when clicked open the side panel
* if scene panel is NOT available, show editable field 

#### Panel available
![2025-07-25 10 00 13](https://github.com/user-attachments/assets/50844ae6-0e86-4079-bbf8-604da77abfc3)

#### Panel NOT available
![2025-07-25 09 59 20](https://github.com/user-attachments/assets/c5eec72e-db86-4d7a-9c48-7cc164852539)

## How did you test this code?
* Flag off, works as intended 
* Flag on, scene panel available, works as intended
* Flag on, scene panel NOT available, renaming works as intended
