### PR TITLE
feat: add metrics for S3 session batch writer

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/metrics.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/metrics.ts
@@ -1,4 +1,4 @@
-import { Counter } from 'prom-client'
+import { Counter, Histogram } from 'prom-client'
 
 export class SessionBatchMetrics {
     private static readonly batchesFlushed = new Counter({
@@ -26,6 +26,38 @@ export class SessionBatchMetrics {
         help: 'Number of console logs stored',
     })
 
+    // S3-specific metrics
+    private static readonly s3BatchesStarted = new Counter({
+        name: 'recording_blob_ingestion_v2_s3_batches_started_total',
+        help: 'Number of S3 batch uploads started',
+    })
+
+    private static readonly s3BatchesUploaded = new Counter({
+        name: 'recording_blob_ingestion_v2_s3_batches_uploaded_total',
+        help: 'Number of S3 batch uploads completed successfully',
+    })
+
+    private static readonly s3UploadErrors = new Counter({
+        name: 'recording_blob_ingestion_v2_s3_upload_errors_total',
+        help: 'Number of S3 upload errors',
+    })
+
+    private static readonly s3UploadTimeouts = new Counter({
+        name: 'recording_blob_ingestion_v2_s3_upload_timeouts_total',
+        help: 'Number of S3 upload timeouts',
+    })
+
+    private static readonly s3UploadLatency = new Histogram({
+        name: 'recording_blob_ingestion_v2_s3_upload_latency_seconds',
+        help: 'Time taken to upload batches to S3 in seconds',
+        buckets: [0, 0.1, 0.5, 1, 2, 5, 10, 30, 60, 120, 300],
+    })
+
+    private static readonly s3BytesWritten = new Counter({
+        name: 'recording_blob_ingestion_v2_s3_bytes_written_total',
+        help: 'Total number of bytes written to S3',
+    })
+
     public static incrementBatchesFlushed(): void {
         this.batchesFlushed.inc()
     }
@@ -44,5 +76,30 @@ export class SessionBatchMetrics {
 
     public static incrementConsoleLogsStored(count: number = 1): void {
         this.consoleLogsStored.inc(count)
+    }
+
+    // S3-specific metric methods
+    public static incrementS3BatchesStarted(): void {
+        this.s3BatchesStarted.inc()
+    }
+
+    public static incrementS3BatchesUploaded(): void {
+        this.s3BatchesUploaded.inc()
+    }
+
+    public static incrementS3UploadErrors(): void {
+        this.s3UploadErrors.inc()
+    }
+
+    public static incrementS3UploadTimeouts(): void {
+        this.s3UploadTimeouts.inc()
+    }
+
+    public static observeS3UploadLatency(seconds: number): void {
+        this.s3UploadLatency.observe(seconds)
+    }
+
+    public static incrementS3BytesWritten(bytes: number): void {
+        this.s3BytesWritten.inc(bytes)
     }
 }


### PR DESCRIPTION
## Problem

We don't report S3 metrics in blobby v2, but we want to have them in the dashboards.

## Changes

Adds various metrics for S3 flushing.

## How did you test this code?

Added unit tests.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
