### PR TITLE
feat: dynamic clickhouse ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,4 +113,4 @@ target/*
 posthog/management/commands/clear_demo_data.py
 
 # Ignore Claude Code settings
-.claude/settings.local.json
+.claude/settings.local.json.migrations_done

--- a/.gitignore
+++ b/.gitignore
@@ -113,4 +113,7 @@ target/*
 posthog/management/commands/clear_demo_data.py
 
 # Ignore Claude Code settings
-.claude/settings.local.json.migrations_done
+.claude/settings.local.json
+
+# Ignore migration marker file
+.migrations_done

--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -130,6 +130,7 @@ _clickhouse_http_pool_mgr = httputil.get_pool_manager(
 def get_http_client(**overrides):
     kwargs = {
         "host": settings.CLICKHOUSE_HOST,
+        "port": int(os.getenv("CLICKHOUSE_HTTP_PORT", "8123")),
         "database": settings.CLICKHOUSE_DATABASE,
         "secure": settings.CLICKHOUSE_SECURE,
         "user": settings.CLICKHOUSE_USER,  # kwargs have user not username
@@ -242,6 +243,7 @@ def default_client(host=settings.CLICKHOUSE_HOST):
 def _make_ch_pool(*, client_settings: Mapping[str, str] | None = None, **overrides) -> ChPool:
     kwargs = {
         "host": settings.CLICKHOUSE_HOST,
+        "port": settings.CLICKHOUSE_PORT,
         "database": settings.CLICKHOUSE_DATABASE,
         "secure": settings.CLICKHOUSE_SECURE,
         "user": settings.CLICKHOUSE_USER,

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -168,6 +168,7 @@ elif TEST:
 CLICKHOUSE_TEST_DB: str = "posthog" + SUFFIX
 
 CLICKHOUSE_HOST: str = os.getenv("CLICKHOUSE_HOST", "localhost")
+CLICKHOUSE_PORT: int = int(os.getenv("CLICKHOUSE_TCP_PORT", os.getenv("CLICKHOUSE_PORT", "9000")))
 CLICKHOUSE_OFFLINE_CLUSTER_HOST: str | None = os.getenv("CLICKHOUSE_OFFLINE_CLUSTER_HOST", None)
 CLICKHOUSE_USER: str = os.getenv("CLICKHOUSE_USER", "default")
 CLICKHOUSE_PASSWORD: str = os.getenv("CLICKHOUSE_PASSWORD", "")

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -241,12 +241,15 @@ with suppress(Exception):
     API_QUERIES_ON_ONLINE_CLUSTER = {int(v) for v in as_json}
 
 _clickhouse_http_protocol = "http://"
-_clickhouse_http_port = "8123"
+_clickhouse_http_port = os.getenv("CLICKHOUSE_HTTP_PORT", "8123")
 if CLICKHOUSE_SECURE:
     _clickhouse_http_protocol = "https://"
-    _clickhouse_http_port = "8443"
+    _clickhouse_http_port = os.getenv("CLICKHOUSE_HTTP_PORT", "8443")
 
-CLICKHOUSE_HTTP_URL: str = f"{_clickhouse_http_protocol}{CLICKHOUSE_HOST}:{_clickhouse_http_port}/"
+# Allow direct override of the full URL
+CLICKHOUSE_HTTP_URL: str = (
+    os.getenv("CLICKHOUSE_HTTP_URL") or f"{_clickhouse_http_protocol}{CLICKHOUSE_HOST}:{_clickhouse_http_port}/"
+)
 
 CLICKHOUSE_OFFLINE_HTTP_URL: str = (
     f"{_clickhouse_http_protocol}{CLICKHOUSE_OFFLINE_CLUSTER_HOST}:{_clickhouse_http_port}/"


### PR DESCRIPTION
## Problem

Supporting dynamic port allocations for mono-repos with dependencies services.

## Changes

## How did you test this code?

Launch local k8 clusters that support dynamic port allocation across multiple clusters and namespaces.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
