### PR TITLE
chore(max): Make thinking message static in UI snapshots

### DIFF
--- a/frontend/src/scenes/max/utils/thinkingMessages.ts
+++ b/frontend/src/scenes/max/utils/thinkingMessages.ts
@@ -88,7 +88,9 @@ export const THINKING_MESSAGES = [
 ]
 
 export const getRandomThinkingMessage = (): string => {
-    if (inStorybookTestRunner()) return 'Thinking'
+    if (inStorybookTestRunner()) {
+        return 'Thinking'
+    }
     const randomIndex = Math.floor(Math.random() * THINKING_MESSAGES.length)
     return THINKING_MESSAGES[randomIndex]
 }

--- a/frontend/src/scenes/max/utils/thinkingMessages.ts
+++ b/frontend/src/scenes/max/utils/thinkingMessages.ts
@@ -1,3 +1,5 @@
+import { inStorybookTestRunner } from 'lib/utils'
+
 export const THINKING_MESSAGES = [
     'Booping', // playful interaction
     'Crunching', // data in progress
@@ -86,6 +88,7 @@ export const THINKING_MESSAGES = [
 ]
 
 export const getRandomThinkingMessage = (): string => {
+    if (inStorybookTestRunner()) return 'Thinking'
     const randomIndex = Math.floor(Math.random() * THINKING_MESSAGES.length)
     return THINKING_MESSAGES[randomIndex]
 }


### PR DESCRIPTION
## Problem

`getRandomThinkingMessage` returns a random string, which causes flaky snapshot tests in the Storybook test runner environment. This leads to inconsistent CI results and unreliable tests for developers.

## Changes

To prevent flakiness, `getRandomThinkingMessage` now always returns `'Thinking'` when executed within the Storybook test runner. This was achieved by:
*   Importing `inStorybookTestRunner` from `lib/utils`.
*   Adding `if (inStorybookTestRunner()) return 'Thinking'` at the beginning of the `getRandomThinkingMessage` function.

## How did you test this code?

This change directly addresses flakiness in Storybook snapshot tests. The expected outcome is that relevant snapshot tests will now be stable and pass consistently when run in the Storybook test runner.

---
[Slack Thread](https://posthog.slack.com/archives/C06NZEZ7V3Q/p1754303336033399?thread_ts=1754303336.033399&cid=C06NZEZ7V3Q)

<a href="https://cursor.com/background-agent?bcId=bc-ceccf89a-5601-4bc3-ba2d-821f31f669a1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ceccf89a-5601-4bc3-ba2d-821f31f669a1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>