### PR TITLE
feat(experiments): adding shared metrics activity log descriptions.

### DIFF
--- a/frontend/src/scenes/experiments/activity-descriptions/experimentChangeDescription.tsx
+++ b/frontend/src/scenes/experiments/activity-descriptions/experimentChangeDescription.tsx
@@ -1,0 +1,101 @@
+import clsx from 'clsx'
+import { ActivityChange } from 'lib/components/ActivityLog/humanizeActivity'
+import { dayjs } from 'lib/dayjs'
+import { Link } from 'lib/lemon-ui/Link'
+import { CONCLUSION_DISPLAY_CONFIG } from 'scenes/experiments/constants'
+import { urls } from 'scenes/urls'
+import { match } from 'ts-pattern'
+import { Experiment, ExperimentConclusion } from '~/types'
+
+const ExperimentConclusionTag = ({ conclusion }: { conclusion: ExperimentConclusion }): JSX.Element => (
+    <div className="font-semibold inline-flex items-center gap-2">
+        <div className={clsx('w-2 h-2 rounded-full', CONCLUSION_DISPLAY_CONFIG[conclusion]?.color || '')} />
+        <span>{CONCLUSION_DISPLAY_CONFIG[conclusion]?.title || conclusion}</span>
+    </div>
+)
+
+/**
+ * if an id is provided, it returns a link to the experiemt. Otherwise, just the name.
+ */
+export const nameOrLinkToExperiment = (name: string | null, id?: string): JSX.Element | string => {
+    if (id) {
+        return <Link to={urls.experiment(id)}>{name}</Link>
+    }
+    return name || '(unknown)'
+}
+
+/**
+ * we pick the allowed properties, and shoehorn in deleted because it's missing from the type
+ */
+type AllowedExperimentFields = Pick<Experiment, 'conclusion' | 'start_date' | 'end_date' | 'metrics'> & {
+    deleted: boolean
+}
+
+export const getExperimentChangeDescription = (experimentChange: ActivityChange): string | JSX.Element | null => {
+    /**
+     * a little type assertion to force field into the allowed experiment fields
+     */
+    return match(experimentChange as ActivityChange & { field: keyof AllowedExperimentFields })
+        .with({ field: 'start_date' }, ({ action, before, after }) => {
+            /**
+             * id start date is created, the experiment has been launched
+             */
+            if (action === 'created' && before === null && after !== null) {
+                return 'launched experiment:'
+            }
+
+            /**
+             * if start date has changed, we report how much time was added or removed
+             */
+            if (action === 'changed' && before !== null && after !== null) {
+                const beforeDate = dayjs(before as string)
+                const afterDate = dayjs(after as string)
+
+                if (beforeDate.isValid() && afterDate.isValid()) {
+                    const diff = afterDate.diff(beforeDate, 'minute')
+                    const duration = dayjs.duration(Math.abs(diff), 'minute')
+                    const sign = diff > 0 ? 'moved the start date forward' : 'moved the start date back'
+
+                    return `${sign} by ${duration.humanize()} on`
+                }
+            }
+
+            return 'updated the start date of'
+        })
+        .with({ field: 'end_date' }, ({ action, before, after }) => {
+            /**
+             * if end date is created, the experiment has been stopped
+             */
+            if (action === 'created' && before === null && after !== null) {
+                return 'stopped experiment'
+            }
+
+            return 'updated the end date of'
+        })
+        .with({ field: 'conclusion' }, ({ action, before, after }) => {
+            /**
+             * if conclusion was creted, the experiment was closed. This is usually
+             * acompanied by the end date creation
+             */
+            if (action === 'created' && before === null) {
+                return (
+                    <span>
+                        completed it as <ExperimentConclusionTag conclusion={after as ExperimentConclusion} />:
+                    </span>
+                )
+            }
+
+            return null
+        })
+        .with({ field: 'metrics' }, ({ action, before, after }) => {
+            /**
+             * if a metric is created, the user has added the first metric to the experiment.
+             */
+            if (action === 'created' && before === null && after !== null) {
+                return 'added the first metric to'
+            }
+
+            return null
+        })
+        .otherwise(() => null)
+}

--- a/frontend/src/scenes/experiments/activity-descriptions/index.ts
+++ b/frontend/src/scenes/experiments/activity-descriptions/index.ts
@@ -1,0 +1,2 @@
+export * from './experimentChangeDescription'
+export * from './sharedMetricChangeDescription'

