### PR TITLE
chore(max): Link to traces from chats

### DIFF
--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -590,6 +590,18 @@ function SuccessActions({ retriable }: { retriable: boolean }): JSX.Element {
                         onClick={() => retryLastMessage()}
                     />
                 )}
+                {(user?.is_staff || location.hostname === 'localhost') && traceId && (
+                    <LemonButton
+                        to={`${
+                            location.hostname !== 'localhost' ? 'https://us.posthog.com/project/2' : ''
+                        }${urls.llmObservabilityTrace(traceId)}`}
+                        icon={<IconEye />}
+                        type="tertiary"
+                        size="xsmall"
+                        tooltip="View trace in LLM observability"
+                        targetBlank
+                    />
+                )}
             </div>
             {feedbackInputStatus !== 'hidden' && (
                 <MessageTemplate type="ai">


### PR DESCRIPTION
## Changes

Adds a link to LLM observability trace from Max chat responses. Only visible to staff users or on localhost for development. Links directly to the trace in LLM observability using the `traceId`.