### PR TITLE
fix(ma): fixing reload all button

### DIFF
--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsFilters/MarketingAnalyticsFilters.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsFilters/MarketingAnalyticsFilters.tsx
@@ -3,23 +3,28 @@ import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { ReloadAll } from '~/queries/nodes/DataNode/Reload'
 import { CompareFilter } from 'lib/components/CompareFilter/CompareFilter'
 import { marketingAnalyticsLogic } from '../../logic/marketingAnalyticsLogic'
+import { dataNodeCollectionLogic } from '~/queries/nodes/DataNode/dataNodeCollectionLogic'
+import { MARKETING_ANALYTICS_DATA_COLLECTION_NODE_ID } from '../../logic/marketingAnalyticsTilesLogic'
+import { BindLogic } from 'kea'
 
 export const MarketingAnalyticsFilters = (): JSX.Element => {
     const { compareFilter, dateFilter } = useValues(marketingAnalyticsLogic)
     const { setCompareFilter, setDates } = useActions(marketingAnalyticsLogic)
 
     return (
-        <div className="flex flex-col md:flex-row md:justify-between gap-2">
-            <ReloadAll />
-            <div className="flex flex-row gap-2 items-center">
-                <CompareFilter compareFilter={compareFilter} updateCompareFilter={setCompareFilter} />
-                <DateFilter
-                    allowTimePrecision
-                    dateFrom={dateFilter.dateFrom}
-                    dateTo={dateFilter.dateTo}
-                    onChange={setDates}
-                />
+        <BindLogic logic={dataNodeCollectionLogic} props={{ key: MARKETING_ANALYTICS_DATA_COLLECTION_NODE_ID }}>
+            <div className="flex flex-col md:flex-row md:justify-between gap-2">
+                <ReloadAll />
+                <div className="flex flex-row gap-2 items-center">
+                    <CompareFilter compareFilter={compareFilter} updateCompareFilter={setCompareFilter} />
+                    <DateFilter
+                        allowTimePrecision
+                        dateFrom={dateFilter.dateFrom}
+                        dateTo={dateFilter.dateTo}
+                        onChange={setDates}
+                    />
+                </div>
             </div>
-        </div>
+        </BindLogic>
     )
 }


### PR DESCRIPTION
## Problem

Nothing happened when clicking the reload all button because the context of the queries was missing. This happened after the refactor, because I renamed the key into `MARKETING_ANALYTICS_DATA_COLLECTION_NODE_ID`

## Changes

Bind the logic with the new key.

## How did you test this code?
Locally:
<img width="370" height="286" alt="image" src="https://github.com/user-attachments/assets/ba35ba22-82e9-49ac-b9b2-3f78da1d7414" />

