### PR TITLE
fix(devex): wrapping loading skeleton flapping

### DIFF
--- a/frontend/src/lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton.scss
+++ b/frontend/src/lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton.scss
@@ -7,4 +7,14 @@
     );
     background-size: 400% 100%;
     animation: LemonSkeleton__shimmer 2s ease infinite;
+
+    .storybook-test-runner & {
+        background: var(--color-skeleton-dark);
+        animation: none;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        background: var(--color-skeleton-dark);
+        animation: none;
+    }
 }


### PR DESCRIPTION
## Problem
😠 

<img width="670" height="102" alt="image" src="https://github.com/user-attachments/assets/9ccd133a-3967-435e-a6d0-eb719eef02ab" />

## Changes
* stop wrapping loading skeleton animation if storybook test runner/reduce motion

## How did you test this code?
Tested test runner class in some parent,
Tested reduced motion set in apple settings
