### PR TITLE
chore: bump the background broker pool to 8 from 1 to speed up ingestion

### DIFF
--- a/docker/clickhouse/config.xml
+++ b/docker/clickhouse/config.xml
@@ -72,7 +72,7 @@
     of the time, in which case a higher number of threads might be required.
     -->
 
-    <background_message_broker_schedule_pool_size>1</background_message_broker_schedule_pool_size>
+    <background_message_broker_schedule_pool_size>8</background_message_broker_schedule_pool_size>
     <max_thread_pool_size>10000</max_thread_pool_size>
 
     <!-- Number of workers to recycle connections in background (see also drain_timeout).


### PR DESCRIPTION
## Problem

the previous change that dropped this to 1 may have slowed down ingestion enough to make some tests flakey

## Changes

bump to a reasonable, but still smaller 8 threads

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
