### PR TITLE
chore: Fix .envrc to use correct Flox environment detection

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,7 @@
 if command -v flox >/dev/null 2>&1; then # Only activate flox if installed
+    # Capture the directory user intended to work in before any Flox operations
+    ORIGINAL_PWD="${PWD}"
+    
     # Check if Flox environment is already active for this project or its subdirectories
     if [ -z "${FLOX_ENV_PROJECT}" ]; then
         # No environment active, safe to activate
@@ -16,8 +19,8 @@ if command -v flox >/dev/null 2>&1; then # Only activate flox if installed
         if [[ ! $REPLY =~ ^[Yy]$ ]]; then
             echo "Skipping Flox activation. To switch environments:"
             echo "  1. Exit current environment: exit"
-            echo "  2. Return to this directory: cd '${PWD}'"
-            echo "  3. Reactivate environment: flox activate"
+            echo "  2. Return to your intended directory: cd '${ORIGINAL_PWD}'"
+            echo "     (Environment will reactivate automatically with direnv)"
             return 0
         fi
         # Clean up conflicting environment variables before activation

--- a/.envrc
+++ b/.envrc
@@ -2,14 +2,21 @@ if command -v flox >/dev/null 2>&1; then # Only activate flox if installed
     # Capture the directory user intended to work in before any Flox operations
     ORIGINAL_PWD="${PWD}"
     
-    # Check if Flox environment is already active for this project or its subdirectories
+    # Use Git to detect if we're in a different project/worktree that should have its own environment
+    CURRENT_WORKTREE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+    ENV_WORKTREE_ROOT=""
+    if [[ -n "${FLOX_ENV_PROJECT}" ]]; then
+        ENV_WORKTREE_ROOT=$(cd "${FLOX_ENV_PROJECT}" && git rev-parse --show-toplevel 2>/dev/null || echo "")
+    fi
+    
     if [ -z "${FLOX_ENV_PROJECT}" ]; then
         # No environment active, safe to activate
         unset VIRTUAL_ENV 2>/dev/null || :
         unset PYTHONPATH 2>/dev/null || :
         unset CONDA_DEFAULT_ENV 2>/dev/null || :
         flox activate
-    elif [[ "${PWD}" != "${FLOX_ENV_PROJECT}"* ]]; then
+    elif [[ -n "$CURRENT_WORKTREE_ROOT" && -n "$ENV_WORKTREE_ROOT" && "$CURRENT_WORKTREE_ROOT" != "$ENV_WORKTREE_ROOT" ]] || \
+         [[ -z "$CURRENT_WORKTREE_ROOT" && "${PWD}" != "${FLOX_ENV_PROJECT}"* ]]; then
         # Different project environment active, check for nesting
         echo "⚠️  About to activate Flox environment in worktree while already in environment for:"
         echo "   ${FLOX_ENV_PROJECT}"

--- a/.envrc
+++ b/.envrc
@@ -1,12 +1,12 @@
 if command -v flox >/dev/null 2>&1; then # Only activate flox if installed
     # Capture the directory user intended to work in before any Flox operations
     ORIGINAL_PWD="${PWD}"
-    
-    # Use Git to detect if we're in a different project/worktree that should have its own environment
-    CURRENT_WORKTREE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
-    ENV_WORKTREE_ROOT=""
+
+    # Use Git to detect if we're in a different working tree (repo or work tree) that should have its own environment
+    CURRENT_WORKING_TREE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+    ENV_WORKING_TREE_ROOT=""
     if [[ -n "${FLOX_ENV_PROJECT}" ]]; then
-        ENV_WORKTREE_ROOT=$(cd "${FLOX_ENV_PROJECT}" && git rev-parse --show-toplevel 2>/dev/null || echo "")
+        ENV_WORKING_TREE_ROOT=$(cd "${FLOX_ENV_PROJECT}" && git rev-parse --show-toplevel 2>/dev/null || echo "")
     fi
     
     if [ -z "${FLOX_ENV_PROJECT}" ]; then
@@ -15,10 +15,10 @@ if command -v flox >/dev/null 2>&1; then # Only activate flox if installed
         unset PYTHONPATH 2>/dev/null || :
         unset CONDA_DEFAULT_ENV 2>/dev/null || :
         flox activate
