### PR TITLE
fix(force-nullable-py-arrow-columns): Force nullable pyarrow columns

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/utils.py
@@ -478,6 +478,10 @@ def table_from_py_list(table_data: list[Any], schema: Optional[pa.Schema] = None
     Convert a list of Python dictionaries to a PyArrow Table.
     This is a wrapper around table_from_iterator for backward compatibility.
     """
+    if schema:
+        nullable_fields = [field.with_nullable(True) for field in schema]
+        schema = pa.schema(nullable_fields)
+
     return table_from_iterator(iter(table_data), schema=schema)
 
 


### PR DESCRIPTION
## Problem

I took a look at some of the parquet files we're dumping into cold storage and saw this that caught my eye.
```json
  {
    "PrimitiveType": {
      "field_info": {
        "name": "$session_id",
        "repetition": "Required",
        "id": null
      },
      "logical_type": "String",
      "converted_type": "Utf8",
      "physical_type": "ByteArray"
    }
  },
  {
    "PrimitiveType": {
      "field_info": {
        "name": "timestamp",
        "repetition": "Required",
        "id": null
      },
      "logical_type": {
        "Timestamp": {
          "unit": "Microseconds",
          "is_adjusted_to_utc": false
        }
      },
      "converted_type": "TimestampMicros",
      "physical_type": "Int64"
    }
  },
```

These fields are required, but the columns do not necessarily return values, and are nullable.

Docs: https://arrow.apache.org/docs/python/generated/pyarrow.Field.html#pyarrow.Field.with_nullable


## How did you test this code?
Not able to recreate this locally.