### PR TITLE
feat(ma): add column pinning action to table

### DIFF
--- a/frontend/src/queries/nodes/DataTable/DataTable.scss
+++ b/frontend/src/queries/nodes/DataTable/DataTable.scss
@@ -3,13 +3,15 @@
         max-width: 20rem;
     }
 
-    .DataTable__row:not(.DataTable__row_pinned) {
+    // This style makes the sticky css fail, so we need to remove it when there are pinned columns
+    .DataTable__row:not(.DataTable__has_pinned_columns) {
         position: relative;
         z-index: 0;
     }
 
+    // This style makes the sticky css fail, so we need to remove it when there are pinned columns
     .DataTable__row td:first-child:not(.LemonTable__cell--pinned, .LemonTable__header--pinned) {
-        &::before {
+        &::after {
             position: absolute;
             top: 0;
             left: 0;

--- a/frontend/src/queries/nodes/DataTable/DataTable.scss
+++ b/frontend/src/queries/nodes/DataTable/DataTable.scss
@@ -3,12 +3,12 @@
         max-width: 20rem;
     }
 
-    .DataTable__row {
+    .DataTable__row:not(.DataTable__row_pinned) {
         position: relative;
         z-index: 0;
     }
 
-    .DataTable__row td:first-child {
+    .DataTable__row td:first-child:not(.LemonTable__cell--pinned, .LemonTable__header--pinned) {
         &::before {
             position: absolute;
             top: 0;

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -83,6 +83,7 @@ export enum ColumnFeature {
     canEdit = 'canEdit',
     canAddColumns = 'canAddColumns',
     canRemove = 'canRemove',
+    canPin = 'canPin',
 }
 
 interface DataTableProps {
@@ -204,7 +205,7 @@ export function DataTable({
     const eventActionsColumnShown =
         showActions && sourceFeatures.has(QueryFeature.eventActionsColumn) && columnsInResponse?.includes('*')
     const allColumns = sourceFeatures.has(QueryFeature.columnsInResponse)
-        ? (columnsInResponse ?? columnsInQuery)
+        ? columnsInResponse ?? columnsInQuery
         : columnsInQuery
     const columnsInLemonTable = allColumns.filter((colName) => {
         const col = getContextColumn(colName, context?.columns)
@@ -404,8 +405,8 @@ export function DataTable({
                                         const hogQl = isActorsQuery(query.source)
                                             ? taxonomicPersonFilterToHogQL(g, v)
                                             : isGroupsQuery(query.source)
-                                              ? taxonomicGroupFilterToHogQL(g, v)
-                                              : taxonomicEventFilterToHogQL(g, v)
+                                            ? taxonomicGroupFilterToHogQL(g, v)
+                                            : taxonomicEventFilterToHogQL(g, v)
                                         if (
                                             setQuery &&
                                             hogQl &&
@@ -443,8 +444,8 @@ export function DataTable({
                                         const hogQl = isActorsQuery(query.source)
                                             ? taxonomicPersonFilterToHogQL(g, v)
                                             : isGroupsQuery(query.source)
-                                              ? taxonomicGroupFilterToHogQL(g, v)
-                                              : taxonomicEventFilterToHogQL(g, v)
+                                            ? taxonomicGroupFilterToHogQL(g, v)
+                                            : taxonomicEventFilterToHogQL(g, v)
                                         if (
                                             setQuery &&
                                             hogQl &&
@@ -519,6 +520,29 @@ export function DataTable({
                                     </LemonButton>
                                 </>
                             )}
+                        {columnFeatures.includes(ColumnFeature.canPin) && (
+                            <>
+                                <LemonDivider />
+                                <LemonButton
+                                    fullWidth
+                                    data-attr="datatable-pin-column"
+                                    onClick={() => {
+                                        let newPinnedColumns = new Set(query.pinnedColumns ?? [])
+                                        if (newPinnedColumns.has(key)) {
+                                            newPinnedColumns.delete(key)
+                                        } else {
+                                            newPinnedColumns.add(key)
+                                        }
+                                        setQuery?.({
+                                            ...query,
+                                            pinnedColumns: Array.from(newPinnedColumns),
+                                        })
+                                    }}
+                                >
+                                    {query.pinnedColumns?.includes(key) ? 'Unpin' : 'Pin column'}
+                                </LemonButton>
+                            </>
+                        )}
                     </>
                 ) : undefined,
         })),
@@ -734,8 +758,8 @@ export function DataTable({
                                                 queryCancelled
                                                     ? 'The query was cancelled'
                                                     : response && 'error' in response
-                                                      ? response.error
-                                                      : responseError
+                                                    ? response.error
+                                                    : responseError
                                             }
                                         />
                                     ) : (
@@ -781,6 +805,7 @@ export function DataTable({
                                         result &&
                                         result[0] &&
                                         result[0]['event'] === '$exception',
+                                    DataTable__row_pinned: (query.pinnedColumns ?? []).length > 0,
                                 })
                             }
                             footer={

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -805,7 +805,7 @@ export function DataTable({
                                         result &&
                                         result[0] &&
                                         result[0]['event'] === '$exception',
-                                    DataTable__row_pinned: (query.pinnedColumns ?? []).length > 0,
+                                    DataTable__has_pinned_columns: (query.pinnedColumns ?? []).length > 0,
                                 })
                             }
                             footer={

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -205,7 +205,7 @@ export function DataTable({
     const eventActionsColumnShown =
         showActions && sourceFeatures.has(QueryFeature.eventActionsColumn) && columnsInResponse?.includes('*')
     const allColumns = sourceFeatures.has(QueryFeature.columnsInResponse)
-        ? columnsInResponse ?? columnsInQuery
+        ? (columnsInResponse ?? columnsInQuery)
         : columnsInQuery
     const columnsInLemonTable = allColumns.filter((colName) => {
         const col = getContextColumn(colName, context?.columns)
@@ -405,8 +405,8 @@ export function DataTable({
                                         const hogQl = isActorsQuery(query.source)
                                             ? taxonomicPersonFilterToHogQL(g, v)
                                             : isGroupsQuery(query.source)
-                                            ? taxonomicGroupFilterToHogQL(g, v)
-                                            : taxonomicEventFilterToHogQL(g, v)
+                                              ? taxonomicGroupFilterToHogQL(g, v)
+                                              : taxonomicEventFilterToHogQL(g, v)
                                         if (
                                             setQuery &&
                                             hogQl &&
@@ -444,8 +444,8 @@ export function DataTable({
                                         const hogQl = isActorsQuery(query.source)
                                             ? taxonomicPersonFilterToHogQL(g, v)
                                             : isGroupsQuery(query.source)
-                                            ? taxonomicGroupFilterToHogQL(g, v)
-                                            : taxonomicEventFilterToHogQL(g, v)
+                                              ? taxonomicGroupFilterToHogQL(g, v)
+                                              : taxonomicEventFilterToHogQL(g, v)
                                         if (
                                             setQuery &&
                                             hogQl &&
@@ -758,8 +758,8 @@ export function DataTable({
                                                 queryCancelled
                                                     ? 'The query was cancelled'
                                                     : response && 'error' in response
-                                                    ? response.error
-                                                    : responseError
+                                                      ? response.error
+                                                      : responseError
                                             }
                                         />
                                     ) : (

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsTable/MarketingAnalyticsTable.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsTable/MarketingAnalyticsTable.tsx
@@ -26,8 +26,7 @@ export const MarketingAnalyticsTable = ({ query, insightProps }: MarketingAnalyt
     const marketingAnalyticsContext: QueryContext = {
         ...webAnalyticsDataTableQueryContext,
         insightProps,
-        formatNumbers: true,
-        columnFeatures: [ColumnFeature.canSort, ColumnFeature.canRemove],
+        columnFeatures: [ColumnFeature.canSort, ColumnFeature.canRemove, ColumnFeature.canPin],
     }
 
     return (


### PR DESCRIPTION
## Problem

There isn't an entry point to pin column from the table it self. And there is a UI bug introduced in https://github.com/PostHog/posthog/issues/35763 where there is a conflict between to ::before css styles. (this conflicts with the pinned with all columns -- my changes -- or with the existing isFirstColumnSticky previous logic)

## Changes

- Added entry point in dropdown
- Fixed weird shadow on pinned columns.

## How did you test this code?
Locally 
UI bug where the shadow in now correct because of the position conflict style.
<img width="428" height="946" alt="image" src="https://github.com/user-attachments/assets/6b5978ba-d70b-4acc-9def-9abf688695d1" />
New dropdown action:
<img width="600" height="230" alt="image" src="https://github.com/user-attachments/assets/5bfa0e69-aef5-4d62-817a-4222caf98d26" />

