### PR TITLE
fix: comment form state

### DIFF
--- a/frontend/src/scenes/session-recordings/player/commenting/PlayerFrameCommentOverlay.tsx
+++ b/frontend/src/scenes/session-recordings/player/commenting/PlayerFrameCommentOverlay.tsx
@@ -14,7 +14,8 @@ const PlayerFrameCommentOverlayContent = (): JSX.Element | null => {
     } = useValues(sessionRecordingPlayerLogic)
     const { setIsCommenting } = useActions(sessionRecordingPlayerLogic)
 
-    const theBuiltOverlayLogic = playerCommentOverlayLogic({ recordingId: sessionRecordingId, ...logicProps })
+    const playerCommentOverlayLogicProps = { recordingId: sessionRecordingId, ...logicProps }
+    const theBuiltOverlayLogic = playerCommentOverlayLogic(playerCommentOverlayLogicProps)
     const { recordingComment, isRecordingCommentSubmitting } = useValues(theBuiltOverlayLogic)
     const { submitRecordingComment, resetRecordingComment } = useActions(theBuiltOverlayLogic)
 
@@ -23,6 +24,7 @@ const PlayerFrameCommentOverlayContent = (): JSX.Element | null => {
             <div className="flex flex-col bg-primary border border-border rounded p-2 shadow-lg">
                 <Form
                     logic={playerCommentOverlayLogic}
+                    props={playerCommentOverlayLogicProps}
                     formKey="recordingComment"
                     id="recording-comment-form"
                     enableFormOnSubmit

--- a/frontend/src/scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic.ts
@@ -1,4 +1,4 @@
-import { actions, connect, kea, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
 import { subscriptions } from 'kea-subscriptions'
 import api from 'lib/api'
@@ -32,6 +32,7 @@ export interface PlayerCommentOverlayLogicProps extends SessionRecordingPlayerLo
 
 export const playerCommentOverlayLogic = kea<playerCommentOverlayLogicType>([
     path(['scenes', 'session-recordings', 'player', 'PlayerFrameAnnotationOverlay']),
+    key((props) => props.recordingId ?? 'unknown'),
     props({} as PlayerCommentOverlayLogicProps),
     connect((props: PlayerCommentOverlayLogicProps) => ({
         values: [sessionRecordingPlayerLogic(props), ['currentPlayerTime', 'currentTimestamp', 'sessionPlayerData']],

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -823,7 +823,9 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 // and we need a short wait until the logic is mounted after calling setIsCommenting
                 const waitForLogic = async (): Promise<BuiltLogic<playerCommentOverlayLogicType> | null> => {
                     for (let attempts = 0; attempts < 5; attempts++) {
-                        const theMountedLogic = playerCommentOverlayLogic.findMounted()
+                        const theMountedLogic = playerCommentOverlayLogic.findMounted({
+                            recordingId: props.sessionRecordingId,
+                        })
                         if (theMountedLogic) {
                             return theMountedLogic
                         }

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -825,6 +825,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                     for (let attempts = 0; attempts < 5; attempts++) {
                         const theMountedLogic = playerCommentOverlayLogic.findMounted({
                             recordingId: props.sessionRecordingId,
+                            ...props,
                         })
                         if (theMountedLogic) {
                             return theMountedLogic


### PR DESCRIPTION
fixes: https://posthoghelp.zendesk.com/agent/tickets/34778 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/36770)

the user observed that as they were jumping between recordings the comments would end up on the wrong recording

i believe it's because I hadn't keyed the logic and so we were sharing an instance and using `findMounted` would not give me what was expected

at worst this won't break it more 🙈 