### PR TITLE
fix(dashboard): include isNull in dashboard variable override

### DIFF
--- a/posthog/hogql_queries/apply_dashboard_filters.py
+++ b/posthog/hogql_queries/apply_dashboard_filters.py
@@ -95,6 +95,7 @@ def apply_dashboard_variables(query: Any, variables_overrides: dict[str, dict], 
                     variableId=variable_id,
                     code_name=query_variable.code_name,
                     value=overriden_hogql_variable.get("value"),
+                    isNull=overriden_hogql_variable.get("isNull"),
                 )
 
         return query.model_copy(update={"variables": updated_variables})


### PR DESCRIPTION
## Problem

Null variables were not passed correctly to the override when they were used on the dashboard. This caused the filters to not work as expected.

Support ticket: https://posthoghelp.zendesk.com/agent/tickets/35144 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/37190)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Pass `isNull` to the override variables

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- create a sql insight with a nullable variable
- confirm the nullable variable works correctly when you are editing the insight (changing it applies the correct filter)
- add the insight to a dashboard and set the variable to null in the dashboard
- confirm the dashboard loads the correct set of results similar to when editing the insight

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
