### PR TITLE
feat(behavioral-cohorts): refactor cohort types into "analytical" and "behavioral"

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1481,6 +1481,7 @@ export interface CohortType {
     }
     experiment_set?: number[]
     _create_in_folder?: string | null
+    cohort_type?: 'analytical' | 'behavioral'
 }
 
 export interface InsightHistory {

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -190,14 +190,16 @@ class CohortSerializer(serializers.ModelSerializer):
     experiment_set: serializers.PrimaryKeyRelatedField = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
 
     # Computed fields for frontend convenience
-    is_behavioral_cohort = serializers.SerializerMethodField()
-    is_analytical_cohort = serializers.SerializerMethodField()
+    has_behavioral_filters = serializers.SerializerMethodField()
+    is_analytical = serializers.SerializerMethodField()
 
-    def get_is_behavioral_cohort(self, obj: Cohort) -> bool:
-        return obj.is_behavioral_cohort
+    def get_has_behavioral_filters(self, obj: Cohort) -> bool:
+        """Returns whether cohort has any behavioral filters"""
+        return obj.has_behavioral_filters
 
-    def get_is_analytical_cohort(self, obj: Cohort) -> bool:
-        return obj.is_analytical_cohort
+    def get_is_analytical(self, obj: Cohort) -> bool:
+        """Returns whether cohort is analytical (requires ClickHouse)"""
+        return obj.is_analytical
 
     class Meta:
         model = Cohort
@@ -217,8 +219,8 @@ class CohortSerializer(serializers.ModelSerializer):
             "count",
             "is_static",
             "cohort_type",
-            "is_behavioral_cohort",
-            "is_analytical_cohort",
+            "has_behavioral_filters",
+            "is_analytical",
             "experiment_set",
             "_create_in_folder",
         ]
@@ -231,8 +233,8 @@ class CohortSerializer(serializers.ModelSerializer):
             "errors_calculating",
             "count",
             "cohort_type",
-            "is_behavioral_cohort",
-            "is_analytical_cohort",
+            "has_behavioral_filters",
+            "is_analytical",
             "experiment_set",
         ]
 

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -333,10 +333,10 @@ class FeatureFlagSerializer(
                         )
                         dependent_cohorts = get_dependent_cohorts(initial_cohort)
                         for cohort in [initial_cohort, *dependent_cohorts]:
-                            # Check cohort type - only behavioral cohorts allowed in feature flags
-                            if cohort.cohort_type == "analytical":
+                            # Check cohort type - only real-time compatible cohorts allowed in feature flags
+                            if not cohort.can_be_used_in_real_time:
                                 raise serializers.ValidationError(
-                                    detail=f"Analytical cohort '{cohort.name}' cannot be used in feature flags. Real-time evaluation only supports behavioral cohorts.",
+                                    detail=f"Cohort '{cohort.name}' (type: {cohort.cohort_type}) cannot be used in feature flags. Only static, person_properties, and behavioral cohorts are supported for real-time evaluation.",
                                     code=ANALYTICAL_COHORT_FOUND_ERROR_CODE,
                                 )
                     except Cohort.DoesNotExist:

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -86,6 +86,7 @@ DATABASE_FOR_LOCAL_EVALUATION = (
 )
 
 BEHAVIOURAL_COHORT_FOUND_ERROR_CODE = "behavioral_cohort_found"
+ANALYTICAL_COHORT_FOUND_ERROR_CODE = "analytical_cohort_found"
 
 MAX_PROPERTY_VALUES = 1000
 
@@ -332,10 +333,11 @@ class FeatureFlagSerializer(
                         )
                         dependent_cohorts = get_dependent_cohorts(initial_cohort)
                         for cohort in [initial_cohort, *dependent_cohorts]:
