### PR TITLE
chore: move local dev from kafka to redpanda

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -121,7 +121,7 @@ services:
         restart: on-failure
 
     kafka:
-        image: docker.redpanda.com/redpandadata/redpanda:v24.1.2
+        image: docker.redpanda.com/redpandadata/redpanda:v25.1.9
         restart: on-failure
         command:
             - redpanda

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -121,17 +121,30 @@ services:
         restart: on-failure
 
     kafka:
-        image: ghcr.io/posthog/kafka-container:v2.8.2
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.2
         restart: on-failure
+        command:
+            - redpanda
+            - start
+            - --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:19092
+            - --advertise-kafka-addr internal://kafka:9092,external://localhost:19092
+            - --pandaproxy-addr internal://0.0.0.0:8082,external://0.0.0.0:18082
+            - --advertise-pandaproxy-addr internal://kafka:8082,external://localhost:18082
+            - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:18081
+            - --rpc-addr kafka:33145
+            - --advertise-rpc-addr kafka:33145
+            - --mode dev-container
+            - --smp 1
+            - --memory 1G
+            - --reserve-memory 200M
+            - --overprovisioned
+            - --set redpanda.empty_seed_starts_cluster=false
+            - --seeds kafka:33145
+            - --set redpanda.auto_create_topics_enabled=true
         environment:
-            KAFKA_BROKER_ID: 1001
-            KAFKA_CFG_RESERVED_BROKER_MAX_ID: 1001
-            KAFKA_CFG_LISTENERS: PLAINTEXT://:9092
-            KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-            KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
             ALLOW_PLAINTEXT_LISTENER: 'true'
         healthcheck:
-            test: kafka-cluster.sh cluster-id --bootstrap-server localhost:9092 || exit 1
+            test: curl -f http://localhost:9644/v1/status/ready || exit 1
             interval: 3s
             timeout: 10s
             retries: 10
@@ -142,6 +155,7 @@ services:
         environment:
             KAFKA_CLUSTERS_0_NAME: local
             KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
+            KAFKA_CLUSTERS_0_SCHEMAREGISTRY: http://kafka:8081
             DYNAMIC_CONFIG_ENABLED: 'true'
 
     objectstorage:

--- a/docker/clickhouse/config.xml
+++ b/docker/clickhouse/config.xml
@@ -72,6 +72,7 @@
     of the time, in which case a higher number of threads might be required.
     -->
 
+    <background_message_broker_schedule_pool_size>1</background_message_broker_schedule_pool_size>
     <max_thread_pool_size>10000</max_thread_pool_size>
 
     <!-- Number of workers to recycle connections in background (see also drain_timeout).

--- a/docker/clickhouse/config.xml
+++ b/docker/clickhouse/config.xml
@@ -7,7 +7,7 @@
 -->
 <clickhouse>
     <logger>
-        <level>trace</level>
+        <level>warning</level>
         <log>/var/log/clickhouse-server/clickhouse-server.log</log>
         <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
         <size>1000M</size>


### PR DESCRIPTION
## Problem

Kafka is using too many resources on local dev

## Changes

Move to redpanda for local dev. Wire compatible with kafka so should be fungible

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
