### PR TITLE
feat(web-analytics): add chart display type functionality and UI options

### DIFF
--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsLogic.ts
@@ -13,7 +13,14 @@ import {
     MarketingAnalyticsColumnsSchemaNames,
     CompareFilter,
 } from '~/queries/schema/schema-general'
-import { DataWarehouseSettingsTab, ExternalDataSource, IntervalType, PipelineNodeTab, PipelineStage } from '~/types'
+import {
+    ChartDisplayType,
+    DataWarehouseSettingsTab,
+    ExternalDataSource,
+    IntervalType,
+    PipelineNodeTab,
+    PipelineStage,
+} from '~/types'
 
 import { MARKETING_ANALYTICS_SCHEMA } from '~/queries/schema/schema-general'
 import type { marketingAnalyticsLogicType } from './marketingAnalyticsLogicType'
@@ -29,6 +36,7 @@ import {
 } from './utils'
 import { getDefaultInterval, isValidRelativeOrAbsoluteDate, updateDatesWithInterval } from 'lib/utils'
 import { uuid } from 'lib/utils'
+import { actionToUrl, urlToAction } from 'kea-router'
 
 export type ExternalTable = {
     name: string
@@ -84,6 +92,7 @@ export const marketingAnalyticsLogic = kea<marketingAnalyticsLogicType>([
         }),
         showColumnConfigModal: true,
         hideColumnConfigModal: true,
+        setChartDisplayType: (chartDisplayType: ChartDisplayType) => ({ chartDisplayType }),
     }),
     reducers({
         draftConversionGoal: [
@@ -171,6 +180,13 @@ export const marketingAnalyticsLogic = kea<marketingAnalyticsLogicType>([
             {
                 showColumnConfigModal: () => true,
                 hideColumnConfigModal: () => false,
+            },
+        ],
+        chartDisplayType: [
+            ChartDisplayType.ActionsAreaGraph as ChartDisplayType,
+            persistConfig,
+            {
+                setChartDisplayType: (_, { chartDisplayType }) => chartDisplayType,
             },
         ],
     }),
@@ -325,6 +341,21 @@ export const marketingAnalyticsLogic = kea<marketingAnalyticsLogicType>([
             },
         ],
     }),
