### PR TITLE
feat: Add feature enrollment state to $feature_enrollment_update events

### DIFF
--- a/frontend/src/layout/FeaturePreviews/FeaturePreviews.tsx
+++ b/frontend/src/layout/FeaturePreviews/FeaturePreviews.tsx
@@ -123,7 +123,7 @@ function ConceptPreview({ feature }: { feature: EnrichedEarlyAccessFeature }): J
                         disabledReason={
                             enabled && "You have already expressed your interest. We'll contact you when it's ready"
                         }
-                        onClick={() => updateEarlyAccessFeatureEnrollment(flagKey, true)}
+                        onClick={() => updateEarlyAccessFeatureEnrollment(flagKey, true, feature.stage)}
                         size="small"
                         sideIcon={enabled ? <IconCheck /> : <IconBell />}
                         className="w-fit"
@@ -159,7 +159,7 @@ function FeaturePreview({ feature }: { feature: EnrichedEarlyAccessFeature }): J
                     <Label className="flex items-center gap-2 cursor-pointer" htmlFor={`${feature.flagKey}-switch`}>
                         <LemonSwitch
                             checked={enabled}
-                            onChange={(newChecked) => updateEarlyAccessFeatureEnrollment(flagKey, newChecked)}
+                            onChange={(newChecked) => updateEarlyAccessFeatureEnrollment(flagKey, newChecked, feature.stage)}
                             id={`${feature.flagKey}-switch`}
                         />
                         <h4 className="font-bold mb-0">{name}</h4>
