### PR TITLE
fix: docker compose caddy routing

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -20,26 +20,34 @@ services:
                 ${CADDY_HOST} {
                     @replay-capture {
                         path /s
+                        path /s/
                         path /s/*
                     }
 
                     @capture {
                         path /e
+                        path /e/
                         path /e/*
+                        path /i/v0
+                        path /i/v0/
                         path /i/v0/*
                         path /batch
-                        path /batch*
+                        path /batch/
+                        path /batch/*
                         path /capture
-                        path /capture*
+                        path /capture/
+                        path /capture/*
                     }
 
                     @flags {
                         path /flags
-                        path /flags*
+                        path /flags/
+                        path /flags/*
                     }
 
                     @webhooks {
                         path /public/webhooks
+                        path /public/webhooks/
                         path /public/webhooks/*
                     }
 


### PR DESCRIPTION
on my self-hosted instance I could not successfully route to flags (i think)
it's really tricky to test 🫠 

Chat GPT confidently informs me that our routing rules for Caddy

```
/flags
/flags*
```

can never match the call the SDK is making `/flags/?x=y`

because `flags` matches `flags` exactly and `/flags*` is to match e.g. `/flagsxys` and cannot match `/flags/`

so...
i've added 

```
/foo
/foo/
/foo/*
```

for all paths we want to match on

in worse case this does nothing

---

checking the robot's work, the caddy docs say

> [Path matching](https://caddyserver.com/docs/caddyfile/matchers#path) is an exact match by default, not a prefix match. You must append a * for a fast prefix match. Note that /foo* will match /foo and /foo/ as well as /foobar; you might actually want /foo/* instead.

so the old rule

```
/flags
/flags*
```

matches 

```
/flags
/flags/
/flagsXYZ
```

which we don't want

we probably only want

`/flags/` 

but this at least means we're only exposing the listed path and its subpaths

instead of any path that begain with that sub-string