### PR TITLE
fix: bin/start --minimal after cassandra & caddy changes

### DIFF
--- a/docker-compose.dev-minimal.yml
+++ b/docker-compose.dev-minimal.yml
@@ -15,12 +15,60 @@ services:
             service: proxy
         ports:
             - 8010:8000
-        depends_on:
-            - capture
-            - feature-flags
         extra_hosts:
             - 'web:host-gateway'
             - 'plugins:host-gateway'
+            - 'capture:host-gateway'
+            - 'replay-capture:host-gateway'
+            - 'feature-flags:host-gateway'
+        environment:
+            CADDYFILE: |
+                http://localhost:8000 {
+                    @replay-capture {
+                        path /s
+                        path /s/*
+                    }
+
+                    @capture {
+                        path /e
+                        path /e/*
+                        path /i/v0/*
+                        path /batch
+                        path /batch*
+                        path /capture
+                        path /capture*
+                    }
+
+                    @flags {
+                        path /flags
+                        path /flags*
+                    }
+
+                    @webhooks {
+                        path /public/webhooks
+                        path /public/webhooks/*
+                    }
+
+                    handle @capture {
+                        reverse_proxy capture:3307
+                    }
+
+                    handle @replay-capture {
+                        reverse_proxy replay-capture:3306
+                    }
+
+                    handle @flags {
+                        reverse_proxy host.docker.internal:3001
+                    }
+
+                    handle @webhooks {
+                        reverse_proxy plugins:6738
+                    }
+
+                    handle {
+                        reverse_proxy web:8000
+                    }
+                }
     db:
         extends:
             file: docker-compose.base.yml
@@ -114,10 +162,3 @@ services:
         depends_on:
             - redis
             - db
-
-    cassandra:
-        extends:
-            file: docker-compose.base.yml
-            service: cassandra
-        ports:
-            - '9042:9042'


### PR DESCRIPTION
## Problem

`bin/start --minimal` broke after some recent changes.

## Changes

copy over recent changes to the full setup such that the minimal config works again.

## How did you test this code?

- Ran the command and verified that the dev env camp up successfully
