### PR TITLE
fix: don't add `project/{projectId}` to URL if `project/{projectApiKey}` is already in URL

### DIFF
--- a/frontend/src/lib/utils/router-utils.test.ts
+++ b/frontend/src/lib/utils/router-utils.test.ts
@@ -9,4 +9,8 @@ describe('router-utils', () => {
         const altered = addProjectIdIfMissing('/project/123/account/two_factor', 123)
         expect(altered).toEqual('/account/two_factor')
     })
+    it('allows project urls to use an API key in place of numeric project id', () => {
+        const altered = addProjectIdIfMissing('/project/phc_gE7SWBNBgFbA4eQ154KPXebyB8KyLJuypR8jg1DSo9Z/replay', 123)
+        expect(altered).toEqual('/project/phc_gE7SWBNBgFbA4eQ154KPXebyB8KyLJuypR8jg1DSo9Z/replay')
+    })
 })

--- a/frontend/src/lib/utils/router-utils.ts
+++ b/frontend/src/lib/utils/router-utils.ts
@@ -21,7 +21,7 @@ function isPathWithoutProjectId(path: string): boolean {
 }
 
 function addProjectIdUnlessPresent(path: string, teamId?: TeamType['id']): string {
-    if (path.match(/^\/project\/\d+/)) {
+    if (path.match(/^\/project\/(\d+|phc_)/)) {
         return path
     }
 


### PR DESCRIPTION
## Problem

A user was having an [issue](https://posthoghelp.zendesk.com/agent/tickets/35028) where URLs in the format `https://app.posthog.com/project/{projectApiKey}/replay/{recordingId}` were redirecting them to `https://us.posthog.com/project/{projectId}/project/{projectApiKey}/replay/{replayId}`, incorrectly adding a second `project` component to the URL.

Originally noticed the issue from the `sessionRecordingUrl` properties which are included on survey events.

## Changes

Look at whether there's a `project/phc_` component in the URL, not just `project/{numericProjectId}`. This won't cover projects that use environment based API keys - not sure if we should?

## How did you test this code?

Added a unit test to cover it. Not totally sure how to test this locally 🤔 