### PR TITLE
fix: adjust admin csp based on initial reports

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -654,10 +654,25 @@ class AdminCSPMiddleware:
     def __call__(self, request):
         response = self.get_response(request)
         if request.path.startswith("/admin/"):
+            # TODO replace with django-loginas `LOGINAS_CSP_FRIENDLY` setting once 0.3.12 is released (https://github.com/skorokithakis/django-loginas/issues/111)
+            django_loginas_inline_script_hash = "sha256-YS9p0l7SQLkAEtvGFGffDcYHRcUBpPzMcbSQe1lRuLc="
+            csp_parts = [
+                "default-src 'self'",
+                "style-src 'self' 'unsafe-inline'",
+                f"script-src 'self' '{django_loginas_inline_script_hash}'",
+                "worker-src 'none'",
+                "child-src 'none'",
+                "object-src 'none'",
+                "frame-ancestors 'none'",
+                "manifest-src 'none'",
+                "base-uri 'self'",
+                "report-uri https://us.i.posthog.com/report/?token=sTMFPsFhdP1Ssg&v=2",
+                "report-to posthog",
+            ]
+
             response.headers["Reporting-Endpoints"] = (
-                'posthog="https://us.i.posthog.com/report/?token=sTMFPsFhdP1Ssg&v=1"'
+                'posthog="https://us.i.posthog.com/report/?token=sTMFPsFhdP1Ssg&v=2"'
             )
-            response.headers["Content-Security-Policy-Report-Only"] = (
-                "default-src 'self'; worker-src 'none'; child-src 'none'; object-src 'none'; frame-ancestors 'none'; manifest-src 'none'; report-uri https://us.i.posthog.com/report/?token=sTMFPsFhdP1Ssg&v=1; report-to posthog"
-            )
+            response.headers["Content-Security-Policy-Report-Only"] = "; ".join(csp_parts)
+
         return response


### PR DESCRIPTION
This change allows unsafe-inline styles and allows the django-loginas script that's added on the user change page. These are the only two csp failures reported thus far.

Follow up to #35529.