### PR TITLE
fix(devex/replay): remove floating container context provider 

### DIFF
--- a/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
@@ -5,7 +5,6 @@ import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
 
 import { BuilderHog2, SleepingHog } from 'lib/components/hedgehogs'
-import { FloatingContainerContext } from 'lib/hooks/useFloatingContainerContext'
 import { HotkeysInterface, useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
 import { usePageVisibilityCb } from 'lib/hooks/usePageVisibility'
 import { useResizeBreakpoints } from 'lib/hooks/useResizeObserver'
@@ -207,71 +206,66 @@ export function SessionRecordingPlayer(props: SessionRecordingPlayerProps): JSX.
                 onMouseMove={() => setPlayNextAnimationInterrupted(true)}
                 onMouseOut={() => setPlayNextAnimationInterrupted(false)}
             >
-                <FloatingContainerContext.Provider value={playerRef}>
-                    {explorerMode ? (
-                        <SessionRecordingPlayerExplorer {...explorerMode} onClose={() => closeExplorer()} />
-                    ) : (
-                        <>
-                            <div
-                                className="SessionRecordingPlayer__main flex flex-col h-full w-full"
-                                ref={playerMainRef}
-                            >
-                                {isRecentAndInvalid ? (
-                                    <div className="flex flex-1 flex-col items-center justify-center">
-                                        <BuilderHog2 height={200} />
-                                        <h1>We're still working on it</h1>
-                                        <p>
-                                            This recording hasn't been fully ingested yet. It should be ready to watch
-                                            in a few minutes.
-                                        </p>
-                                        <LemonButton type="secondary" onClick={loadSnapshots}>
-                                            Reload
+                {explorerMode ? (
+                    <SessionRecordingPlayerExplorer {...explorerMode} onClose={() => closeExplorer()} />
+                ) : (
+                    <>
+                        <div className="SessionRecordingPlayer__main flex flex-col h-full w-full" ref={playerMainRef}>
+                            {isRecentAndInvalid ? (
+                                <div className="flex flex-1 flex-col items-center justify-center">
+                                    <BuilderHog2 height={200} />
+                                    <h1>We're still working on it</h1>
+                                    <p>
+                                        This recording hasn't been fully ingested yet. It should be ready to watch in a
+                                        few minutes.
+                                    </p>
+                                    <LemonButton type="secondary" onClick={loadSnapshots}>
+                                        Reload
+                                    </LemonButton>
+                                </div>
+                            ) : isLikelyPastTTL ? (
+                                <div
+                                    className="flex flex-1 flex-col items-center justify-center"
+                                    data-attr="session-recording-player-past-ttl"
+                                >
+                                    <SleepingHog height={200} />
+                                    <h1>This recording is no longer available</h1>
+                                    <p>
+                                        We store session recordings for a limited time, and this one has expired and
+                                        been deleted.
+                                    </p>
+                                    <div className="text-right">
+                                        <LemonButton
+                                            type="secondary"
+                                            to="https://posthog.com/docs/session-replay/data-retention"
+                                        >
+                                            Learn more about data retention
                                         </LemonButton>
                                     </div>
-                                ) : isLikelyPastTTL ? (
-                                    <div
-                                        className="flex flex-1 flex-col items-center justify-center"
-                                        data-attr="session-recording-player-past-ttl"
-                                    >
-                                        <SleepingHog height={200} />
-                                        <h1>This recording is no longer available</h1>
-                                        <p>
-                                            We store session recordings for a limited time, and this one has expired and
-                                            been deleted.
-                                        </p>
-                                        <div className="text-right">
-                                            <LemonButton
-                                                type="secondary"
-                                                to="https://posthog.com/docs/session-replay/data-retention"
-                                            >
-                                                Learn more about data retention
-                                            </LemonButton>
-                                        </div>
-                                    </div>
-                                ) : (
-                                    <div className="flex w-full h-full">
-                                        <div className="flex flex-col flex-1 w-full">
-                                            {!noMeta || isFullScreen ? <PlayerMeta /> : null}
+                                </div>
+                            ) : (
+                                <div className="flex w-full h-full">
+                                    <div className="flex flex-col flex-1 w-full">
+                                        {!noMeta || isFullScreen ? <PlayerMeta /> : null}
 
-                                            <div
-                                                className="SessionRecordingPlayer__body"
-                                                draggable={draggable}
-                                                {...elementProps}
-                                            >
-                                                <PlayerFrame />
-                                                <PlayerFrameOverlay />
-                                                <PlayerFrameCommentOverlay />
-                                            </div>
-                                            <PlayerController />
+                                        <div
+                                            className="SessionRecordingPlayer__body"
+                                            draggable={draggable}
+                                            {...elementProps}
+                                        >
+                                            <PlayerFrame />
+                                            <PlayerFrameOverlay />
+                                            <PlayerFrameCommentOverlay />
                                         </div>
+                                        <PlayerController />
                                     </div>
-                                )}
-                            </div>
+                                </div>
+                            )}
+                        </div>
 
-                            {!noInspector && <PlayerSidebar />}
-                        </>
-                    )}
-                </FloatingContainerContext.Provider>
+                        {!noInspector && <PlayerSidebar />}
+                    </>
+                )}
             </div>
             <SessionRecordingNextConfirmation />
         </BindLogic>

--- a/frontend/src/scenes/session-recordings/player/player-meta/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/PlayerMeta.tsx
@@ -21,11 +21,9 @@ import { urls } from 'scenes/urls'
 
 import { getCurrentExporterData } from '~/exporter/exporterViewLogic'
 import { Logo } from '~/toolbar/assets/Logo'
-import { FloatingContainerContext } from 'lib/hooks/useFloatingContainerContext'
 
 import { playerMetaLogic } from './playerMetaLogic'
 import { PlayerPersonMeta } from './PlayerPersonMeta'
-import { RefObject } from 'react'
 
 export function parseUrl(lastUrl: unknown): { urlToUse: string | undefined; isValidUrl: boolean } {
     let urlToUse: string | undefined = typeof lastUrl === 'string' ? lastUrl : undefined
@@ -180,39 +178,36 @@ export function PlayerMeta(): JSX.Element {
                     'PlayerMeta--fullscreen': isFullScreen,
                 })}
             >
