### PR TITLE
fix(rust): revert suspect Rust workspace changes

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -94,11 +94,18 @@ jobs:
             - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               if: needs.changes.outputs.rust == 'true'
 
-            - name: Setup main repo dependencies
-              if: needs.changes.outputs.rust == 'true'
+            - name: Setup main repo dependencies for flags
+              if: needs.changes.outputs.rust == 'true' && matrix.package == 'feature-flags'
               run: |
                   docker compose -f ../docker-compose.dev.yml down
                   docker compose -f ../docker-compose.dev.yml up -d
+                  echo "127.0.0.1 kafka clickhouse" | sudo tee -a /etc/hosts
+
+            - name: Setup dependencies
+              if: needs.changes.outputs.rust == 'true' && matrix.package == 'others'
+              run: |
+                  docker compose up kafka redis db echo_server objectstorage -d --wait
+                  docker compose up setup_test_db
                   echo "127.0.0.1 kafka clickhouse" | sudo tee -a /etc/hosts
 
             # please keep the tag version here in sync with rust-version in rust/*/Cargo.toml

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -407,14 +407,6 @@ services:
         networks:
             - otel_network
 
-    echo_server:
-        image: docker.io/library/caddy:2
-        container_name: echo-server
-        restart: on-failure
-        ports:
-            - '18081:8081'
-        volumes:
-            - ./rust/docker/echo-server/Caddyfile:/etc/caddy/Caddyfile
     jaeger:
         image: jaegertracing/all-in-one:latest
         container_name: jaeger-local

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -233,13 +233,6 @@ services:
         depends_on:
             - jaeger
 
-    echo_server:
-        extends:
-            file: docker-compose.base.yml
-            service: echo_server
-        expose:
-            - '18081:18081'
-
     jaeger:
         extends:
             file: docker-compose.base.yml

--- a/rust/.env
+++ b/rust/.env
@@ -1,1 +1,1 @@
-DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog
+DATABASE_URL=postgres://posthog:posthog@localhost:15432/test_database

--- a/rust/Dockerfile.migrate-hooks
+++ b/rust/Dockerfile.migrate-hooks
@@ -12,4 +12,6 @@ COPY migrations /sqlx/migrations/
 
 COPY --from=builder /app/target/release/bin/sqlx /usr/local/bin
 
-CMD sqlx database create && sqlx migrate run
+RUN chmod +x ./bin/migrate
+
+CMD ["./bin/migrate"]

--- a/rust/bin/migrate
+++ b/rust/bin/migrate
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+sqlx database create
+sqlx migrate run

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -308,15 +308,6 @@ impl KafkaSink {
                         "Event rejected by kafka during send".to_string(),
                     ))
                 }
-                Some(RDKafkaErrorCode::QueueFull) => {
-                    // Don't make this retryable, the queue is already full
-                    report_dropped_events("kafka_queue_full", 1);
-                    error!(
-                        "Kafka producer queue full - dropping event to prevent retry storm: {}",
-                        e
-                    );
-                    Err(CaptureError::NonRetryableSinkError)
-                }
                 _ => {
                     // TODO(maybe someday): Don't drop them but write them somewhere and try again
                     report_dropped_events("kafka_write_error", 1);

--- a/rust/docker-compose.yml
+++ b/rust/docker-compose.yml
@@ -1,0 +1,101 @@
+version: '3'
+
+services:
+    zookeeper:
+        image: zookeeper:3.7.0
+        restart: on-failure
+
+    kafka:
+        image: ghcr.io/posthog/kafka-container:v2.8.2
+        restart: on-failure
+        depends_on:
+            - zookeeper
+        environment:
+            KAFKA_BROKER_ID: 1001
+            KAFKA_CFG_RESERVED_BROKER_MAX_ID: 1001
+            KAFKA_CFG_LISTENERS: PLAINTEXT://:9092
+            KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+            KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
+            ALLOW_PLAINTEXT_LISTENER: 'true'
+        ports:
+            - '9092:9092'
+        healthcheck:
+            test: kafka-cluster.sh cluster-id --bootstrap-server localhost:9092 || exit 1
+            interval: 3s
+            timeout: 10s
+            retries: 10
+
+    redis:
+        image: redis:6.2.7-alpine
+        restart: on-failure
+        command: redis-server --maxmemory-policy allkeys-lru --maxmemory 200mb
+        ports:
+            - '6379:6379'
+        healthcheck:
+            test: ['CMD', 'redis-cli', 'ping']
+            interval: 3s
+            timeout: 10s
+            retries: 10
+
+    objectstorage:
+        image: minio/minio:RELEASE.2025-01-20T14-49-07Z
+        restart: on-failure
+        ports:
+            - '19000:19000'
+            - '19001:19001'
+        environment:
+            MINIO_ROOT_USER: object_storage_root_user
+            MINIO_ROOT_PASSWORD: object_storage_root_password
+        entrypoint: sh
+        command: -c 'mkdir -p /data/capture && minio server --address ":19000" --console-address ":19001" /data' # create the 'capture' bucket before starting the service
+
+    kafka-ui:
+        image: provectuslabs/kafka-ui:latest
+        profiles: ['ui']
+        ports:
+            - '8080:8080'
+        depends_on:
+            - zookeeper
+            - kafka
+        environment:
+            KAFKA_CLUSTERS_0_NAME: local
+            KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
+            KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
+
+    db:
+        container_name: db
+        image: docker.io/library/postgres:16-alpine
+        restart: on-failure
+        environment:
+            POSTGRES_USER: posthog
+            POSTGRES_DB: posthog
+            POSTGRES_PASSWORD: posthog
+        healthcheck:
+            test: ['CMD-SHELL', 'pg_isready -U posthog']
+            interval: 5s
+            timeout: 5s
+        ports:
+            - '15432:5432'
+        command: postgres -c max_connections=1000 -c idle_in_transaction_session_timeout=300000
+
+    setup_test_db:
+        container_name: setup-test-db
+        build:
+            context: .
+            dockerfile: Dockerfile.migrate-hooks
+        restart: on-failure
+        depends_on:
+            db:
+                condition: service_healthy
+                restart: true
+        environment:
+            DATABASE_URL: postgres://posthog:posthog@db:5432/test_database
+
+    echo_server:
+        image: docker.io/library/caddy:2
+        container_name: echo-server
+        restart: on-failure
+        ports:
+            - '18081:8081'
+        volumes:
+            - ./docker/echo-server/Caddyfile:/etc/caddy/Caddyfile


### PR DESCRIPTION
## Problem
Some innocent-seeming housekeeping PRs around Postgres in CI landed in line with some unexpected behavior changes in deployed Rust services use of `rdkafka`. Let's remove them out of an abundance of caution, and see if it helps remediate.

## Changes
* Revert housekeeping PRs
* Revert quick-fix from incident yesterday that is not needed long-term

## How did you test this code?
Locally and in CI

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
