### PR TITLE
fix: email verification button may not exist

### DIFF
--- a/posthog/templates/admin/posthog/user/change_form.html
+++ b/posthog/templates/admin/posthog/user/change_form.html
@@ -5,7 +5,7 @@
 
   <script nonce="{{ request.admin_csp_nonce }}">
     window.addEventListener("DOMContentLoaded", () => {
-        document.getElementById("send_verification_email_button").addEventListener("click", (event) => {
+        document.getElementById("send_verification_email_button")?.addEventListener("click", (event) => {
             // prevent anchor tag from navigating
             event.preventDefault();
 


### PR DESCRIPTION
Follow up to #35685. Currently breaking on user Admin pages where the email is already verified 🙃 