### PR TITLE
fix(err): if over PA billing limit, only filter non exceptions

### DIFF
--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -239,7 +239,7 @@ async fn handle_legacy(
         let start_len = events.len();
         // TODO - right now the exception billing limits are applied only in ET's pipeline,
         // we should apply both ET and PA limits here, and remove both types of events as needed.
-        events.retain(|e| e.event != "$exception");
+        events.retain(|e| e.event == "$exception");
         report_dropped_events("over_quota", (start_len - events.len()) as u64);
         if events.is_empty() {
             return Err(CaptureError::BillingLimit);
@@ -387,7 +387,7 @@ async fn handle_common(
         let start_len = events.len();
         // TODO - right now the exception billing limits are applied only in ET's pipeline,
         // we should apply both ET and PA limits here, and remove both types of events as needed.
-        events.retain(|e| e.event != "$exception");
+        events.retain(|e| e.event == "$exception");
         report_dropped_events("over_quota", (start_len - events.len()) as u64);
         if events.is_empty() {
             return Err(CaptureError::BillingLimit);

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -382,9 +382,16 @@ async fn handle_common(
         .is_limited(context.token.as_str())
         .await;
 
+    let mut events = events;
     if billing_limited {
-        report_dropped_events("over_quota", events.len() as u64);
-        return Err(CaptureError::BillingLimit);
+        let start_len = events.len();
+        // TODO - right now the exception billing limits are applied only in ET's pipeline,
+        // we should apply both ET and PA limits here, and remove both types of events as needed.
+        events.retain(|e| e.event != "$exception");
+        report_dropped_events("over_quota", (start_len - events.len()) as u64);
+        if events.is_empty() {
+            return Err(CaptureError::BillingLimit);
+        }
     }
 
     debug!(context=?context, events=?events, "decoded request");

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -237,7 +237,8 @@ async fn handle_legacy(
     let mut events = events;
     if billing_limited {
         let start_len = events.len();
-        // TODO - right now the exception billing limits are applied in ET's pipeline
+        // TODO - right now the exception billing limits are applied only in ET's pipeline,
+        // we should apply both ET and PA limits here, and remove both types of events as needed.
         events.retain(|e| e.event != "$exception");
         report_dropped_events("over_quota", (start_len - events.len()) as u64);
         if events.is_empty() {


### PR DESCRIPTION
We were dropping exceptions for customers due to them hitting their analytics usage limits. The "proper" fix here is for capture to be aware of the exception `QuotaResource`, and apply both limits as needed, but rather than thread a new limiter through the internals immediately (particularly for a service I haven't worked on in a while), we can apply this fix for now, as the ET pipeline applies billing limits itself anyway.

Tagged the ingestion team on review, more context here https://posthog.slack.com/archives/C07RP0HQ63B/p1753783302922149