### PR TITLE
fix: using unmemoized function as dep

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -13,7 +13,7 @@ import { propertyFilterTypeToPropertyDefinitionType } from 'lib/components/Prope
 import { dayjs } from 'lib/dayjs'
 import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
 import { formatDate, isOperatorDate, isOperatorFlag, isOperatorMulti, toString } from 'lib/utils'
-import { useEffect } from 'react'
+import { useCallback, useEffect } from 'react'
 
 import {
     PROPERTY_FILTER_TYPES_WITH_ALL_TIME_SUGGESTIONS,
@@ -71,16 +71,19 @@ export function PropertyValue({
     const isAssigneeProperty =
         propertyKey && describeProperty(propertyKey, propertyDefinitionType) === PropertyType.Assignee
 
-    const load = (newInput: string | undefined): void => {
-        loadPropertyValues({
-            endpoint,
-            type: propertyDefinitionType,
-            newInput,
-            propertyKey,
-            eventNames,
-            properties: [],
-        })
-    }
+    const load = useCallback(
+        (newInput: string | undefined): void => {
+            loadPropertyValues({
+                endpoint,
+                type: propertyDefinitionType,
+                newInput,
+                propertyKey,
+                eventNames,
+                properties: [],
+            })
+        },
+        [loadPropertyValues, endpoint, propertyDefinitionType, propertyKey, eventNames]
+    )
 
     const setValue = (newValue: PropertyValueProps['value']): void => onSet(newValue)
 


### PR DESCRIPTION
maybe...

see https://posthog.slack.com/archives/C02E3BKC78F/p1754045962800629

we recently added the `load` function to the dependencies of some useEffects in this component, but load is recreated on every render, so it will always appear to be changed

this wraps it in `useCallback` to try avoid that

i couldn't recreate this locally but this feels like a safe change so 🤷 

![2025-08-01 12 01 47](https://github.com/user-attachments/assets/ec3155c5-e5cd-4b27-af84-a16a329be0de)