--- a/frontend/src/scenes/experiments/activity-descriptions/sharedMetricChangeDescription.tsx
+++ b/frontend/src/scenes/experiments/activity-descriptions/sharedMetricChangeDescription.tsx
@@ -1,0 +1,32 @@
+import { ActivityChange } from 'lib/components/ActivityLog/humanizeActivity'
+import { Link } from 'lib/lemon-ui/Link'
+import { urls } from 'scenes/urls'
+import { match } from 'ts-pattern'
+import { SharedMetric } from '../SharedMetrics/sharedMetricLogic'
+
+/**
+ * id an id is provided, it returns a link to the shared metric. Otherwise, just the name.
+ */
+export const nameOrLinkToSharedMetric = (name: string | null, id?: string): JSX.Element | string => {
+    if (id) {
+        return <Link to={urls.experimentsSharedMetric(id)}>{name}</Link>
+    }
+
+    return name || '(unknown)'
+}
+
+/**
+ * list of allowed fields for shared metric changes
+ */
+type AllowedSharedMetricFields = Pick<SharedMetric, 'query'>
+
+export const getSharedMetricChangeDescription = (sharedMetricChange: ActivityChange): string | JSX.Element | null => {
+    /**
+     * a little type assertion to force field into the allowed shared metric fields
+     */
+    return match(sharedMetricChange as ActivityChange & { field: keyof AllowedSharedMetricFields })
+        .with({ field: 'query' }, () => {
+            return 'updated shared metric:'
+        })
+        .otherwise(() => null)
+}

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
@@ -62,9 +62,6 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
 
     return match(logItem)
         .with({ activity: 'created' }, () => {
-            /**
-             * created experiments always have the draft status.
-             */
             return {
                 description: (
                     <SentenceList
@@ -195,16 +192,17 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
                 description: null,
             }
         })
-        .with({ activity: 'deleted' }, () => {
+        .with({ activity: 'deleted', detail: { type: 'shared_metric' } }, () => {
             /**
-             * today we do soft deletes, so we keep this for future proofing
+             * experiments have soft deletes, so this applies only to
+             * shared metrics
              */
             return {
                 description: (
                     <SentenceList
-                        listParts={['deleted experiment']}
+                        listParts={['deleted shared metric:']}
                         prefix={<strong>{userNameForLogItem(logItem)}</strong>}
-                        suffix={logItem?.detail.name}
+                        suffix={logItem.detail.name}
                     />
                 ),
             }

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
@@ -1,130 +1,15 @@
-import clsx from 'clsx'
-import {
-    ActivityChange,
-    ActivityLogItem,
-    HumanizedChange,
-    userNameForLogItem,
-} from 'lib/components/ActivityLog/humanizeActivity'
+import { ActivityLogItem, HumanizedChange, userNameForLogItem } from 'lib/components/ActivityLog/humanizeActivity'
 import { SentenceList } from 'lib/components/ActivityLog/SentenceList'
-import { dayjs } from 'lib/dayjs'
 import { LemonCard } from 'lib/lemon-ui/LemonCard'
-import { Link } from 'lib/lemon-ui/Link'
-import { CONCLUSION_DISPLAY_CONFIG } from 'scenes/experiments/constants'
-import { urls } from 'scenes/urls'
 import { match } from 'ts-pattern'
-import { Experiment, ExperimentConclusion, ProgressStatus } from '~/types'
+import { ProgressStatus } from '~/types'
+import {
+    getExperimentChangeDescription,
+    getSharedMetricChangeDescription,
+    nameOrLinkToExperiment,
+    nameOrLinkToSharedMetric,
+} from './activity-descriptions'
 import { StatusTag } from './ExperimentView/components'
-
-/**
- * if an id is provided, it returns a link to the experiemt. Otherwise, just the name.
- */
-const nameOrLinkToExperiment = (name: string | null, id?: string): JSX.Element | string => {
-    if (id) {
-        return <Link to={urls.experiment(id)}>{name}</Link>
-    }
-    return name || '(unknown)'
-}
-
-/**
- * id an id is provided, it returns a link to the shared metric. Otherwise, just the name.
- */
-const nameOrLinkToSharedMetric = (name: string | null, id?: string): JSX.Element | string => {
-    if (id) {
-        return <Link to={urls.experimentsSharedMetric(id)}>{name}</Link>
-    }
-
-    return name || '(unknown)'
-}
-
-/**
- * we pick the allowed properties, and shoehorn in deleted because it's missing from the type
- */
-type AllowedExperimentFields = Pick<Experiment, 'conclusion' | 'start_date' | 'end_date' | 'metrics'> & {
-    deleted: boolean
-}
-
-const getSharedMetricChangeMappings = (sharedMetricChange: ActivityChange): string | JSX.Element | null => {
-    return match(sharedMetricChange).otherwise(() => null)
-}
-
-const getExperimentChangeMappings = (experimentChange: ActivityChange): string | JSX.Element | null => {
-    /**
-     * a little type assertion to force field into the allowed experiment fields
-     */
-    return match(experimentChange as ActivityChange & { field: keyof AllowedExperimentFields })
-        .with({ field: 'start_date' }, ({ action, before, after }) => {
-            /**
-             * id start date is created, the experiment has been launched
-             */
-            if (action === 'created' && before === null && after !== null) {
-                return 'launched experiment:'
-            }
-
-            /**
-             * if start date has changed, we report how much time was added or removed
-             */
-            if (action === 'changed' && before !== null && after !== null) {
-                const beforeDate = dayjs(before as string)
-                const afterDate = dayjs(after as string)
-
-                if (beforeDate.isValid() && afterDate.isValid()) {
-                    const diff = afterDate.diff(beforeDate, 'minute')
-                    const duration = dayjs.duration(Math.abs(diff), 'minute')
-                    const sign = diff > 0 ? 'moved the start date forward' : 'moved the start date back'
-
-                    return `${sign} by ${duration.humanize()} on`
-                }
-            }
-
-            return 'updated the start date of'
-        })
-        .with({ field: 'end_date' }, ({ action, before, after }) => {
-            /**
-             * if end date is created, the experiment has been stopped
-             */
-            if (action === 'created' && before === null && after !== null) {
-                return 'stopped experiment'
-            }
-
-            return 'updated the end date of'
-        })
-        .with({ field: 'conclusion' }, ({ action, before, after }) => {
-            /**
-             * if conclusion was creted, the experiment was closed. This is usually
-             * acompanied by the end date creation
-             */
-            if (action === 'created' && before === null) {
-                return (
-                    <span>
-                        completed it as <ExperimentConclusionTag conclusion={after as ExperimentConclusion} />:
-                    </span>
-                )
-            }
-
-            return null
-        })
-        .with({ field: 'metrics' }, ({ action, before, after }) => {
-            /**
-             * if a metric is created, the user has added the first metric to the experiment.
-             */
-            if (action === 'created' && before === null && after !== null) {
-                return 'added the first metric to'
-            }
-
-            return null
-        })
-        .with({ field: 'deleted' }, ({ action, before, after }) => {
-            /**
-             * if deleted has been changed from false to true, the experiment has been
-             * deleted
-             */
-            if (action === 'changed' && !before && after) {
-                return 'deleted experiment:'
-            }
-            return null
-        })
-        .otherwise(() => null)
-}
 
 //exporting so the linter doesn't complain about this not being used
 export const ExperimentDetails = ({
@@ -157,13 +42,6 @@ const UnknownAction = ({ logItem }: { logItem: ActivityLogItem }): JSX.Element =
     )
 }
 
-const ExperimentConclusionTag = ({ conclusion }: { conclusion: ExperimentConclusion }): JSX.Element => (
-    <div className="font-semibold inline-flex items-center gap-2">
-        <div className={clsx('w-2 h-2 rounded-full', CONCLUSION_DISPLAY_CONFIG[conclusion]?.color || '')} />
-        <span>{CONCLUSION_DISPLAY_CONFIG[conclusion]?.title || conclusion}</span>
-    </div>
-)
-
 export const experimentActivityDescriber = (logItem: ActivityLogItem): HumanizedChange => {
     /**
      * we only have two item types, `shared_metric` or the `null` default for
@@ -173,6 +51,9 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
 
     return match(logItem)
         .with({ activity: 'created' }, () => {
+            /**
+             * we handle both experiments and shared metrics creation here.
+             */
             return {
                 description: (
                     <SentenceList
@@ -194,9 +75,37 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
                 ),
             }
         })
+        .with({ activity: 'updated', detail: { changes: [{ field: 'deleted', before: false, after: true }] } }, () => {
+            /**
+             * Experiment deletion is a spacial case of `updated`. If `deleted` has been changed
+             * from false to true, the experiment has been deleted.
+             */
+            return {
+                description: (
+                    <SentenceList
+                        prefix={<strong>{userNameForLogItem(logItem)}</strong>}
+                        listParts={['deleted experiment:']}
+                        suffix={logItem.detail.name}
+                    />
+                ),
+            }
+        })
+        .with({ activity: 'deleted', detail: { type: 'shared_metric' } }, () => {
+            /**
+             * Shared metrics are not soft deleted.
+             */
+            return {
+                description: (
+                    <SentenceList
+                        prefix={<strong>{userNameForLogItem(logItem)}</strong>}
+                        listParts={['deleted shared metric:']}
+                        suffix={logItem.detail.name}
+                    />
+                ),
+            }
+        })
         .with({ activity: 'updated' }, () => {
             const changes = logItem.detail.changes || []
-
             /**
              * if there are no changes, we don't need to describe the update.
              */
@@ -216,7 +125,9 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
             }
 
             const listParts = changes
-                .map((change) => (isSharedMetric ? getSharedMetricChangeMappings : getExperimentChangeMappings)(change))
+                .map((change) =>
+                    (isSharedMetric ? getSharedMetricChangeDescription : getExperimentChangeDescription)(change)
+                )
                 .filter((part) => part !== null)
 
             if (listParts.length === 0) {
@@ -235,21 +146,6 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
                             logItem.detail.name,
                             logItem.item_id
                         )}
-                    />
-                ),
-            }
-        })
-        .with({ activity: 'deleted', detail: { type: 'shared_metric' } }, () => {
-            /**
-             * experiments have soft deletes, so this applies only to
-             * shared metrics
-             */
-            return {
-                description: (
-                    <SentenceList
-                        listParts={['deleted shared metric:']}
-                        prefix={<strong>{userNameForLogItem(logItem)}</strong>}
-                        suffix={logItem.detail.name}
                     />
                 ),
             }

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
@@ -1,12 +1,23 @@
-import { ActivityLogItem, HumanizedChange, userNameForLogItem } from 'lib/components/ActivityLog/humanizeActivity'
+import clsx from 'clsx'
+import {
+    ActivityChange,
+    ActivityLogItem,
+    HumanizedChange,
+    userNameForLogItem,
+} from 'lib/components/ActivityLog/humanizeActivity'
 import { SentenceList } from 'lib/components/ActivityLog/SentenceList'
+import { dayjs } from 'lib/dayjs'
 import { LemonCard } from 'lib/lemon-ui/LemonCard'
 import { Link } from 'lib/lemon-ui/Link'
+import { CONCLUSION_DISPLAY_CONFIG } from 'scenes/experiments/constants'
 import { urls } from 'scenes/urls'
 import { match } from 'ts-pattern'
-import { ProgressStatus } from '~/types'
+import { Experiment, ExperimentConclusion, ProgressStatus } from '~/types'
 import { StatusTag } from './ExperimentView/components'
 
+/**
+ * if an id is provided, it returns a link to the experiemt. Otherwise, just the name.
+ */
 const nameOrLinkToExperiment = (name: string | null, id?: string): JSX.Element | string => {
     if (id) {
         return <Link to={urls.experiment(id)}>{name}</Link>
@@ -14,12 +25,105 @@ const nameOrLinkToExperiment = (name: string | null, id?: string): JSX.Element |
     return name || '(unknown)'
 }
 
+/**
+ * id an id is provided, it returns a link to the shared metric. Otherwise, just the name.
+ */
 const nameOrLinkToSharedMetric = (name: string | null, id?: string): JSX.Element | string => {
     if (id) {
         return <Link to={urls.experimentsSharedMetric(id)}>{name}</Link>
     }
 
     return name || '(unknown)'
+}
+
+/**
+ * we pick the allowed properties, and shoehorn in deleted because it's missing from the type
+ */
+type AllowedExperimentFields = Pick<Experiment, 'conclusion' | 'start_date' | 'end_date' | 'metrics'> & {
+    deleted: boolean
+}
+
+const getSharedMetricChangeMappings = (sharedMetricChange: ActivityChange): string | JSX.Element | null => {
+    return match(sharedMetricChange).otherwise(() => null)
+}
+
+const getExperimentChangeMappings = (experimentChange: ActivityChange): string | JSX.Element | null => {
+    /**
+     * a little type assertion to force field into the allowed experiment fields
+     */
+    return match(experimentChange as ActivityChange & { field: keyof AllowedExperimentFields })
+        .with({ field: 'start_date' }, ({ action, before, after }) => {
+            /**
+             * id start date is created, the experiment has been launched
+             */
+            if (action === 'created' && before === null && after !== null) {
+                return 'launched experiment:'
+            }
+
+            /**
+             * if start date has changed, we report how much time was added or removed
+             */
+            if (action === 'changed' && before !== null && after !== null) {
+                const beforeDate = dayjs(before as string)
+                const afterDate = dayjs(after as string)
+
+                if (beforeDate.isValid() && afterDate.isValid()) {
+                    const diff = afterDate.diff(beforeDate, 'minute')
+                    const duration = dayjs.duration(Math.abs(diff), 'minute')
+                    const sign = diff > 0 ? 'moved the start date forward' : 'moved the start date back'
+
+                    return `${sign} by ${duration.humanize()} on`
+                }
+            }
+
+            return 'updated the start date of'
+        })
+        .with({ field: 'end_date' }, ({ action, before, after }) => {
+            /**
+             * if end date is created, the experiment has been stopped
+             */
+            if (action === 'created' && before === null && after !== null) {
+                return 'stopped experiment'
+            }
+
+            return 'updated the end date of'
+        })
+        .with({ field: 'conclusion' }, ({ action, before, after }) => {
+            /**
+             * if conclusion was creted, the experiment was closed. This is usually
+             * acompanied by the end date creation
+             */
+            if (action === 'created' && before === null) {
+                return (
+                    <span>
+                        completed it as <ExperimentConclusionTag conclusion={after as ExperimentConclusion} />:
+                    </span>
+                )
+            }
+
+            return null
+        })
+        .with({ field: 'metrics' }, ({ action, before, after }) => {
+            /**
+             * if a metric is created, the user has added the first metric to the experiment.
+             */
+            if (action === 'created' && before === null && after !== null) {
+                return 'added the first metric to'
+            }
+
+            return null
+        })
+        .with({ field: 'deleted' }, ({ action, before, after }) => {
+            /**
+             * if deleted has been changed from false to true, the experiment has been
+             * deleted
+             */
+            if (action === 'changed' && !before && after) {
+                return 'deleted experiment:'
+            }
+            return null
+        })
+        .otherwise(() => null)
 }
 
 //exporting so the linter doesn't complain about this not being used
@@ -48,10 +152,17 @@ const UnknownAction = ({ logItem }: { logItem: ActivityLogItem }): JSX.Element =
         <SentenceList
             prefix={<strong>{userNameForLogItem(logItem)}</strong>}
             listParts={['performed an unknown action on']}
-            suffix={nameOrLinkToExperiment(logItem.item_id, logItem.detail.name)}
+            suffix={nameOrLinkToExperiment(logItem.detail.name, logItem.item_id)}
         />
     )
 }
+
+const ExperimentConclusionTag = ({ conclusion }: { conclusion: ExperimentConclusion }): JSX.Element => (
+    <div className="font-semibold inline-flex items-center gap-2">
+        <div className={clsx('w-2 h-2 rounded-full', CONCLUSION_DISPLAY_CONFIG[conclusion]?.color || '')} />
+        <span>{CONCLUSION_DISPLAY_CONFIG[conclusion]?.title || conclusion}</span>
+    </div>
+)
 
 export const experimentActivityDescriber = (logItem: ActivityLogItem): HumanizedChange => {
     /**
@@ -84,10 +195,7 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
             }
         })
         .with({ activity: 'updated' }, () => {
-            /**
-             * the experiment UI only allows for atomic updates of a single property at a time.
-             */
-            const changes = logItem.detail?.changes || []
+            const changes = logItem.detail.changes || []
 
             /**
              * if there are no changes, we don't need to describe the update.
@@ -98,98 +206,37 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
                         <SentenceList
                             prefix={<strong>{userNameForLogItem(logItem)}</strong>}
                             listParts={['updated']}
-                            suffix={nameOrLinkToExperiment(logItem.detail.name, logItem.item_id)}
+                            suffix={(isSharedMetric ? nameOrLinkToSharedMetric : nameOrLinkToExperiment)(
+                                logItem.detail.name,
+                                logItem.item_id
+                            )}
                         />
                     ),
                 }
             }
 
-            /**
-             * this needs to be refactored to handle multiple changes, for example,
-             * when an experiment stops and we set a conclusion.
-             */
-            const change = changes[0]
+            const listParts = changes
+                .map((change) => (isSharedMetric ? getSharedMetricChangeMappings : getExperimentChangeMappings)(change))
+                .filter((part) => part !== null)
 
-            /**
-             * if a start date is created, the experiment has been launched.
-             */
-            if (
-                change.action === 'created' &&
-                change.field === 'start_date' &&
-                change.before === null &&
-                change.after !== null
-            ) {
-                return {
-                    description: (
-                        <SentenceList
-                            prefix={<strong>{userNameForLogItem(logItem)}</strong>}
-                            listParts={['launched experiment']}
-                            suffix={nameOrLinkToExperiment(logItem.detail.name, logItem.item_id)}
-                        />
-                    ),
-                }
+            if (listParts.length === 0) {
+                return { description: null }
             }
 
             /**
-             * if an end date is created, the experiment has been completed.
-             */
-            if (
-                change.action === 'created' &&
-                change.field === 'end_date' &&
-                change.before === null &&
-                change.after !== null
-            ) {
-                return {
-                    description: (
-                        <SentenceList
-                            prefix={<strong>{userNameForLogItem(logItem)}</strong>}
-                            listParts={['stopped experiment']}
-                            suffix={nameOrLinkToExperiment(logItem.detail.name, logItem.item_id)}
-                        />
-                    ),
-                }
-            }
-
-            /**
-             * if a metric is created, the user has added the first metric to the experiment.
-             */
-            if (
-                change.action === 'created' &&
-                change.field === 'metrics' &&
-                change.before === null &&
-                change.after !== null
-            ) {
-                return {
-                    description: (
-                        <SentenceList
-                            prefix={<strong>{userNameForLogItem(logItem)}</strong>}
-                            listParts={['added the first metric to']}
-                            suffix={nameOrLinkToExperiment(logItem.detail.name, logItem.item_id)}
-                        />
-                    ),
-                }
-            }
-
-            /**
-             * soft deletes
-             */
-            if (change.action === 'changed' && change.field === 'deleted' && !change.before && change.after) {
-                return {
-                    description: (
-                        <SentenceList
-                            prefix={<strong>{userNameForLogItem(logItem)}</strong>}
-                            listParts={['deleted experiment']}
-                            suffix={nameOrLinkToExperiment(logItem.detail.name, logItem.item_id)}
-                        />
-                    ),
-                }
-            }
-
-            /**
-             * TODO: return null for now, until we cover all existing uses.
+             * we always prefix with the user name, and suffix with a link to the resource
              */
             return {
-                description: null,
+                description: (
+                    <SentenceList
+                        prefix={<strong>{userNameForLogItem(logItem)}</strong>}
+                        listParts={listParts}
+                        suffix={(isSharedMetric ? nameOrLinkToSharedMetric : nameOrLinkToExperiment)(
+                            logItem.detail.name,
+                            logItem.item_id
+                        )}
+                    />
+                ),
             }
         })
         .with({ activity: 'deleted', detail: { type: 'shared_metric' } }, () => {


### PR DESCRIPTION
## Problem

Although we log all activity for Experiments and Shared Metrics, we only display a limited number of core events for Experiments on the activity log and the history tab.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

This is the first big refactor to support more complex activity descriptions and to expand reporting to Shared Metrics.
We are adding activity descriptions for the core shared metric activities: `create`, `update`, and `delete`.

| Shared Metric Activities |
| - |
| <img width="458" height="160" alt="image" src="https://github.com/user-attachments/assets/37cd1ab6-63a5-45cb-aeae-7d5da385f3da" /> |

For Experiments, we are adding more complex reporting for date changes and including a conclusion when an experiment is closed.

| Start Date Change | Complete Status |
| - | - |
| <img width="455" height="84" alt="image" src="https://github.com/user-attachments/assets/799d8dc7-0ce7-48ec-a4e5-c9f992b4b492" /> | <img width="457" height="87" alt="image" src="https://github.com/user-attachments/assets/d1218854-b8a6-4f14-b0e2-248286563121" /> |

> [!IMPORTANT]
> Activity descriptions are limited to `prefix`+`description`+`resource link`. We'll return the more complex `ChangeMapping` in a future refactor to account for more complex reporting.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/2c4792c5-7d08-4af6-a463-cb538861c95a)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
