### PR TITLE
fix(experiments): only show time window input when relevant

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentMetricConversionWindowFilter.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricConversionWindowFilter.tsx
@@ -69,29 +69,31 @@ export function ExperimentMetricConversionWindowFilter({
                         },
                     ]}
                 />
-                <div className="flex items-center gap-2">
+                {metric.conversion_window_unit !== undefined && (
                     <div className="flex items-center gap-2">
-                        <LemonInput
-                            type="number"
-                            className="max-w-20"
-                            fullWidth={false}
-                            min={intervalBounds[0]}
-                            max={intervalBounds[1]}
-                            value={metric.conversion_window_unit === undefined ? 14 : metric.conversion_window || 1}
-                            onChange={(value) => {
-                                handleSetMetric({ ...metric, conversion_window: value || undefined })
-                            }}
-                        />
-                        <LemonSelect
-                            dropdownMatchSelectWidth={false}
-                            value={metric.conversion_window_unit || FunnelConversionWindowTimeUnit.Day}
-                            onChange={(value) =>
-                                handleSetMetric({ ...metric, conversion_window_unit: value || undefined })
-                            }
-                            options={options}
-                        />
+                        <div className="flex items-center gap-2">
+                            <LemonInput
+                                type="number"
+                                className="max-w-20"
+                                fullWidth={false}
+                                min={intervalBounds[0]}
+                                max={intervalBounds[1]}
+                                value={metric.conversion_window || 1}
+                                onChange={(value) => {
+                                    handleSetMetric({ ...metric, conversion_window: value || undefined })
+                                }}
+                            />
+                            <LemonSelect
+                                dropdownMatchSelectWidth={false}
+                                value={metric.conversion_window_unit}
+                                onChange={(value) =>
+                                    handleSetMetric({ ...metric, conversion_window_unit: value || undefined })
+                                }
+                                options={options}
+                            />
+                        </div>
                     </div>
-                </div>
+                )}
             </div>
         </div>
     )


### PR DESCRIPTION
## Changes
Only show the window input field when "Time window" is selected in the experiment metric form since it's irrelevant when "Experiment duration" is selected.

## How did you test this code?
https://www.loom.com/share/f02d85c37cfc440da371a15b1d97f0bd?sid=1f7963f8-be95-4073-8535-69bf4eb0fd59