### PR TITLE
chore: Remove unused `additionalPropertiesFilter` property from `PropertyValue`

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -35,7 +35,6 @@ export interface PropertyValueProps {
     eventNames?: string[]
     addRelativeDateTimeOptions?: boolean
     inputClassName?: string
-    additionalPropertiesFilter?: { key: string; values: string | string[] }[]
     groupTypeIndex?: GroupTypeIndex
     size?: 'xsmall' | 'small' | 'medium'
     editable?: boolean
@@ -55,7 +54,6 @@ export function PropertyValue({
     eventNames = [],
     addRelativeDateTimeOptions = false,
     inputClassName = undefined,
-    additionalPropertiesFilter = [],
     groupTypeIndex = undefined,
     editable = true,
     preloadValues = false,
@@ -80,7 +78,7 @@ export function PropertyValue({
             newInput,
             propertyKey,
             eventNames,
-            properties: additionalPropertiesFilter,
+            properties: [],
         })
     }
 


### PR DESCRIPTION
## Problem

The `additionalPropertiesFilter` property was added for the Survey team but is no longer used by any components (I also confirmed the [survey team no longer needs it](https://posthog.slack.com/archives/C07QD3LT8U9/p1753826879252799)). This commit removes:

- additionalPropertiesFilter prop from PropertyValueProps interface
- additionalPropertiesFilter parameter from PropertyValue function
- Usage of additionalPropertiesFilter in loadPropertyValues call

The property had a default value of [] so setting properties: [] maintains the same behavior.

## Changes

Remove the `additionalPropertiesFilter` property.

A couple React Hook dependency array fixes that were automatically applied by the linter/formatter during the pre-commit hook.

## How did you test this code?

Manually.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
