### PR TITLE
fix(cdp): Retrieving individual non-destination templates

### DIFF
--- a/posthog/api/hog_function_template.py
+++ b/posthog/api/hog_function_template.py
@@ -66,16 +66,16 @@ class PublicHogFunctionTemplateViewSet(
     # TODO
 
     def filter_queryset(self, queryset: QuerySet) -> QuerySet:
-        types = ["destination"]
-        if self.request.GET.get("type"):
-            types = [self.request.GET["type"]]
-        elif self.request.GET.get("types"):
-            types = self.request.GET["types"].split(",")
-
-        queryset = queryset.filter(type__in=types)
-
-        # Don't include deprecated templates when listing
         if self.action == "list":
+            types = ["destination"]
+            if self.request.GET.get("type"):
+                types = [self.request.GET["type"]]
+            elif self.request.GET.get("types"):
+                types = self.request.GET["types"].split(",")
+
+            queryset = queryset.filter(type__in=types)
+
+            # Don't include deprecated templates when listing
             queryset = queryset.exclude(status="deprecated")
 
         if self.request.path.startswith("/api/public_hog_function_templates"):

--- a/posthog/api/test/test_hog_function_templates.py
+++ b/posthog/api/test/test_hog_function_templates.py
@@ -135,6 +135,13 @@ class TestHogFunctionTemplates(ClickhouseTestMixin, APIBaseTest, QueryMatchingTe
         response = self.client.get("/api/projects/@current/hog_function_templates/template-slack")
         assert response.status_code == status.HTTP_200_OK, response.json()
         assert response.json()["id"] == "template-slack"
+        assert response.json()["type"] == "destination"
+
+    def test_retrieve_function_template_with_other_type(self):
+        response = self.client.get("/api/projects/@current/hog_function_templates/template-site-destination")
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert response.json()["id"] == "template-site-destination"
+        assert response.json()["type"] == "site_destination"
 
     def test_public_list_function_templates(self):
         self.client.logout()


### PR DESCRIPTION
## Problem

Can't retrieve non destination templates

## Changes

* Fixes it with a test

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
