### PR TITLE
chore: Autocreate topics if they dont exist in dev

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -129,6 +129,7 @@ services:
             KAFKA_CFG_LISTENERS: PLAINTEXT://:9092
             KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
             KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
+            KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: 'true'
             ALLOW_PLAINTEXT_LISTENER: 'true'
         healthcheck:
             test: kafka-cluster.sh cluster-id --bootstrap-server localhost:9092 || exit 1


### PR DESCRIPTION
## Problem
Clickhouse is cooking kafka on local dev because topics do not exist

## Changes
autocreate topics on kafka

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
