### PR TITLE
fix: Add UUID to deduplication logic

### DIFF
--- a/plugin-server/src/ingestion/deduplication/events.test.ts
+++ b/plugin-server/src/ingestion/deduplication/events.test.ts
@@ -57,8 +57,8 @@ describe('deduplicateEvents', () => {
 
         // Mock deduplicateIds to return duplicates
         const duplicateKeys = new Set([
-            '7a184cabe9cce485b181a9b8113845fededc36f56d7d4eff4fbebca53abd55f7',
-            'd0eafb964a9b3a603d44cea8376f5434e24fec80760e0bed1cd5b76ee5869796',
+            '7ebcf011d2a6c17c9405fb2da91cba540aceab53ca59e562f49eacf6fd47996d',
+            '7bfa9b827deb2126be762b189062579f0f962c169d25d4f002341c2679f4502b',
         ])
         deduplicationRedis.deduplicateIds = jest.fn().mockResolvedValue({
             duplicates: duplicateKeys,
@@ -69,8 +69,8 @@ describe('deduplicateEvents', () => {
 
         expect(deduplicationRedis.deduplicateIds).toHaveBeenCalledWith({
             keys: [
-                '7a184cabe9cce485b181a9b8113845fededc36f56d7d4eff4fbebca53abd55f7',
-                'd0eafb964a9b3a603d44cea8376f5434e24fec80760e0bed1cd5b76ee5869796',
+                '7ebcf011d2a6c17c9405fb2da91cba540aceab53ca59e562f49eacf6fd47996d',
+                '7bfa9b827deb2126be762b189062579f0f962c169d25d4f002341c2679f4502b',
             ],
         })
         expect(deduplicationRedis.deduplicate).not.toHaveBeenCalled()
@@ -128,7 +128,7 @@ describe('deduplicateEvents', () => {
         await deduplicateEvents(deduplicationRedis, messages)
 
         expect(deduplicationRedis.deduplicateIds).toHaveBeenCalledWith({
-            keys: ['7a184cabe9cce485b181a9b8113845fededc36f56d7d4eff4fbebca53abd55f7'],
+            keys: ['7ebcf011d2a6c17c9405fb2da91cba540aceab53ca59e562f49eacf6fd47996d'],
         })
         expect(deduplicationRedis.deduplicate).not.toHaveBeenCalled()
 

--- a/plugin-server/src/ingestion/deduplication/events.ts
+++ b/plugin-server/src/ingestion/deduplication/events.ts
@@ -85,7 +85,7 @@ function extractDeduplicationKeysWithMapping(messages: IncomingEvent[]): {
         }
 
         // Create a composite key that matches ClickHouse deduplication logic
-        // Format: token:event_name:distinct_id:timestamp
+        // Format: token:timestamp:event_name:distinct_id:uuid
         const key = `${token}:${timestamp}:${eventName}:${distinct_id}:${uuid}`
         // Hash the key to prevent it from being too long
         const hashedKey = crypto.createHash('sha256').update(key).digest('hex')

--- a/plugin-server/src/ingestion/deduplication/events.ts
+++ b/plugin-server/src/ingestion/deduplication/events.ts
@@ -76,17 +76,17 @@ function extractDeduplicationKeysWithMapping(messages: IncomingEvent[]): {
     messages.forEach(({ event }) => {
         // Create a robust deduplication key using (event_name, distinct_id, timestamp, uuid)
         // This prevents gaming the system when SDKs have bugs or apply naive retry strategies
-        const { token, event: eventName, distinct_id, timestamp, properties } = event
+        const { token, event: eventName, distinct_id, timestamp, properties, uuid } = event
         const source = properties?.$lib ?? 'unknown'
 
         // Only create a key if we have all required fields
-        if (!token || !eventName || !distinct_id || !timestamp) {
+        if (!token || !eventName || !distinct_id || !timestamp || !uuid) {
             return null
         }
 
         // Create a composite key that matches ClickHouse deduplication logic
         // Format: token:event_name:distinct_id:timestamp
-        const key = `${token}:${eventName}:${distinct_id}:${timestamp}`
+        const key = `${token}:${timestamp}:${eventName}:${distinct_id}:${uuid}`
         // Hash the key to prevent it from being too long
         const hashedKey = crypto.createHash('sha256').update(key).digest('hex')
         keys.add(hashedKey)


### PR DESCRIPTION
## Problem

CH uses UUID for deduplication, we should use the same logic

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
