### PR TITLE
feat(crm): Add support for discussions under group details page

### DIFF
--- a/frontend/src/scenes/groups/groupLogic.ts
+++ b/frontend/src/scenes/groups/groupLogic.ts
@@ -15,9 +15,12 @@ import { groupsModel } from '~/models/groupsModel'
 import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
 import { DataTableNode, Node, NodeKind } from '~/queries/schema/schema-general'
 import { isDataTableNode } from '~/queries/utils'
-import { Breadcrumb, Group, GroupTypeIndex, PropertyFilterType, PropertyOperator } from '~/types'
+import { ActivityScope, Breadcrumb, Group, GroupTypeIndex, PropertyFilterType, PropertyOperator } from '~/types'
 
 import type { groupLogicType } from './groupLogicType'
+import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 
 function getGroupEventsQuery(groupTypeIndex: number, groupKey: string): DataTableNode {
     return {
@@ -50,7 +53,14 @@ export const groupLogic = kea<groupLogicType>([
     path((key) => ['scenes', 'groups', 'groupLogic', key]),
     connect(() => ({
         actions: [groupsModel, ['createDetailDashboard']],
-        values: [teamLogic, ['currentTeamId'], groupsModel, ['groupTypes', 'aggregationLabel']],
+        values: [
+            teamLogic,
+            ['currentTeamId'],
+            groupsModel,
+            ['groupTypes', 'aggregationLabel'],
+            featureFlagLogic,
+            ['featureFlags'],
+        ],
     })),
     actions(() => ({
         setGroupData: (group: Group) => ({ group }),
@@ -193,6 +203,18 @@ export const groupLogic = kea<groupLogicType>([
                 })
 
                 return breadcrumbs
+            },
+        ],
+        [SIDE_PANEL_CONTEXT_KEY]: [
+            (s, p) => [p.groupTypeIndex, p.groupKey, s.featureFlags],
+            (groupTypeIndex, groupKey, featureFlags): SidePanelSceneContext | null => {
+                if (!featureFlags[FEATURE_FLAGS.CRM_ITERATION_ONE]) {
+                    return null
+                }
+                return {
+                    activity_scope: ActivityScope.GROUP,
+                    activity_item_id: `${groupTypeIndex}-${groupKey}`,
+                }
             },
         ],
     }),


### PR DESCRIPTION
## Problem
Closes https://github.com/PostHog/posthog/issues/35893
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
_This change is gated by `crm-iteration-one` feature flag_
- Support discussion in group details page, allowing for group-specific comments
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

### Before
<img width="4064" height="2334" alt="image" src="https://github.com/user-attachments/assets/a89f8171-fcec-42ca-98cd-555f3c246cc0" />

### After
<img width="4064" height="2334" alt="image" src="https://github.com/user-attachments/assets/a9e93f52-d3cd-4813-a3b8-1ba384408823" />

## How did you test this code?
- Adding a new comment, checking if it was persisted
- Adding a new comment to 2 groups with the same `groupKey` and different `groupTypeIndex` and ensuring the comment did not leak 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
