### PR TITLE
chore(capture-rs): add /batch/ endpoint to mirror deploy scoped special casing

### DIFF
--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -152,25 +152,39 @@ pub fn router<
         )
         .layer(DefaultBodyLimit::max(BATCH_BODY_SIZE));
 
-    let batch_router = Router::new()
-        .route(
-            "/batch",
-            post(v0_endpoint::event)
-                .get(v0_endpoint::event)
-                .options(v0_endpoint::options),
-        )
-        .route(
-            "/batch/",
-            post(v0_endpoint::event)
-                .get(v0_endpoint::event)
-                .options(v0_endpoint::options),
-        )
-        .layer(DefaultBodyLimit::max(BATCH_BODY_SIZE)); // Have to use this, rather than RequestBodyLimitLayer, because we use `Bytes` in the handler (this limit applies specifically to Bytes body types)
+    let mut batch_router = Router::new();
+    batch_router = if is_mirror_deploy {
+        batch_router
+            .route(
+                "/batch",
+                post(v0_endpoint::event_legacy)
+                    .get(v0_endpoint::event)
+                    .options(v0_endpoint::options),
+            )
+            .route(
+                "/batch/",
+                post(v0_endpoint::event_legacy)
+                    .get(v0_endpoint::event)
+                    .options(v0_endpoint::options),
+            )
+    } else {
+        batch_router
+            .route(
+                "/batch",
+                post(v0_endpoint::event)
+                    .get(v0_endpoint::event)
+                    .options(v0_endpoint::options),
+            )
+            .route(
+                "/batch/",
+                post(v0_endpoint::event)
+                    .get(v0_endpoint::event)
+                    .options(v0_endpoint::options),
+            )
+    };
+    batch_router = batch_router.layer(DefaultBodyLimit::max(BATCH_BODY_SIZE)); // Have to use this, rather than RequestBodyLimitLayer, because we use `Bytes` in the handler (this limit applies specifically to Bytes body types)
 
     let mut event_router = Router::new()
-        // only full /i/v0/e/ is supported; send these to default handler
-        .route("/i/v0", get(index))
-        .route("/i/v0/", get(index))
         // legacy endpoints registered here
         .route(
             "/e",


### PR DESCRIPTION
## Problem
We want to test migrating the `/i/v0/e` and `/batch/` capture endpoints to be handled by the legacy event processing codepath. If successful, we can eliminate the original "new capture" handling from `capture-rs` and unify `CaptureMode::Events` processing to rely only on the "legacy" codepath.

As the new integration test suite illustrates, the "legacy" processing is a superset of the original codepath's payload support capabilities but identical once request payload is extracted and events are hydrated.

## Changes
* Add `/batch/` endpoint to the special-cased routing applied only in `capture-mirrored` deployments
* Process both `/i/v0/e/` and `/batch/` endpoints with legacy handlers in mirror deploy testing
* Prereq for shipping the corresponding deploy-enablement PR 

## How did you test this code?
Locally and in CI, but this is low-risk either way - we've shipped a lot of these conditional routing changes previously during legacy endpoint support rollout