### PR TITLE
feat(crm): Save columns and ordering to group views

### DIFF
--- a/frontend/src/scenes/groups/groupsListLogic.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.ts
@@ -100,8 +100,20 @@ export const groupsListLogic = kea<groupsListLogicType>([
         setQuery: () => {
             const searchParams: Record<string, string> = {}
 
-            if (values.query.source.kind === NodeKind.GroupsQuery && values.query.source.properties?.length) {
+            if (values.query.source.kind !== NodeKind.GroupsQuery) {
+                return [router.values.location.pathname, searchParams, undefined, { replace: true }]
+            }
+
+            if (values.query.source.properties?.length) {
                 searchParams[`properties_${props.groupTypeIndex}`] = JSON.stringify(values.query.source.properties)
+            }
+
+            if (values.query.source.select?.length) {
+                searchParams[`select_${props.groupTypeIndex}`] = JSON.stringify(values.query.source.select)
+            }
+
+            if (values.query.source.orderBy?.length) {
+                searchParams[`orderBy_${props.groupTypeIndex}`] = JSON.stringify(values.query.source.orderBy)
             }
 
             return [router.values.location.pathname, searchParams, undefined, { replace: true }]
@@ -122,23 +134,35 @@ export const groupsListLogic = kea<groupsListLogicType>([
                 return
             }
 
-            const properties = searchParams[`properties_${props.groupTypeIndex}`]
-            if (properties) {
+            const queryOverrides = {} as Record<string, Array<string> | object>
+            const parseParam = (paramName: string): void => {
+                const rawParam = searchParams[`${paramName}_${props.groupTypeIndex}`]
+                if (!rawParam) {
+                    return
+                }
+
                 try {
-                    const parsedProperties = JSON.parse(properties)
-                    if (parsedProperties && Array.isArray(parsedProperties)) {
-                        actions.setQuery({
-                            ...values.query,
-                            source: {
-                                ...values.query.source,
-                                properties: parsedProperties,
-                                orderBy: values.sorting,
-                            },
-                        })
+                    const parsedParam = JSON.parse(rawParam)
+                    if (parsedParam) {
+                        queryOverrides[paramName] = parsedParam
                     }
                 } catch (error: any) {
-                    posthog.captureException('Failed to parse properties', error)
+                    posthog.captureException('Failed to parse query overrides from URL', error)
                 }
+            }
+
+            parseParam('properties')
+            parseParam('select')
+            parseParam('orderBy')
+
+            if (Object.keys(queryOverrides).length > 0) {
+                actions.setQuery({
+                    ...values.query,
+                    source: {
+                        ...values.query.source,
+                        ...queryOverrides,
+                    },
+                })
             } else {
                 actions.setQuery({
                     ...values.query,


### PR DESCRIPTION
## Problem
Closes https://github.com/PostHog/posthog/issues/35795
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Add/parse `select` and `orderBy` params to/from URL
	- This leads to the URL that's saved as `group view` to also contain these params, resulting in saved views with custom filters, columns and ordering. 
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally in the UI and unit tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
