### PR TITLE
fix: Codeowners for plugin-server

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,7 @@ posthog/tasks/test/test_stop_surveys_reached_target.py @PostHog/team-surveys
 
 # plugin server ownership is split between ingestion and messaging teams
 plugin-server/src/ @PostHog/team-ingestion @PostHog/team-messaging
+plugin-server/tests/ @PostHog/team-ingestion
 plugin-server/src/ingestion/ @PostHog/team-ingestion
 plugin-server/src/cdp/ @PostHog/team-messaging
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,9 +15,9 @@ posthog/tasks/update_survey_iteration @PostHog/team-surveys
 posthog/tasks/test/test_stop_surveys_reached_target.py @PostHog/team-surveys
 
 # plugin server ownership is split between ingestion and messaging teams
+plugin-server/src/ @PostHog/team-ingestion @PostHog/team-messaging
 plugin-server/src/ingestion/ @PostHog/team-ingestion
 plugin-server/src/cdp/ @PostHog/team-messaging
-plugin-server/src/ @PostHog/team-ingestion @PostHog/team-messaging
 
 # ClickHouse team owns Clickhouse migrations
 posthog/clickhouse/migrations/** @PostHog/clickhouse


### PR DESCRIPTION
## Problem

Apparently later values take precedence. 

## Changes

* Fix ordering
* Adds tests folder for ingestion team (all cdp tests are co-located in src)

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
