### PR TITLE
feat(flags): Add feature flag condition that depends on other flags

### DIFF
--- a/frontend/src/lib/components/PropertiesTable/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable/PropertiesTable.tsx
@@ -245,6 +245,7 @@ export function PropertiesTable({
                     [PropertyDefinitionType.Meta]: TaxonomicFilterGroupType.Metadata,
                     [PropertyDefinitionType.Resource]: TaxonomicFilterGroupType.Resources,
                     [PropertyDefinitionType.Log]: TaxonomicFilterGroupType.LogAttributes,
+                    [PropertyDefinitionType.FlagValue]: TaxonomicFilterGroupType.FeatureFlags,
                 }
 
                 const propertyType = propertyTypeMap[type] || TaxonomicFilterGroupType.EventProperties

--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -114,6 +114,8 @@ export function OperatorValueSelect({
             propertyType = PropertyType.Selector
         } else if (propertyKey === 'id' && type === PropertyFilterType.Cohort) {
             propertyType = PropertyType.Cohort
+        } else if (type === PropertyFilterType.Flag) {
+            propertyType = PropertyType.Flag
         } else if (propertyKey === 'assignee' && type === PropertyFilterType.ErrorTrackingIssue) {
             propertyType = PropertyType.Assignee
         } else if (

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -90,16 +90,16 @@ export function PropertyValue({
     const setValue = (newValue: PropertyValueProps['value']): void => onSet(newValue)
 
     useEffect(() => {
-        if (preloadValues) {
+        if (preloadValues && propertyOptions?.status !== 'loading' && propertyOptions?.status !== 'loaded') {
             load('')
         }
-    }, [preloadValues, load])
+    }, [preloadValues, load, propertyOptions?.status])
 
     useEffect(() => {
-        if (!isDateTimeProperty) {
+        if (!isDateTimeProperty && propertyOptions?.status !== 'loading' && propertyOptions?.status !== 'loaded') {
             load('')
         }
-    }, [propertyKey, isDateTimeProperty, load])
+    }, [propertyKey, isDateTimeProperty, load, propertyOptions?.status])
 
     const displayOptions = propertyOptions?.values || []
 

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -9,7 +9,7 @@ import { useActions, useValues } from 'kea'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { DurationPicker } from 'lib/components/DurationPicker/DurationPicker'
 import { PropertyFilterDatePicker } from 'lib/components/PropertyFilters/components/PropertyFilterDatePicker'
-import { isFlagPropertyFilter, propertyFilterTypeToPropertyDefinitionType } from 'lib/components/PropertyFilters/utils'
+import { propertyFilterTypeToPropertyDefinitionType } from 'lib/components/PropertyFilters/utils'
 import { dayjs } from 'lib/dayjs'
 import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
 import { formatDate, isOperatorDate, isOperatorFlag, isOperatorMulti, toString } from 'lib/utils'
@@ -61,6 +61,7 @@ export function PropertyValue({
     const { formatPropertyValueForDisplay, describeProperty, options } = useValues(propertyDefinitionsModel)
     const { loadPropertyValues } = useActions(propertyDefinitionsModel)
     const propertyOptions = options[propertyKey]
+    const isFlagDependencyProperty = type === PropertyFilterType.Flag
 
     const isMultiSelect = operator && isOperatorMulti(operator)
     const isDateTimeProperty = operator && isOperatorDate(operator)
@@ -206,7 +207,7 @@ export function PropertyValue({
         if (name === '') {
             return <i>(empty string)</i>
         }
-        if (isFlagPropertyFilter(value) && typeof value === 'boolean') {
+        if (isFlagDependencyProperty && typeof value === 'boolean') {
             return <code>{name}</code>
         }
         return <>{formatPropertyValueForDisplay(propertyKey, name, propertyDefinitionType, groupTypeIndex)}</>

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -145,6 +145,15 @@ export function PropertyValue({
         (label) => String(formatPropertyValueForDisplay(propertyKey, label, propertyDefinitionType, groupTypeIndex))
     )
 
+    // For flag dependencies, we need to preserve the original typed values
+    const typedValues = isFlagDependencyProperty
+        ? value === null || value === undefined
+            ? []
+            : Array.isArray(value)
+            ? value
+            : [value]
+        : formattedValues
+
     if (!editable) {
         return <>{formattedValues.join(' or ')}</>
     }
@@ -218,7 +227,7 @@ export function PropertyValue({
             className={inputClassName}
             data-attr="prop-val"
             loading={propertyOptions?.status === 'loading'}
-            value={formattedValues}
+            value={isFlagDependencyProperty ? typedValues : formattedValues}
             mode={isMultiSelect ? 'multiple' : 'single'}
             allowCustomValues={propertyOptions?.allowCustomValues ?? true}
             onChange={(nextVal) => (isMultiSelect ? setValue(nextVal) : setValue(nextVal[0]))}

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -60,6 +60,7 @@ export function PropertyValue({
 }: PropertyValueProps): JSX.Element {
     const { formatPropertyValueForDisplay, describeProperty, options } = useValues(propertyDefinitionsModel)
     const { loadPropertyValues } = useActions(propertyDefinitionsModel)
+    const propertyOptions = options[propertyKey]
 
     const isMultiSelect = operator && isOperatorMulti(operator)
     const isDateTimeProperty = operator && isOperatorDate(operator)
@@ -99,7 +100,7 @@ export function PropertyValue({
         }
     }, [propertyKey, isDateTimeProperty, load])
 
-    const displayOptions = options[propertyKey]?.values || []
+    const displayOptions = propertyOptions?.values || []
 
     const onSearchTextChange = (newInput: string): void => {
         if (!Object.keys(options).includes(newInput) && !(operator && isOperatorFlag(operator))) {
@@ -204,10 +205,10 @@ export function PropertyValue({
         <LemonInputSelect
             className={inputClassName}
             data-attr="prop-val"
-            loading={options[propertyKey]?.status === 'loading'}
+            loading={propertyOptions?.status === 'loading'}
             value={formattedValues}
             mode={isMultiSelect ? 'multiple' : 'single'}
-            allowCustomValues={options[propertyKey]?.allowCustomValues ?? true}
+            allowCustomValues={propertyOptions?.allowCustomValues ?? true}
             onChange={(nextVal) => (isMultiSelect ? setValue(nextVal) : setValue(nextVal[0]))}
             onInputChange={onSearchTextChange}
             placeholder={placeholder}

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -9,7 +9,7 @@ import { useActions, useValues } from 'kea'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { DurationPicker } from 'lib/components/DurationPicker/DurationPicker'
 import { PropertyFilterDatePicker } from 'lib/components/PropertyFilters/components/PropertyFilterDatePicker'
-import { propertyFilterTypeToPropertyDefinitionType } from 'lib/components/PropertyFilters/utils'
+import { isFlagPropertyFilter, propertyFilterTypeToPropertyDefinitionType } from 'lib/components/PropertyFilters/utils'
 import { dayjs } from 'lib/dayjs'
 import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
 import { formatDate, isOperatorDate, isOperatorFlag, isOperatorMulti, toString } from 'lib/utils'
@@ -201,6 +201,17 @@ export function PropertyValue({
         )
     }
 
+    function formatLabelContent(value: any): JSX.Element {
+        const name = toString(value)
+        if (name === '') {
+            return <i>(empty string)</i>
+        }
+        if (isFlagPropertyFilter(value) && typeof value === 'boolean') {
+            return <code>{name}</code>
+        }
+        return <>{formatPropertyValueForDisplay(propertyKey, name, propertyDefinitionType, groupTypeIndex)}</>
+    }
+
     return (
         <LemonInputSelect
             className={inputClassName}
@@ -228,11 +239,7 @@ export function PropertyValue({
                     label: name,
                     labelComponent: (
                         <span key={name} data-attr={'prop-val-' + index} className="ph-no-capture" title={name}>
-                            {name === '' ? (
-                                <i>(empty string)</i>
-                            ) : (
-                                formatPropertyValueForDisplay(propertyKey, name, propertyDefinitionType, groupTypeIndex)
-                            )}
+                            {formatLabelContent(name)}
                         </span>
                     ),
                 }

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -145,15 +145,6 @@ export function PropertyValue({
         (label) => String(formatPropertyValueForDisplay(propertyKey, label, propertyDefinitionType, groupTypeIndex))
     )
 
-    // For flag dependencies, we need to preserve the original typed values
-    const typedValues = isFlagDependencyProperty
-        ? value === null || value === undefined
-            ? []
-            : Array.isArray(value)
-            ? value
-            : [value]
-        : formattedValues
-
     if (!editable) {
         return <>{formattedValues.join(' or ')}</>
     }
@@ -227,7 +218,7 @@ export function PropertyValue({
             className={inputClassName}
             data-attr="prop-val"
             loading={propertyOptions?.status === 'loading'}
-            value={isFlagDependencyProperty ? typedValues : formattedValues}
+            value={formattedValues}
             mode={isMultiSelect ? 'multiple' : 'single'}
             allowCustomValues={propertyOptions?.allowCustomValues ?? true}
             onChange={(nextVal) => (isMultiSelect ? setValue(nextVal) : setValue(nextVal[0]))}
@@ -247,9 +238,10 @@ export function PropertyValue({
                 return {
                     key: name,
                     label: name,
+                    value: isFlagDependencyProperty ? _name : undefined, // Preserve original type for flags
                     labelComponent: (
                         <span key={name} data-attr={'prop-val-' + index} className="ph-no-capture" title={name}>
-                            {formatLabelContent(name)}
+                            {formatLabelContent(isFlagDependencyProperty ? _name : name)}
                         </span>
                     ),
                 }

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -189,6 +189,8 @@ export function TaxonomicPropertyFilter({
             ? filter.cohort_name || `Cohort #${filter?.value}`
             : filter?.type === PropertyFilterType.EventMetadata && filter?.key?.startsWith('$group_')
               ? filter.label || `Group ${filter?.value}`
+              : filter?.type === PropertyFilterType.Flag && filter?.label
+              ? filter.label  
               : filter?.key && (
                     <PropertyKeyInfo
                         value={filter.key}

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -144,6 +144,7 @@ export function TaxonomicPropertyFilter({
             excludedProperties={excludedProperties}
             optionsFromProp={taxonomicFilterOptionsFromProp}
             hideBehavioralCohorts={hideBehavioralCohorts}
+            selectFirstItem={!cohortOrOtherValue}
         />
     )
 

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -164,7 +164,7 @@ export function TaxonomicPropertyFilter({
                 if (filter?.key && filter?.type) {
                     setFilter(index, {
                         key: filter?.key,
-                        value: newValue || null,
+                        value: newValue === undefined ? null : newValue,
                         operator: newOperator,
                         type: filter?.type,
                         label: filter?.label,

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -191,15 +191,15 @@ export function TaxonomicPropertyFilter({
             : filter?.type === PropertyFilterType.EventMetadata && filter?.key?.startsWith('$group_')
               ? filter.label || `Group ${filter?.value}`
               : filter?.type === PropertyFilterType.Flag && filter?.label
-              ? filter.label  
-              : filter?.key && (
-                    <PropertyKeyInfo
-                        value={filter.key}
-                        disablePopover
-                        ellipsis
-                        type={PROPERTY_FILTER_TYPE_TO_TAXONOMIC_FILTER_GROUP_TYPE[filter.type]}
-                    />
-                )
+                ? filter.label
+                : filter?.key && (
+                      <PropertyKeyInfo
+                          value={filter.key}
+                          disablePopover
+                          ellipsis
+                          type={PROPERTY_FILTER_TYPE_TO_TAXONOMIC_FILTER_GROUP_TYPE[filter.type]}
+                      />
+                  )
 
     return (
         <div

--- a/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.ts
@@ -15,7 +15,13 @@ import {
 } from 'lib/components/TaxonomicFilter/types'
 
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
-import { AnyPropertyFilter, CohortPropertyFilter, EventMetadataPropertyFilter, PropertyFilterType } from '~/types'
+import {
+    AnyPropertyFilter,
+    CohortPropertyFilter,
+    EventMetadataPropertyFilter,
+    FlagPropertyFilter,
+    PropertyFilterType,
+} from '~/types'
 
 import type { taxonomicPropertyFilterLogicType } from './taxonomicPropertyFilterLogicType'
 
@@ -97,6 +103,12 @@ export const taxonomicPropertyFilterLogic = kea<taxonomicPropertyFilterLogicType
                 if (propertyType === 'cohort' && item?.name) {
                     const cohortFilter = filter as CohortPropertyFilter
                     cohortFilter.cohort_name = item.name
+                }
+
+                // Add flag key for display if this is a feature flag filter
+                if (propertyType === PropertyFilterType.Flag && item?.key) {
+                    const featureFilter = filter as FlagPropertyFilter
+                    featureFilter.label = item.key
                 }
 
                 if (propertyType === PropertyFilterType.EventMetadata && item.id.startsWith('$group_')) {

--- a/frontend/src/lib/components/PropertyFilters/utils.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.ts
@@ -477,6 +477,16 @@ export function createDefaultPropertyFilter(
         return hogQLProperty
     }
 
+    if (propertyType === PropertyFilterType.Flag) {
+        const flagProperty: FlagPropertyFilter = {
+            type: propertyType,
+            key: String(propertyKey),
+            value: true, // Default to true
+            operator: PropertyOperator.FlagEvaluatesTo,
+        }
+        return flagProperty
+    }
+
     const apiType = propertyFilterTypeToPropertyDefinitionType(propertyType) ?? PropertyDefinitionType.Event
 
     const propertyValueType = describeProperty(propertyKey, apiType, taxonomicGroup.groupTypeIndex)

--- a/frontend/src/lib/components/PropertyFilters/utils.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.ts
@@ -40,7 +40,7 @@ import {
     RecordingPropertyFilter,
     RevenueAnalyticsPropertyFilter,
     SessionPropertyFilter,
-    FlagDependencyPropertyFilter,
+    FlagPropertyFilter,
 } from '~/types'
 
 export function isPropertyGroup(
@@ -252,7 +252,7 @@ export function isDataWarehousePersonPropertyFilter(
 export function isFeaturePropertyFilter(filter?: AnyFilterLike | null): filter is FeaturePropertyFilter {
     return filter?.type === PropertyFilterType.Feature
 }
-export function isFlagDependencyPropertyFilter(filter?: AnyFilterLike | null): filter is FlagDependencyPropertyFilter {
+export function isFlagPropertyFilter(filter?: AnyFilterLike | null): filter is FlagPropertyFilter {
     return filter?.type === PropertyFilterType.Flag
 }
 export function isHogQLPropertyFilter(filter?: AnyFilterLike | null): filter is HogQLPropertyFilter {
@@ -271,7 +271,7 @@ export function isAnyPropertyfilter(filter?: AnyFilterLike | null): filter is An
         isRecordingPropertyFilter(filter) ||
         isLogEntryPropertyFilter(filter) ||
         isFeaturePropertyFilter(filter) ||
-        isFlagDependencyPropertyFilter(filter) ||
+        isFlagPropertyFilter(filter) ||
         isGroupPropertyFilter(filter) ||
         isLogPropertyFilter(filter)
     )
@@ -303,7 +303,7 @@ export function isPropertyFilterWithOperator(
             isRecordingPropertyFilter(filter) ||
             isLogEntryPropertyFilter(filter) ||
             isFeaturePropertyFilter(filter) ||
-            isFlagDependencyPropertyFilter(filter) ||
+            isFlagPropertyFilter(filter) ||
             isGroupPropertyFilter(filter) ||
             isCohortPropertyFilter(filter) ||
             isDataWarehousePropertyFilter(filter) ||

--- a/frontend/src/lib/components/PropertyFilters/utils.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.ts
@@ -40,6 +40,7 @@ import {
     RecordingPropertyFilter,
     RevenueAnalyticsPropertyFilter,
     SessionPropertyFilter,
+    FlagDependencyPropertyFilter,
 } from '~/types'
 
 export function isPropertyGroup(
@@ -251,6 +252,9 @@ export function isDataWarehousePersonPropertyFilter(
 export function isFeaturePropertyFilter(filter?: AnyFilterLike | null): filter is FeaturePropertyFilter {
     return filter?.type === PropertyFilterType.Feature
 }
+export function isFlagDependencyPropertyFilter(filter?: AnyFilterLike | null): filter is FlagDependencyPropertyFilter {
+    return filter?.type === PropertyFilterType.Flag
+}
 export function isHogQLPropertyFilter(filter?: AnyFilterLike | null): filter is HogQLPropertyFilter {
     return filter?.type === PropertyFilterType.HogQL
 }
@@ -267,6 +271,7 @@ export function isAnyPropertyfilter(filter?: AnyFilterLike | null): filter is An
         isRecordingPropertyFilter(filter) ||
         isLogEntryPropertyFilter(filter) ||
         isFeaturePropertyFilter(filter) ||
+        isFlagDependencyPropertyFilter(filter) ||
         isGroupPropertyFilter(filter) ||
         isLogPropertyFilter(filter)
     )
@@ -298,6 +303,7 @@ export function isPropertyFilterWithOperator(
             isRecordingPropertyFilter(filter) ||
             isLogEntryPropertyFilter(filter) ||
             isFeaturePropertyFilter(filter) ||
+            isFlagDependencyPropertyFilter(filter) ||
             isGroupPropertyFilter(filter) ||
             isCohortPropertyFilter(filter) ||
             isDataWarehousePropertyFilter(filter) ||
@@ -376,6 +382,7 @@ export function propertyFilterTypeToPropertyDefinitionType(
         [PropertyFilterType.ErrorTrackingIssue]: PropertyDefinitionType.Resource,
         [PropertyFilterType.Log]: PropertyDefinitionType.Log,
         [PropertyFilterType.RevenueAnalytics]: PropertyDefinitionType.RevenueAnalytics,
+        [PropertyFilterType.Flag]: PropertyDefinitionType.FlagValue,
     }
 
     return mapping[filterType as PropertyFilterType] ?? PropertyDefinitionType.Event
@@ -412,6 +419,11 @@ export function taxonomicFilterTypeToPropertyFilterType(
 
     if (filterType == TaxonomicFilterGroupType.ErrorTrackingIssues) {
         return PropertyFilterType.ErrorTrackingIssue
+    }
+
+    if (filterType === TaxonomicFilterGroupType.FeatureFlags) {
+        // Feature flags dependencies (flag + value) as a property filter
+        return PropertyFilterType.Flag
     }
 
     if (filterType == TaxonomicFilterGroupType.LogAttributes) {

--- a/frontend/src/lib/components/PropertyFilters/utils.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.ts
@@ -335,6 +335,7 @@ const propertyFilterMapping: Partial<Record<PropertyFilterType, TaxonomicFilterG
     [PropertyFilterType.ErrorTrackingIssue]: TaxonomicFilterGroupType.ErrorTrackingIssues,
     [PropertyFilterType.Log]: TaxonomicFilterGroupType.LogAttributes,
     [PropertyFilterType.RevenueAnalytics]: TaxonomicFilterGroupType.RevenueAnalyticsProperties,
+    [PropertyFilterType.Flag]: TaxonomicFilterGroupType.FeatureFlags,
 }
 
 export const filterToTaxonomicFilterType = (

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -246,23 +246,6 @@ export function InfiniteList({ popupAnchorElement }: InfiniteListProps): JSX.Ele
 
         const isSelected = listGroupType === groupType && itemValue === normalizedValue
 
-        // Debug logging for flag dependencies selection
-        if (listGroupType === TaxonomicFilterGroupType.FeatureFlags && typeof window !== 'undefined') {
-            // eslint-disable-next-line no-console
-            console.log(`[InfiniteList] Selection debug for row ${rowIndex}:`, {
-                listGroupType,
-                groupType,
-                itemValue,
-                itemValueType: typeof itemValue,
-                value,
-                valueType: typeof value,
-                normalizedValue,
-                normalizedValueType: typeof normalizedValue,
-                isSelected,
-                itemName: item?.name || item?.key,
-            })
-        }
-
         const isHighlighted = rowIndex === index && isActiveTab
 
         // Show create custom event option when there are no results

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -240,7 +240,29 @@ export function InfiniteList({ popupAnchorElement }: InfiniteListProps): JSX.Ele
         const item = results[rowIndex]
         const itemGroup = getItemGroup(item, taxonomicGroups, group)
         const itemValue = item ? itemGroup?.getValue?.(item) : null
-        const isSelected = listGroupType === groupType && itemValue === value
+
+        // Normalize value to match itemValue type before comparison
+        const normalizedValue = typeof itemValue === 'number' && typeof value === 'string' ? Number(value) : value
+
+        const isSelected = listGroupType === groupType && itemValue === normalizedValue
+
+        // Debug logging for flag dependencies selection
+        if (listGroupType === TaxonomicFilterGroupType.FeatureFlags && typeof window !== 'undefined') {
+            // eslint-disable-next-line no-console
+            console.log(`[InfiniteList] Selection debug for row ${rowIndex}:`, {
+                listGroupType,
+                groupType,
+                itemValue,
+                itemValueType: typeof itemValue,
+                value,
+                valueType: typeof value,
+                normalizedValue,
+                normalizedValueType: typeof normalizedValue,
+                isSelected,
+                itemName: item?.name || item?.key,
+            })
+        }
+
         const isHighlighted = rowIndex === index && isActiveTab
 
         // Show create custom event option when there are no results

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -619,7 +619,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                     {
                         name: 'Feature Flags',
                         searchPlaceholder: 'feature flags',
-                        type: TaxonomicFilterGroupType.FeatureFlags,
+                        type: TaxonomicFilterGroupType.FeatureFlags, // Feature flag dependencies
                         endpoint: combineUrl(`api/projects/${projectId}/feature_flags/`).url,
                         getName: (featureFlag: FeatureFlagType) => featureFlag.key || featureFlag.name,
                         getValue: (featureFlag: FeatureFlagType) => featureFlag.id || '',

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -624,6 +624,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         getName: (featureFlag: FeatureFlagType) => featureFlag.key || featureFlag.name,
                         getValue: (featureFlag: FeatureFlagType) => featureFlag.id || '',
                         getPopoverHeader: () => `Feature Flags`,
+                        excludedProperties: excludedProperties?.[TaxonomicFilterGroupType.FeatureFlags],
                     },
                     {
                         name: 'Experiments',

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -287,6 +287,7 @@ export const FEATURE_FLAGS = {
     DATA_WAREHOUSE_SCENE: 'data-warehouse-scene', // owner: @naumaanh #team-data-warehouse
     MAX_BILLING_CONTEXT: 'max-billing-context', // owner: @pawel-cebula #team-billing
     SCENE_TABS: 'scene-tabs', // owner @mariusandra #team-devex
+    FEATURE_FLAGS_FLAG_DEPENDENCY: 'feature-flags-flag-dependency', // owner: @haacked #team-feature-flags
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -270,6 +270,10 @@ export const cohortOperatorMap: Record<string, string> = {
     not_in: 'user not in',
 }
 
+export const featureFlagOperatorMap: Record<string, string> = {
+    flag_evaluates_to: '= evaluates to',
+}
+
 export const stickinessOperatorMap: Record<string, string> = {
     exact: '= Exactly',
     gte: '≥ At least',
@@ -298,6 +302,7 @@ export const allOperatorsMapping: Record<string, string> = {
     ...durationOperatorMap,
     ...selectorOperatorMap,
     ...cohortOperatorMap,
+    ...featureFlagOperatorMap,
     ...cleanedPathOperatorMap,
     // slight overkill to spread all of these into the map
     // but gives freedom for them to diverge more over time
@@ -311,6 +316,7 @@ const operatorMappingChoice: Record<keyof typeof PropertyType, Record<string, st
     Duration: durationOperatorMap,
     Selector: selectorOperatorMap,
     Cohort: cohortOperatorMap,
+    Flag: featureFlagOperatorMap,
     Assignee: assigneeOperatorMap,
     StringArray: stringArrayOperatorMap,
 }

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -400,7 +400,7 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
                 methodOptions
             )
             breakpoint()
-            actions.setOptions(propertyKey, propValues, true)
+            actions.setOptions(propertyKey, propValues, type !== PropertyDefinitionType.FlagValue)
             cache.abortController = null
 
             await captureTimeToSeeData(teamLogic.values.currentTeamId, {

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -143,8 +143,17 @@ const constructValuesEndpoint = (
     newInput: string | undefined,
     properties?: { key: string; values: string | string[] }[]
 ): string => {
-    const basePath =
-        type === PropertyDefinitionType.Session ? `api/environments/${teamId}/${type}s/values` : `api/${type}/values`
+    let basePath: string
+
+    if (type === PropertyDefinitionType.Session) {
+        basePath = `api/environments/${teamId}/${type}s/values`
+    } else if (type === PropertyDefinitionType.FlagValue) {
+        // FlagValue is project-scoped, so use the project-scoped endpoint
+        basePath = `api/projects/${teamId}/${type}/values`
+    } else {
+        basePath = `api/${type}/values`
+    }
+
     const path = endpoint ? endpoint : basePath + `?key=${encodeURIComponent(propertyKey)}`
 
     let eventParams = ''

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -1,7 +1,7 @@
 import './FeatureFlag.scss'
 
-import { IconCopy, IconPlus, IconTrash } from '@posthog/icons'
-import { LemonInput, LemonSelect, LemonSnack, Link } from '@posthog/lemon-ui'
+import { IconCopy, IconPlus, IconTrash, IconFlag } from '@posthog/icons'
+import { LemonInput, LemonSelect, LemonSnack, Link, Tooltip } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
@@ -22,11 +22,9 @@ import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 import { capitalizeFirstLetter, dateFilterToText, dateStringToComponents, humanFriendlyNumber } from 'lib/utils'
 import { urls } from 'scenes/urls'
-
 import { groupsModel } from '~/models/groupsModel'
 import { getFilterLabel } from '~/taxonomy/helpers'
-import { AnyPropertyFilter, FeatureFlagGroupType, PropertyOperator } from '~/types'
-
+import { AnyPropertyFilter, FeatureFlagGroupType, PropertyFilterType, PropertyOperator } from '~/types'
 import { featureFlagLogic } from './featureFlagLogic'
 import {
     featureFlagReleaseConditionsLogic,
@@ -57,7 +55,8 @@ function PropertyValueComponent({ property }: { property: AnyPropertyFilter }): 
         <>
             {propertyValues.map((val, idx) => (
                 <LemonSnack key={idx}>
-                    {val}
+                    {String(val)}
+                    {}
                     <span>
                         {isPropertyFilterWithOperator(property) &&
                         ['is_date_before', 'is_date_after'].includes(property.operator) &&
@@ -136,6 +135,11 @@ export function FeatureFlagReleaseConditions({
     const filterGroups: FeatureFlagGroupType[] = (isSuper ? filters?.super_groups : filters?.groups) || []
     // :KLUDGE: Match by select only allows Select.Option as children, so render groups option directly rather than as a child
     const matchByGroupsIntroductionOption = GroupsIntroductionOption()
+
+    // Get flag key data for all flag dependencies
+    const { getFlagKey, flagKeysLoading } = useValues(releaseConditionsLogic)
+    const flagKeyData = (flagId: string): string => getFlagKey(flagId)
+
     const hasNonInstantProperty = (properties: AnyPropertyFilter[]): boolean => {
         return !!properties.find(
             (property) => property.type === 'cohort' || !INSTANTLY_AVAILABLE_PROPERTIES.includes(property.key || '')
@@ -255,14 +259,29 @@ export function FeatureFlagReleaseConditions({
                                     ) : (
                                         <LemonButton icon={<span className="text-sm">&</span>} size="small" />
                                     )}
-                                    {property?.type !== 'cohort' &&
+                                    {property?.type !== PropertyFilterType.Cohort &&
+                                        property?.type !== PropertyFilterType.Flag &&
                                         getFilterLabel(
                                             property.key,
-                                            property.type === 'person'
+                                            property.type === PropertyFilterType.Person
                                                 ? TaxonomicFilterGroupType.PersonProperties
                                                 : TaxonomicFilterGroupType.EventProperties
                                         )}
-                                    <LemonSnack>{property.type === 'cohort' ? 'Cohort' : property.key} </LemonSnack>
+                                    {property.type === PropertyFilterType.Flag &&
+                                        (() => {
+                                            const flagId = property.key || ''
+                                            return (
+                                                <Tooltip title={flagId}>
+                                                    <LemonSnack>
+                                                        <IconFlag className="mr-1" />
+                                                        {flagKeysLoading ? 'Loading...' : flagKeyData(flagId)}
+                                                    </LemonSnack>
+                                                </Tooltip>
+                                            )
+                                        })()}
+                                    {property.type !== PropertyFilterType.Flag && (
+                                        <LemonSnack>{property.type === 'cohort' ? 'Cohort' : property.key}</LemonSnack>
+                                    )}
                                     {isPropertyFilterWithOperator(property) ? (
                                         <span>{allOperatorsToHumanName(property.operator)} </span>
                                     ) : null}
@@ -287,6 +306,11 @@ export function FeatureFlagReleaseConditions({
                                 hasRowOperator={false}
                                 sendAllKeyUpdates
                                 allowRelativeDateOptions
+                                excludedProperties={
+                                    featureFlagKey
+                                        ? { [TaxonomicFilterGroupType.FeatureFlags]: [featureFlagKey] }
+                                        : undefined
+                                }
                                 errorMessages={
                                     propertySelectErrors?.[index]?.properties?.some((message) => !!message.value)
                                         ? propertySelectErrors[index].properties?.map((message, index) => {

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -32,7 +32,7 @@ import {
 } from './featureFlagReleaseConditionsLogic'
 
 function PropertyValueComponent({ property }: { property: AnyPropertyFilter }): JSX.Element {
-    if (property.type === 'cohort') {
+    if (property.type === PropertyFilterType.Cohort) {
         return (
             <LemonButton
                 type="secondary"
@@ -141,7 +141,9 @@ export function FeatureFlagReleaseConditions({
 
     const hasNonInstantProperty = (properties: AnyPropertyFilter[]): boolean => {
         return !!properties.find(
-            (property) => property.type === 'cohort' || !INSTANTLY_AVAILABLE_PROPERTIES.includes(property.key || '')
+            (property) =>
+                property.type === PropertyFilterType.Cohort ||
+                !INSTANTLY_AVAILABLE_PROPERTIES.includes(property.key || '')
         )
     }
 
@@ -291,7 +293,9 @@ export function FeatureFlagReleaseConditions({
                                             )
                                         })()}
                                     {property.type !== PropertyFilterType.Flag && (
-                                        <LemonSnack>{property.type === 'cohort' ? 'Cohort' : property.key}</LemonSnack>
+                                        <LemonSnack>
+                                            {property.type === PropertyFilterType.Cohort ? 'Cohort' : property.key}
+                                        </LemonSnack>
                                     )}
                                     {isPropertyFilterWithOperator(property) ? (
                                         <span>{allOperatorsToHumanName(property.operator)} </span>

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -278,10 +278,16 @@ export function FeatureFlagReleaseConditions({
                                             const flagId = property.key || ''
                                             return (
                                                 <Tooltip title={flagId}>
-                                                    <LemonSnack>
-                                                        <IconFlag className="mr-1" />
-                                                        {flagKeysLoading ? 'Loading...' : flagKeyData(flagId)}
-                                                    </LemonSnack>
+                                                    <LemonButton
+                                                        to={urls.featureFlag(flagId)}
+                                                        size="small"
+                                                        className="p-0"
+                                                    >
+                                                        <LemonSnack>
+                                                            <IconFlag className="mr-1" />
+                                                            {flagKeysLoading ? 'Loading...' : flagKeyData(flagId)}
+                                                        </LemonSnack>
+                                                    </LemonButton>
                                                 </Tooltip>
                                             )
                                         })()}

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -56,7 +56,6 @@ function PropertyValueComponent({ property }: { property: AnyPropertyFilter }): 
             {propertyValues.map((val, idx) => (
                 <LemonSnack key={idx}>
                     {String(val)}
-                    {}
                     <span>
                         {isPropertyFilterWithOperator(property) &&
                         ['is_date_before', 'is_date_after'].includes(property.operator) &&

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -246,6 +246,12 @@ export function FeatureFlagReleaseConditions({
                             </Link>
                         </LemonBanner>
                     )}
+                    {group.properties?.some((property) => property.type === PropertyFilterType.Flag) && (
+                        <LemonBanner type="warning" className="mt-3 mb-3">
+                            Local evaluation is not supported for feature flags with dependencies. These flags will
+                            require a server request to evaluate.
+                        </LemonBanner>
+                    )}
 
                     {readOnly ? (
                         <>

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
@@ -354,7 +354,12 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                 const validIds = uncachedIds
                     .map((id: string) => {
                         const parsed = parseInt(id, 10)
-                        return !isNaN(parsed) ? parsed : null
+                        if (!isNaN(parsed)) {
+                            return parsed
+                        }
+                        // This should pretty much never happen, but we'll log it just in case
+                        console.warn(`Non-numeric flag ID detected and skipped: "${id}"`)
+                        return null
                     })
                     .filter((id): id is number => id !== null)
 
@@ -376,6 +381,7 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                 // For any IDs that weren't returned (not found), use the ID as fallback
                 uncachedIds.forEach((id: string) => {
                     if (!keys[id]) {
+                        // This should rarely happen.
                         console.warn(`Flag with ID ${id} not found. Using ID as fallback key.`)
                         flagKeyMapping[id] = id
                     }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3606,6 +3606,7 @@ export enum PropertyType {
     Cohort = 'Cohort',
     Assignee = 'Assignee',
     StringArray = 'StringArray',
+    Flag = 'Flag',
 }
 
 export enum PropertyDefinitionType {
@@ -3619,6 +3620,7 @@ export enum PropertyDefinitionType {
     Meta = 'meta',
     Resource = 'resource',
     Log = 'log',
+    FlagValue = 'flag_value',
 }
 
 export interface PropertyDefinition {
@@ -5149,6 +5151,7 @@ export type CyclotronJobFilterPropertyFilter =
     | GroupPropertyFilter
     | FeaturePropertyFilter
     | HogQLPropertyFilter
+    | FlagPropertyFilter
 
 export interface CyclotronJobFiltersType {
     source?: 'events' | 'person-updates'

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -409,7 +409,6 @@ class FeatureFlagSerializer(
 
     def _validate_flag_reference(self, flag_reference):
         """Validate and convert flag reference to flag key."""
-        from posthog.models import FeatureFlag
         from posthog.utils import safe_int
 
         flag_id = safe_int(flag_reference)
@@ -439,7 +438,6 @@ class FeatureFlagSerializer(
 
     def _check_flag_circular_dependencies(self, filters):
         """Check for circular dependencies in feature flag conditions."""
-        from posthog.models import FeatureFlag
 
         current_flag_key = getattr(self.instance, "key", None) if self.instance else self.initial_data.get("key")
         if not current_flag_key:

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -916,6 +916,16 @@ class FeatureFlagViewSet(
             elif key == "evaluation_runtime":
                 evaluation_runtime = request.GET["evaluation_runtime"]
                 queryset = queryset.filter(evaluation_runtime=evaluation_runtime)
+            elif key == "excluded_properties":
+                import json
+
+                try:
+                    excluded_keys = json.loads(request.GET["excluded_properties"])
+                    if excluded_keys:
+                        queryset = queryset.exclude(key__in=excluded_keys)
+                except (json.JSONDecodeError, TypeError):
+                    # If the JSON is invalid, ignore the filter
+                    pass
 
         return queryset
 
@@ -998,6 +1008,13 @@ class FeatureFlagViewSet(
                 required=False,
                 enum=["server", "client", "both"],
                 description="Filter feature flags by their evaluation runtime.",
+            ),
+            OpenApiParameter(
+                "excluded_properties",
+                OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                description="JSON-encoded list of feature flag keys to exclude from the results.",
             ),
         ]
     )

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -370,6 +370,13 @@ def property_to_expr(
             return ast.Or(exprs=[property_to_expr(p, team, scope, strict=strict) for p in property.values])
     elif isinstance(property, EmptyPropertyFilter):
         return ast.Constant(value=1)
+    elif isinstance(property, FlagPropertyFilter):
+        # Flag dependencies are evaluated at the API layer, not in HogQL.
+        # They should never reach this point, but we handle them gracefully
+        # to satisfy type checking since FlagPropertyFilter is part
+        # of the AnyPropertyFilter union used throughout the codebase.
+        # Return a neutral filter that doesn't affect the query.
+        return ast.Constant(value=1)
     elif isinstance(property, BaseModel):
         try:
             property = Property(**property.dict())

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -314,8 +314,9 @@ def property_to_Q(
 ) -> Q:
     if override_property_values is None:
         override_property_values = {}
-    if property.type not in ["person", "group", "cohort", "event"]:
+    if property.type not in ["person", "group", "cohort", "event", "flag"]:
         # We need to support event type for backwards compatibility, even though it's treated as a person property type
+        # Note: "flag" type is not supported here as flag dependencies are handled at the API layer during validation
         raise ValueError(f"property_to_Q: type is not supported: {repr(property.type)}")
 
     value = property._parse_value(property.value)


### PR DESCRIPTION
https://www.loom.com/share/b371a79b1d6544f0a18b1b1a6aeb9bd3?sid=6929e3d9-ebaf-4084-99f6-47681d7fc1c0

> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We want to be able to have flags that depend on the evaluation of other flags.

Fixes #29016 

## Changes

1. When selecting conditions, adds a flags tab to select feature flags
2. Allows selecting a flag value
3. Prevents circular dependencies
4. Prevents deleting a flag that other flags depend on.
5. This is all hidden behind a feature flag

## Did you write or update any docs for this change?

- [x] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs): ([DRAFT docs](https://github.com/PostHog/posthog.com/pull/12211))
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

Manual testing.