### PR TITLE
fix(devex): docker compose project name

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,6 @@
+# Docker Compose project name - forces all containers to use "posthog" namespace
+export COMPOSE_PROJECT_NAME=posthog
+
 if command -v flox >/dev/null 2>&1; then # Only activate flox if installed
     # Capture the directory user intended to work in before any Flox operations
     ORIGINAL_PWD="${PWD}"


### PR DESCRIPTION
## Problem
When switching to a different Git Worktree, our local dev Docker compose setup tries to recreate all containers using the folder's name. This PR sets the `COMPOSE_PROJECT_NAME` env var to `posthog` so that you can just close your running instance, change worktree, restart with `bin/start` and keep on working with the same containers.

## Changes
- Set `COMPOSE_PROJECT_NAME=posthog` in `.envrc`

## How did you test this code?
Locally