### PR TITLE
feat(cdp): Turn hog watcher back on

### DIFF
--- a/plugin-server/src/cdp/services/monitoring/hog-watcher.service.ts
+++ b/plugin-server/src/cdp/services/monitoring/hog-watcher.service.ts
@@ -104,7 +104,7 @@ export class HogWatcherService {
             previousState,
         })
 
-        if (team && process.env.CDP_HOG_WATCHER_2_CAPTURE_ENABLED === 'true') {
+        if (team && this.hub.CDP_WATCHER_SEND_EVENTS) {
             captureTeamEvent(team, 'hog_function_state_change', {
                 hog_function_id: hogFunction.id,
                 hog_function_type: hogFunction.type,
@@ -260,10 +260,6 @@ export class HogWatcherService {
     }
 
     public async observeResults(results: CyclotronJobInvocationResult[]): Promise<void> {
-        if (process.env.CDP_HOG_WATCHER_2_ENABLED !== 'true') {
-            return
-        }
-
         const functionCosts: Record<
             CyclotronJobInvocation['functionId'],
             {

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -169,7 +169,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         CDP_WATCHER_REFILL_RATE: 10,
         CDP_WATCHER_STATE_LOCK_TTL: 60, // 1 minute
         CDP_WATCHER_DISABLED_TEMPORARY_MAX_COUNT: 3,
-        CDP_WATCHER_SEND_EVENTS: false,
+        CDP_WATCHER_SEND_EVENTS: isProdEnv() ? false : true,
         CDP_HOG_FILTERS_TELEMETRY_TEAMS: '',
         CDP_REDIS_PASSWORD: '',
         CDP_EVENT_PROCESSOR_EXECUTE_FIRST_STEP: true,

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -169,6 +169,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         CDP_WATCHER_REFILL_RATE: 10,
         CDP_WATCHER_STATE_LOCK_TTL: 60, // 1 minute
         CDP_WATCHER_DISABLED_TEMPORARY_MAX_COUNT: 3,
+        CDP_WATCHER_SEND_EVENTS: false,
         CDP_HOG_FILTERS_TELEMETRY_TEAMS: '',
         CDP_REDIS_PASSWORD: '',
         CDP_EVENT_PROCESSOR_EXECUTE_FIRST_STEP: true,

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -111,6 +111,7 @@ export type CdpConfig = {
     CDP_WATCHER_DISABLED_TEMPORARY_TTL: number // How long a function should be temporarily disabled for
     CDP_WATCHER_DISABLED_TEMPORARY_MAX_COUNT: number // How many times a function can be disabled before it is disabled permanently
     CDP_WATCHER_AUTOMATICALLY_DISABLE_FUNCTIONS: boolean // If true then degraded functions will be automatically disabled
+    CDP_WATCHER_SEND_EVENTS: boolean // If true then the watcher will send events to posthog for messaging
     CDP_HOG_FILTERS_TELEMETRY_TEAMS: string
     CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_KIND: CyclotronJobQueueKind
     CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_MODE: CyclotronJobQueueSource


### PR DESCRIPTION
## Problem

When we're happy with the new and improved hog watcher we can turn it back on.

## Changes

* Turns it back on
* Keeps the message sending as a config option

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
