### PR TITLE
feat: enable CSP enforcement on Admin

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -673,6 +673,6 @@ class AdminCSPMiddleware:
             response.headers["Reporting-Endpoints"] = (
                 'posthog="https://us.i.posthog.com/report/?token=sTMFPsFhdP1Ssg&v=2"'
             )
-            response.headers["Content-Security-Policy-Report-Only"] = "; ".join(csp_parts)
+            response.headers["Content-Security-Policy"] = "; ".join(csp_parts)
 
         return response


### PR DESCRIPTION
Follow up to #35529. Our CSP reporting indicates this can be enabled without issue. We'll still receive CSP reports if anything unexpectedly breaks.
