### PR TITLE
feat: Expose hog watcher states to the api

### DIFF
--- a/plugin-server/src/cdp/cdp-api.test.ts
+++ b/plugin-server/src/cdp/cdp-api.test.ts
@@ -499,61 +499,31 @@ describe('CDP API', () => {
 
             const res = await supertest(app).get('/api/hog_functions/states')
             expect(res.status).toEqual(200)
-            expect(res.body).toMatchInlineSnapshot(
-                {
-                    results: [
-                        {
-                            function_enabled: true,
-                            function_id: hogFunctionMultiFetch.id,
-                            function_name: 'test hog function multi fetch',
-                            function_team_id: 2,
-                            function_type: 'destination',
-                            state: 'disabled',
-                            state_numeric: 3,
-                            tokens: 10000,
-                        },
-                        {
-                            function_enabled: true,
-                            function_id: hogFunction.id,
-                            function_name: 'test hog function',
-                            function_team_id: 2,
-                            function_type: 'destination',
-                            state: 'degraded',
-                            state_numeric: 2,
-                            tokens: 10000,
-                        },
-                    ],
-
-                    total: 2,
-                },
-                `
-                {
-                  "results": [
+            expect(res.body).toEqual({
+                results: [
                     {
-                      "function_enabled": true,
-                      "function_id": "c4cae7a9-6188-4c77-8d3a-e1e6d372df3b",
-                      "function_name": "test hog function multi fetch",
-                      "function_team_id": 2,
-                      "function_type": "destination",
-                      "state": "disabled",
-                      "state_numeric": 3,
-                      "tokens": 10000,
+                        function_enabled: true,
+                        function_id: hogFunctionMultiFetch.id,
+                        function_name: 'test hog function multi fetch',
+                        function_team_id: hogFunctionMultiFetch.team_id,
+                        function_type: 'destination',
+                        state: 'disabled',
+                        state_numeric: 3,
+                        tokens: 10000,
                     },
                     {
-                      "function_enabled": true,
-                      "function_id": "5dba1b0c-d414-4b9a-8961-c38e0aaf8002",
-                      "function_name": "test hog function",
-                      "function_team_id": 2,
-                      "function_type": "destination",
-                      "state": "degraded",
-                      "state_numeric": 2,
-                      "tokens": 10000,
+                        function_enabled: true,
+                        function_id: hogFunction.id,
+                        function_name: 'test hog function',
+                        function_team_id: hogFunction.team_id,
+                        function_type: 'destination',
+                        state: 'degraded',
+                        state_numeric: 2,
+                        tokens: 10000,
                     },
-                  ],
-                  "total": 2,
-                }
-            `
-            )
+                ],
+                total: 2,
+            })
         })
     })
 })

--- a/plugin-server/src/cdp/cdp-api.test.ts
+++ b/plugin-server/src/cdp/cdp-api.test.ts
@@ -16,6 +16,9 @@ import { posthogFilterOutPlugin } from './legacy-plugins/_transformations/postho
 import { HogFunctionInvocationGlobals, HogFunctionType } from './types'
 import { Server } from 'http'
 import { setupExpressApp } from '~/router'
+import { createCdpRedisPool } from './redis'
+import { deleteKeysWithPrefix } from './_tests/redis'
+import { BASE_REDIS_KEY, HogWatcherState } from './services/monitoring/hog-watcher.service'
 
 describe('CDP API', () => {
     let hub: Hub
@@ -75,12 +78,14 @@ describe('CDP API', () => {
         mockFetch.mockClear()
 
         hogFunction = await insertHogFunction({
+            name: 'test hog function',
             ...HOG_EXAMPLES.simple_fetch,
             ...HOG_INPUTS_EXAMPLES.simple_fetch,
             ...HOG_FILTERS_EXAMPLES.no_filters,
         })
 
         hogFunctionMultiFetch = await insertHogFunction({
+            name: 'test hog function multi fetch',
             ...HOG_EXAMPLES.recursive_fetch,
             ...HOG_INPUTS_EXAMPLES.simple_fetch,
             ...HOG_FILTERS_EXAMPLES.no_filters,
@@ -478,6 +483,77 @@ describe('CDP API', () => {
             expect(res.status).toEqual(200)
             expect(res.body.logs.map((log: any) => log.message)).toMatchInlineSnapshot(`[]`)
             expect(res.body.result).toMatchInlineSnapshot(`null`)
+        })
+    })
+
+    describe('hog function states', () => {
+        beforeEach(async () => {
+            jest.spyOn(hub.teamManager, 'getTeam').mockResolvedValue(team)
+            const redis = createCdpRedisPool(hub)
+            await deleteKeysWithPrefix(redis, BASE_REDIS_KEY)
+        })
+
+        it('returns the states of all hog functions', async () => {
+            await api['hogWatcher'].forceStateChange(hogFunction, HogWatcherState.degraded)
+            await api['hogWatcher'].forceStateChange(hogFunctionMultiFetch, HogWatcherState.disabled)
+
+            const res = await supertest(app).get('/api/hog_functions/states')
+            expect(res.status).toEqual(200)
+            expect(res.body).toMatchInlineSnapshot(
+                {
+                    results: [
+                        {
+                            function_enabled: true,
+                            function_id: hogFunctionMultiFetch.id,
+                            function_name: 'test hog function multi fetch',
+                            function_team_id: 2,
+                            function_type: 'destination',
+                            state: 'disabled',
+                            state_numeric: 3,
+                            tokens: 10000,
+                        },
+                        {
+                            function_enabled: true,
+                            function_id: hogFunction.id,
+                            function_name: 'test hog function',
+                            function_team_id: 2,
+                            function_type: 'destination',
+                            state: 'degraded',
+                            state_numeric: 2,
+                            tokens: 10000,
+                        },
+                    ],
+
+                    total: 2,
+                },
+                `
+                {
+                  "results": [
+                    {
+                      "function_enabled": true,
+                      "function_id": "c4cae7a9-6188-4c77-8d3a-e1e6d372df3b",
+                      "function_name": "test hog function multi fetch",
+                      "function_team_id": 2,
+                      "function_type": "destination",
+                      "state": "disabled",
+                      "state_numeric": 3,
+                      "tokens": 10000,
+                    },
+                    {
+                      "function_enabled": true,
+                      "function_id": "5dba1b0c-d414-4b9a-8961-c38e0aaf8002",
+                      "function_name": "test hog function",
+                      "function_team_id": 2,
+                      "function_type": "destination",
+                      "state": "degraded",
+                      "state_numeric": 2,
+                      "tokens": 10000,
+                    },
+                  ],
+                  "total": 2,
+                }
+            `
+            )
         })
     })
 })

--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -160,9 +160,8 @@ export class CdpApi {
                         tokens: state.tokens,
                         state_numeric: state.state,
                     }))
