### PR TITLE
fix(messaging): hide trigger options on testing tab

### DIFF
--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFilters.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFilters.tsx
@@ -85,7 +85,7 @@ export function HogFunctionFilters({ embedded = false }: { embedded?: boolean })
         return types
     }, [isTransformation, groupsTaxonomicTypes])
 
-    const showMasking = type === 'destination' && !isLegacyPlugin
+    const showMasking = type === 'destination' && !isLegacyPlugin && !embedded
     const showDropEvents = false // TODO coming back to this later for the dropEvents Transformation
 
     if (type === 'internal_destination') {

--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFilters.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFilters.tsx
@@ -48,7 +48,13 @@ function sanitizeActionFilters(filters?: FilterType): Partial<CyclotronJobFilter
     return sanitized
 }
 
-export function HogFunctionFilters({ embedded = false }: { embedded?: boolean }): JSX.Element {
+export function HogFunctionFilters({
+    embedded = false,
+    showTriggerOptions = true,
+}: {
+    embedded?: boolean
+    showTriggerOptions?: boolean
+}): JSX.Element {
     const { groupsTaxonomicTypes } = useValues(groupsModel)
     const { configuration, type, useMapping, filtersContainPersonProperties, oldFilters, newFilters, featureFlags } =
         useValues(hogFunctionConfigurationLogic)
@@ -85,7 +91,7 @@ export function HogFunctionFilters({ embedded = false }: { embedded?: boolean })
         return types
     }, [isTransformation, groupsTaxonomicTypes])
 
-    const showMasking = type === 'destination' && !isLegacyPlugin && !embedded
+    const showMasking = type === 'destination' && !isLegacyPlugin && showTriggerOptions
     const showDropEvents = false // TODO coming back to this later for the dropEvents Transformation
 
     if (type === 'internal_destination') {

--- a/frontend/src/scenes/hog-functions/testing/HogFunctionTesting.tsx
+++ b/frontend/src/scenes/hog-functions/testing/HogFunctionTesting.tsx
@@ -318,7 +318,7 @@ function RunsFilters({ id }: { id: string }): JSX.Element {
                         formKey="configuration"
                         className="deprecated-space-y-3"
                     >
-                        <HogFunctionFilters embedded={true} />
+                        <HogFunctionFilters embedded={true} showTriggerOptions={false} />
                         <div className="flex justify-end mt-2">
                             <LemonButton size="small" type="primary" onClick={() => setDropdownOpen(false)}>
                                 Done


### PR DESCRIPTION
## Problem

We don't want to show the trigger options on the embedded filters

## Changes

![2025-07-28 at 10 21 45](https://github.com/user-attachments/assets/a2787745-7783-476a-a9c5-e6efb4d19d12)

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
