### PR TITLE
feat: Add activity logs to a bunch of models and their views

### DIFF
--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -180,6 +180,8 @@ def handle_subscription_change(sender, scope, before_update, after_update, activ
         resource_name = f"Dashboard: {after_update.dashboard.name}"
     elif after_update.insight:
         resource_name = f"Insight: {after_update.insight.name}"
+    else:
+        resource_name = "Subscribable object"
 
     log_activity(
         organization_id=after_update.team.organization_id,

--- a/ee/api/test/test_event_definition.py
+++ b/ee/api/test/test_event_definition.py
@@ -189,9 +189,8 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
             {"official", "internal"},
         )
 
-        activity_log: Optional[ActivityLog] = ActivityLog.objects.first()
+        activity_log: Optional[ActivityLog] = ActivityLog.objects.filter(scope="EventDefinition").first()
         assert activity_log is not None
-        self.assertEqual(activity_log.scope, "EventDefinition")
         self.assertEqual(activity_log.activity, "changed")
         self.assertEqual(activity_log.detail["name"], "enterprise event")
         self.assertEqual(activity_log.user, self.user)

--- a/ee/api/test/test_property_definition.py
+++ b/ee/api/test/test_property_definition.py
@@ -156,9 +156,8 @@ class TestPropertyDefinitionEnterpriseAPI(APIBaseTest):
             {"official", "internal"},
         )
 
-        activity_log: Optional[ActivityLog] = ActivityLog.objects.first()
+        activity_log: Optional[ActivityLog] = ActivityLog.objects.filter(scope="PropertyDefinition").first()
         assert activity_log is not None
-        self.assertEqual(activity_log.scope, "PropertyDefinition")
         self.assertEqual(activity_log.activity, "changed")
         self.assertEqual(activity_log.detail["name"], "enterprise property")
         self.assertEqual(activity_log.detail["type"], "event")

--- a/ee/api/test/test_property_definition.py
+++ b/ee/api/test/test_property_definition.py
@@ -156,7 +156,7 @@ class TestPropertyDefinitionEnterpriseAPI(APIBaseTest):
             {"official", "internal"},
         )
 
-        activity_log: Optional[ActivityLog] = ActivityLog.objects.filter(scope="PropertyDefinition").first()
+        activity_log: Optional[ActivityLog] = ActivityLog.objects.filter(scope="PropertyDefinition").last()
         assert activity_log is not None
         self.assertEqual(activity_log.activity, "changed")
         self.assertEqual(activity_log.detail["name"], "enterprise property")

--- a/posthog/api/annotation.py
+++ b/posthog/api/annotation.py
@@ -11,6 +11,8 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.event_usage import report_user_action
 from posthog.models import Annotation
+from posthog.models.activity_logging.activity_log import Detail, log_activity, changes_between
+from posthog.models.signals import model_activity_signal
 
 
 class AnnotationSerializer(serializers.ModelSerializer):
@@ -149,3 +151,24 @@ def annotation_created(sender, instance, created, raw, using, **kwargs):
     if instance.created_by:
         event_name: str = "annotation created" if created else "annotation updated"
         report_user_action(instance.created_by, event_name, instance.get_analytics_metadata())
+
+
+@receiver(model_activity_signal, sender=Annotation)
+def handle_annotation_change(sender, scope, before_update, after_update, activity, was_impersonated=False, **kwargs):
+    from posthog.utils import get_current_user_from_thread
+
+    user = get_current_user_from_thread()
+
+    log_activity(
+        organization_id=after_update.organization_id or after_update.team.organization_id,
+        team_id=after_update.team_id,
+        user=user,
+        was_impersonated=was_impersonated,
+        item_id=after_update.id,
+        scope=scope,
+        activity=activity,
+        detail=Detail(
+            changes=changes_between(scope, previous=before_update, current=after_update),
+            name=after_update.content,
+        ),
+    )

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -16,6 +16,9 @@ from posthog.auth import PersonalAPIKeyAuthentication
 from posthog.cloud_utils import is_cloud
 from posthog.constants import INTERNAL_BOT_EMAIL_SUFFIX, AvailableFeature
 from posthog.event_usage import report_organization_deleted, groups
+from posthog.models.activity_logging.activity_log import Detail, log_activity, changes_between
+from posthog.models.signals import model_activity_signal
+from django.dispatch import receiver
 from posthog.models import (
     User,
     Team,
@@ -390,3 +393,44 @@ class OrganizationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         )
 
         return Response({"success": True, "message": "Migration started"}, status=202)
+
+
+@receiver(model_activity_signal, sender=Organization)
+def handle_organization_change(sender, scope, before_update, after_update, activity, was_impersonated=False, **kwargs):
+    from posthog.utils import get_current_user_from_thread
+
+    user = get_current_user_from_thread()
+
+    log_activity(
+        organization_id=after_update.id,
+        team_id=None,
+        user=user,
+        was_impersonated=was_impersonated,
+        item_id=after_update.id,
+        scope=scope,
+        activity=activity,
+        detail=Detail(
+            changes=changes_between(scope, previous=before_update, current=after_update), name=after_update.name
+        ),
+    )
+
+
+@receiver(model_activity_signal, sender=OrganizationMembership)
+def handle_organization_membership_change(
+    sender, scope, before_update, after_update, activity, was_impersonated=False, **kwargs
+):
+    from posthog.utils import get_current_user_from_thread
+
+    user = get_current_user_from_thread()
+    name = f"{after_update.user.email} ({after_update.get_level_display()})"
+
+    log_activity(
+        organization_id=after_update.organization.id,
+        team_id=None,
+        user=user,
+        was_impersonated=was_impersonated,
+        item_id=after_update.id,
+        scope=scope,
+        activity=activity,
+        detail=Detail(changes=changes_between(scope, previous=before_update, current=after_update), name=name),
+    )

--- a/posthog/api/personal_api_key.py
+++ b/posthog/api/personal_api_key.py
@@ -212,7 +212,7 @@ def handle_personal_api_key_change(
         if len(after_update.scoped_organizations) == 1:
             try:
                 # scoped_organizations contains string UUIDs
-                organization_id = uuid.UUID(after_update.scoped_organizations[0])
+                organization_id = uuid.UUID(str(after_update.scoped_organizations[0]))
             except (ValueError, TypeError):
                 pass
 

--- a/posthog/api/test/test_activity_log.py
+++ b/posthog/api/test/test_activity_log.py
@@ -196,8 +196,6 @@ class TestActivityLog(APIBaseTest, QueryMatchingTest):
 
 class TestActivityLogTransactions(TransactionTestCase):
     def setUp(self):
-        from posthog.models import User
-
         self.organization = Organization.objects.create(name="Test Organization")
         self.team = Team.objects.create(
             organization=self.organization,

--- a/posthog/api/test/test_event_definition.py
+++ b/posthog/api/test/test_event_definition.py
@@ -133,7 +133,7 @@ class TestEventDefinitionAPI(APIBaseTest):
             },
         )
 
-        activity_log: Optional[ActivityLog] = ActivityLog.objects.first()
+        activity_log: Optional[ActivityLog] = ActivityLog.objects.last()
         assert activity_log is not None
         assert activity_log.activity == "deleted"
         assert activity_log.item_id == str(event_definition.id)

--- a/posthog/api/test/test_property_definition.py
+++ b/posthog/api/test/test_property_definition.py
@@ -413,7 +413,7 @@ class TestPropertyDefinitionAPI(APIBaseTest):
             },
         )
 
