### PR TITLE
fix: Revert "chore: Remove temporary rate limiting on persons API"

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -70,6 +70,8 @@ from posthog.queries.util import get_earliest_timestamp
 from posthog.rate_limit import (
     ClickHouseBurstRateThrottle,
     ClickHouseSustainedRateThrottle,
+    BreakGlassBurstThrottle,
+    BreakGlassSustainedThrottle,
 )
 from posthog.renderers import SafeJSONRenderer
 from posthog.settings import EE_AVAILABLE
@@ -146,6 +148,14 @@ class PersonsThrottle(ClickHouseSustainedRateThrottle):
     # Throttle class that's scoped just to the person endpoint.
     # This makes the rate limit apply to all endpoints under /api/person/
     # and independent of other endpoints.
+    scope = "persons"
+
+
+class PersonsBreakGlassBurstThrottle(BreakGlassBurstThrottle):
+    scope = "persons"
+
+
+class PersonsBreakGlassSustainedThrottle(BreakGlassSustainedThrottle):
     scope = "persons"
 
 
@@ -234,6 +244,8 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     throttle_classes = [
         ClickHouseBurstRateThrottle,
         PersonsThrottle,
+        PersonsBreakGlassBurstThrottle,
+        PersonsBreakGlassSustainedThrottle,
     ]
     lifecycle_class = Lifecycle
     stickiness_class = Stickiness


### PR DESCRIPTION
Reverts PostHog/posthog#36070