### PR TITLE
fix(external-tables): Fuse external tables w/ model path parsing

### DIFF
--- a/posthog/models/property/util.py
+++ b/posthog/models/property/util.py
@@ -985,6 +985,11 @@ class S3TableVisitor(TraversingVisitor):
         super().__init__()
         self.tables = set()
 
+    def visit_join_expr(self, node):
+        # visit the join's subquery
+        self.visit(node.table)
+        super().visit_join_expr(node)
+
     def visit_table_type(self, node):
         if isinstance(node.table, S3Table):
             self.tables.add(node.table.name)

--- a/posthog/models/property/util.py
+++ b/posthog/models/property/util.py
@@ -985,11 +985,6 @@ class S3TableVisitor(TraversingVisitor):
         super().__init__()
         self.tables = set()
 
-    def visit_join_expr(self, node):
-        # visit the join's subquery
-        self.visit(node.table)
-        super().visit_join_expr(node)
-
     def visit_table_type(self, node):
         if isinstance(node.table, S3Table):
             self.tables.add(node.table.name)

--- a/posthog/warehouse/api/lineage.py
+++ b/posthog/warehouse/api/lineage.py
@@ -102,7 +102,7 @@ def get_upstream_dag(team_id: int, model_id: str) -> dict[str, list[Any]]:
                     except ValueError:
                         continue
 
-        #  Deduplicate dependencies, these would be materialized views since they are both external and in the model paths
+        #  Deduplicate dependencies, which would be materialized views since they are both external and in the model paths
         all_dependencies = list(dict.fromkeys(external_tables + saved_query_names))
 
         unseen_dependencies = [dep for dep in all_dependencies if dep not in seen_nodes]

--- a/posthog/warehouse/api/lineage.py
+++ b/posthog/warehouse/api/lineage.py
@@ -55,7 +55,7 @@ def topological_sort(nodes: list[str], edges: list[dict[str, str]]) -> list[str]
         node = queue.popleft()
         result.append(node)
 
-    # root node and its external tables
+        # root node and its external tables
         for neighbor in graph[node]:
             in_degree[neighbor] -= 1
             if in_degree[neighbor] == 0:

--- a/posthog/warehouse/api/lineage.py
+++ b/posthog/warehouse/api/lineage.py
@@ -112,19 +112,24 @@ def get_upstream_dag(team_id: int, model_id: str) -> dict[str, list[Any]]:
         all_dependencies = list(dict.fromkeys(external_tables + saved_query_names))
 
         unseen_dependencies = [dep for dep in all_dependencies if dep not in seen_nodes]
+        saved_queries: dict[str, DataWarehouseSavedQuery] = {}
+        tables: dict[str, DataWarehouseTable] = {}
         if unseen_dependencies:
-            saved_query_names = []
-            table_names = []
+            unseen_saved_query_names = []
+            unseen_table_names = []
             for dep in unseen_dependencies:
                 if DataWarehouseSavedQuery.objects.filter(name=dep, team_id=team_id).exists():
-                    saved_query_names.append(dep)
+                    unseen_saved_query_names.append(dep)
                 else:
-                    table_names.append(dep)
+                    unseen_table_names.append(dep)
 
             saved_queries = {
-                q.name: q for q in DataWarehouseSavedQuery.objects.filter(name__in=saved_query_names, team_id=team_id)
+                q.name: q
+                for q in DataWarehouseSavedQuery.objects.filter(name__in=unseen_saved_query_names, team_id=team_id)
             }
-            tables = {t.name: t for t in DataWarehouseTable.objects.filter(name__in=table_names, team_id=team_id)}
+            tables = {
+                t.name: t for t in DataWarehouseTable.objects.filter(name__in=unseen_table_names, team_id=team_id)
+            }
 
         for dependency in all_dependencies:
             if dependency != current_name:

--- a/posthog/warehouse/api/lineage.py
+++ b/posthog/warehouse/api/lineage.py
@@ -102,7 +102,8 @@ def get_upstream_dag(team_id: int, model_id: str) -> dict[str, list[Any]]:
                     except ValueError:
                         continue
 
-        all_dependencies = external_tables + saved_query_names
+        #  Deduplicate dependencies, these would be materialized views since they are both external and in the model paths
+        all_dependencies = list(dict.fromkeys(external_tables + saved_query_names))
 
         unseen_dependencies = [dep for dep in all_dependencies if dep not in seen_nodes]
         if unseen_dependencies:

