### PR TITLE
chore: Remove temporary rate limiting on persons API

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -70,8 +70,6 @@ from posthog.queries.util import get_earliest_timestamp
 from posthog.rate_limit import (
     ClickHouseBurstRateThrottle,
     ClickHouseSustainedRateThrottle,
-    BreakGlassBurstThrottle,
-    BreakGlassSustainedThrottle,
 )
 from posthog.renderers import SafeJSONRenderer
 from posthog.settings import EE_AVAILABLE
@@ -148,14 +146,6 @@ class PersonsThrottle(ClickHouseSustainedRateThrottle):
     # Throttle class that's scoped just to the person endpoint.
     # This makes the rate limit apply to all endpoints under /api/person/
     # and independent of other endpoints.
-    scope = "persons"
-
-
-class PersonsBreakGlassBurstThrottle(BreakGlassBurstThrottle):
-    scope = "persons"
-
-
-class PersonsBreakGlassSustainedThrottle(BreakGlassSustainedThrottle):
     scope = "persons"
 
 
@@ -244,8 +234,6 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     throttle_classes = [
         ClickHouseBurstRateThrottle,
         PersonsThrottle,
-        PersonsBreakGlassBurstThrottle,
-        PersonsBreakGlassSustainedThrottle,
     ]
     lifecycle_class = Lifecycle
     stickiness_class = Stickiness


### PR DESCRIPTION
## Problem

See https://posthog.slack.com/archives/C09978UHG0Y/p1754145139689729?thread_ts=1754075506.483049&cid=C09978UHG0Y

## Changes
Remove temporary rate limits

## How did you test this code?

n/a
