### PR TITLE
fix: typo on WEB_PRE_AGGREGATED_TEAM_SELECTION_DICTIONARY_NAME

### DIFF
--- a/posthog/models/web_preaggregated/sql.py
+++ b/posthog/models/web_preaggregated/sql.py
@@ -1,6 +1,7 @@
 from posthog.clickhouse.table_engines import MergeTreeEngine, ReplicationScheme
 from posthog.clickhouse.cluster import ON_CLUSTER_CLAUSE
 from posthog.hogql.database.schema.web_analytics_s3 import get_s3_function_args
+from posthog.models.web_preaggregated.team_selection import WEB_PRE_AGGREGATED_TEAM_SELECTION_DICTIONARY_NAME
 
 
 def TABLE_TEMPLATE(table_name, columns, order_by):
@@ -202,9 +203,9 @@ def get_team_filters(team_ids):
         }
     else:
         return {
-            "raw_sessions": "dictHas('web_preaggregated_teams_dict', raw_sessions.team_id)",
-            "person_distinct_id_overrides": "dictHas('web_preaggregated_teams_dict', person_distinct_id_overrides.team_id)",
-            "events": "dictHas('web_preaggregated_teams_dict', e.team_id)",
+            "raw_sessions": f"dictHas('{WEB_PRE_AGGREGATED_TEAM_SELECTION_DICTIONARY_NAME}', raw_sessions.team_id)",
+            "person_distinct_id_overrides": f"dictHas('{WEB_PRE_AGGREGATED_TEAM_SELECTION_DICTIONARY_NAME}', person_distinct_id_overrides.team_id)",
+            "events": f"dictHas('{WEB_PRE_AGGREGATED_TEAM_SELECTION_DICTIONARY_NAME}', e.team_id)",
         }
 
 


### PR DESCRIPTION
## Problem

This was the earlier version, it was recreated on https://github.com/PostHog/posthog/pull/35728 as `web_pre_aggregated_teams_dict` (one more underscore)

## Changes

Use the var instead, as it should already be doing

## How did you test this code?

Materializing locally, which didn't fail before, but I checked on Metabase, this is indeed the correct name.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
