### PR TITLE
feat(llmo): include all AI providers when generating LLM cost JSON

### DIFF
--- a/plugin-server/src/ingestion/ai-costs/providers/generated-providers.json
+++ b/plugin-server/src/ingestion/ai-costs/providers/generated-providers.json
@@ -1,5 +1,47 @@
 [
     {
+        "model": "aion-1.0",
+        "cost": {
+            "prompt_token": 0.000004,
+            "completion_token": 0.000008
+        }
+    },
+    {
+        "model": "aion-1.0-mini",
+        "cost": {
+            "prompt_token": 7e-7,
+            "completion_token": 0.0000014
+        }
+    },
+    {
+        "model": "aion-rp-llama-3.1-8b",
+        "cost": {
+            "prompt_token": 2e-7,
+            "completion_token": 2e-7
+        }
+    },
+    {
+        "model": "anubis-70b-v1.1",
+        "cost": {
+            "prompt_token": 5e-7,
+            "completion_token": 8e-7
+        }
+    },
+    {
+        "model": "anubis-pro-105b-v1",
+        "cost": {
+            "prompt_token": 5e-7,
+            "completion_token": 0.000001
+        }
+    },
+    {
+        "model": "auto",
+        "cost": {
+            "prompt_token": -1,
+            "completion_token": -1
+        }
+    },
+    {
         "model": "chatgpt-4o-latest",
         "cost": {
             "prompt_token": 0.000005,
@@ -160,6 +202,20 @@
         }
     },
     {
+        "model": "codellama-7b-instruct-solidity",
+        "cost": {
+            "prompt_token": 8e-7,
+            "completion_token": 0.0000012
+        }
+    },
+    {
+        "model": "coder-large",
+        "cost": {
+            "prompt_token": 5e-7,
+            "completion_token": 8e-7
+        }
+    },
+    {
         "model": "codestral-2501",
         "cost": {
             "prompt_token": 3e-7,
@@ -235,6 +291,34 @@
         "cost": {
             "prompt_token": 3.75e-8,
             "completion_token": 1.5e-7
+        }
+    },
+    {
+        "model": "deepcoder-14b-preview",
+        "cost": {
+            "prompt_token": 1.5e-8,
+            "completion_token": 1.5e-8
+        }
+    },
+    {
+        "model": "deepcoder-14b-preview:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "deephermes-3-llama-3-8b-preview:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "deephermes-3-mistral-24b-preview",
+        "cost": {
+            "prompt_token": 1.41e-7,
+            "completion_token": 1.41e-7
         }
     },
     {
@@ -364,6 +448,27 @@
         }
     },
     {
+        "model": "deepseek-r1t-chimera:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "deepseek-r1t2-chimera",
+        "cost": {
+            "prompt_token": 3.02e-7,
+            "completion_token": 3.02e-7
+        }
+    },
+    {
+        "model": "deepseek-r1t2-chimera:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
         "model": "deepseek-v3-base",
         "cost": {
             "prompt_token": 3.02e-7,
@@ -396,6 +501,62 @@
         "cost": {
             "prompt_token": 0,
             "completion_token": 0
+        }
+    },
+    {
+        "model": "dolphin-mistral-24b-venice-edition:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "dolphin-mixtral-8x22b",
+        "cost": {
+            "prompt_token": 9e-7,
+            "completion_token": 9e-7
+        }
+    },
+    {
+        "model": "dolphin3.0-mistral-24b:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "dolphin3.0-r1-mistral-24b",
+        "cost": {
+            "prompt_token": 1.3e-8,
+            "completion_token": 1.3e-8
+        }
+    },
+    {
+        "model": "dolphin3.0-r1-mistral-24b:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "ernie-4.5-300b-a47b",
+        "cost": {
+            "prompt_token": 2.8e-7,
+            "completion_token": 0.0000011
+        }
+    },
+    {
+        "model": "eva-qwen-2.5-72b",
+        "cost": {
+            "prompt_token": 0.000004,
+            "completion_token": 0.000006
+        }
+    },
+    {
+        "model": "fimbulvetr-11b-v2",
+        "cost": {
+            "prompt_token": 8e-7,
+            "completion_token": 0.0000012
         }
     },
     {
@@ -592,6 +753,71 @@
         }
     },
     {
+        "model": "glm-4-32b",
+        "cost": {
+            "prompt_token": 1e-7,
+            "completion_token": 1e-7
+        }
+    },
+    {
+        "model": "glm-4-32b",
+        "cost": {
+            "prompt_token": 2.4e-7,
+            "completion_token": 2.4e-7
+        }
+    },
+    {
+        "model": "glm-4-32b:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "glm-4.1v-9b-thinking",
+        "cost": {
+            "prompt_token": 3.5e-8,
+            "completion_token": 1.38e-7
+        }
+    },
+    {
+        "model": "glm-4.5",
+        "cost": {
+            "prompt_token": 6e-7,
+            "completion_token": 0.0000022,
+            "cache_read_token": 1.1e-7
+        }
+    },
+    {
+        "model": "glm-4.5-air",
+        "cost": {
+            "prompt_token": 2e-7,
+            "completion_token": 0.0000011,
+            "cache_read_token": 3e-8
+        }
+    },
+    {
+        "model": "glm-z1-32b",
+        "cost": {
+            "prompt_token": 3e-8,
+            "completion_token": 3e-8
+        }
+    },
+    {
+        "model": "glm-z1-32b:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "goliath-120b",
+        "cost": {
+            "prompt_token": 0.000009,
+            "completion_token": 0.000011
+        }
+    },
+    {
         "model": "gpt-3.5-turbo",
         "cost": {
             "prompt_token": 5e-7,
@@ -747,6 +973,221 @@
         }
     },
     {
+        "model": "grok-2-1212",
+        "cost": {
+            "prompt_token": 0.000002,
+            "completion_token": 0.00001
+        }
+    },
+    {
+        "model": "grok-2-vision-1212",
+        "cost": {
+            "prompt_token": 0.000002,
+            "completion_token": 0.00001
+        }
+    },
+    {
+        "model": "grok-3",
+        "cost": {
+            "prompt_token": 0.000003,
+            "completion_token": 0.000015,
+            "cache_read_token": 7.5e-7
+        }
+    },
+    {
+        "model": "grok-3-beta",
+        "cost": {
+            "prompt_token": 0.000003,
+            "completion_token": 0.000015,
+            "cache_read_token": 7.5e-7
+        }
+    },
+    {
+        "model": "grok-3-mini",
+        "cost": {
+            "prompt_token": 3e-7,
+            "completion_token": 5e-7,
+            "cache_read_token": 7.5e-8
+        }
+    },
+    {
+        "model": "grok-3-mini-beta",
+        "cost": {
+            "prompt_token": 3e-7,
+            "completion_token": 5e-7,
+            "cache_read_token": 7.5e-8
+        }
+    },
+    {
+        "model": "grok-4",
+        "cost": {
+            "prompt_token": 0.000003,
+            "completion_token": 0.000015,
+            "cache_read_token": 7.5e-7
+        }
+    },
+    {
+        "model": "grok-vision-beta",
+        "cost": {
+            "prompt_token": 0.000005,
+            "completion_token": 0.000015
+        }
+    },
+    {
+        "model": "hermes-2-pro-llama-3-8b",
+        "cost": {
+            "prompt_token": 2.5e-8,
+            "completion_token": 4e-8
+        }
+    },
+    {
+        "model": "hermes-3-llama-3.1-405b",
+        "cost": {
+            "prompt_token": 7e-7,
+            "completion_token": 8e-7
+        }
+    },
+    {
+        "model": "hermes-3-llama-3.1-70b",
+        "cost": {
+            "prompt_token": 1e-7,
+            "completion_token": 2.8e-7
+        }
+    },
+    {
+        "model": "hunyuan-a13b-instruct",
+        "cost": {
+            "prompt_token": 3e-8,
+            "completion_token": 3e-8
+        }
+    },
+    {
+        "model": "hunyuan-a13b-instruct:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "inflection-3-pi",
+        "cost": {
+            "prompt_token": 0.0000025,
+            "completion_token": 0.00001
+        }
+    },
+    {
+        "model": "inflection-3-productivity",
+        "cost": {
+            "prompt_token": 0.0000025,
+            "completion_token": 0.00001
+        }
+    },
+    {
+        "model": "internvl3-14b",
+        "cost": {
+            "prompt_token": 2e-7,
+            "completion_token": 4e-7
+        }
+    },
+    {
+        "model": "jamba-1.6-large",
+        "cost": {
+            "prompt_token": 0.000002,
+            "completion_token": 0.000008
+        }
+    },
+    {
+        "model": "jamba-1.6-mini",
+        "cost": {
+            "prompt_token": 2e-7,
+            "completion_token": 4e-7
+        }
+    },
+    {
+        "model": "kimi-dev-72b:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "kimi-k2",
+        "cost": {
+            "prompt_token": 1.3e-7,
+            "completion_token": 1.3e-7
+        }
+    },
+    {
+        "model": "kimi-k2:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "kimi-vl-a3b-thinking",
+        "cost": {
+            "prompt_token": 3.8e-8,
+            "completion_token": 3.8e-8
+        }
+    },
+    {
+        "model": "kimi-vl-a3b-thinking:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "l3-euryale-70b",
+        "cost": {
+            "prompt_token": 0.00000148,
+            "completion_token": 0.00000148
+        }
+    },
+    {
+        "model": "l3-lunaris-8b",
+        "cost": {
+            "prompt_token": 2e-8,
+            "completion_token": 5e-8
+        }
+    },
+    {
+        "model": "l3.1-euryale-70b",
+        "cost": {
+            "prompt_token": 6.5e-7,
+            "completion_token": 7.5e-7
+        }
+    },
+    {
+        "model": "l3.3-euryale-70b",
+        "cost": {
+            "prompt_token": 6.5e-7,
+            "completion_token": 7.5e-7
+        }
+    },
+    {
+        "model": "lfm-3b",
+        "cost": {
+            "prompt_token": 2e-8,
+            "completion_token": 2e-8
+        }
+    },
+    {
+        "model": "lfm-40b",
+        "cost": {
+            "prompt_token": 1.5e-7,
+            "completion_token": 1.5e-7
+        }
+    },
+    {
+        "model": "lfm-7b",
+        "cost": {
+            "prompt_token": 1e-8,
+            "completion_token": 1e-8
+        }
+    },
+    {
         "model": "llama-3-70b-instruct",
         "cost": {
             "prompt_token": 3e-7,
@@ -758,6 +1199,13 @@
         "cost": {
             "prompt_token": 3e-8,
             "completion_token": 6e-8
+        }
+    },
+    {
+        "model": "llama-3-lumimaid-70b",
+        "cost": {
+            "prompt_token": 0.000004,
+            "completion_token": 0.000006
         }
     },
     {
@@ -793,6 +1241,34 @@
         "cost": {
             "prompt_token": 1.5e-8,
             "completion_token": 2e-8
+        }
+    },
+    {
+        "model": "llama-3.1-lumimaid-8b",
+        "cost": {
+            "prompt_token": 1.8e-7,
+            "completion_token": 0.000001
+        }
+    },
+    {
+        "model": "llama-3.1-nemotron-70b-instruct",
+        "cost": {
+            "prompt_token": 1.2e-7,
+            "completion_token": 3e-7
+        }
+    },
+    {
+        "model": "llama-3.1-nemotron-ultra-253b-v1",
+        "cost": {
+            "prompt_token": 6e-7,
+            "completion_token": 0.0000018
+        }
+    },
+    {
+        "model": "llama-3.1-nemotron-ultra-253b-v1:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
         }
     },
     {
@@ -852,6 +1328,13 @@
         }
     },
     {
+        "model": "llama-3.3-nemotron-super-49b-v1",
+        "cost": {
+            "prompt_token": 1.3e-7,
+            "completion_token": 4e-7
+        }
+    },
+    {
         "model": "llama-4-maverick",
         "cost": {
             "prompt_token": 1.5e-7,
@@ -887,6 +1370,27 @@
         }
     },
     {
+        "model": "llama3.1-typhoon2-70b-instruct",
+        "cost": {
+            "prompt_token": 8.8e-7,
+            "completion_token": 8.8e-7
+        }
+    },
+    {
+        "model": "llemma_7b",
+        "cost": {
+            "prompt_token": 8e-7,
+            "completion_token": 0.0000012
+        }
+    },
+    {
+        "model": "maestro-reasoning",
+        "cost": {
+            "prompt_token": 9e-7,
+            "completion_token": 0.0000033
+        }
+    },
+    {
         "model": "magistral-medium-2506",
         "cost": {
             "prompt_token": 0.000002,
@@ -905,6 +1409,69 @@
         "cost": {
             "prompt_token": 5e-7,
             "completion_token": 0.0000015
+        }
+    },
+    {
+        "model": "magnum-v2-72b",
+        "cost": {
+            "prompt_token": 0.000003,
+            "completion_token": 0.000003
+        }
+    },
+    {
+        "model": "magnum-v4-72b",
+        "cost": {
+            "prompt_token": 0.0000025,
+            "completion_token": 0.000003
+        }
+    },
+    {
+        "model": "mai-ds-r1",
+        "cost": {
+            "prompt_token": 3.02e-7,
+            "completion_token": 3.02e-7
+        }
+    },
+    {
+        "model": "mai-ds-r1:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "mercury",
+        "cost": {
+            "prompt_token": 2.5e-7,
+            "completion_token": 0.000001
+        }
+    },
+    {
+        "model": "mercury-coder",
+        "cost": {
+            "prompt_token": 2.5e-7,
+            "completion_token": 0.000001
+        }
+    },
+    {
+        "model": "midnight-rose-70b",
+        "cost": {
+            "prompt_token": 8e-7,
+            "completion_token": 8e-7
+        }
+    },
+    {
+        "model": "minimax-01",
+        "cost": {
+            "prompt_token": 2e-7,
+            "completion_token": 0.0000011
+        }
+    },
+    {
+        "model": "minimax-m1",
+        "cost": {
+            "prompt_token": 3e-7,
+            "completion_token": 0.00000165
         }
     },
     {
@@ -1076,6 +1643,90 @@
         }
     },
     {
+        "model": "mn-celeste-12b",
+        "cost": {
+            "prompt_token": 8e-7,
+            "completion_token": 0.0000012
+        }
+    },
+    {
+        "model": "mn-inferor-12b",
+        "cost": {
+            "prompt_token": 8e-7,
+            "completion_token": 0.0000012
+        }
+    },
+    {
+        "model": "morph-v2",
+        "cost": {
+            "prompt_token": 0.0000012,
+            "completion_token": 0.0000027
+        }
+    },
+    {
+        "model": "morph-v3-fast",
+        "cost": {
+            "prompt_token": 0.0000012,
+            "completion_token": 0.0000027
+        }
+    },
+    {
+        "model": "morph-v3-large",
+        "cost": {
+            "prompt_token": 0.0000012,
+            "completion_token": 0.0000027
+        }
+    },
+    {
+        "model": "mythalion-13b",
+        "cost": {
+            "prompt_token": 8e-7,
+            "completion_token": 0.0000012
+        }
+    },
+    {
+        "model": "mythomax-l2-13b",
+        "cost": {
+            "prompt_token": 6e-8,
+            "completion_token": 6e-8
+        }
+    },
+    {
+        "model": "noromaid-20b",
+        "cost": {
+            "prompt_token": 0.00000125,
+            "completion_token": 0.000002
+        }
+    },
+    {
+        "model": "nous-hermes-2-mixtral-8x7b-dpo",
+        "cost": {
+            "prompt_token": 6e-7,
+            "completion_token": 6e-7
+        }
+    },
+    {
+        "model": "nova-lite-v1",
+        "cost": {
+            "prompt_token": 6e-8,
+            "completion_token": 2.4e-7
+        }
+    },
+    {
+        "model": "nova-micro-v1",
+        "cost": {
+            "prompt_token": 3.5e-8,
+            "completion_token": 1.4e-7
+        }
+    },
+    {
+        "model": "nova-pro-v1",
+        "cost": {
+            "prompt_token": 8e-7,
+            "completion_token": 0.0000032
+        }
+    },
+    {
         "model": "o1",
         "cost": {
             "prompt_token": 0.000015,
@@ -1167,6 +1818,48 @@
             "prompt_token": 0.0000011,
             "completion_token": 0.0000044,
             "cache_read_token": 2.75e-7
+        }
+    },
+    {
+        "model": "phi-3-medium-128k-instruct",
+        "cost": {
+            "prompt_token": 0.000001,
+            "completion_token": 0.000001
+        }
+    },
+    {
+        "model": "phi-3-mini-128k-instruct",
+        "cost": {
+            "prompt_token": 1e-7,
+            "completion_token": 1e-7
+        }
+    },
+    {
+        "model": "phi-3.5-mini-128k-instruct",
+        "cost": {
+            "prompt_token": 1e-7,
+            "completion_token": 1e-7
+        }
+    },
+    {
+        "model": "phi-4",
+        "cost": {
+            "prompt_token": 6e-8,
+            "completion_token": 1.4e-7
+        }
+    },
+    {
+        "model": "phi-4-multimodal-instruct",
+        "cost": {
+            "prompt_token": 5e-8,
+            "completion_token": 1e-7
+        }
+    },
+    {
+        "model": "phi-4-reasoning-plus",
+        "cost": {
+            "prompt_token": 7e-8,
+            "completion_token": 3.5e-7
         }
     },
     {
@@ -1404,10 +2097,31 @@
         }
     },
     {
+        "model": "qwerky-72b:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
         "model": "qwq-32b",
         "cost": {
             "prompt_token": 7.5e-8,
             "completion_token": 1.5e-7
+        }
+    },
+    {
+        "model": "qwq-32b-arliai-rpr-v1",
+        "cost": {
+            "prompt_token": 1.5e-8,
+            "completion_token": 1.5e-8
+        }
+    },
+    {
+        "model": "qwq-32b-arliai-rpr-v1:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
         }
     },
     {
@@ -1429,6 +2143,76 @@
         "cost": {
             "prompt_token": 0.000002,
             "completion_token": 0.000008
+        }
+    },
+    {
+        "model": "reka-flash-3",
+        "cost": {
+            "prompt_token": 1.3e-8,
+            "completion_token": 1.3e-8
+        }
+    },
+    {
+        "model": "reka-flash-3:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "remm-slerp-l2-13b",
+        "cost": {
+            "prompt_token": 7e-7,
+            "completion_token": 0.000001
+        }
+    },
+    {
+        "model": "rocinante-12b",
+        "cost": {
+            "prompt_token": 2e-7,
+            "completion_token": 5e-7
+        }
+    },
+    {
+        "model": "router",
+        "cost": {
+            "prompt_token": 8.5e-7,
+            "completion_token": 0.0000034
+        }
+    },
+    {
+        "model": "sarvam-m",
+        "cost": {
+            "prompt_token": 2.2e-8,
+            "completion_token": 2.2e-8
+        }
+    },
+    {
+        "model": "sarvam-m:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "shisa-v2-llama3.3-70b",
+        "cost": {
+            "prompt_token": 3e-8,
+            "completion_token": 3e-8
+        }
+    },
+    {
+        "model": "shisa-v2-llama3.3-70b:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "skyfall-36b-v2",
+        "cost": {
+            "prompt_token": 1.512e-8,
+            "completion_token": 1.512e-8
         }
     },
     {
@@ -1464,6 +2248,69 @@
         "cost": {
             "prompt_token": 0.000002,
             "completion_token": 0.000008
+        }
+    },
+    {
+        "model": "sorcererlm-8x22b",
+        "cost": {
+            "prompt_token": 0.0000045,
+            "completion_token": 0.0000045
+        }
+    },
+    {
+        "model": "spotlight",
+        "cost": {
+            "prompt_token": 1.8e-7,
+            "completion_token": 1.8e-7
+        }
+    },
+    {
+        "model": "toppy-m-7b",
+        "cost": {
+            "prompt_token": 8e-7,
+            "completion_token": 0.0000012
+        }
+    },
+    {
+        "model": "ui-tars-1.5-7b",
+        "cost": {
+            "prompt_token": 1e-7,
+            "completion_token": 2e-7
+        }
+    },
+    {
+        "model": "unslopnemo-12b",
+        "cost": {
+            "prompt_token": 4e-7,
+            "completion_token": 4e-7
+        }
+    },
+    {
+        "model": "valkyrie-49b-v1",
+        "cost": {
+            "prompt_token": 6.5e-7,
+            "completion_token": 0.000001
+        }
+    },
+    {
+        "model": "virtuoso-large",
+        "cost": {
+            "prompt_token": 7.5e-7,
+            "completion_token": 0.0000012
+        }
+    },
+    {
+        "model": "weaver",
+        "cost": {
+            "prompt_token": 0.0000015,
+            "completion_token": 0.0000015
+        }
+    },
+    {
+        "model": "wizardlm-2-8x22b",
+        "cost": {
+            "prompt_token": 4.8e-7,
+            "completion_token": 4.8e-7
         }
     }
 ]