-                {/* This context proivder is necessary to make the popover positioning to work correctly */}
-                <FloatingContainerContext.Provider value={ref as RefObject<HTMLElement>}>
-                    <div className="flex flex-row items-center justify-between gap-x-1 whitespace-nowrap overflow-hidden px-1 py-0.5 text-xs">
-                        {loading ? (
-                            <LemonSkeleton className="w-1/3 h-4 my-1" />
-                        ) : (
-                            <>
-                                <LemonSelect
-                                    size="xsmall"
-                                    options={windowOptions}
-                                    value={trackedWindow}
-                                    disabledReason={windowIds.length <= 1 ? "There's only one window" : undefined}
-                                    onSelect={(value) => setTrackedWindow(value)}
-                                />
+                <div className="flex flex-row items-center justify-between gap-x-1 whitespace-nowrap overflow-hidden px-1 py-0.5 text-xs">
+                    {loading ? (
+                        <LemonSkeleton className="w-1/3 h-4 my-1" />
+                    ) : (
+                        <>
+                            <LemonSelect
+                                size="xsmall"
+                                options={windowOptions}
+                                value={trackedWindow}
+                                disabledReason={windowIds.length <= 1 ? "There's only one window" : undefined}
+                                onSelect={(value) => setTrackedWindow(value)}
+                            />
 
-                                <URLOrScreen url={currentURL} />
-                                {lastPageviewEvent?.properties?.['$screen_name'] && (
+                            <URLOrScreen url={currentURL} />
+                            {lastPageviewEvent?.properties?.['$screen_name'] && (
+                                <span className="flex flex-row items-center gap-x-1 truncate">
+                                    <span>·</span>
                                     <span className="flex flex-row items-center gap-x-1 truncate">
-                                        <span>·</span>
-                                        <span className="flex flex-row items-center gap-x-1 truncate">
-                                            {lastPageviewEvent?.properties['$screen_name']}
-                                        </span>
+                                        {lastPageviewEvent?.properties['$screen_name']}
                                     </span>
-                                )}
-                            </>
-                        )}
-                        <div className={clsx('flex-1', size === 'small' ? 'min-w-[1rem]' : 'min-w-[5rem]')} />
-                        {!isCinemaMode && <PlayerMetaLinks size={size} />}
-                        {!isCinemaMode && <ResolutionView size={size} />}
-                        <PlayerPersonMeta />
-                    </div>
-                    {!isCinemaMode && <PlayerMetaBottomSettings size={size} />}
-                </FloatingContainerContext.Provider>
+                                </span>
+                            )}
+                        </>
+                    )}
+                    <div className={clsx('flex-1', size === 'small' ? 'min-w-[1rem]' : 'min-w-[5rem]')} />
+                    {!isCinemaMode && <PlayerMetaLinks size={size} />}
+                    {!isCinemaMode && <ResolutionView size={size} />}
+                    <PlayerPersonMeta />
+                </div>
+                {!isCinemaMode && <PlayerMetaBottomSettings size={size} />}
             </div>
         </DraggableToNotebook>
     )

--- a/frontend/src/scenes/session-recordings/player/player-meta/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/PlayerMeta.tsx
@@ -21,9 +21,11 @@ import { urls } from 'scenes/urls'
 
 import { getCurrentExporterData } from '~/exporter/exporterViewLogic'
 import { Logo } from '~/toolbar/assets/Logo'
