### PR TITLE
fix(tabs): support multiple instances of the same logic

### DIFF
--- a/frontend/src/layout/scenes/sceneTabsLogic.tsx
+++ b/frontend/src/layout/scenes/sceneTabsLogic.tsx
@@ -1,4 +1,4 @@
-import { actions, connect, kea, listeners, reducers, path, afterMount } from 'kea'
+import { actions, connect, kea, listeners, reducers, path, afterMount, selectors } from 'kea'
 import { combineUrl, router } from 'kea-router'
 import { subscriptions } from 'kea-subscriptions'
 import { breadcrumbsLogic } from '~/layout/navigation/Breadcrumbs/breadcrumbsLogic'
@@ -7,6 +7,7 @@ import { arrayMove } from '@dnd-kit/sortable'
 import type { sceneTabsLogicType } from './sceneTabsLogicType'
 import { addProjectIdIfMissing } from 'lib/utils/router-utils'
 import { urls } from 'scenes/urls'
+import { sceneLogic } from 'scenes/sceneLogic'
 
 export interface SceneTab {
     id: string
@@ -37,8 +38,8 @@ const generateTabId = (): string => crypto?.randomUUID?.() ?? `${Date.now()}-${M
 export const sceneTabsLogic = kea<sceneTabsLogicType>([
     path(['layout', 'scenes', 'sceneTabsLogic']),
     connect(() => ({
-        actions: [router, ['locationChanged', 'push']],
-        values: [breadcrumbsLogic, ['title']],
+        actions: [router, ['locationChanged', 'push'], sceneLogic, ['setScene']],
+        values: [breadcrumbsLogic, ['title'], sceneLogic, ['activeSceneLogic']],
     })),
     actions({
         setTabs: (tabs: SceneTab[]) => ({ tabs }),
@@ -105,7 +106,27 @@ export const sceneTabsLogic = kea<sceneTabsLogicType>([
             },
         ],
     }),
-    listeners(({ values, actions }) => ({
+    selectors({
+        activeTab: [
+            (s) => [s.tabs],
+            (tabs: SceneTab[]): SceneTab | null => {
+                return tabs.find((tab) => tab.active) || null
+            },
+        ],
+        tabIds: [
+            (s) => [s.tabs],
+            (tabs: SceneTab[]): Record<string, boolean> => {
+                return tabs.reduce(
+                    (acc, tab) => {
+                        acc[tab.id] = true
+                        return acc
+                    },
+                    {} as Record<string, boolean>
+                )
+            },
+        ],
+    }),
+    listeners(({ values, actions, cache }) => ({
         setTabs: () => persistTabs(values.tabs),
         newTab: () => {
             persistTabs(values.tabs)
@@ -114,7 +135,7 @@ export const sceneTabsLogic = kea<sceneTabsLogicType>([
         activateTab: () => persistTabs(values.tabs),
         removeTab: ({ tab }) => {
             if (tab.active) {
-                const activeTab = values.tabs.find((tab) => tab.active)
+                const { activeTab } = values
                 if (activeTab) {
                     router.actions.push(activeTab.pathname, activeTab.search, activeTab.hash)
                 } else {
@@ -187,6 +208,24 @@ export const sceneTabsLogic = kea<sceneTabsLogicType>([
             }
             persistTabs(values.tabs)
         },
+        setScene: ({ loadedScene, params }) => {
+            if (!cache.mountedTabLogic) {
+                cache.mountedTabLogic = {} as Record<string, () => void>
+            }
+            const activeTabId = values.activeTab?.id
+            if (!activeTabId) {
+                console.warn('No active tab found when setting scene logic')
+                return
+            }
+            const unmount = cache.mountedTabLogic[activeTabId]
+            if (unmount) {
+                window.setTimeout(unmount, 50)
+                delete cache.mountedTabLogic[activeTabId]
+            }
+            if (loadedScene?.logic) {
+                cache.mountedTabLogic[activeTabId] = loadedScene?.logic(loadedScene?.paramsToProps?.(params)).mount()
+            }
+        },
     })),
     subscriptions(({ actions, values, cache }) => ({
         title: (title) => {
@@ -220,6 +259,24 @@ export const sceneTabsLogic = kea<sceneTabsLogicType>([
             // When the title changes, trigger a history REPLACE event to persist the new title in the browser
             const { currentLocation } = router.values
             router.actions.replace(currentLocation.pathname, currentLocation.search, currentLocation.hash)
+        },
+        tabs: (tabs) => {
+            const tabIds = tabs.reduce(
+                (acc: Record<string, boolean>, tab: SceneTab) => {
+                    acc[tab.id] = true
+                    return acc
+                },
+                {} as Record<string, boolean>
+            )
+            for (const id of Object.keys(cache.mountedTabLogic)) {
+                if (!tabIds[id]) {
+                    const mountedTabLogic = cache.mountedTabLogic[id]
+                    if (mountedTabLogic) {
+                        mountedTabLogic.unmount()
+                    }
+                    delete cache.mountedTabLogic[id]
+                }
+            }
         },
     })),
     afterMount(({ actions, cache, values }) => {

--- a/frontend/src/layout/scenes/sceneTabsLogic.tsx
+++ b/frontend/src/layout/scenes/sceneTabsLogic.tsx
@@ -272,7 +272,11 @@ export const sceneTabsLogic = kea<sceneTabsLogicType>([
                 if (!tabIds[id]) {
                     const mountedTabLogic = cache.mountedTabLogic[id]
                     if (mountedTabLogic) {
-                        mountedTabLogic.unmount()
+                        try {
+                            mountedTabLogic.unmount()
+                        } catch (error) {
+                            console.error('Error unmounting tab logic:', error)
+                        }
                     }
                     delete cache.mountedTabLogic[id]
                 }

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -92,11 +92,18 @@ export const sceneLogic = kea<sceneLogicType>([
             method,
         }),
         // 3. Set the `scene` reducer
-        setScene: (scene: string, sceneKey: string | null, params: SceneParams, scrollToTop: boolean = false) => ({
+        setScene: (
+            scene: string,
+            sceneKey: string | null,
+            params: SceneParams,
+            scrollToTop: boolean = false,
+            loadedScene?: LoadedScene
+        ) => ({
             scene,
             sceneKey,
             params,
             scrollToTop,
+            loadedScene,
         }),
         setLoadedScene: (loadedScene: LoadedScene) => ({
             loadedScene,
@@ -337,12 +344,12 @@ export const sceneLogic = kea<sceneLogicType>([
         loadScene: async ({ scene, sceneKey, params, method }, breakpoint) => {
             const clickedLink = method === 'PUSH'
             if (values.scene === scene) {
-                actions.setScene(scene, sceneKey, params, clickedLink)
+                actions.setScene(scene, sceneKey, params, clickedLink, values.loadedScenes[scene])
                 return
             }
 
             if (!props.scenes?.[scene]) {
-                actions.setScene(Scene.Error404, null, emptySceneParams, clickedLink)
+                actions.setScene(Scene.Error404, null, emptySceneParams, clickedLink, values.loadedScenes[scene])
                 return
             }
 
@@ -420,7 +427,7 @@ export const sceneLogic = kea<sceneLogicType>([
                     }
                 }
             }
-            actions.setScene(scene, sceneKey, params, clickedLink || wasNotLoaded)
+            actions.setScene(scene, sceneKey, params, clickedLink || wasNotLoaded, loadedScene)
         },
         reloadBrowserDueToImportError: () => {
             window.location.reload()


### PR DESCRIPTION
## Problem

You could not open two dashboards in two tabs --> only the latest would persist, and things would reload whenever you clicked around.

## Changes

![2025-08-04 11 44 36](https://github.com/user-attachments/assets/8c13d6fb-78a9-4f0e-a7eb-eb60af01ddd0)

Now you can

## How did you test this code?

Clicked around locally