### PR TITLE
chore: even more spans

### DIFF
--- a/posthog/session_recordings/queries/session_recording_list_from_query.py
+++ b/posthog/session_recordings/queries/session_recording_list_from_query.py
@@ -30,8 +30,10 @@ from posthog.session_recordings.queries.utils import (
     _strip_person_and_event_and_cohort_properties,
     expand_test_account_filters,
 )
+from opentelemetry import trace
 
 logger = structlog.get_logger(__name__)
+tracer = trace.get_tracer(__name__)
 
 
 class SessionRecordingListFromQuery(SessionRecordingsListingBaseQuery):
@@ -118,6 +120,7 @@ class SessionRecordingListFromQuery(SessionRecordingsListingBaseQuery):
         )
         self._hogql_query_modifiers = hogql_query_modifiers
 
+    @tracer.start_as_current_span("SessionRecordingListFromQuery.run")
     def run(self) -> SessionRecordingQueryResult:
         query = self.get_query()
 
@@ -136,6 +139,7 @@ class SessionRecordingListFromQuery(SessionRecordingsListingBaseQuery):
             timings=paginated_response.timings,
         )
 
+    @tracer.start_as_current_span("SessionRecordingListFromQuery.get_query")
     def get_query(self):
         parsed_query = parse_select(
             self.BASE_QUERY,


### PR DESCRIPTION
we keep narrowing down where there are unexpected "gaps"/delays in processing during recording listing

here there is an unexpectedly long gap between starting to load recordings and actually hitting clickhouse

let's add some more spans so we can see what might be causing that gap without guessing (as much)

<img width="1474" height="371" alt="Screenshot 2025-08-01 at 11 03 10" src="https://github.com/user-attachments/assets/9a34000a-8830-4bd9-b738-b72aed8a5eec" />