-                            if [prop for prop in cohort.properties.flat if prop.type == "behavioral"]:
+                            # Check cohort type - only behavioral cohorts allowed in feature flags
+                            if cohort.cohort_type == "analytical":
                                 raise serializers.ValidationError(
-                                    detail=f"Cohort '{cohort.name}' with filters on events cannot be used in feature flags.",
-                                    code=BEHAVIOURAL_COHORT_FOUND_ERROR_CODE,
+                                    detail=f"Analytical cohort '{cohort.name}' cannot be used in feature flags. Only behavioral cohorts are supported for real-time evaluation.",
+                                    code=ANALYTICAL_COHORT_FOUND_ERROR_CODE,
                                 )
                     except Cohort.DoesNotExist:
                         raise serializers.ValidationError(

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -336,7 +336,7 @@ class FeatureFlagSerializer(
                             # Check cohort type - only behavioral cohorts allowed in feature flags
                             if cohort.cohort_type == "analytical":
                                 raise serializers.ValidationError(
-                                    detail=f"Analytical cohort '{cohort.name}' cannot be used in feature flags. Only behavioral cohorts are supported for real-time evaluation.",
+                                    detail=f"Analytical cohort '{cohort.name}' cannot be used in feature flags. Real-time evaluation only supports behavioral cohorts.",
                                     code=ANALYTICAL_COHORT_FOUND_ERROR_CODE,
                                 )
                     except Cohort.DoesNotExist:

--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -2346,15 +2346,15 @@ email@example.org,
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["cohort_type"], "analytical")
 
-    def test_static_cohort_type_is_behavioral(self):
-        """Test that static cohorts are automatically set to behavioral type"""
+    def test_static_cohort_type_is_static(self):
+        """Test that static cohorts are automatically set to static type"""
         response = self.client.post(
             f"/api/projects/{self.team.id}/cohorts", data={"name": "static_cohort", "is_static": True}, format="json"
         )
         self.assertEqual(response.status_code, 201)
 
         data = response.json()
-        self.assertEqual(data["cohort_type"], "behavioral")
+        self.assertEqual(data["cohort_type"], "static")
         self.assertFalse(data["has_behavioral_filters"])  # No behavioral filters
         self.assertFalse(data["is_analytical"])  # Not analytical
 

--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -2242,11 +2242,11 @@ email@example.org,
 
         data = response.json()
         self.assertIn("cohort_type", data)
-        self.assertIn("is_behavioral_cohort", data)
-        self.assertIn("is_analytical_cohort", data)
+        self.assertIn("has_behavioral_filters", data)
+        self.assertIn("is_analytical", data)
         self.assertEqual(data["cohort_type"], "behavioral")
-        self.assertTrue(data["is_behavioral_cohort"])
-        self.assertFalse(data["is_analytical_cohort"])
+        self.assertTrue(data["has_behavioral_filters"])
+        self.assertFalse(data["is_analytical"])
 
     def test_cohort_type_auto_updated_on_create(self):
         """Test that cohort type is automatically set on creation"""
@@ -2280,8 +2280,11 @@ email@example.org,
 
         data = response.json()
         self.assertEqual(data["cohort_type"], "analytical")
-        self.assertTrue(data["is_behavioral_cohort"])
-        self.assertTrue(data["is_analytical_cohort"])
+        # Complex behavioral filters result in both flags being true:
+        # - has_behavioral_filters=True because it has behavioral filters
+        # - is_analytical=True because it's an analytical cohort (requires ClickHouse)
+        self.assertTrue(data["has_behavioral_filters"])  # Has behavioral filters
+        self.assertTrue(data["is_analytical"])  # Is analytical cohort
 
     def test_cohort_type_auto_updated_on_update(self):
         """Test that cohort type is automatically updated when filters change"""
@@ -2352,8 +2355,8 @@ email@example.org,
 
         data = response.json()
         self.assertEqual(data["cohort_type"], "behavioral")
-        self.assertFalse(data["is_behavioral_cohort"])  # No behavioral filters
-        self.assertFalse(data["is_analytical_cohort"])  # No complex behavioral filters
+        self.assertFalse(data["has_behavioral_filters"])  # No behavioral filters
+        self.assertFalse(data["is_analytical"])  # Not analytical
 
     def test_cohort_type_read_only_in_api(self):
         """Test that cohort_type cannot be directly set via API"""

--- a/posthog/migrations/0810_add_cohort_type.py
+++ b/posthog/migrations/0810_add_cohort_type.py
@@ -1,0 +1,54 @@
+# Generated manually for adding cohort_type field
+
+from django.db import migrations, models
+
+
+def set_initial_cohort_types(apps, schema_editor):
+    """
+    Set initial cohort types based on existing cohort filters.
+    All existing cohorts will start as 'analytical' for backward compatibility.
+    """
+    Cohort = apps.get_model("posthog", "Cohort")
+
+    # Process cohorts in batches to avoid memory issues
+    batch_size = 1000
+    processed = 0
+
+    while True:
+        cohorts = list(Cohort.objects.filter(deleted=False)[processed : processed + batch_size])
+
+        if not cohorts:
+            break
+
+        for cohort in cohorts:
+            # All existing cohorts start as analytical to maintain backward compatibility
+            # This ensures no breaking changes for existing feature flags
+            cohort.cohort_type = "analytical"
+
+        Cohort.objects.bulk_update(cohorts, ["cohort_type"], batch_size=batch_size)
+        processed += len(cohorts)
+
+
+def reverse_cohort_types(apps, schema_editor):
+    """Reverse migration - nothing to do as field will be removed"""
+    pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "0809_insight_query_metadata"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="cohort",
+            name="cohort_type",
+            field=models.CharField(
+                choices=[("analytical", "Analytical"), ("behavioral", "Behavioral")],
+                default="analytical",
+                help_text="Determines where this cohort can be used. Analytical cohorts are for analytics only, behavioral cohorts can be used in real-time features.",
+                max_length=20,
+            ),
+        ),
+        migrations.RunPython(set_initial_cohort_types, reverse_cohort_types),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0809_insight_query_metadata
+0810_add_cohort_type