--- a/posthog/warehouse/api/lineage.py
+++ b/posthog/warehouse/api/lineage.py
@@ -4,9 +4,12 @@ from rest_framework.response import Response
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from rest_framework.permissions import IsAuthenticated
 from posthog.warehouse.models.datawarehouse_saved_query import DataWarehouseSavedQuery
-from posthog.warehouse.models.table import DataWarehouseTable
 from typing import Any
 from collections import defaultdict, deque
+from django.db.models import Q
+import uuid
+from posthog.warehouse.models.modeling import DataWarehouseModelPath
+from posthog.warehouse.models.table import DataWarehouseTable
 import logging
 
 
@@ -32,7 +35,6 @@ def topological_sort(nodes: list[str], edges: list[dict[str, str]]) -> list[str]
     Performs a topological sort on the DAG to determine execution order.
     Returns nodes ordered from most upstream to the node itself.
     """
-    # Build adjacency list and in-degree count
     graph = defaultdict(list)
     in_degree: dict[str, int] = defaultdict(int)
 
@@ -43,11 +45,9 @@ def topological_sort(nodes: list[str], edges: list[dict[str, str]]) -> list[str]
         if source not in in_degree:
             in_degree[source] = 0
 
-    # Initialize queue with nodes that have no incoming edges
     queue = deque([node for node in nodes if in_degree[node] == 0])
     result = []
 
-    # Process nodes
     while queue:
         node = queue.popleft()
         result.append(node)
@@ -65,7 +65,6 @@ def get_upstream_dag(team_id: int, model_id: str) -> dict[str, list[Any]]:
     seen_nodes: set[str] = set()
     node_data: dict[str, dict] = {}
 
-    # root node and its external tables
     root_query = DataWarehouseSavedQuery.objects.filter(id=model_id, team_id=team_id).first()
     if not root_query:
         return dag
@@ -79,57 +78,80 @@ def get_upstream_dag(team_id: int, model_id: str) -> dict[str, list[Any]]:
         "status": root_query.status,
     }
     seen_nodes.add(root_query.name)
-
-    # Recursively fetch all dependencies with a bfs
-    # Fetch everything by names, ids and names are the same right now
-    to_process = [(root_query.name, root_query.external_tables)]
+    to_process = [(root_query.name, root_query.external_tables, [])]
 
     while to_process:
-        current_id, external_tables = to_process.pop(0)
+        current_name, external_tables, saved_query_names = to_process.pop(0)
 
-        # Batch lookup all external tables at this level
-        unseen_external_tables = [et for et in external_tables if et not in seen_nodes]
-        if unseen_external_tables:
+        current_saved_query = DataWarehouseSavedQuery.objects.filter(name=current_name, team_id=team_id).first()
+        if current_saved_query:
+            query = Q(team_id=team_id, saved_query_id=current_saved_query.id)
+            paths = DataWarehouseModelPath.objects.filter(query)
+
+            for path in paths:
+                components = path.path if isinstance(path.path, list) else path.path.split(".")
+                for component in components:
+                    try:
+                        uuid.UUID(component)
+                        if (
+                            DataWarehouseSavedQuery.objects.filter(id=component, team_id=team_id).exists()
+                            and component != current_saved_query.id
+                        ):
+                            saved_query = DataWarehouseSavedQuery.objects.get(id=component, team_id=team_id)
+                            saved_query_names.append(saved_query.name)
+                    except ValueError:
+                        continue
+
+        all_dependencies = external_tables + saved_query_names
+
+        unseen_dependencies = [dep for dep in all_dependencies if dep not in seen_nodes]
+        if unseen_dependencies:
+            saved_query_names = []
+            table_names = []
+            for dep in unseen_dependencies:
+                if DataWarehouseSavedQuery.objects.filter(name=dep, team_id=team_id).exists():
+                    saved_query_names.append(dep)
+                else:
+                    table_names.append(dep)
+
             saved_queries = {
-                sq.name: sq
-                for sq in DataWarehouseSavedQuery.objects.filter(name__in=unseen_external_tables, team_id=team_id)
+                q.name: q for q in DataWarehouseSavedQuery.objects.filter(name__in=saved_query_names, team_id=team_id)
             }
-            tables = {
-                t.name: t for t in DataWarehouseTable.objects.filter(name__in=unseen_external_tables, team_id=team_id)
-            }
+            tables = {t.name: t for t in DataWarehouseTable.objects.filter(name__in=table_names, team_id=team_id)}
 
-        for external_table in external_tables:
-            edge = {"source": external_table, "target": current_id}
-            if edge not in dag["edges"]:
-                dag["edges"].append(edge)
+        for dependency in all_dependencies:
+            if dependency != current_name:
+                edge = {"source": dependency, "target": current_name}
+                if edge not in dag["edges"]:
+                    dag["edges"].append(edge)
 
-            if external_table not in seen_nodes:
-                seen_nodes.add(external_table)
+            if dependency not in seen_nodes:
+                seen_nodes.add(dependency)
 
-                # Process the current external table
-                saved_query = saved_queries.get(external_table)
+                saved_query = saved_queries.get(dependency)
                 if saved_query:
-                    node_data[external_table] = {
-                        "id": external_table,
+                    node_data[dependency] = {
+                        "id": dependency,
                         "type": "view",
                         "name": saved_query.name,
                         "sync_frequency": saved_query.sync_frequency_interval,
                         "last_run_at": saved_query.last_run_at,
                         "status": saved_query.status,
                     }
-                    to_process.append((external_table, saved_query.external_tables))
+                    to_process.append((saved_query.name, saved_query.external_tables, []))
                 else:
-                    table = tables.get(external_table)
+                    table = tables.get(dependency)
                     if not table:
-                        logging.warning(f"Upstream table not found for external_table: {external_table}")
-                    node_data[external_table] = {
-                        "id": external_table,
+                        logging.warning(f"Upstream table not found for dependency: {dependency}")
+                    node_data[dependency] = {
+                        "id": dependency,
                         "type": "table",
-                        "name": table.name if table else external_table,
+                        "name": table.name if table else dependency,
                     }
 
-    # Order nodes by dependency order
     ordered_nodes = topological_sort(list(node_data.keys()), dag["edges"])
+    if root_query.name not in ordered_nodes:
+        ordered_nodes.append(root_query.name)
     dag["nodes"] = [node_data[node_id] for node_id in ordered_nodes]
 
     return dag

--- a/posthog/warehouse/api/lineage.py
+++ b/posthog/warehouse/api/lineage.py
@@ -11,7 +11,6 @@ import uuid
 from posthog.warehouse.models.modeling import DataWarehouseModelPath
 from posthog.warehouse.models.table import DataWarehouseTable
 import logging
-from typing import Tuple, List
 
 
 class LineageViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):

--- a/posthog/warehouse/api/lineage.py
+++ b/posthog/warehouse/api/lineage.py
@@ -35,6 +35,7 @@ def topological_sort(nodes: list[str], edges: list[dict[str, str]]) -> list[str]
     Performs a topological sort on the DAG to determine execution order.
     Returns nodes ordered from most upstream to the node itself.
     """
