### PR TITLE
fix: Improve `direnv` detection in Flox manifest to prevent false prompts

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -71,7 +71,7 @@ UV_PROJECT_ENVIRONMENT = "$FLOX_ENV_CACHE/venv"
 on-activate = '''
 # Guide through installing and configuring direnv if it's not present (optionally)
 
-if [[ -t 0 ]] && [[ -z "${DIRENV_DIR:-}" ]] && [ ! -f "$FLOX_ENV_CACHE/.hush-direnv" ]; then
+if [[ -t 0 ]] && ! command -v direnv >/dev/null 2>&1 && [ ! -f "$FLOX_ENV_CACHE/.hush-direnv" ]; then
   read -p "👉 For auto-activation of the environment, we recommend direnv (https://direnv.net).
 ❓ Would you like direnv to be set up in $(basename "$SHELL") now? (Y/n)" -n 1 -r
   echo


### PR DESCRIPTION
## Problem

The [previous fix](https://github.com/PostHog/posthog/pull/36001) I attempted checked if `DIRENV_DIR` was set, but this created a race condition where `Flox` would activate before `direnv`, causing the prompt to appear even when `direnv` was installed and configured. It worked some of the time, but not all of the time.

## Changes

Changed to check if `direnv` command exists instead, which is more reliable and avoids timing issues while still only prompting when `direnv` is not available. This should hopefully work all of the time.

## How did you test this code?

Manually.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
