### PR TITLE
fix(hogql parser): Hogql parser is parsing `order_expr` incorrectly when a `COALESCE` is used in the statement

### DIFF
--- a/posthog/hogql/test/_test_parser.py
+++ b/posthog/hogql/test/_test_parser.py
@@ -1283,6 +1283,24 @@ def parser_test_factory(backend: Literal["python", "cpp"]):
                     end=14,
                 ),
             )
+            self.assertEqual(
+                parse_order_expr("""COALESCE(
+        events.properties
+    ) -- How likely are you to recommend us to a friend? DESC"""),
+                ast.OrderExpr(
+                    expr=ast.Call(
+                        start=0,
+                        end=41,
+                        name="COALESCE",
+                        args=[
+                            ast.Field(chain=["events", "properties"], start=18, end=35),
+                        ],
+                    ),
+                    order="DESC",
+                    start=0,
+                    end=41,
+                ),
+            )
 
         def test_select_order_by(self):
             self.assertEqual(


### PR DESCRIPTION
## Problem

Related to #35342

## Changes

This is a simplified version of the failure case. The parser seems to parse the order incorrectly when a `COALESCE` is used in the order expression. 

I'm still looking for a solution, but the hogql parser is currently way out of my depth so I'm sharing this test case to see if anyone is interested in taking this up. 

