### PR TITLE
fix: Remove consumer wait for tasks in disconnect

### DIFF
--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -600,14 +600,6 @@ export class KafkaConsumer {
         // Mark as stopping - this will also essentially stop the consumer loop
         this.isStopping = true
 
-        // Wait for background tasks to complete before disconnecting
-        logger.info('🔁', 'waiting_for_background_tasks_before_disconnect', {
-            backgroundTaskCount: this.backgroundTask.length,
-        })
-        await Promise.all(this.backgroundTask)
-
-        logger.info('🔁', 'background_tasks_completed_proceeding_with_disconnect')
-
         // Allow the in progress consumer loop to finish if possible
         if (this.consumerLoop) {
             await this.consumerLoop.catch((error) => {


### PR DESCRIPTION
## Problem

We already wait for the promiseScheduler there's no need to wait for backgroundTasks at the consumer level

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
