### PR TITLE
fix(paths): only use ui table on settings page

### DIFF
--- a/frontend/src/lib/components/PathCleanFilters/PathCleanFilters.tsx
+++ b/frontend/src/lib/components/PathCleanFilters/PathCleanFilters.tsx
@@ -1,16 +1,12 @@
 import { useState, useEffect } from 'react'
-import { useValues } from 'kea'
 import { PathCleaningFilter } from '~/types'
 
 import { PathCleanFilterAddItemButton } from './PathCleanFilterAddItemButton'
 import { ensureFilterOrder, updateFilterOrder } from './pathCleaningUtils'
-import { PathCleanFiltersTable } from './PathCleanFiltersTable'
 import { PathCleanFilterItem } from './PathCleanFilterItem'
 import { closestCenter, DndContext, PointerSensor, useSensor, useSensors } from '@dnd-kit/core'
 import { restrictToParentElement } from '@dnd-kit/modifiers'
 import { rectSortingStrategy, SortableContext } from '@dnd-kit/sortable'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 
 export interface PathCleanFiltersProps {
     filters?: PathCleaningFilter[]
@@ -23,8 +19,6 @@ export const keyFromFilter = (filter: PathCleaningFilter): string => {
 
 export function PathCleanFilters({ filters = [], setFilters }: PathCleanFiltersProps): JSX.Element {
     const [localFilters, setLocalFilters] = useState(filters)
-    const { featureFlags } = useValues(featureFlagLogic)
-    const useTableUI = featureFlags[FEATURE_FLAGS.PATH_CLEANING_FILTER_TABLE_UI]
 
     useEffect(() => {
         setLocalFilters(ensureFilterOrder(filters))
@@ -64,18 +58,6 @@ export function PathCleanFilters({ filters = [], setFilters }: PathCleanFiltersP
 
     const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 1 } }))
 
-    if (useTableUI) {
-        return (
-            <div className="flex flex-col gap-4">
-                <PathCleanFiltersTable filters={localFilters} setFilters={updateFilters} />
-                <div>
-                    <PathCleanFilterAddItemButton onAdd={onAddFilter} />
-                </div>
-            </div>
-        )
-    }
-
-    // Original pills UI
     return (
         <div className="flex flex-col gap-2">
             <div className="flex items-center gap-2 flex-wrap">

--- a/frontend/src/scenes/settings/environment/PathCleaningFiltersConfig.tsx
+++ b/frontend/src/scenes/settings/environment/PathCleaningFiltersConfig.tsx
@@ -55,7 +55,6 @@ export function PathCleaningFiltersConfig(): JSX.Element | null {
     const readableTestPath = parseAliasToReadable(cleanedTestPath)
 
     const useTableUI = featureFlags[FEATURE_FLAGS.PATH_CLEANING_FILTER_TABLE_UI]
-    const useDebuggerPanel = featureFlags[FEATURE_FLAGS.PATH_CLEANING_FILTER_TABLE_UI]
 
     const updateFilters = (filters: PathCleaningFilter[]): void => {
         updateCurrentTeam({ path_cleaning_filters: filters })
@@ -132,7 +131,7 @@ export function PathCleaningFiltersConfig(): JSX.Element | null {
                 </span>
             </div>
 
-            {useDebuggerPanel && (
+            {useTableUI && (
                 <PathCleaningRulesDebugger
                     testPath={testValue}
                     filters={currentTeam.path_cleaning_filters ?? []}


### PR DESCRIPTION
## Problem

This component was shared with Product Analytics "User Paths" insight, and it looks a bit weird there as-is, so let's just keep using the Pills one there.

The table was introduced on https://github.com/PostHog/posthog/pull/35603, alongside a debug panel, as an approach to handling a Zendesk ticket where rules were being broken when reordered.

It is behind a FF and only enabled for two teams (ourselves and the said customer)

## Changes


User Paths insight

| Before | After |
| -----  | ----- |
| <img width="2136" height="825" alt="image" src="https://github.com/user-attachments/assets/cff43861-1d66-4b09-9882-7c67243af502" /> | <img width="2137" height="741" alt="image" src="https://github.com/user-attachments/assets/45ffd1ed-3188-4b71-b8f4-f4d3e33122bd" /> |

Settings (Keeping the table UI for those with the flag enabled):
<img width="1800" height="582" alt="image" src="https://github.com/user-attachments/assets/44f7917f-96d0-4287-bdbd-a854362143ff" />

## How did you test this code?

Manually.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
