### PR TITLE
fix(devex): change popover to strategy 'absolute' from 'fixed'

### DIFF
--- a/frontend/src/lib/lemon-ui/Popover/Popover.tsx
+++ b/frontend/src/lib/lemon-ui/Popover/Popover.tsx
@@ -134,7 +134,7 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(function P
     } = useFloating<HTMLElement>({
         open: visible,
         placement,
-        strategy: 'fixed',
+        strategy: 'absolute',
         middleware: [
             ...(fallbackPlacements
                 ? [


### PR DESCRIPTION
## Problem
in replay (behind flag `new-scene-layout` SOME `<Popover>`'s are not staying stuck to their trigger... this PR fixes them.

It's something to do with the `SessionRecordingPlayer__main` element... I can't figure it out.
![2025-07-30 13 36 56](https://github.com/user-attachments/assets/9b24f09d-90c1-42f9-a5fe-90dd43d9b8c7)

## Changes
change popover to strategy 'absolute' from 'fixed'

Working examples of `<Popover>`
![2025-07-30 13 37 39](https://github.com/user-attachments/assets/cae6b217-6ddb-4ccb-8d86-265f02074e3e)
![2025-07-30 13 37 39](https://github.com/user-attachments/assets/7aa9bd4f-3aa3-400a-b45c-d2280152032d)


## How did you test this code?
I looked at a lot of implementations of Popover/`<LemonMenu>` (which uses popover)  and it seems all working as expected.
