### PR TITLE
fix: use only the date part for backup run_keys

### DIFF
--- a/dags/backups.py
+++ b/dags/backups.py
@@ -417,15 +417,15 @@ def prepare_run_config(config: BackupConfig) -> dagster.RunConfig:
 
 
 def run_backup_request(table: str, incremental: bool) -> dagster.RunRequest:
-    timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    timestamp = datetime.now(UTC)
     config = BackupConfig(
         database=settings.CLICKHOUSE_DATABASE,
-        date=timestamp,
+        date=timestamp.strftime("%Y-%m-%dT%H:%M:%SZ"),
         table=table,
         incremental=incremental,
     )
     return dagster.RunRequest(
-        run_key=f"{timestamp}-{table}",
+        run_key=f"{timestamp.strftime('%Y%m%d')}-{table}",
         run_config=prepare_run_config(config),
         tags={
             "backup_type": "incremental" if incremental else "full",


### PR DESCRIPTION
## Problem

We have two Dagster+ agents. One of them was initialized wrongly. There is an issue that, for some reason, the agents could not register properly the ticks from the schedule, so they were in an infinite loop trying to run the same job every minute.

## Changes

While this does not solve the problem (seems to be Dagster+ related somehow), at least the schedule won't create a new run every minute. At most, it will create one run per day.


