### PR TITLE
chore(devex): scene panel replay collections

### DIFF
--- a/frontend/src/lib/components/Scenes/SceneDescription.tsx
+++ b/frontend/src/lib/components/Scenes/SceneDescription.tsx
@@ -4,8 +4,11 @@ import { useEffect, useState } from 'react'
 import { ScenePanelLabel } from '~/layout/scenes/SceneLayout'
 import { SceneLoadingSkeleton } from './SceneLoadingSkeleton'
 import { SceneInputProps, SceneSaveCancelButtons } from './utils'
+import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown/LemonMarkdown'
 
-type SceneDescriptionProps = SceneInputProps
+type SceneDescriptionProps = SceneInputProps & {
+    markdown?: boolean
+}
 
 export function SceneDescription({
     defaultValue,
@@ -14,6 +17,7 @@ export function SceneDescription({
     optional = false,
     canEdit = true,
     isLoading = false,
+    markdown = false,
 }: SceneDescriptionProps): JSX.Element {
     const [localValue, setLocalValue] = useState(defaultValue)
     const [localIsEditing, setLocalIsEditing] = useState(false)
@@ -59,6 +63,7 @@ export function SceneDescription({
                     data-attr={`${dataAttrKey}-description-input`}
                     autoFocus
                     error={!!error}
+                    markdown={markdown}
                 />
             </ScenePanelLabel>
 
@@ -85,7 +90,11 @@ export function SceneDescription({
                 inert={!canEdit}
             >
                 {defaultValue !== '' ? (
-                    defaultValue
+                    markdown ? (
+                        <LemonMarkdown lowKeyHeadings>{defaultValue}</LemonMarkdown>
+                    ) : (
+                        defaultValue
+                    )
                 ) : (
                     <span className="text-tertiary font-normal">No description {optional ? '(optional)' : ''}</span>
                 )}

--- a/frontend/src/lib/ui/TextInputPrimitive/TextInputPrimitive.tsx
+++ b/frontend/src/lib/ui/TextInputPrimitive/TextInputPrimitive.tsx
@@ -14,6 +14,7 @@ export const textInputVariants = cva({
             sm: 'h-[var(--text-input-height-sm)]',
             default: 'h-[var(--text-input-height-base)]',
             lg: 'h-[var(--text-input-height-lg)]',
+            auto: '',
         },
         error: {
             true: 'border-error bg-fill-error-highlight hover:border-error focus-visible:border-error',

--- a/frontend/src/lib/ui/TextareaPrimitive/TextareaPrimitive.tsx
+++ b/frontend/src/lib/ui/TextareaPrimitive/TextareaPrimitive.tsx
@@ -2,30 +2,49 @@ import { cn } from 'lib/utils/css-classes'
 import TextareaAutosize, { TextareaAutosizeProps } from 'react-textarea-autosize'
 import { TextInputBaseProps, textInputVariants } from '../TextInputPrimitive/TextInputPrimitive'
 import { forwardRef } from 'react'
+import { IconMarkdown } from 'lib/lemon-ui/icons/icons'
+import { ButtonPrimitive } from '../Button/ButtonPrimitives'
 
 type TextareaPrimitiveProps = TextareaAutosizeProps &
     TextInputBaseProps & {
         error?: boolean
+        markdown?: boolean
     }
 
 export const TextareaPrimitive = forwardRef<HTMLTextAreaElement, TextareaPrimitiveProps>(
-    ({ className, variant, error, ...rest }, ref): JSX.Element => {
+    ({ className, variant, error, markdown = false, ...rest }, ref): JSX.Element => {
         // Ensure cursor is at the end of the textarea when it is focused
         function onFocus(e: React.FocusEvent<HTMLTextAreaElement>): void {
             e.currentTarget.setSelectionRange(e.currentTarget.value.length, e.currentTarget.value.length)
         }
 
         return (
-            <TextareaAutosize
-                ref={ref}
-                onFocus={onFocus}
-                {...rest}
-                className={cn(
-                    textInputVariants({ variant, error: !!error }),
-                    'h-auto show-scrollbar-on-hover px-[var(--button-padding-x-base)] py-[var(--button-padding-y-base)]',
-                    className
+            <div className="relative flex flex-col gap-0">
+                <TextareaAutosize
+                    ref={ref}
+                    onFocus={onFocus}
+                    aria-label={markdown ? 'Markdown supported' : undefined}
+                    {...rest}
+                    className={cn(
+                        textInputVariants({ variant, error: !!error, size: 'auto' }),
+                        'resize-y show-scrollbar-on-hover px-[var(--button-padding-x-base)] py-[var(--button-padding-y-base)]',
+                        className
+                    )}
+                />
+                {markdown && (
+                    <ButtonPrimitive
+                        className="absolute bottom-1 right-1"
+                        tooltip="Markdown supported"
+                        tooltipPlacement="top"
+                        inert
+                        size="xs"
+                        iconOnly
+                        aria-hidden
+                    >
+                        <IconMarkdown className="text-tertiary size-4" />
+                    </ButtonPrimitive>
                 )}
-            />
+            </div>
         )
     }
 )

--- a/frontend/src/scenes/actions/ActionEdit.tsx
+++ b/frontend/src/scenes/actions/ActionEdit.tsx
@@ -230,6 +230,7 @@ export function ActionEdit({ action: loadedAction, id }: ActionEditLogicProps): 
                             dataAttrKey={RESOURCE_TYPE}
                             optional
                             isLoading={actionLoading}
+                            markdown
                         />
 
                         <SceneTags

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -507,6 +507,7 @@ export function DashboardHeader(): JSX.Element | null {
                         optional
                         canEdit={canEditDashboard}
                         isLoading={dashboardLoading}
+                        markdown
                     />
 
                     <SceneTags

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -619,6 +619,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                             dataAttrKey={RESOURCE_TYPE}
                             optional
                             canEdit={canEditInsight}
+                            markdown
                         />
 
                         <SceneTags

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistScene.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistScene.tsx
@@ -149,7 +149,6 @@ export function SessionRecordingsPlaylistScene(): JSX.Element {
                                 maxLength={400}
                                 data-attr="playlist-description"
                                 compactButtons
-                                onModeToggle={(viewMode) => {}}
                             />
                             <UserActivityIndicator
                                 at={playlist.last_modified_at}

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistScene.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistScene.tsx
@@ -14,7 +14,24 @@ import { isUniversalFilters } from '../utils'
 import { SessionRecordingsPlaylist } from './SessionRecordingsPlaylist'
 import { convertLegacyFiltersToUniversalFilters } from './sessionRecordingsPlaylistLogic'
 import { sessionRecordingsPlaylistSceneLogic } from './sessionRecordingsPlaylistSceneLogic'
+import {
+    ScenePanel,
+    ScenePanelActions,
+    ScenePanelCommonActions,
+    ScenePanelDivider,
+    ScenePanelMetaInfo,
+} from '~/layout/scenes/SceneLayout'
+import { SceneCommonButtons } from 'lib/components/Scenes/SceneCommonButtons'
+import { SceneFile } from 'lib/components/Scenes/SceneFile'
+import { SceneActivityIndicator } from 'lib/components/Scenes/SceneUpdateActivityInfo'
+import { SceneMetalyticsSummaryButton } from 'lib/components/Scenes/SceneMetalyticsSummaryButton'
+import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+import { SceneDescription } from 'lib/components/Scenes/SceneDescription'
+import { SceneName } from 'lib/components/Scenes/SceneName'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 
+const RESOURCE_TYPE = 'replay-collection'
 export const scene: SceneExport = {
     component: SessionRecordingsPlaylistScene,
     logic: sessionRecordingsPlaylistSceneLogic,
@@ -32,6 +49,8 @@ export function SessionRecordingsPlaylistScene(): JSX.Element {
 
     const { showFilters } = useValues(playerSettingsLogic)
     const { setShowFilters } = useActions(playerSettingsLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const newSceneLayout = featureFlags[FEATURE_FLAGS.NEW_SCENE_LAYOUT]
 
     if (playlistLoading) {
         return (
@@ -68,37 +87,42 @@ export function SessionRecordingsPlaylistScene(): JSX.Element {
             <PageHeader
                 buttons={
                     <div className="flex justify-between items-center gap-2">
-                        <More
-                            overlay={
-                                <>
-                                    <LemonButton
-                                        onClick={() => duplicatePlaylist()}
-                                        fullWidth
-                                        data-attr="duplicate-playlist"
-                                    >
-                                        Duplicate
-                                    </LemonButton>
-                                    <LemonButton
-                                        onClick={() =>
-                                            updatePlaylist({
-                                                short_id: playlist.short_id,
-                                                pinned: !playlist.pinned,
-                                            })
-                                        }
-                                        fullWidth
-                                    >
-                                        {playlist.pinned ? 'Unpin collection' : 'Pin collection'}
-                                    </LemonButton>
-                                    <LemonDivider />
+                        {!newSceneLayout && (
+                            <>
+                                <More
+                                    overlay={
+                                        <>
+                                            <LemonButton
+                                                onClick={() => duplicatePlaylist()}
+                                                fullWidth
+                                                data-attr="duplicate-playlist"
+                                            >
+                                                Duplicate
+                                            </LemonButton>
+                                            <LemonButton
+                                                onClick={() =>
+                                                    updatePlaylist({
+                                                        short_id: playlist.short_id,
+                                                        pinned: !playlist.pinned,
+                                                    })
+                                                }
+                                                fullWidth
+                                            >
+                                                {playlist.pinned ? 'Unpin collection' : 'Pin collection'}
+                                            </LemonButton>
+                                            <LemonDivider />
 
-                                    <LemonButton status="danger" onClick={() => deletePlaylist()} fullWidth>
-                                        Delete collection
-                                    </LemonButton>
-                                </>
-                            }
-                        />
+                                            <LemonButton status="danger" onClick={() => deletePlaylist()} fullWidth>
+                                                Delete collection
+                                            </LemonButton>
+                                        </>
+                                    }
+                                />
 
-                        <LemonDivider vertical />
+                                <LemonDivider vertical />
+                            </>
+                        )}
+
                         <LemonButton
                             type="primary"
                             disabledReason={showFilters && !hasChanges ? 'No changes to save' : undefined}
@@ -112,27 +136,73 @@ export function SessionRecordingsPlaylistScene(): JSX.Element {
                     </div>
                 }
                 caption={
-                    <>
-                        <EditableField
-                            multiline
-                            name="description"
-                            markdown
-                            value={playlist.description || ''}
-                            placeholder="Description (optional)"
-                            onSave={(value) => updatePlaylist({ description: value })}
-                            saveOnBlur={true}
-                            maxLength={400}
-                            data-attr="playlist-description"
-                            compactButtons
-                        />
-                        <UserActivityIndicator
-                            at={playlist.last_modified_at}
-                            by={playlist.last_modified_by}
-                            className="mt-2"
-                        />
-                    </>
+                    !newSceneLayout && (
+                        <>
+                            <EditableField
+                                multiline
+                                name="description"
+                                markdown
+                                value={playlist.description || ''}
+                                placeholder="Description (optional)"
+                                onSave={(value) => updatePlaylist({ description: value })}
+                                saveOnBlur={true}
+                                maxLength={400}
+                                data-attr="playlist-description"
+                                compactButtons
+                                onModeToggle={(viewMode) => {}}
+                            />
+                            <UserActivityIndicator
+                                at={playlist.last_modified_at}
+                                by={playlist.last_modified_by}
+                                className="mt-2"
+                            />
+                        </>
+                    )
                 }
             />
+
+            <ScenePanel>
+                <ScenePanelCommonActions>
+                    <SceneCommonButtons
+                        dataAttrKey={RESOURCE_TYPE}
+                        duplicate={{
+                            onClick: () => duplicatePlaylist(),
+                        }}
+                        pinned={{
+                            active: playlist.pinned,
+                            onClick: () => updatePlaylist({ pinned: !playlist.pinned }),
+                        }}
+                    />
+                </ScenePanelCommonActions>
+                <ScenePanelMetaInfo>
+                    <SceneName
+                        defaultValue={playlist.name || ''}
+                        onSave={(value) => updatePlaylist({ name: value })}
+                        dataAttrKey={RESOURCE_TYPE}
+                    />
+
+                    <SceneDescription
+                        defaultValue={playlist.description || ''}
+                        onSave={(value) => updatePlaylist({ description: value })}
+                        dataAttrKey={RESOURCE_TYPE}
+                        optional
+                        markdown
+                    />
+                    <SceneFile dataAttrKey={RESOURCE_TYPE} />
+                    <SceneActivityIndicator
+                        at={playlist.last_modified_at}
+                        by={playlist.last_modified_by}
+                        prefix="Last modified"
+                    />
+                </ScenePanelMetaInfo>
+                <ScenePanelDivider />
+                <ScenePanelActions>
+                    <SceneMetalyticsSummaryButton dataAttrKey={RESOURCE_TYPE} />
+                    <ButtonPrimitive variant="danger" onClick={() => deletePlaylist()} menuItem>
+                        Delete collection
+                    </ButtonPrimitive>
+                </ScenePanelActions>
+            </ScenePanel>
 
             <div className="SessionRecordingPlaylistHeightWrapper">
                 <SessionRecordingsPlaylist


### PR DESCRIPTION
## Problem
Top bar is cluttered, busy and cramped, let's simplify things

- [x] [Product analytics](https://github.com/PostHog/posthog/pull/35033) 
- [x] [Dashboards](https://github.com/PostHog/posthog/pull/35346)
- [x] [Actions](https://github.com/PostHog/posthog/pull/35346)
- [x] [Cohorts](https://github.com/PostHog/posthog/pull/35756)
- [x] [Surveys](https://github.com/PostHog/posthog/pull/35774)
- [x] [Early access features](https://github.com/PostHog/posthog/pull/35939)
- [ ] Replay collections

## Changes
* Add new scene layout to replay collections
* Added markdown support for `<SceneDescription>` and edited all supporting resources with the prop

![2025-07-31 13 21 00](https://github.com/user-attachments/assets/750f1dc6-d641-4f96-bd00-c15c7ded9f8f)

<img width="343" height="276" alt="image" src="https://github.com/user-attachments/assets/1cd0fde1-65ec-4c72-b114-f5e9042d465b" />


## How did you test this code?
Locally, with flag `new-scene-layout` on/ flag off.\
* Off is normal experience ✅ 
* On is new experience ✅ 