### PR TITLE
fix: exceptions in logger in temporal

### DIFF
--- a/ee/tasks/subscriptions/__init__.py
+++ b/ee/tasks/subscriptions/__init__.py
@@ -66,7 +66,7 @@ async def deliver_subscription_report_async(
     insights, assets = await database_sync_to_async(generate_assets)(subscription, use_celery=False)
 
     if not assets:
-        logger.warning("subscription_has_no_assets", subscription_id=subscription.id)
+        capture_exception(Exception("No assets are in this subscription"), {"subscription_id": subscription.id})
         return
 
     if subscription.target_type == "email":
@@ -161,8 +161,7 @@ def deliver_subscription_report_sync(
     insights, assets = generate_assets(subscription)
 
     if not assets:
-        # Log this as a warning instead of creating an exception
-        logger.warning("subscription_has_no_assets", subscription_id=subscription.id)
+        capture_exception(Exception("No assets are in this subscription"), {"subscription_id": subscription.id})
         return
 
     if subscription.target_type == "email":

--- a/ee/tasks/subscriptions/__init__.py
+++ b/ee/tasks/subscriptions/__init__.py
@@ -66,7 +66,8 @@ async def deliver_subscription_report_async(
     insights, assets = await database_sync_to_async(generate_assets)(subscription, use_celery=False)
 
     if not assets:
-        capture_exception(Exception("No assets are in this subscription"), {"subscription_id": subscription.id})
+        # Log this as a warning instead of creating an exception
+        logger.warning("subscription_has_no_assets", subscription_id=subscription.id)
         return
 
     if subscription.target_type == "email":
@@ -161,7 +162,8 @@ def deliver_subscription_report_sync(
     insights, assets = generate_assets(subscription)
 
     if not assets:
-        capture_exception(Exception("No assets are in this subscription"), {"subscription_id": subscription.id})
+        # Log this as a warning instead of creating an exception
+        logger.warning("subscription_has_no_assets", subscription_id=subscription.id)
         return
 
     if subscription.target_type == "email":

--- a/ee/tasks/subscriptions/__init__.py
+++ b/ee/tasks/subscriptions/__init__.py
@@ -66,7 +66,6 @@ async def deliver_subscription_report_async(
     insights, assets = await database_sync_to_async(generate_assets)(subscription, use_celery=False)
 
     if not assets:
-        # Log this as a warning instead of creating an exception
         logger.warning("subscription_has_no_assets", subscription_id=subscription.id)
         return
 

--- a/posthog/exceptions_capture.py
+++ b/posthog/exceptions_capture.py
@@ -14,6 +14,7 @@ def celery_properties() -> dict:
 
 
 def capture_exception(error=None, additional_properties=None):
+    import sys
     import structlog
     from posthoganalytics import api_key, capture_exception as posthog_capture_exception
 
@@ -28,11 +29,25 @@ def capture_exception(error=None, additional_properties=None):
 
     properties.update(celery_properties())
 
+    # logger.exception() uses sys.exc_info() internally, so we should check this first
+    exc_info = sys.exc_info()
+    has_valid_exc_info = exc_info[0] is not None
+
     if api_key:
         uuid = posthog_capture_exception(error, properties=properties)
 
         # Only log if captured
         if uuid is not None:
-            logger.exception(error, event_id=uuid)
+            if has_valid_exc_info:
+                logger.exception(error, event_id=uuid)
+            else:
+                logger.error(
+                    f"Exception captured: {error}",
+                    event_id=uuid,
+                    exception_type=type(error).__name__ if error else "None",
+                )
     else:
-        logger.exception(error)
+        if has_valid_exc_info:
+            logger.exception(error)
+        else:
+            logger.error(f"Exception captured: {error}", exception_type=type(error).__name__ if error else "None")


### PR DESCRIPTION
## Problem
Calling capture exception when we're not actually in an exception context throws an exception

```
  File \"/code/ee/tasks/subscriptions/__init__.py\", line 62, in _deliver_subscription_report
    capture_exception(Exception(\"No assets are in this subscription\"), {\"subscription_id\": subscription.id})

  File \"/code/posthog/exceptions_capture.py\", line 36, in capture_exception
    logger.exception(error, event_id=uuid)

  File \"/python-runtime/lib/python3.11/site-packages/structlog/stdlib.py\", line 217, in exception
    return self.error(event, *args, **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File \"/python-runtime/lib/python3.11/site-packages/structlog/stdlib.py\", line 200, in error
    return self._proxy_to_logger(\"error\", event, *args, **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File \"/python-runtime/lib/python3.11/site-packages/structlog/stdlib.py\", line 247, in _proxy_to_logger
    return super()._proxy_to_logger(method_name, event=event, **event_kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File \"/python-runtime/lib/python3.11/site-packages/structlog/_base.py\", line 222, in _proxy_to_logger
    args, kw = self._process_event(method_name, event, event_kw)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File \"/python-runtime/lib/python3.11/site-packages/structlog/_base.py\", line 171, in _process_event
    event_dict = proc(self._logger, method_name, event_dict)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File \"/python-runtime/lib/python3.11/site-packages/structlog/processors.py\", line 412, in __call__
    event_dict[\"exception\"] = self.format_exception(
                              ^^^^^^^^^^^^^^^^^^^^^^

  File \"/python-runtime/lib/python3.11/site-packages/structlog/tracebacks.py\", line 262, in __call__
    trace = extract(
            ^^^^^^^^

  File \"/python-runtime/lib/python3.11/site-packages/structlog/tracebacks.py\", line 156, in extract
    exc_type=safe_str(exc_type.__name__),
                      ^^^^^^^^^^^^^^^^^
```

## Changes
Handle this


