### PR TITLE
chore: update kea to 3.1.6

### DIFF
--- a/frontend/@posthog/lemon-ui/package.json
+++ b/frontend/@posthog/lemon-ui/package.json
@@ -13,7 +13,7 @@
         "prepublishOnly": "pnpm build"
     },
     "dependencies": {
-        "kea": "^3.1.5",
+        "kea": "^3.1.6",
         "kea-router": "^3.4.0"
     },
     "devDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -158,7 +158,7 @@
         "husky": "^7.0.4",
         "idb": "^8.0.3",
         "image-blob-reduce": "^4.1.0",
-        "kea": "^3.1.5",
+        "kea": "^3.1.6",
         "kea-forms": "^3.2.0",
         "kea-loaders": "^3.1.1",
         "kea-localstorage": "^3.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -812,32 +812,32 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       kea:
-        specifier: ^3.1.5
-        version: 3.1.5(react@18.2.0)
+        specifier: ^3.1.6
+        version: 3.1.6(react@18.2.0)
       kea-forms:
         specifier: ^3.2.0
-        version: 3.2.0(kea@3.1.5(react@18.2.0))
+        version: 3.2.0(kea@3.1.6(react@18.2.0))
       kea-loaders:
         specifier: ^3.1.1
-        version: 3.1.1(kea@3.1.5(react@18.2.0))
+        version: 3.1.1(kea@3.1.6(react@18.2.0))
       kea-localstorage:
         specifier: ^3.1.0
-        version: 3.1.0(kea@3.1.5(react@18.2.0))
+        version: 3.1.0(kea@3.1.6(react@18.2.0))
       kea-router:
         specifier: ^3.4.0
-        version: 3.4.0(kea@3.1.5(react@18.2.0))
+        version: 3.4.0(kea@3.1.6(react@18.2.0))
       kea-subscriptions:
         specifier: ^3.0.1
-        version: 3.0.1(kea@3.1.5(react@18.2.0))
+        version: 3.0.1(kea@3.1.6(react@18.2.0))
       kea-test-utils:
         specifier: ^0.2.4
-        version: 0.2.4(kea@3.1.5(react@18.2.0))
+        version: 0.2.4(kea@3.1.6(react@18.2.0))
       kea-waitfor:
         specifier: ^0.2.1
-        version: 0.2.1(kea@3.1.5(react@18.2.0))
+        version: 0.2.1(kea@3.1.6(react@18.2.0))
       kea-window-values:
         specifier: ^3.0.0
-        version: 3.0.0(kea@3.1.5(react@18.2.0))
+        version: 3.0.0(kea@3.1.6(react@18.2.0))
       liquidjs:
         specifier: ^10.21.1
         version: 10.21.1
@@ -1595,14 +1595,14 @@ importers:
         specifier: '*'
         version: 6.6.2
       kea:
-        specifier: ^3.1.5
-        version: 3.1.5(react@18.2.0)
+        specifier: ^3.1.6
+        version: 3.1.6(react@18.2.0)
       kea-loaders:
         specifier: ^3.1.1
-        version: 3.1.1(kea@3.1.5(react@18.2.0))
+        version: 3.1.1(kea@3.1.6(react@18.2.0))
       kea-router:
         specifier: ^3.4.0
-        version: 3.4.0(kea@3.1.5(react@18.2.0))
+        version: 3.4.0(kea@3.1.6(react@18.2.0))
       react:
         specifier: '*'
         version: 18.2.0
@@ -1622,14 +1622,14 @@ importers:
         specifier: '*'
         version: 6.6.2
       kea:
-        specifier: ^3.1.5
-        version: 3.1.5(react@18.2.0)
+        specifier: ^3.1.6
+        version: 3.1.6(react@18.2.0)
       kea-loaders:
         specifier: ^3.1.1
-        version: 3.1.1(kea@3.1.5(react@18.2.0))
+        version: 3.1.1(kea@3.1.6(react@18.2.0))
       kea-router:
         specifier: ^3.4.0
-        version: 3.4.0(kea@3.1.5(react@18.2.0))
+        version: 3.4.0(kea@3.1.6(react@18.2.0))
       react:
         specifier: '*'
         version: 18.2.0
@@ -1649,14 +1649,14 @@ importers:
         specifier: '*'
         version: 6.6.2
       kea:
-        specifier: ^3.1.5
-        version: 3.1.5(react@18.2.0)
+        specifier: ^3.1.6
+        version: 3.1.6(react@18.2.0)
       kea-loaders:
         specifier: ^3.1.1
