### PR TITLE
feat(cdp): Omit creds on test fetch

### DIFF
--- a/frontend/src/scenes/hog-functions/configuration/components/hogFunctionSourceWebhookTestLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/components/hogFunctionSourceWebhookTestLogic.tsx
@@ -73,6 +73,7 @@ export const hogFunctionSourceWebhookTestLogic = kea<hogFunctionSourceWebhookTes
                     method: 'POST',
                     headers: tryJsonParse(data.headers),
                     body: data.body,
+                    credentials: 'omit',
                 })
 
                 actions.setTestResult({


### PR DESCRIPTION
## Problem

We don't want to send cookies with the test webhook which was causing issues with large headers.

## Changes

* Omit creds in the request

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
