### PR TITLE
fix: rebuild clickhouse dictionary with user/pwd on the query source

### DIFF
--- a/posthog/clickhouse/migrations/0128_rebuild_web_pre_aggregated_teams_dictionary.py
+++ b/posthog/clickhouse/migrations/0128_rebuild_web_pre_aggregated_teams_dictionary.py
@@ -1,0 +1,13 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.clickhouse.cluster import NodeRole
+from posthog.models.web_preaggregated.team_selection import (
+    DROP_WEB_PRE_AGGREGATED_TEAM_SELECTION_DICTIONARY_SQL,
+    WEB_PRE_AGGREGATED_TEAM_SELECTION_DICTIONARY_SQL,
+)
+
+operations = [
+    run_sql_with_exceptions(
+        DROP_WEB_PRE_AGGREGATED_TEAM_SELECTION_DICTIONARY_SQL(on_cluster=False), node_role=NodeRole.ALL
+    ),
+    run_sql_with_exceptions(WEB_PRE_AGGREGATED_TEAM_SELECTION_DICTIONARY_SQL(on_cluster=False), node_role=NodeRole.ALL),
+]

--- a/posthog/models/web_preaggregated/team_selection.py
+++ b/posthog/models/web_preaggregated/team_selection.py
@@ -1,5 +1,6 @@
 from posthog.clickhouse.cluster import ON_CLUSTER_CLAUSE
 from posthog.clickhouse.table_engines import ReplacingMergeTree
+from posthog.settings.data_stores import CLICKHOUSE_PASSWORD, CLICKHOUSE_USER
 
 WEB_PRE_AGGREGATED_TEAM_SELECTION_TABLE_NAME = "web_pre_aggregated_teams"
 WEB_PRE_AGGREGATED_TEAM_SELECTION_DICTIONARY_NAME = "web_pre_aggregated_teams_dict"
@@ -51,12 +52,14 @@ CREATE DICTIONARY IF NOT EXISTS {dictionary_name} {on_cluster_clause} (
     team_id UInt64
 )
 PRIMARY KEY team_id
-SOURCE(CLICKHOUSE(QUERY '{query}'))
+SOURCE(CLICKHOUSE(QUERY '{query}' USER '{clickhouse_user}' PASSWORD '{clickhouse_password}'))
 LIFETIME(MIN 3000 MAX 3600)
 LAYOUT(HASHED())""".format(
         dictionary_name=f"`{WEB_PRE_AGGREGATED_TEAM_SELECTION_DICTIONARY_NAME}`",
         on_cluster_clause=ON_CLUSTER_CLAUSE(on_cluster),
         query=WEB_PRE_AGGREGATED_TEAM_SELECTION_DICTIONARY_QUERY(),
+        clickhouse_user=CLICKHOUSE_USER,
+        clickhouse_password=CLICKHOUSE_PASSWORD,
     )
 
 


### PR DESCRIPTION
## Problem

The syntax for the dictionary source at https://github.com/PostHog/posthog/pull/35408 was a bit off, so it was not reloading. This should fix it.

## Changes

- Drop and recreate the dictionary following what has been done in the exchange rate: https://github.com/PostHog/posthog/blob/6eba7faefc15f6fbee99a35b2101ee9b055bff0b/posthog/models/exchange_rate/sql.py#L219

## How did you test this code?

Running the migrations.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
