### PR TITLE
chore(rust): fix SQLX migration in hook-migrator Action

### DIFF
--- a/rust/Dockerfile.migrate-hooks
+++ b/rust/Dockerfile.migrate-hooks
@@ -12,6 +12,4 @@ COPY migrations /sqlx/migrations/
 
 COPY --from=builder /app/target/release/bin/sqlx /usr/local/bin
 
-RUN chmod +x ./bin/migrate
-
-CMD ["./bin/migrate"]
+CMD sqlx database create && sqlx migrate run


### PR DESCRIPTION
## Problem
Replace use of `rust/bin/migrate` script with the SQLX CLI commands it ran

## Changes
* Update `rust-docker-build.yml` Action to remove deleted dependency

## How did you test this code?
Locally and in CI

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
