### PR TITLE
fix: plugin id casing

### DIFF
--- a/posthog/plugins/plugin_server_api.py
+++ b/posthog/plugins/plugin_server_api.py
@@ -54,7 +54,7 @@ def reload_integrations_on_workers(team_id: int, integration_ids: list[int]):
 
 def populate_plugin_capabilities_on_workers(plugin_id: str):
     logger.info(f"Populating plugin capabilities for plugin {plugin_id} on workers")
-    publish_message("populate-plugin-capabilities", {"plugin_id": plugin_id})
+    publish_message("populate-plugin-capabilities", {"pluginId": plugin_id})
 
 
 def create_hog_invocation_test(team_id: int, hog_function_id: str, payload: dict) -> requests.Response:


### PR DESCRIPTION
this casing difference was causing my self hosted instance to be unable to start the plugin server

tested this fix on that instance and it can start and then ingest events 

(no idea if it's desirable or why it fails in self hosted not elsewhere 🙈)

see: https://posthog.slack.com/archives/C06GG249PR6/p1753819386864169