### PR TITLE
fix(capture-rs): ensure router builder layer() calls come last after all route registrations

### DIFF
--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -158,13 +158,13 @@ pub fn router<
             .route(
                 "/batch",
                 post(v0_endpoint::event_legacy)
-                    .get(v0_endpoint::event)
+                    .get(v0_endpoint::event_legacy)
                     .options(v0_endpoint::options),
             )
             .route(
                 "/batch/",
                 post(v0_endpoint::event_legacy)
-                    .get(v0_endpoint::event)
+                    .get(v0_endpoint::event_legacy)
                     .options(v0_endpoint::options),
             )
     } else {
@@ -233,8 +233,7 @@ pub fn router<
             post(v0_endpoint::event_legacy)
                 .get(v0_endpoint::event_legacy)
                 .options(v0_endpoint::options),
-        )
-        .layer(DefaultBodyLimit::max(EVENT_BODY_SIZE));
+        );
 
     // conditionally allow legacy event handler to process /i/v0/e/
     // (modern capture) events for observation in mirror deploy
@@ -267,6 +266,7 @@ pub fn router<
                     .options(v0_endpoint::options),
             )
     };
+    event_router = event_router.layer(DefaultBodyLimit::max(EVENT_BODY_SIZE));
 
     let status_router = Router::new()
         .route("/", get(index))


### PR DESCRIPTION
## Problem
Making the router builder conditional for smoke testing in mirror deploy may have left several routes not receiving proper limit caps.

## Changes
Purely defensive change, just want to make sure the current codepath doesn't accidentally stick around after the smoke test plumbing goes away 👍 

## How did you test this code?
Locally and in CI

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
