### PR TITLE
fix(cdp): API should allow multiple fetches

### DIFF
--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -10,7 +10,7 @@ import { delay, UUID, UUIDT } from '../utils/utils'
 import { CdpSourceWebhooksConsumer } from './consumers/cdp-source-webhooks.consumer'
 import { HogTransformerService } from './hog-transformations/hog-transformer.service'
 import { createCdpRedisPool } from './redis'
-import { HogExecutorExecuteOptions, HogExecutorService } from './services/hog-executor.service'
+import { HogExecutorExecuteAsyncOptions, HogExecutorService, MAX_ASYNC_STEPS } from './services/hog-executor.service'
 import { HogFlowExecutorService } from './services/hogflows/hogflow-executor.service'
 import { HogFlowManagerService } from './services/hogflows/hogflow-manager.service'
 import { HogFunctionManagerService } from './services/managers/hog-function-manager.service'
@@ -233,7 +233,8 @@ export class CdpApi {
                 for (const invocation of invocations) {
                     invocation.id = invocationID
 
-                    const options: HogExecutorExecuteOptions = {
+                    const options: HogExecutorExecuteAsyncOptions = {
+                        maxAsyncFunctions: MAX_ASYNC_STEPS,
                         asyncFunctionsNames: mock_async_functions ? ['fetch', 'sendEmail'] : undefined,
                         functions: mock_async_functions
                             ? {

--- a/plugin-server/src/cdp/services/hog-executor.service.ts
+++ b/plugin-server/src/cdp/services/hog-executor.service.ts
@@ -96,6 +96,10 @@ export type HogExecutorExecuteOptions = {
     asyncFunctionsNames?: ('fetch' | 'sendEmail')[]
 }
 
+export type HogExecutorExecuteAsyncOptions = HogExecutorExecuteOptions & {
+    maxAsyncFunctions?: number
+}
+
 export class HogExecutorService {
     private telemetryMatcher: ValueMatcher<number>
     private hogInputsService: HogInputsService
@@ -237,9 +241,7 @@ export class HogExecutorService {
 
     async executeWithAsyncFunctions(
         invocation: CyclotronJobInvocationHogFunction,
-        options?: HogExecutorExecuteOptions & {
-            maxAsyncFunctions?: number
-        }
+        options?: HogExecutorExecuteAsyncOptions
     ): Promise<CyclotronJobInvocationResult<CyclotronJobInvocationHogFunction>> {
         let asyncFunctionCount = 0
         const maxAsyncFunctions = options?.maxAsyncFunctions ?? 1


### PR DESCRIPTION
## Problem

Testing with the API only allowed 1 fetch when it should really run the full thing

## Changes

* Fix to pass the correct options

## How did you test this code?

* With tests!
