### PR TITLE
fix(insights): remove updateData dependency from useEffect hook

### DIFF
--- a/frontend/src/scenes/trends/viz/ActionsPie.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsPie.tsx
@@ -83,7 +83,7 @@ export function ActionsPie({ inSharedMode, showPersonsModal = true, context }: C
         if (indexedResults) {
             updateData()
         }
-    }, [indexedResults, hiddenLegendIndexes, updateData])
+    }, [indexedResults, hiddenLegendIndexes])
 
     let onClick: ((payload: GraphPointPayload) => void) | undefined = undefined
     if (onDataPointClick) {


### PR DESCRIPTION
## Problem

The pre commit hooks introduced a bug in this PR (https://github.com/PostHog/posthog/pull/35759) by automatically adding updateData to the useEffect dependencies. This caused a React issue (`Maximum update depth exceeded.`), which in turn caused the legend tooltips to not show on the pie charts.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Remove `updateData` from useEffect and push without the git hooks applied.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

view an insight that has a pie chart and hover over it to show the legend

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
