### PR TITLE
fix(hx): nested deserialization bug

### DIFF
--- a/posthog/hogql/ast.py
+++ b/posthog/hogql/ast.py
@@ -915,10 +915,9 @@ class HogQLXAttribute(AST):
 
 
 @dataclass(kw_only=True)
-class HogQLXTag(AST):
+class HogQLXTag(Expr):
     kind: str
     attributes: list[HogQLXAttribute]
-    type: Optional[Type] = None
 
     def to_dict(self):
         return {

--- a/posthog/hogql/test/test_utils.py
+++ b/posthog/hogql/test/test_utils.py
@@ -71,9 +71,9 @@ class TestUtils(BaseTest):
                 right=ast.ArithmeticOperation(
                     left=ast.Call(name="now", args=[]),
                     right=ast.Call(name="toIntervalDay", args=[ast.Constant(value=1)]),
-                    op="-",
+                    op=ast.ArithmeticOperationOp.Sub,
                 ),
-                op=">",
+                op=ast.CompareOperationOp.Gt,
             ),
             group_by=[ast.Field(chain=["event"])],
         )

--- a/posthog/hogql/test/test_utils.py
+++ b/posthog/hogql/test/test_utils.py
@@ -25,6 +25,59 @@ class TestUtils(BaseTest):
             }
         ) == ast.Call(name="hello", args=[ast.Constant(value="is it me?")])
 
+        assert deserialize_hx_ast(
+            {
+                "__hx_ast": "SelectQuery",
+                "group_by": [{"__hx_ast": "Field", "chain": ["event"]}],
+                "select": [
+                    {"__hx_tag": "blink", "children": [{"__hx_ast": "Field", "chain": ["event"]}]},
+                    {
+                        "__hx_ast": "Call",
+                        "args": [{"__hx_ast": "Field", "chain": ["*"]}],
+                        "distinct": False,
+                        "name": "count",
+                    },
+                    "ewrew222",
+                ],
+                "select_from": {"__hx_ast": "JoinExpr", "table": {"__hx_ast": "Field", "chain": ["events"]}},
+                "where": {
+                    "__hx_ast": "CompareOperation",
+                    "left": {"__hx_ast": "Field", "chain": ["timestamp"]},
+                    "op": ">",
+                    "right": {
+                        "__hx_ast": "ArithmeticOperation",
+                        "left": {"__hx_ast": "Call", "args": [], "distinct": False, "name": "now"},
+                        "op": "-",
+                        "right": {
+                            "__hx_ast": "Call",
+                            "args": [{"__hx_ast": "Constant", "value": 1}],
+                            "distinct": False,
+                            "name": "toIntervalDay",
+                        },
+                    },
+                },
+            }
+        ) == ast.SelectQuery(
+            select=[
+                ast.HogQLXTag(
+                    kind="blink", attributes=[ast.HogQLXAttribute(name="children", value=[ast.Field(chain=["event"])])]
+                ),
+                ast.Call(name="count", args=[ast.Field(chain=["*"])]),
+                ast.Constant(value="ewrew222"),
+            ],
+            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+            where=ast.CompareOperation(
+                left=ast.Field(chain=["timestamp"]),
+                right=ast.ArithmeticOperation(
+                    left=ast.Call(name="now", args=[]),
+                    right=ast.Call(name="toIntervalDay", args=[ast.Constant(value=1)]),
+                    op="-",
+                ),
+                op=">",
+            ),
+            group_by=[ast.Field(chain=["event"])],
+        )
+
     def test_deserialize_hx_ast_error(self):
         with self.assertRaises(ValueError) as e:
             deserialize_hx_ast(
@@ -44,15 +97,3 @@ class TestUtils(BaseTest):
                 }
             )
         self.assertEqual(str(e.exception), "Invalid or missing '__hx_ast' kind: Invalid")
-
-        with self.assertRaises(ValueError) as e:
-            deserialize_hx_ast(
-                {
-                    "__hx_ast": "Call",
-                    "name": "hello",
-                    "args": ["invalid type"],
-                }
-            )
-        self.assertEqual(
-            str(e.exception), "Invalid type for field 'args' in AST node 'Call'. Expected 'Expr', got 'str'"
-        )


### PR DESCRIPTION
## Problem

There was an issue deserializing doubly nested "__hx_ast" lists.

## Changes

Fixed it by making the code recursive.

## How did you test this code?

Added a test case that broke before, but works now