### PR TITLE
fix(max): max needs to use camel case of functions

### DIFF
--- a/ee/hogai/graph/sql/prompts.py
+++ b/ee/hogai/graph/sql/prompts.py
@@ -137,7 +137,7 @@ Expressions can use operators to filter and combine data. These include:
 ## Functions and aggregations
 
 You can filter, modify, or aggregate accessed data with [supported ClickHouse functions](/docs/sql/clickhouse-functions.md) like `dateDiff()` and `concat()` and [aggregations](/docs/hogql/aggregations.md) like `sumIf()` and `count()`.
-Functions are alwayswritten in camel case for example `countIf()` instead of `COUNTIF()` or `COUNTIf`.
+Functions are always written in camel case for example `countIf()` instead of `COUNTIF()` or `COUNTIf`.
 
 Here are some of the most common and useful ones:
 

--- a/ee/hogai/graph/sql/prompts.py
+++ b/ee/hogai/graph/sql/prompts.py
@@ -137,6 +137,7 @@ Expressions can use operators to filter and combine data. These include:
 ## Functions and aggregations
 
 You can filter, modify, or aggregate accessed data with [supported ClickHouse functions](/docs/sql/clickhouse-functions.md) like `dateDiff()` and `concat()` and [aggregations](/docs/hogql/aggregations.md) like `sumIf()` and `count()`.
+Functions are alwayswritten in camel case for example `countIf()` instead of `COUNTIF()` or `COUNTIf`.
 
 Here are some of the most common and useful ones:
 


### PR DESCRIPTION
## Problem
Max is sometimes generating  HOGQL queries using all caps or inconsistent casing for the function names. 
See example here https://eu.posthog.com/uploaded_media/0194efa7-d417-0000-ba53-93d7388e7192

## Changes
Added a line to always stick to camel case for the function names 