### PR TITLE
fix: only schedule SF enrichment in US

### DIFF
--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -157,7 +157,8 @@ schedules = [
 
 if settings.EE_AVAILABLE:
     schedules.append(create_schedule_all_subscriptions_schedule)
-    schedules.append(create_salesforce_enrichment_schedule)
+    if settings.CLOUD_DEPLOYMENT == "US":
+        schedules.append(create_salesforce_enrichment_schedule)
 
 
 async def a_init_general_queue_schedules():


### PR DESCRIPTION
## Problem

We only want to run the Salesforce enrichment workflow once - we don't want it to be scheduled in US and in EU.

## Changes

Limit Salesforce enrichment workflow schedule to US only.

## How did you test this code?

n/a
