### PR TITLE
fix(capture): circuit break when local kafka queue is full

### DIFF
--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -309,13 +309,12 @@ impl KafkaSink {
                     ))
                 }
                 Some(RDKafkaErrorCode::QueueFull) => {
-                    // Don't make this retryable - it causes retry death spirals
+                    // Don't make this retryable, the queue is already full
                     report_dropped_events("kafka_queue_full", 1);
                     error!(
                         "Kafka producer queue full - dropping event to prevent retry storm: {}",
                         e
                     );
-                    // Return NonRetryableSinkError to avoid HTTP 503 and client retries
                     Err(CaptureError::NonRetryableSinkError)
                 }
                 _ => {


### PR DESCRIPTION
## Problem

We don't want to immediately retry sending an event when the local queue is full. Can cause issues

## Changes

Catch local queue full errors and not trhow a retryable error when we get it

## How did you test this code?

Haven't tested it

