### PR TITLE
fix: Add emergency rate limiting to the persons endpoints

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -70,6 +70,8 @@ from posthog.queries.util import get_earliest_timestamp
 from posthog.rate_limit import (
     ClickHouseBurstRateThrottle,
     ClickHouseSustainedRateThrottle,
+    BreakGlassBurstThrottle,
+    BreakGlassSustainedThrottle,
 )
 from posthog.renderers import SafeJSONRenderer
 from posthog.settings import EE_AVAILABLE
@@ -146,6 +148,14 @@ class PersonsThrottle(ClickHouseSustainedRateThrottle):
     # Throttle class that's scoped just to the person endpoint.
     # This makes the rate limit apply to all endpoints under /api/person/
     # and independent of other endpoints.
+    scope = "persons"
+
+
+class PersonsBreakGlassBurstThrottle(BreakGlassBurstThrottle):
+    scope = "persons"
+
+
+class PersonsBreakGlassSustainedThrottle(BreakGlassSustainedThrottle):
     scope = "persons"
 
 
@@ -231,7 +241,12 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     queryset = Person.objects.all()
     serializer_class = PersonSerializer
     pagination_class = PersonLimitOffsetPagination
-    throttle_classes = [ClickHouseBurstRateThrottle, PersonsThrottle]
+    throttle_classes = [
+        ClickHouseBurstRateThrottle,
+        PersonsThrottle,
+        PersonsBreakGlassBurstThrottle,
+        PersonsBreakGlassSustainedThrottle,
+    ]
     lifecycle_class = Lifecycle
     stickiness_class = Stickiness
 

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -442,10 +442,10 @@ class SetupWizardQueryRateThrottle(SimpleRateThrottle):
 class BreakGlassBurstThrottle(UserOrEmailRateThrottle):
     # Throttle class that can be applied when a bug is causing too many requests to hit and an endpoint, e.g. a bug in the frontend hitting an endpoint in a loop.
     # Prefer making a subclass of this for specific endpoints, and setting a scope
-    rate = "60/minute"
+    rate = "15/minute"
 
 
 class BreakGlassSustainedThrottle(UserOrEmailRateThrottle):
     # Throttle class that can be applied when a bug is causing too many requests to hit and an endpoint, e.g. a bug in the frontend hitting an endpoint in a loop
     # Prefer making a subclass of this for specific endpoints, and setting a scope
-    rate = "300/hour"
+    rate = "75/hour"

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -317,7 +317,7 @@ class ClickHouseBurstRateThrottle(PersonalApiKeyRateThrottle):
 
 
 class ClickHouseSustainedRateThrottle(PersonalApiKeyRateThrottle):
-    # Throttle class that's a bit more aggressive and is used specifically on endpoints that hit OpenAI
+    # Throttle class that's a bit more aggressive and is used specifically on endpoints that hit ClickHouse
     # Intended to block slower but sustained bursts of requests, per project
     scope = "clickhouse_sustained"
     rate = "1200/hour"
@@ -437,3 +437,15 @@ class SetupWizardQueryRateThrottle(SimpleRateThrottle):
         if not hash:
             return self.get_ident(request)
         return f"throttle_wizard_query_{hash}"
+
+
+class BreakGlassBurstThrottle(UserOrEmailRateThrottle):
+    # Throttle class that can be applied when a bug is causing too many requests to hit and an endpoint, e.g. a bug in the frontend hitting an endpoint in a loop.
+    # Prefer making a subclass of this for specific endpoints, and setting a scope
+    rate = "60/minute"
+
+
+class BreakGlassSustainedThrottle(UserOrEmailRateThrottle):
+    # Throttle class that can be applied when a bug is causing too many requests to hit and an endpoint, e.g. a bug in the frontend hitting an endpoint in a loop
+    # Prefer making a subclass of this for specific endpoints, and setting a scope
+    rate = "300/hour"


### PR DESCRIPTION
## Problem

See #inc-2025-08-01-high-volume-of-api-requests-eu

## Changes
Add per-user rate-limiting to the persons endpoints (specifically, persons/values is the one being hit hard)

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
