### PR TITLE
chore: include soft-deleted insights in backfill query

### DIFF
--- a/posthog/management/commands/backfill_insights_query_metadata.py
+++ b/posthog/management/commands/backfill_insights_query_metadata.py
@@ -80,7 +80,9 @@ class Command(BaseCommand):
         Uses proper row locking to prevent race conditions.
         """
         # Build base query
-        base_query = Insight.objects.filter(Q(query_metadata__isnull=True) | Q(query_metadata={}))
+        base_query = Insight.objects_including_soft_deleted.filter(
+            Q(query_metadata__isnull=True) | Q(query_metadata={})
+        )
 
         if team_id:
             base_query = base_query.filter(team_id=team_id)

--- a/posthog/management/commands/backfill_insights_query_metadata.py
+++ b/posthog/management/commands/backfill_insights_query_metadata.py
@@ -152,7 +152,7 @@ class Command(BaseCommand):
 
                 # Update all modified insights in this batch
                 if insights_to_update and not dry_run:
-                    Insight.objects.bulk_update(insights_to_update, ["query_metadata"])
+                    Insight.objects_including_soft_deleted.bulk_update(insights_to_update, ["query_metadata"])
 
                 total_updated += batch_updated
                 total_processed += len(insights)


### PR DESCRIPTION
## Problem

Backfilling the soft deleted insights currently won't work because we aren't querying them. If we don't fill the query_metadata and then the insight is recovered it won't be filled on update (because the query hasn't changed)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Queries and updates the query_metadata for insights that are soft deleted in the `backfill_insights_query_metadata` command.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- Delete an insight
- Remove the `query_metadata` from it in the DB
- Run `backfill_insights_query_metadata` command
- Confirm the `query_metadata` is filled for the insight in the DB table (`posthog_dashboarditem`)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
