### PR TITLE
chore: add debug and move some scripts in external surveys

### DIFF
--- a/posthog/api/test/test_external_surveys.py
+++ b/posthog/api/test/test_external_surveys.py
@@ -135,7 +135,7 @@ class TestExternalSurveys(APIBaseTest):
         self.assertContains(response, "posthog-survey-container")
 
         # Check PostHog configuration is injected
-        self.assertContains(response, "window.projectConfig")
+        self.assertContains(response, "projectConfig")
         self.assertContains(response, survey.team.api_token)
 
     def test_survey_appearance_configuration(self):
@@ -148,7 +148,7 @@ class TestExternalSurveys(APIBaseTest):
         self.assertEqual(response.status_code, 200)
 
         # Check appearance data is injected
-        self.assertContains(response, "window.surveyAppearance")
+        self.assertContains(response, "surveyAppearance")
         self.assertContains(response, "#ff0000")
         self.assertContains(response, "#00ff00")
 
@@ -161,13 +161,13 @@ class TestExternalSurveys(APIBaseTest):
 
         # Verify project config contains required fields
         content = response.content.decode()
-        self.assertIn("window.projectConfig", content)
+        self.assertIn("projectConfig", content)
         self.assertIn(survey.team.api_token, content)
 
         # Extract and validate project config JSON
         import re
 
-        config_match = re.search(r"window\.projectConfig = ({.*?});", content)
+        config_match = re.search(r"projectConfig = ({.*?});", content)
         self.assertIsNotNone(config_match)
         assert config_match is not None  # Type guard for mypy
 

--- a/posthog/templates/surveys/public_survey.html
+++ b/posthog/templates/surveys/public_survey.html
@@ -583,10 +583,10 @@
     <!-- PostHog JavaScript -->
     <script>
         // Project config from Django and helper functions
-        window.projectConfig = {{ project_config_json | safe }};
-        window.surveyName = "{{ name }}";
-        window.surveyId = "{{ id }}";
-        window.surveyAppearance = {{ appearance | safe }};
+        const projectConfig = {{ project_config_json | safe }};
+        const surveyName = "{{ name }}";
+        const surveyId = "{{ id }}";
+        const surveyAppearance = {{ appearance | safe }};
 
         const BLACK_TEXT_COLOR = '#020617'
 
@@ -876,8 +876,8 @@
         }
 
         // Apply survey appearance if available
