### PR TITLE
fix: implement function to handle array values in URL

### DIFF
--- a/frontend/src/scenes/billing/billing-utils.ts
+++ b/frontend/src/scenes/billing/billing-utils.ts
@@ -332,7 +332,8 @@ export function syncBillingSearchParams(
  */
 export function updateBillingSearchParams<T>(searchParams: Params, key: string, value: T, defaultValue: T): void {
     if (!equal(value, defaultValue)) {
-        searchParams[key] = value
+        // JSON stringify arrays to ensure proper URL parameter format
+        searchParams[key] = Array.isArray(value) ? JSON.stringify(value) : value
     } else {
         delete searchParams[key]
     }


### PR DESCRIPTION
## Problem

Context here: https://posthoghelp.zendesk.com/agent/tickets/35377 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/40756)

## Changes

Probably this happened after https://github.com/PostHog/posthog/pull/35469 where we are giving a default breakdowns parameter array to admin users. I was able to reproduce with a couple of users. I wasn't able to reproduce locally though, but added test to check the resulting encoding.

## How did you test this code?
Unit test
