### PR TITLE
feat(insights): show insights using events on event definition

### DIFF
--- a/frontend/src/scenes/data-management/definition/DefinitionView.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionView.tsx
@@ -16,6 +16,7 @@ import { SpinnerOverlay } from 'lib/lemon-ui/Spinner/Spinner'
 import { useMemo } from 'react'
 import { definitionLogic, DefinitionLogicProps } from 'scenes/data-management/definition/definitionLogic'
 import { EventDefinitionProperties } from 'scenes/data-management/events/EventDefinitionProperties'
+import { EventDefinitionInsights } from 'scenes/data-management/events/EventDefinitionInsights'
 import { LinkedHogFunctions } from 'scenes/hog-functions/list/LinkedHogFunctions'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
@@ -275,7 +276,8 @@ export function DefinitionView(props: DefinitionLogicProps = {}): JSX.Element {
             {isEvent && definition.id !== 'new' && (
                 <>
                     <EventDefinitionProperties definition={definition} />
-
+                    <LemonDivider className="my-6" />
+                    <EventDefinitionInsights definition={definition} />
                     <LemonDivider className="my-6" />
                     <h2 className="flex-1 subtitle">Connected destinations</h2>
                     <p>Get notified via Slack, webhooks or more whenever this event is captured.</p>

--- a/frontend/src/scenes/data-management/events/EventDefinitionInsights.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionInsights.tsx
@@ -12,12 +12,9 @@ import { createdByColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
 import { useSummarizeInsight } from 'scenes/insights/summarizeInsight'
 
 export function EventDefinitionInsights({ definition }: { definition: EventDefinition }): JSX.Element {
-    const { page, insights, count, filters, insightsLoading, sorting } = useValues(eventInsightsLogic)
+    const { page, insights, filters, insightsLoading, sorting } = useValues(eventInsightsLogic)
     const { setPage, setFilters } = useActions(eventInsightsLogic)
     const summarizeInsight = useSummarizeInsight()
-
-    const startCount = (page - 1) * INSIGHTS_PER_PAGE + 1
-    const endCount = Math.min(page * INSIGHTS_PER_PAGE, count)
 
     useEffect(() => {
         setFilters({ events: [definition.name] })
@@ -54,21 +51,13 @@ export function EventDefinitionInsights({ definition }: { definition: EventDefin
     return (
         <div className="saved-insights">
             <h3>Insights using event</h3>
-            <div className="flex justify-between mb-4 gap-2 flex-wrap mt-2 items-center">
-                <span className="text-secondary">
-                    {count
-                        ? `${startCount}${endCount - startCount > 1 ? '-' + endCount : ''} of ${count} insight${
-                              count === 1 ? '' : 's'
-                          }`
-                        : null}
-                </span>
-                <LemonInput
-                    type="search"
-                    placeholder="Search..."
-                    onChange={(value) => setFilters({ search: value })}
-                    value={filters.search || ''}
-                />
-            </div>
+            <LemonInput
+                type="search"
+                className="mb-2"
+                placeholder="Search..."
+                onChange={(value) => setFilters({ search: value })}
+                value={filters.search || ''}
+            />
             <LemonTable
                 id={`event-definition-insights-table-${definition.id}`}
                 loading={insightsLoading}

--- a/frontend/src/scenes/data-management/events/EventDefinitionInsights.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionInsights.tsx
@@ -1,0 +1,110 @@
+import { LemonInput, Link } from '@posthog/lemon-ui'
+import { useActions, useValues } from 'kea'
+import { LemonTable, LemonTableColumn, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
+import { useEffect } from 'react'
+import { urls } from 'scenes/urls'
+
+import { EventDefinition, QueryBasedInsightModel } from '~/types'
+
+import { eventInsightsLogic, INSIGHTS_PER_PAGE } from 'scenes/data-management/events/eventInsightsLogic'
+import { InsightIcon } from 'scenes/saved-insights/SavedInsights'
+import { createdByColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
+import { useSummarizeInsight } from 'scenes/insights/summarizeInsight'
+
+export function EventDefinitionInsights({ definition }: { definition: EventDefinition }): JSX.Element {
+    const { page, insights, count, filters, insightsLoading, sorting } = useValues(eventInsightsLogic)
+    const { setPage, setFilters } = useActions(eventInsightsLogic)
+    const summarizeInsight = useSummarizeInsight()
+
+    const startCount = (page - 1) * INSIGHTS_PER_PAGE + 1
+    const endCount = Math.min(page * INSIGHTS_PER_PAGE, count)
+
+    useEffect(() => {
+        setFilters({ events: [definition.name] })
+    }, [definition, setFilters])
+
+    const columns: LemonTableColumns<QueryBasedInsightModel> = [
+        {
+            key: 'id',
+            width: 32,
+            render: function renderType(_, insight) {
+                return <InsightIcon insight={insight} className="text-secondary text-2xl" />
+            },
+        },
+        {
+            title: 'Name',
+            dataIndex: 'name',
+            key: 'name',
+            render: function renderName(name: string, insight) {
+                return (
+                    <>
+                        <div className="flex flex-col gap-1">
+                            <div className="inline-flex">
+                                <Link to={urls.insightView(insight.short_id)} target="_blank">
+                                    {name || <i>{summarizeInsight(insight.query)}</i>}
+                                </Link>
+                            </div>
+                            <div className="text-xs text-tertiary">{insight.description}</div>
+                        </div>
+                    </>
+                )
+            },
+        },
+        createdByColumn() as LemonTableColumn<QueryBasedInsightModel, keyof QueryBasedInsightModel | undefined>,
+    ]
+
+    return (
+        <div className="saved-insights">
+            <h3>Insights using event</h3>
+            <div className="flex justify-between mb-4 gap-2 flex-wrap mt-2 items-center">
+                <span className="text-secondary">
+                    {count
+                        ? `${startCount}${endCount - startCount > 1 ? '-' + endCount : ''} of ${count} insight${
+                              count === 1 ? '' : 's'
+                          }`
+                        : null}
+                </span>
+                <LemonInput
+                    type="search"
+                    placeholder="Search..."
+                    onChange={(value) => setFilters({ search: value })}
+                    value={filters.search || ''}
+                />
+            </div>
+            <LemonTable
+                id={`event-definition-insights-table-${definition.id}`}
+                loading={insightsLoading}
+                columns={columns}
+                data-attr="event-definition-insights-table"
+                dataSource={insights.results ? insights.results : []}
+                pagination={{
+                    controlled: true,
+                    currentPage: insights?.page ?? 1,
+                    entryCount: insights?.count ?? 0,
+                    pageSize: INSIGHTS_PER_PAGE,
+                    onForward: insights?.next
+                        ? () => {
+                              setPage(page + 1)
+                          }
+                        : undefined,
+                    onBackward: insights?.previous
+                        ? () => {
+                              setPage(page - 1)
+                          }
+                        : undefined,
+                }}
+                sorting={sorting}
+                onSort={(newSorting) =>
+                    setFilters({
+                        order: newSorting ? `${newSorting.order === -1 ? '-' : ''}${newSorting.columnKey}` : undefined,
+                    })
+                }
+                rowKey="id"
+                loadingSkeletonRows={INSIGHTS_PER_PAGE}
+                nouns={['insight', 'insights']}
+                useURLForSorting={false}
+                emptyState="No insights found"
+            />
+        </div>
+    )
+}

--- a/frontend/src/scenes/data-management/events/EventDefinitionInsights.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionInsights.tsx
@@ -1,4 +1,4 @@
-import { LemonInput, Link } from '@posthog/lemon-ui'
+import { LemonInput } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { LemonTable, LemonTableColumn, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { urls } from 'scenes/urls'
@@ -7,8 +7,10 @@ import { EventDefinition, QueryBasedInsightModel } from '~/types'
 
 import { eventInsightsLogic, INSIGHTS_PER_PAGE } from 'scenes/data-management/events/eventInsightsLogic'
 import { InsightIcon } from 'scenes/saved-insights/SavedInsights'
-import { createdByColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
+import { createdAtColumn, createdByColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
 import { useSummarizeInsight } from 'scenes/insights/summarizeInsight'
+import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
+import { TZLabel } from 'lib/components/TZLabel'
 
 export function EventDefinitionInsights({ definition }: { definition: EventDefinition }): JSX.Element {
     const event = definition.name
@@ -30,18 +32,29 @@ export function EventDefinitionInsights({ definition }: { definition: EventDefin
             key: 'name',
             render: function renderName(name: string, insight) {
                 return (
-                    <div className="flex flex-col gap-1">
-                        <div className="inline-flex">
-                            <Link to={urls.insightView(insight.short_id)} target="_blank">
-                                {name || <i>{summarizeInsight(insight.query)}</i>}
-                            </Link>
-                        </div>
-                        <div className="text-xs text-tertiary">{insight.description}</div>
-                    </div>
+                    <>
+                        <LemonTableLink
+                            to={urls.insightView(insight.short_id)}
+                            title={<>{name || <i>{summarizeInsight(insight.query)}</i>}</>}
+                            description={insight.description}
+                        />
+                    </>
+                )
+            },
+            sorter: (a, b) => (a.name || summarizeInsight(a.query)).localeCompare(b.name || summarizeInsight(b.query)),
+        },
+        createdByColumn() as LemonTableColumn<QueryBasedInsightModel, keyof QueryBasedInsightModel | undefined>,
+        createdAtColumn() as LemonTableColumn<QueryBasedInsightModel, keyof QueryBasedInsightModel | undefined>,
+        {
+            title: 'Last modified',
+            sorter: true,
+            dataIndex: 'last_modified_at',
+            render: function renderLastModified(last_modified_at: string) {
+                return (
+                    <div className="whitespace-nowrap">{last_modified_at && <TZLabel time={last_modified_at} />}</div>
                 )
             },
         },
-        createdByColumn() as LemonTableColumn<QueryBasedInsightModel, keyof QueryBasedInsightModel | undefined>,
     ]
 
     return (

--- a/frontend/src/scenes/data-management/events/EventDefinitionInsights.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionInsights.tsx
@@ -74,18 +74,18 @@ export function EventDefinitionInsights({ definition }: { definition: EventDefin
                 loading={insightsLoading}
                 columns={columns}
                 data-attr="event-definition-insights-table"
-                dataSource={insights.results ? insights.results : []}
+                dataSource={insights.results}
                 pagination={{
                     controlled: true,
                     currentPage: page ?? 1,
-                    entryCount: insights?.count ?? 0,
+                    entryCount: insights.count,
                     pageSize: INSIGHTS_PER_PAGE,
-                    onForward: insights?.next
+                    onForward: insights.next
                         ? () => {
                               setPage(page + 1)
                           }
                         : undefined,
-                    onBackward: insights?.previous
+                    onBackward: insights.previous
                         ? () => {
                               setPage(page - 1)
                           }

--- a/frontend/src/scenes/data-management/events/EventDefinitionInsights.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionInsights.tsx
@@ -1,7 +1,6 @@
 import { LemonInput, Link } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { LemonTable, LemonTableColumn, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
-import { useEffect } from 'react'
 import { urls } from 'scenes/urls'
 
 import { EventDefinition, QueryBasedInsightModel } from '~/types'
@@ -12,13 +11,10 @@ import { createdByColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
 import { useSummarizeInsight } from 'scenes/insights/summarizeInsight'
 
 export function EventDefinitionInsights({ definition }: { definition: EventDefinition }): JSX.Element {
-    const { page, insights, filters, insightsLoading, sorting } = useValues(eventInsightsLogic)
-    const { setPage, setFilters } = useActions(eventInsightsLogic)
+    const event = definition.name
+    const { page, insights, filters, insightsLoading, sorting } = useValues(eventInsightsLogic({ event }))
+    const { setPage, setFilters } = useActions(eventInsightsLogic({ event }))
     const summarizeInsight = useSummarizeInsight()
-
-    useEffect(() => {
-        setFilters({ events: [definition.name] })
-    }, [definition, setFilters])
 
     const columns: LemonTableColumns<QueryBasedInsightModel> = [
         {

--- a/frontend/src/scenes/data-management/events/EventDefinitionInsights.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionInsights.tsx
@@ -37,16 +37,14 @@ export function EventDefinitionInsights({ definition }: { definition: EventDefin
             key: 'name',
             render: function renderName(name: string, insight) {
                 return (
-                    <>
-                        <div className="flex flex-col gap-1">
-                            <div className="inline-flex">
-                                <Link to={urls.insightView(insight.short_id)} target="_blank">
-                                    {name || <i>{summarizeInsight(insight.query)}</i>}
-                                </Link>
-                            </div>
-                            <div className="text-xs text-tertiary">{insight.description}</div>
+                    <div className="flex flex-col gap-1">
+                        <div className="inline-flex">
+                            <Link to={urls.insightView(insight.short_id)} target="_blank">
+                                {name || <i>{summarizeInsight(insight.query)}</i>}
+                            </Link>
                         </div>
-                    </>
+                        <div className="text-xs text-tertiary">{insight.description}</div>
+                    </div>
                 )
             },
         },

--- a/frontend/src/scenes/data-management/events/EventDefinitionInsights.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionInsights.tsx
@@ -79,7 +79,7 @@ export function EventDefinitionInsights({ definition }: { definition: EventDefin
                 dataSource={insights.results ? insights.results : []}
                 pagination={{
                     controlled: true,
-                    currentPage: insights?.page ?? 1,
+                    currentPage: page ?? 1,
                     entryCount: insights?.count ?? 0,
                     pageSize: INSIGHTS_PER_PAGE,
                     onForward: insights?.next

--- a/frontend/src/scenes/data-management/events/eventInsightsLogic.ts
+++ b/frontend/src/scenes/data-management/events/eventInsightsLogic.ts
@@ -7,9 +7,8 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { getQueryBasedInsightModel } from '~/queries/nodes/InsightViz/utils'
-import { QueryBasedInsightModel } from '~/types'
 
-import { cleanFilters, SavedInsightFilters } from 'scenes/saved-insights/savedInsightsLogic'
+import { cleanFilters, InsightsResult, SavedInsightFilters } from 'scenes/saved-insights/savedInsightsLogic'
 
 import type { eventInsightsLogicType } from './eventInsightsLogicType'
 
@@ -28,7 +27,7 @@ export const eventInsightsLogic = kea<eventInsightsLogicType>([
     }),
     loaders(({ values }) => ({
         insights: {
-            __default: { results: [] as QueryBasedInsightModel[], count: 0 },
+            __default: { results: [], count: 0, filters: null, offset: 0 } as InsightsResult,
             loadInsights: async () => {
                 const { filters } = values
                 const { order, page, events, search } = filters
@@ -38,10 +37,8 @@ export const eventInsightsLogic = kea<eventInsightsLogicType>([
                         results: [],
                         count: 0,
                         filters,
-                        page: 1,
-                        previous: null,
-                        next: null,
-                    }
+                        offset: 0,
+                    } as InsightsResult
                 }
 
                 const params: Record<string, any> = {
@@ -64,12 +61,8 @@ export const eventInsightsLogic = kea<eventInsightsLogicType>([
                 return {
                     ...response,
                     filters,
-                    count: response.count,
-                    page,
-                    previous: response.previous,
-                    next: response.next,
                     results: response.results.map((rawInsight: any) => getQueryBasedInsightModel(rawInsight)),
-                }
+                } as InsightsResult
             },
         },
     })),

--- a/frontend/src/scenes/data-management/events/eventInsightsLogic.ts
+++ b/frontend/src/scenes/data-management/events/eventInsightsLogic.ts
@@ -1,0 +1,115 @@
+import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+import api from 'lib/api'
+import { Sorting } from 'lib/lemon-ui/LemonTable'
+import { objectsEqual, toParams } from 'lib/utils'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { getQueryBasedInsightModel } from '~/queries/nodes/InsightViz/utils'
+import { QueryBasedInsightModel } from '~/types'
+
+import { cleanFilters, SavedInsightFilters } from 'scenes/saved-insights/savedInsightsLogic'
+
+import type { eventInsightsLogicType } from './eventInsightsLogicType'
+
+export const INSIGHTS_PER_PAGE = 10
+
+export const eventInsightsLogic = kea<eventInsightsLogicType>([
+    path(['scenes', 'saved-insights', 'addSavedInsightsModalLogic']),
+    connect(() => ({
+        values: [teamLogic, ['currentTeamId']],
+        logic: [eventUsageLogic],
+    })),
+    actions({
+        setFilters: (filters: Partial<SavedInsightFilters>) => ({ filters }),
+        loadInsights: true,
+        setPage: (page: number) => ({ page }),
+    }),
+    loaders(({ values }) => ({
+        insights: {
+            __default: { results: [] as QueryBasedInsightModel[], count: 0 },
+            loadInsights: async () => {
+                const { filters } = values
+                const { order, page, events, search } = filters
+
+                if (!events || events.length === 0) {
+                    return { results: [], count: 0 }
+                }
+
+                const params: Record<string, any> = {
+                    order,
+                    events,
+                    limit: INSIGHTS_PER_PAGE,
+                    offset: Math.max(0, (page - 1) * INSIGHTS_PER_PAGE),
+                    saved: true,
+                    basic: true,
+                }
+
+                if (search) {
+                    params.search = search
+                }
+
+                const response = await api.get(
+                    `api/environments/${teamLogic.values.currentTeamId}/insights/?${toParams(params)}`
+                )
+
+                return {
+                    ...response,
+                    filters,
+                    count: response.count,
+                    page,
+                    previous: response.previous,
+                    next: response.next,
+                    results: response.results.map((rawInsight: any) => getQueryBasedInsightModel(rawInsight)),
+                }
+            },
+        },
+    })),
+    reducers({
+        rawFilters: [
+            null as Partial<SavedInsightFilters> | null,
+            {
+                setFilters: (state, { filters }) => {
+                    return cleanFilters({
+                        ...state,
+                        ...filters,
+                        ...('page' in filters ? {} : { page: 1 }),
+                    })
+                },
+            },
+        ],
+    }),
+    selectors({
+        filters: [(s) => [s.rawFilters], (rawFilters: object): SavedInsightFilters => cleanFilters(rawFilters || {})],
+        count: [(s) => [s.insights], (insights) => insights.count],
+        sorting: [
+            (s) => [s.filters],
+            (filters): Sorting | null =>
+                filters.order
+                    ? filters.order.startsWith('-')
+                        ? { columnKey: filters.order.slice(1), order: -1 }
+                        : { columnKey: filters.order, order: 1 }
+                    : null,
+        ],
+        page: [(s) => [s.filters], (filters) => filters.page],
+        usingFilters: [
+            (s) => [s.filters],
+            (filters) => !objectsEqual(cleanFilters({ ...filters, events: undefined }), cleanFilters({})),
+        ],
+    }),
+    listeners(({ actions, values, selectors }) => ({
+        setPage: async ({ page }) => {
+            actions.setFilters({ page })
+            actions.loadInsights()
+        },
+        setFilters: async ({}, breakpoint, __, previousState) => {
+            const oldFilters = selectors.filters(previousState)
+            const newFilters = values.filters
+            await breakpoint(300)
+            if (!objectsEqual(oldFilters, newFilters) && newFilters.events && newFilters.events.length > 0) {
+                actions.loadInsights()
+            }
+        },
+    })),
+])

--- a/frontend/src/scenes/data-management/events/eventInsightsLogic.ts
+++ b/frontend/src/scenes/data-management/events/eventInsightsLogic.ts
@@ -54,9 +54,7 @@ export const eventInsightsLogic = kea<eventInsightsLogicType>([
                     params.search = search
                 }
 
-                const response = await api.get(
-                    `api/environments/${teamLogic.values.currentTeamId}/insights/?${toParams(params)}`
-                )
+                const response = await api.get(`api/environments/${values.currentTeamId}/insights/?${toParams(params)}`)
 
                 return {
                     ...response,

--- a/frontend/src/scenes/data-management/events/eventInsightsLogic.ts
+++ b/frontend/src/scenes/data-management/events/eventInsightsLogic.ts
@@ -15,7 +15,7 @@ import type { eventInsightsLogicType } from './eventInsightsLogicType'
 export const INSIGHTS_PER_PAGE = 10
 
 export const eventInsightsLogic = kea<eventInsightsLogicType>([
-    path(['scenes', 'saved-insights', 'addSavedInsightsModalLogic']),
+    path(['scenes', 'data-management', 'events', 'eventInsightsLogic']),
     connect(() => ({
         values: [teamLogic, ['currentTeamId']],
         logic: [eventUsageLogic],

--- a/frontend/src/scenes/data-management/events/eventInsightsLogic.ts
+++ b/frontend/src/scenes/data-management/events/eventInsightsLogic.ts
@@ -34,7 +34,14 @@ export const eventInsightsLogic = kea<eventInsightsLogicType>([
                 const { order, page, events, search } = filters
 
                 if (!events || events.length === 0) {
-                    return { results: [], count: 0 }
+                    return {
+                        results: [],
+                        count: 0,
+                        filters,
+                        page: 1,
+                        previous: null,
+                        next: null,
+                    }
                 }
 
                 const params: Record<string, any> = {

--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
@@ -45,6 +45,7 @@ export interface SavedInsightFilters {
     dateTo: string | dayjs.Dayjs | undefined | null
     page: number
     dashboardId: number | undefined | null
+    events: string[] | undefined | null
 }
 
 export function cleanFilters(values: Partial<SavedInsightFilters>): SavedInsightFilters {
@@ -59,6 +60,7 @@ export function cleanFilters(values: Partial<SavedInsightFilters>): SavedInsight
         dateTo: values.dateTo || undefined,
         page: parseInt(String(values.page)) || 1,
         dashboardId: values.dashboardId,
+        events: values.events,
     }
 }
 

--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
@@ -45,7 +45,6 @@ export interface SavedInsightFilters {
     dateTo: string | dayjs.Dayjs | undefined | null
     page: number
     dashboardId: number | undefined | null
-    events: string[] | undefined | null
 }
 
 export function cleanFilters(values: Partial<SavedInsightFilters>): SavedInsightFilters {
@@ -60,7 +59,6 @@ export function cleanFilters(values: Partial<SavedInsightFilters>): SavedInsight
         dateTo: values.dateTo || undefined,
         page: parseInt(String(values.page)) || 1,
         dashboardId: values.dashboardId,
-        events: values.events,
     }
 }
 
@@ -242,10 +240,6 @@ export const savedInsightsLogic = kea<savedInsightsLogicType>([
                 ...(!!filters.dashboardId && {
                     dashboards: [filters.dashboardId],
                 }),
-                ...(filters.events &&
-                    filters.events.length > 0 && {
-                        events: filters.events,
-                    }),
             }),
         ],
         pagination: [

--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
@@ -45,6 +45,7 @@ export interface SavedInsightFilters {
     dateTo: string | dayjs.Dayjs | undefined | null
     page: number
     dashboardId: number | undefined | null
+    events: string[] | undefined | null
 }
 
 export function cleanFilters(values: Partial<SavedInsightFilters>): SavedInsightFilters {
@@ -59,6 +60,7 @@ export function cleanFilters(values: Partial<SavedInsightFilters>): SavedInsight
         dateTo: values.dateTo || undefined,
         page: parseInt(String(values.page)) || 1,
         dashboardId: values.dashboardId,
+        events: values.events,
     }
 }
 
@@ -240,6 +242,10 @@ export const savedInsightsLogic = kea<savedInsightsLogicType>([
                 ...(!!filters.dashboardId && {
                     dashboards: [filters.dashboardId],
                 }),
+                ...(filters.events &&
+                    filters.events.length > 0 && {
+                        events: filters.events,
+                    }),
             }),
         ],
         pagination: [


### PR DESCRIPTION
## Problem

No way to see the list of insights using an events in the event definition page

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

This adds a table on the event definition page to view a list of insights that are using this event.

<img width="1238" height="348" alt="image" src="https://github.com/user-attachments/assets/6df967cc-5fe4-4776-a3fa-c1fe749546f1" />

Empty state:
<img width="1250" height="226" alt="image" src="https://github.com/user-attachments/assets/898a9ae2-a93a-490f-82e5-c11a814014db" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- Create a new insight and use an event (if not creating a new one, make sure the management command in this [PR](https://github.com/PostHog/posthog/pull/35399) is applied to backfill data for previously created insights)
- View the event in the Data Management > Event definitions
- Confirm the newly created insight is displayed on the table (it might take a while to show up depending on Celery backlog)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