-        version: 3.1.1(kea@3.1.5(react@18.2.0))
+        version: 3.1.1(kea@3.1.6(react@18.2.0))
       kea-router:
         specifier: ^3.4.0
-        version: 3.4.0(kea@3.1.5(react@18.2.0))
+        version: 3.4.0(kea@3.1.6(react@18.2.0))
       react:
         specifier: '*'
         version: 18.2.0
@@ -1676,17 +1676,17 @@ importers:
         specifier: '*'
         version: 1.2.1
       kea:
-        specifier: ^3.1.5
-        version: 3.1.5(react@18.2.0)
+        specifier: ^3.1.6
+        version: 3.1.6(react@18.2.0)
       kea-forms:
         specifier: ^3.2.0
-        version: 3.2.0(kea@3.1.5(react@18.2.0))
+        version: 3.2.0(kea@3.1.6(react@18.2.0))
       kea-loaders:
         specifier: ^3.1.1
-        version: 3.1.1(kea@3.1.5(react@18.2.0))
+        version: 3.1.1(kea@3.1.6(react@18.2.0))
       kea-router:
         specifier: ^3.4.0
-        version: 3.4.0(kea@3.1.5(react@18.2.0))
+        version: 3.4.0(kea@3.1.6(react@18.2.0))
       react:
         specifier: '*'
         version: 18.2.0
@@ -1736,20 +1736,20 @@ importers:
         specifier: '*'
         version: 6.6.2
       kea:
-        specifier: ^3.1.5
-        version: 3.1.5(react@18.2.0)
+        specifier: ^3.1.6
+        version: 3.1.6(react@18.2.0)
       kea-forms:
         specifier: ^3.2.0
-        version: 3.2.0(kea@3.1.5(react@18.2.0))
+        version: 3.2.0(kea@3.1.6(react@18.2.0))
       kea-loaders:
         specifier: ^3.1.1
-        version: 3.1.1(kea@3.1.5(react@18.2.0))
+        version: 3.1.1(kea@3.1.6(react@18.2.0))
       kea-router:
         specifier: ^3.4.0
-        version: 3.4.0(kea@3.1.5(react@18.2.0))
+        version: 3.4.0(kea@3.1.6(react@18.2.0))
       kea-subscriptions:
         specifier: ^3.0.1
-        version: 3.0.1(kea@3.1.5(react@18.2.0))
+        version: 3.0.1(kea@3.1.6(react@18.2.0))
       posthog-js:
         specifier: 1.258.5
         version: 1.258.5(@rrweb/types@2.0.0-alpha.17)
@@ -1784,14 +1784,14 @@ importers:
         specifier: '*'
         version: 6.6.2
       kea:
-        specifier: ^3.1.5
-        version: 3.1.5(react@18.2.0)
+        specifier: ^3.1.6
+        version: 3.1.6(react@18.2.0)
       kea-loaders:
         specifier: ^3.1.1
-        version: 3.1.1(kea@3.1.5(react@18.2.0))
+        version: 3.1.1(kea@3.1.6(react@18.2.0))
       kea-router:
         specifier: ^3.4.0
-        version: 3.4.0(kea@3.1.5(react@18.2.0))
+        version: 3.4.0(kea@3.1.6(react@18.2.0))
       react:
         specifier: '*'
         version: 18.2.0
@@ -1811,14 +1811,14 @@ importers:
         specifier: '*'
         version: 6.6.2
       kea:
-        specifier: ^3.1.5
-        version: 3.1.5(react@18.2.0)
+        specifier: ^3.1.6
+        version: 3.1.6(react@18.2.0)
       kea-loaders:
         specifier: ^3.1.1
-        version: 3.1.1(kea@3.1.5(react@18.2.0))
+        version: 3.1.1(kea@3.1.6(react@18.2.0))
       kea-router:
         specifier: ^3.4.0
-        version: 3.4.0(kea@3.1.5(react@18.2.0))
+        version: 3.4.0(kea@3.1.6(react@18.2.0))
       react:
         specifier: '*'
         version: 18.2.0
@@ -1838,14 +1838,14 @@ importers:
         specifier: '*'
         version: 6.6.2
       kea:
-        specifier: ^3.1.5
-        version: 3.1.5(react@18.2.0)
+        specifier: ^3.1.6
+        version: 3.1.6(react@18.2.0)
       kea-loaders:
         specifier: ^3.1.1