### PR DESCRIPTION
## Problem

  We're implementing support for real-time behavioral filtering in cohorts as outlined in the RFC. We need to distinguish between:

  - **Analytical Cohorts**: Traditional cohorts for analytics only, supporting full ClickHouse features including complex lifecycle filters
  - **Behavioral Cohorts**: Optimized for real-time evaluation in feature flags, CDP, and messaging, with a focused feature set

  This enables real-time cohort evaluation while maintaining backward compatibility.

  ## Changes

  **1. Added `cohort_type` field to Cohort model**
  - CharField with choices: `'analytical'` (default) and `'behavioral'`
  - Auto-classification logic based on filter complexity
  - Migration sets all existing cohorts to 'analytical' for backward compatibility

  **2. Updated feature flag validation**
  - Blocks analytical cohorts from feature flags with new error code `ANALYTICAL_COHORT_FOUND_ERROR_CODE`
  - Allows behavioral cohorts for real-time evaluation

  **3. Enhanced cohort API**
  - Added `cohort_type`, `is_behavioral_cohort`, `is_analytical_cohort` fields to serializer
  - Made `cohort_type` read-only (auto-determined)
  - Auto-updates cohort type when filters change

  **4. Updated TypeScript types**
  - Added `cohort_type?: 'analytical' | 'behavioral'` to `CohortType` interface

  ## How did you test this code?

  **Automated Tests (13 new tests):**
  - Model tests: cohort type classification scenarios (static, behavioral, analytical, mixed filters)
  - API tests: serializer behavior, auto-update on create/update, read-only enforcement
  - Feature flag tests: analytical cohorts blocked, behavioral cohorts allowed

  **Manual Testing:**
  - Migration applies correctly and maintains backward compatibility
  - Cohort creation auto-classifies based on filter types
  - Feature flag validation works with appropriate error messages

  **Key Test Cases:**
  - ✅ Static cohorts → behavioral type
  - ✅ Simple behavioral filters → behavioral type
  - ✅ Complex behavioral filters → analytical type
  - ✅ Auto-update when filters change
  - ✅ Feature flag validation blocks analytical cohorts