### PR TITLE
fix(experiments): show details view when single primary metric

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/Metrics.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/Metrics.tsx
@@ -111,24 +111,20 @@ export function Metrics({ isSecondary }: { isSecondary?: boolean }): JSX.Element
                                 isSecondary={!!isSecondary}
                                 getInsightType={getInsightType}
                             />
-                            {metrics.length === 1 &&
-                                results[0] &&
-                                hasMinimumExposureForResults &&
-                                !isSecondary &&
-                                !useNewMetricsTable && (
-                                    <div className="mt-4">
-                                        <ResultDetails
-                                            metric={metrics[0] as ExperimentMetric}
-                                            result={{
-                                                ...results[0],
-                                                metric: metrics[0] as ExperimentMetric,
-                                            }}
-                                            experiment={experiment}
-                                            metricIndex={0}
-                                            isSecondary={!!isSecondary}
-                                        />
-                                    </div>
-                                )}
+                            {metrics.length === 1 && results[0] && hasMinimumExposureForResults && !isSecondary && (
+                                <div className="mt-4">
+                                    <ResultDetails
+                                        metric={metrics[0] as ExperimentMetric}
+                                        result={{
+                                            ...results[0],
+                                            metric: metrics[0] as ExperimentMetric,
+                                        }}
+                                        experiment={experiment}
+                                        metricIndex={0}
+                                        isSecondary={!!isSecondary}
+                                    />
+                                </div>
+                            )}
                         </>
                     ) : (
                         <div className="w-full overflow-x-auto">


### PR DESCRIPTION
## Problem
Users liked to see the details view when there is only a single primary metric

## Changes
Change the condition such that we show the details view also for the new metrics table.
<img width="1588" height="986" alt="Screenshot 2025-07-29 at 11 33 54" src="https://github.com/user-attachments/assets/344c05f1-db41-45b5-9647-896f5b253d98" />

## How did you test this code?
* 👀 
