### PR TITLE
chore(ingestion): rms infinity from db metrics

### DIFF
--- a/plugin-server/src/utils/db/metrics.ts
+++ b/plugin-server/src/utils/db/metrics.ts
@@ -20,12 +20,12 @@ export const pluginLogEntryCounter = new Counter({
 export const moveDistinctIdsCountHistogram = new Histogram({
     name: 'move_distinct_ids_count',
     help: 'Number of distinct IDs moved in merge operations',
-    buckets: [0, 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, Infinity],
+    buckets: [0, 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000],
 })
 
 export const personPropertiesSizeHistogram = new Histogram({
     name: 'person_properties_size',
     help: 'histogram of compressed person JSONB bytes retrieved in Person DB calls',
     labelNames: ['at'],
-    buckets: [1024, 8192, 65536, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 67108864, Infinity],
+    buckets: [1024, 8192, 65536, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 67108864],
 })


### PR DESCRIPTION
## Problem

Prometheus creates an inf+ bucket by default, so including an Infinity value creates a duplicate.

## Changes

Rms Infinity value in historgram metrics

## How did you test this code?

Haven't tested it, doesn't effect prodcution behaviour, only observability