-    elif [[ -n "$CURRENT_WORKTREE_ROOT" && -n "$ENV_WORKTREE_ROOT" && "$CURRENT_WORKTREE_ROOT" != "$ENV_WORKTREE_ROOT" ]] || \
-         [[ -z "$CURRENT_WORKTREE_ROOT" && "${PWD}" != "${FLOX_ENV_PROJECT}"* ]]; then
+    elif [[ -n "$CURRENT_WORKING_TREE_ROOT" && -n "$ENV_WORKING_TREE_ROOT" && "$CURRENT_WORKING_TREE_ROOT" != "$ENV_WORKING_TREE_ROOT" ]] || \
+         [[ -z "$CURRENT_WORKING_TREE_ROOT" && "${PWD}" != "${FLOX_ENV_PROJECT}"* ]]; then
         # Different project environment active, check for nesting
-        echo "⚠️  About to activate Flox environment in worktree while already in environment for:"
+        echo "⚠️  About to activate Flox environment in working tree while already in environment for:"
         echo "   ${FLOX_ENV_PROJECT}"
         echo ""
         printf "Continue with nested activation? (y/N): "

--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,20 @@
 if command -v flox >/dev/null 2>&1; then # Only activate flox if installed
-    if [ -z "${FLOX_VERSION}" ]; then # Don't activate if already activated
+    # Check if Flox environment is already active for this project or its subdirectories
+    if [ -z "${FLOX_ENV_PROJECT}" ] || [[ "${PWD}" != "${FLOX_ENV_PROJECT}"* ]]; then
+        # Check if we would be nesting environments
+        if [ -n "${FLOX_ENV_PROJECT}" ]; then
+            echo "⚠️  About to activate Flox environment in worktree while already in environment for:"
+            echo "   ${FLOX_ENV_PROJECT}"
+            echo ""
+            read -p "Continue with nested activation? (y/N): " -n 1 -r
+            echo ""
+            if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+                echo "Skipping Flox activation. Run 'exit' first if you want to switch environments."
+                return 0
+            fi
+        fi
+        # Clean up conflicting environment variables before activation
+        unset VIRTUAL_ENV PYTHONPATH CONDA_DEFAULT_ENV 2>/dev/null || true
         flox activate
     fi
 fi

--- a/.envrc
+++ b/.envrc
@@ -2,23 +2,28 @@ if command -v flox >/dev/null 2>&1; then # Only activate flox if installed
     # Check if Flox environment is already active for this project or its subdirectories
     if [ -z "${FLOX_ENV_PROJECT}" ]; then
         # No environment active, safe to activate
-        unset VIRTUAL_ENV PYTHONPATH CONDA_DEFAULT_ENV 2>/dev/null || true
+        unset VIRTUAL_ENV 2>/dev/null || :
+        unset PYTHONPATH 2>/dev/null || :
+        unset CONDA_DEFAULT_ENV 2>/dev/null || :
         flox activate
     elif [[ "${PWD}" != "${FLOX_ENV_PROJECT}"* ]]; then
         # Different project environment active, check for nesting
         echo "⚠️  About to activate Flox environment in worktree while already in environment for:"
         echo "   ${FLOX_ENV_PROJECT}"
         echo ""
-        read -p "Continue with nested activation? (y/N): " -n 1 -r
-        echo ""
+        printf "Continue with nested activation? (y/N): "
+        read -r REPLY
         if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-            echo "Skipping Flox activation. To switch to this environment, run:"
-            echo "  exit"
-            echo "  cd ${PWD}"
+            echo "Skipping Flox activation. To switch environments:"
+            echo "  1. Exit current environment: exit"
+            echo "  2. Return to this directory: cd '${PWD}'"
+            echo "  3. Reactivate environment: flox activate"
             return 0
         fi
         # Clean up conflicting environment variables before activation
-        unset VIRTUAL_ENV PYTHONPATH CONDA_DEFAULT_ENV 2>/dev/null || true
+        unset VIRTUAL_ENV 2>/dev/null || :
+        unset PYTHONPATH 2>/dev/null || :
+        unset CONDA_DEFAULT_ENV 2>/dev/null || :
         flox activate
     fi
 fi

--- a/.envrc
+++ b/.envrc
@@ -10,6 +10,9 @@ if command -v flox >/dev/null 2>&1; then # Only activate flox if installed
             echo ""
             if [[ ! $REPLY =~ ^[Yy]$ ]]; then
                 echo "Skipping Flox activation. Run 'exit' first if you want to switch environments."
+                echo "To switch to this environment, run:"
+                echo "  exit"
+                echo "  cd ${PWD}"
                 return 0
             fi
         fi

