### PR TITLE
fix: external surveys should be rendered with the correct method

### DIFF
--- a/posthog/templates/surveys/public_survey.html
+++ b/posthog/templates/surveys/public_survey.html
@@ -910,7 +910,7 @@
         posthog.init(window.projectConfig.token, config);
 
         posthog.onSurveysLoaded(() => {
-            posthog.renderSurvey(window.surveyId, '#posthog-survey-container');
+            posthog.surveys["_renderExternalSurvey"](window.surveyId, '#posthog-survey-container');
         });
     </script>
 </body>


### PR DESCRIPTION
missed this change after updating [posthog-js](https://github.com/PostHog/posthog-js/pull/2091) to add a new method just for external surveys

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
