### PR TITLE
refactor: Remove debug output from pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,7 +2,3 @@
 . "$(dirname "$0")/_/husky.sh"
 
 NODE_OPTIONS='--max-old-space-size=8192' pnpm lint-staged
-echo "PATH in pre-commit: $PATH"
-echo "VIRTUAL_ENV in pre-commit: $VIRTUAL_ENV"
-echo "Node version: $(node --version)"
-which prettier || echo "prettier not found"


### PR DESCRIPTION
This was added for debugging purposes and we merged it in by mistake, oops! Let's clean this up, make debug output cleaner
