### PR TITLE
chore(data-modeling): Add a 10min timeout to modeling queries

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -376,7 +376,6 @@ posthog/temporal/data_imports/sources/postgres/postgres.py:0: error: No overload
 posthog/temporal/data_modeling/run_workflow.py:0: error: Need type annotation for "matching_paths" (hint: "matching_paths: list[<type>] = ...")  [var-annotated]
 posthog/temporal/data_modeling/run_workflow.py:0: error: Too many arguments  [call-arg]
 posthog/temporal/data_modeling/run_workflow.py:0: error: Too many arguments  [call-arg]
-posthog/temporal/data_modeling/run_workflow.py:0: error: Value of type variable "_T_AST" of function cannot be "SelectQuery | SelectSetQuery | None"  [type-var]
 posthog/temporal/tests/common/test_error_tracking.py:0: error: Incompatible types in assignment (expression has type "OptionallyFailingInputs", variable has type "OptionallyFailingInputsWithPropertiesToLog")  [assignment]
 posthog/temporal/tests/data_imports/conftest.py:0: error: Incompatible types in assignment (expression has type "ExternalDataJob | None", variable has type "ExternalDataJob")  [assignment]
 posthog/temporal/tests/data_imports/test_end_to_end.py:0: error: Incompatible types in assignment (expression has type "ExternalDataJob | None", variable has type "ExternalDataJob")  [assignment]


### PR DESCRIPTION
## Problem
- Materialization queries currently have an unlimited query execution timeout - this is causing issues with super duper long queries
- See this - https://posthog.slack.com/archives/C019RAX2XBN/p1753433815851269

## Changes
- Add a 10min timeout for query execution 
