### PR TITLE
fix: alert hack

### DIFF
--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -340,11 +340,15 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
 
             const currentScene = sceneLogic.findMounted()?.values
 
+            const alertChanged = alert_id !== values.alertId
+
             if (
                 currentScene?.activeScene === Scene.Insight &&
                 currentScene.activeSceneLogic &&
                 (currentScene.activeSceneLogic as BuiltLogic<insightSceneLogicType>).values.insightId === insightId &&
-                (currentScene.activeSceneLogic as BuiltLogic<insightSceneLogicType>).values.insightMode === insightMode
+                (currentScene.activeSceneLogic as BuiltLogic<insightSceneLogicType>).values.insightMode ===
+                    insightMode &&
+                !alertChanged
             ) {
                 // If nothing about the scene has changed, don't do anything
                 return
@@ -363,7 +367,7 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
                 insightId !== values.insightId ||
                 insightMode !== values.insightMode ||
                 itemId !== values.itemId ||
-                alert_id !== values.alertId ||
+                alertChanged ||
                 !objectsEqual(variablesOverride, values.variablesOverride) ||
                 !objectsEqual(filtersOverride, values.filtersOverride) ||
                 dashboard !== values.dashboardId ||


### PR DESCRIPTION
New alerts modal ceased to appear as of this PR: https://github.com/PostHog/posthog/pull/35902. Hacky fix to get it back, not confident of what the goal is with this code

I don't pretend to understand this logic - i'm not sure what the shortcut on line 343 is doing and why the logic for when we return early is different than the logic later on line 362 for when we `setSceneState`

343
```if (
      currentScene?.activeScene === Scene.Insight &&
      currentScene.activeSceneLogic &&
      (currentScene.activeSceneLogic as BuiltLogic<insightSceneLogicType>).values.insightId === insightId &&
      (currentScene.activeSceneLogic as BuiltLogic<insightSceneLogicType>).values.insightMode === insightMode
    
```

362
```if (
        insightId !== values.insightId ||
        insightMode !== values.insightMode ||
        itemId !== values.itemId ||
        alert_id !== values.alertId ||
        alertChanged ||
        !objectsEqual(variablesOverride, values.variablesOverride) ||
        !objectsEqual(filtersOverride, values.filtersOverride) ||
        dashboard !== values.dashboardId ||
        dashboardName !== values.dashboardName
    )
            ```