### PR TITLE
feat(msg): write events for person to cassandra

### DIFF
--- a/plugin-server/cassandra/migrations/003_person_event_occurrences.cql
+++ b/plugin-server/cassandra/migrations/003_person_event_occurrences.cql
@@ -1,0 +1,24 @@
+-- Migration: Create person event occurrences table
+-- Created: 2025-07-25
+-- Description: Table to track whether a person has performed a specific event
+-- Optimized for occurrence tracking (set semantics) with efficient queries by person_id and event_name
+
+-- Create the person event occurrences table
+-- This table stores occurrences with the pattern:
+-- team_id:person_id:event_name
+-- If a record exists, the event occurred
+CREATE TABLE IF NOT EXISTS person_event_occurrences (
+    team_id INT,
+    person_id UUID,  
+    event_name TEXT,
+    PRIMARY KEY (team_id, person_id, event_name)
+) WITH CLUSTERING ORDER BY (person_id ASC, event_name ASC)
+  AND compaction = {
+    'class': 'LeveledCompactionStrategy',
+    'sstable_size_in_mb': 160
+  }
+  AND gc_grace_seconds = 86400;
+
+-- Note: Using LeveledCompactionStrategy for read-heavy workloads with frequent updates
+-- The table is optimized for queries by team_id + person_id + event_name
+-- gc_grace_seconds is set to 1 day since we expect frequent overwrites

--- a/plugin-server/cassandra/migrations/003_person_event_occurrences.cql
+++ b/plugin-server/cassandra/migrations/003_person_event_occurrences.cql
@@ -15,10 +15,9 @@ CREATE TABLE IF NOT EXISTS person_event_occurrences (
 ) WITH CLUSTERING ORDER BY (person_id ASC, event_name ASC)
   AND compaction = {
     'class': 'LeveledCompactionStrategy',
-    'sstable_size_in_mb': 160
-  }
-  AND gc_grace_seconds = 86400;
+    'sstable_size_in_mb': 1024
+  };
 
 -- Note: Using LeveledCompactionStrategy for read-heavy workloads with frequent updates
 -- The table is optimized for queries by team_id + person_id + event_name
--- gc_grace_seconds is set to 1 day since we expect frequent overwrites
+-- Using default gc_grace_seconds (10 days) initially - can be tuned based on actual usage patterns

--- a/plugin-server/src/utils/db/cassandra/person-event-occurrence.repository.ts
+++ b/plugin-server/src/utils/db/cassandra/person-event-occurrence.repository.ts
@@ -1,0 +1,72 @@
+import { Client as CassandraClient, types as CassandraTypes } from 'cassandra-driver'
+
+export interface PersonEventOccurrenceRow {
+    team_id: number
+    person_id: string
+    event_name: string
+}
+
+export interface OccurrenceUpdate {
+    teamId: number
+    personId: string
+    eventName: string
+}
+
+export class PersonEventOccurrenceRepository {
+    constructor(private cassandra: CassandraClient) {}
+
+    /**
+     * Maps a Cassandra row to a PersonEventOccurrenceRow
+     */
+    private mapRowToPersonEventOccurrence(row: any): PersonEventOccurrenceRow {
+        return {
+            team_id: row.team_id,
+            person_id: row.person_id.toString(),
+            event_name: row.event_name,
+        }
+    }
+
+    /**
+     * Checks if a person has performed a specific event
+     */
+    async hasOccurred(params: { teamId: number; personId: string; eventName: string }): Promise<boolean> {
+        const { teamId, personId, eventName } = params
+        const result = await this.cassandra.execute(
+            'SELECT team_id FROM person_event_occurrences WHERE team_id = ? AND person_id = ? AND event_name = ?',
+            [teamId, CassandraTypes.Uuid.fromString(personId), eventName],
+            { prepare: true }
+        )
+
+        return result.rows.length > 0
+    }
+
+    /**
+     * Gets all events that a person has performed
+     */
+    async getEventsForPerson(teamId: number, personId: string): Promise<PersonEventOccurrenceRow[]> {
+        const result = await this.cassandra.execute(
+            'SELECT team_id, person_id, event_name FROM person_event_occurrences WHERE team_id = ? AND person_id = ?',
+            [teamId, CassandraTypes.Uuid.fromString(personId)],
+            { prepare: true }
+        )
+
+        return result.rows.map((row) => this.mapRowToPersonEventOccurrence(row))
+    }
+
+    /**
+     * Batch inserts multiple person event occurrences
+     * Uses regular INSERT - compaction will handle duplicates efficiently
+     */
+    async batchInsertOccurrences(updates: OccurrenceUpdate[]): Promise<void> {
+        if (updates.length === 0) {
+            return
+        }
+
+        const batch = updates.map((update) => ({
+            query: 'INSERT INTO person_event_occurrences (team_id, person_id, event_name) VALUES (?, ?, ?)',
+            params: [update.teamId, CassandraTypes.Uuid.fromString(update.personId), update.eventName],
+        }))
+
+        await this.cassandra.batch(batch, { prepare: true, logged: false })
+    }
+}

--- a/plugin-server/tests/helpers/cassandra.ts
+++ b/plugin-server/tests/helpers/cassandra.ts
@@ -10,3 +10,10 @@ import { Client as CassandraClient } from 'cassandra-driver'
 export async function truncateBehavioralCounters(cassandra: CassandraClient): Promise<void> {
     await cassandra.execute('TRUNCATE behavioral_event_counters')
 }
+
+/**
+ * Truncates the person_event_occurrences table (useful for tests)
+ */
+export async function truncatePersonEventOccurrences(cassandra: CassandraClient): Promise<void> {
+    await cassandra.execute('TRUNCATE person_event_occurrences')
+}


### PR DESCRIPTION
## Problem

For Behavioural Stuff we need to implement the follwing 

```
Simple Event Completion:
   - Basic "has performed event" tracking
   - Implemented as simple person.id:event.name lookups
   - No additional filtering options
   - Always available for conditional checking
   - dedicated storage for quick lookups
  ```

## Changes

<img width="1043" height="530" alt="Screenshot 2025-07-25 at 16 11 11" src="https://github.com/user-attachments/assets/8fe76e34-3f3b-4826-98f2-6494147d0030" />

- added new table to cassandra with (teamId, personId, eventName)
- using LeveledCompactionStrategy for read-heavy workloads with frequent updates
- hide behind same flag as behavioural filters writing

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- added tests
- local dev

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
