### PR TITLE
fix(max): broken equality check

### DIFF
--- a/frontend/src/scenes/max/maxBillingContextLogic.tsx
+++ b/frontend/src/scenes/max/maxBillingContextLogic.tsx
@@ -305,14 +305,17 @@ export const maxBillingContextLogic = kea<maxBillingContextLogicType>([
             },
             {
                 equalityCheck: (prev: any[], next: any[]) => {
+                    if (!prev || !next) {
+                        return prev === next
+                    }
                     return (
-                        prev[0] === next[0] &&
-                        prev[1] === next[1] &&
-                        prev[2] === next[2] &&
-                        prev[3] === next[3] &&
-                        prev[4]?.autocapture_opt_out === next[4]?.autocapture_opt_out &&
-                        prev[5] === next[5] &&
-                        prev[6]?.length === next[6]?.length
+                        prev[0] === next[0] && // billing
+                        prev[1] === next[1] && // billingUsageResponse
+                        prev[2] === next[2] && // billingSpendResponse
+                        prev[3] === next[3] && // isAdminOrOwner
+                        prev[4]?.autocapture_opt_out === next[4]?.autocapture_opt_out && // currentTeam
+                        prev[5] === next[5] && // featureFlags
+                        prev[6]?.length === next[6]?.length // destinations
                     )
                 },
             },


### PR DESCRIPTION
## Problem
We use a custom `equalityCheck` prop in `maxBillingLogic.tsx`. Kea equality checks might have null states at initialization. That crashes the logic.

## Changes
- Add check for null `prev`/`next` during equality check

## How did you test this code?
Locally