### PR TITLE
fix: sync

### DIFF
--- a/ee/tasks/subscriptions/__init__.py
+++ b/ee/tasks/subscriptions/__init__.py
@@ -10,7 +10,7 @@ from prometheus_client import Counter
 
 from ee.tasks.subscriptions.email_subscriptions import send_email_subscription_report
 from ee.tasks.subscriptions.slack_subscriptions import send_slack_subscription_report
-from ee.tasks.subscriptions.subscription_utils import generate_assets
+from ee.tasks.subscriptions.subscription_utils import generate_assets, generate_assets_async
 from posthog import settings
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Team
@@ -126,6 +126,96 @@ def _deliver_subscription_report(
     return not is_new_subscription_target
 
 
+async def _deliver_subscription_report_async(
+    subscription: Subscription,
+    previous_value: Optional[str] = None,
+    invite_message: Optional[str] = None,
+) -> bool:
+    """Async core logic for delivering subscription reports (Temporal-compatible).
+
+    Args:
+        subscription: The subscription object to process
+        previous_value: Previous target value for "new" or "invite" messages
+        invite_message: Optional invite message for new subscriptions
+
+    Returns:
+        bool: True if subscription should be updated (next_delivery_date), False otherwise
+    """
+    is_new_subscription_target = False
+    if previous_value is not None:
+        # If previous_value is set we are triggering a "new" or "invite" message
+        is_new_subscription_target = subscription.target_value != previous_value
+
+        if not is_new_subscription_target:
+            # Same value as before so nothing to do
+            return False
+
+    # Use async version of generate_assets (Temporal-compatible)
+    insights, assets = await generate_assets_async(subscription)
+
+    if not assets:
+        capture_exception(Exception("No assets are in this subscription"), {"subscription_id": subscription.id})
+        return False
+
+    if subscription.target_type == "email":
+        SUBSCRIPTION_QUEUED.labels(destination="email").inc()
+
+        # Send emails
+        emails = subscription.target_value.split(",")
+        if is_new_subscription_target:
+            previous_emails = previous_value.split(",") if previous_value else []
+            emails = list(set(emails) - set(previous_emails))
+
+        for email in emails:
+            try:
+                await database_sync_to_async(send_email_subscription_report)(
+                    email,
+                    subscription,
+                    assets,
+                    invite_message=invite_message or "" if is_new_subscription_target else None,
+                    total_asset_count=len(insights),
+                )
+            except Exception as e:
+                SUBSCRIPTION_FAILURE.labels(destination="email").inc()
+                logger.error(
+                    "sending subscription failed",
+                    subscription_id=subscription.id,
+                    next_delivery_date=subscription.next_delivery_date,
+                    destination=subscription.target_type,
+                    exc_info=True,
+                )
+                capture_exception(e)
+
+        SUBSCRIPTION_SUCCESS.labels(destination="email").inc()
+
+    elif subscription.target_type == "slack":
+        SUBSCRIPTION_QUEUED.labels(destination="slack").inc()
+
+        try:
+            await database_sync_to_async(send_slack_subscription_report)(
+                subscription,
+                assets,
+                total_asset_count=len(insights),
+                is_new_subscription=is_new_subscription_target,
+            )
+            SUBSCRIPTION_SUCCESS.labels(destination="slack").inc()
+        except Exception as e:
+            SUBSCRIPTION_FAILURE.labels(destination="slack").inc()
+            logger.error(
+                "sending subscription failed",
+                subscription_id=subscription.id,
+                next_delivery_date=subscription.next_delivery_date,
+                destination=subscription.target_type,
+                exc_info=True,
+            )
+            capture_exception(e)
+    else:
+        raise NotImplementedError(f"{subscription.target_type} is not supported")
+
+    # Return True if we should update subscription (for regular subscriptions, not new target changes)
+    return not is_new_subscription_target
+
+
 async def deliver_subscription_report_async(
     subscription_id: int,
     previous_value: Optional[str] = None,
@@ -139,8 +229,8 @@ async def deliver_subscription_report_async(
         .get
     )(pk=subscription_id)
 
-    # Call core logic
-    should_update = _deliver_subscription_report(subscription, previous_value, invite_message)
+    # Call async core logic
+    should_update = await _deliver_subscription_report_async(subscription, previous_value, invite_message)
 
     # Update subscription if needed
     if should_update:

--- a/ee/tasks/subscriptions/__init__.py
+++ b/ee/tasks/subscriptions/__init__.py
@@ -104,7 +104,7 @@ async def deliver_subscription_report_async(
         SUBSCRIPTION_QUEUED.labels(destination="slack").inc()
 
         try:
-            integration = await database_sync_to_async(get_slack_integration_for_team)(subscription.team)
+            integration = await database_sync_to_async(get_slack_integration_for_team)(subscription.team_id)
 
             if not integration:
                 logger.error("No Slack integration found for team...")

--- a/ee/tasks/subscriptions/__init__.py
+++ b/ee/tasks/subscriptions/__init__.py
@@ -85,6 +85,7 @@ def _deliver_subscription_report(
                     invite_message=invite_message or "" if is_new_subscription_target else None,
                     total_asset_count=len(insights),
                 )
+                SUBSCRIPTION_SUCCESS.labels(destination="email").inc()
             except Exception as e:
                 SUBSCRIPTION_FAILURE.labels(destination="email").inc()
                 logger.error(
@@ -95,8 +96,6 @@ def _deliver_subscription_report(
                     exc_info=True,
                 )
                 capture_exception(e)
-
-        SUBSCRIPTION_SUCCESS.labels(destination="email").inc()
 
     elif subscription.target_type == "slack":
         SUBSCRIPTION_QUEUED.labels(destination="slack").inc()
@@ -174,6 +173,7 @@ async def _deliver_subscription_report_async(
                     assets,
                     invite_message=invite_message or "" if is_new_subscription_target else None,
                     total_asset_count=len(insights),
+                    send_async=False,
                 )
             except Exception as e:
                 SUBSCRIPTION_FAILURE.labels(destination="email").inc()

--- a/ee/tasks/subscriptions/__init__.py
+++ b/ee/tasks/subscriptions/__init__.py
@@ -175,6 +175,7 @@ async def _deliver_subscription_report_async(
                     total_asset_count=len(insights),
                     send_async=False,
                 )
+                SUBSCRIPTION_SUCCESS.labels(destination="email").inc()
             except Exception as e:
                 SUBSCRIPTION_FAILURE.labels(destination="email").inc()
                 logger.error(
@@ -185,8 +186,6 @@ async def _deliver_subscription_report_async(
                     exc_info=True,
                 )
                 capture_exception(e)
-
-        SUBSCRIPTION_SUCCESS.labels(destination="email").inc()
 
     elif subscription.target_type == "slack":
         SUBSCRIPTION_QUEUED.labels(destination="slack").inc()

--- a/ee/tasks/subscriptions/email_subscriptions.py
+++ b/ee/tasks/subscriptions/email_subscriptions.py
@@ -18,6 +18,7 @@ def send_email_subscription_report(
     assets: list[ExportedAsset],
     invite_message: Optional[str] = None,
     total_asset_count: Optional[int] = None,
+    send_async: bool = True,
 ) -> None:
     utm_tags = f"{UTM_TAGS_BASE}&utm_medium=email"
 
@@ -64,4 +65,4 @@ def send_email_subscription_report(
         },
     )
     message.add_recipient(email=email)
-    message.send()
+    message.send(send_async=send_async)

--- a/ee/tasks/subscriptions/slack_subscriptions.py
+++ b/ee/tasks/subscriptions/slack_subscriptions.py
@@ -10,11 +10,6 @@ logger = structlog.get_logger(__name__)
 UTM_TAGS_BASE = "utm_source=posthog&utm_campaign=subscription_report"
 
 
-def get_slack_integration_for_team(team) -> Integration | None:
-    """Get Slack integration for a team. Returns None if not found."""
-    return Integration.objects.filter(team=team, kind="slack").first()
-
-
 def _block_for_asset(asset: ExportedAsset) -> dict:
     image_url = asset.get_public_content_url()
     alt_text = None
@@ -27,6 +22,11 @@ def _block_for_asset(asset: ExportedAsset) -> dict:
     return {"type": "image", "image_url": image_url, "alt_text": alt_text}
 
 
+def get_slack_integration_for_team(team_id: int) -> Integration | None:
+    """Get Slack integration for a team. Returns None if not found."""
+    return Integration.objects.filter(team_id=team_id, kind="slack").first()
+
+
 def send_slack_subscription_report(
     subscription: Subscription,
     assets: list[ExportedAsset],
@@ -34,7 +34,7 @@ def send_slack_subscription_report(
     is_new_subscription: bool = False,
 ) -> None:
     """Send Slack subscription report."""
-    integration = get_slack_integration_for_team(subscription.team)
+    integration = get_slack_integration_for_team(subscription.team_id)
 
     if not integration:
         # TODO: Write error to subscription...

--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -10,6 +10,7 @@ from posthog.models.exported_asset import ExportedAsset
 from posthog.models.insight import Insight
 from posthog.models.sharing_configuration import SharingConfiguration
 from posthog.models.subscription import Subscription
+from posthog.sync import database_sync_to_async
 from posthog.tasks import exporter
 from posthog.utils import wait_for_parallel_celery_group
 
@@ -65,5 +66,54 @@ def generate_assets(
             parallel_job,
             expires=exports_expire,
         )
+
+        return insights, assets
+
+
+async def generate_assets_async(
+    resource: Union[Subscription, SharingConfiguration],
+    max_asset_count: int = DEFAULT_MAX_ASSET_COUNT,
+) -> tuple[list[Insight], list[ExportedAsset]]:
+    """Temporal-compatible version of generate_assets that doesn't use Celery."""
+    with SUBSCRIPTION_ASSET_GENERATION_TIMER.time():
+        # Get insights - same logic as sync version
+        if resource.dashboard:
+            tiles = await database_sync_to_async(get_tiles_ordered_by_position)(resource.dashboard, "sm")
+            insights = [tile.insight for tile in tiles if tile.insight]
+        elif resource.insight:
+            insights = [resource.insight]
+        else:
+            raise Exception("There are no insights to be sent for this Subscription")
+
+        # Create all the assets we need - same as sync version
+        assets = [
+            ExportedAsset(
+                team=resource.team,
+                export_format="image/png",
+                insight=insight,
+                dashboard=resource.dashboard,
+            )
+            for insight in insights[:max_asset_count]
+        ]
+        await database_sync_to_async(ExportedAsset.objects.bulk_create)(assets)
+
+        if not assets:
+            return insights, assets
+
+        # Export each asset directly using the export function (not Celery)
+        for asset in assets:
+            try:
+                await database_sync_to_async(exporter.export_asset)(asset.id)
+            except Exception as e:
+                logger.error(
+                    "Failed to export asset for subscription",
+                    asset_id=asset.id,
+                    subscription_id=getattr(resource, "id", None),
+                    error=str(e),
+                    exc_info=True,
+                )
+                # Continue with other assets even if one fails
+                asset.exception = str(e)
+                await database_sync_to_async(asset.save)()
 
         return insights, assets

--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -54,7 +54,6 @@ def generate_assets(
         if not assets:
             return insights, assets
 
-        # Export assets - branch based on execution context
         if use_celery:
             # Celery approach - queue tasks and wait for completion
             tasks = [exporter.export_asset.si(asset.id) for asset in assets]

--- a/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
+++ b/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
@@ -14,12 +14,12 @@ from django.conf import settings
 
 
 from posthog.models.subscription import Subscription
+from posthog.sync import database_sync_to_async
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_internal_logger
 
-from ee.tasks.subscriptions import _deliver_subscription_report, team_use_temporal_flag
-from posthog.sync import database_sync_to_async
+from ee.tasks.subscriptions import deliver_subscription_report_async, team_use_temporal_flag
 
 logger = structlog.get_logger(__name__)
 
@@ -96,7 +96,7 @@ async def deliver_subscription_report_activity(inputs: DeliverSubscriptionReport
             subscription_id=inputs.subscription_id,
         )
 
-        await database_sync_to_async(_deliver_subscription_report)(
+        await deliver_subscription_report_async(
             subscription_id=inputs.subscription_id,
             previous_value=inputs.previous_value,
             invite_message=inputs.invite_message,

--- a/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
+++ b/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
@@ -12,7 +12,6 @@ import temporalio.common
 import temporalio.workflow
 from django.conf import settings
 
-from asgiref.sync import sync_to_async
 
 from posthog.models.subscription import Subscription
 from posthog.temporal.common.base import PostHogWorkflow
@@ -45,7 +44,7 @@ async def fetch_due_subscriptions_activity(inputs: FetchDueSubscriptionsActivity
     logger = get_internal_logger()
     now_with_buffer = dt.datetime.utcnow() + dt.timedelta(minutes=inputs.buffer_minutes)
 
-    @sync_to_async
+    @database_sync_to_async
     def get_subscription_ids() -> list[Subscription]:
         return list(
             Subscription.objects.filter(next_delivery_date__lte=now_with_buffer, deleted=False)

--- a/posthog/temporal/tests/test_subscriptions_workflows.py
+++ b/posthog/temporal/tests/test_subscriptions_workflows.py
@@ -135,7 +135,7 @@ async def test_subscription_delivery_scheduling(
 
     # Each subscription has 2 recipients -> 4 emails expected (only first two subs)
     assert mock_send_email.call_count == 4
-    delivered_sub_ids = {args[0][1].id for args in mock_send_email.call_args_list[::2]}
+    delivered_sub_ids = {args[0][1].id for args in mock_send_email.call_args_list}
     assert delivered_sub_ids == {subscriptions[0].id, subscriptions[1].id}
 
 

--- a/posthog/temporal/tests/test_subscriptions_workflows.py
+++ b/posthog/temporal/tests/test_subscriptions_workflows.py
@@ -140,7 +140,7 @@ async def test_subscription_delivery_scheduling(
 
 
 @patch("posthoganalytics.feature_enabled", return_value=True)
-@patch("ee.tasks.subscriptions.send_slack_subscription_report")
+@patch("ee.tasks.subscriptions.get_slack_integration_for_team", return_value=None)
 @patch("ee.tasks.subscriptions.send_email_subscription_report")
 @patch("ee.tasks.subscriptions.generate_assets")
 @freeze_time("2022-02-02T08:55:00.000Z")
@@ -255,12 +255,13 @@ async def test_handle_subscription_value_change_email(
             [asset],
             invite_message="My invite message",
             total_asset_count=1,
+            send_async=False,
         )
     ]
 
 
 @patch("posthoganalytics.feature_enabled", return_value=True)
-@patch("ee.tasks.subscriptions.send_slack_subscription_report")
+@patch("ee.tasks.subscriptions.get_slack_integration_for_team", return_value=None)
 @patch("ee.tasks.subscriptions.generate_assets")
 @pytest.mark.asyncio
 async def test_deliver_subscription_report_slack(
@@ -304,6 +305,3 @@ async def test_deliver_subscription_report_slack(
             )
 
     assert mock_send_slack.call_count == 1
-    assert mock_send_slack.call_args_list == [
-        call(subscription, [asset], total_asset_count=1, is_new_subscription=False)
-    ]


### PR DESCRIPTION
## Problem
Temporal subscriptions are flaky. Slack messages aren't going out.

## Changes
Realized that temporal subscriptions were still using a celery chain to actually generate the exported assets. Do these directly in the temporal task now.

Also do some refactoring to more properly apply database_sync_to_async as needed in the temporal flow.

## How did you test this code?
Made sure tests worked. Need to deploy to really test, but is feature flagged.