--- a/plugin-server/src/ingestion/ai-costs/providers/generated-providers.json
+++ b/plugin-server/src/ingestion/ai-costs/providers/generated-providers.json
@@ -7,48 +7,6 @@
         }
     },
     {
-        "model": "claude-2",
-        "cost": {
-            "prompt_token": 0.000008,
-            "completion_token": 0.000024
-        }
-    },
-    {
-        "model": "claude-2:beta",
-        "cost": {
-            "prompt_token": 0.000008,
-            "completion_token": 0.000024
-        }
-    },
-    {
-        "model": "claude-2.0",
-        "cost": {
-            "prompt_token": 0.000008,
-            "completion_token": 0.000024
-        }
-    },
-    {
-        "model": "claude-2.0:beta",
-        "cost": {
-            "prompt_token": 0.000008,
-            "completion_token": 0.000024
-        }
-    },
-    {
-        "model": "claude-2.1",
-        "cost": {
-            "prompt_token": 0.000008,
-            "completion_token": 0.000024
-        }
-    },
-    {
-        "model": "claude-2.1:beta",
-        "cost": {
-            "prompt_token": 0.000008,
-            "completion_token": 0.000024
-        }
-    },
-    {
         "model": "claude-3-haiku",
         "cost": {
             "prompt_token": 2.5e-7,
@@ -94,15 +52,6 @@
         }
     },
     {
-        "model": "claude-3-sonnet:beta",
-        "cost": {
-            "prompt_token": 0.000003,
-            "completion_token": 0.000015,
-            "cache_read_token": 3e-7,
-            "cache_write_token": 0.00000375
-        }
-    },
-    {
         "model": "claude-3.5-haiku",
         "cost": {
             "prompt_token": 8e-7,
@@ -113,15 +62,6 @@
     },
     {
         "model": "claude-3.5-haiku-20241022",
-        "cost": {
-            "prompt_token": 8e-7,
-            "completion_token": 0.000004,
-            "cache_read_token": 8e-8,
-            "cache_write_token": 0.000001
-        }
-    },
-    {
-        "model": "claude-3.5-haiku-20241022:beta",
         "cost": {
             "prompt_token": 8e-7,
             "completion_token": 0.000004,
@@ -244,8 +184,8 @@
     {
         "model": "command-a",
         "cost": {
-            "prompt_token": 0.0000025,
-            "completion_token": 0.00001
+            "prompt_token": 0.000002,
+            "completion_token": 0.000008
         }
     },
     {
@@ -300,26 +240,19 @@
     {
         "model": "deepseek-chat",
         "cost": {
-            "prompt_token": 3.8e-7,
-            "completion_token": 8.9e-7
+            "prompt_token": 2.72e-7,
+            "completion_token": 2.72e-7
         }
     },
     {
         "model": "deepseek-chat-v3-0324",
         "cost": {
-            "prompt_token": 2.8e-7,
-            "completion_token": 8.8e-7
+            "prompt_token": 2.5e-7,
+            "completion_token": 8.5e-7
         }
     },
     {
         "model": "deepseek-chat-v3-0324:free",
-        "cost": {
-            "prompt_token": 0,
-            "completion_token": 0
-        }
-    },
-    {
-        "model": "deepseek-chat:free",
         "cost": {
             "prompt_token": 0,
             "completion_token": 0
@@ -335,15 +268,15 @@
     {
         "model": "deepseek-r1",
         "cost": {
-            "prompt_token": 4.5e-7,
-            "completion_token": 0.00000215
+            "prompt_token": 4e-7,
+            "completion_token": 0.000002
         }
     },
     {
         "model": "deepseek-r1-0528",
         "cost": {
-            "prompt_token": 5e-7,
-            "completion_token": 0.00000215
+            "prompt_token": 2.72e-7,
+            "completion_token": 2.72e-7
         }
     },
     {
@@ -370,8 +303,8 @@
     {
         "model": "deepseek-r1-distill-llama-70b",
         "cost": {
-            "prompt_token": 1e-7,
-            "completion_token": 4e-7
+            "prompt_token": 5e-8,
+            "completion_token": 5e-8
         }
     },
     {
@@ -431,21 +364,35 @@
         }
     },
     {
-        "model": "deepseek-v3-base:free",
+        "model": "deepseek-v3-base",
         "cost": {
-            "prompt_token": 0,
-            "completion_token": 0
+            "prompt_token": 3.02e-7,
+            "completion_token": 3.02e-7
+        }
+    },
+    {
+        "model": "devstral-medium",
+        "cost": {
+            "prompt_token": 4e-7,
+            "completion_token": 0.000002
         }
     },
     {
         "model": "devstral-small",
         "cost": {
-            "prompt_token": 6e-8,
-            "completion_token": 1.2e-7
+            "prompt_token": 7e-8,
+            "completion_token": 2.8e-7
         }
     },
     {
-        "model": "devstral-small:free",
+        "model": "devstral-small-2505",
+        "cost": {
+            "prompt_token": 3e-8,
+            "completion_token": 3e-8
+        }
+    },
+    {
+        "model": "devstral-small-2505:free",
         "cost": {
             "prompt_token": 0,
             "completion_token": 0
@@ -484,46 +431,21 @@
         }
     },
     {
+        "model": "gemini-2.5-flash-lite",
+        "cost": {
+            "prompt_token": 1e-7,
+            "completion_token": 4e-7,
+            "cache_read_token": 2.5e-8,
+            "cache_write_token": 1.833e-7
+        }
+    },
+    {
         "model": "gemini-2.5-flash-lite-preview-06-17",
         "cost": {
             "prompt_token": 1e-7,
-            "completion_token": 4e-7
-        }
-    },
-    {
-        "model": "gemini-2.5-flash-preview",
-        "cost": {
-            "prompt_token": 1.5e-7,
-            "completion_token": 6e-7,
-            "cache_read_token": 3.75e-8,
-            "cache_write_token": 2.333e-7
-        }
-    },
-    {
-        "model": "gemini-2.5-flash-preview-05-20",
-        "cost": {
-            "prompt_token": 1.5e-7,
-            "completion_token": 6e-7,
-            "cache_read_token": 3.75e-8,
-            "cache_write_token": 2.333e-7
-        }
-    },
-    {
-        "model": "gemini-2.5-flash-preview-05-20:thinking",
-        "cost": {
-            "prompt_token": 1.5e-7,
-            "completion_token": 0.0000035,
-            "cache_read_token": 3.75e-8,
-            "cache_write_token": 2.333e-7
-        }
-    },
-    {
-        "model": "gemini-2.5-flash-preview:thinking",
-        "cost": {
-            "prompt_token": 1.5e-7,
-            "completion_token": 0.0000035,
-            "cache_read_token": 3.75e-8,
-            "cache_write_token": 2.333e-7
+            "completion_token": 4e-7,
+            "cache_read_token": 2.5e-8,
+            "cache_write_token": 1.833e-7
         }
     },
     {
@@ -588,15 +510,15 @@
     {
         "model": "gemma-2-27b-it",
         "cost": {
-            "prompt_token": 8e-7,
-            "completion_token": 8e-7
+            "prompt_token": 6.5e-7,
+            "completion_token": 6.5e-7
         }
     },
     {
         "model": "gemma-2-9b-it",
         "cost": {
-            "prompt_token": 2e-7,
-            "completion_token": 2e-7
+            "prompt_token": 4e-9,
+            "completion_token": 4e-9
         }
     },
     {
@@ -609,8 +531,8 @@
     {
         "model": "gemma-3-12b-it",
         "cost": {
-            "prompt_token": 5e-8,
-            "completion_token": 1e-7
+            "prompt_token": 3e-8,
+            "completion_token": 3e-8
         }
     },
     {
@@ -649,6 +571,13 @@
         }
     },
     {
+        "model": "gemma-3n-e2b-it:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
         "model": "gemma-3n-e4b-it",
         "cost": {
             "prompt_token": 2e-8,
@@ -660,6 +589,13 @@
         "cost": {
             "prompt_token": 0,
             "completion_token": 0
+        }
+    },
+    {
+        "model": "gpt-3.5-turbo",
+        "cost": {
+            "prompt_token": 5e-7,
+            "completion_token": 0.0000015
         }
     },
     {
@@ -740,14 +676,6 @@
             "prompt_token": 1e-7,
             "completion_token": 4e-7,
             "cache_read_token": 2.5e-8
-        }
-    },
-    {
-        "model": "gpt-4.5-preview",
-        "cost": {
-            "prompt_token": 0.000075,
-            "completion_token": 0.00015,
-            "cache_read_token": 0.0000375
         }
     },
     {
@@ -847,6 +775,13 @@
         }
     },
     {
+        "model": "llama-3.1-405b-instruct:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
         "model": "llama-3.1-70b-instruct",
         "cost": {
             "prompt_token": 1e-7,
@@ -856,22 +791,8 @@
     {
         "model": "llama-3.1-8b-instruct",
         "cost": {
-            "prompt_token": 1.6e-8,
+            "prompt_token": 1.5e-8,
             "completion_token": 2e-8
-        }
-    },
-    {
-        "model": "llama-3.1-sonar-large-128k-online",
-        "cost": {
-            "prompt_token": 0.000001,
-            "completion_token": 0.000001
-        }
-    },
-    {
-        "model": "llama-3.1-sonar-small-128k-online",
-        "cost": {
-            "prompt_token": 2e-7,
-            "completion_token": 2e-7
         }
     },
     {
@@ -903,6 +824,13 @@
         }
     },
     {
+        "model": "llama-3.2-3b-instruct:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
         "model": "llama-3.2-90b-vision-instruct",
         "cost": {
             "prompt_token": 0.0000012,
@@ -912,7 +840,7 @@
     {
         "model": "llama-3.3-70b-instruct",
         "cost": {
-            "prompt_token": 3.9e-8,
+            "prompt_token": 3.8e-8,
             "completion_token": 1.2e-7
         }
     },
@@ -931,24 +859,10 @@
         }
     },
     {
-        "model": "llama-4-maverick:free",
-        "cost": {
-            "prompt_token": 0,
-            "completion_token": 0
-        }
-    },
-    {
         "model": "llama-4-scout",
         "cost": {
             "prompt_token": 8e-8,
             "completion_token": 3e-7
-        }
-    },
-    {
-        "model": "llama-4-scout:free",
-        "cost": {
-            "prompt_token": 0,
-            "completion_token": 0
         }
     },
     {
@@ -1073,8 +987,8 @@
     {
         "model": "mistral-nemo",
         "cost": {
-            "prompt_token": 9e-9,
-            "completion_token": 1e-9
+            "prompt_token": 7.5e-9,
+            "completion_token": 5e-8
         }
     },
     {
@@ -1101,8 +1015,8 @@
     {
         "model": "mistral-small-24b-instruct-2501",
         "cost": {
-            "prompt_token": 5e-8,
-            "completion_token": 9e-8
+            "prompt_token": 3e-8,
+            "completion_token": 3e-8
         }
     },
     {
@@ -1115,8 +1029,8 @@
     {
         "model": "mistral-small-3.1-24b-instruct",
         "cost": {
-            "prompt_token": 5e-8,
-            "completion_token": 1e-7
+            "prompt_token": 2.7e-8,
+            "completion_token": 2.7e-8
         }
     },
     {
@@ -1267,6 +1181,247 @@
         "cost": {
             "prompt_token": 0.000002,
             "completion_token": 0.000006
+        }
+    },
+    {
+        "model": "qwen-2-72b-instruct",
+        "cost": {
+            "prompt_token": 9e-7,
+            "completion_token": 9e-7
+        }
+    },
+    {
+        "model": "qwen-2.5-72b-instruct",
+        "cost": {
+            "prompt_token": 1.01e-7,
+            "completion_token": 1.01e-7
+        }
+    },
+    {
+        "model": "qwen-2.5-72b-instruct:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "qwen-2.5-7b-instruct",
+        "cost": {
+            "prompt_token": 4e-8,
+            "completion_token": 1e-7
+        }
+    },
+    {
+        "model": "qwen-2.5-coder-32b-instruct",
+        "cost": {
+            "prompt_token": 6e-8,
+            "completion_token": 1.5e-7
+        }
+    },
+    {
+        "model": "qwen-2.5-coder-32b-instruct:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "qwen-2.5-vl-7b-instruct",
+        "cost": {
+            "prompt_token": 2e-7,
+            "completion_token": 2e-7
+        }
+    },
+    {
+        "model": "qwen-max",
+        "cost": {
+            "prompt_token": 0.0000016,
+            "completion_token": 0.0000064,
+            "cache_read_token": 6.4e-7
+        }
+    },
+    {
+        "model": "qwen-plus",
+        "cost": {
+            "prompt_token": 4e-7,
+            "completion_token": 0.0000012,
+            "cache_read_token": 1.6e-7
+        }
+    },
+    {
+        "model": "qwen-turbo",
+        "cost": {
+            "prompt_token": 5e-8,
+            "completion_token": 2e-7,
+            "cache_read_token": 2e-8
+        }
+    },
+    {
+        "model": "qwen-vl-max",
+        "cost": {
+            "prompt_token": 8e-7,
+            "completion_token": 0.0000032
+        }
+    },
+    {
+        "model": "qwen-vl-plus",
+        "cost": {
+            "prompt_token": 2.1e-7,
+            "completion_token": 6.3e-7
+        }
+    },
+    {
+        "model": "qwen2.5-vl-32b-instruct",
+        "cost": {
+            "prompt_token": 2e-7,
+            "completion_token": 6e-7
+        }
+    },
+    {
+        "model": "qwen2.5-vl-32b-instruct:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "qwen2.5-vl-72b-instruct",
+        "cost": {
+            "prompt_token": 2.5e-7,
+            "completion_token": 7.5e-7
+        }
+    },
+    {
+        "model": "qwen2.5-vl-72b-instruct:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "qwen3-14b",
+        "cost": {
+            "prompt_token": 6e-8,
+            "completion_token": 2.4e-7
+        }
+    },
+    {
+        "model": "qwen3-14b:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "qwen3-235b-a22b",
+        "cost": {
+            "prompt_token": 1.3e-7,
+            "completion_token": 6e-7
+        }
+    },
+    {
+        "model": "qwen3-235b-a22b-2507",
+        "cost": {
+            "prompt_token": 1.2e-7,
+            "completion_token": 5.9e-7
+        }
+    },
+    {
+        "model": "qwen3-235b-a22b-2507:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "qwen3-235b-a22b-thinking-2507",
+        "cost": {
+            "prompt_token": 1.179e-7,
+            "completion_token": 1.179e-7
+        }
+    },
+    {
+        "model": "qwen3-235b-a22b:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "qwen3-30b-a3b",
+        "cost": {
+            "prompt_token": 8e-8,
+            "completion_token": 2.9e-7
+        }
+    },
+    {
+        "model": "qwen3-30b-a3b:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "qwen3-32b",
+        "cost": {
+            "prompt_token": 2.7e-8,
+            "completion_token": 2.7e-8
+        }
+    },
+    {
+        "model": "qwen3-4b:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "qwen3-8b",
+        "cost": {
+            "prompt_token": 3.5e-8,
+            "completion_token": 1.38e-7
+        }
+    },
+    {
+        "model": "qwen3-8b:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "qwen3-coder",
+        "cost": {
+            "prompt_token": 3e-7,
+            "completion_token": 0.0000012
+        }
+    },
+    {
+        "model": "qwen3-coder:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "qwq-32b",
+        "cost": {
+            "prompt_token": 7.5e-8,
+            "completion_token": 1.5e-7
+        }
+    },
+    {
+        "model": "qwq-32b-preview",
+        "cost": {
+            "prompt_token": 2e-7,
+            "completion_token": 2e-7
+        }
+    },
+    {
+        "model": "qwq-32b:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
         }
     },
     {

--- a/plugin-server/src/ingestion/ai-costs/scripts/update-ai-costs.ts
+++ b/plugin-server/src/ingestion/ai-costs/scripts/update-ai-costs.ts
@@ -21,6 +21,7 @@ const supportedProviderList = [
     'cohere',
     'mistralai',
     'meta-llama',
+    'qwen',
 ]
 
 const PATH_TO_PROVIDERS = path.join(__dirname, '../providers')

--- a/plugin-server/src/ingestion/ai-costs/scripts/update-ai-costs.ts
+++ b/plugin-server/src/ingestion/ai-costs/scripts/update-ai-costs.ts
@@ -12,18 +12,6 @@ interface ModelRow {
     }
 }
 
-const supportedProviderList = [
-    'openai',
-    'anthropic',
-    'google',
-    'deepseek',
-    'perplexity',
-    'cohere',
-    'mistralai',
-    'meta-llama',
-    'qwen',
-]
-
 const PATH_TO_PROVIDERS = path.join(__dirname, '../providers')
 
 const main = async () => {
@@ -55,9 +43,7 @@ const main = async () => {
             continue
         }
         const [provider, ...modelParts] = model.id.split('/')
-        if (!supportedProviderList.includes(provider)) {
-            continue
-        }
+
         if (!providerModels.has(provider)) {
             providerModels.set(provider, [])
         }


### PR DESCRIPTION
## Problem

Some AI providers are missing from the cost JSON because they are being filtered out of the OpenRouter API call, when generating the JSON.

This results in some users having a cost of 0 for some models.

## Changes

- Remove the LLM provider filter, and include them all in the costs JSON.
