### PR TITLE
feat: add human-friendly number formatting to query context

### DIFF
--- a/frontend/src/queries/nodes/DataTable/renderColumn.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumn.tsx
@@ -9,7 +9,7 @@ import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
 import { Link } from 'lib/lemon-ui/Link'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
-import { autoCaptureEventToDescription } from 'lib/utils'
+import { autoCaptureEventToDescription, humanFriendlyNumber } from 'lib/utils'
 import { GroupActorDisplay } from 'scenes/persons/GroupActorDisplay'
 import { PersonDisplay, PersonDisplayProps } from 'scenes/persons/PersonDisplay'
 import { urls } from 'scenes/urls'
@@ -352,5 +352,11 @@ export function renderColumn(
             // do nothing
         }
     }
+
+    // Add number formatting for numeric values
+    if (context?.formatNumbers && typeof value === 'number') {
+        return humanFriendlyNumber(value)
+    }
+
     return String(value)
 }

--- a/frontend/src/queries/types.ts
+++ b/frontend/src/queries/types.ts
@@ -37,6 +37,8 @@ export interface QueryContext<Q extends QuerySchema = QuerySchema> {
     extraDataTableQueryFeatures?: QueryFeature[]
     /** Allow customization of file name when exporting */
     fileNameForExport?: string
+    /** Whether to format numbers in human friendly format. */
+    formatNumbers?: boolean
 }
 
 export type QueryContextColumnTitleComponent = ComponentType<{

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsTable/MarketingAnalyticsTable.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsTable/MarketingAnalyticsTable.tsx
@@ -203,6 +203,7 @@ export const MarketingAnalyticsTable = ({ query, insightProps }: MarketingAnalyt
             }, {} as Record<string, QueryContextColumn>),
             ...conversionGoalColumns,
         },
+        formatNumbers: true,
     }
 
     return (


### PR DESCRIPTION
## Changes

Allowing formatting numbers to the DataTable component

## How did you test this code?

<img width="854" height="350" alt="image" src="https://github.com/user-attachments/assets/4e7a86a5-a4e4-4f4d-a762-6cf296190600" />

