### PR TITLE
chore: tighten rate limit again

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -413,8 +413,8 @@ class SourceVaryingSnapshotThrottle(PersonalApiKeyRateThrottle):
         num_requests, duration = self.parse_rate(self.get_rate())
 
         divisors = {
-            "realtime": 8,
-            "blob": 4,
+            "realtime": 32,
+            "blob": 24,
             "blob_v2": 1,
         }
 


### PR DESCRIPTION
folk are still using blob v1... let's tighten the rate limit even more to incentivise the work to transfer