### PR TITLE
feat(messaging): add a opt in flag warning for `site_destinations`

### DIFF
--- a/frontend/src/scenes/hog-functions/configuration/HogFunctionConfiguration.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/HogFunctionConfiguration.tsx
@@ -252,7 +252,9 @@ export function HogFunctionConfiguration({ templateId, id, logicKey }: HogFuncti
                                 just fine but for others there may be unexpected issues and we do not offer official
                                 customer support for it in these cases.
                             </p>
-                            {['template-reddit-conversions-api', 'template-snapchat-ads'].includes(templateId ?? hogFunction?.template?.id ?? '') ? (
+                            {['template-reddit-conversions-api', 'template-snapchat-ads'].includes(
+                                templateId ?? hogFunction?.template?.id ?? ''
+                            ) ? (
                                 <span className="mt-2">
                                     The receiving destination imposes a rate limit of 10 events per second. Exceeding
                                     this limit may result in some events failing to be delivered.

--- a/frontend/src/scenes/hog-functions/configuration/HogFunctionConfiguration.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/HogFunctionConfiguration.tsx
@@ -252,10 +252,15 @@ export function HogFunctionConfiguration({ templateId, id, logicKey }: HogFuncti
                                 just fine but for others there may be unexpected issues and we do not offer official
                                 customer support for it in these cases.
                             </p>
-                            {['template-reddit-conversions-api', 'template-snapchat-ads'].includes(templateId ?? '') ? (
+                            {['template-reddit-conversions-api', 'template-snapchat-ads'].includes(templateId ?? hogFunction?.template?.id ?? '') ? (
                                 <span className="mt-2">
                                     The receiving destination imposes a rate limit of 10 events per second. Exceeding
                                     this limit may result in some events failing to be delivered.
+                                </span>
+                            ) : null}
+                            {['site_destination'].includes(template?.type ?? hogFunction?.template?.type ?? '') ? (
+                                <span className="mt-2">
+                                    Make sure to enable the `opt_in_site_apps` flag in your `posthog.init` config.
                                 </span>
                             ) : null}
                         </LemonBanner>


### PR DESCRIPTION
## Problem

We need to let users know that they have to enable the `opt_in_site_apps` flag

## Changes

<img width="1113" height="1180" alt="2025-07-31 at 14 55 14" src="https://github.com/user-attachments/assets/f6057927-96e9-4666-969e-f481084f24eb" />

- Add a warning to enable the `opt_in_site_apps` flag

Followup:
- [ ] [roll out site destinations to 100%](https://us.posthog.com/project/2/feature_flags/88876)

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
