### PR TITLE
feat(devex): scene tabs love

### DIFF
--- a/frontend/src/layout/scenes/SceneHeader.tsx
+++ b/frontend/src/layout/scenes/SceneHeader.tsx
@@ -28,10 +28,11 @@ export function SceneHeader({ className }: { className?: string }): JSX.Element 
     const { showLayoutNavBar } = useActions(panelLayoutLogic)
     const { isLayoutNavbarVisibleForMobile } = useValues(panelLayoutLogic)
     const { projectTreeRefEntry } = useValues(projectTreeDataLogic)
-    const { scenePanelOpen, scenePanelIsPresent } = useValues(sceneLayoutLogic)
+    const { scenePanelOpen, scenePanelIsPresent, useSceneTabs } = useValues(sceneLayoutLogic)
     const { setScenePanelOpen } = useActions(sceneLayoutLogic)
 
-    return breadcrumbs.length || projectTreeRefEntry ? (
+    const effectiveBreadcrumbs = useSceneTabs ? breadcrumbs.slice(1) : breadcrumbs
+    return effectiveBreadcrumbs.length || projectTreeRefEntry ? (
         <>
             <div
                 className={cn(
@@ -48,16 +49,19 @@ export function SceneHeader({ className }: { className?: string }): JSX.Element 
                     />
                 )}
                 <div className="flex gap-1 justify-between w-full items-center overflow-x-hidden py-1">
-                    {breadcrumbs.length > 0 && (
+                    {effectiveBreadcrumbs.length > 0 && (
                         <ScrollableShadows
                             direction="horizontal"
                             styledScrollbars
                             className="h-[var(--scene-layout-header-height)] pr-2 flex-1"
                             innerClassName="flex gap-0 flex-1 items-center overflow-x-auto show-scrollbar-on-hover h-full"
                         >
-                            {breadcrumbs.map((breadcrumb, index) => (
+                            {effectiveBreadcrumbs.map((breadcrumb, index) => (
                                 <React.Fragment key={joinBreadcrumbKey(breadcrumb.key)}>
-                                    <Breadcrumb breadcrumb={breadcrumb} here={index === breadcrumbs.length - 1} />
+                                    <Breadcrumb
+                                        breadcrumb={breadcrumb}
+                                        here={index === effectiveBreadcrumbs.length - 1}
+                                    />
                                     {index < breadcrumbs.length - 1 && (
                                         <span className="flex items-center shrink-0 opacity-50">
                                             <IconSlash fontSize="1rem" />
@@ -101,7 +105,7 @@ function Breadcrumb({ breadcrumb, here, isOnboarding }: BreadcrumbProps): JSX.El
 
     const { assureVisibility } = useActions(projectTreeLogic({ key: PROJECT_TREE_KEY }))
     const { showLayoutPanel, setActivePanelIdentifier } = useActions(panelLayoutLogic)
-    const { scenePanelOpen, scenePanelIsPresent } = useValues(sceneLayoutLogic)
+    const { scenePanelOpen, scenePanelIsPresent, useSceneTabs } = useValues(sceneLayoutLogic)
     const { setScenePanelOpen } = useActions(sceneLayoutLogic)
     const { renameState } = useValues(breadcrumbsLogic)
     const { tentativelyRename, finishRenaming } = useActions(breadcrumbsLogic)
@@ -148,7 +152,7 @@ function Breadcrumb({ breadcrumb, here, isOnboarding }: BreadcrumbProps): JSX.El
         </Component>
     )
 
-    if (breadcrumb.isPopoverProject) {
+    if (breadcrumb.isPopoverProject && !useSceneTabs) {
         return (
             <ProjectDropdownMenu
                 buttonProps={{

--- a/frontend/src/layout/scenes/SceneLayout.tsx
+++ b/frontend/src/layout/scenes/SceneLayout.tsx
@@ -124,10 +124,10 @@ export function SceneLayout({ children, className, layoutConfig }: SceneLayoutPr
                     block: layoutConfig?.layout === 'app-raw-no-header',
                 })}
             >
+                {useSceneTabs ? <SceneTabs /> : null}
                 {layoutConfig?.layout !== 'app-raw-no-header' && (
                     <SceneHeader className="row-span-1 col-span-1 min-w-0" />
                 )}
-                {useSceneTabs ? <SceneTabs /> : null}
 
                 {scenePanelIsPresent && (
                     <>

--- a/frontend/src/layout/scenes/SceneTabs.tsx
+++ b/frontend/src/layout/scenes/SceneTabs.tsx
@@ -1,15 +1,16 @@
-import { cn } from 'lib/utils/css-classes'
-import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { IconPlus, IconX } from '@posthog/icons'
+import { cn } from 'lib/utils/css-classes'
 
 import { useActions, useValues } from 'kea'
-import { sceneTabsLogic, SceneTab } from '~/layout/scenes/sceneTabsLogic'
 import { Link } from 'lib/lemon-ui/Link'
 import { urls } from 'scenes/urls'
+import { SceneTab, sceneTabsLogic } from '~/layout/scenes/sceneTabsLogic'
 
-import { DndContext, PointerSensor, useSensor, useSensors, DragEndEvent } from '@dnd-kit/core'
-import { SortableContext, useSortable, horizontalListSortingStrategy } from '@dnd-kit/sortable'
+import { DndContext, DragEndEvent, PointerSensor, useSensor, useSensors } from '@dnd-kit/core'
+import { horizontalListSortingStrategy, SortableContext, useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
+import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+import { ProjectDropdownMenu } from '../panel-layout/ProjectDropdownMenu'
 
 export interface SceneTabsProps {
     className?: string
@@ -30,27 +31,41 @@ export function SceneTabs({ className }: SceneTabsProps): JSX.Element {
     return (
         <div
             className={cn(
-                'flex items-center w-full sticky top-0 bg-surface-secondary z-[var(--z-top-navigation)] border-b border-primary',
+                'flex items-center w-full sticky top-0 bg-surface-tertiary z-[var(--z-top-navigation)] px-1.5 border-b border-primary',
                 className
             )}
         >
             <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
                 <SortableContext items={[...tabs.map((t) => t.id), 'new']} strategy={horizontalListSortingStrategy}>
-                    <div className={cn('flex flex-row flex-wrap', className)}>
+                    <div className={cn('flex flex-row flex-wrap gap-1 pt-1', className)}>
+                        <div className="flex items-center gap-1">
+                            <ProjectDropdownMenu
+                                buttonProps={{
+                                    className: 'h-[32px] mt-[-2px]',
+                                }}
+                            />
+                        </div>
                         {tabs.map((tab) => (
                             <SortableSceneTab key={tab.id} tab={tab} />
                         ))}
-                        <Link
-                            to={urls.newTab()}
-                            className="rounded-none px-2 py-1.5 text-primary hover:text-primary-hover hover:bg-surface-primary focus:text-primary-hover focus:outline-none"
-                            data-attr="scene-tab-new-button"
-                            onClick={(e) => {
-                                e.preventDefault()
-                                newTab()
-                            }}
-                        >
-                            <IconPlus className="!ml-0" fontSize={14} />
-                        </Link>
+                        <div className="py-1">
+                            <Link
+                                to={urls.newTab()}
+                                data-attr="scene-tab-new-button"
+                                onClick={(e) => {
+                                    e.preventDefault()
+                                    newTab()
+                                }}
+                                buttonProps={{
+                                    size: 'sm',
+                                    className:
+                                        'p-1 flex flex-row items-center gap-1 cursor-pointer rounded-tr rounded-tl border-b',
+                                    iconOnly: true,
+                                }}
+                            >
+                                <IconPlus className="!ml-0" fontSize={14} />
+                            </Link>
+                        </div>
                     </div>
                 </SortableContext>
             </DndContext>
@@ -94,26 +109,28 @@ function SceneTabComponent({ tab, className, isDragging }: SceneTabProps): JSX.E
             }}
             to={isDragging ? undefined : `${tab.pathname}${tab.search}${tab.hash}`}
             className={cn(
-                'deprecated-space-y-px p-1 flex border-b-2 flex-row items-center gap-1 cursor-pointer',
+                'h-[37px] p-0.5 flex flex-row items-center gap-1 rounded-tr rounded-tl border border-transparent bottom-[-1px] relative',
                 tab.active
-                    ? 'text-primary bg-surface-primary !border-brand-yellow'
-                    : 'text-secondary bg-surface-secondary border-transparent',
-                canRemoveTab ? 'pl-3 pr-2' : 'px-3',
-                'hover:bg-surface-primary hover:text-primary-hover focus:outline-none',
+                    ? 'cursor-default text-primary bg-surface-secondary border-primary border-b-transparent'
+                    : 'cursor-pointer text-secondary bg-transparent hover:bg-surface-primary hover:text-primary-hover',
+                canRemoveTab ? 'pl-2 pr-1' : 'px-3',
+                'focus:outline-none',
                 className
             )}
         >
             <div className="flex-grow text-left whitespace-pre">{tab.title}</div>
             {canRemoveTab && (
-                <LemonButton
+                <ButtonPrimitive
                     onClick={(e) => {
                         e.stopPropagation()
                         e.preventDefault()
                         removeTab(tab)
                     }}
-                    size="xsmall"
-                    icon={<IconX />}
-                />
+                    iconOnly
+                    size="xs"
+                >
+                    <IconX />
+                </ButtonPrimitive>
             )}
         </Link>
     )


### PR DESCRIPTION
## Problem
Hierarchy and styles needed a bit of love

![2025-08-01 10 55 22](https://github.com/user-attachments/assets/c3572c31-d7e9-419d-88ff-df74058a8bd7)

## Changes
- Move tabs above scene header
- Update tabs styles (better sizes, hover, active states etc)
- Hide project dropdown in scene header if flag exists
- Add project dropdown to scene tabs

## How did you test this code?
little testing really
