### PR TITLE
fix(max): fix issues with sql editor

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -537,8 +537,6 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
         setSuggestedQueryInput: ({ suggestedQueryInput, source }) => {
             // If there's no active tab, create one first to ensure Monaco Editor is available
             if (!values.activeModelUri || values.allTabs.length === 0) {
-                // Create a new tab with the suggested query and then return early
-                // The tab creation will handle setting up Monaco Editor properly
                 actions.createTab(suggestedQueryInput)
                 return
             }

--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -535,6 +535,14 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
             }
         },
         setSuggestedQueryInput: ({ suggestedQueryInput, source }) => {
+            // If there's no active tab, create one first to ensure Monaco Editor is available
+            if (!values.activeModelUri || values.allTabs.length === 0) {
+                // Create a new tab with the suggested query and then return early
+                // The tab creation will handle setting up Monaco Editor properly
+                actions.createTab(suggestedQueryInput)
+                return
+            }
+
             if (values.queryInput) {
                 actions._setSuggestionPayload({
                     suggestedValue: suggestedQueryInput,


### PR DESCRIPTION
## Problem
While going through Zendesk the following issue appeared while the user asked for the SQL generation. I saw this appearing in another session too. ~Sadly, I cannot reproduce neither in prod or local. But maybe adding more defensive checks for it might avoid it~ The logs also pinpoint to the SQL editor being the issue. 

Session: https://us.posthog.com/project/sTMFPsFhdP1Ssg/replay/01985b80-3af2-701f-985c-b237d793bb89?t=2561
Exceptions: https://us.posthog.com/project/2/error_tracking?filterGroup=%7B%22type%22%3A%22AND%22%2C%22values%22%3A%5B%7B%22type%22%3A%22AND%22%2C%22values%22%3A%5B%7B%22key%22%3A%22%24session_id%22%2C%22value%22%3A%5B%2201985b80-3af2-701f-985c-b237d793bb89%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22event%22%7D%5D%7D%5D%7D


other issue:

Session: https://us.posthog.com/project/sTMFPsFhdP1Ssg/replay/019898dc-4987-79e4-a5b5-1b196563b8df?t=2083
Exceptions: https://us.posthog.com/project/2/error_tracking?filterGroup=%7B%22type%22%3A%22AND%22%2C%22values%22%3A%5B%7B%22type%22%3A%22AND%22%2C%22values%22%3A%5B%7B%22key%22%3A%22%24session_id%22%2C%22value%22%3A%5B%22019898dc-4987-79e4-a5b5-1b196563b8df%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22event%22%7D%5D%7D%5D%7D


## Changes
1. Create the SQL tab if it does not exist before we set the suggested query

##
👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
