### PR TITLE
fix(devex): remove 'view' from products tooltip

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -635,7 +635,7 @@ export function ProjectTree({
                 const user = item.record?.user as UserBasicType | undefined
                 const nameNode: JSX.Element = <span className="font-semibold">{item.displayName}</span>
                 if (root === 'products://' || root === 'data://' || root === 'persons://') {
-                    return <>View {nameNode}</>
+                    return <>{nameNode}</>
                 }
                 if (root === 'new://') {
                     if (item.children) {


### PR DESCRIPTION
## Problem
the word view is redundant in project tree (product) tooltip

<img width="514" height="158" alt="image" src="https://github.com/user-attachments/assets/70b807b5-f791-4400-b5b3-d92f1bbc6120" />

## Changes
Remove word view from project tree (product) tooltip