@@ -202,7 +202,7 @@ function FeaturePreview({ feature }: { feature: EnrichedEarlyAccessFeature }): J
                         onChange={(value) => setFeedback(value)}
                         onKeyDown={(e) => {
                             if (e.key === 'Enter' && e.metaKey) {
-                                updateEarlyAccessFeatureEnrollment(flagKey, enabled)
+                                updateEarlyAccessFeatureEnrollment(flagKey, enabled, feature.stage)
                             } else if (e.key === 'Escape') {
                                 cancelEarlyAccessFeatureFeedback()
                                 setFeedback('')

--- a/frontend/src/layout/FeaturePreviews/FeaturePreviews.tsx
+++ b/frontend/src/layout/FeaturePreviews/FeaturePreviews.tsx
@@ -159,7 +159,9 @@ function FeaturePreview({ feature }: { feature: EnrichedEarlyAccessFeature }): J
                     <Label className="flex items-center gap-2 cursor-pointer" htmlFor={`${feature.flagKey}-switch`}>
                         <LemonSwitch
                             checked={enabled}
-                            onChange={(newChecked) => updateEarlyAccessFeatureEnrollment(flagKey, newChecked, feature.stage)}
+                            onChange={(newChecked) =>
+                                updateEarlyAccessFeatureEnrollment(flagKey, newChecked, feature.stage)
+                            }
                             id={`${feature.flagKey}-switch`}
                         />
                         <h4 className="font-bold mb-0">{name}</h4>
@@ -202,7 +204,9 @@ function FeaturePreview({ feature }: { feature: EnrichedEarlyAccessFeature }): J
                         onChange={(value) => setFeedback(value)}
                         onKeyDown={(e) => {
                             if (e.key === 'Enter' && e.metaKey) {
-                                updateEarlyAccessFeatureEnrollment(flagKey, enabled, feature.stage)
+                                void submitEarlyAccessFeatureFeedback(feedback).then(() => {
+                                    setFeedback('')
+                                })
                             } else if (e.key === 'Escape') {
                                 cancelEarlyAccessFeatureFeedback()
                                 setFeedback('')

--- a/frontend/src/layout/FeaturePreviews/featurePreviewsLogic.test.ts
+++ b/frontend/src/layout/FeaturePreviews/featurePreviewsLogic.test.ts
@@ -1,5 +1,6 @@
 import { expectLogic } from 'kea-test-utils'
 import { MOCK_DEFAULT_USER } from 'lib/api.mock'
+import posthog from 'posthog-js'
 import { userLogic } from 'scenes/userLogic'
 
 import { useMocks } from '~/mocks/jest'
@@ -7,10 +8,19 @@ import { initKeaTests } from '~/test/init'
 
 import { featurePreviewsLogic } from './featurePreviewsLogic'
 
-describe('featurePreviewsLogic', () => {
+// Mock posthog-js
+jest.mock('posthog-js')
+
+// Set up the mock methods that various parts of the code need
+const mockedPosthog = posthog as jest.Mocked<typeof posthog>
+mockedPosthog.get_session_replay_url = jest.fn(() => 'http://localhost/replay/123')
+
+describe('featurePreviewsLogic - submitEarlyAccessFeatureFeedback', () => {
     let logic: ReturnType<typeof featurePreviewsLogic.build>
 
     beforeEach(() => {
+        jest.clearAllMocks()
+
         useMocks({
             post: {
                 'https://posthoghelp.zendesk.com/api/v2/requests.json': [200, {}],
@@ -33,5 +43,49 @@ describe('featurePreviewsLogic', () => {
         await expectLogic(logic)
             .toMatchValues({ activeFeedbackFlagKeyLoading: false })
             .toDispatchActions(['submitEarlyAccessFeatureFeedbackSuccess'])
+    })
+})
+
+describe('featurePreviewsLogic - updateEarlyAccessFeatureEnrollment', () => {
+    let logic: ReturnType<typeof featurePreviewsLogic.build>
+    const mockUpdateEnrollment = jest.fn()
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+
+        // Set up the mock implementation for posthog
+        ;(posthog as any).updateEarlyAccessFeatureEnrollment = mockUpdateEnrollment
+
+        useMocks({
+            post: {
+                'https://posthoghelp.zendesk.com/api/v2/requests.json': [200, {}],
+            },
+        })
+        initKeaTests()
+        logic = featurePreviewsLogic()
+        logic.mount()
+        userLogic.actions.loadUserSuccess(MOCK_DEFAULT_USER)
+    })
+
+    test('updating early access feature enrollment without stage', () => {
+        logic.actions.updateEarlyAccessFeatureEnrollment('test-flag', true)
+
+        expect(mockUpdateEnrollment).toHaveBeenCalledWith('test-flag', true, undefined)
+    })
+
+    test('updating early access feature enrollment with stage', () => {
+        logic.actions.updateEarlyAccessFeatureEnrollment('test-flag', true, 'beta')
+
+        expect(mockUpdateEnrollment).toHaveBeenCalledWith('test-flag', true, 'beta')
+    })
+
+    test('updating early access feature enrollment with different stages', () => {
+        // Test concept stage
+        logic.actions.updateEarlyAccessFeatureEnrollment('concept-flag', false, 'concept')
+        expect(mockUpdateEnrollment).toHaveBeenCalledWith('concept-flag', false, 'concept')
+
+        // Test alpha stage
+        logic.actions.updateEarlyAccessFeatureEnrollment('alpha-flag', true, 'alpha')
+        expect(mockUpdateEnrollment).toHaveBeenCalledWith('alpha-flag', true, 'alpha')
     })
 })

--- a/frontend/src/layout/FeaturePreviews/featurePreviewsLogic.tsx
+++ b/frontend/src/layout/FeaturePreviews/featurePreviewsLogic.tsx
@@ -26,7 +26,11 @@ export const featurePreviewsLogic = kea<featurePreviewsLogicType>([
         actions: [supportLogic, ['submitZendeskTicket']],
     })),
     actions({
-        updateEarlyAccessFeatureEnrollment: (flagKey: string, enabled: boolean) => ({ flagKey, enabled }),
+        updateEarlyAccessFeatureEnrollment: (flagKey: string, enabled: boolean, stage?: string) => ({
+            flagKey,
+            enabled,
+            stage,
+        }),
         beginEarlyAccessFeatureFeedback: (flagKey: string) => ({ flagKey }),
         cancelEarlyAccessFeatureFeedback: true,
         submitEarlyAccessFeatureFeedback: (message: string) => ({ message }),
@@ -74,8 +78,8 @@ export const featurePreviewsLogic = kea<featurePreviewsLogicType>([
         },
     }),
     listeners(() => ({
-        updateEarlyAccessFeatureEnrollment: ({ flagKey, enabled }) => {
-            posthog.updateEarlyAccessFeatureEnrollment(flagKey, enabled)
+        updateEarlyAccessFeatureEnrollment: ({ flagKey, enabled, stage }) => {
+            posthog.updateEarlyAccessFeatureEnrollment(flagKey, enabled, stage)
         },
         copyExternalFeaturePreviewLink: ({ flagKey }) => {
             void copyToClipboard(urls.absolute(`/settings/user-feature-previews#${flagKey}`))


### PR DESCRIPTION
This is a follow-up to https://github.com/PostHog/posthog-js/pull/2099 which is a follow-up to this internal discussion: https://posthog.slack.com/archives/C02E3BKC78F/p1753190373231089

## Problem

We're building this for Joe.

## Changes

Changes calls to `updateEarlyAccessFeatureEnrollment` to pass in the stage.

## How did you test this code?

* Unit tests
* Manual tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
