### PR TITLE
fix: ORM lazy loading raises errors in async context

### DIFF
--- a/posthog/session_recordings/models/session_recording.py
+++ b/posthog/session_recordings/models/session_recording.py
@@ -166,7 +166,10 @@ class SessionRecording(UUIDModel):
     @staticmethod
     def get_or_build(session_id: str, team: Team) -> "SessionRecording":
         try:
-            return SessionRecording.objects.get(session_id=session_id, team=team)
+            # we have to select the team now instead of lazy loading
+            # because this recording object is sometimes used in an async context
+            # and lazy loading in the async context causes an error
+            return SessionRecording.objects.select_related("team").get(session_id=session_id, team=team)
         except SessionRecording.DoesNotExist:
             return SessionRecording(session_id=session_id, team=team)
 


### PR DESCRIPTION
we periodically see errors loading snapshots
it's because the Django ORM will lazy load foreign key objects when they're accessed and we sometimes access team

but if we do that in an async context it makes django raise an error

let's preload the team and avoid the error