-        version: 3.1.1(kea@3.1.5(react@18.2.0))
+        version: 3.1.1(kea@3.1.6(react@18.2.0))
       kea-router:
         specifier: ^3.4.0
-        version: 3.4.0(kea@3.1.5(react@18.2.0))
+        version: 3.4.0(kea@3.1.6(react@18.2.0))
       react:
         specifier: '*'
         version: 18.2.0
@@ -1865,14 +1865,14 @@ importers:
         specifier: '*'
         version: 6.6.2
       kea:
-        specifier: ^3.1.5
-        version: 3.1.5(react@18.2.0)
+        specifier: ^3.1.6
+        version: 3.1.6(react@18.2.0)
       kea-loaders:
         specifier: ^3.1.1
-        version: 3.1.1(kea@3.1.5(react@18.2.0))
+        version: 3.1.1(kea@3.1.6(react@18.2.0))
       kea-router:
         specifier: ^3.4.0
-        version: 3.4.0(kea@3.1.5(react@18.2.0))
+        version: 3.4.0(kea@3.1.6(react@18.2.0))
       react:
         specifier: '*'
         version: 18.2.0
@@ -1892,17 +1892,17 @@ importers:
         specifier: '*'
         version: 1.2.1
       kea:
-        specifier: ^3.1.5
-        version: 3.1.5(react@18.2.0)
+        specifier: ^3.1.6
+        version: 3.1.6(react@18.2.0)
       kea-forms:
         specifier: ^3.2.0
-        version: 3.2.0(kea@3.1.5(react@18.2.0))
+        version: 3.2.0(kea@3.1.6(react@18.2.0))
       kea-loaders:
         specifier: ^3.1.1
-        version: 3.1.1(kea@3.1.5(react@18.2.0))
+        version: 3.1.1(kea@3.1.6(react@18.2.0))
       kea-router:
         specifier: ^3.4.0
-        version: 3.4.0(kea@3.1.5(react@18.2.0))
+        version: 3.4.0(kea@3.1.6(react@18.2.0))
       qrcode.react:
         specifier: ^4.2.0
         version: 4.2.0(react@18.2.0)
@@ -1934,14 +1934,14 @@ importers:
         specifier: '*'
         version: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
       kea:
-        specifier: ^3.1.5
-        version: 3.1.5(react@18.2.0)
+        specifier: ^3.1.6
+        version: 3.1.6(react@18.2.0)
       kea-loaders:
         specifier: ^3.1.1
-        version: 3.1.1(kea@3.1.5(react@18.2.0))
+        version: 3.1.1(kea@3.1.6(react@18.2.0))
       kea-router:
         specifier: ^3.4.0
-        version: 3.4.0(kea@3.1.5(react@18.2.0))
+        version: 3.4.0(kea@3.1.6(react@18.2.0))
       prettier:
         specifier: '*'
         version: 3.4.2
@@ -1988,14 +1988,14 @@ importers:
         specifier: '*'
         version: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
       kea:
-        specifier: ^3.1.5
-        version: 3.1.5(react@18.2.0)
+        specifier: ^3.1.6
+        version: 3.1.6(react@18.2.0)
       kea-loaders:
         specifier: ^3.1.1
-        version: 3.1.1(kea@3.1.5(react@18.2.0))
+        version: 3.1.1(kea@3.1.6(react@18.2.0))
       kea-router:
         specifier: ^3.4.0
-        version: 3.4.0(kea@3.1.5(react@18.2.0))
+        version: 3.4.0(kea@3.1.6(react@18.2.0))
       prettier:
         specifier: '*'
         version: 3.4.2
@@ -2019,22 +2019,22 @@ importers:
         version: 0.26.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@posthog/lemon-ui':
         specifier: '*'
