### PR TITLE
feat: Save group filters view as shortcut in People tab

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -45,7 +45,7 @@ import { projectTreeLogic } from './projectTreeLogic'
 import { TreeFiltersDropdownMenu } from './TreeFiltersDropdownMenu'
 import { TreeSearchField } from './TreeSearchField'
 import { TreeSortDropdownMenu } from './TreeSortDropdownMenu'
-import { calculateMovePath, isGroupViewShortcut } from './utils'
+import { calculateMovePath } from './utils'
 
 export interface ProjectTreeProps {
     logicKey?: string // key override?
@@ -120,7 +120,6 @@ export function ProjectTree({
     const treeRef = useRef<LemonTreeRef>(null)
     const { projectTreeMode } = useValues(projectTreeLogic({ key: PROJECT_TREE_KEY }))
     const { setProjectTreeMode } = useActions(projectTreeLogic({ key: PROJECT_TREE_KEY }))
-    const hasCrmIterationOneEnabled = useFeatureFlag('CRM_ITERATION_ONE')
 
     const showFilterDropdown = root === 'project://'
     const showSortDropdown = root === 'project://'
@@ -348,15 +347,7 @@ export function ProjectTree({
                         asChild
                         onClick={(e) => {
                             e.stopPropagation()
-                            // Use deleteShortcut for saved views (group view shortcuts), deleteItem for others
-                            if (
-                                hasCrmIterationOneEnabled &&
-                                isGroupViewShortcut(item.record as unknown as FileSystemEntry)
-                            ) {
-                                item.record && deleteShortcut(item.record?.id)
-                            } else {
-                                deleteItem(item.record as unknown as FileSystemEntry, logicKey ?? uniqueKey)
-                            }
+                            deleteItem(item.record as unknown as FileSystemEntry, logicKey ?? uniqueKey)
                         }}
                         data-attr="tree-item-menu-delete-shortcut-button"
                     >

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -1,6 +1,5 @@
 import { IconCheckbox, IconChevronRight, IconFolderPlus, IconPlusSmall } from '@posthog/icons'
 import { BindLogic, useActions, useValues } from 'kea'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { router } from 'kea-router'
 import { moveToLogic } from 'lib/components/FileSystem/MoveTo/moveToLogic'
 import { ResizableElement } from 'lib/components/ResizeElement/ResizeElement'

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -1,5 +1,6 @@
 import { IconCheckbox, IconChevronRight, IconFolderPlus, IconPlusSmall } from '@posthog/icons'
 import { BindLogic, useActions, useValues } from 'kea'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { router } from 'kea-router'
 import { moveToLogic } from 'lib/components/FileSystem/MoveTo/moveToLogic'
 import { ResizableElement } from 'lib/components/ResizeElement/ResizeElement'
@@ -119,6 +120,7 @@ export function ProjectTree({
     const treeRef = useRef<LemonTreeRef>(null)
     const { projectTreeMode } = useValues(projectTreeLogic({ key: PROJECT_TREE_KEY }))
     const { setProjectTreeMode } = useActions(projectTreeLogic({ key: PROJECT_TREE_KEY }))
+    const hasCrmIterationOneEnabled = useFeatureFlag('CRM_ITERATION_ONE')
 
     const showFilterDropdown = root === 'project://'
     const showSortDropdown = root === 'project://'
@@ -131,7 +133,7 @@ export function ProjectTree({
         if (projectSortMethod !== (sortMethod ?? 'folder')) {
             setSortMethod(sortMethod ?? 'folder')
         }
-    }, [sortMethod, projectSortMethod])
+    }, [sortMethod, projectSortMethod, setSortMethod])
 
     // When logic requests a scroll, focus the item and clear the request
     useEffect(() => {
@@ -347,7 +349,10 @@ export function ProjectTree({
                         onClick={(e) => {
                             e.stopPropagation()
                             // Use deleteShortcut for saved views (group view shortcuts), deleteItem for others
-                            if (isGroupViewShortcut(item.record as unknown as FileSystemEntry)) {
+                            if (
+                                hasCrmIterationOneEnabled &&
+                                isGroupViewShortcut(item.record as unknown as FileSystemEntry)
+                            ) {
                                 item.record && deleteShortcut(item.record?.id)
                             } else {
                                 deleteItem(item.record as unknown as FileSystemEntry, logicKey ?? uniqueKey)

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -44,7 +44,7 @@ import { projectTreeLogic } from './projectTreeLogic'
 import { TreeFiltersDropdownMenu } from './TreeFiltersDropdownMenu'
 import { TreeSearchField } from './TreeSearchField'
 import { TreeSortDropdownMenu } from './TreeSortDropdownMenu'
-import { calculateMovePath } from './utils'
+import { calculateMovePath, isGroupViewShortcut } from './utils'
 
 export interface ProjectTreeProps {
     logicKey?: string // key override?
@@ -346,7 +346,12 @@ export function ProjectTree({
                         asChild
                         onClick={(e) => {
                             e.stopPropagation()
-                            deleteItem(item.record as unknown as FileSystemEntry, logicKey ?? uniqueKey)
+                            // Use deleteShortcut for saved views (group view shortcuts), deleteItem for others
+                            if (isGroupViewShortcut(item.record as unknown as FileSystemEntry)) {
+                                item.record && deleteShortcut(item.record?.id)
+                            } else {
+                                deleteItem(item.record as unknown as FileSystemEntry, logicKey ?? uniqueKey)
+                            }
                         }}
                         data-attr="tree-item-menu-delete-shortcut-button"
                     >

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
@@ -583,7 +583,9 @@ export const projectTreeDataLogic = kea<projectTreeDataLogicType>([
                 const groupFilterShortcuts = shortcutData
                     .filter((shortcut) => isGroupViewShortcut(shortcut))
                     .map((shortcut) => ({
+                        id: shortcut.id,
                         path: shortcut.path,
+                        type: shortcut.type,
                         category: 'Saved Views',
                         iconType: 'database' as const,
                         href: shortcut.href || '',

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
@@ -579,7 +579,7 @@ export const projectTreeDataLogic = kea<projectTreeDataLogicType>([
                           visualOrder: 30 + groupType.group_type_index,
                       }))
 
-                // Add saved group filter shortcuts - these are created when users save filtered views
+                // these are created when users save filtered views
                 // from the groups page and should appear in the persons:// tree under "Saved Views"
                 const groupFilterShortcuts = featureFlags[FEATURE_FLAGS.CRM_ITERATION_ONE]
                     ? shortcutData
@@ -612,6 +612,7 @@ export const projectTreeDataLogic = kea<projectTreeDataLogicType>([
                 return function getStaticItems(searchTerm: string, onlyFolders: boolean): TreeDataItem[] {
                     const newShortcutData = []
                     for (const shortcut of shortcutData.filter(
+                        // only remove shortcuts that are group view shortcuts when CRM iteration one is enabled
                         (shortcut) => !(featureFlags[FEATURE_FLAGS.CRM_ITERATION_ONE] && isGroupViewShortcut(shortcut))
                     )) {
                         const shortcutTreeItem = convertFileSystemEntryToTreeDataItem({

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
@@ -777,6 +777,11 @@ export const projectTreeDataLogic = kea<projectTreeDataLogicType>([
             actions.addLoadedResults(items as any as SearchResults)
         },
         deleteItem: async ({ item, projectTreeLogicKey }) => {
+            if (isGroupViewShortcut(item) && values.featureFlags[FEATURE_FLAGS.CRM_ITERATION_ONE]) {
+                actions.deleteShortcut(item?.id)
+                return
+            }
+
             if (!item.id) {
                 const response = await api.fileSystem.list({ type: 'folder', path: item.path })
                 const items = response.results ?? []

--- a/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
@@ -435,3 +435,7 @@ export function appendResultsToFolders(
     }
     return newState
 }
+
+export const isGroupViewShortcut = (shortcut: FileSystemEntry): boolean => {
+    return !!shortcut?.type?.startsWith('group_') && !!shortcut?.type?.endsWith('_view')
+}

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -398,6 +398,11 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportDataManagementDefinitionHovered: (type: TaxonomicFilterGroupType) => ({ type }),
         reportDataManagementDefinitionClickView: (type: TaxonomicFilterGroupType) => ({ type }),
         reportDataManagementDefinitionClickEdit: (type: TaxonomicFilterGroupType) => ({ type }),
+        // Group Filter Shortcuts
+        reportGroupFilterShortcutSaved: (groupTypeIndex: number, shortcutName: string) => ({
+            groupTypeIndex,
+            shortcutName,
+        }),
         reportDataManagementDefinitionSaveSucceeded: (type: TaxonomicFilterGroupType, loadTime: number) => ({
             type,
             loadTime,
@@ -1096,6 +1101,12 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             posthog.capture('role custom added to a resource', {
                 resource_type: resourceType,
                 roles_length: rolesLength,
+            })
+        },
+        reportGroupFilterShortcutSaved: ({ groupTypeIndex, shortcutName }) => {
+            posthog.capture('group filter shortcut saved', {
+                group_type_index: groupTypeIndex,
+                shortcut_name: shortcutName,
             })
         },
         reportFlagsCodeExampleInteraction: ({ optionType }) => {

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -398,8 +398,8 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportDataManagementDefinitionHovered: (type: TaxonomicFilterGroupType) => ({ type }),
         reportDataManagementDefinitionClickView: (type: TaxonomicFilterGroupType) => ({ type }),
         reportDataManagementDefinitionClickEdit: (type: TaxonomicFilterGroupType) => ({ type }),
-        // Group Filter Shortcuts
-        reportGroupFilterShortcutSaved: (groupTypeIndex: number, shortcutName: string) => ({
+        // Group view Shortcuts
+        reportGroupViewSaved: (groupTypeIndex: number, shortcutName: string) => ({
             groupTypeIndex,
             shortcutName,
         }),
@@ -1103,8 +1103,8 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 roles_length: rolesLength,
             })
         },
-        reportGroupFilterShortcutSaved: ({ groupTypeIndex, shortcutName }) => {
-            posthog.capture('group filter shortcut saved', {
+        reportGroupViewSaved: ({ groupTypeIndex, shortcutName }) => {
+            posthog.capture('group view saved', {
                 group_type_index: groupTypeIndex,
                 shortcut_name: shortcutName,
             })

--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -66,10 +66,11 @@ import {
     isPersonsNode,
     isTracesQuery,
 } from '~/queries/utils'
-import { TeamType } from '~/types'
+import { GroupTypeIndex, TeamType } from '~/types'
 
 import type { dataNodeLogicType } from './dataNodeLogicType'
 import { sceneLogic } from 'scenes/sceneLogic'
+import { groupsListLogic } from 'scenes/groups/groupsListLogic'
 
 export interface DataNodeLogicProps {
     key: string
@@ -160,6 +161,10 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                 'collectionNodeLoadDataSuccess',
                 'collectionNodeLoadDataFailure',
             ],
+            groupsListLogic({
+                groupTypeIndex: isGroupsQuery(props.query) ? (props.query?.group_type_index as GroupTypeIndex) : 0,
+            }),
+            ['setSaveFiltersModalOpen'],
         ],
     })),
     props({ query: {}, variablesOverride: undefined, autoLoad: true } as DataNodeLogicProps),

--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -66,11 +66,10 @@ import {
     isPersonsNode,
     isTracesQuery,
 } from '~/queries/utils'
-import { GroupTypeIndex, TeamType } from '~/types'
+import { TeamType } from '~/types'
 
 import type { dataNodeLogicType } from './dataNodeLogicType'
 import { sceneLogic } from 'scenes/sceneLogic'
-import { groupsListLogic } from 'scenes/groups/groupsListLogic'
 
 export interface DataNodeLogicProps {
     key: string
@@ -161,10 +160,6 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                 'collectionNodeLoadDataSuccess',
                 'collectionNodeLoadDataFailure',
             ],
-            groupsListLogic({
-                groupTypeIndex: isGroupsQuery(props.query) ? (props.query?.group_type_index as GroupTypeIndex) : 0,
-            }),
-            ['setSaveFiltersModalOpen'],
         ],
     })),
     props({ query: {}, variablesOverride: undefined, autoLoad: true } as DataNodeLogicProps),

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -72,6 +72,7 @@ import { EventType, InsightLogicProps } from '~/types'
 import { GroupPropertyFilters } from '../GroupsQuery/GroupPropertyFilters'
 import { GroupsSearch } from '../GroupsQuery/GroupsSearch'
 import { DataTableOpenEditor } from './DataTableOpenEditor'
+import { groupViewLogic } from 'scenes/groups/groupViewLogic'
 
 interface DataTableProps {
     uniqueKey?: string | number
@@ -136,7 +137,7 @@ export function DataTable({
         highlightedRows,
         backToSourceQuery,
     } = useValues(builtDataNodeLogic)
-    const { setSaveFiltersModalOpen } = useActions(builtDataNodeLogic)
+    const { setSaveGroupViewModalOpen } = useActions(groupViewLogic)
 
     const canUseWebAnalyticsPreAggregatedTables = useFeatureFlag('SETTINGS_WEB_ANALYTICS_PRE_AGGREGATED_TABLES')
     const hasCrmIterationOneEnabled = useFeatureFlag('CRM_ITERATION_ONE')
@@ -510,7 +511,7 @@ export function DataTable({
                     <LemonButton
                         data-attr="save-group-filters"
                         type="primary"
-                        onClick={() => setSaveFiltersModalOpen(true)}
+                        onClick={() => setSaveGroupViewModalOpen(true)}
                     >
                         Save filters
                     </LemonButton>

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -1,7 +1,7 @@
 import './DataTable.scss'
 
 import clsx from 'clsx'
-import { BindLogic, useValues } from 'kea'
+import { BindLogic, useActions, useValues } from 'kea'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TaxonomicPopover } from 'lib/components/TaxonomicPopover/TaxonomicPopover'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
@@ -136,6 +136,7 @@ export function DataTable({
         highlightedRows,
         backToSourceQuery,
     } = useValues(builtDataNodeLogic)
+    const { setSaveFiltersModalOpen } = useActions(builtDataNodeLogic)
 
     const canUseWebAnalyticsPreAggregatedTables = useFeatureFlag('SETTINGS_WEB_ANALYTICS_PRE_AGGREGATED_TABLES')
     const usedWebAnalyticsPreAggregatedTables =
@@ -498,7 +499,20 @@ export function DataTable({
             />
         ) : null,
         showPropertyFilter && sourceFeatures.has(QueryFeature.groupPropertyFilters) ? (
-            <GroupPropertyFilters key="group-property" query={query.source as GroupsQuery} setQuery={setQuerySource} />
+            <div className="flex gap-2">
+                <GroupPropertyFilters
+                    key="group-property"
+                    query={query.source as GroupsQuery}
+                    setQuery={setQuerySource}
+                />
+                <LemonButton
+                    data-attr="save-group-filters"
+                    type="primary"
+                    onClick={() => setSaveFiltersModalOpen(true)}
+                >
+                    Save filters
+                </LemonButton>
+            </div>
         ) : null,
     ].filter((x) => !!x)
 

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -509,11 +509,12 @@ export function DataTable({
                 />
                 {hasCrmIterationOneEnabled && (
                     <LemonButton
-                        data-attr="save-group-filters"
+                        data-attr="save-group-view"
                         type="primary"
+                        size="small"
                         onClick={() => setSaveGroupViewModalOpen(true)}
                     >
-                        Save filters
+                        Save view
                     </LemonButton>
                 )}
             </div>

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -139,6 +139,7 @@ export function DataTable({
     const { setSaveFiltersModalOpen } = useActions(builtDataNodeLogic)
 
     const canUseWebAnalyticsPreAggregatedTables = useFeatureFlag('SETTINGS_WEB_ANALYTICS_PRE_AGGREGATED_TABLES')
+    const hasCrmIterationOneEnabled = useFeatureFlag('CRM_ITERATION_ONE')
     const usedWebAnalyticsPreAggregatedTables =
         canUseWebAnalyticsPreAggregatedTables &&
         response &&
@@ -505,13 +506,15 @@ export function DataTable({
                     query={query.source as GroupsQuery}
                     setQuery={setQuerySource}
                 />
-                <LemonButton
-                    data-attr="save-group-filters"
-                    type="primary"
-                    onClick={() => setSaveFiltersModalOpen(true)}
-                >
-                    Save filters
-                </LemonButton>
+                {hasCrmIterationOneEnabled && (
+                    <LemonButton
+                        data-attr="save-group-filters"
+                        type="primary"
+                        onClick={() => setSaveFiltersModalOpen(true)}
+                    >
+                        Save filters
+                    </LemonButton>
+                )}
             </div>
         ) : null,
     ].filter((x) => !!x)

--- a/frontend/src/scenes/groups/Groups.tsx
+++ b/frontend/src/scenes/groups/Groups.tsx
@@ -6,14 +6,13 @@ import { GroupsIntroduction } from 'scenes/groups/GroupsIntroduction'
 import { SceneExport } from 'scenes/sceneTypes'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 
 import { Query } from '~/queries/Query/Query'
 import { GroupTypeIndex } from '~/types'
 
 import { groupsListLogic } from './groupsListLogic'
 import { groupsSceneLogic } from './groupsSceneLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { QueryContext } from '~/queries/types'
 import { getCRMColumns } from './crm/utils'
 
@@ -26,7 +25,7 @@ export function Groups({ groupTypeIndex }: { groupTypeIndex: GroupTypeIndex }): 
         groupsListLogic({ groupTypeIndex })
     )
     const { groupsAccessStatus } = useValues(groupsAccessLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
+    const hasCrmIterationOneEnabled = useFeatureFlag('CRM_ITERATION_ONE')
 
     if (groupTypeIndex === undefined) {
         throw new Error('groupTypeIndex is undefined')
@@ -50,7 +49,7 @@ export function Groups({ groupTypeIndex }: { groupTypeIndex: GroupTypeIndex }): 
         },
     } as QueryContext['columns']
     let hiddenColumns = [] as string[]
-    if (featureFlags[FEATURE_FLAGS.CRM_ITERATION_ONE]) {
+    if (hasCrmIterationOneEnabled) {
         columns = getCRMColumns(groupTypeName, groupTypeIndex)
         hiddenColumns.push('key')
     }
@@ -82,33 +81,35 @@ export function Groups({ groupTypeIndex }: { groupTypeIndex: GroupTypeIndex }): 
                 dataAttr="groups-table"
             />
 
-            <LemonModal
-                isOpen={saveFiltersModalOpen}
-                onClose={() => setSaveFiltersModalOpen(false)}
-                title="Save filtered groups view"
-                footer={
-                    <>
-                        <LemonButton onClick={() => setSaveFiltersModalOpen(false)}>Cancel</LemonButton>
-                        <LemonButton
-                            type="primary"
-                            onClick={() => saveFilterAsShortcut(window.location.href)}
-                            disabledReason={!filterShortcutName.trim() ? 'Name is required' : undefined}
-                        >
-                            Save
-                        </LemonButton>
-                    </>
-                }
-            >
-                <div className="space-y-4">
-                    <p>Save this filtered view as a shortcut in the People panel.</p>
-                    <LemonInput
-                        placeholder="Enter shortcut name"
-                        value={filterShortcutName}
-                        onChange={setFilterShortcutName}
-                        autoFocus
-                    />
-                </div>
-            </LemonModal>
+            {hasCrmIterationOneEnabled && (
+                <LemonModal
+                    isOpen={saveFiltersModalOpen}
+                    onClose={() => setSaveFiltersModalOpen(false)}
+                    title="Save filtered groups view"
+                    footer={
+                        <>
+                            <LemonButton onClick={() => setSaveFiltersModalOpen(false)}>Cancel</LemonButton>
+                            <LemonButton
+                                type="primary"
+                                onClick={() => saveFilterAsShortcut(window.location.href)}
+                                disabledReason={!filterShortcutName.trim() ? 'Name is required' : undefined}
+                            >
+                                Save
+                            </LemonButton>
+                        </>
+                    }
+                >
+                    <div className="space-y-4">
+                        <p>Save this filtered view as a shortcut in the People panel.</p>
+                        <LemonInput
+                            placeholder="Enter shortcut name"
+                            value={filterShortcutName}
+                            onChange={setFilterShortcutName}
+                            autoFocus
+                        />
+                    </div>
+                </LemonModal>
+            )}
         </>
     )
 }

--- a/frontend/src/scenes/groups/Groups.tsx
+++ b/frontend/src/scenes/groups/Groups.tsx
@@ -1,8 +1,11 @@
 import { useActions, useValues } from 'kea'
 import { groupsAccessLogic, GroupsAccessStatus } from 'lib/introductions/groupsAccessLogic'
 import { Link } from 'lib/lemon-ui/Link'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { GroupsIntroduction } from 'scenes/groups/GroupsIntroduction'
 import { SceneExport } from 'scenes/sceneTypes'
+import { LemonModal } from 'lib/lemon-ui/LemonModal'
+import { LemonInput } from 'lib/lemon-ui/LemonInput'
 
 import { Query } from '~/queries/Query/Query'
 import { GroupTypeIndex } from '~/types'
@@ -16,8 +19,12 @@ import { getCRMColumns } from './crm/utils'
 
 export function Groups({ groupTypeIndex }: { groupTypeIndex: GroupTypeIndex }): JSX.Element {
     const { groupTypeName, groupTypeNamePlural } = useValues(groupsSceneLogic)
-    const { query, queryWasModified } = useValues(groupsListLogic({ groupTypeIndex }))
-    const { setQuery } = useActions(groupsListLogic({ groupTypeIndex }))
+    const { query, queryWasModified, saveFiltersModalOpen, filterShortcutName } = useValues(
+        groupsListLogic({ groupTypeIndex })
+    )
+    const { setQuery, setSaveFiltersModalOpen, setFilterShortcutName, saveFilterAsShortcut } = useActions(
+        groupsListLogic({ groupTypeIndex })
+    )
     const { groupsAccessStatus } = useValues(groupsAccessLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 
@@ -49,30 +56,60 @@ export function Groups({ groupTypeIndex }: { groupTypeIndex: GroupTypeIndex }): 
     }
 
     return (
-        <Query
-            query={{ ...query, hiddenColumns }}
-            setQuery={setQuery}
-            context={{
-                refresh: 'blocking',
-                emptyStateHeading: queryWasModified
-                    ? `No ${groupTypeNamePlural} found`
-                    : `No ${groupTypeNamePlural} exist because none have been identified`,
-                emptyStateDetail: queryWasModified ? (
-                    'Try changing the date range or property filters.'
-                ) : (
+        <>
+            <Query
+                query={{ ...query, hiddenColumns }}
+                setQuery={setQuery}
+                context={{
+                    refresh: 'blocking',
+                    emptyStateHeading: queryWasModified
+                        ? `No ${groupTypeNamePlural} found`
+                        : `No ${groupTypeNamePlural} exist because none have been identified`,
+                    emptyStateDetail: queryWasModified ? (
+                        'Try changing the date range or property filters.'
+                    ) : (
+                        <>
+                            Go to the{' '}
+                            <Link to="https://posthog.com/docs/product-analytics/group-analytics#how-to-create-groups">
+                                group analytics docs
+                            </Link>{' '}
+                            to learn what needs to be done
+                        </>
+                    ),
+                    columns,
+                    groupTypeLabel: groupTypeNamePlural,
+                }}
+                dataAttr="groups-table"
+            />
+
+            <LemonModal
+                isOpen={saveFiltersModalOpen}
+                onClose={() => setSaveFiltersModalOpen(false)}
+                title="Save filtered groups view"
+                footer={
                     <>
-                        Go to the{' '}
-                        <Link to="https://posthog.com/docs/product-analytics/group-analytics#how-to-create-groups">
-                            group analytics docs
-                        </Link>{' '}
-                        to learn what needs to be done
+                        <LemonButton onClick={() => setSaveFiltersModalOpen(false)}>Cancel</LemonButton>
+                        <LemonButton
+                            type="primary"
+                            onClick={() => saveFilterAsShortcut(window.location.href)}
+                            disabledReason={!filterShortcutName.trim() ? 'Name is required' : undefined}
+                        >
+                            Save
+                        </LemonButton>
                     </>
-                ),
-                columns,
-                groupTypeLabel: groupTypeNamePlural,
-            }}
-            dataAttr="groups-table"
-        />
+                }
+            >
+                <div className="space-y-4">
+                    <p>Save this filtered view as a shortcut in the People panel.</p>
+                    <LemonInput
+                        placeholder="Enter shortcut name"
+                        value={filterShortcutName}
+                        onChange={setFilterShortcutName}
+                        autoFocus
+                    />
+                </div>
+            </LemonModal>
+        </>
     )
 }
 

--- a/frontend/src/scenes/groups/Groups.tsx
+++ b/frontend/src/scenes/groups/Groups.tsx
@@ -15,15 +15,14 @@ import { groupsListLogic } from './groupsListLogic'
 import { groupsSceneLogic } from './groupsSceneLogic'
 import { QueryContext } from '~/queries/types'
 import { getCRMColumns } from './crm/utils'
+import { groupViewLogic } from './groupViewLogic'
 
 export function Groups({ groupTypeIndex }: { groupTypeIndex: GroupTypeIndex }): JSX.Element {
     const { groupTypeName, groupTypeNamePlural } = useValues(groupsSceneLogic)
-    const { query, queryWasModified, saveFiltersModalOpen, filterShortcutName } = useValues(
-        groupsListLogic({ groupTypeIndex })
-    )
-    const { setQuery, setSaveFiltersModalOpen, setFilterShortcutName, saveFilterAsShortcut } = useActions(
-        groupsListLogic({ groupTypeIndex })
-    )
+    const { query, queryWasModified } = useValues(groupsListLogic({ groupTypeIndex }))
+    const { setQuery } = useActions(groupsListLogic({ groupTypeIndex }))
+    const { saveGroupViewModalOpen, groupViewName } = useValues(groupViewLogic)
+    const { setSaveGroupViewModalOpen, setGroupViewName, saveGroupView } = useActions(groupViewLogic)
     const { groupsAccessStatus } = useValues(groupsAccessLogic)
     const hasCrmIterationOneEnabled = useFeatureFlag('CRM_ITERATION_ONE')
 
@@ -83,16 +82,16 @@ export function Groups({ groupTypeIndex }: { groupTypeIndex: GroupTypeIndex }): 
 
             {hasCrmIterationOneEnabled && (
                 <LemonModal
-                    isOpen={saveFiltersModalOpen}
-                    onClose={() => setSaveFiltersModalOpen(false)}
+                    isOpen={saveGroupViewModalOpen}
+                    onClose={() => setSaveGroupViewModalOpen(false)}
                     title="Save filtered groups view"
                     footer={
                         <>
-                            <LemonButton onClick={() => setSaveFiltersModalOpen(false)}>Cancel</LemonButton>
+                            <LemonButton onClick={() => setSaveGroupViewModalOpen(false)}>Cancel</LemonButton>
                             <LemonButton
                                 type="primary"
-                                onClick={() => saveFilterAsShortcut(window.location.href)}
-                                disabledReason={!filterShortcutName.trim() ? 'Name is required' : undefined}
+                                onClick={() => saveGroupView(window.location.href, groupTypeIndex)}
+                                disabledReason={!groupViewName.trim() ? 'Name is required' : undefined}
                             >
                                 Save
                             </LemonButton>
@@ -102,9 +101,9 @@ export function Groups({ groupTypeIndex }: { groupTypeIndex: GroupTypeIndex }): 
                     <div className="space-y-4">
                         <p>Save this filtered view as a shortcut in the People panel.</p>
                         <LemonInput
-                            placeholder="Enter shortcut name"
-                            value={filterShortcutName}
-                            onChange={setFilterShortcutName}
+                            placeholder="Enter view name"
+                            value={groupViewName}
+                            onChange={setGroupViewName}
                             autoFocus
                         />
                     </div>

--- a/frontend/src/scenes/groups/groupViewLogic.ts
+++ b/frontend/src/scenes/groups/groupViewLogic.ts
@@ -1,0 +1,63 @@
+import { lemonToast } from '@posthog/lemon-ui'
+import { actions, connect, kea, listeners, path, reducers } from 'kea'
+import posthog from 'posthog-js'
+import type { groupViewLogicType } from './groupViewLogicType'
+import { projectTreeDataLogic } from '~/layout/panel-layout/ProjectTree/projectTreeDataLogic'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { GroupTypeIndex } from '~/types'
+
+export const groupViewLogic = kea<groupViewLogicType>([
+    path(['scenes', 'groups', 'groupView']),
+    connect(() => ({
+        actions: [projectTreeDataLogic, ['addShortcutItem'], eventUsageLogic, ['reportGroupViewSaved']],
+    })),
+    actions(() => ({
+        setSaveGroupViewModalOpen: (isOpen: boolean) => ({ isOpen }),
+        setGroupViewName: (name: string) => ({ name }),
+        saveGroupView: (href: string, groupTypeIndex: GroupTypeIndex) => ({ href, groupTypeIndex }),
+    })),
+    reducers(() => ({
+        saveGroupViewModalOpen: [
+            false,
+            {
+                setSaveGroupViewModalOpen: (_, { isOpen }) => isOpen,
+            },
+        ],
+        groupViewName: [
+            '',
+            {
+                setGroupViewName: (_, { name }) => name,
+                setSaveGroupViewModalOpen: (state, { isOpen }) => {
+                    if (isOpen) {
+                        return state
+                    }
+                    return ''
+                },
+            },
+        ],
+    })),
+    listeners(({ actions, values }) => ({
+        saveGroupView: async ({ href, groupTypeIndex }) => {
+            if (!values.groupViewName.trim()) {
+                return
+            }
+            try {
+                const currentUrl = new URL(href)
+                actions.addShortcutItem({
+                    id: '',
+                    path: values.groupViewName,
+                    type: `group_${groupTypeIndex}_view`,
+                    href: currentUrl.pathname + currentUrl.search,
+                    ref: `groups/${groupTypeIndex}`,
+                    created_at: new Date().toISOString(),
+                })
+                actions.reportGroupViewSaved(groupTypeIndex, values.groupViewName)
+                actions.setSaveGroupViewModalOpen(false)
+                lemonToast.success('Filter view saved')
+            } catch (error) {
+                posthog.captureException(error)
+                lemonToast.error('Failed to save filter shortcut')
+            }
+        },
+    })),
+])

--- a/frontend/src/scenes/groups/groupViewLogic.ts
+++ b/frontend/src/scenes/groups/groupViewLogic.ts
@@ -4,6 +4,7 @@ import posthog from 'posthog-js'
 import type { groupViewLogicType } from './groupViewLogicType'
 import { projectTreeDataLogic } from '~/layout/panel-layout/ProjectTree/projectTreeDataLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { FileSystemEntry } from '~/queries/schema/schema-general'
 import { GroupTypeIndex } from '~/types'
 
 export const groupViewLogic = kea<groupViewLogicType>([
@@ -44,19 +45,18 @@ export const groupViewLogic = kea<groupViewLogicType>([
             try {
                 const currentUrl = new URL(href)
                 actions.addShortcutItem({
-                    id: '',
                     path: values.groupViewName,
                     type: `group_${groupTypeIndex}_view`,
                     href: currentUrl.pathname + currentUrl.search,
                     ref: `groups/${groupTypeIndex}`,
                     created_at: new Date().toISOString(),
-                })
+                } as FileSystemEntry)
                 actions.reportGroupViewSaved(groupTypeIndex, values.groupViewName)
                 actions.setSaveGroupViewModalOpen(false)
-                lemonToast.success('Filter view saved')
+                lemonToast.success('Group view saved')
             } catch (error) {
                 posthog.captureException(error)
-                lemonToast.error('Failed to save filter shortcut')
+                lemonToast.error('Failed to save group view')
             }
         },
     })),

--- a/frontend/src/scenes/groups/groupsListLogic.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.ts
@@ -1,6 +1,7 @@
 import { actions, afterMount, connect, kea, key, listeners, path, props, reducers } from 'kea'
 import { actionToUrl, router, urlToAction } from 'kea-router'
 import { groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { groupsModel } from '~/models/groupsModel'
@@ -11,6 +12,8 @@ import { GroupPropertyFilter, GroupTypeIndex } from '~/types'
 
 import type { groupsListLogicType } from './groupsListLogicType'
 import posthog from 'posthog-js'
+import { projectTreeDataLogic } from '~/layout/panel-layout/ProjectTree/projectTreeDataLogic'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 export interface GroupsListLogicProps {
     groupTypeIndex: GroupTypeIndex
@@ -36,11 +39,15 @@ export const groupsListLogic = kea<groupsListLogicType>([
             groupsAccessLogic,
             ['groupsEnabled'],
         ],
+        actions: [projectTreeDataLogic, ['addShortcutItem'], eventUsageLogic, ['reportGroupFilterShortcutSaved']],
     })),
     actions(() => ({
         setQuery: (query: DataTableNode) => ({ query }),
         setQueryWasModified: (queryWasModified: boolean) => ({ queryWasModified }),
         setGroupFilters: (filters: GroupPropertyFilter[]) => ({ filters }),
+        setSaveFiltersModalOpen: (isOpen: boolean) => ({ isOpen }),
+        setFilterShortcutName: (name: string) => ({ name }),
+        saveFilterAsShortcut: (href: string) => ({ href }),
     })),
     reducers(({ props }) => ({
         query: [
@@ -90,10 +97,50 @@ export const groupsListLogic = kea<groupsListLogicType>([
                 setQueryWasModified: (_, { queryWasModified }) => queryWasModified,
             },
         ],
+        saveFiltersModalOpen: [
+            false,
+            {
+                setSaveFiltersModalOpen: (_, { isOpen }) => isOpen,
+            },
+        ],
+        filterShortcutName: [
+            '',
+            {
+                setFilterShortcutName: (_, { name }) => name,
+                setSaveFiltersModalOpen: (state, { isOpen }) => {
+                    if (isOpen) {
+                        return state
+                    }
+                    return ''
+                },
+            },
+        ],
     })),
-    listeners(({ actions }) => ({
+    listeners(({ actions, values, props }) => ({
         setQuery: () => {
             actions.setQueryWasModified(true)
+        },
+        saveFilterAsShortcut: ({ href }) => {
+            if (!values.filterShortcutName.trim()) {
+                return
+            }
+            try {
+                const currentUrl = new URL(href)
+                actions.addShortcutItem({
+                    id: '',
+                    path: values.filterShortcutName,
+                    type: `group_${props.groupTypeIndex}_view`,
+                    href: currentUrl.pathname + currentUrl.search,
+                    ref: `groups/${props.groupTypeIndex}`,
+                    created_at: new Date().toISOString(),
+                })
+                actions.reportGroupFilterShortcutSaved(props.groupTypeIndex, values.filterShortcutName)
+                actions.setSaveFiltersModalOpen(false)
+                lemonToast.success('Filter view saved')
+            } catch (error) {
+                posthog.captureException(error)
+                lemonToast.error('Failed to save filter shortcut')
+            }
         },
     })),
     actionToUrl(({ values, props }) => ({

--- a/frontend/src/scenes/groups/groupsListLogic.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.ts
@@ -68,7 +68,6 @@ export const groupsListLogic = kea<groupsListLogicType>([
         ],
         groupFilters: [
             INITIAL_GROUPS_FILTER,
-            persistConfig(props.groupTypeIndex),
             {
                 setGroupFilters: (_, { filters }) => filters,
                 setQuery: (state, { query }) => {

--- a/frontend/src/scenes/groups/groupsListLogic.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.ts
@@ -61,6 +61,7 @@ export const groupsListLogic = kea<groupsListLogicType>([
         ],
         groupFilters: [
             INITIAL_GROUPS_FILTER,
+            persistConfig(props.groupTypeIndex),
             {
                 setGroupFilters: (_, { filters }) => filters,
                 setQuery: (state, { query }) => {


### PR DESCRIPTION
## Problem
Filters in groups list are now persistent, but there is no way to save multiple filtered views and access them later.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Relates to https://github.com/PostHog/posthog/issues/35076

## Changes
Code is not super pretty, but it's a starting point. Everything should be feature flagged.
- Leverage shortcuts to build a `Group Views` section under people tab
	- `Save filters` button is displayed in groups list page
	- The button opens a modal to save the view with a name
	- Saved views (shortcuts) are shown under people tab, but not under shortcuts tab (filtering out by `type`)

Potential follow ups:
- Also save columns in the shortcut
- Move some of the logic to the backend:
	- Filtering out group view shortcuts by type can be moved, as well as having another api call to return only those to compose `People` tab
- Organize views by group type
- Have a dedicated icon 
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
https://www.loom.com/share/ac267789c14541058b2a8ff8f00935ae?sid=8dd00e73-5db6-4bf5-8b9f-833ccd559ca4
## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
