### PR TITLE
refactor(max): Properly handle empty reasoning summaries

### DIFF
--- a/ee/hogai/assistant.py
+++ b/ee/hogai/assistant.py
@@ -546,10 +546,15 @@ class Assistant:
     def _chunk_reasoning_headline(self, reasoning: dict[str, Any]) -> Optional[str]:
         """Process a chunk of OpenAI `reasoning`, and if a new headline was just finalized, return it."""
         try:
-            summary_text_chunk = reasoning["summary"][0]["text"]
-        except (KeyError, IndexError) as e:
-            capture_exception(e)
-            self._reasoning_headline_chunk = None  # not expected, so let's just reset
+            if summary := reasoning.get("summary"):
+                summary_text_chunk = summary[0]["text"]
+            else:
+                self._reasoning_headline_chunk = None  # Reset as we don't have any summary yet
+                return None
+        except Exception as e:
+            logger.exception("Error in chunk_reasoning_headline", error=e)
+            capture_exception(e)  # not expected, so let's capture
+            self._reasoning_headline_chunk = None
             return None
 
         bold_marker_index = summary_text_chunk.find("**")

--- a/ee/hogai/graph/title_generator/nodes.py
+++ b/ee/hogai/graph/title_generator/nodes.py
@@ -7,6 +7,7 @@ from ee.hogai.graph.base import AssistantNode
 from ee.hogai.graph.title_generator.prompts import TITLE_GENERATION_PROMPT
 from ee.hogai.utils.helpers import find_last_message_of_type
 from ee.hogai.utils.types import AssistantState, PartialAssistantState
+from ee.models.assistant import Conversation
 from posthog.schema import HumanMessage
 
 
@@ -28,7 +29,7 @@ class TitleGeneratorNode(AssistantNode):
 
         title = runnable.invoke({"user_input": human_message.content}, config=config)
 
-        conversation.title = title
+        conversation.title = title[: Conversation.TITLE_MAX_LENGTH]
         conversation.save()
 
         return None

--- a/ee/hogai/graph/title_generator/nodes.py
+++ b/ee/hogai/graph/title_generator/nodes.py
@@ -29,7 +29,7 @@ class TitleGeneratorNode(AssistantNode):
 
         title = runnable.invoke({"user_input": human_message.content}, config=config)
 
-        conversation.title = title[: Conversation.TITLE_MAX_LENGTH]
+        conversation.title = title[: Conversation.TITLE_MAX_LENGTH].strip()
         conversation.save()
 
         return None

--- a/ee/hogai/graph/title_generator/test/test_title_generator.py
+++ b/ee/hogai/graph/title_generator/test/test_title_generator.py
@@ -32,7 +32,7 @@ class TestTitleGenerator(BaseTest):
             self.assertEqual(self.conversation.title, "Test Title")
 
     def test_saves_a_long_title_truncated(self):
-        """Test that if a title over our legnth is generated, it is truncated on save, without error."""
+        """Test that if a title over our length is generated, it is truncated on save, without error."""
         with patch(
             "ee.hogai.graph.title_generator.nodes.TitleGeneratorNode._model",
             return_value=FakeChatOpenAI(responses=[LangchainAIMessage(content=("Long " * 100).strip())]),

--- a/ee/hogai/graph/title_generator/test/test_title_generator.py
+++ b/ee/hogai/graph/title_generator/test/test_title_generator.py
@@ -31,6 +31,25 @@ class TestTitleGenerator(BaseTest):
             self.conversation.refresh_from_db()
             self.assertEqual(self.conversation.title, "Test Title")
 
+    def test_saves_a_long_title_truncated(self):
+        """Test that if a title over our legnth is generated, it is truncated on save, without error."""
+        with patch(
+            "ee.hogai.graph.title_generator.nodes.TitleGeneratorNode._model",
+            return_value=FakeChatOpenAI(responses=[LangchainAIMessage(content=("Long " * 100).strip())]),
+        ):
+            node = TitleGeneratorNode(self.team, self.user)
+            new_state = node.run(
+                AssistantState(messages=[HumanMessage(content="Test Message")]),
+                {"configurable": {"thread_id": self.conversation.id}},
+            )
+            self.assertIsNone(new_state)
+            # Refresh from DB to ensure we get latest value
+            self.conversation.refresh_from_db()
+            self.assertEqual(
+                self.conversation.title,
+                "Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long",
+            )
+
     def test_title_already_set_should_stay_the_same(self):
         """Test that existing conversation titles are not overwritten."""
         self.conversation.title = "Existing Title"

--- a/ee/models/assistant.py
+++ b/ee/models/assistant.py
@@ -9,6 +9,8 @@ from posthog.models.utils import UUIDModel
 
 
 class Conversation(UUIDModel):
+    TITLE_MAX_LENGTH = 250
+
     class Meta:
         indexes = [
             models.Index(fields=["updated_at"]),
@@ -29,7 +31,7 @@ class Conversation(UUIDModel):
     updated_at = models.DateTimeField(auto_now=True, null=True)
     status = models.CharField(max_length=20, choices=Status.choices, default=Status.IDLE)
     type = models.CharField(max_length=20, choices=Type.choices, default=Type.ASSISTANT)
-    title = models.CharField(null=True, blank=True, help_text="Title of the conversation.", max_length=250)
+    title = models.CharField(null=True, blank=True, help_text="Title of the conversation.", max_length=TITLE_MAX_LENGTH)
 
 
 class ConversationCheckpoint(UUIDModel):


### PR DESCRIPTION
## Problem

Looking at `hogai` errors, we throw a lot of these IndexErrors:
https://us.posthog.com/project/2/error_tracking/019860b8-1fc9-7d11-a0a2-dcd1dfe15240

They're harmless, since handled, but confusing to see raised. We should just handle this case normally.

Also some a few rare errors where the title generator output more than 250 characters – not seeing why exactly.

## Changes

We now have an `if/else` branch for empty reasoning summaries. And `conversation.title` is truncated.

## How did you test this code?

Should just continue to work. (For the title length case, added a small test.)