### PR TITLE
fix: handle query metadata failures by storing empty values

### DIFF
--- a/posthog/management/commands/backfill_insights_query_metadata.py
+++ b/posthog/management/commands/backfill_insights_query_metadata.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 import time
 import math
 
@@ -8,6 +9,7 @@ from django.core.management.base import BaseCommand
 from django.db import transaction
 from django.db.models import Q
 
+from posthog.hogql_queries.query_metadata import InsightQueryMetadata
 from posthog.models import Insight
 
 logger = structlog.get_logger(__name__)
@@ -133,13 +135,18 @@ class Command(BaseCommand):
                     # Generate metadata
                     try:
                         insight.generate_query_metadata()
-                        insights_to_update.append(insight)
                         batch_updated += 1
-
                         if verbose:
                             self.stdout.write(f"Insight {insight.id}: Generated query metadata")
                     except Exception as e:
                         logger.exception(f"Failed to generate metadata for insight {insight.id}: {e}")
+                        # store an empty metadata to avoid reprocessing, with a specific datetime to know which ones failed via this command (hacky, I know)
+                        failed_datetime = datetime(2025, 1, 1, 0, 0, 0)
+                        insight.query_metadata = InsightQueryMetadata(events=[], updated_at=failed_datetime).model_dump(
+                            exclude_none=True, mode="json"
+                        )
+
+                    insights_to_update.append(insight)
 
                 # Update all modified insights in this batch
                 if insights_to_update and not dry_run:


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

When running `backfill_insights_query_metadata` management cmd on production I noticed some events use invalid query nodes (nodes that no longer exist in the code) so the extraction job would fail. This failure would be logged but we would still try to reprocess the failed insights in the next batch so it was causing loops.

## Changes

This is a hacky attempt at fixing the issue by setting an empty query metadata value for insights that we fail to process. Another way to handle this would've been to fetch all the IDs first and go through them in the batch but that would increase memory usage. This job will only have to be run once so it's okay to set them empty. I've set a arbitrary `updated_at` time for the failed records so I can later look them up in the DB and see how many failures we have. We can then later retry them or figure out another way to handle those insights.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Add an exception to the backfill_insights_query_metadata command and run it. The query_metadata field of your insights (the ones that are currently null) should be filled with `{"events": [], "updated_at": "2025-01-01T00:00:00"}`

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
