### PR TITLE
chore(migrations): Skip cassandra migrations if cassandra isn't up locally

### DIFF
--- a/plugin-server/bin/migrate-cassandra
+++ b/plugin-server/bin/migrate-cassandra
@@ -34,6 +34,10 @@ done
 
 if [ $attempt -eq $max_attempts ]; then
     echo "ERROR: Cassandra failed to become ready after $max_attempts attempts"
+    if [ "$DEBUG" = "1" ]; then
+        echo "DEBUG mode enabled, skipping Cassandra migrations"
+        exit 0
+    fi
     exit 1
 fi
 


### PR DESCRIPTION
## Problem
- You currently need to have cassandra running locally to migrate postgres, even if you're not using Cassandra or behavioral cohorts

## Changes
- if the `DEBUG=1` env var is set and cassandra isn't available, then skip the cassandra migrations and not exit with error code 1
