### PR TITLE
fix: display project profile in replay viewers

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarOverviewOtherWatchers.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarOverviewOtherWatchers.tsx
@@ -10,6 +10,8 @@ import { urls } from 'scenes/urls'
 import { sessionRecordingPlayerLogic } from '../sessionRecordingPlayerLogic'
 import { playerSidebarLogic } from './playerSidebarLogic'
 
+const MAX_VISIBLE_AVATARS = 3
+
 function OtherWatchersLoading(): JSX.Element {
     return (
         <div className="flex flex-row deprecated-space-x-2 items-center justify-center px-2 py-1">
@@ -37,14 +39,14 @@ function OtherWatchersDisplay({ startExpanded = false }: { startExpanded?: boole
         <div className="flex flex-col gap-2 px-2 py-1">
             <div className="flex flex-row deprecated-space-x-2 items-center justify-center">
                 <div className="flex flex-row -space-x-1">
-                    {viewers.slice(0, 3).map((viewer, index) => (
-                        <div key={viewer} className="relative" style={{ zIndex: 3 - index }}>
+                    {viewers.slice(0, MAX_VISIBLE_AVATARS).map((viewer, index) => (
+                        <div key={viewer} className="relative" style={{ zIndex: MAX_VISIBLE_AVATARS - index }}>
                             <ProfilePicture user={{ email: viewer }} size="sm" />
                         </div>
                     ))}
-                    {viewers.length > 3 && (
+                    {viewers.length > MAX_VISIBLE_AVATARS && (
                         <div className="flex items-center justify-center w-6 h-6 bg-primary-alt rounded-full text-xs font-medium text-primary border-2 border-bg-light">
-                            +{viewers.length - 3}
+                            +{viewers.length - MAX_VISIBLE_AVATARS}
                         </div>
                     )}
                 </div>

--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarOverviewOtherWatchers.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarOverviewOtherWatchers.tsx
@@ -4,7 +4,7 @@ import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Link } from 'lib/lemon-ui/Link'
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 import { membersLogic } from 'scenes/organization/membersLogic'
@@ -33,14 +33,13 @@ function OtherWatchersDisplay({
     const { members } = useValues(membersLogic)
     const [isExpanded, setIsExpanded] = useState(startExpanded)
 
-    if (!metadata?.viewers) {
-        return null
-    }
-
-    const otherViewers = metadata.viewers.filter((viewer) => viewer !== currentUser?.email)
+    const otherViewers = useMemo(
+        () => metadata?.viewers?.filter((viewer) => viewer !== currentUser?.email) || [],
+        [metadata?.viewers, currentUser?.email]
+    )
     const count = otherViewers.length
 
-    if (count === 0) {
+    if (!metadata?.viewers || count === 0) {
         return null
     }
 

--- a/frontend/src/scenes/session-recordings/player/sidebar/playerSidebarLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sidebar/playerSidebarLogic.ts
@@ -1,7 +1,11 @@
-import { actions, kea, path, reducers } from 'kea'
+import { actions, kea, path, reducers, selectors } from 'kea'
 import { actionToUrl, router, urlToAction } from 'kea-router'
 
 import { SessionRecordingSidebarTab } from '~/types'
+
+import { sessionRecordingPlayerLogic } from '../sessionRecordingPlayerLogic'
+import { userLogic } from 'scenes/userLogic'
+import { membersLogic } from 'scenes/organization/membersLogic'
 
 import type { playerSidebarLogicType } from './playerSidebarLogicType'
 
@@ -17,6 +21,32 @@ export const playerSidebarLogic = kea<playerSidebarLogicType>([
             SessionRecordingSidebarTab.INSPECTOR as SessionRecordingSidebarTab,
             { setTab: (_, { tab }) => tab },
         ],
+    })),
+
+    selectors(() => ({
+        sessionPlayerMetaData: [
+            () => [sessionRecordingPlayerLogic.selectors.sessionPlayerMetaData],
+            (sessionPlayerMetaData) => sessionPlayerMetaData,
+        ],
+        currentUser: [() => [userLogic.selectors.user], (user) => user],
+        members: [() => [membersLogic.selectors.members], (members) => members],
+        viewers: [
+            (s) => [s.sessionPlayerMetaData, s.currentUser],
+            (sessionPlayerMetaData, currentUser) => {
+                return sessionPlayerMetaData?.viewers?.filter((viewer) => viewer !== currentUser?.email) || []
+            },
+        ],
+        viewerMembers: [
+            (s) => [s.viewers, s.members],
+            (viewers, members) => {
+                return viewers.map((viewer) => {
+                    const member = members?.find((m) => m.user.email === viewer)
+                    return member?.user || { email: viewer }
+                })
+            },
+        ],
+        viewerCount: [(s) => [s.viewers], (viewers) => viewers.length],
+        hasOtherViewers: [(s) => [s.viewerCount], (viewerCount) => viewerCount > 0],
     })),
 
     actionToUrl(() => ({


### PR DESCRIPTION
## Problem

Using proper display of project profile

## Changes

- Rendering clickable user names now
- Moved logic to `playerSideBarLogic.ts`
- Memoized viewers
- Moved magic number to constant

## How did you test this code?

tested locally
