### PR TITLE
fix(flags): Fix flaky test by adding deterministic ordering to dependent flags query

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -690,6 +690,7 @@ class FeatureFlagSerializer(
                 ],
                 params=[str(flag_to_delete.id)],
             )
+            .order_by("key")
         )
 
     def _update_filters(self, validated_data):


### PR DESCRIPTION
## Problem

The `test_cannot_delete_flag_with_multiple_dependents` test was flaky because the `_find_dependent_flags` method returned flags in non-deterministic database order. This caused the error message to show different flags on different test runs, making assertions fail intermittently.

## Changes

Added `.order_by('key')` to ensure consistent alphabetical ordering of dependent flags in error messages, making both the test and user experience deterministic.

## How did you test this code?

Ran unit tests multiple times.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