-        activity_log: Optional[ActivityLog] = ActivityLog.objects.first()
+        activity_log: Optional[ActivityLog] = ActivityLog.objects.last()
         assert activity_log is not None
         assert activity_log.detail["type"] == "event"
         assert activity_log.item_id == str(property_definition.id)

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -59,6 +59,9 @@ from posthog.models import (
 from posthog.schema import HogQLQueryModifiers, PersonsOnEventsMode
 from posthog.temporal.common.client import sync_connect
 from posthog.utils import relative_date_parse
+from posthog.models.activity_logging.activity_log import Detail, log_activity, changes_between
+from posthog.models.signals import model_activity_signal
+from django.dispatch import receiver
 from products.batch_exports.backend.api.destination_tests import get_destination_test
 from products.batch_exports.backend.temporal.destinations.s3_batch_export import (
     SUPPORTED_COMPRESSIONS,
@@ -810,3 +813,23 @@ class BatchExportBackfillViewSet(
             raise ValidationError(f"Cannot cancel a backfill that is in '{batch_export_backfill.status}' status")
 
         return response.Response({"cancelled": True})
+
+
+@receiver(model_activity_signal, sender=BatchExport)
+def handle_batch_export_change(sender, scope, before_update, after_update, activity, was_impersonated=False, **kwargs):
+    from posthog.utils import get_current_user_from_thread
+
+    user = get_current_user_from_thread()
+
+    log_activity(
+        organization_id=after_update.team.organization_id,
+        team_id=after_update.team.id,
+        user=user,
+        was_impersonated=was_impersonated,
+        item_id=after_update.id,
+        scope=scope,
+        activity=activity,
+        detail=Detail(
+            changes=changes_between(scope, previous=before_update, current=after_update), name=after_update.name
+        ),
+    )

--- a/posthog/batch_exports/models.py
+++ b/posthog/batch_exports/models.py
@@ -8,6 +8,7 @@ from django.db import models
 from posthog.clickhouse.client import sync_execute
 from posthog.helpers.encrypted_fields import EncryptedJSONField
 from posthog.models.utils import UUIDModel
+from posthog.models.activity_logging.model_activity import ModelActivityMixin
 
 
 class BatchExportDestination(UUIDModel):
@@ -175,7 +176,7 @@ BATCH_EXPORT_INTERVALS = [
 ]
 
 
-class BatchExport(UUIDModel):
+class BatchExport(ModelActivityMixin, UUIDModel):
     """
     Defines the configuration of PostHog to export data to a destination,
     either on a schedule (via the interval parameter), or manually by a

--- a/posthog/models/activity_logging/model_activity.py
+++ b/posthog/models/activity_logging/model_activity.py
@@ -32,12 +32,12 @@ class ModelActivityMixin(models.Model):
         abstract = True
 
     def save(self, *args: Any, **kwargs: Any) -> None:
-        change_type = "updated" if self.pk else "created"
+        change_type = "created" if self._state.adding else "updated"
         should_log = True
         before_update = None
 
         # For updates, check if we need activity logging at all
-        if change_type == "updated" and self.pk:
+        if change_type == "updated":
             should_log, before_update = self._should_log_activity_for_update(**kwargs)
 
         super().save(*args, **kwargs)

--- a/posthog/models/activity_logging/utils.py
+++ b/posthog/models/activity_logging/utils.py
@@ -1,5 +1,9 @@
 from typing import cast
 from django.db import models
+import structlog
+import traceback
+
+logger = structlog.get_logger(__name__)
 
 
 def get_changed_fields_local(before_update: models.Model, after_update: models.Model) -> list[str]:
@@ -33,6 +37,15 @@ def get_changed_fields_local(before_update: models.Model, after_update: models.M
                     changed_fields.append(field.name)
             except Exception:
                 # If we can't safely compare, assume it changed to be safe
+                logger.warning(
+                    "Field comparison failed",
+                    model_name=model_name,
+                    field_name=field.name,
+                    before_update=before_update,
+                    after_update=after_update,
+                    error=traceback.format_exc(),
+                )
+
                 changed_fields.append(field.name)
 
     return changed_fields

--- a/posthog/models/activity_logging/utils.py
+++ b/posthog/models/activity_logging/utils.py
@@ -1,0 +1,38 @@
+from typing import cast
+from django.db import models
+
+
+def get_changed_fields_local(before_update: models.Model, after_update: models.Model) -> list[str]:
+    """
+    Get the fields that have changed on a model.
+    This is a local function that does not use the database.
+    """
+
+    from posthog.models.activity_logging.activity_log import (
+        ActivityScope,
+        common_field_exclusions,
+        field_exclusions,
+        signal_exclusions,
+    )
+
+    model_name = cast(ActivityScope, before_update.__class__.__name__)
+    signal_excluded_fields = signal_exclusions.get(model_name, [])
+    all_excluded_fields = field_exclusions.get(model_name, []) + common_field_exclusions + signal_excluded_fields
+
+    changed_fields = []
+    for field in before_update._meta.get_fields():
+        if not hasattr(field, "name") or field.name in all_excluded_fields:
+            continue
+
+        if hasattr(before_update, field.name) and hasattr(after_update, field.name):
+            try:
+                old_val = getattr(before_update, field.name, None)
+                new_val = getattr(after_update, field.name, None)
+
+                if old_val != new_val:
+                    changed_fields.append(field.name)
+            except Exception:
+                # If we can't safely compare, assume it changed to be safe
+                changed_fields.append(field.name)
+
+    return changed_fields

--- a/posthog/models/alert.py
+++ b/posthog/models/alert.py
@@ -9,6 +9,7 @@ import pydantic
 from posthog.models.insight import Insight
 from posthog.models.utils import UUIDModel, CreatedMetaFields
 from posthog.schema import InsightThreshold, AlertState, AlertCalculationInterval
+from posthog.models.activity_logging.model_activity import ModelActivityMixin
 
 
 ALERT_STATE_CHOICES = [
@@ -65,7 +66,7 @@ class Threshold(CreatedMetaFields, UUIDModel):
                 raise ValidationError("Lower threshold must be less than upper threshold")
 
 
-class AlertConfiguration(CreatedMetaFields, UUIDModel):
+class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDModel):
     ALERTS_ALLOWED_ON_FREE_TIER = 2
 
     team = models.ForeignKey("Team", on_delete=models.CASCADE)

--- a/posthog/models/annotation.py
+++ b/posthog/models/annotation.py
@@ -3,9 +3,10 @@ from typing import Optional
 from django.db import models
 from django.utils import timezone
 from django_deprecate_fields import deprecate_field
+from posthog.models.activity_logging.model_activity import ModelActivityMixin
 
 
-class Annotation(models.Model):
+class Annotation(ModelActivityMixin, models.Model):
     class Scope(models.TextChoices):
         INSIGHT = "dashboard_item", "insight"
         DASHBOARD = "dashboard", "dashboard"

--- a/posthog/models/batch_imports.py
+++ b/posthog/models/batch_imports.py
@@ -4,6 +4,7 @@ from posthog.models.utils import UUIDModel
 from posthog.models.team import Team
 
 from posthog.helpers.encrypted_fields import EncryptedJSONStringField
+from posthog.models.activity_logging.model_activity import ModelActivityMixin
 
 from typing import Self
 from enum import Enum
@@ -23,7 +24,7 @@ class ContentType(str, Enum):
         return {"type": self.value}
 
 
-class BatchImport(UUIDModel):
+class BatchImport(ModelActivityMixin, UUIDModel):
     class Status(models.TextChoices):
         COMPLETED = "completed", "Completed"
         FAILED = "failed", "Failed"

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -30,6 +30,7 @@ import structlog
 
 from posthog.plugins.plugin_server_api import reload_integrations_on_workers
 from posthog.sync import database_sync_to_async
+from posthog.models.activity_logging.model_activity import ModelActivityMixin
 
 logger = structlog.get_logger(__name__)
 
@@ -53,7 +54,7 @@ def dot_get(d: Any, path: str, default: Any = None) -> Any:
 ERROR_TOKEN_REFRESH_FAILED = "TOKEN_REFRESH_FAILED"
 
 
-class Integration(models.Model):
+class Integration(ModelActivityMixin, models.Model):
     class IntegrationKind(models.TextChoices):
         SLACK = "slack"
         SALESFORCE = "salesforce"

--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -23,6 +23,7 @@ from posthog.models.utils import (
     create_with_slug,
     sane_repr,
 )
+from posthog.models.activity_logging.model_activity import ModelActivityMixin
 
 if TYPE_CHECKING:
     from posthog.models import Team, User
@@ -94,7 +95,7 @@ class OrganizationManager(models.Manager):
         return organization, organization_membership, team
 
 
-class Organization(UUIDModel):
+class Organization(ModelActivityMixin, UUIDModel):
     class Meta:
         constraints = [
             models.UniqueConstraint(
@@ -275,7 +276,7 @@ def organization_about_to_be_created(sender, instance: Organization, raw, using,
             instance.plugins_access_level = Organization.PluginsAccessLevel.ROOT
 
 
-class OrganizationMembership(UUIDModel):
+class OrganizationMembership(ModelActivityMixin, UUIDModel):
     class Level(models.IntegerChoices):
         """Keep in sync with TeamMembership.Level (only difference being projects not having an Owner)."""
 

--- a/posthog/models/personal_api_key.py
+++ b/posthog/models/personal_api_key.py
@@ -7,6 +7,7 @@ from django.db import models
 from django.utils import timezone
 
 from .utils import generate_random_token
+from .activity_logging.model_activity import ModelActivityMixin
 
 ModeType = Literal["sha256", "pbkdf2"]
 PERSONAL_API_KEY_MODES_TO_TRY: tuple[tuple[ModeType, Optional[int]], ...] = (
@@ -35,7 +36,7 @@ def hash_key_value(value: str, mode: ModeType = "sha256", iterations: Optional[i
     return f"sha256${value}"  # Following format from Django's PBKDF2PasswordHasher
 
 
-class PersonalAPIKey(models.Model):
+class PersonalAPIKey(ModelActivityMixin, models.Model):
     id = models.CharField(primary_key=True, max_length=50, default=generate_random_token)
     user = models.ForeignKey("posthog.User", on_delete=models.CASCADE, related_name="personal_api_keys")
     label = models.CharField(max_length=40)

--- a/posthog/models/subscription.py
+++ b/posthog/models/subscription.py
@@ -21,6 +21,7 @@ from posthog.exceptions_capture import capture_exception
 
 from posthog.jwt import PosthogJwtAudience, decode_jwt, encode_jwt
 from posthog.utils import absolute_uri
+from posthog.models.activity_logging.model_activity import ModelActivityMixin
 
 # Copied from rrule as it is not exported
 FREQNAMES = ["YEARLY", "MONTHLY", "WEEKLY", "DAILY", "HOURLY", "MINUTELY", "SECONDLY"]
@@ -45,7 +46,7 @@ class SubscriptionResourceInfo:
     url: str
 
 
-class Subscription(models.Model):
+class Subscription(ModelActivityMixin, models.Model):
     """
     Rather than re-invent the wheel, we are roughly following the iCalender format for recurring schedules
     https://dateutil.readthedocs.io/en/stable/rrule.html

--- a/posthog/models/tag.py
+++ b/posthog/models/tag.py
@@ -1,13 +1,14 @@
 from django.db import models
 
 from posthog.models.utils import UUIDModel, RootTeamMixin
+from posthog.models.activity_logging.model_activity import ModelActivityMixin
 
 
 def tagify(tag: str):
     return tag.strip().lower()
 
 
-class Tag(UUIDModel, RootTeamMixin):
+class Tag(ModelActivityMixin, UUIDModel, RootTeamMixin):
     name = models.CharField(max_length=255)
     team = models.ForeignKey("Team", on_delete=models.CASCADE)
 

--- a/posthog/models/tagged_item.py
+++ b/posthog/models/tagged_item.py
@@ -2,6 +2,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 
 from posthog.models.utils import UUIDModel, build_unique_relationship_check, build_partial_uniqueness_constraint
+from posthog.models.activity_logging.model_activity import ModelActivityMixin
 
 RELATED_OBJECTS = (
     "dashboard",
@@ -14,7 +15,7 @@ RELATED_OBJECTS = (
 )
 
 
-class TaggedItem(UUIDModel):
+class TaggedItem(ModelActivityMixin, UUIDModel):
     """
     Taggable describes global tag-object relationships.
     Note: This is an EE only feature, however the model exists in posthog so that it is backwards accessible from all

--- a/posthog/settings/__init__.py
+++ b/posthog/settings/__init__.py
@@ -21,6 +21,7 @@ from posthog.settings.logs import *
 from posthog.settings.base_variables import *
 
 from posthog.settings.access import *
+from posthog.settings.activity_log import *
 from posthog.settings.async_migrations import *
 from posthog.settings.celery import *
 from posthog.settings.data_stores import *

--- a/posthog/settings/activity_log.py
+++ b/posthog/settings/activity_log.py
@@ -1,0 +1,6 @@
+from posthog.settings.base_variables import TEST
+from posthog.settings.utils import get_from_env, str_to_bool
+
+ACTIVITY_LOG_TRANSACTION_MANAGEMENT = get_from_env(
+    "ACTIVITY_LOG_TRANSACTION_MANAGEMENT", not TEST, type_cast=str_to_bool
+)

--- a/posthog/settings/activity_log.py
+++ b/posthog/settings/activity_log.py
@@ -1,6 +1,4 @@
 from posthog.settings.base_variables import TEST
-from posthog.settings.utils import get_from_env, str_to_bool
+from posthog.settings.utils import get_from_env
 
-ACTIVITY_LOG_TRANSACTION_MANAGEMENT = get_from_env(
-    "ACTIVITY_LOG_TRANSACTION_MANAGEMENT", not TEST, type_cast=str_to_bool
-)
+ACTIVITY_LOG_TRANSACTION_MANAGEMENT = get_from_env("ACTIVITY_LOG_TRANSACTION_MANAGEMENT", not TEST, type_cast=bool)

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -1,6 +1,7 @@
 from typing import Optional
 from unittest.mock import MagicMock, patch
 
+from django.test.utils import override_settings
 from freezegun import freeze_time
 
 from posthog.models.alert import AlertCheck
@@ -310,6 +311,7 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
                 error_message = latest_alert_check.error["message"]
                 assert "Some error" in error_message
 
+    @override_settings(ACTIVITY_LOG_TRANSACTION_MANAGEMENT=True)
     def test_alert_with_insight_with_filter(
         self, mock_send_notifications_for_breaches: MagicMock, mock_send_errors: MagicMock
     ) -> None:

--- a/posthog/test/activity_log_helpers.py
+++ b/posthog/test/activity_log_helpers.py
@@ -1,0 +1,797 @@
+"""
+ActivityLogTestHelper - Comprehensive test helper for activity logging models.
+
+This module provides a test helper class with methods to create and update all models
+covered by the activity logging system in PostHog. Each method:
+
+1. Creates necessary prerequisites (e.g., feature flags for experiments)
+2. Makes successful API calls using the REST API endpoints
+3. Returns the created/updated model data as JSON
+4. Handles authentication and team/organization setup automatically
+
+Usage:
+    class MyTest(ActivityLogTestHelper):
+        def test_something(self):
+            # Create models
+            cohort = self.create_cohort("My Cohort")
+            flag = self.create_feature_flag("my-flag")
+            dashboard = self.create_dashboard("My Dashboard")
+
+            # Update models
+            updated_cohort = self.update_cohort(cohort["id"], {"name": "Updated Name"})
+
+Supported Models (from ActivityScope):
+- Cohort, FeatureFlag, Person, Group, Insight, Plugin, PluginConfig
+- HogFunction, EventDefinition, PropertyDefinition, Notebook, Dashboard
+- Replay (SessionRecordingPlaylist), Experiment, Survey, EarlyAccessFeature
+- Comment, Team, Organization, OrganizationMembership, Role, BatchExport
+- Integration, Annotation, Tag, Subscription, AlertConfiguration
+- PersonalAPIKey, User, Action, DataWarehouseSavedQuery, ErrorTrackingIssue
+- UserGroup, ExperimentSavedMetric, BatchImport, TaggedItem, Project
+
+Note: Some models like Experiment have complex validation rules that may require
+specific setup. The helper methods handle most common cases but may need adjustment
+for edge cases.
+"""
+
+from typing import Any, Optional
+from uuid import uuid4
+
+from django.utils import timezone
+from rest_framework import status
+
+from ee.api.test.base import APILicensedTest
+
+
+class ActivityLogTestHelper(APILicensedTest):
+    """Helper class for creating and updating models with activity logging."""
+
+    def setUp(self):
+        super().setUp()
+        # Ensure we have an authenticated user
+        from posthog.models import User
+
+        if not hasattr(self, "user") or not self.user:
+            self.user = User.objects.create_user(
+                email="test@posthog.com", password="testpass123", first_name="Test", last_name="User"
+            )
+            self.organization.members.add(self.user)
+            self.client.force_login(self.user)
+
+    # Cohort
+    def create_cohort(self, name: str = "Test Cohort", **kwargs) -> dict[str, Any]:
+        """Create a cohort via API."""
+        data = {
+            "name": name,
+            "groups": [
+                {"properties": [{"key": "email", "type": "person", "value": "test@example.com", "operator": "exact"}]}
+            ],
+            **kwargs,
+        }
+        response = self.client.post(f"/api/projects/{self.team.id}/cohorts/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_cohort(self, cohort_id: int, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update a cohort via API."""
+        response = self.client.patch(f"/api/projects/{self.team.id}/cohorts/{cohort_id}/", updates, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # FeatureFlag
+    def create_feature_flag(self, key: str = "test-flag", **kwargs) -> dict[str, Any]:
+        """Create a feature flag via API."""
+        data = {
+            "key": key,
+            "name": "Test Feature Flag",
+            "filters": {"groups": [{"properties": [], "rollout_percentage": 50}]},
+            "active": True,
+            **kwargs,
+        }
+        response = self.client.post(f"/api/projects/{self.team.id}/feature_flags/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_feature_flag(self, flag_id: int, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update a feature flag via API."""
+        response = self.client.patch(f"/api/projects/{self.team.id}/feature_flags/{flag_id}/", updates, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # Person
+    def create_person(self, distinct_id: Optional[str] = None, **kwargs) -> dict[str, Any]:
+        """Create a person via API."""
+        if not distinct_id:
+            distinct_id = str(uuid4())
+        data = {
+            "distinct_ids": [distinct_id],
+            "properties": {"email": "person@test.com", **kwargs.get("properties", {})},
+        }
+        response = self.client.post(f"/api/projects/{self.team.id}/persons/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_person(self, person_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update a person via API."""
+        response = self.client.patch(f"/api/projects/{self.team.id}/persons/{person_id}/", updates, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # Group
+    def create_group(self, group_type_index: int = 0, group_key: Optional[str] = None, **kwargs) -> dict[str, Any]:
+        """Create a group via API."""
+        # First ensure group type exists
+        from posthog.models.group_type_mapping import GroupTypeMapping
+
+        GroupTypeMapping.objects.get_or_create(
+            team=self.team, group_type_index=group_type_index, defaults={"group_type": "organization"}
+        )
+
+        if not group_key:
+            group_key = f"org:{uuid4()}"
+
+        data = {
+            "group_type_index": group_type_index,
+            "group_key": group_key,
+            "properties": {"name": "Test Organization", **kwargs.get("properties", {})},
+        }
+        response = self.client.post(f"/api/projects/{self.team.id}/groups/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_group(self, group_type_index: int, group_key: str, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update a group via API."""
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/groups/{group_type_index}/{group_key}/", updates, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # Insight
+    def create_insight(self, name: str = "Test Insight", **kwargs) -> dict[str, Any]:
+        """Create an insight via API."""
+        data = {
+            "name": name,
+            "filters": {"events": [{"id": "$pageview"}], "display": "ActionsLineGraph"},
+            "description": "Test insight description",
+            **kwargs,
+        }
+        response = self.client.post(f"/api/projects/{self.team.id}/insights/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_insight(self, insight_id: int, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update an insight via API."""
+        response = self.client.patch(f"/api/projects/{self.team.id}/insights/{insight_id}/", updates, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # Plugin
+    def create_plugin(self, name: str = "Test Plugin", **kwargs) -> dict[str, Any]:
+        """Create a plugin via API."""
+        data = {
+            "name": name,
+            "plugin_type": "local",
+            "description": "Test plugin",
+            "url": "https://github.com/PostHog/posthog-plugin-test",
+            **kwargs,
+        }
+        response = self.client.post("/api/organizations/@current/plugins/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_plugin(self, plugin_id: int, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update a plugin via API."""
+        response = self.client.patch(f"/api/organizations/@current/plugins/{plugin_id}/", updates, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # PluginConfig
+    def create_plugin_config(self, plugin_id: int, **kwargs) -> dict[str, Any]:
+        """Create a plugin config via API."""
+        data = {"plugin": plugin_id, "enabled": True, "order": 0, "config": {"key": "value"}, **kwargs}
+        response = self.client.post(f"/api/projects/{self.team.id}/plugin_configs/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_plugin_config(self, config_id: int, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update a plugin config via API."""
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/plugin_configs/{config_id}/", updates, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # HogFunction (using Plugin as base)
+    def create_hog_function(self, name: str = "Test Hog Function", **kwargs) -> dict[str, Any]:
+        """Create a hog function via API."""
+        data = {
+            "name": name,
+            "description": "Test hog function",
+            "enabled": True,
+            "inputs": {},
+            "hog": "export function onEvent(event, { inputs }) { console.log(event) }",
+            **kwargs,
+        }
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_functions/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_hog_function(self, function_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update a hog function via API."""
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_functions/{function_id}/", updates, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # EventDefinition
+    def create_event_definition(self, name: str = "$pageview", **kwargs) -> dict[str, Any]:
+        """Create an event definition via API."""
+        data = {"name": name, "description": "Page view event", "tags": [], **kwargs}
+        response = self.client.post(f"/api/projects/{self.team.id}/event_definitions/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_event_definition(self, definition_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update an event definition via API."""
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/event_definitions/{definition_id}/", updates, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # PropertyDefinition
+    def create_property_definition(self, name: str = "test_property", **kwargs) -> dict[str, Any]:
+        """Create a property definition via API."""
+        data = {"name": name, "description": "Test property", "type": "String", **kwargs}
+        response = self.client.post(f"/api/projects/{self.team.id}/property_definitions/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_property_definition(self, definition_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update a property definition via API."""
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/property_definitions/{definition_id}/", updates, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # Notebook
+    def create_notebook(self, title: str = "Test Notebook", **kwargs) -> dict[str, Any]:
+        """Create a notebook via API."""
+        data = {
+            "title": title,
+            "content": {
+                "type": "doc",
+                "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Test content"}]}],
+            },
+            **kwargs,
+        }
+        response = self.client.post(f"/api/projects/{self.team.id}/notebooks/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_notebook(self, notebook_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update a notebook via API."""
+        response = self.client.patch(f"/api/projects/{self.team.id}/notebooks/{notebook_id}/", updates, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # Dashboard
+    def create_dashboard(self, name: str = "Test Dashboard", **kwargs) -> dict[str, Any]:
+        """Create a dashboard via API."""
+        data = {"name": name, "description": "Test dashboard", "tags": [], **kwargs}
+        response = self.client.post(f"/api/projects/{self.team.id}/dashboards/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_dashboard(self, dashboard_id: int, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update a dashboard via API."""
+        response = self.client.patch(f"/api/projects/{self.team.id}/dashboards/{dashboard_id}/", updates, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # Replay (SessionRecordingPlaylist)
+    def create_session_recording_playlist(self, name: str = "Test Playlist", **kwargs) -> dict[str, Any]:
+        """Create a session recording playlist via API."""
+        data = {
+            "name": name,
+            "description": "Test playlist",
+            "filters": {
+                "session_recording_duration": {"type": "recording", "key": "duration", "value": 60, "operator": "gt"}
+            },
+            **kwargs,
+        }
+        response = self.client.post(f"/api/projects/{self.team.id}/session_recording_playlists/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_session_recording_playlist(self, playlist_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update a session recording playlist via API."""
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/session_recording_playlists/{playlist_id}/", updates, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # Experiment
+    def create_experiment(self, name: str = "Test Experiment", **kwargs) -> dict[str, Any]:
+        """Create an experiment via API."""
+        # Create a feature flag first that's eligible for experiments
+        flag_key = f"experiment-{uuid4()}"
+        flag = self.create_feature_flag(
+            key=flag_key,
+            filters={
+                "groups": [{"properties": [], "rollout_percentage": 0}, {"properties": [], "rollout_percentage": 100}],
+                "multivariate": {
+                    "variants": [
+                        {
+                            "key": "control",
+                            "name": "Control Group",
+                            "rollout_percentage": 50,
+                        },
+                        {
+                            "key": "test",
+                            "name": "Test Variant",
+                            "rollout_percentage": 50,
+                        },
+                    ]
+                },
+            },
+        )
+
+        data = {
+            "name": name,
+            "description": "Test experiment",
+            "feature_flag_key": flag["key"],
+            "parameters": {
+                "minimum_detectable_effect": 1,
+                "recommended_sample_size": 1000,
+                "recommended_running_time": 14,
+            },
+            "filters": {"events": [{"id": "$pageview"}], "display": "ActionsLineGraph"},
+            **kwargs,
+        }
+        response = self.client.post(f"/api/projects/{self.team.id}/experiments/", data, format="json")
+        if response.status_code != status.HTTP_201_CREATED:
+            # Some experiments might fail due to complex validation rules
+            # This is expected and we should handle it gracefully in tests
+            error_detail = response.json().get("detail", "Unknown error")
+            raise AssertionError(f"Experiment creation failed: {error_detail}")
+        return response.json()
+
+    def update_experiment(self, experiment_id: int, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update an experiment via API."""
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/experiments/{experiment_id}/", updates, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # Survey
+    def create_survey(self, name: str = "Test Survey", **kwargs) -> dict[str, Any]:
+        """Create a survey via API."""
+        data = {
+            "name": name,
+            "description": "Test survey",
+            "type": "popover",
+            "questions": [{"type": "open", "question": "What do you think?"}],
+            "targeting_flag_filters": {"groups": []},
+            **kwargs,
+        }
+        response = self.client.post(f"/api/projects/{self.team.id}/surveys/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_survey(self, survey_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update a survey via API."""
+        response = self.client.patch(f"/api/projects/{self.team.id}/surveys/{survey_id}/", updates, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # EarlyAccessFeature
+    def create_early_access_feature(self, name: str = "Test Early Access", **kwargs) -> dict[str, Any]:
+        """Create an early access feature via API."""
+        # Create a feature flag first
+        flag = self.create_feature_flag(key=f"early-access-{uuid4()}")
+
+        data = {
+            "name": name,
+            "description": "Test early access feature",
+            "stage": "beta",
+            "feature_flag_key": flag["key"],
+            **kwargs,
+        }
+        response = self.client.post(f"/api/projects/{self.team.id}/early_access_features/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_early_access_feature(self, feature_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update an early access feature via API."""
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/early_access_features/{feature_id}/", updates, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # Comment
+    def create_comment(self, content: str = "Test comment", **kwargs) -> dict[str, Any]:
+        """Create a comment via API."""
+        # Create an insight first to comment on
+        insight = self.create_insight()
+
+        data = {"content": content, "scope": "Insight", "item_id": str(insight["id"]), **kwargs}
+        response = self.client.post(f"/api/projects/{self.team.id}/comments/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_comment(self, comment_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update a comment via API."""
+        response = self.client.patch(f"/api/projects/{self.team.id}/comments/{comment_id}/", updates, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # Team
+    def create_team(self, name: str = "Test Team", **kwargs) -> dict[str, Any]:
+        """Create a team via API."""
+        data = {"name": name, "timezone": "UTC", **kwargs}
+        response = self.client.post("/api/projects/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_team(self, team_id: int, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update a team via API."""
+        response = self.client.patch(f"/api/projects/{team_id}/", updates, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # Organization
+    def create_organization(self, name: str = "Test Org", **kwargs) -> dict[str, Any]:
+        """Create an organization via API."""
+        data = {"name": name, **kwargs}
+        response = self.client.post("/api/organizations/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_organization(self, org_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update an organization via API."""
+        response = self.client.patch(f"/api/organizations/{org_id}/", updates, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # OrganizationMembership
+    def create_organization_membership(self, email: str = "newmember@test.com", **kwargs) -> dict[str, Any]:
+        """Create an organization membership (invite) via API."""
+        data = {
+            "target_email": email,
+            "level": 8,  # Member level
+            **kwargs,
+        }
+        response = self.client.post(f"/api/organizations/{self.organization.id}/invites/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_organization_membership(self, user_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update an organization membership via API."""
+        response = self.client.patch(
+            f"/api/organizations/{self.organization.id}/members/{user_id}/", updates, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # Role
+    def create_role(self, name: str = "Test Role", **kwargs) -> dict[str, Any]:
+        """Create a role via API."""
+        data = {
+            "name": name,
+            "feature_flags_access_level": 21,  # Can edit all
+            **kwargs,
+        }
+        response = self.client.post(f"/api/organizations/{self.organization.id}/roles/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_role(self, role_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update a role via API."""
+        response = self.client.patch(
+            f"/api/organizations/{self.organization.id}/roles/{role_id}/", updates, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # BatchExport
+    def create_batch_export(self, name: str = "Test Export", **kwargs) -> dict[str, Any]:
+        """Create a batch export via API."""
+        data = {
+            "name": name,
+            "destination": {
+                "type": "S3",
+                "config": {
+                    "bucket_name": "test-bucket",
+                    "region": "us-east-1",
+                    "prefix": "posthog-events/",
+                    "aws_access_key_id": "test-key",
+                    "aws_secret_access_key": "test-secret",
+                },
+            },
+            "interval": "hour",
+            **kwargs,
+        }
+        response = self.client.post(f"/api/projects/{self.team.id}/batch_exports/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_batch_export(self, export_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update a batch export via API."""
+        response = self.client.patch(f"/api/projects/{self.team.id}/batch_exports/{export_id}/", updates, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # Integration
+    def create_integration(self, kind: str = "slack", **kwargs) -> dict[str, Any]:
+        """Create an integration via API."""
+        data = {"kind": kind, "config": {"team_id": "T1234", "team_name": "Test Workspace"}, **kwargs}
+        response = self.client.post(f"/api/projects/{self.team.id}/integrations/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_integration(self, integration_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update an integration via API."""
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/integrations/{integration_id}/", updates, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # Annotation
+    def create_annotation(self, content: str = "Test annotation", **kwargs) -> dict[str, Any]:
+        """Create an annotation via API."""
+        data = {"content": content, "date_marker": timezone.now().isoformat(), "scope": "project", **kwargs}
+        response = self.client.post(f"/api/projects/{self.team.id}/annotations/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_annotation(self, annotation_id: int, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update an annotation via API."""
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/annotations/{annotation_id}/", updates, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # Tag
+    def create_tag(self, name: str = "test-tag", **kwargs) -> dict[str, Any]:
+        """Create a tag via API."""
+        # Tags are typically created implicitly when tagging items
+        # Create an insight and tag it
+        insight = self.create_insight()
+        updates = {"tags": [name]}
+        return self.update_insight(insight["id"], updates)
+
+    def update_tag(self, tag_name: str, new_name: str) -> dict[str, Any]:
+        """Update a tag via API (rename)."""
+        # Tags don't have a direct update endpoint, they're managed through tagged items
+        # This would typically be done by updating all items with the old tag to the new tag
+        return {"name": new_name}
+
+    # Subscription
+    def create_subscription(self, title: str = "Test Subscription", **kwargs) -> dict[str, Any]:
+        """Create a subscription via API."""
+        # Create a dashboard first
+        dashboard = self.create_dashboard()
+
+        data = {
+            "dashboard": dashboard["id"],
+            "target_type": "email",
+            "target_value": "test@example.com",
+            "frequency": "weekly",
+            "interval": 1,
+            "start_date": timezone.now().isoformat(),
+            "title": title,
+            **kwargs,
+        }
+        response = self.client.post(f"/api/projects/{self.team.id}/subscriptions/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_subscription(self, subscription_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update a subscription via API."""
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/subscriptions/{subscription_id}/", updates, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # AlertConfiguration
+    def create_alert_configuration(self, name: str = "Test Alert", **kwargs) -> dict[str, Any]:
+        """Create an alert configuration via API."""
+        # Create an insight first
+        insight = self.create_insight()
+
+        data = {
+            "name": name,
+            "insight": insight["id"],
+            "config": {"type": "TrendsAlertConfig", "series_index": 0},
+            "threshold": {"configuration": {"type": "absolute", "bounds": {"lower": 100, "upper": 1000}}},
+            "enabled": True,
+            "subscribed_users": [self.user.id],  # Subscribe the current test user
+            **kwargs,
+        }
+        response = self.client.post(f"/api/projects/{self.team.id}/alerts/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_alert_configuration(self, alert_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update an alert configuration via API."""
+        response = self.client.patch(f"/api/projects/{self.team.id}/alerts/{alert_id}/", updates, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # PersonalAPIKey
+    def create_personal_api_key(self, label: str = "Test API Key", **kwargs) -> dict[str, Any]:
+        """Create a personal API key via API."""
+        data = {
+            "label": label,
+            "scopes": ["*"],  # Default to all permissions
+            "scoped_teams": [],  # No team restrictions by default
+            "scoped_organizations": [],  # No organization restrictions by default
+            **kwargs,
+        }
+        response = self.client.post("/api/personal_api_keys/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_personal_api_key(self, key_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update a personal API key via API."""
+        response = self.client.patch(f"/api/personal_api_keys/{key_id}/", updates, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # User
+    def create_user(self, email: Optional[str] = None, **kwargs) -> dict[str, Any]:
+        """Create a user via API (as admin)."""
+        if not email:
+            email = f"user-{uuid4()}@test.com"
+
+        # Make current user a staff member to create other users
+        self.user.is_staff = True
+        self.user.save()
+
+        data = {"first_name": "Test", "email": email, **kwargs}
+        response = self.client.post(f"/api/organizations/{self.organization.id}/invites/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_user(self, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update current user via API."""
+        response = self.client.patch("/api/users/@me/", updates, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # Action
+    def create_action(self, name: str = "Test Action", **kwargs) -> dict[str, Any]:
+        """Create an action via API."""
+        data = {
+            "name": name,
+            "description": "Test action",
+            "steps": [{"event": "$pageview", "url": "https://example.com", "url_matching": "contains"}],
+            **kwargs,
+        }
+        response = self.client.post(f"/api/projects/{self.team.id}/actions/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_action(self, action_id: int, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update an action via API."""
+        response = self.client.patch(f"/api/projects/{self.team.id}/actions/{action_id}/", updates, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # DataWarehouseSavedQuery
+    def create_data_warehouse_saved_query(self, name: str = "Test Query", **kwargs) -> dict[str, Any]:
+        """Create a data warehouse saved query via API."""
+        data = {"name": name, "query": {"kind": "HogQLQuery", "query": "SELECT event FROM events LIMIT 10"}, **kwargs}
+        response = self.client.post(f"/api/projects/{self.team.id}/warehouse_saved_queries/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_data_warehouse_saved_query(self, query_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update a data warehouse saved query via API."""
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/warehouse_saved_queries/{query_id}/", updates, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # ErrorTrackingIssue
+    def create_error_tracking_issue(self, name: str = "Test Error", **kwargs) -> dict[str, Any]:
+        """Create an error tracking issue via API."""
+        # Error tracking issues are typically created automatically from ingested errors
+        # This is a simplified version for testing
+        data = {"name": name, "description": "Test error issue", "status": "active", **kwargs}
+        response = self.client.post(f"/api/projects/{self.team.id}/error_tracking/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_error_tracking_issue(self, issue_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update an error tracking issue via API."""
+        response = self.client.patch(f"/api/projects/{self.team.id}/error_tracking/{issue_id}/", updates, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # UserGroup
+    def create_user_group(self, name: str = "Test User Group", **kwargs) -> dict[str, Any]:
+        """Create a user group via API."""
+        data = {"name": name, "members": [self.user.id], **kwargs}
+        response = self.client.post(f"/api/organizations/{self.organization.id}/user_groups/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_user_group(self, group_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update a user group via API."""
+        response = self.client.patch(
+            f"/api/organizations/{self.organization.id}/user_groups/{group_id}/", updates, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # ExperimentSavedMetric
+    def create_experiment_saved_metric(self, name: str = "Test Metric", **kwargs) -> dict[str, Any]:
+        """Create an experiment saved metric via API."""
+        data = {
+            "name": name,
+            "description": "Test saved metric",
+            "query": {"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "$pageview"}]},
+            **kwargs,
+        }
+        response = self.client.post(f"/api/projects/{self.team.id}/experiment_saved_metrics/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_experiment_saved_metric(self, metric_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update an experiment saved metric via API."""
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/experiment_saved_metrics/{metric_id}/", updates, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # BatchImport
+    def create_batch_import(self, name: str = "Test Import", **kwargs) -> dict[str, Any]:
+        """Create a batch import via API."""
+        data = {
+            "name": name,
+            "source_type": "events",
+            "import_config": {"format": "csv", "mapping": {"event": "event_name", "timestamp": "event_time"}},
+            **kwargs,
+        }
+        response = self.client.post(f"/api/projects/{self.team.id}/batch_imports/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
+
+    def update_batch_import(self, import_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update a batch import via API."""
+        response = self.client.patch(f"/api/projects/{self.team.id}/batch_imports/{import_id}/", updates, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()
+
+    # TaggedItem
+    def create_tagged_item(self, tag_name: str, item_type: str, item_id: str) -> dict[str, Any]:
+        """Create a tagged item by tagging an existing item."""
+        # This is typically done by updating the item with tags
+        if item_type == "Insight":
+            return self.update_insight(int(item_id), {"tags": [tag_name]})
+        elif item_type == "Dashboard":
+            return self.update_dashboard(int(item_id), {"tags": [tag_name]})
+        # Add more item types as needed
+        return {"tag": tag_name, "item_type": item_type, "item_id": item_id}
+
+    # Project (alias for Team in the API)
+    def create_project(self, name: str = "Test Project", **kwargs) -> dict[str, Any]:
+        """Create a project via API."""
+        return self.create_team(name, **kwargs)
+
+    def update_project(self, project_id: int, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update a project via API."""
+        return self.update_team(project_id, updates)

--- a/posthog/test/activity_logging/test_activity_logging.py
+++ b/posthog/test/activity_logging/test_activity_logging.py
@@ -56,6 +56,7 @@ class TestActivityLogModel(BaseTest):
         self.assertEqual(log.activity, "added_to_clink_expander")
 
     def test_does_not_save_impersonated_activity_without_user(self) -> None:
+        initial_count = ActivityLog.objects.count()
         log_activity(
             organization_id=self.organization.id,
             team_id=self.team.id,
@@ -66,8 +67,7 @@ class TestActivityLogModel(BaseTest):
             activity="added_to_clink_expander",
             detail=Detail(),
         )
-        with pytest.raises(ActivityLog.DoesNotExist):
-            ActivityLog.objects.latest("id")
+        self.assertEqual(ActivityLog.objects.count(), initial_count)
 
     def test_does_not_save_if_there_is_neither_a_team_id_nor_an_organisation_id(self) -> None:
         # even when there are logs with team id or org id saved

--- a/posthog/test/test_activity_log_helpers.py
+++ b/posthog/test/test_activity_log_helpers.py
@@ -1,0 +1,177 @@
+"""
+Test the activity log helper methods to ensure they work correctly.
+"""
+
+from posthog.test.activity_log_helpers import ActivityLogTestHelper
+
+
+class TestActivityLogHelpers(ActivityLogTestHelper):
+    """Test the activity log helper methods."""
+
+    def test_create_cohort(self):
+        """Test creating a cohort via API."""
+        cohort = self.create_cohort("Test Cohort")
+        self.assertEqual(cohort["name"], "Test Cohort")
+
+    def test_update_cohort(self):
+        """Test updating a cohort via API."""
+        cohort = self.create_cohort("Original Name")
+        updated = self.update_cohort(cohort["id"], {"name": "Updated Name"})
+        self.assertEqual(updated["name"], "Updated Name")
+
+    def test_create_feature_flag(self):
+        """Test creating a feature flag via API."""
+        flag = self.create_feature_flag("test-flag")
+        self.assertEqual(flag["key"], "test-flag")
+
+    def test_update_feature_flag(self):
+        """Test updating a feature flag via API."""
+        flag = self.create_feature_flag("test-flag")
+        updated = self.update_feature_flag(flag["id"], {"name": "Updated Flag Name"})
+        self.assertEqual(updated["name"], "Updated Flag Name")
+
+    def test_create_insight(self):
+        """Test creating an insight via API."""
+        insight = self.create_insight("Test Insight")
+        self.assertEqual(insight["name"], "Test Insight")
+
+    def test_update_insight(self):
+        """Test updating an insight via API."""
+        insight = self.create_insight("Original Name")
+        updated = self.update_insight(insight["id"], {"name": "Updated Name"})
+        self.assertEqual(updated["name"], "Updated Name")
+
+    def test_create_dashboard(self):
+        """Test creating a dashboard via API."""
+        dashboard = self.create_dashboard("Test Dashboard")
+        self.assertEqual(dashboard["name"], "Test Dashboard")
+
+    def test_update_dashboard(self):
+        """Test updating a dashboard via API."""
+        dashboard = self.create_dashboard("Original Name")
+        updated = self.update_dashboard(dashboard["id"], {"name": "Updated Name"})
+        self.assertEqual(updated["name"], "Updated Name")
+
+    def test_create_notebook(self):
+        """Test creating a notebook via API."""
+        notebook = self.create_notebook("Test Notebook")
+        self.assertEqual(notebook["title"], "Test Notebook")
+
+    def test_update_notebook(self):
+        """Test updating a notebook via API."""
+        notebook = self.create_notebook("Original Title")
+        updated = self.update_notebook(notebook["short_id"], {"title": "Updated Title"})
+        self.assertEqual(updated["title"], "Updated Title")
+
+    def test_create_survey(self):
+        """Test creating a survey via API."""
+        survey = self.create_survey("Test Survey")
+        self.assertEqual(survey["name"], "Test Survey")
+
+    def test_update_survey(self):
+        """Test updating a survey via API."""
+        survey = self.create_survey("Original Name")
+        updated = self.update_survey(survey["id"], {"name": "Updated Name"})
+        self.assertEqual(updated["name"], "Updated Name")
+
+    def test_create_experiment(self):
+        """Test creating an experiment via API."""
+        experiment = self.create_experiment("Test Experiment")
+        self.assertEqual(experiment["name"], "Test Experiment")
+
+    def test_update_experiment(self):
+        """Test updating an experiment via API."""
+        experiment = self.create_experiment("Original Name")
+        updated = self.update_experiment(experiment["id"], {"name": "Updated Name"})
+        self.assertEqual(updated["name"], "Updated Name")
+
+    def test_create_action(self):
+        """Test creating an action via API."""
+        action = self.create_action("Test Action")
+        self.assertEqual(action["name"], "Test Action")
+
+    def test_update_action(self):
+        """Test updating an action via API."""
+        action = self.create_action("Original Name")
+        updated = self.update_action(action["id"], {"name": "Updated Name"})
+        self.assertEqual(updated["name"], "Updated Name")
+
+
+class TestComprehensiveActivityLogHelpers(ActivityLogTestHelper):
+    """Test comprehensive coverage of activity log helper methods."""
+
+    def test_multiple_model_creation_and_updates(self):
+        """Test creating and updating multiple model types in sequence."""
+
+        # Create various models
+        cohort = self.create_cohort("Test Cohort")
+        self.assertIsNotNone(cohort["id"])
+
+        flag = self.create_feature_flag("test-flag")
+        self.assertEqual(flag["key"], "test-flag")
+
+        insight = self.create_insight("Test Insight")
+        self.assertEqual(insight["name"], "Test Insight")
+
+        dashboard = self.create_dashboard("Test Dashboard")
+        self.assertEqual(dashboard["name"], "Test Dashboard")
+
+        notebook = self.create_notebook("Test Notebook")
+        self.assertEqual(notebook["title"], "Test Notebook")
+
+        survey = self.create_survey("Test Survey")
+        self.assertEqual(survey["name"], "Test Survey")
+
+        action = self.create_action("Test Action")
+        self.assertEqual(action["name"], "Test Action")
+
+        # Update the models
+        cohort_updated = self.update_cohort(cohort["id"], {"name": "Updated Cohort"})
+        self.assertEqual(cohort_updated["name"], "Updated Cohort")
+
+        flag_updated = self.update_feature_flag(flag["id"], {"name": "Updated Flag"})
+        self.assertEqual(flag_updated["name"], "Updated Flag")
+
+        insight_updated = self.update_insight(insight["id"], {"name": "Updated Insight"})
+        self.assertEqual(insight_updated["name"], "Updated Insight")
+
+        dashboard_updated = self.update_dashboard(dashboard["id"], {"name": "Updated Dashboard"})
+        self.assertEqual(dashboard_updated["name"], "Updated Dashboard")
+
+        notebook_updated = self.update_notebook(notebook["short_id"], {"title": "Updated Notebook"})
+        self.assertEqual(notebook_updated["title"], "Updated Notebook")
+
+        survey_updated = self.update_survey(survey["id"], {"name": "Updated Survey"})
+        self.assertEqual(survey_updated["name"], "Updated Survey")
+
+        action_updated = self.update_action(action["id"], {"name": "Updated Action"})
+        self.assertEqual(action_updated["name"], "Updated Action")
+
+    def test_models_with_prerequisites(self):
+        """Test models that require other models as prerequisites."""
+
+        # Create a comment (requires an insight)
+        self.create_insight("Insight for Comment")
+        comment = self.create_comment("Test comment")
+        self.assertEqual(comment["content"], "Test comment")
+
+        # Create subscription (requires a dashboard)
+        self.create_dashboard("Dashboard for Subscription")
+        subscription = self.create_subscription("Test Subscription")
+        self.assertEqual(subscription["title"], "Test Subscription")
+
+        # Create alert (requires an insight)
+        self.create_insight("Insight for Alert")
+        alert = self.create_alert_configuration("Test Alert")
+        self.assertEqual(alert["name"], "Test Alert")
+
+    def test_organization_level_models(self):
+        """Test organization-level models."""
+
+        # Test personal API key
+        api_key = self.create_personal_api_key("Test API Key")
+        self.assertEqual(api_key["label"], "Test API Key")
+
+        # Test user updates
+        user_update = self.update_user({"first_name": "Updated Name"})
+        self.assertEqual(user_update["first_name"], "Updated Name")

--- a/posthog/test/test_activity_log_scopes.py
+++ b/posthog/test/test_activity_log_scopes.py
@@ -17,8 +17,28 @@ Models requiring further investigation (may need additional setup):
 This provides a solid foundation for testing activity logging on the most critical models.
 """
 
+from unittest.mock import patch
+from django.test.utils import override_settings
+from django.test import TransactionTestCase
 from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.test.activity_log_helpers import ActivityLogTestHelper
+from posthog.constants import AvailableFeature
+
+
+@override_settings(ACTIVITY_LOG_TRANSACTION_MANAGEMENT=False)
+class TestActivityLogScopesWithTransactions(ActivityLogTestHelper, TransactionTestCase):
+    """Test activity logging for models that require transaction management for proper activity logging."""
+
+    def test_alert_configuration_creation_activity_logging(self):
+        alert = self.create_alert_configuration("Test Alert")
+
+        activity_logs = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="AlertConfiguration", item_id=str(alert["id"]), activity="created"
+        )
+        self.assertEqual(activity_logs.count(), 1)
+        log = activity_logs.first()
+        self.assertIsNotNone(log)
+        self.assertIsNotNone(log.detail)
 
 
 class TestActivityLogScopes(ActivityLogTestHelper):
@@ -31,7 +51,9 @@ class TestActivityLogScopes(ActivityLogTestHelper):
             team_id=self.team.id, scope="Subscription", item_id=str(subscription["id"]), activity="created"
         )
         self.assertEqual(activity_logs.count(), 1)
-        self.assertIsNotNone(activity_logs.first().detail)
+        log = activity_logs.first()
+        self.assertIsNotNone(log)
+        self.assertIsNotNone(log.detail)
 
     def test_subscription_update_activity_logging(self):
         subscription = self.create_subscription("Original Subscription")
@@ -50,7 +72,8 @@ class TestActivityLogScopes(ActivityLogTestHelper):
             team_id=self.team.id, scope="Subscription", item_id=str(subscription["id"]), activity="updated"
         ).first()
         self.assertIsNotNone(update_log)
-        self.assertIsNotNone(update_log.detail)
+        if update_log:
+            self.assertIsNotNone(update_log.detail)
 
     def test_feature_flag_creation_activity_logging(self):
         flag = self.create_feature_flag("test-flag")
@@ -59,7 +82,9 @@ class TestActivityLogScopes(ActivityLogTestHelper):
             team_id=self.team.id, scope="FeatureFlag", item_id=str(flag["id"]), activity="created"
         )
         self.assertEqual(activity_logs.count(), 1)
-        self.assertIsNotNone(activity_logs.first().detail)
+        log = activity_logs.first()
+        self.assertIsNotNone(log)
+        self.assertIsNotNone(log.detail)
 
     def test_feature_flag_update_activity_logging(self):
         flag = self.create_feature_flag("original-flag")
@@ -78,7 +103,8 @@ class TestActivityLogScopes(ActivityLogTestHelper):
             team_id=self.team.id, scope="FeatureFlag", item_id=str(flag["id"]), activity="updated"
         ).first()
         self.assertIsNotNone(update_log)
-        self.assertIsNotNone(update_log.detail)
+        if update_log:
+            self.assertIsNotNone(update_log.detail)
 
     def test_experiment_creation_activity_logging(self):
         experiment = self.create_experiment("Test Experiment")
@@ -87,7 +113,9 @@ class TestActivityLogScopes(ActivityLogTestHelper):
             team_id=self.team.id, scope="Experiment", item_id=str(experiment["id"]), activity="created"
         )
         self.assertEqual(activity_logs.count(), 1)
-        self.assertIsNotNone(activity_logs.first().detail)
+        log = activity_logs.first()
+        self.assertIsNotNone(log)
+        self.assertIsNotNone(log.detail)
 
     def test_experiment_update_activity_logging(self):
         experiment = self.create_experiment("Original Experiment")
@@ -106,7 +134,8 @@ class TestActivityLogScopes(ActivityLogTestHelper):
             team_id=self.team.id, scope="Experiment", item_id=str(experiment["id"]), activity="updated"
         ).first()
         self.assertIsNotNone(update_log)
-        self.assertIsNotNone(update_log.detail)
+        if update_log:
+            self.assertIsNotNone(update_log.detail)
 
     def test_annotation_creation_activity_logging(self):
         annotation = self.create_annotation("Test annotation")
@@ -115,7 +144,9 @@ class TestActivityLogScopes(ActivityLogTestHelper):
             team_id=self.team.id, scope="Annotation", item_id=str(annotation["id"]), activity="created"
         )
         self.assertEqual(activity_logs.count(), 1)
-        self.assertIsNotNone(activity_logs.first().detail)
+        log = activity_logs.first()
+        self.assertIsNotNone(log)
+        self.assertIsNotNone(log.detail)
 
     def test_annotation_update_activity_logging(self):
         annotation = self.create_annotation("Original annotation")
@@ -134,7 +165,8 @@ class TestActivityLogScopes(ActivityLogTestHelper):
             team_id=self.team.id, scope="Annotation", item_id=str(annotation["id"]), activity="updated"
         ).first()
         self.assertIsNotNone(update_log)
-        self.assertIsNotNone(update_log.detail)
+        if update_log:
+            self.assertIsNotNone(update_log.detail)
 
     def test_comprehensive_activity_log_verification(self):
         flag = self.create_feature_flag("detailed-test-flag")
@@ -143,8 +175,9 @@ class TestActivityLogScopes(ActivityLogTestHelper):
             team_id=self.team.id, scope="FeatureFlag", item_id=str(flag["id"]), activity="created"
         ).first()
         self.assertIsNotNone(creation_log)
-        self.assertEqual(creation_log.user, self.user)
-        self.assertIsNotNone(creation_log.detail)
+        if creation_log:
+            self.assertEqual(creation_log.user, self.user)
+            self.assertIsNotNone(creation_log.detail)
 
         self.update_feature_flag(flag["id"], {"name": "Updated Detailed Flag Name", "active": False})
 
@@ -152,13 +185,14 @@ class TestActivityLogScopes(ActivityLogTestHelper):
             team_id=self.team.id, scope="FeatureFlag", item_id=str(flag["id"]), activity="updated"
         ).first()
         self.assertIsNotNone(update_log)
-        self.assertEqual(update_log.user, self.user)
-        self.assertIsNotNone(update_log.detail)
+        if update_log:
+            self.assertEqual(update_log.user, self.user)
+            self.assertIsNotNone(update_log.detail)
 
-        if hasattr(update_log.detail, "changes") and update_log.detail.changes:
-            change_fields = [change.field for change in update_log.detail.changes]
-            self.assertIn("name", change_fields)
-            self.assertIn("active", change_fields)
+            if hasattr(update_log.detail, "changes") and update_log.detail.changes:
+                change_fields = [change.field for change in update_log.detail.changes]
+                self.assertIn("name", change_fields)
+                self.assertIn("active", change_fields)
 
     def test_core_models_activity_logging_coverage(self):
         initial_log_count = ActivityLog.objects.filter(team_id=self.team.id).count()
@@ -189,3 +223,196 @@ class TestActivityLogScopes(ActivityLogTestHelper):
         for log in all_recent_logs:
             self.assertIsNotNone(log.detail)
             self.assertIn(log.activity, ["created", "updated"])
+
+    def test_batch_import_creation_activity_logging(self):
+        batch_import = self.create_batch_import("Test Import")
+
+        activity_logs = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="BatchImport", item_id=str(batch_import["id"]), activity="created"
+        )
+        self.assertEqual(activity_logs.count(), 1)
+        log = activity_logs.first()
+        self.assertIsNotNone(log)
+        self.assertIsNotNone(log.detail)
+
+    def test_batch_import_update_activity_logging(self):
+        batch_import = self.create_batch_import("Original Import")
+        initial_log_count = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="BatchImport", item_id=str(batch_import["id"])
+        ).count()
+
+        self.update_batch_import(batch_import["id"], {"status": "paused"})
+
+        final_log_count = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="BatchImport", item_id=str(batch_import["id"])
+        ).count()
+        self.assertEqual(final_log_count - initial_log_count, 1)
+
+        update_log = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="BatchImport", item_id=str(batch_import["id"]), activity="updated"
+        ).first()
+        self.assertIsNotNone(update_log)
+        if update_log:
+            self.assertIsNotNone(update_log.detail)
+
+    def test_organization_creation_activity_logging(self):
+        organization = self.create_organization("Test Organization")
+
+        activity_logs = ActivityLog.objects.filter(
+            organization_id=organization["id"],
+            scope="Organization",
+            item_id=str(organization["id"]),
+            activity="created",
+        )
+        self.assertEqual(activity_logs.count(), 1)
+        log = activity_logs.first()
+        self.assertIsNotNone(log)
+        self.assertIsNotNone(log.detail)
+
+    def test_organization_update_activity_logging(self):
+        organization = self.create_organization("Original Organization")
+        initial_log_count = ActivityLog.objects.filter(
+            organization_id=organization["id"], scope="Organization", item_id=str(organization["id"])
+        ).count()
+
+        self.update_organization(organization["id"], {"name": "Updated Organization"})
+
+        final_log_count = ActivityLog.objects.filter(
+            organization_id=organization["id"], scope="Organization", item_id=str(organization["id"])
+        ).count()
+        self.assertEqual(final_log_count - initial_log_count, 1)
+
+        update_log = ActivityLog.objects.filter(
+            organization_id=organization["id"],
+            scope="Organization",
+            item_id=str(organization["id"]),
+            activity="updated",
+        ).first()
+        self.assertIsNotNone(update_log)
+        if update_log:
+            self.assertIsNotNone(update_log.detail)
+
+    def test_tag_creation_activity_logging(self):
+        self.create_tag("test-tag")
+
+        activity_logs = ActivityLog.objects.filter(team_id=self.team.id, scope="Tag", activity="created")
+        self.assertGreaterEqual(activity_logs.count(), 1)
+        log = activity_logs.first()
+        self.assertIsNotNone(log)
+        self.assertIsNotNone(log.detail)
+
+    def test_tagged_item_creation_activity_logging(self):
+        insight = self.create_insight("Test Insight for Tagging")
+        self.create_tagged_item("test-tag", "Insight", str(insight["id"]))
+
+        activity_logs = ActivityLog.objects.filter(team_id=self.team.id, scope="TaggedItem", activity="created")
+        self.assertGreaterEqual(activity_logs.count(), 1)
+        log = activity_logs.first()
+        self.assertIsNotNone(log)
+        self.assertIsNotNone(log.detail)
+
+    def test_integration_creation_activity_logging(self):
+        with patch("products.messaging.backend.providers.twilio.TwilioProvider.get_account_info") as mock_account_info:
+            mock_account_info.return_value = {"sid": "AC123456", "friendly_name": "Test Account", "status": "active"}
+
+            integration = self.create_integration()
+
+            activity_logs = ActivityLog.objects.filter(
+                team_id=self.team.id, scope="Integration", item_id=str(integration["id"]), activity="created"
+            )
+            self.assertEqual(activity_logs.count(), 1)
+            log = activity_logs.first()
+            self.assertIsNotNone(log)
+            self.assertIsNotNone(log.detail)
+
+    def test_batch_export_creation_activity_logging(self):
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.DATA_PIPELINES, "name": AvailableFeature.DATA_PIPELINES}
+        ]
+        self.organization.save()
+
+        batch_export = self.create_batch_export("Test Export")
+
+        activity_logs = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="BatchExport", item_id=str(batch_export["id"]), activity="created"
+        )
+        self.assertEqual(activity_logs.count(), 1)
+        log = activity_logs.first()
+        self.assertIsNotNone(log)
+        self.assertIsNotNone(log.detail)
+
+    def test_batch_export_update_activity_logging(self):
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.DATA_PIPELINES, "name": AvailableFeature.DATA_PIPELINES}
+        ]
+        self.organization.save()
+
+        batch_export = self.create_batch_export("Original Export")
+        initial_log_count = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="BatchExport", item_id=str(batch_export["id"])
+        ).count()
+
+        self.update_batch_export(batch_export["id"], {"name": "Updated Export"})
+
+        final_log_count = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="BatchExport", item_id=str(batch_export["id"])
+        ).count()
+        self.assertEqual(final_log_count - initial_log_count, 1)
+
+        update_log = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="BatchExport", item_id=str(batch_export["id"]), activity="updated"
+        ).first()
+        self.assertIsNotNone(update_log)
+        if update_log:
+            self.assertIsNotNone(update_log.detail)
+
+    def test_alert_configuration_update_activity_logging(self):
+        alert = self.create_alert_configuration("Original Alert")
+        initial_log_count = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="AlertConfiguration", item_id=str(alert["id"])
+        ).count()
+
+        self.update_alert_configuration(alert["id"], {"name": "Updated Alert"})
+
+        final_log_count = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="AlertConfiguration", item_id=str(alert["id"])
+        ).count()
+        self.assertEqual(final_log_count - initial_log_count, 1)
+
+        update_log = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="AlertConfiguration", item_id=str(alert["id"]), activity="updated"
+        ).first()
+        self.assertIsNotNone(update_log)
+        if update_log:
+            self.assertIsNotNone(update_log.detail)
+
+    def test_personal_api_key_creation_activity_logging(self):
+        api_key = self.create_personal_api_key("Test API Key")
+
+        activity_logs = ActivityLog.objects.filter(
+            organization_id=self.organization.id, scope="PersonalAPIKey", item_id=str(api_key["id"]), activity="created"
+        )
+        self.assertEqual(activity_logs.count(), 1)
+        log = activity_logs.first()
+        self.assertIsNotNone(log)
+        self.assertIsNotNone(log.detail)
+
+    def test_personal_api_key_update_activity_logging(self):
+        api_key = self.create_personal_api_key("Original API Key")
+        initial_log_count = ActivityLog.objects.filter(
+            organization_id=self.organization.id, scope="PersonalAPIKey", item_id=str(api_key["id"])
+        ).count()
+
+        self.update_personal_api_key(api_key["id"], {"label": "Updated API Key"})
+
+        final_log_count = ActivityLog.objects.filter(
+            organization_id=self.organization.id, scope="PersonalAPIKey", item_id=str(api_key["id"])
+        ).count()
+        self.assertEqual(final_log_count - initial_log_count, 1)
+
+        update_log = ActivityLog.objects.filter(
+            organization_id=self.organization.id, scope="PersonalAPIKey", item_id=str(api_key["id"]), activity="updated"
+        ).first()
+        self.assertIsNotNone(update_log)
+        if update_log:
+            self.assertIsNotNone(update_log.detail)

--- a/posthog/test/test_activity_log_scopes.py
+++ b/posthog/test/test_activity_log_scopes.py
@@ -1,0 +1,191 @@
+"""
+Test activity logging for core PostHog models to ensure proper activity log creation.
+
+This test file focuses on the most commonly used models with confirmed activity logging:
+- FeatureFlag: Has ModelActivityMixin + signal handler ✅
+- Experiment: Has ModelActivityMixin + signal handler ✅
+- Subscription: Has ModelActivityMixin + signal handler ✅
+- Annotation: Has ModelActivityMixin ✅
+
+Models requiring further investigation (may need additional setup):
+- AlertConfiguration: Should have activity logging but tests suggest otherwise
+- PersonalAPIKey: Should have activity logging but tests suggest otherwise
+- Comment: Should have manual activity logging but tests suggest otherwise
+- BatchExport, Integration: May need specific conditions to trigger logging
+- Action, Dashboard, User: Missing ModelActivityMixin entirely
+
+This provides a solid foundation for testing activity logging on the most critical models.
+"""
+
+from posthog.models.activity_logging.activity_log import ActivityLog
+from posthog.test.activity_log_helpers import ActivityLogTestHelper
+
+
+class TestActivityLogScopes(ActivityLogTestHelper):
+    """Test activity logging for core PostHog models with confirmed activity logging support."""
+
+    def test_subscription_creation_activity_logging(self):
+        subscription = self.create_subscription("Test Subscription")
+
+        activity_logs = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="Subscription", item_id=str(subscription["id"]), activity="created"
+        )
+        self.assertEqual(activity_logs.count(), 1)
+        self.assertIsNotNone(activity_logs.first().detail)
+
+    def test_subscription_update_activity_logging(self):
+        subscription = self.create_subscription("Original Subscription")
+        initial_log_count = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="Subscription", item_id=str(subscription["id"])
+        ).count()
+
+        self.update_subscription(subscription["id"], {"title": "Updated Subscription"})
+
+        final_log_count = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="Subscription", item_id=str(subscription["id"])
+        ).count()
+        self.assertEqual(final_log_count - initial_log_count, 1)
+
+        update_log = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="Subscription", item_id=str(subscription["id"]), activity="updated"
+        ).first()
+        self.assertIsNotNone(update_log)
+        self.assertIsNotNone(update_log.detail)
+
+    def test_feature_flag_creation_activity_logging(self):
+        flag = self.create_feature_flag("test-flag")
+
+        activity_logs = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="FeatureFlag", item_id=str(flag["id"]), activity="created"
+        )
+        self.assertEqual(activity_logs.count(), 1)
+        self.assertIsNotNone(activity_logs.first().detail)
+
+    def test_feature_flag_update_activity_logging(self):
+        flag = self.create_feature_flag("original-flag")
+        initial_log_count = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="FeatureFlag", item_id=str(flag["id"])
+        ).count()
+
+        self.update_feature_flag(flag["id"], {"name": "Updated Flag"})
+
+        final_log_count = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="FeatureFlag", item_id=str(flag["id"])
+        ).count()
+        self.assertEqual(final_log_count - initial_log_count, 1)
+
+        update_log = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="FeatureFlag", item_id=str(flag["id"]), activity="updated"
+        ).first()
+        self.assertIsNotNone(update_log)
+        self.assertIsNotNone(update_log.detail)
+
+    def test_experiment_creation_activity_logging(self):
+        experiment = self.create_experiment("Test Experiment")
+
+        activity_logs = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="Experiment", item_id=str(experiment["id"]), activity="created"
+        )
+        self.assertEqual(activity_logs.count(), 1)
+        self.assertIsNotNone(activity_logs.first().detail)
+
+    def test_experiment_update_activity_logging(self):
+        experiment = self.create_experiment("Original Experiment")
+        initial_log_count = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="Experiment", item_id=str(experiment["id"])
+        ).count()
+
+        self.update_experiment(experiment["id"], {"name": "Updated Experiment"})
+
+        final_log_count = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="Experiment", item_id=str(experiment["id"])
+        ).count()
+        self.assertEqual(final_log_count - initial_log_count, 1)
+
+        update_log = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="Experiment", item_id=str(experiment["id"]), activity="updated"
+        ).first()
+        self.assertIsNotNone(update_log)
+        self.assertIsNotNone(update_log.detail)
+
+    def test_annotation_creation_activity_logging(self):
+        annotation = self.create_annotation("Test annotation")
+
+        activity_logs = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="Annotation", item_id=str(annotation["id"]), activity="created"
+        )
+        self.assertEqual(activity_logs.count(), 1)
+        self.assertIsNotNone(activity_logs.first().detail)
+
+    def test_annotation_update_activity_logging(self):
+        annotation = self.create_annotation("Original annotation")
+        initial_log_count = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="Annotation", item_id=str(annotation["id"])
+        ).count()
+
+        self.update_annotation(annotation["id"], {"content": "Updated annotation"})
+
+        final_log_count = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="Annotation", item_id=str(annotation["id"])
+        ).count()
+        self.assertEqual(final_log_count - initial_log_count, 1)
+
+        update_log = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="Annotation", item_id=str(annotation["id"]), activity="updated"
+        ).first()
+        self.assertIsNotNone(update_log)
+        self.assertIsNotNone(update_log.detail)
+
+    def test_comprehensive_activity_log_verification(self):
+        flag = self.create_feature_flag("detailed-test-flag")
+
+        creation_log = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="FeatureFlag", item_id=str(flag["id"]), activity="created"
+        ).first()
+        self.assertIsNotNone(creation_log)
+        self.assertEqual(creation_log.user, self.user)
+        self.assertIsNotNone(creation_log.detail)
+
+        self.update_feature_flag(flag["id"], {"name": "Updated Detailed Flag Name", "active": False})
+
+        update_log = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="FeatureFlag", item_id=str(flag["id"]), activity="updated"
+        ).first()
+        self.assertIsNotNone(update_log)
+        self.assertEqual(update_log.user, self.user)
+        self.assertIsNotNone(update_log.detail)
+
+        if hasattr(update_log.detail, "changes") and update_log.detail.changes:
+            change_fields = [change.field for change in update_log.detail.changes]
+            self.assertIn("name", change_fields)
+            self.assertIn("active", change_fields)
+
+    def test_core_models_activity_logging_coverage(self):
+        initial_log_count = ActivityLog.objects.filter(team_id=self.team.id).count()
+
+        self.create_subscription("Coverage Test Subscription")
+        self.create_feature_flag("coverage-test-flag")
+        self.create_experiment("Coverage Test Experiment")
+        self.create_annotation("Coverage Test Annotation")
+
+        final_log_count = ActivityLog.objects.filter(team_id=self.team.id).count()
+        self.assertGreaterEqual(final_log_count - initial_log_count, 4)
+
+        confirmed_scopes = ["Subscription", "FeatureFlag", "Experiment", "Annotation"]
+        for scope in confirmed_scopes:
+            scope_logs = ActivityLog.objects.filter(team_id=self.team.id, scope=scope, activity="created")
+            self.assertGreaterEqual(scope_logs.count(), 1, f"No creation log found for confirmed scope {scope}")
+
+        recent_logs = ActivityLog.objects.filter(team_id=self.team.id).order_by("-created_at")[:10]
+        user_logs = [log for log in recent_logs if log.user is not None]
+        self.assertGreaterEqual(len(user_logs), 2)
+
+        for log in user_logs:
+            if log.user is not None:
+                self.assertIsNotNone(log.detail)
+                self.assertIn(log.activity, ["created", "updated"])
+
+        all_recent_logs = ActivityLog.objects.filter(team_id=self.team.id).order_by("-created_at")[:5]
+        for log in all_recent_logs:
+            self.assertIsNotNone(log.detail)
+            self.assertIn(log.activity, ["created", "updated"])

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -1609,3 +1609,12 @@ def opt_slash_path(route: str, view: Callable, name: Optional[str] = None) -> UR
     """Catches path with or without trailing slash, taking into account query param and hash."""
     # Ignoring the type because while name can be optional on re_path, mypy doesn't agree
     return re_path(rf"^{route}/?(?:[?#].*)?$", view, name=name)  # type: ignore
+
+
+def get_current_user_from_thread() -> Optional["User"]:
+    from threading import current_thread
+
+    request = getattr(current_thread(), "request", None)
+    if request and hasattr(request, "user"):
+        return request.user
+    return None


### PR DESCRIPTION

## Changes

- Added activity logging to 11 more models - whenever users create/update/delete things like organizations, API keys, integrations, etc. those changes now get logged in the db.

## How did you test this code?

- Manually and unit