### PR TITLE
fix: Return plain prefix if containing invalid variables

### DIFF
--- a/posthog/temporal/tests/conftest.py
+++ b/posthog/temporal/tests/conftest.py
@@ -10,8 +10,8 @@ from django.conf import settings
 from psycopg import sql
 from temporalio.testing import ActivityEnvironment
 
-from posthog.otel_instrumentation import initialize_otel
 from posthog.models import Organization, Team
+from posthog.otel_instrumentation import initialize_otel
 from posthog.temporal.common.clickhouse import ClickHouseClient
 from posthog.temporal.common.client import connect
 
@@ -150,10 +150,7 @@ async def temporal_worker(temporal_client, workflows, activities):
 
 @pytest.fixture(scope="session")
 def event_loop():
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        loop = asyncio.new_event_loop()
+    loop = asyncio.new_event_loop()
     yield loop
     loop.close()
 

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -148,7 +148,9 @@ def get_s3_key_prefix(inputs: S3InsertInputs) -> str:
     try:
         return inputs.prefix.format(**template_variables)
     except KeyError as e:
-        EXTERNAL_LOGGER.warning(f"The key prefix '{inputs.prefix}' contains invalid template variables: {str(e)}")
+        EXTERNAL_LOGGER.warning(
+            f"The key prefix '{inputs.prefix}' will be used as-is since it contains invalid template variables: {str(e)}"
+        )
         return inputs.prefix
 
 

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -127,7 +127,7 @@ class S3InsertInputs(BatchExportInsertInputs):
     use_virtual_style_addressing: bool = False
 
 
-def get_allowed_template_variables(inputs) -> dict[str, str]:
+def get_allowed_template_variables(inputs: S3InsertInputs) -> dict[str, str]:
     """Derive from inputs a dictionary of supported template variables for the S3 key prefix."""
     export_datetime = dt.datetime.fromisoformat(inputs.data_interval_end)
     return {
@@ -137,7 +137,7 @@ def get_allowed_template_variables(inputs) -> dict[str, str]:
         "day": f"{export_datetime:%d}",
         "month": f"{export_datetime:%m}",
         "year": f"{export_datetime:%Y}",
-        "data_interval_start": inputs.data_interval_start,
+        "data_interval_start": inputs.data_interval_start or "START",
         "data_interval_end": inputs.data_interval_end,
         "table": inputs.batch_export_model.name if inputs.batch_export_model is not None else "events",
     }
@@ -145,7 +145,11 @@ def get_allowed_template_variables(inputs) -> dict[str, str]:
 
 def get_s3_key_prefix(inputs: S3InsertInputs) -> str:
     template_variables = get_allowed_template_variables(inputs)
-    return inputs.prefix.format(**template_variables)
+    try:
+        return inputs.prefix.format(**template_variables)
+    except KeyError as e:
+        EXTERNAL_LOGGER.warning(f"The key prefix '{inputs.prefix}' contains invalid template variables: {str(e)}")
+        return inputs.prefix
 
 
 def get_s3_key(inputs: S3InsertInputs, file_number: int = 0) -> str:

--- a/products/batch_exports/backend/tests/temporal/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/conftest.py
@@ -77,7 +77,7 @@ def activity_environment():
     return ActivityEnvironment()
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest_asyncio.fixture(scope="module")
 async def clickhouse_client(event_loop):
     """Provide a ClickHouseClient to use in tests."""
     async with ClickHouseClient(
@@ -141,10 +141,7 @@ async def activities(request):
 
 @pytest.fixture(scope="session")
 def event_loop():
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        loop = asyncio.new_event_loop()
+    loop = asyncio.new_event_loop()
     yield loop
     loop.close()
 

--- a/products/batch_exports/backend/tests/temporal/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/conftest.py
@@ -78,7 +78,7 @@ def activity_environment():
 
 
 @pytest_asyncio.fixture(scope="module")
-async def clickhouse_client():
+async def clickhouse_client(event_loop):
     """Provide a ClickHouseClient to use in tests."""
     async with ClickHouseClient(
         url=settings.CLICKHOUSE_HTTP_URL,

--- a/products/batch_exports/backend/tests/temporal/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/conftest.py
@@ -139,7 +139,7 @@ async def activities(request):
         return ACTIVITIES
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def event_loop():
     loop = asyncio.new_event_loop()
     yield loop

--- a/products/batch_exports/backend/tests/temporal/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/conftest.py
@@ -77,7 +77,7 @@ def activity_environment():
     return ActivityEnvironment()
 
 
-@pytest_asyncio.fixture(scope="module")
+@pytest_asyncio.fixture(scope="session")
 async def clickhouse_client(event_loop):
     """Provide a ClickHouseClient to use in tests."""
     async with ClickHouseClient(

--- a/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
@@ -1694,6 +1694,15 @@ base_inputs = {"bucket_name": "test", "region": "test", "team_id": 1}
         ),
         (
             S3InsertInputs(
+                prefix="invalid-template-variables-{invalid}",
+                data_interval_start="2023-01-01 00:00:00",
+                data_interval_end="2023-01-01 01:00:00",
+                **base_inputs,  # type: ignore
+            ),
+            "invalid-template-variables-{invalid}/2023-01-01 00:00:00-2023-01-01 01:00:00.jsonl",
+        ),
+        (
+            S3InsertInputs(
                 prefix="",
                 data_interval_start="2023-01-01 00:00:00",
                 data_interval_end="2023-01-01 01:00:00",


### PR DESCRIPTION
## Problem

We support users that want to specify key prefixes with template variables, like:
`my-events-{table}` turns into files prefixed with `my-events-events/`. However, if a non-supported template variable is used, the batch export fails with a retryable `KeyError` that will retry forever.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

If the prefix provided contains invalid template variables, return the prefix without formatting and log an external warning for the user.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Added a unit test.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
