### PR TITLE
feat: show exact timestamp of important dates

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -657,6 +657,13 @@ export function humanFriendlyDetailedTime(
     return parsedDate.format(formatString)
 }
 
+export function detailedTime(date: dayjs.Dayjs | string | null | undefined): string {
+    if (!date) {
+        return ''
+    }
+    return dayjs(date).format('MMMM DD, YYYY h:mm:ss A')
+}
+
 // Pad numbers with leading zeros
 export const zeroPad = (num: number, places: number): string => String(num).padStart(places, '0')
 

--- a/frontend/src/scenes/settings/user/PersonalAPIKeys.tsx
+++ b/frontend/src/scenes/settings/user/PersonalAPIKeys.tsx
@@ -21,7 +21,7 @@ import { IconErrorOutline } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { API_KEY_SCOPE_PRESETS, API_SCOPES, MAX_API_KEYS_PER_USER } from 'lib/scopes'
-import { capitalizeFirstLetter, humanFriendlyDetailedTime } from 'lib/utils'
+import { capitalizeFirstLetter, detailedTime, humanFriendlyDetailedTime } from 'lib/utils'
 import { Fragment, useEffect } from 'react'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
@@ -452,19 +452,37 @@ function PersonalAPIKeysTable(): JSX.Element {
                     title: 'Last Used',
                     dataIndex: 'last_used_at',
                     key: 'lastUsedAt',
-                    render: (_, key) => humanFriendlyDetailedTime(key.last_used_at, 'MMMM DD, YYYY', 'h A'),
+                    render: (_, key) => {
+                        return (
+                            <Tooltip title={detailedTime(key.last_used_at)} placement="bottom">
+                                {humanFriendlyDetailedTime(key.last_used_at, 'MMMM DD, YYYY', 'h A')}
+                            </Tooltip>
+                        )
+                    },
                 },
                 {
                     title: 'Created',
                     dataIndex: 'created_at',
                     key: 'createdAt',
-                    render: (_, key) => humanFriendlyDetailedTime(key.created_at),
+                    render: (_, key) => {
+                        return (
+                            <Tooltip title={detailedTime(key.created_at)} placement="bottom">
+                                {humanFriendlyDetailedTime(key.created_at)}
+                            </Tooltip>
+                        )
+                    },
                 },
                 {
                     title: 'Last Rolled',
                     dataIndex: 'last_rolled_at',
                     key: 'lastRolledAt',
-                    render: (_, key) => humanFriendlyDetailedTime(key.last_rolled_at, 'MMMM DD, YYYY', 'h A'),
+                    render: (_, key) => {
+                        return (
+                            <Tooltip title={detailedTime(key.last_rolled_at)} placement="bottom">
+                                {humanFriendlyDetailedTime(key.last_rolled_at, 'MMMM DD, YYYY', 'h A')}
+                            </Tooltip>
+                        )
+                    },
                 },
                 {
                     title: '',

--- a/frontend/src/scenes/settings/user/UserDangerZone.tsx
+++ b/frontend/src/scenes/settings/user/UserDangerZone.tsx
@@ -1,9 +1,9 @@
 import { IconTrash } from '@posthog/icons'
-import { LemonButton, LemonDialog, LemonInput, LemonModal, LemonTable, LemonTag } from '@posthog/lemon-ui'
+import { LemonButton, LemonDialog, LemonInput, LemonModal, LemonTable, LemonTag, Tooltip } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { OrganizationMembershipLevel } from 'lib/constants'
-import { humanFriendlyDetailedTime, isNotNil } from 'lib/utils'
+import { detailedTime, humanFriendlyDetailedTime, isNotNil } from 'lib/utils'
 import { useEffect } from 'react'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
@@ -34,7 +34,7 @@ export function DeleteUserModal({
 
     useEffect(() => {
         loadKeys()
-    }, [])
+    }, [loadKeys])
 
     return (
         <>
@@ -174,8 +174,17 @@ export function DeleteUserModal({
                                             title: 'Last Used',
                                             dataIndex: 'last_used_at',
                                             key: 'lastUsedAt',
-                                            render: (_, key) =>
-                                                humanFriendlyDetailedTime(key.last_used_at, 'MMMM DD, YYYY', 'h A'),
+                                            render: (_, key) => {
+                                                return (
+                                                    <Tooltip title={detailedTime(key.last_used_at)} placement="bottom">
+                                                        {humanFriendlyDetailedTime(
+                                                            key.last_used_at,
+                                                            'MMMM DD, YYYY',
+                                                            'h A'
+                                                        )}
+                                                    </Tooltip>
+                                                )
+                                            },
                                         },
                                         {
                                             title: 'Scopes',


### PR DESCRIPTION
For particularly important operations, like when a key was last used, it's useful to always be able to see an absolute timestamp.

<img width="1336" height="289" alt="Screenshot 2025-07-29 at 15 06 44" src="https://github.com/user-attachments/assets/4001c868-e5dc-42ad-9977-74814d168ae5" />