-        version: 0.0.0(antd@5.26.0(date-fns@2.30.0)(luxon@3.5.0)(moment@2.29.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(kea-router@3.4.0(kea@3.1.5(react@18.2.0)))(kea@3.1.5(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 0.0.0(antd@5.26.0(date-fns@2.30.0)(luxon@3.5.0)(moment@2.29.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(kea-router@3.4.0(kea@3.1.6(react@18.2.0)))(kea@3.1.6(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
       kea:
-        specifier: ^3.1.5
-        version: 3.1.5(react@18.2.0)
+        specifier: ^3.1.6
+        version: 3.1.6(react@18.2.0)
       kea-forms:
         specifier: ^3.2.0
-        version: 3.2.0(kea@3.1.5(react@18.2.0))
+        version: 3.2.0(kea@3.1.6(react@18.2.0))
       kea-loaders:
         specifier: ^3.1.1
-        version: 3.1.1(kea@3.1.5(react@18.2.0))
+        version: 3.1.1(kea@3.1.6(react@18.2.0))
       kea-router:
         specifier: ^3.4.0
-        version: 3.4.0(kea@3.1.5(react@18.2.0))
+        version: 3.4.0(kea@3.1.6(react@18.2.0))
       react:
         specifier: '*'
         version: 18.2.0
@@ -2063,20 +2063,20 @@ importers:
         specifier: '*'
         version: 6.6.2
       kea:
-        specifier: ^3.1.5
-        version: 3.1.5(react@18.2.0)
+        specifier: ^3.1.6
+        version: 3.1.6(react@18.2.0)
       kea-forms:
         specifier: ^3.2.0
-        version: 3.2.0(kea@3.1.5(react@18.2.0))
+        version: 3.2.0(kea@3.1.6(react@18.2.0))
       kea-loaders:
         specifier: ^3.1.1
-        version: 3.1.1(kea@3.1.5(react@18.2.0))
+        version: 3.1.1(kea@3.1.6(react@18.2.0))
       kea-router:
         specifier: ^3.4.0
-        version: 3.4.0(kea@3.1.5(react@18.2.0))
+        version: 3.4.0(kea@3.1.6(react@18.2.0))
       kea-subscriptions:
         specifier: ^3.0.1
-        version: 3.0.1(kea@3.1.5(react@18.2.0))
+        version: 3.0.1(kea@3.1.6(react@18.2.0))
       posthog-js:
         specifier: 1.258.5
         version: 1.258.5(@rrweb/types@2.0.0-alpha.17)
@@ -2102,14 +2102,14 @@ importers:
         specifier: '*'
         version: 6.6.2
       kea:
-        specifier: ^3.1.5
-        version: 3.1.5(react@18.2.0)
+        specifier: ^3.1.6
+        version: 3.1.6(react@18.2.0)
       kea-loaders:
         specifier: ^3.1.1
-        version: 3.1.1(kea@3.1.5(react@18.2.0))
+        version: 3.1.1(kea@3.1.6(react@18.2.0))
       kea-router:
         specifier: ^3.4.0
-        version: 3.4.0(kea@3.1.5(react@18.2.0))
+        version: 3.4.0(kea@3.1.6(react@18.2.0))
       react:
         specifier: '*'
         version: 18.2.0
@@ -2129,14 +2129,14 @@ importers:
         specifier: '*'
         version: 6.6.2
       kea:
-        specifier: ^3.1.5
-        version: 3.1.5(react@18.2.0)
+        specifier: ^3.1.6
+        version: 3.1.6(react@18.2.0)
       kea-loaders:
         specifier: ^3.1.1
-        version: 3.1.1(kea@3.1.5(react@18.2.0))
+        version: 3.1.1(kea@3.1.6(react@18.2.0))
       kea-router:
         specifier: ^3.4.0
-        version: 3.4.0(kea@3.1.5(react@18.2.0))
+        version: 3.4.0(kea@3.1.6(react@18.2.0))
       react:
         specifier: '*'
         version: 18.2.0
@@ -2156,14 +2156,14 @@ importers:
         specifier: '*'
         version: 6.6.2
       kea:
-        specifier: ^3.1.5
-        version: 3.1.5(react@18.2.0)
+        specifier: ^3.1.6
+        version: 3.1.6(react@18.2.0)
       kea-loaders:
         specifier: ^3.1.1
-        version: 3.1.1(kea@3.1.5(react@18.2.0))
+        version: 3.1.1(kea@3.1.6(react@18.2.0))
       kea-router:
         specifier: ^3.4.0
-        version: 3.4.0(kea@3.1.5(react@18.2.0))
+        version: 3.4.0(kea@3.1.6(react@18.2.0))
       react:
         specifier: '*'
         version: 18.2.0
@@ -2183,14 +2183,14 @@ importers:
         specifier: '*'
         version: 6.6.2
       kea:
-        specifier: ^3.1.5
-        version: 3.1.5(react@18.2.0)
+        specifier: ^3.1.6
+        version: 3.1.6(react@18.2.0)
       kea-loaders:
         specifier: ^3.1.1
-        version: 3.1.1(kea@3.1.5(react@18.2.0))
+        version: 3.1.1(kea@3.1.6(react@18.2.0))
       kea-router:
         specifier: ^3.4.0
-        version: 3.4.0(kea@3.1.5(react@18.2.0))
+        version: 3.4.0(kea@3.1.6(react@18.2.0))
       react:
         specifier: '*'
         version: 18.2.0
@@ -2210,17 +2210,17 @@ importers:
         specifier: '*'
         version: 1.2.1
       kea:
-        specifier: ^3.1.5
-        version: 3.1.5(react@18.2.0)
+        specifier: ^3.1.6
+        version: 3.1.6(react@18.2.0)
       kea-forms:
         specifier: ^3.2.0
-        version: 3.2.0(kea@3.1.5(react@18.2.0))
+        version: 3.2.0(kea@3.1.6(react@18.2.0))
       kea-loaders:
         specifier: ^3.1.1
-        version: 3.1.1(kea@3.1.5(react@18.2.0))
+        version: 3.1.1(kea@3.1.6(react@18.2.0))
       kea-router:
         specifier: ^3.4.0
-        version: 3.4.0(kea@3.1.5(react@18.2.0))
+        version: 3.4.0(kea@3.1.6(react@18.2.0))
       react:
         specifier: '*'
         version: 18.2.0
@@ -2240,14 +2240,14 @@ importers:
         specifier: '*'
         version: 6.6.2
       kea:
-        specifier: ^3.1.5
-        version: 3.1.5(react@18.2.0)
+        specifier: ^3.1.6
+        version: 3.1.6(react@18.2.0)
       kea-loaders:
         specifier: ^3.1.1
-        version: 3.1.1(kea@3.1.5(react@18.2.0))
+        version: 3.1.1(kea@3.1.6(react@18.2.0))
       kea-router:
         specifier: ^3.4.0
-        version: 3.4.0(kea@3.1.5(react@18.2.0))
+        version: 3.4.0(kea@3.1.6(react@18.2.0))
       react:
         specifier: '*'
         version: 18.2.0
@@ -2264,14 +2264,14 @@ importers:
         specifier: '*'
         version: 1.2.1
       kea:
-        specifier: ^3.1.5
-        version: 3.1.5(react@18.2.0)
+        specifier: ^3.1.6
+        version: 3.1.6(react@18.2.0)
       kea-loaders:
         specifier: ^3.1.1
-        version: 3.1.1(kea@3.1.5(react@18.2.0))
+        version: 3.1.1(kea@3.1.6(react@18.2.0))
       kea-router:
         specifier: ^3.4.0
-        version: 3.4.0(kea@3.1.5(react@18.2.0))
+        version: 3.4.0(kea@3.1.6(react@18.2.0))
       posthog-js:
         specifier: 1.258.5
         version: 1.258.5(@rrweb/types@2.0.0-alpha.17)
@@ -2294,14 +2294,14 @@ importers:
         specifier: '*'
         version: 6.6.2
       kea:
-        specifier: ^3.1.5
-        version: 3.1.5(react@18.2.0)
+        specifier: ^3.1.6
+        version: 3.1.6(react@18.2.0)
       kea-loaders:
         specifier: ^3.1.1
-        version: 3.1.1(kea@3.1.5(react@18.2.0))
+        version: 3.1.1(kea@3.1.6(react@18.2.0))
       kea-router:
         specifier: ^3.4.0
-        version: 3.4.0(kea@3.1.5(react@18.2.0))
+        version: 3.4.0(kea@3.1.6(react@18.2.0))
       react:
         specifier: '*'
         version: 18.2.0
@@ -12374,8 +12374,8 @@ packages:
     peerDependencies:
       kea: '>= 3'
 
-  kea@3.1.5:
-    resolution: {integrity: sha512-jkChXczG+F0Z1DZXeOC93wVVbuRKmGrEE0xxg0odAgrVA9Cn5LqkKN8wktyULAeAbTv/KrTfDpU8xfrPehL6mw==}
+  kea@3.1.6:
+    resolution: {integrity: sha512-EftYkqGyI8hdC8Eo9r6jGtUSxdykNe1L+Cpu+7t/SEWc9f3OPFtNFPF+hdxdYBeZp2Je3EY6BAEQfWhP4mbUPA==}
     peerDependencies:
       react: '>= 16.8'
 
@@ -20522,41 +20522,6 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 22.15.17
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.10.14(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   '@jest/core@29.7.0(ts-node@10.9.1(@swc/core@1.10.14(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))':
     dependencies:
       '@jest/console': 29.7.0
@@ -21929,11 +21894,11 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  '@posthog/lemon-ui@0.0.0(antd@5.26.0(date-fns@2.30.0)(luxon@3.5.0)(moment@2.29.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(kea-router@3.4.0(kea@3.1.5(react@18.2.0)))(kea@3.1.5(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@posthog/lemon-ui@0.0.0(antd@5.26.0(date-fns@2.30.0)(luxon@3.5.0)(moment@2.29.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(kea-router@3.4.0(kea@3.1.6(react@18.2.0)))(kea@3.1.6(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       antd: 5.26.0(date-fns@2.30.0)(luxon@3.5.0)(moment@2.29.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      kea: 3.1.5(react@18.2.0)
-      kea-router: 3.4.0(kea@3.1.5(react@18.2.0))
+      kea: 3.1.6(react@18.2.0)
+      kea-router: 3.4.0(kea@3.1.6(react@18.2.0))
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
@@ -22027,7 +21992,7 @@ snapshots:
 
   '@radix-ui/react-arrow@1.0.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.24.0
+      '@babel/runtime': 7.28.2
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -22680,7 +22645,7 @@ snapshots:
 
   '@radix-ui/react-toggle@1.0.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.24.0
+      '@babel/runtime': 7.28.2
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.3.23)(react@18.2.0)
@@ -22768,7 +22733,7 @@ snapshots:
 
   '@radix-ui/react-use-escape-keydown@1.0.3(@types/react@18.3.23)(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.24.0
+      '@babel/runtime': 7.28.2
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.3.23)(react@18.2.0)
       react: 18.2.0
     optionalDependencies:
@@ -22816,7 +22781,7 @@ snapshots:
 
   '@radix-ui/react-use-rect@1.0.1(@types/react@18.3.23)(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.24.0
+      '@babel/runtime': 7.28.2
       '@radix-ui/rect': 1.0.1
       react: 18.2.0
     optionalDependencies:
@@ -22838,7 +22803,7 @@ snapshots:
 
   '@radix-ui/react-use-size@1.0.1(@types/react@18.3.23)(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.24.0
+      '@babel/runtime': 7.28.2
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.3.23)(react@18.2.0)
       react: 18.2.0
     optionalDependencies:
@@ -22870,7 +22835,7 @@ snapshots:
 
   '@radix-ui/rect@1.0.1':
     dependencies:
-      '@babel/runtime': 7.24.0
+      '@babel/runtime': 7.28.2
 
   '@radix-ui/rect@1.1.0': {}
 
@@ -22994,11 +22959,11 @@ snapshots:
 
   '@remirror/core-constants@2.0.0':
     dependencies:
-      '@babel/runtime': 7.24.0
+      '@babel/runtime': 7.28.2
 
   '@remirror/core-helpers@2.0.1':
     dependencies:
-      '@babel/runtime': 7.24.0
+      '@babel/runtime': 7.28.2
       '@linaria/core': 3.0.0-beta.13
       '@remirror/core-constants': 2.0.0
       '@remirror/types': 1.0.0
@@ -24509,7 +24474,7 @@ snapshots:
       commander: 9.4.1
       expect-playwright: 0.8.0
       glob: 10.4.5
-      jest: 29.7.0
+      jest: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.10.14(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-junit: 16.0.0
@@ -27360,21 +27325,6 @@ snapshots:
       ripemd160: 2.0.2
       safe-buffer: 5.2.1
       sha.js: 2.4.11
-
-  create-jest@29.7.0:
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.10.14(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
 
   create-jest@29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.10.14(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2)):
     dependencies:
@@ -30359,25 +30309,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0:
-    dependencies:
-      '@jest/core': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0
-      exit: 0.1.2
-      import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.10.14(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-cli@29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.10.14(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.10.14(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
@@ -30592,7 +30523,7 @@ snapshots:
   jest-playwright-preset@4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0):
     dependencies:
       expect-playwright: 0.8.0
-      jest: 29.7.0
+      jest: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.10.14(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-process-manager: 0.4.0
@@ -30750,7 +30681,7 @@ snapshots:
     dependencies:
       ansi-escapes: 6.0.0
       chalk: 5.4.1
-      jest: 29.7.0
+      jest: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.10.14(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -30780,18 +30711,6 @@ snapshots:
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
-
-  jest@29.7.0:
-    dependencies:
-      '@jest/core': 29.7.0
-      '@jest/types': 29.6.3
-      import-local: 3.1.0
-      jest-cli: 29.7.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
 
   jest@29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.10.14(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2)):
     dependencies:
@@ -30980,31 +30899,31 @@ snapshots:
 
   kdbush@4.0.2: {}
 
-  kea-forms@3.2.0(kea@3.1.5(react@18.2.0)):
+  kea-forms@3.2.0(kea@3.1.6(react@18.2.0)):
     dependencies:
-      kea: 3.1.5(react@18.2.0)
+      kea: 3.1.6(react@18.2.0)
 
-  kea-loaders@3.1.1(kea@3.1.5(react@18.2.0)):
+  kea-loaders@3.1.1(kea@3.1.6(react@18.2.0)):
     dependencies:
-      kea: 3.1.5(react@18.2.0)
+      kea: 3.1.6(react@18.2.0)
 
-  kea-localstorage@3.1.0(kea@3.1.5(react@18.2.0)):
+  kea-localstorage@3.1.0(kea@3.1.6(react@18.2.0)):
     dependencies:
-      kea: 3.1.5(react@18.2.0)
+      kea: 3.1.6(react@18.2.0)
 
-  kea-router@3.4.0(kea@3.1.5(react@18.2.0)):
+  kea-router@3.4.0(kea@3.1.6(react@18.2.0)):
     dependencies:
-      kea: 3.1.5(react@18.2.0)
+      kea: 3.1.6(react@18.2.0)
       url-pattern: 1.0.3
 
-  kea-subscriptions@3.0.1(kea@3.1.5(react@18.2.0)):
+  kea-subscriptions@3.0.1(kea@3.1.6(react@18.2.0)):
     dependencies:
-      kea: 3.1.5(react@18.2.0)
+      kea: 3.1.6(react@18.2.0)
 
-  kea-test-utils@0.2.4(kea@3.1.5(react@18.2.0)):
+  kea-test-utils@0.2.4(kea@3.1.6(react@18.2.0)):
     dependencies:
-      kea: 3.1.5(react@18.2.0)
-      kea-waitfor: 0.2.1(kea@3.1.5(react@18.2.0))
+      kea: 3.1.6(react@18.2.0)
+      kea-waitfor: 0.2.1(kea@3.1.6(react@18.2.0))
 
   kea-typegen@3.5.0(typescript@5.2.2):
     dependencies:
@@ -31019,20 +30938,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  kea-waitfor@0.2.1(kea@3.1.5(react@18.2.0)):
+  kea-waitfor@0.2.1(kea@3.1.6(react@18.2.0)):
     dependencies:
-      kea: 3.1.5(react@18.2.0)
+      kea: 3.1.6(react@18.2.0)
 
-  kea-window-values@3.0.0(kea@3.1.5(react@18.2.0)):
+  kea-window-values@3.0.0(kea@3.1.6(react@18.2.0)):
     dependencies:
-      kea: 3.1.5(react@18.2.0)
+      kea: 3.1.6(react@18.2.0)
 
-  kea@3.1.5(react@18.2.0):
+  kea@3.1.6(react@18.2.0):
     dependencies:
       react: 18.2.0
       redux: 4.2.0
       reselect: 4.1.7
-      use-sync-external-store: 1.2.0(react@18.2.0)
+      use-sync-external-store: 1.5.0(react@18.2.0)
 
   keyv@4.5.4:
     dependencies:
@@ -34338,7 +34257,7 @@ snapshots:
 
   redux@4.2.0:
     dependencies:
-      '@babel/runtime': 7.24.0
+      '@babel/runtime': 7.28.2
 
   refractor@3.6.0:
     dependencies:

--- a/products/actions/package.json
+++ b/products/actions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@posthog/products-actions",
     "dependencies": {
-        "kea": "^3.1.5",
+        "kea": "^3.1.6",
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.0"
     },

--- a/products/cohorts/package.json
+++ b/products/cohorts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@posthog/products-cohorts",
     "dependencies": {
-        "kea": "^3.1.5",
+        "kea": "^3.1.6",
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.0"
     },

--- a/products/dashboards/package.json
+++ b/products/dashboards/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@posthog/products-dashboards",
     "dependencies": {
-        "kea": "^3.1.5",
+        "kea": "^3.1.6",
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.0"
     },

--- a/products/early_access_features/package.json
+++ b/products/early_access_features/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@posthog/products-early-access-features",
     "dependencies": {
-        "kea": "^3.1.5",
+        "kea": "^3.1.6",
         "kea-forms": "^3.2.0",
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.0"

--- a/products/error_tracking/package.json
+++ b/products/error_tracking/package.json
@@ -2,7 +2,7 @@
     "name": "@posthog/products-error-tracking",
     "scripts": {},
     "dependencies": {
-        "kea": "^3.1.5",
+        "kea": "^3.1.6",
         "kea-forms": "^3.2.0",
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.0",

--- a/products/experiments/package.json
+++ b/products/experiments/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@posthog/products-experiments",
     "dependencies": {
-        "kea": "^3.1.5",
+        "kea": "^3.1.6",
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.0"
     },

--- a/products/feature_flags/package.json
+++ b/products/feature_flags/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@posthog/products-feature-flags",
     "dependencies": {
-        "kea": "^3.1.5",
+        "kea": "^3.1.6",
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.0"
     },

--- a/products/games/package.json
+++ b/products/games/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@posthog/products-games",
     "dependencies": {
-        "kea": "^3.1.5",
+        "kea": "^3.1.6",
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.0"
     },

--- a/products/groups/package.json
+++ b/products/groups/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@posthog/products-groups",
     "dependencies": {
-        "kea": "^3.1.5",
+        "kea": "^3.1.6",
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.0"
     },

--- a/products/links/package.json
+++ b/products/links/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@posthog/products-links",
     "dependencies": {
-        "kea": "^3.1.5",
+        "kea": "^3.1.6",
         "kea-forms": "^3.2.0",
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.0",

--- a/products/llm_observability/package.json
+++ b/products/llm_observability/package.json
@@ -2,7 +2,7 @@
     "name": "@posthog/products-llm-observability",
     "scripts": {},
     "dependencies": {
-        "kea": "^3.1.5",
+        "kea": "^3.1.6",
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.0"
     },

--- a/products/logs/package.json
+++ b/products/logs/package.json
@@ -2,7 +2,7 @@
     "name": "@posthog/products-logs",
     "scripts": {},
     "dependencies": {
-        "kea": "^3.1.5",
+        "kea": "^3.1.6",
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.0"
     },

--- a/products/managed_migrations/package.json
+++ b/products/managed_migrations/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@posthog/products-managed-migrations",
     "dependencies": {
-        "kea": "^3.1.5",
+        "kea": "^3.1.6",
         "kea-forms": "^3.2.0",
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.0"

--- a/products/messaging/package.json
+++ b/products/messaging/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@posthog/products-messaging",
     "dependencies": {
-        "kea": "^3.1.5",
+        "kea": "^3.1.6",
         "kea-forms": "^3.2.0",
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.0",

--- a/products/notebooks/package.json
+++ b/products/notebooks/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@posthog/products-notebooks",
     "dependencies": {
-        "kea": "^3.1.5",
+        "kea": "^3.1.6",
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.0"
     },

--- a/products/persons/package.json
+++ b/products/persons/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@posthog/products-persons",
     "dependencies": {
-        "kea": "^3.1.5",
+        "kea": "^3.1.6",
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.0"
     },

--- a/products/product_analytics/package.json
+++ b/products/product_analytics/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@posthog/products-product-analytics",
     "dependencies": {
-        "kea": "^3.1.5",
+        "kea": "^3.1.6",
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.0"
     },

--- a/products/replay/package.json
+++ b/products/replay/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@posthog/products-replay",
     "dependencies": {
-        "kea": "^3.1.5",
+        "kea": "^3.1.6",
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.0"
     },

--- a/products/revenue_analytics/package.json
+++ b/products/revenue_analytics/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@posthog/products-revenue-analytics",
     "dependencies": {
-        "kea": "^3.1.5",
+        "kea": "^3.1.6",
         "kea-forms": "^3.2.0",
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.0"

--- a/products/surveys/package.json
+++ b/products/surveys/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@posthog/products-surveys",
     "dependencies": {
-        "kea": "^3.1.5",
+        "kea": "^3.1.6",
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.0"
     },

--- a/products/user_interviews/package.json
+++ b/products/user_interviews/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@posthog/products-user-interviews",
     "dependencies": {
-        "kea": "^3.1.5",
+        "kea": "^3.1.6",
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.0",
         "posthog-js": "1.258.5"

--- a/products/web_analytics/package.json
+++ b/products/web_analytics/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@posthog/products-web-analytics",
     "dependencies": {
-        "kea": "^3.1.5",
+        "kea": "^3.1.6",
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.0"
     },


### PR DESCRIPTION
## Problem

We were locked at 3.1.5 and I would like to use the increase in the selectors amount https://github.com/keajs/kea/commit/a785db4a4822e8aab77ae43bfa4dfce114b5573f

## Changes

Be explicit about the patch version and update lock file

## How did you test this code?

Didn't explode

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
