### PR TITLE
feat(experiments): add UUIDs to metrics

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -10570,6 +10570,9 @@
                     },
                     "type": "array"
                 },
+                "uuid": {
+                    "type": "string"
+                },
                 "version": {
                     "description": "version of the node, used for schema migrations",
                     "type": "number"
@@ -10776,6 +10779,9 @@
                 "upper_bound_percentile": {
                     "type": "number"
                 },
+                "uuid": {
+                    "type": "string"
+                },
                 "version": {
                     "description": "version of the node, used for schema migrations",
                     "type": "number"
@@ -10832,6 +10838,9 @@
                 },
                 "response": {
                     "type": "object"
+                },
+                "uuid": {
+                    "type": "string"
                 },
                 "version": {
                     "description": "version of the node, used for schema migrations",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2383,6 +2383,7 @@ export const enum ExperimentMetricType {
 
 export interface ExperimentMetricBaseProperties extends Node {
     kind: NodeKind.ExperimentMetric
+    uuid?: string
     name?: string
     conversion_window?: integer
     conversion_window_unit?: FunnelConversionWindowTimeUnit

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -7,7 +7,7 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { hasFormErrors, toParams } from 'lib/utils'
+import { hasFormErrors, toParams, uuid } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { ProductIntentContext } from 'lib/utils/product-intents'
 import { addProjectIdIfMissing } from 'lib/utils/router-utils'
@@ -689,7 +689,7 @@ export const experimentLogic = kea<experimentLogicType>([
                         ? `${getDefaultMetricTitle(originalMetric)} (copy)`
                         : undefined
 
-                    const newMetric = { ...originalMetric, id: undefined, name }
+                    const newMetric = { ...originalMetric, uuid: uuid(), name }
                     metrics.splice(metricIndex + 1, 0, newMetric)
 
                     return {

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -1,6 +1,7 @@
 import { getSeriesColor } from 'lib/colors'
 import { EXPERIMENT_DEFAULT_DURATION, FunnelLayout } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
+import { uuid } from 'lib/utils'
 
 import merge from 'lodash.merge'
 import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
@@ -361,6 +362,7 @@ export function getDefaultFunnelsMetric(): ExperimentFunnelsQuery {
 export function getDefaultFunnelMetric(): ExperimentMetric {
     return {
         kind: NodeKind.ExperimentMetric,
+        uuid: uuid(),
         metric_type: ExperimentMetricType.FUNNEL,
         series: [
             {
@@ -378,6 +380,7 @@ export function getDefaultFunnelMetric(): ExperimentMetric {
 export function getDefaultCountMetric(): ExperimentMetric {
     return {
         kind: NodeKind.ExperimentMetric,
+        uuid: uuid(),
         metric_type: ExperimentMetricType.MEAN,
         source: {
             kind: NodeKind.EventsNode,

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -3437,6 +3437,7 @@ class ExperimentMetricBaseProperties(BaseModel):
     kind: Literal["ExperimentMetric"] = "ExperimentMetric"
     name: Optional[str] = None
     response: Optional[dict[str, Any]] = None
+    uuid: Optional[str] = None
     version: Optional[float] = Field(default=None, description="version of the node, used for schema migrations")
 
 
@@ -11291,6 +11292,7 @@ class ExperimentFunnelMetric(BaseModel):
     name: Optional[str] = None
     response: Optional[dict[str, Any]] = None
     series: list[Union[EventsNode, ActionsNode]]
+    uuid: Optional[str] = None
     version: Optional[float] = Field(default=None, description="version of the node, used for schema migrations")
 
 
@@ -11307,6 +11309,7 @@ class ExperimentMeanMetric(BaseModel):
     response: Optional[dict[str, Any]] = None
     source: Union[EventsNode, ActionsNode, ExperimentDataWarehouseNode]
     upper_bound_percentile: Optional[float] = None
+    uuid: Optional[str] = None
     version: Optional[float] = Field(default=None, description="version of the node, used for schema migrations")
 
 


### PR DESCRIPTION
## Changes
Implement UUIDs for experiment metrics. This will enable, for example:

- **Scheduled metric recalculation**: We need a persistent way to identify metrics since metric index isn't stable when metrics are removed
- **Metrics reordering**

Named this field `uuid` (instead of `id`) to make it clear this identifier doesn't come from the database and also not to confuse it with the top-level `id` on a shared metric.

 UUIDs are added to metrics when:
- A single-use metric is added to an experiment
- A single-use metric is duplicated
- A shared metric is created - here, UUIDs are nested under the `query` field, but this works fine since the UI extracts `sharedMetric.query` when rendering it alongside single-use metrics.

The `uuid` field is optional for backward compatibility. Once deployed, I'll manually populate UUIDs for existing metrics that don't have them yet.

## How did you test this code?
Manually tested:
- Add single-use metric
- Duplicate single-use metric
- Create shared metric