### PR TITLE
fix(cohorts): apply HogQL global settings to cohort queries

### DIFF
--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -105,7 +105,10 @@ def print_cohort_hogql_query(cohort: Cohort, hogql_context: HogQLContext, *, tea
     hogql_context.enable_select_queries = True
     hogql_context.limit_top_select = False
     create_default_modifiers_for_team(team, hogql_context.modifiers)
-    return print_ast(query, context=hogql_context, dialect="clickhouse")
+
+    # Apply HogQL global settings to ensure consistency with regular queries
+    settings = HogQLGlobalSettings()
+    return print_ast(query, context=hogql_context, dialect="clickhouse", settings=settings)
 
 
 def format_static_cohort_query(cohort: Cohort, index: int, prepend: str) -> tuple[str, dict[str, Any]]:


### PR DESCRIPTION
Cohort queries were missing critical settings like transform_null_in=1, causing funnel-to-cohort conversions to return empty results. Now cohort queries use the same settings as regular HogQL queries.

## Problem

Save as Cohort wasn't working for some funnel insights. See https://posthoghelp.zendesk.com/agent/tickets/34771 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/37665) for an example.

## Changes

Pass `HogQLGlobalSettings()` to `print_cohort_hogql_query`

## How did you test this code?

Ran unit tests.
Manually tested. I wasn't able to confirm fix because I couldn't repro issue locally.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