+    # Build adjacency list and in-degree count
     graph = defaultdict(list)
     in_degree: dict[str, int] = defaultdict(int)
 
@@ -45,13 +46,16 @@ def topological_sort(nodes: list[str], edges: list[dict[str, str]]) -> list[str]
         if source not in in_degree:
             in_degree[source] = 0
 
+    # Initialize queue with nodes that have no incoming edges
     queue = deque([node for node in nodes if in_degree[node] == 0])
     result = []
 
+    # Process nodes
     while queue:
         node = queue.popleft()
         result.append(node)
 
+    # root node and its external tables
         for neighbor in graph[node]:
             in_degree[neighbor] -= 1
             if in_degree[neighbor] == 0:
@@ -78,6 +82,8 @@ def get_upstream_dag(team_id: int, model_id: str) -> dict[str, list[Any]]:
         "status": root_query.status,
     }
     seen_nodes.add(root_query.name)
+    # Fetch all dependencies with a bfs
+    # Fetch everything by names, ids and names are the same right now
     to_process = [(root_query.name, root_query.external_tables, [])]
 
     while to_process:


### PR DESCRIPTION
## Problem

We need to partially bring some of the 1st implementation of the upstream graph because I missed some nuances related to views being captured as `external_tables`, which they are not, while materialized views are in our system. This was not clear to me because I tested manually with only materialized views.

It's also a little hard to test this as the mocked data is really synthetic and not reflective of the actual models that are percolated by user actions.

Includes all views, mat views, and external tables.
<img width="1122" height="736" alt="image" src="https://github.com/user-attachments/assets/a62600f4-0a2f-45b8-80c3-f662cc35dfac" />