+import { FloatingContainerContext } from 'lib/hooks/useFloatingContainerContext'
 
 import { playerMetaLogic } from './playerMetaLogic'
 import { PlayerPersonMeta } from './PlayerPersonMeta'
+import { RefObject } from 'react'
 
 export function parseUrl(lastUrl: unknown): { urlToUse: string | undefined; isValidUrl: boolean } {
     let urlToUse: string | undefined = typeof lastUrl === 'string' ? lastUrl : undefined
@@ -178,36 +180,39 @@ export function PlayerMeta(): JSX.Element {
                     'PlayerMeta--fullscreen': isFullScreen,
                 })}
             >
-                <div className="flex flex-row items-center justify-between gap-x-1 whitespace-nowrap overflow-hidden px-1 py-0.5 text-xs">
-                    {loading ? (
-                        <LemonSkeleton className="w-1/3 h-4 my-1" />
-                    ) : (
-                        <>
-                            <LemonSelect
-                                size="xsmall"
-                                options={windowOptions}
-                                value={trackedWindow}
-                                disabledReason={windowIds.length <= 1 ? "There's only one window" : undefined}
-                                onSelect={(value) => setTrackedWindow(value)}
-                            />
+                {/* This context proivder is necessary to make the popover positioning to work correctly */}
+                <FloatingContainerContext.Provider value={ref as RefObject<HTMLElement>}>
+                    <div className="flex flex-row items-center justify-between gap-x-1 whitespace-nowrap overflow-hidden px-1 py-0.5 text-xs">
+                        {loading ? (
+                            <LemonSkeleton className="w-1/3 h-4 my-1" />
+                        ) : (
+                            <>
+                                <LemonSelect
+                                    size="xsmall"
+                                    options={windowOptions}
+                                    value={trackedWindow}
+                                    disabledReason={windowIds.length <= 1 ? "There's only one window" : undefined}
+                                    onSelect={(value) => setTrackedWindow(value)}
+                                />
 
-                            <URLOrScreen url={currentURL} />
-                            {lastPageviewEvent?.properties?.['$screen_name'] && (
-                                <span className="flex flex-row items-center gap-x-1 truncate">
-                                    <span>·</span>
+                                <URLOrScreen url={currentURL} />
+                                {lastPageviewEvent?.properties?.['$screen_name'] && (
                                     <span className="flex flex-row items-center gap-x-1 truncate">
-                                        {lastPageviewEvent?.properties['$screen_name']}
+                                        <span>·</span>
+                                        <span className="flex flex-row items-center gap-x-1 truncate">
+                                            {lastPageviewEvent?.properties['$screen_name']}
+                                        </span>
                                     </span>
-                                </span>
-                            )}
-                        </>
-                    )}
-                    <div className={clsx('flex-1', size === 'small' ? 'min-w-[1rem]' : 'min-w-[5rem]')} />
-                    {!isCinemaMode && <PlayerMetaLinks size={size} />}
-                    {!isCinemaMode && <ResolutionView size={size} />}
-                    <PlayerPersonMeta />
-                </div>
-                {!isCinemaMode && <PlayerMetaBottomSettings size={size} />}
+                                )}
+                            </>
+                        )}
+                        <div className={clsx('flex-1', size === 'small' ? 'min-w-[1rem]' : 'min-w-[5rem]')} />
+                        {!isCinemaMode && <PlayerMetaLinks size={size} />}
+                        {!isCinemaMode && <ResolutionView size={size} />}
+                        <PlayerPersonMeta />
+                    </div>
+                    {!isCinemaMode && <PlayerMetaBottomSettings size={size} />}
+                </FloatingContainerContext.Provider>
             </div>
         </DraggableToNotebook>
     )


### PR DESCRIPTION
## Problem
~When SceneLayout's panel is active, it creates a complex layout context that interferes with popover positioning:~
* ~CSS Container Context: SceneLayout uses container-type: size creating a new containment context~
* ~Fixed positioning shifts: The panel uses fixed positioning with CSS custom properties~
* ~Layout boundary conflicts: Popovers use document.body as the positioning boundary, but SceneLayout changes the effective layout~

`<FloatingContainerContext.Provider value={playerRef}>` was set in `SessionRecordingPlayer.tsx` and this seems unnecessary with the flag (`new-scene-layout`) or not! It set the base of our floating-ui (mainly popover here) and caused our popovers to misaligned when the new flag was active.

![2025-07-30 15 32 55](https://github.com/user-attachments/assets/9a3864d8-1f7d-4877-9e72-b810e7bde598)

![2025-07-30 16 20 49](https://github.com/user-attachments/assets/9ab617e6-0b4f-4a86-947c-7308486fc602)

## Changes
Remove the context provider in `SessionRecordingPlayer.tsx`

## How did you test this code?
Manually, with flag off and on, seems to work as expected.

