### PR TITLE
fix: disable feature flags, but not /flags

### DIFF
--- a/posthog/templates/surveys/public_survey.html
+++ b/posthog/templates/surveys/public_survey.html
@@ -911,7 +911,7 @@
             capture_heatmaps: false,
             capture_dead_clicks: false,
             capture_exceptions: false,
-            advanced_disable_flags: true,
+            advanced_disable_feature_flags: true,
         };
 
         const distinctID = searchParams.get('distinct_id');


### PR DESCRIPTION
feature flags are not needed, but we still need the `/flags` endpoint call to enable surveys