### PR TITLE
chore(paths): quality of life improvements to path cleaning table

### DIFF
--- a/frontend/src/lib/components/PathCleanFilters/PathCleanFilters.tsx
+++ b/frontend/src/lib/components/PathCleanFilters/PathCleanFilters.tsx
@@ -3,6 +3,7 @@ import { useValues } from 'kea'
 import { PathCleaningFilter } from '~/types'
 
 import { PathCleanFilterAddItemButton } from './PathCleanFilterAddItemButton'
+import { ensureFilterOrder, updateFilterOrder } from './pathCleaningUtils'
 import { PathCleanFiltersTable } from './PathCleanFiltersTable'
 import { PathCleanFilterItem } from './PathCleanFilterItem'
 import { closestCenter, DndContext, PointerSensor, useSensor, useSensors } from '@dnd-kit/core'
@@ -25,19 +26,22 @@ export function PathCleanFilters({ filters = [], setFilters }: PathCleanFiltersP
     const { featureFlags } = useValues(featureFlagLogic)
     const useTableUI = featureFlags[FEATURE_FLAGS.PATH_CLEANING_FILTER_TABLE_UI]
 
-    // Sync local state with props
     useEffect(() => {
-        setLocalFilters(filters)
+        setLocalFilters(ensureFilterOrder(filters))
     }, [filters])
 
     const updateFilters = (newFilters: PathCleaningFilter[]): void => {
-        // Optimistic update
-        setLocalFilters(newFilters)
-        setFilters(newFilters)
+        const filtersWithOrder = updateFilterOrder(newFilters)
+        setLocalFilters(filtersWithOrder)
+        setFilters(filtersWithOrder)
     }
 
     const onAddFilter = (filter: PathCleaningFilter): void => {
-        updateFilters([...filters, filter])
+        const filterWithOrder = {
+            ...filter,
+            order: filters.length,
+        }
+        updateFilters([...filters, filterWithOrder])
     }
 
     const onEditFilter = (index: number, filter: PathCleaningFilter): void => {

--- a/frontend/src/lib/components/PathCleanFilters/PathCleanFiltersTable.tsx
+++ b/frontend/src/lib/components/PathCleanFilters/PathCleanFiltersTable.tsx
@@ -74,20 +74,20 @@ function SortableRow({ filter, index, onEdit, onRemove }: SortableRowProps): JSX
                     'shadow-lg': isDragging,
                 })}
             >
-                <td className="p-2 w-8">
+                <td className="py-1 px-2 w-8">
                     <div
                         className="flex items-center justify-center cursor-grab active:cursor-grabbing"
                         {...attributes}
                         {...listeners}
                     >
-                        <SortableDragIcon className="text-muted-alt" />
+                        <SortableDragIcon className="text-muted-alt h-3 w-3" />
                     </div>
                 </td>
-                <td className="p-2 w-12 text-center text-muted font-medium">{index + 1}</td>
-                <td className="p-2">
+                <td className="py-1 px-2 w-12 text-center text-muted font-medium text-sm">{index + 1}</td>
+                <td className="py-1 px-2">
                     <Tooltip title={isInvalidRegex ? 'Invalid regex pattern' : null}>
                         <code
