### PR TITLE
chore: Fix persistent direnv setup prompt in Flox manifest

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -71,7 +71,7 @@ UV_PROJECT_ENVIRONMENT = "$FLOX_ENV_CACHE/venv"
 on-activate = '''
 # Guide through installing and configuring direnv if it's not present (optionally)
 
-if [[ -t 0 ]] && [ ! -d "$DIRENV_FILE" ] && [ ! -f "$FLOX_ENV_CACHE/.hush-direnv" ]; then
+if [[ -t 0 ]] && [[ -z "${DIRENV_DIR:-}" ]] && [ ! -f "$FLOX_ENV_CACHE/.hush-direnv" ]; then
   read -p "👉 For auto-activation of the environment, we recommend direnv (https://direnv.net).
 ❓ Would you like direnv to be set up in $(basename "$SHELL") now? (Y/n)" -n 1 -r
   echo


### PR DESCRIPTION
## Problem

The activation hook was checking an undefined variable DIRENV_FILE instead of properly detecting direnv status, causing the setup prompt to appear on every activation regardless of direnv configuration.

## Changes

- Changed from: [ \! -d "$DIRENV_FILE" ] (undefined variable)
- Changed to: [[ -z "${DIRENV_DIR:-}" ]] (proper direnv detection)

DIRENV_DIR is set by direnv when active, so this correctly detects when direnv is not loaded and only prompts in that case.

Fixes the issue where users with direnv already configured would see: "❓ Would you like direnv to be set up in zsh now? (Y/n)"

## How did you test this code?

Manually

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
