### PR TITLE
refactor: Track attempts with counters

### DIFF
--- a/products/batch_exports/backend/temporal/metrics.py
+++ b/products/batch_exports/backend/temporal/metrics.py
@@ -94,21 +94,30 @@ class _BatchExportsMetricsActivityInboundInterceptor(ActivityInboundInterceptor)
             "interval": interval,
         }
 
-        activity_attempt = activity_info.attempt
         meter = get_metric_meter(histogram_attributes)
-        hist = meter.create_histogram(
-            name="batch_exports_activity_attempt",
-            description="Histogram tracking attempts made by critical batch export activities",
-        )
-        hist.record(activity_attempt)
 
-        with ExecutionTimeRecorder(
-            "batch_exports_activity_interval_execution_latency",
-            description="Histogram tracking execution latency for critical batch export activities by interval",
-            histogram_attributes=histogram_attributes,
-            log=False,
-        ):
-            return await super().execute_activity(input)
+        try:
+            with ExecutionTimeRecorder(
+                "batch_exports_activity_interval_execution_latency",
+                description="Histogram tracking execution latency for critical batch export activities by interval",
+                histogram_attributes=histogram_attributes,
+                log=False,
+            ):
+                result = await super().execute_activity(input)
+        finally:
+            attempts_total_counter = meter.create_counter(
+                name="batch_exports_activity_attempts",
+                description="Counter tracking every attempt at running an activity",
+            )
+            attempts_total_counter.add(1)
+
+        attempts_completed_counter = meter.create_counter(
+            name="batch_exports_activity_completed_attempts",
+            description="Counter tracking the attempts it took to complete activities",
+        )
+        attempts_completed_counter.add(activity_info.attempt)
+
+        return result
 
 
 class _BatchExportsMetricsWorkflowInterceptor(WorkflowInboundInterceptor):

--- a/products/batch_exports/backend/temporal/metrics.py
+++ b/products/batch_exports/backend/temporal/metrics.py
@@ -111,11 +111,11 @@ class _BatchExportsMetricsActivityInboundInterceptor(ActivityInboundInterceptor)
             )
             attempts_total_counter.add(1)
 
-        attempts_completed_counter = meter.create_counter(
-            name="batch_exports_activity_completed_attempts",
+        attempts_success_counter = meter.create_counter(
+            name="batch_exports_activity_success_attempts",
             description="Counter tracking the attempts it took to complete activities",
         )
-        attempts_completed_counter.add(activity_info.attempt)
+        attempts_success_counter.add(activity_info.attempt)
 
         return result
 

--- a/products/batch_exports/backend/tests/temporal/test_metrics.py
+++ b/products/batch_exports/backend/tests/temporal/test_metrics.py
@@ -136,7 +136,7 @@ async def test_interceptor_calls_histogram_metrics(
             description="Counter tracking every attempt at running an activity",
         )
         mocked_meter.return_value.create_counter.assert_any_call(
-            name="batch_exports_activity_completed_attempts",
+            name="batch_exports_activity_success_attempts",
             description="Counter tracking the attempts it took to complete activities",
         )
 

--- a/products/batch_exports/backend/tests/temporal/test_metrics.py
+++ b/products/batch_exports/backend/tests/temporal/test_metrics.py
@@ -120,11 +120,6 @@ async def test_interceptor_calls_histogram_metrics(
                 "exception": "",
             }
         )
-
-        mocked_meter.return_value.create_histogram.assert_any_call(
-            name="batch_exports_activity_attempt",
-            description="Histogram tracking attempts made by critical batch export activities",
-        )
         mocked_meter.return_value.create_histogram_timedelta.assert_any_call(
             name="batch_exports_workflow_interval_execution_latency",
             description="Histogram tracking execution latency for batch export workflows by interval",
@@ -136,11 +131,21 @@ async def test_interceptor_calls_histogram_metrics(
             unit="ms",
         )
 
-        number_of_record_calls = len(
-            mocked_meter.return_value.create_histogram_timedelta.return_value.record.mock_calls
+        mocked_meter.return_value.create_counter.assert_any_call(
+            name="batch_exports_activity_attempts",
+            description="Counter tracking every attempt at running an activity",
         )
+        mocked_meter.return_value.create_counter.assert_any_call(
+            name="batch_exports_activity_completed_attempts",
+            description="Counter tracking the attempts it took to complete activities",
+        )
+
+        number_of_record_calls = mocked_meter.return_value.create_histogram_timedelta.return_value.record.call_count
         assert (
             number_of_record_calls == 2
         ), f"expected to have recorded two metrics: for workflow and activity execution latency, but only found {number_of_record_calls}"
 
-        mocked_meter.return_value.create_histogram.return_value.record.assert_called_once_with(1)
+        number_of_add_calls = mocked_meter.return_value.create_counter.return_value.add.call_count
+        expected_calls = [mock.call(1)] * number_of_add_calls
+
+        assert mocked_meter.return_value.create_counter.return_value.add.mock_calls == expected_calls


### PR DESCRIPTION
## Problem

An histogram doesn't quite work for tracking attempt counts: There is no way to subtract from the histogram, which we would like to do once an activity that has been retrying a bunch finally succeeds.

Moreover, now that we do not raise user errors, looking at failure count is a simpler way to indicate an error we should investigate.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Remove histogram tracking attempts.
Track total attempt count.
Track attempt count of completed activities (we may use this to resolve alerts automatically).

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