-                            className={clsx('font-mono text-sm px-2 py-1 rounded bg-accent-light text-accent', {
+                            className={clsx('font-mono text-xs px-1 py-0.5 rounded bg-accent-light text-accent', {
                                 'text-danger border border-danger bg-red-50': isInvalidRegex,
                             })}
                         >
@@ -95,10 +95,10 @@ function SortableRow({ filter, index, onEdit, onRemove }: SortableRowProps): JSX
                         </code>
                     </Tooltip>
                 </td>
-                <td className="p-2">
-                    <div className="font-mono text-sm">{parseAliasToReadable(filter.alias || '(Empty)')}</div>
+                <td className="py-1 px-2">
+                    <div className="font-mono text-xs">{parseAliasToReadable(filter.alias || '(Empty)')}</div>
                 </td>
-                <td className="p-2 w-24">
+                <td className="py-1 px-2 w-20">
                     <div className="flex items-center gap-1">
                         <LemonButton
                             icon={<IconPencil />}
@@ -195,17 +195,17 @@ export function PathCleanFiltersTable({ filters = [], setFilters }: PathCleanFil
                 <table className="w-full bg-white">
                     <thead className="bg-gray-50">
                         <tr>
-                            <th className="p-3 w-8" />
-                            <th className="p-3 w-12 text-left text-xs font-semibold text-muted-alt uppercase tracking-wider">
+                            <th className="py-2 px-2 w-8" />
+                            <th className="py-2 px-2 w-12 text-left text-xs font-semibold text-muted-alt uppercase tracking-wider">
                                 Order
                             </th>
-                            <th className="p-3 text-left text-xs font-semibold text-muted-alt uppercase tracking-wider">
+                            <th className="py-2 px-2 text-left text-xs font-semibold text-muted-alt uppercase tracking-wider">
                                 Regex Pattern
                             </th>
-                            <th className="p-3 text-left text-xs font-semibold text-muted-alt uppercase tracking-wider">
+                            <th className="py-2 px-2 text-left text-xs font-semibold text-muted-alt uppercase tracking-wider">
                                 Alias
                             </th>
-                            <th className="p-3 w-24 text-left text-xs font-semibold text-muted-alt uppercase tracking-wider">
+                            <th className="py-2 px-2 w-20 text-left text-xs font-semibold text-muted-alt uppercase tracking-wider">
                                 Actions
                             </th>
                         </tr>

--- a/frontend/src/lib/components/PathCleanFilters/PathCleanFiltersTable.tsx
+++ b/frontend/src/lib/components/PathCleanFilters/PathCleanFiltersTable.tsx
@@ -20,6 +20,7 @@ import { useState, useEffect } from 'react'
 import { PathCleaningFilter } from '~/types'
 
 import { PathRegexModal } from './PathRegexModal'
+import { ensureFilterOrder, updateFilterOrder } from './pathCleaningUtils'
 import { parseAliasToReadable } from './PathCleanFilterItem'
 import { SortableDragIcon } from 'lib/lemon-ui/icons'
 
@@ -126,7 +127,7 @@ export function PathCleanFiltersTable({ filters = [], setFilters }: PathCleanFil
     // Sync local state with props, but not during drag to avoid flicker
     useEffect(() => {
         if (!isDragging) {
-            setLocalFilters(filters)
+            setLocalFilters(ensureFilterOrder(filters))
         }
     }, [filters, isDragging])
 
@@ -142,9 +143,9 @@ export function PathCleanFiltersTable({ filters = [], setFilters }: PathCleanFil
     )
 
     const updateFilters = (newFilters: PathCleaningFilter[]): void => {
-        // Optimistic update
-        setLocalFilters(newFilters)
-        setFilters(newFilters)
+        const filtersWithOrder = updateFilterOrder(newFilters)
+        setLocalFilters(filtersWithOrder)
+        setFilters(filtersWithOrder)
     }
 
     const onEditFilter = (index: number, filter: PathCleaningFilter): void => {

--- a/frontend/src/lib/components/PathCleanFilters/PathCleaningRulesDebugger.tsx
+++ b/frontend/src/lib/components/PathCleanFilters/PathCleaningRulesDebugger.tsx
@@ -87,7 +87,7 @@ export function PathCleaningRulesDebugger({
                                 {debugSteps.map((step) => (
                                     <div
                                         key={step.stepNumber}
-                                        className="flex gap-3 items-center py-2 px-3 text-xs hover:bg-accent-light border-b border-gray-100"
+                                        className="flex gap-3 items-center px-3 text-xs hover:bg-accent-light border-b border-gray-100"
                                     >
                                         <div className="w-8 flex-shrink-0 text-center text-muted-alt font-medium">
                                             {step.stepNumber}

--- a/frontend/src/lib/components/PathCleanFilters/PathCleaningRulesDebugger.tsx
+++ b/frontend/src/lib/components/PathCleanFilters/PathCleaningRulesDebugger.tsx
@@ -54,59 +54,99 @@ export function PathCleaningRulesDebugger({
     const debugSteps = cleanPathWithDebugSteps(testPath, filters)
 
     return (
-        <div className="mt-4">
+        <div className="mt-3">
             <LemonCollapse
                 panels={[
                     {
                         key: 'debug',
                         header: 'Debug: Step-by-step processing',
                         content: (
-                            <div className="space-y-3">
+                            <div className="space-y-1">
+                                {/* Column Headers */}
+                                <div className="flex gap-3 items-center py-2 px-3 text-xs font-medium text-muted-alt border-b bg-accent-3000">
+                                    <div
+                                        className="w-8 flex-shrink-0 text-center"
+                                        title="Rule number in processing order"
+                                    >
+                                        #
+                                    </div>
+                                    <div className="flex-1 min-w-0" title="Regex pattern and replacement alias">
+                                        Pattern → Alias
+                                    </div>
+                                    <div className="flex-1 min-w-0" title="Path after this rule is applied">
+                                        Output
+                                    </div>
+                                    <div
+                                        className="w-6 flex-shrink-0 flex justify-center"
+                                        title="Whether this rule matched and modified the path"
+                                    >
+                                        ✓
+                                    </div>
+                                </div>
+
                                 {debugSteps.map((step) => (
-                                    <div key={step.stepNumber} className="flex items-center gap-2 p-2 border rounded">
-                                        <div className="flex items-center gap-2 flex-1">
-                                            <span className="text-sm font-semibold text-muted-alt w-16">
-                                                Rule {step.stepNumber}:
-                                            </span>
-                                            <div className="flex items-center gap-2 flex-1">
-                                                <code
-                                                    className={`font-mono text-sm px-2 py-1 rounded ${
-                                                        step.isValidRegex
-                                                            ? 'bg-accent-light text-accent'
-                                                            : 'bg-red-50 text-danger border border-danger'
-                                                    }`}
-                                                >
-                                                    {step.filter.regex || '(Empty)'}
-                                                </code>
-                                                <IconChevronRight className="text-muted-alt" />
-                                                <span className="font-mono text-sm">
-                                                    {parseAliasToReadable(step.filter.alias || '(Empty)')}
-                                                </span>
-                                            </div>
+                                    <div
+                                        key={step.stepNumber}
+                                        className="flex gap-3 items-center py-2 px-3 text-xs hover:bg-accent-light border-b border-gray-100"
+                                    >
+                                        <div className="w-8 flex-shrink-0 text-center text-muted-alt font-medium">
+                                            {step.stepNumber}
                                         </div>
-                                        <div className="flex items-center flex-1 gap-2">
-                                            <span className="text-sm font-semibold text-muted-alt w-16">Output:</span>
-                                            <span className="font-mono text-sm">
+                                        <div className="flex-1 min-w-0 flex items-center gap-2">
+                                            <code
+                                                className={`font-mono text-xs px-2 py-1 rounded flex-shrink-0 max-w-32 overflow-hidden text-ellipsis whitespace-nowrap ${
+                                                    step.isValidRegex
+                                                        ? 'bg-accent-light text-accent'
+                                                        : 'bg-red-50 text-danger'
+                                                }`}
+                                                title={step.filter.regex || '(Empty)'}
+                                            >
+                                                {step.filter.regex || '(Empty)'}
+                                            </code>
+                                            <IconChevronRight className="text-muted-alt h-3 w-3 flex-shrink-0" />
+                                            <span
+                                                className="font-mono text-xs min-w-0 overflow-hidden text-ellipsis whitespace-nowrap"
+                                                title={step.filter.alias || '(Empty)'}
+                                            >
+                                                {parseAliasToReadable(step.filter.alias || '(Empty)')}
+                                            </span>
+                                        </div>
+                                        <div className="flex-1 min-w-0">
+                                            <span
+                                                className="font-mono text-xs block overflow-hidden text-ellipsis whitespace-nowrap"
+                                                title={step.outputPath}
+                                            >
                                                 {parseAliasToReadable(step.outputPath)}
                                             </span>
                                         </div>
-                                        <div className="flex items-center gap-2">
+                                        <div className="w-6 flex-shrink-0 flex justify-center">
                                             {step.wasModified ? (
-                                                <span className="text-xs text-success font-semibold bg-green-100 px-2 py-1 rounded">
-                                                    MATCHED
-                                                </span>
+                                                <div
+                                                    className="w-2 h-2 rounded-full bg-success"
+                                                    title="Matched and modified"
+                                                />
                                             ) : (
-                                                <span className="text-xs text-muted-alt font-semibold bg-gray-100 px-2 py-1 rounded">
-                                                    NO MATCH
-                                                </span>
+                                                <div
+                                                    className="w-2 h-2 rounded-full bg-muted-alt"
+                                                    title="No match, unchanged"
+                                                />
                                             )}
                                         </div>
                                     </div>
                                 ))}
 
-                                <div className="flex items-center gap-2 p-2 bg-blue-50 rounded border border-blue-200">
-                                    <span className="text-sm font-semibold text-blue-700">Final result:</span>
-                                    <code className="font-mono text-sm text-blue-800">{finalResult}</code>
+                                <div className="flex gap-3 items-center py-3 px-3 bg-blue-50 border border-blue-200 rounded mt-3">
+                                    <div className="w-20 flex-shrink-0 text-xs font-medium text-blue-700">
+                                        Final result:
+                                    </div>
+                                    <div className="flex-1 min-w-0">
+                                        <code
+                                            className="font-mono text-xs text-blue-800 block overflow-hidden text-ellipsis whitespace-nowrap"
+                                            title={String(finalResult)}
+                                        >
+                                            {finalResult}
+                                        </code>
+                                    </div>
                                 </div>
                             </div>
                         ),

--- a/frontend/src/lib/components/PathCleanFilters/PathRegexModal.tsx
+++ b/frontend/src/lib/components/PathCleanFilters/PathRegexModal.tsx
@@ -95,7 +95,11 @@ export function PathRegexModal({ filter, isOpen, onSave, onClose }: PathRegexMod
                             <LemonButton
                                 type="primary"
                                 onClick={() => {
-                                    onSave({ alias: alias.trim(), regex: regex.trim() })
+                                    onSave({
+                                        alias: alias.trim(),
+                                        regex: regex.trim(),
+                                        order: filter?.order,
+                                    })
                                 }}
                                 disabledReason={disabledReason}
                             >

--- a/frontend/src/lib/components/PathCleanFilters/pathCleaningUtils.ts
+++ b/frontend/src/lib/components/PathCleanFilters/pathCleaningUtils.ts
@@ -1,0 +1,21 @@
+import { PathCleaningFilter } from '~/types'
+
+/**
+ * Ensures all filters have order values, using array position as fallback
+ */
+export function ensureFilterOrder(filters: PathCleaningFilter[]): PathCleaningFilter[] {
+    return filters.map((filter, index) => ({
+        ...filter,
+        order: filter.order ?? index,
+    }))
+}
+
+/**
+ * Updates all filter order values to match their array position
+ */
+export function updateFilterOrder(filters: PathCleaningFilter[]): PathCleaningFilter[] {
+    return filters.map((filter, index) => ({
+        ...filter,
+        order: index,
+    }))
+}

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -15176,6 +15176,9 @@
                 "alias": {
                     "type": "string"
                 },
+                "order": {
+                    "type": "number"
+                },
                 "regex": {
                     "type": "string"
                 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -756,7 +756,7 @@ export interface ToolbarProps extends ToolbarParams {
     disableExternalStyles?: boolean
 }
 
-export type PathCleaningFilter = { alias?: string; regex?: string }
+export type PathCleaningFilter = { alias?: string; regex?: string; order?: number }
 
 export type PropertyFilterBaseValue = string | number | bigint
 export type PropertyFilterValue = PropertyFilterBaseValue | PropertyFilterBaseValue[] | null

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
@@ -2477,6 +2477,66 @@
                     allow_experimental_join_condition=1
   '''
 # ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_with_order_field_and_baseline_urls
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_cleaning_with_order_field_and_baseline_urls.1
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', ''), '/item/(\\d+)/list/(\\d+)/spp/insessionForm/(\\d+)', '/item/<id>/list/<list_id>/spp/insessionForm/<form>'), '/item/(\\d+)/detail1/(\\d+)', '/item/<id>/detail1/<consultation>'), '/item/(\\d+)/list/(\\d+)', '/item/<id>/list/<list_id>'), '/item/(\\d+)', '/item/<id>') AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 00:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-06 23:59:59', 'UTC')), toIntervalDay(3))))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-06 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1
+  '''
+# ---
 # name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions
   '''
   

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -571,7 +571,7 @@ class Team(UUIDClassicModel):
                 filters.append(PathCleaningFilter.model_validate(f))
             except pydantic.ValidationError:
                 continue
-        return sorted(filters, key=lambda x: x.order if x.order is not None else 0)
+        return filters
 
     def reset_token_and_save(self, *, user: "User", is_impersonated_session: bool):
         from posthog.models.activity_logging.activity_log import Change, Detail, log_activity

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -571,7 +571,7 @@ class Team(UUIDClassicModel):
                 filters.append(PathCleaningFilter.model_validate(f))
             except pydantic.ValidationError:
                 continue
-        return filters
+        return sorted(filters, key=lambda x: x.order if x.order is not None else 0)
 
     def reset_token_and_save(self, *, user: "User", is_impersonated_session: bool):
         from posthog.models.activity_logging.activity_log import Change, Detail, log_activity

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1790,6 +1790,7 @@ class PathCleaningFilter(BaseModel):
         extra="forbid",
     )
     alias: Optional[str] = None
+    order: Optional[float] = None
     regex: Optional[str] = None
 
 


### PR DESCRIPTION
## Problem

We were missing the `order` field on the type, which is used in the `Pills` version, so we're ensuring that we use it as the order.

Also, this makes the UI even more compact.

## Changes

- Make the UI more compact
- Use the `order` field on the path cleaning to sort it when applying the rules so that the frontend tests UI meet the backend.

## How did you test this code?

Manually.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
