### PR TITLE
fix(experiments): don't reload preview on name change

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -141,9 +141,18 @@ export function ExperimentMetricForm({
 
     const metricFilter = getFilter(metric)
 
-    useEffect(() => {
-        loadEventCount(metric, filterTestAccounts, setEventCount, setIsLoading)
-    }, [metric, filterTestAccounts])
+    useEffect(
+        () => {
+            loadEventCount(metric, filterTestAccounts, setEventCount, setIsLoading)
+        },
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [
+            metric.metric_type,
+            isExperimentMeanMetric(metric) ? metric.source : null,
+            isExperimentFunnelMetric(metric) ? metric.series : null,
+            filterTestAccounts,
+        ]
+    )
 
     const hideDeleteBtn = (_: any, index: number): boolean => index === 0
 


### PR DESCRIPTION
## Changes
Don't reload the preview query on metric `name` change.

## How did you test this code?
👀 