+    actionToUrl(({ values }) => ({
+        setChartDisplayType: () => {
+            const searchParams = new URLSearchParams(window.location.search)
+            searchParams.set('chart_display_type', values.chartDisplayType)
+            return [window.location.pathname, searchParams.toString()]
+        },
+    })),
+    urlToAction(({ actions }) => ({
+        '*': (_, searchParams) => {
+            const chartDisplayType = searchParams.chart_display_type as ChartDisplayType | undefined
+            if (chartDisplayType && Object.values(ChartDisplayType).includes(chartDisplayType)) {
+                actions.setChartDisplayType(chartDisplayType)
+            }
+        },
+    })),
     listeners(({ actions }) => ({
         saveDraftConversionGoal: () => {
             // Create a new local conversion goal with new id

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/shared.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/shared.tsx
@@ -1,0 +1,11 @@
+import { IconGraph, IconLineGraph } from '@posthog/icons'
+import { LemonSegmentedButtonOption } from '@posthog/lemon-ui'
+import { IconAreaChart } from 'lib/lemon-ui/icons'
+import { ChartDisplayType } from '~/types'
+
+// Simple mapping for the display mode options and their icons
+export const DISPLAY_MODE_OPTIONS: LemonSegmentedButtonOption<ChartDisplayType>[] = [
+    { value: ChartDisplayType.ActionsLineGraph, icon: <IconLineGraph /> },
+    { value: ChartDisplayType.ActionsAreaGraph, icon: <IconAreaChart /> },
+    { value: ChartDisplayType.ActionsBar, icon: <IconGraph /> },
+]

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -1,5 +1,5 @@
 import { IconChevronDown, IconTrending, IconWarning } from '@posthog/icons'
-import { Link, Tooltip } from '@posthog/lemon-ui'
+import { LemonSegmentedButton, Link, Tooltip } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { getColorVar } from 'lib/colors'
@@ -53,6 +53,7 @@ import { ReplayButton } from '../CrossSellButtons/ReplayButton'
 import { pageReportsLogic } from '../pageReportsLogic'
 import { MarketingAnalyticsTable } from '../tabs/marketing-analytics/frontend/components/MarketingAnalyticsTable/MarketingAnalyticsTable'
 import { marketingAnalyticsLogic } from '../tabs/marketing-analytics/frontend/logic/marketingAnalyticsLogic'
+import { DISPLAY_MODE_OPTIONS } from '../tabs/marketing-analytics/frontend/shared'
 
 export const toUtcOffsetFormat = (value: number): string => {
     if (value === 0) {
@@ -496,17 +497,23 @@ export const MarketingAnalyticsTrendTile = ({
     showIntervalTile,
     insightProps,
 }: QueryWithInsightProps<InsightVizNode> & { showIntervalTile?: boolean }): JSX.Element => {
-    const { setInterval } = useActions(marketingAnalyticsLogic)
-    const { dateFilter } = useValues(marketingAnalyticsLogic)
+    const { setInterval, setChartDisplayType } = useActions(marketingAnalyticsLogic)
+    const { dateFilter, chartDisplayType } = useValues(marketingAnalyticsLogic)
 
     return (
         <div className="border rounded bg-surface-primary flex-1 flex flex-col">
             {showIntervalTile && (
                 <div className="flex flex-row items-center justify-end m-2 mr-4">
-                    <div className="flex flex-row items-center">
+                    <div className="flex flex-row items-center mr-4">
                         <span className="mr-2">Group by</span>
                         <IntervalFilterStandalone interval={dateFilter.interval} onIntervalChange={setInterval} />
                     </div>
+                    <LemonSegmentedButton
+                        value={chartDisplayType}
+                        onChange={setChartDisplayType}
+                        options={DISPLAY_MODE_OPTIONS}
+                        size="small"
+                    />
                 </div>
             )}
             <Query query={query} readOnly={true} context={{ insightProps: { ...insightProps, query } }} />

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -455,6 +455,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 'draftConversionGoal',
                 'compareFilter as marketingCompareFilter',
                 'dateFilter as marketingDateFilter',
+                'chartDisplayType',
             ],
             marketingAnalyticsTableLogic,
             ['query', 'defaultColumns'],
@@ -978,11 +979,17 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
             }),
         ],
         marketingContext: [
-            (s) => [s.createMarketingDataWarehouseNodes, s.marketingCompareFilter, s.marketingDateFilter],
-            (createMarketingDataWarehouseNodes, marketingCompareFilter, marketingDateFilter) => ({
+            (s) => [
+                s.createMarketingDataWarehouseNodes,
+                s.marketingCompareFilter,
+                s.marketingDateFilter,
+                s.chartDisplayType,
+            ],
+            (createMarketingDataWarehouseNodes, marketingCompareFilter, marketingDateFilter, chartDisplayType) => ({
                 createMarketingDataWarehouseNodes,
                 marketingCompareFilter,
                 marketingDateFilter,
+                chartDisplayType,
             }),
         ],
         tiles: [
@@ -1021,8 +1028,12 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 campaignCostsBreakdown,
                 marketingContext
             ): WebAnalyticsTile[] => {
-                const { createMarketingDataWarehouseNodes, marketingCompareFilter, marketingDateFilter } =
-                    marketingContext
+                const {
+                    createMarketingDataWarehouseNodes,
+                    marketingCompareFilter,
+                    marketingDateFilter,
+                    chartDisplayType,
+                } = marketingContext
                 const dateRange = { date_from: dateFrom, date_to: dateTo }
                 const sampling = { enabled: false, forceSamplingRate: { numerator: 1, denominator: 10 } }
 
@@ -1331,7 +1342,6 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                 kind: NodeKind.InsightVizNode,
                                 embedded: true,
                                 hidePersonsModal: true,
-                                hideTooltipOnScroll: true,
                                 source: {
                                     kind: NodeKind.TrendsQuery,
                                     compareFilter: marketingCompareFilter,
@@ -1353,14 +1363,14 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                         date_to: marketingDateFilter.dateTo,
                                     },
                                     trendsFilter: {
-                                        display: ChartDisplayType.ActionsAreaGraph,
+                                        display: chartDisplayType,
                                         aggregationAxisFormat: 'numeric',
                                         aggregationAxisPrefix: '$',
                                     },
                                 },
                             },
                             showIntervalSelect: true,
-                            insightProps: createInsightProps(TileId.MARKETING),
+                            insightProps: createInsightProps(TileId.MARKETING, `${chartDisplayType}`),
                             canOpenInsight: true,
                             canOpenModal: false,
                             docs: {


### PR DESCRIPTION
## Changes

Allowing to select chart display in marketing analytics by:
- adding new state property
- setting it into the url + localStorage


## How did you test this code?
Manually:
<img width="455" height="408" alt="image" src="https://github.com/user-attachments/assets/0c793156-34b6-4850-8d7d-dc86ea459952" />
<img width="379" height="400" alt="image" src="https://github.com/user-attachments/assets/cef4acba-ad52-4514-81f0-f30c9f8d28b3" />
<img width="390" height="394" alt="image" src="https://github.com/user-attachments/assets/29c8cc5f-ec28-4cd7-b2e1-bd312c0616b7" />
