### PR TITLE
fix: filter organization when deleting invite

### DIFF
--- a/posthog/models/organization_invite.py
+++ b/posthog/models/organization_invite.py
@@ -167,7 +167,9 @@ class OrganizationInvite(UUIDModel):
                     "organization_id": self.organization_id,
                 }
             )
-        OrganizationInvite.objects.filter(target_email__iexact=self.target_email).delete()
+        OrganizationInvite.objects.filter(
+            organization=self.organization, target_email__iexact=self.target_email
+        ).delete()
 
     def is_expired(self) -> bool:
         """Check if invite is older than INVITE_DAYS_VALIDITY days."""


### PR DESCRIPTION
## Problem
Accepting an invite deletes all invites for the same email, even from other organizations.

## Changes
Filtered invite deletion to only delete invites from the current organization.

## How did you test this code?
Added a unit test