### PR TITLE
fix(data-warehouse): Fix syncing stripe invoice items

### DIFF
--- a/posthog/temporal/data_imports/sources/stripe/stripe.py
+++ b/posthog/temporal/data_imports/sources/stripe/stripe.py
@@ -90,14 +90,14 @@ def stripe_source(
         # check for any objects less than the minimum object we already have
         if db_incremental_field_earliest_value is not None:
             logger.debug(
-                f"Stripe: iterating earliest objects from resource: {incremental_field_name}[lt] = {db_incremental_field_earliest_value}"
+                f"Stripe: iterating earliest objects from resource: created[lt] = {db_incremental_field_earliest_value}"
             )
 
             stripe_objects = resource.method(
                 params={
                     **default_params,
                     **resource.params,
-                    f"{incremental_field_name}[lt]": db_incremental_field_earliest_value,
+                    f"created[lt]": db_incremental_field_earliest_value,
                 }
             )
             yield from stripe_objects.auto_paging_iter()
@@ -105,14 +105,14 @@ def stripe_source(
         # check for any objects more than the maximum object we already have
         if db_incremental_field_last_value is not None:
             logger.debug(
-                f"Stripe: iterating latest objects from resource: {incremental_field_name}[gt] = {db_incremental_field_last_value}"
+                f"Stripe: iterating latest objects from resource: created[gt] = {db_incremental_field_last_value}"
             )
 
             stripe_objects = resource.method(
                 params={
                     **default_params,
                     **resource.params,
-                    f"{incremental_field_name}[gt]": db_incremental_field_last_value,
+                    f"created[gt]": db_incremental_field_last_value,
                 }
             )
             for obj in stripe_objects.auto_paging_iter():

--- a/posthog/warehouse/models/external_table_definitions.py
+++ b/posthog/warehouse/models/external_table_definitions.py
@@ -625,20 +625,6 @@ external_tables: dict[str, dict[str, DatabaseField]] = {
         "id": StringDatabaseField(name="id"),
         "object": StringDatabaseField(name="object"),
         "amount": IntegerDatabaseField(name="amount"),
-        "__created": IntegerDatabaseField(name="created", hidden=True),
-        "created_at": ast.ExpressionField(
-            isolate_scope=True,
-            expr=ast.Call(
-                name="toDateTime",
-                args=[
-                    ast.Call(
-                        name="toString",
-                        args=[ast.Field(chain=["__created"])],
-                    )
-                ],
-            ),
-            name="created_at",
-        ),
         "currency": StringDatabaseField(name="currency"),
         "customer_id": StringDatabaseField(name="customer"),
         "__date": IntegerDatabaseField(name="date", hidden=True),


### PR DESCRIPTION
## Problem
- Invoice item syncs are breaking because we're trying to query the stripe api with `?date[gt]=...` which is not a supported query param
  - https://docs.stripe.com/api/invoiceitems/list?lang=curl&api-version=2024-09-30.acacia

## Changes
- Use the correct query param (`created` vs `date`)
- Remove `created` as a field from the table definition - this isn't a thing for `InvoiceItems`
