### PR TITLE
fix: Local dev for hogflows consumer

### DIFF
--- a/plugin-server/src/cdp/consumers/cdp-cyclotron-worker-hogflow.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-cyclotron-worker-hogflow.consumer.ts
@@ -14,8 +14,7 @@ export class CdpCyclotronWorkerHogFlow extends CdpCyclotronWorker {
     protected name = 'CdpCyclotronWorkerHogFlow'
 
     constructor(hub: Hub) {
-        super(hub)
-        this.queue = 'hogflow' // NOTE: Hogflows are a different processing logic to hogfunctions so we currently explicitly set the queue
+        super(hub, 'hogflow')
     }
 
     public async processInvocations(invocations: CyclotronJobInvocation[]): Promise<CyclotronJobInvocationResult[]> {

--- a/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
@@ -20,9 +20,9 @@ export class CdpCyclotronWorker extends CdpConsumerBase {
     protected cyclotronJobQueue: CyclotronJobQueue
     protected queue: CyclotronJobQueueKind
 
-    constructor(hub: Hub) {
+    constructor(hub: Hub, queue?: CyclotronJobQueueKind) {
         super(hub)
-        this.queue = hub.CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_KIND
+        this.queue = queue ?? hub.CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_KIND
 
         if (!CYCLOTRON_INVOCATION_JOB_QUEUES.includes(this.queue)) {
             throw new Error(`Invalid cyclotron job queue kind: ${this.queue}`)


### PR DESCRIPTION
## Problem

On prod we configure all this with env vars but locally we dont. 

## Changes

* Fix it to always use the given value if given

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
