### PR TITLE
chore: Make DatatypeMismatch non-retryable in Redshift

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -85,6 +85,10 @@ NON_RETRYABLE_ERROR_TYPES = (
     # This can also happen when merging tables with a different number of columns:
     # "Target relation and source relation must have the same number of columns"
     "FeatureNotSupported",
+    # There is a mismatch between the schema of the table and our data. This
+    # usually means the table was created by the user, as we resolve types the
+    # same way every time.
+    "DatatypeMismatch",
 )
 
 


### PR DESCRIPTION
## Problem

This error can occur when the table schema doesn't match data schema. There is nothing that retrying will fix here as it requires intervention. This was already non-retryable in PostgreSQL, now we are applying it to Redshift too.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Make `DatatypeMismatch` non-retryable in Redshift.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