-                    .sort((a, b) => a.tokens - b.tokens) // Sort by tokens ascending
+                    .sort((a, b) => b.state_numeric - a.state_numeric)
 
-                console.log(statesArray)
                 const hogFunctions = await this.hogFunctionManager.getHogFunctions(
                     statesArray.map((x) => x.function_id)
                 )

--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -162,6 +162,7 @@ export class CdpApi {
                     }))
                     .sort((a, b) => a.tokens - b.tokens) // Sort by tokens ascending
 
+                console.log(statesArray)
                 const hogFunctions = await this.hogFunctionManager.getHogFunctions(
                     statesArray.map((x) => x.function_id)
                 )
@@ -170,12 +171,13 @@ export class CdpApi {
                     ...x,
                     function_name: hogFunctions[x.function_id]?.name,
                     function_team_id: hogFunctions[x.function_id]?.team_id,
+                    function_type: hogFunctions[x.function_id]?.type,
+                    function_enabled: hogFunctions[x.function_id]?.enabled && !hogFunctions[x.function_id]?.deleted,
                 }))
 
                 res.json({
                     results,
                     total: results.length,
-                    timestamp: new Date().toISOString(),
                 })
             } catch (error) {
                 logger.error('[CdpApi] Error getting all function states', error)

--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -92,6 +92,7 @@ export class CdpApi {
         router.post('/api/projects/:team_id/hog_flows/:id/invocations', asyncHandler(this.postHogflowInvocation))
         router.get('/api/projects/:team_id/hog_functions/:id/status', asyncHandler(this.getFunctionStatus()))
         router.patch('/api/projects/:team_id/hog_functions/:id/status', asyncHandler(this.patchFunctionStatus()))
+        router.get('/api/hog_functions/states', asyncHandler(this.getFunctionStates()))
         router.get('/api/hog_function_templates', this.getHogFunctionTemplates)
         router.post('/public/messaging/mailjet_webhook', asyncHandler(this.postMailjetWebhook()))
         router.post('/public/webhooks/:webhook_id', asyncHandler(this.postWebhook()))
@@ -143,6 +144,43 @@ export class CdpApi {
             await delay(100)
 
             res.json(await this.hogWatcher.getPersistedState(id))
+        }
+
+    private getFunctionStates =
+        () =>
+        async (req: express.Request, res: express.Response): Promise<void> => {
+            try {
+                const allStates = await this.hogWatcher.getAllFunctionStates()
+
+                // Transform the data for better consumption by Grafana and sort by tokens ascending
+                const statesArray = Object.entries(allStates)
+                    .map(([functionId, state]) => ({
+                        function_id: functionId,
+                        state: HogWatcherState[state.state], // Convert numeric state to readable string
+                        tokens: state.tokens,
+                        state_numeric: state.state,
+                    }))
+                    .sort((a, b) => a.tokens - b.tokens) // Sort by tokens ascending
+
+                const hogFunctions = await this.hogFunctionManager.getHogFunctions(
+                    statesArray.map((x) => x.function_id)
+                )
+
+                const results = statesArray.map((x) => ({
+                    ...x,
+                    function_name: hogFunctions[x.function_id]?.name,
+                    function_team_id: hogFunctions[x.function_id]?.team_id,
+                }))
+
+                res.json({
+                    results,
+                    total: results.length,
+                    timestamp: new Date().toISOString(),
+                })
+            } catch (error) {
+                logger.error('[CdpApi] Error getting all function states', error)
+                res.status(500).json({ error: 'Failed to get function states' })
+            }
         }
 
     private postFunctionInvocation = async (req: express.Request, res: express.Response): Promise<any> => {

--- a/plugin-server/src/cdp/services/monitoring/hog-watcher.service.ts
+++ b/plugin-server/src/cdp/services/monitoring/hog-watcher.service.ts
@@ -177,7 +177,7 @@ export class HogWatcherService {
             let cursor = '0'
 
             do {
-                const [newCursor, batch] = await client.scan(cursor, 'MATCH', `${REDIS_KEY_STATE}/*`)
+                const [newCursor, batch] = await client.scan(cursor, 'MATCH', `${REDIS_KEY_STATE}/*`, 'COUNT', 500)
                 cursor = newCursor
                 keys.push(...batch)
             } while (cursor !== '0')


### PR DESCRIPTION
## Problem

It would be really useful to be able to get the states and display them in grafana

## Changes

* Adds an endpoint for loading all states

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
