### PR TITLE
fix(max): catch exceptions from clean up function of `sync_vectors`

### DIFF
--- a/posthog/temporal/tests/ai/test_sync_vectors.py
+++ b/posthog/temporal/tests/ai/test_sync_vectors.py
@@ -43,7 +43,11 @@ from posthog.temporal.common.clickhouse import get_client
 @pytest.fixture(autouse=True)
 def cleanup():
     yield
-    sync_execute(TRUNCATE_PG_EMBEDDINGS_TABLE_SQL())
+
+    try:
+        sync_execute(TRUNCATE_PG_EMBEDDINGS_TABLE_SQL())
+    except:
+        pass
 
 
 @pytest.fixture


### PR DESCRIPTION
## Problem

It's started throwing an exception in CI tests because the database doesn't exist. If it doesn't exist, we don't need to truncate data.

## Changes

Add the try/except block.

## How did you test this code?

N/A
