### PR TITLE
fix(max): remove memory_updated from state

### DIFF
--- a/ee/hogai/graph/memory/nodes.py
+++ b/ee/hogai/graph/memory/nodes.py
@@ -408,7 +408,7 @@ class MemoryCollectorNode(MemoryOnboardingShouldRunMixin):
                 config=config,
             )
         except MemoryCollectionCompleted:
-            return PartialAssistantState(memory_updated=len(node_messages) > 0, memory_collection_messages=None)
+            return PartialAssistantState(memory_collection_messages=None)
         return PartialAssistantState(memory_collection_messages=[*node_messages, cast(LangchainAIMessage, response)])
 
     def router(self, state: AssistantState) -> Literal["tools", "next"]:

--- a/ee/hogai/graph/memory/test/test_nodes.py
+++ b/ee/hogai/graph/memory/test/test_nodes.py
@@ -743,7 +743,6 @@ class TestMemoryCollectorNode(ClickhouseTestMixin, BaseTest):
             )
 
             new_state = self.node.run(state, {})
-            self.assertEqual(new_state.memory_updated, True)
             self.assertEqual(new_state.memory_collection_messages, None)
 
     def test_appends_new_message(self):

--- a/ee/hogai/utils/types.py
+++ b/ee/hogai/utils/types.py
@@ -1,7 +1,7 @@
 import uuid
 from collections.abc import Sequence
 from enum import StrEnum
-from typing import Annotated, Literal, Optional, Union, TypeVar
+from typing import Annotated, Literal, Optional, TypeVar, Union
 
 from langchain_core.agents import AgentAction
 from langchain_core.messages import (
@@ -114,90 +114,84 @@ class _SharedAssistantState(BaseState):
     The state of the root node.
     """
 
+    start_id: Optional[str] = Field(default=None)
     """
     The ID of the message from which the conversation started.
     """
-    start_id: Optional[str] = Field(default=None)
+    graph_status: Optional[Literal["resumed", "interrupted", ""]] = Field(default=None)
     """
     Whether the graph was interrupted or resumed.
     """
-    graph_status: Optional[Literal["resumed", "interrupted", ""]] = Field(default=None)
 
-    """
-    Actions taken by the ReAct agent.
-    """
     intermediate_steps: Optional[list[IntermediateStep]] = Field(default=None)
+    """
+    Actions taken by the query planner agent.
+    """
+    plan: Optional[str] = Field(default=None)
     """
     The insight generation plan.
     """
-    plan: Optional[str] = Field(default=None)
 
+    onboarding_question: Optional[str] = Field(default=None)
     """
     A clarifying question asked during the onboarding process.
     """
-    onboarding_question: Optional[str] = Field(default=None)
 
-    """
-    Whether the memory was updated in the `MemoryCollectorNode`.
-    """
-    memory_updated: Optional[bool] = Field(default=None)
+    memory_collection_messages: Optional[Sequence[LangchainBaseMessage]] = Field(default=None)
     """
     The messages with tool calls to collect memory in the `MemoryCollectorToolsNode`.
     """
-    memory_collection_messages: Optional[Sequence[LangchainBaseMessage]] = Field(default=None)
 
+    root_conversation_start_id: Optional[str] = Field(default=None)
     """
     The ID of the message to start from to keep the message window short enough.
     """
-    root_conversation_start_id: Optional[str] = Field(default=None)
+    root_tool_call_id: Optional[str] = Field(default=None)
     """
     The ID of the tool call from the root node.
     """
-    root_tool_call_id: Optional[str] = Field(default=None)
+    root_tool_insight_plan: Optional[str] = Field(default=None)
     """
     The insight plan to generate.
     """
-    root_tool_insight_plan: Optional[str] = Field(default=None)
+    root_tool_insight_type: Optional[str] = Field(default=None)
     """
     The type of insight to generate.
     """
-    root_tool_insight_type: Optional[str] = Field(default=None)
+    root_tool_calls_count: Optional[int] = Field(default=None)
     """
     Tracks the number of tool calls made by the root node to terminate the loop.
     """
-    root_tool_calls_count: Optional[int] = Field(default=None)
+    query_planner_previous_response_id: Optional[str] = Field(default=None)
     """
     The ID of the previous OpenAI Responses API response made by the query planner.
     """
-    query_planner_previous_response_id: Optional[str] = Field(default=None)
+    rag_context: Optional[str] = Field(default=None)
     """
     The context for taxonomy agent.
     """
-    rag_context: Optional[str] = Field(default=None)
+    query_generation_retry_count: Annotated[int, merge_retry_counts] = Field(default=0)
     """
     Tracks the number of times the query generation has been retried.
     """
-    query_generation_retry_count: Annotated[int, merge_retry_counts] = Field(default=0)
+    search_insights_query: Optional[str] = Field(default=None)
     """
     The user's search query for finding existing insights.
     """
-    search_insights_query: Optional[str] = Field(default=None)
 
 
 class AssistantState(_SharedAssistantState):
+    messages: Annotated[Sequence[AssistantMessageUnion], add_and_merge_messages] = Field(default=[])
     """
     Messages exposed to the user.
     """
-
-    messages: Annotated[Sequence[AssistantMessageUnion], add_and_merge_messages] = Field(default=[])
 
 
 class PartialAssistantState(_SharedAssistantState):
+    messages: Sequence[AssistantMessageUnion] = Field(default=[])
     """
     Messages exposed to the user.
     """
-
-    messages: Sequence[AssistantMessageUnion] = Field(default=[])
 
 
 class AssistantNodeName(StrEnum):


### PR DESCRIPTION
## Problem

Observed today [this](https://us.posthog.com/project/2/error_tracking/0197d715-9253-77e2-b75c-9facfe361fde?timestamp=2025-07-29%2000:18:06.898000-07:00) exception locally. When state updates with the same keys are complete simultaneously, they must have a reducer function to be properly merged.

## Changes

Remove this field as it is unused.

## How did you test this code?

Unit tests
