### PR TITLE
fix(err): fallback to first_seen when filters are too narrow

### DIFF
--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -276,7 +276,7 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
             description: 'Posts a message to Microsoft Teams when an issue is created',
             inputs: {
                 text: {
-                    value: '**🔴 {event.properties.name} created:** {event.properties.description} (View in [Posthog]({project.url}/error_tracking/{event.distinct_id}?fingerprint={event.properties.fingerprint}))',
+                    value: '**🔴 {event.properties.name} created:** {event.properties.description} (View in [Posthog]({project.url}/error_tracking/{event.distinct_id}?fingerprint={event.properties.fingerprint}&timestamp={event.properties.exception_timestamp}))',
                 },
             },
         },
@@ -304,7 +304,7 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
                             type: 'actions',
                             elements: [
                                 {
-                                    url: '{project.url}/error_tracking/{event.distinct_id}?fingerprint={event.properties.fingerprint}',
+                                    url: '{project.url}/error_tracking/{event.distinct_id}?fingerprint={event.properties.fingerprint}&timestamp={event.properties.exception_timestamp}',
                                     text: { text: 'View Issue', type: 'plain_text' },
                                     type: 'button',
                                 },
@@ -349,7 +349,7 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
             description: 'Posts a message to Microsoft Teams when an issue is reopened',
             inputs: {
                 text: {
-                    value: '**🔄 {event.properties.name} reopened:** {event.properties.description}',
+                    value: '**🔄 {event.properties.name} reopened:** {event.properties.description} (View in [Posthog]({project.url}/error_tracking/{event.distinct_id}?fingerprint={event.properties.fingerprint}&timestamp={event.properties.exception_timestamp}))',
                 },
             },
         },
@@ -377,7 +377,7 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
                             type: 'actions',
                             elements: [
                                 {
-                                    url: '{project.url}/error_tracking/{event.distinct_id}?fingerprint={event.properties.fingerprint}',
+                                    url: '{project.url}/error_tracking/{event.distinct_id}?fingerprint={event.properties.fingerprint}&timestamp={event.properties.exception_timestamp}',
                                     text: { text: 'View Issue', type: 'plain_text' },
                                     type: 'button',
                                 },

--- a/products/error_tracking/frontend/errorTrackingIssueSceneLogic.ts
+++ b/products/error_tracking/frontend/errorTrackingIssueSceneLogic.ts
@@ -81,9 +81,9 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
         summary: {},
         lastSeen: {
             setLastSeen: (prevLastSeen, { lastSeen }) => {
-                lastSeen = dayjs(lastSeen)
-                if (!prevLastSeen || prevLastSeen.isBefore(lastSeen)) {
-                    return lastSeen
+                const lastSeenDayjs = dayjs(lastSeen)
+                if (!prevLastSeen || prevLastSeen.isBefore(lastSeenDayjs)) {
+                    return lastSeenDayjs
                 }
                 return prevLastSeen
             },
@@ -260,7 +260,7 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
             setFilterGroup: actions.loadSummary,
             setFilterTestAccounts: actions.loadSummary,
             setSearchQuery: actions.loadSummary,
-            loadSummarySuccess: ({ summary }) => {
+            loadSummarySuccess: ({ summary }: { summary: ErrorTrackingIssueSummary | null }) => {
                 if (summary && summary.last_seen) {
                     actions.setLastSeen(summary.last_seen)
                     actions.setInitialEventTimestamp(summary.last_seen)
@@ -310,5 +310,7 @@ function getNarrowDateRange(timestamp: Dayjs | string): DateRange {
 }
 
 export type ErrorTrackingIssueSummary = {
+    last_seen?: string
+    first_seen?: string
     aggregations: ErrorTrackingIssueAggregations
 }


### PR DESCRIPTION
Fix: https://posthoghelp.zendesk.com/agent/tickets/35340 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/37295)

## Problem

- When timestamp is not specified in the url (notification for instance) and filters are too narrow, exception properties do not load

## Changes

- fallback to first_seen timestamp to load event as we cannot get last_seen