--- a/.envrc
+++ b/.envrc
@@ -1,20 +1,21 @@
 if command -v flox >/dev/null 2>&1; then # Only activate flox if installed
     # Check if Flox environment is already active for this project or its subdirectories
-    if [ -z "${FLOX_ENV_PROJECT}" ] || [[ "${PWD}" != "${FLOX_ENV_PROJECT}"* ]]; then
-        # Check if we would be nesting environments
-        if [ -n "${FLOX_ENV_PROJECT}" ]; then
-            echo "⚠️  About to activate Flox environment in worktree while already in environment for:"
-            echo "   ${FLOX_ENV_PROJECT}"
-            echo ""
-            read -p "Continue with nested activation? (y/N): " -n 1 -r
-            echo ""
-            if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-                echo "Skipping Flox activation. Run 'exit' first if you want to switch environments."
-                echo "To switch to this environment, run:"
-                echo "  exit"
-                echo "  cd ${PWD}"
-                return 0
-            fi
+    if [ -z "${FLOX_ENV_PROJECT}" ]; then
+        # No environment active, safe to activate
+        unset VIRTUAL_ENV PYTHONPATH CONDA_DEFAULT_ENV 2>/dev/null || true
+        flox activate
+    elif [[ "${PWD}" != "${FLOX_ENV_PROJECT}"* ]]; then
+        # Different project environment active, check for nesting
+        echo "⚠️  About to activate Flox environment in worktree while already in environment for:"
+        echo "   ${FLOX_ENV_PROJECT}"
+        echo ""
+        read -p "Continue with nested activation? (y/N): " -n 1 -r
+        echo ""
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            echo "Skipping Flox activation. To switch to this environment, run:"
+            echo "  exit"
+            echo "  cd ${PWD}"
+            return 0
         fi
         # Clean up conflicting environment variables before activation
         unset VIRTUAL_ENV PYTHONPATH CONDA_DEFAULT_ENV 2>/dev/null || true

--- a/.envrc
+++ b/.envrc
@@ -22,7 +22,12 @@ if command -v flox >/dev/null 2>&1; then # Only activate flox if installed
         echo "   ${FLOX_ENV_PROJECT}"
         echo ""
         printf "Continue with nested activation? (y/N): "
-        read -r REPLY
+        if [ -t 0 ]; then
+            read -r REPLY
+        else
+            echo "Non-interactive shell detected. Defaulting to 'no'."
+            REPLY="n"
+        fi
         if [[ ! $REPLY =~ ^[Yy]$ ]]; then
             echo "Skipping Flox activation. To switch environments:"
             echo "  1. Exit current environment: exit"


### PR DESCRIPTION
1. Fixes that annoying: "❌ ERROR: Environment 'posthog' is already active" error when calling flox activate.
2. Fixes making sure that other clones (if you have multiple clones of posthog/posthog) or git worktrees are activated properly.

## Problem

In my shell, I'd often see the error when changing directories. For example:

```bash
(posthog) (flox)  ~/dev/posthog/posthog> cd ..
(posthog) (flox)  ~/dev/posthog>  cd posthog
❌ ERROR: Environment 'posthog' is already active
```

The reason for this error is the current `.envrc` was checking the wrong environment variable (`FLOX_VERSION`) to determine whether it's already in a flox environment or not, causing it to always try to activate a new environment.

The other issue is that it's possible to have posthog/posthog in multiple different directories. For example, I could clone it in multiple places or I might use `git worktree` to create multiple working directories. In those cases, we would want to re-activate it because the env vars for one directory is not valid for another.

## Solution

Updated `.envrc` to use `FLOX_ENV_PROJECT` (documented in [official Flox docs](https://flox.dev/docs/reference/command-reference/flox-activate/)) with smart directory-aware logic:

1. **Same project detection**: If `FLOX_ENV_PROJECT` matches the current directory tree, don't reactivate.
2. If `FLOX_ENV_PROJECT` is different (aka going from one flox path to another), prompt the user:
  i. Ask whether they want to continue resulting in a nested flox env 
  ii. Or if they want to stop so they can exit the current flox env first before continuing.

The issue with changing directory from one flox environment to another is there's no way automatically deactivate the first while activating the second. So you end up with nested flox environments. It's not terrible, but maybe you don't want that. So `.envrc` prompts the user. If the user doesn't want to nest flox environments, they can respond with `n`	 and then call `exit` to exit the flox env.

## How did you test this code?

Manual testing.

Only affects our dev environment setup - no impact on production code.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._