### PR TITLE
chore: even more spans

### DIFF
--- a/posthog/session_recordings/queries/session_recording_list_from_query.py
+++ b/posthog/session_recordings/queries/session_recording_list_from_query.py
@@ -30,8 +30,10 @@ from posthog.session_recordings.queries.utils import (
     _strip_person_and_event_and_cohort_properties,
     expand_test_account_filters,
 )
+from opentelemetry import trace
 
 logger = structlog.get_logger(__name__)
+tracer = trace.get_tracer(__name__)
 
 
 class SessionRecordingListFromQuery(SessionRecordingsListingBaseQuery):
@@ -118,6 +120,7 @@ class SessionRecordingListFromQuery(SessionRecordingsListingBaseQuery):
         )
         self._hogql_query_modifiers = hogql_query_modifiers
 
+    @tracer.start_as_current_span("SessionRecordingListFromQuery.run")
     def run(self) -> SessionRecordingQueryResult:
         query = self.get_query()
 
@@ -136,6 +139,7 @@ class SessionRecordingListFromQuery(SessionRecordingsListingBaseQuery):
             timings=paginated_response.timings,
         )
 
+    @tracer.start_as_current_span("SessionRecordingListFromQuery.get_query")
     def get_query(self):
         parsed_query = parse_select(
             self.BASE_QUERY,

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -53,7 +53,7 @@ from posthog.rate_limit import (
     PersonalApiKeyRateThrottle,
 )
 from posthog.renderers import ServerSentEventRenderer
-from posthog.schema import HogQLQueryModifiers, PropertyFilterType, QueryTiming, RecordingsQuery
+from posthog.schema import PropertyFilterType, QueryTiming, RecordingsQuery
 from posthog.session_recordings.ai_data.ai_regex_prompts import AI_REGEX_PROMPTS
 from posthog.session_recordings.ai_data.ai_regex_schema import AiRegexSchema
 from posthog.session_recordings.models.session_recording import SessionRecording
@@ -590,12 +590,7 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
                 "Must specify at least one event or action filter, or event properties filter",
             )
 
-        distinct_id = str(cast(User, request.user).distinct_id)
-        modifiers = safely_read_modifiers_overrides(distinct_id, self.team)
-
-        results, _, timings = ReplayFiltersEventsSubQuery(
-            query=query, team=self.team, hogql_query_modifiers=modifiers
-        ).get_event_ids_for_session()
+        results, _, timings = ReplayFiltersEventsSubQuery(query=query, team=self.team).get_event_ids_for_session()
 
         response = JsonResponse(data={"results": results})
 
@@ -1504,15 +1499,13 @@ def list_recordings_from_query(
             query.session_ids = remaining_session_ids
 
     if (all_session_ids and query.session_ids) or not all_session_ids:
-        modifiers = safely_read_modifiers_overrides(str(user.distinct_id), team) if user else None
-
         with (
             timer("load_recordings_from_hogql"),
             posthoganalytics.new_context(),
             tracer.start_as_current_span("load_recordings_from_hogql"),
         ):
             (ch_session_recordings, more_recordings_available, hogql_timings) = SessionRecordingListFromQuery(
-                query=query, team=team, hogql_query_modifiers=modifiers
+                query=query, team=team
             ).run()
 
         with timer("build_recordings"), tracer.start_as_current_span("build_recordings"):
@@ -1595,34 +1588,6 @@ def current_user_viewed(recording_ids_in_list: list[str], user: User | None, tea
         .values_list("session_id", flat=True)
     )
     return viewed_session_recordings
-
-
-@tracer.start_as_current_span("safely_read_modifiers_overrides")
-def safely_read_modifiers_overrides(distinct_id: str, team: Team) -> HogQLQueryModifiers:
-    modifiers = HogQLQueryModifiers()
-
-    try:
-        groups = {"organization": str(team.organization_id)}
-        flag_key = "HOG_QL_ORG_QUERY_OVERRIDES"
-        with tracer.start_as_current_span("get_all_flags_and_payloads"):
-            flags_n_bags = posthoganalytics.get_all_flags_and_payloads(
-                distinct_id,
-                groups=groups,
-            )
-        # this loads nothing whereas the payload is available
-        # modifier_overrides = posthoganalytics.get_feature_flag_payload(
-        #     flag_key,
-        #     distinct_id,
-        #     groups=groups,
-        # )
-        modifier_overrides = (flags_n_bags.get("featureFlagPayloads") or {}).get(flag_key, None)
-        if modifier_overrides:
-            modifiers.optimizeJoinedFilters = json.loads(modifier_overrides).get("optimizeJoinedFilters", None)
-    except:
-        # be extra safe
-        pass
-
-    return modifiers
 
 
 def create_openai_messages(system_content: str, user_content: str) -> list[ChatCompletionMessageParam]:

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -1505,7 +1505,9 @@ def list_recordings_from_query(
             tracer.start_as_current_span("load_recordings_from_hogql"),
         ):
             (ch_session_recordings, more_recordings_available, hogql_timings) = SessionRecordingListFromQuery(
-                query=query, team=team
+                query=query,
+                team=team,
+                hogql_query_modifiers=None,
             ).run()
 
         with timer("build_recordings"), tracer.start_as_current_span("build_recordings"):


### PR DESCRIPTION
we see the call to get flag playloads for the https://us.posthog.com/project/2/feature_flags/50011 flag take ~120ms when listing recordings

that's not much, but it turns out the flag is rolled out to 0 teams

so we don't need to check it at all