### PR TITLE
feat(admin): disallow impersonating other staff

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -220,6 +220,8 @@ IMPERSONATION_IDLE_TIMEOUT_SECONDS = get_from_env("IMPERSONATION_IDLE_TIMEOUT_SE
 IMPERSONATION_COOKIE_LAST_ACTIVITY_KEY = get_from_env(
     "IMPERSONATION_COOKIE_LAST_ACTIVITY_KEY", "impersonation_last_activity"
 )
+# Disallow impersonating other staff
+CAN_LOGIN_AS = lambda request, target_user: request.user.is_staff and not target_user.is_staff
 
 SESSION_COOKIE_CREATED_AT_KEY = get_from_env("SESSION_COOKIE_CREATED_AT_KEY", "session_created_at")
 


### PR DESCRIPTION
## Problem

Impersonation is incredibly useful for helping customers debug issues, but it shouldn't ever be used to impersonate other PostHog staff.

## How did you test this code?

Verified ability to impersonate non-staff user and verified error received when attempting to impersonate staff user.

Docs: https://github.com/skorokithakis/django-loginas?tab=readme-ov-file#configuring