### PR TITLE
fix: dont sync usage and spend params via max

### DIFF
--- a/frontend/src/scenes/billing/BillingSpendView.tsx
+++ b/frontend/src/scenes/billing/BillingSpendView.tsx
@@ -25,7 +25,7 @@ export function BillingSpendView(): JSX.Element {
         minimumAccessLevel: OrganizationMembershipLevel.Admin,
         scope: RestrictionScope.Organization,
     })
-    const logic = billingSpendLogic({ dashboardItemId: 'spendView' })
+    const logic = billingSpendLogic({ syncWithUrl: true })
     const {
         series,
         dates,

--- a/frontend/src/scenes/billing/BillingUsage.tsx
+++ b/frontend/src/scenes/billing/BillingUsage.tsx
@@ -23,7 +23,7 @@ export function BillingUsage(): JSX.Element {
         minimumAccessLevel: OrganizationMembershipLevel.Admin,
         scope: RestrictionScope.Organization,
     })
-    const logic = billingUsageLogic({ dashboardItemId: 'usage' })
+    const logic = billingUsageLogic({ syncWithUrl: true })
     const {
         series,
         dates,

--- a/frontend/src/scenes/billing/billing-utils.ts
+++ b/frontend/src/scenes/billing/billing-utils.ts
@@ -320,7 +320,6 @@ export function syncBillingSearchParams(
 ): [string, Params, Record<string, any>, { replace: boolean }] {
     const currentSearchParams = { ...router.values.searchParams }
     const updatedSearchParams = updateParams(currentSearchParams)
-
     if (!equal(updatedSearchParams, router.values.searchParams)) {
         return [router.values.location.pathname, updatedSearchParams, router.values.hashParams, { replace: true }]
     }

--- a/frontend/src/scenes/billing/billing-utils.ts
+++ b/frontend/src/scenes/billing/billing-utils.ts
@@ -320,6 +320,7 @@ export function syncBillingSearchParams(
 ): [string, Params, Record<string, any>, { replace: boolean }] {
     const currentSearchParams = { ...router.values.searchParams }
     const updatedSearchParams = updateParams(currentSearchParams)
+
     if (!equal(updatedSearchParams, router.values.searchParams)) {
         return [router.values.location.pathname, updatedSearchParams, router.values.hashParams, { replace: true }]
     }

--- a/frontend/src/scenes/billing/billingSpendLogic.ts
+++ b/frontend/src/scenes/billing/billingSpendLogic.ts
@@ -61,7 +61,7 @@ export interface BillingSpendLogicProps {
     initialFilters?: BillingFilters
     dateFrom?: string
     dateTo?: string
-    syncWithUrl?: boolean
+    syncWithUrl?: boolean // Default false - only intended on usage and spend pages
 }
 
 export const billingSpendLogic = kea<billingSpendLogicType>([

--- a/frontend/src/scenes/billing/billingSpendLogic.ts
+++ b/frontend/src/scenes/billing/billingSpendLogic.ts
@@ -61,7 +61,7 @@ export interface BillingSpendLogicProps {
     initialFilters?: BillingFilters
     dateFrom?: string
     dateTo?: string
-    syncWithUrl?: boolean // Default false for safety, set to true for main billing pages
+    syncWithUrl?: boolean
 }
 
 export const billingSpendLogic = kea<billingSpendLogicType>([
@@ -284,22 +284,15 @@ export const billingSpendLogic = kea<billingSpendLogicType>([
 
     actionToUrl(({ values, props }) => {
         const buildURL = (): [string, Params, Record<string, any>, { replace: boolean }] => {
-            // Only sync with URL if explicitly enabled (defaults to false for safety)
+            const keepCurrentUrl: [string, Params, Record<string, any>, { replace: boolean }] = [
+                router.values.location.pathname,
+                router.values.searchParams,
+                router.values.hashParams,
+                { replace: false },
+            ]
+
             if (props.syncWithUrl !== true) {
-                return [
-                    router.values.location.pathname,
-                    router.values.searchParams,
-                    router.values.hashParams,
-                    { replace: false },
-                ]
-            }
-
-            // Only sync params when on billing pages
-            const pathname = router.values.location.pathname
-            const isBillingPage = pathname.includes('/billing')
-
-            if (!isBillingPage) {
-                return [pathname, router.values.searchParams, router.values.hashParams, { replace: false }]
+                return keepCurrentUrl
             }
 
             return syncBillingSearchParams(router, (params: Params) => {
@@ -355,16 +348,7 @@ export const billingSpendLogic = kea<billingSpendLogicType>([
 
     urlToAction(({ actions, values, props }) => {
         const urlToAction = (_: any, params: Params): void => {
-            // Only parse URL if explicitly enabled (defaults to false for safety)
             if (props.syncWithUrl !== true) {
-                return
-            }
-
-            // Only process URL params when on billing pages
-            const pathname = router.values.location.pathname
-            const isBillingPage = pathname.includes('/billing')
-
-            if (!isBillingPage) {
                 return
             }
 

--- a/frontend/src/scenes/billing/billingUsageLogic.ts
+++ b/frontend/src/scenes/billing/billingUsageLogic.ts
@@ -290,22 +290,15 @@ export const billingUsageLogic = kea<billingUsageLogicType>([
 
     actionToUrl(({ values, props }) => {
         const buildURL = (): [string, Params, Record<string, any>, { replace: boolean }] => {
-            // Only sync with URL if explicitly enabled (defaults to false for safety)
+            const keepCurrentUrl: [string, Params, Record<string, any>, { replace: boolean }] = [
+                router.values.location.pathname,
+                router.values.searchParams,
+                router.values.hashParams,
+                { replace: false },
+            ]
+
             if (props.syncWithUrl !== true) {
-                return [
-                    router.values.location.pathname,
-                    router.values.searchParams,
-                    router.values.hashParams,
-                    { replace: false },
-                ]
-            }
-
-            // Only sync params when on billing pages
-            const pathname = router.values.location.pathname
-            const isBillingPage = pathname.includes('/billing')
-
-            if (!isBillingPage) {
-                return [pathname, router.values.searchParams, router.values.hashParams, { replace: false }]
+                return keepCurrentUrl
             }
 
             return syncBillingSearchParams(router, (params: Params) => {
@@ -361,16 +354,7 @@ export const billingUsageLogic = kea<billingUsageLogicType>([
 
     urlToAction(({ actions, values, props }) => {
         const urlToAction = (_: any, params: Params): void => {
-            // Only parse URL if explicitly enabled (defaults to false for safety)
             if (props.syncWithUrl !== true) {
-                return
-            }
-
-            // Only process URL params when on billing pages
-            const pathname = router.values.location.pathname
-            const isBillingPage = pathname.includes('/billing')
-
-            if (!isBillingPage) {
                 return
             }
 

--- a/frontend/src/scenes/billing/billingUsageLogic.ts
+++ b/frontend/src/scenes/billing/billingUsageLogic.ts
@@ -64,7 +64,7 @@ export interface BillingUsageLogicProps {
     initialFilters?: BillingFilters
     dateFrom?: string
     dateTo?: string
-    syncWithUrl?: boolean // Default false for safety, set to true for main billing pages
+    syncWithUrl?: boolean // Default false - only intended on usage and spend pages
 }
 
 export const billingUsageLogic = kea<billingUsageLogicType>([

--- a/frontend/src/scenes/billing/billingUsageLogic.ts
+++ b/frontend/src/scenes/billing/billingUsageLogic.ts
@@ -64,6 +64,7 @@ export interface BillingUsageLogicProps {
     initialFilters?: BillingFilters
     dateFrom?: string
     dateTo?: string
+    syncWithUrl?: boolean // Default false for safety, set to true for main billing pages
 }
 
 export const billingUsageLogic = kea<billingUsageLogicType>([
@@ -287,8 +288,26 @@ export const billingUsageLogic = kea<billingUsageLogicType>([
         ],
     }),
 
-    actionToUrl(({ values }) => {
+    actionToUrl(({ values, props }) => {
         const buildURL = (): [string, Params, Record<string, any>, { replace: boolean }] => {
+            // Only sync with URL if explicitly enabled (defaults to false for safety)
+            if (props.syncWithUrl !== true) {
+                return [
+                    router.values.location.pathname,
+                    router.values.searchParams,
+                    router.values.hashParams,
+                    { replace: false },
+                ]
+            }
+
+            // Only sync params when on billing pages
+            const pathname = router.values.location.pathname
+            const isBillingPage = pathname.includes('/billing')
+
+            if (!isBillingPage) {
+                return [pathname, router.values.searchParams, router.values.hashParams, { replace: false }]
+            }
+
             return syncBillingSearchParams(router, (params: Params) => {
                 updateBillingSearchParams(
                     params,
@@ -340,8 +359,21 @@ export const billingUsageLogic = kea<billingUsageLogicType>([
         }
     }),
 
-    urlToAction(({ actions, values }) => {
+    urlToAction(({ actions, values, props }) => {
         const urlToAction = (_: any, params: Params): void => {
+            // Only parse URL if explicitly enabled (defaults to false for safety)
+            if (props.syncWithUrl !== true) {
+                return
+            }
+
+            // Only process URL params when on billing pages
+            const pathname = router.values.location.pathname
+            const isBillingPage = pathname.includes('/billing')
+
+            if (!isBillingPage) {
+                return
+            }
+
             const filtersFromUrl: Partial<BillingFilters> = {}
 
             if (params.usage_types && !equal(params.usage_types, values.filters.usage_types)) {

--- a/frontend/src/scenes/max/maxBillingContextLogic.tsx
+++ b/frontend/src/scenes/max/maxBillingContextLogic.tsx
@@ -245,32 +245,36 @@ export const billingToMaxContext = (
 
 export const maxBillingContextLogic = kea<maxBillingContextLogicType>([
     path(['scenes', 'max', 'maxBillingContextLogic']),
-    connect(() => ({
-        values: [
-            billingLogic,
-            ['billing'],
-            billingUsageLogic({
-                initialFilters: { breakdowns: ['type', 'team'] },
-                dateFrom: DEFAULT_BILLING_DATE_FROM, // we set them here so we are sure it will stay fixed to a 1 month period even if the usage logic changes default values
-                dateTo: DEFAULT_BILLING_DATE_TO,
-            }),
-            ['billingUsageResponse'],
-            billingSpendLogic({
-                initialFilters: { breakdowns: ['type', 'team'] },
-                dateFrom: DEFAULT_BILLING_DATE_FROM, // same here for spend
-                dateTo: DEFAULT_BILLING_DATE_TO,
-            }),
-            ['billingSpendResponse'],
-            organizationLogic,
-            ['isAdminOrOwner'],
-            teamLogic,
-            ['currentTeam'],
-            featureFlagLogic,
-            ['featureFlags'],
-            pipelineDestinationsLogic({ types: DESTINATION_TYPES }),
-            ['destinations'],
-        ],
-    })),
+    connect(() => {
+        return {
+            values: [
+                billingLogic,
+                ['billing'],
+                billingUsageLogic({
+                    initialFilters: { breakdowns: ['type', 'team'] },
+                    dateFrom: DEFAULT_BILLING_DATE_FROM, // we set them here so we are sure it will stay fixed to a 1 month period even if the usage logic changes default values
+                    dateTo: DEFAULT_BILLING_DATE_TO,
+                    dashboardItemId: 'max-billing-context', // This makes it a separate instance
+                }),
+                ['billingUsageResponse'],
+                billingSpendLogic({
+                    initialFilters: { breakdowns: ['type', 'team'] },
+                    dateFrom: DEFAULT_BILLING_DATE_FROM, // same here for spend
+                    dateTo: DEFAULT_BILLING_DATE_TO,
+                    dashboardItemId: 'max-billing-context', // This makes it a separate instance
+                }),
+                ['billingSpendResponse'],
+                organizationLogic,
+                ['isAdminOrOwner'],
+                teamLogic,
+                ['currentTeam'],
+                featureFlagLogic,
+                ['featureFlags'],
+                pipelineDestinationsLogic({ types: DESTINATION_TYPES }),
+                ['destinations'],
+            ],
+        }
+    }),
     selectors({
         billingContext: [
             (s: any) => [

--- a/frontend/src/scenes/max/maxBillingContextLogic.tsx
+++ b/frontend/src/scenes/max/maxBillingContextLogic.tsx
@@ -245,36 +245,34 @@ export const billingToMaxContext = (
 
 export const maxBillingContextLogic = kea<maxBillingContextLogicType>([
     path(['scenes', 'max', 'maxBillingContextLogic']),
-    connect(() => {
-        return {
-            values: [
-                billingLogic,
-                ['billing'],
-                billingUsageLogic({
-                    initialFilters: { breakdowns: ['type', 'team'] },
-                    dateFrom: DEFAULT_BILLING_DATE_FROM, // we set them here so we are sure it will stay fixed to a 1 month period even if the usage logic changes default values
-                    dateTo: DEFAULT_BILLING_DATE_TO,
-                    dashboardItemId: 'max-billing-context', // This makes it a separate instance
-                }),
-                ['billingUsageResponse'],
-                billingSpendLogic({
-                    initialFilters: { breakdowns: ['type', 'team'] },
-                    dateFrom: DEFAULT_BILLING_DATE_FROM, // same here for spend
-                    dateTo: DEFAULT_BILLING_DATE_TO,
-                    dashboardItemId: 'max-billing-context', // This makes it a separate instance
-                }),
-                ['billingSpendResponse'],
-                organizationLogic,
-                ['isAdminOrOwner'],
-                teamLogic,
-                ['currentTeam'],
-                featureFlagLogic,
-                ['featureFlags'],
-                pipelineDestinationsLogic({ types: DESTINATION_TYPES }),
-                ['destinations'],
-            ],
-        }
-    }),
+    connect(() => ({
+        values: [
+            billingLogic,
+            ['billing'],
+            billingUsageLogic({
+                initialFilters: { breakdowns: ['type', 'team'] },
+                dateFrom: DEFAULT_BILLING_DATE_FROM, // we set them here so we are sure it will stay fixed to a 1 month period even if the usage logic changes default values
+                dateTo: DEFAULT_BILLING_DATE_TO,
+                dashboardItemId: 'max-billing-context', // This makes it a separate instance, prevents conflicts with the spend logic on the usage page
+            }),
+            ['billingUsageResponse'],
+            billingSpendLogic({
+                initialFilters: { breakdowns: ['type', 'team'] },
+                dateFrom: DEFAULT_BILLING_DATE_FROM, // same here for spend
+                dateTo: DEFAULT_BILLING_DATE_TO,
+                dashboardItemId: 'max-billing-context', // This makes it a separate instance, prevents conflicts with the spend logic on the spend page
+            }),
+            ['billingSpendResponse'],
+            organizationLogic,
+            ['isAdminOrOwner'],
+            teamLogic,
+            ['currentTeam'],
+            featureFlagLogic,
+            ['featureFlags'],
+            pipelineDestinationsLogic({ types: DESTINATION_TYPES }),
+            ['destinations'],
+        ],
+    })),
     selectors({
         billingContext: [
             (s: any) => [


### PR DESCRIPTION
## Problem

- Billing usage/spend logics were interfering with URL params on non-billing pages
- Since Max queries usage and spend, and the usage/spend logics read url params, they would read web analytics params and try to sync their own params to the URL (and since the param formatting is different, it would lead to errors)
  - See ticket here: https://posthoghelp.zendesk.com/agent/tickets/35377 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/40756)

## Changes

- Added `syncWithUrl` prop to usage/spend logics that defaults to false for safety
- Only billing pages explicitly set `syncWithUrl: true` to enable URL synchronization
- Sidebar instances (via `maxBillingContextLogic`)
  - Use default false and stay isolated from URLs
  - Now have `dashboardItemId` defined to ensure they're separate instances

## How did you test this code?

Manually
- Reproduced the issues user was facing on master
- Implemented a fix and tested the same scenario as above + tested regular usage/spend dashboard usage