### PR TITLE
fix(max): invalid state updates

### DIFF
--- a/ee/hogai/utils/test/test_assistant_types.py
+++ b/ee/hogai/utils/test/test_assistant_types.py
@@ -54,3 +54,7 @@ class TestAssistantTypes(BaseTest):
 
         # Should return a PartialAssistantState instance
         self.assertIsInstance(reset_state, PartialAssistantState)
+
+    def test_ignoring_fields(self):
+        """Test that all fields have default values"""
+        self.assertNotIn("memory_collection_messages", AssistantState.get_reset_state().model_dump(exclude_unset=True))

--- a/ee/hogai/utils/types.py
+++ b/ee/hogai/utils/types.py
@@ -1,7 +1,7 @@
 import uuid
 from collections.abc import Sequence
 from enum import StrEnum
-from typing import Annotated, Any, ClassVar, Literal, Optional, Self, TypeVar, Union
+from typing import Annotated, Any, Literal, Optional, Self, TypeVar, Union
 
 from langchain_core.agents import AgentAction
 from langchain_core.messages import (
@@ -125,7 +125,12 @@ class _SharedAssistantState(BaseState):
     The state of the root node.
     """
 
-    _ignored_reset_fields: ClassVar[set[str]] = {"memory_collection_messages"}
+    @staticmethod
+    def _get_ignored_reset_fields() -> set[str]:
+        """
+        Fields to ignore during state resets due to race conditions.
+        """
+        return {"memory_collection_messages"}
 
     start_id: Optional[str] = Field(default=None)
     """

--- a/ee/hogai/utils/types.py
+++ b/ee/hogai/utils/types.py
@@ -155,7 +155,7 @@ class _SharedAssistantState(BaseState):
     A clarifying question asked during the onboarding process.
     """
 
-    memory_collection_messages: Annotated[Optional[Sequence[LangchainBaseMessage]], merge] = Field(default=[])
+    memory_collection_messages: Annotated[Optional[Sequence[LangchainBaseMessage]], merge] = Field(default=None)
     """
     The messages with tool calls to collect memory in the `MemoryCollectorToolsNode`.
     """

--- a/ee/hogai/utils/types.py
+++ b/ee/hogai/utils/types.py
@@ -1,7 +1,7 @@
 import uuid
 from collections.abc import Sequence
 from enum import StrEnum
-from typing import Annotated, Literal, Optional, TypeVar, Union
+from typing import Annotated, Any, Literal, Optional, TypeVar, Union
 
 from langchain_core.agents import AgentAction
 from langchain_core.messages import (
@@ -36,6 +36,10 @@ AssistantOutput = (
     tuple[Literal[AssistantEventType.CONVERSATION], Conversation]
     | tuple[Literal[AssistantEventType.MESSAGE], AssistantMessageOrStatusUnion]
 )
+
+
+def merge(left: Any | None, right: Any | None) -> Any | None:
+    return right
 
 
 def add_and_merge_messages(
@@ -80,9 +84,6 @@ def add_and_merge_messages(
     return merged
 
 
-IntermediateStep = tuple[AgentAction, Optional[str]]
-
-
 def merge_retry_counts(left: int, right: int) -> int:
     """Merges two retry counts by taking the maximum value.
 
@@ -95,6 +96,8 @@ def merge_retry_counts(left: int, right: int) -> int:
     """
     return max(left, right)
 
+
+IntermediateStep = tuple[AgentAction, Optional[str]]
 
 StateType = TypeVar("StateType", bound=BaseModel)
 PartialStateType = TypeVar("PartialStateType", bound=BaseModel)
@@ -137,7 +140,7 @@ class _SharedAssistantState(BaseState):
     A clarifying question asked during the onboarding process.
     """
 
-    memory_collection_messages: Optional[Sequence[LangchainBaseMessage]] = Field(default=None)
+    memory_collection_messages: Annotated[Sequence[LangchainBaseMessage], merge] = Field(default=[])
     """
     The messages with tool calls to collect memory in the `MemoryCollectorToolsNode`.
     """

--- a/ee/hogai/utils/types.py
+++ b/ee/hogai/utils/types.py
@@ -38,7 +38,7 @@ AssistantOutput = (
 )
 
 
-def merge(left: Any | None, right: Any | None) -> Any | None:
+def merge(_: Any | None, right: Any | None) -> Any | None:
     return right
 
 
@@ -140,7 +140,7 @@ class _SharedAssistantState(BaseState):
     A clarifying question asked during the onboarding process.
     """
 
-    memory_collection_messages: Annotated[Sequence[LangchainBaseMessage], merge] = Field(default=[])
+    memory_collection_messages: Annotated[Optional[Sequence[LangchainBaseMessage]], merge] = Field(default=[])
     """
     The messages with tool calls to collect memory in the `MemoryCollectorToolsNode`.
     """

--- a/ee/hogai/utils/types.py
+++ b/ee/hogai/utils/types.py
@@ -106,15 +106,18 @@ PartialStateType = TypeVar("PartialStateType", bound=BaseModel)
 class BaseState(BaseModel):
     """Base state class with reset functionality."""
 
-    _ignored_reset_fields: ClassVar[set[str]] = set()
-    """
-    Fields to ignore during state resets due to race conditions.
-    """
+    @staticmethod
+    def _get_ignored_reset_fields() -> set[str]:
+        """
+        Fields to ignore during state resets due to race conditions.
+        """
+        return set()
 
     @classmethod
     def get_reset_state(cls) -> Self:
         """Returns a new instance with all fields reset to their default values."""
-        return cls(**{k: v.default for k, v in cls.model_fields.items() if k not in cls._ignored_reset_fields})
+        ignored_fields = cls._get_ignored_reset_fields()
+        return cls(**{k: v.default for k, v in cls.model_fields.items() if k not in ignored_fields})
 
 
 class _SharedAssistantState(BaseState):


### PR DESCRIPTION
## Problem

Parallel graph executions throw `InvalidStateUpdate`, which resolves with a reducer function.

## Changes

Add a simple reducer function for the only concurrent field.

## How did you test this code?

Unit tests
