### PR TITLE
fix: no overwriting caddyfile in hobby install

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -124,18 +124,7 @@ then
 export REGISTRY_URL="posthog/posthog"
 fi
 
-# rewrite caddyfile
-rm -f Caddyfile
-envsubst > Caddyfile <<EOF
-{
-$TLS_BLOCK
-}
-$DOMAIN, http://, https:// {
-encode gzip zstd
-reverse_proxy http://web:8000
-reverse_proxy http://livestream:8666
-}
-EOF
+
 
 # Write .env file
 envsubst > .env <<EOF

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -11,8 +11,13 @@ services:
         volumes:
             - /root/.caddy
         environment:
+            CADDY_TLS_BLOCK: ''
+            CADDY_HOST: 'http://localhost:8000'
             CADDYFILE: |
-                http://localhost:8000 {
+                {
+                ${CADDY_TLS_BLOCK}
+                }
+                ${CADDY_HOST} {
                     @replay-capture {
                         path /s
                         path /s/*

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -142,16 +142,19 @@ services:
             - kafka
             - objectstorage
 
-    caddy:
-        image: caddy:2.6.1
-        restart: unless-stopped
+    proxy:
+        extends:
+            file: docker-compose.base.yml
+            service: proxy
         ports:
             - '80:80'
             - '443:443'
         volumes:
-            - ./Caddyfile:/etc/caddy/Caddyfile
             - caddy-data:/data
             - caddy-config:/config
+        environment:
+            CADDY_TLS_BLOCK: ${TLS_BLOCK}
+            CADDY_HOST: '${DOMAIN}, http://, https://'
         depends_on:
             - web
     objectstorage:


### PR DESCRIPTION
we used to have simple proxy rules and overwriting the config in the hobby install was fine

but the caddy file has got pretty complex, and replacing it entirely breaks the hobby install completely now

let's not replace the whole thing, just template in the data we need