-        if (window.surveyAppearance) {
-            applySurveyAppearance(window.surveyAppearance);
+        if (surveyAppearance) {
+            applySurveyAppearance(surveyAppearance);
         }
     </script>
     <script>
@@ -888,7 +888,7 @@
 
         // Initialize PostHog with project configuration
         const config = {
-            api_host: window.projectConfig.api_host,
+            api_host: projectConfig.api_host,
             disable_surveys_automatic_display: true,
             debug: searchParams.get('__posthog_debug__') === 'true',
             advanced_disable_toolbar_metrics: true,
@@ -905,14 +905,14 @@
         }
 
         // Add ui_host if available (for reverse proxy setups)
-        if (window.projectConfig.ui_host) {
-            config.ui_host = window.projectConfig.ui_host;
+        if (projectConfig.ui_host) {
+            config.ui_host = projectConfig.ui_host;
         }
 
-        posthog.init(window.projectConfig.token, config);
+        posthog.init(projectConfig.token, config);
 
         posthog.onSurveysLoaded(() => {
-            posthog.surveys["_renderExternalSurvey"](window.surveyId, '#posthog-survey-container');
+            posthog.surveys["_renderExternalSurvey"](surveyId, '#posthog-survey-container');
         });
     </script>
 </body>

--- a/posthog/templates/surveys/public_survey.html
+++ b/posthog/templates/surveys/public_survey.html
@@ -582,7 +582,7 @@
 
     <!-- PostHog JavaScript -->
     <script>
-        // Project configuration from Django context
+        // Project config from Django and helper functions
         window.projectConfig = {{ project_config_json | safe }};
         window.surveyName = "{{ name }}";
         window.surveyId = "{{ id }}";
@@ -879,22 +879,24 @@
         if (window.surveyAppearance) {
             applySurveyAppearance(window.surveyAppearance);
         }
-
+    </script>
+    <script>
         // Load PostHog from CDN
         !function (t, e) { var o, n, p, r; e.__SV || (window.posthog = e, e._i = [], e.init = function (i, s, a) { function g(t, e) { var o = e.split("."); 2 == o.length && (t = t[o[0]], e = o[1]), t[e] = function () { t.push([e].concat(Array.prototype.slice.call(arguments, 0))) } } (p = t.createElement("script")).type = "text/javascript", p.crossOrigin = "anonymous", p.async = !0, p.src = s.api_host.replace(".i.posthog.com", "-assets.i.posthog.com") + "/static/array.js", (r = t.getElementsByTagName("script")[0]).parentNode.insertBefore(p, r); var u = e; for (void 0 !== a ? u = e[a] = [] : a = "posthog", u.people = u.people || [], u.toString = function (t) { var e = "posthog"; return "posthog" !== a && (e += "." + a), t || (e += " (stub)"), e }, u.people.toString = function () { return u.toString(1) + ".people (stub)" }, o = "init Ie Ts Ms Ee Es Rs capture Ge calculateEventProperties Os register register_once register_for_session unregister unregister_for_session js getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty Ds Fs createPersonProfile Ls Ps opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing Cs debug I As getPageViewId captureTraceFeedback captureTraceMetric".split(" "), n = 0; n < o.length; n++)g(u, o[n]); e._i.push([i, s, a]) }, e.__SV = 1) }(document, window.posthog || []);
+
+        const searchParams = new URLSearchParams(window.location.search);
 
         // Initialize PostHog with project configuration
         const config = {
             api_host: window.projectConfig.api_host,
             disable_surveys_automatic_display: true,
-            debug: false,
+            debug: searchParams.get('__posthog_debug__') === 'true',
             advanced_disable_toolbar_metrics: true,
-            persistence: 'localStorage',
             capture_pageview: false, // Don't capture pageviews for survey pages
             capture_pageleave: false
         };
 
-        const distinctID = new URLSearchParams(window.location.search).get('distinct_id');
+        const distinctID = searchParams.get('distinct_id');
 
         if (distinctID) {
             config.bootstrap = {

--- a/posthog/templates/surveys/public_survey.html
+++ b/posthog/templates/surveys/public_survey.html
@@ -4,8 +4,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ name }}</title>
-    <meta name="description" content="Take our survey: {{ name }}">
+    <link rel="apple-touch-icon" sizes="180x180" href="/static/icons/apple-touch-icon.png?v=2023-07-07">
+    <link rel="icon" type="image/png" sizes="32x32" href="/static/icons/favicon-32x32.png?v=2023-07-07">
+    <link rel="icon" type="image/png" sizes="16x16" href="/static/icons/favicon-16x16.png?v=2023-07-07">
+    <link rel="mask-icon" href="/static/icons/safari-pinned-tab.svg?v=2023-07-07" color="#FF053C">
+    <link rel="manifest" href="/static/site.webmanifest?v=2023-07-07">
+    <meta name="apple-mobile-web-app-title" content="{{ name }} • PostHog Surveys">
+    <meta name="application-name" content="{{ name }} • PostHog Surveys">
+    <title>{{ name }} • PostHog Surveys</title>
+    <meta name="description" content="Take our survey: {{ name }} • PostHog Surveys">
     <style>
         /* CSS Variables */
         :root {


### PR DESCRIPTION
Make sure that the __posthog_debug__ query param also work for external surveys.

Also breaks down the script into two `<script>` tags to divide between the actual functionality to render the survey and helper functions.

Also add the missing favicon to our external surveys URLs