### PR TITLE
chore: Remove EAF for hedgehog mode

### DIFF
--- a/frontend/src/lib/components/HedgehogBuddy/hedgehogBuddyLogic.ts
+++ b/frontend/src/lib/components/HedgehogBuddy/hedgehogBuddyLogic.ts
@@ -171,16 +171,5 @@ export const hedgehogBuddyLogic = kea<hedgehogBuddyLogicType>([
         } else {
             actions.loadRemoteConfig()
         }
-
-        posthog.getEarlyAccessFeatures((features) => {
-            const relatedEAF = features.find((x) => x.flagKey === FEATURE_FLAGS.HEDGEHOG_MODE)
-            if (relatedEAF) {
-                if (posthog.getFeatureFlag(FEATURE_FLAGS.HEDGEHOG_MODE)) {
-                    actions.setHedgehogModeEnabled(true)
-                }
-
-                posthog.updateEarlyAccessFeatureEnrollment(FEATURE_FLAGS.HEDGEHOG_MODE, false)
-            }
-        })
     }),
 ])

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -150,7 +150,6 @@ export const FEATURE_FLAGS = {
     ONBOARDING_V2_DEMO: 'onboarding-v2-demo', // owner: #team-growth
     QUERY_RUNNING_TIME: 'query_running_time', // owner: @mariusandra
     QUERY_TIMINGS: 'query-timings', // owner: @mariusandra
-    HEDGEHOG_MODE: 'hedgehog-mode', // owner: @benjackwhite
     HEDGEHOG_MODE_DEBUG: 'hedgehog-mode-debug', // owner: @benjackwhite
     HIGH_FREQUENCY_BATCH_EXPORTS: 'high-frequency-batch-exports', // owner: @tomasfarias
     PERSON_BATCH_EXPORTS: 'person-batch-exports', // owner: @tomasfarias


### PR DESCRIPTION
## Problem

A bug in the JS SDK means that EAFs are cached forever so the evaluation here led to true and then the "update enrollement" thing was called way too often

## Changes

* Removes it

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
