### PR TITLE
refactor: added signatures for min and max

### DIFF
--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -1643,9 +1643,35 @@ HOGQL_AGGREGATIONS: dict[str, HogQLFunctionMeta] = {
     "countStateIf": HogQLFunctionMeta("countStateIf", 1, 2, aggregate=True),
     "countDistinctIf": HogQLFunctionMeta("countDistinctIf", 1, 2, aggregate=True),
     "countMapIf": HogQLFunctionMeta("countMapIf", 2, 3, aggregate=True),
-    "min": HogQLFunctionMeta("min", 1, 1, aggregate=True, case_sensitive=False),
+    "min": HogQLFunctionMeta(
+        "min", 
+        1, 
+        1, 
+        aggregate=True, 
+        case_sensitive=False,
+        signatures=[
+            ((DateTimeType(),), DateTimeType()),  # MIN(DateTime) return DateTime
+            ((DateType(),), DateType()),          # MIN(Date) return Date
+            ((IntegerType(),), IntegerType()),    # MIN(Integer) return Integer
+            ((FloatType(),), FloatType()),        # MIN(Float) return Float
+            ((StringType(),), StringType()),      # MIN(String) return String
+        ]
+    ),
     "minIf": HogQLFunctionMeta("minIf", 2, 2, aggregate=True),
-    "max": HogQLFunctionMeta("max", 1, 1, aggregate=True, case_sensitive=False),
+    "max": HogQLFunctionMeta(
+        "max", 
+        1, 
+        1, 
+        aggregate=True, 
+        case_sensitive=False,
+        signatures=[
+            ((DateTimeType(),), DateTimeType()),  # MIN(DateTime) return DateTime
+            ((DateType(),), DateType()),          # MIN(Date) return Date
+            ((IntegerType(),), IntegerType()),    # MIN(Integer) return Integer
+            ((FloatType(),), FloatType()),        # MIN(Float) return Float
+            ((StringType(),), StringType()),      # MIN(String) return String
+        ]
+    ),
     "maxIf": HogQLFunctionMeta("maxIf", 2, 2, aggregate=True),
     "sum": HogQLFunctionMeta("sum", 1, 1, aggregate=True, case_sensitive=False),
     "sumForEach": HogQLFunctionMeta("sumForEach", 1, 1, aggregate=True),

--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -1650,11 +1650,11 @@ HOGQL_AGGREGATIONS: dict[str, HogQLFunctionMeta] = {
         aggregate=True,
         case_sensitive=False,
         signatures=[
-            ((DateTimeType(),), DateTimeType()),  # MIN(DateTime) return DateTime
-            ((DateType(),), DateType()),          # MIN(Date) return Date
-            ((IntegerType(),), IntegerType()),    # MIN(Integer) return Integer
-            ((FloatType(),), FloatType()),        # MIN(Float) return Float
-            ((StringType(),), StringType()),      # MIN(String) return String
+            ((DateTimeType(),), DateTimeType()),
+            ((DateType(),), DateType()),
+            ((IntegerType(),), IntegerType()),
+            ((FloatType(),), FloatType()),
+            ((StringType(),), StringType()),
         ],
     ),
     "minIf": HogQLFunctionMeta("minIf", 2, 2, aggregate=True),
@@ -1665,11 +1665,11 @@ HOGQL_AGGREGATIONS: dict[str, HogQLFunctionMeta] = {
         aggregate=True,
         case_sensitive=False,
         signatures=[
-            ((DateTimeType(),), DateTimeType()),  # MAX(DateTime) return DateTime
-            ((DateType(),), DateType()),          # MAX(Date) return Date
-            ((IntegerType(),), IntegerType()),    # MAX(Integer) return Integer
-            ((FloatType(),), FloatType()),        # MAX(Float) return Float
-            ((StringType(),), StringType()),      # MAX(String) return String
+            ((DateTimeType(),), DateTimeType()),
+            ((DateType(),), DateType()),
+            ((IntegerType(),), IntegerType()),
+            ((FloatType(),), FloatType()),
+            ((StringType(),), StringType()),
         ],
     ),
     "maxIf": HogQLFunctionMeta("maxIf", 2, 2, aggregate=True),

--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -1644,10 +1644,10 @@ HOGQL_AGGREGATIONS: dict[str, HogQLFunctionMeta] = {
     "countDistinctIf": HogQLFunctionMeta("countDistinctIf", 1, 2, aggregate=True),
     "countMapIf": HogQLFunctionMeta("countMapIf", 2, 3, aggregate=True),
     "min": HogQLFunctionMeta(
-        "min", 
-        1, 
-        1, 
-        aggregate=True, 
+        "min",
+        1,
+        1,
+        aggregate=True,
         case_sensitive=False,
         signatures=[
             ((DateTimeType(),), DateTimeType()),  # MIN(DateTime) return DateTime
@@ -1659,17 +1659,17 @@ HOGQL_AGGREGATIONS: dict[str, HogQLFunctionMeta] = {
     ),
     "minIf": HogQLFunctionMeta("minIf", 2, 2, aggregate=True),
     "max": HogQLFunctionMeta(
-        "max", 
-        1, 
-        1, 
-        aggregate=True, 
+        "max",
+        1,
+        1,
+        aggregate=True,
         case_sensitive=False,
         signatures=[
-            ((DateTimeType(),), DateTimeType()),  # MIN(DateTime) return DateTime
-            ((DateType(),), DateType()),          # MIN(Date) return Date
-            ((IntegerType(),), IntegerType()),    # MIN(Integer) return Integer
-            ((FloatType(),), FloatType()),        # MIN(Float) return Float
-            ((StringType(),), StringType()),      # MIN(String) return String
+            ((DateTimeType(),), DateTimeType()),  # MAX(DateTime) return DateTime
+            ((DateType(),), DateType()),          # MAX(Date) return Date
+            ((IntegerType(),), IntegerType()),    # MAX(Integer) return Integer
+            ((FloatType(),), FloatType()),        # MAX(Float) return Float
+            ((StringType(),), StringType()),      # MAX(String) return String
         ]
     ),
     "maxIf": HogQLFunctionMeta("maxIf", 2, 2, aggregate=True),

--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -1655,7 +1655,7 @@ HOGQL_AGGREGATIONS: dict[str, HogQLFunctionMeta] = {
             ((IntegerType(),), IntegerType()),    # MIN(Integer) return Integer
             ((FloatType(),), FloatType()),        # MIN(Float) return Float
             ((StringType(),), StringType()),      # MIN(String) return String
-        ]
+        ],
     ),
     "minIf": HogQLFunctionMeta("minIf", 2, 2, aggregate=True),
     "max": HogQLFunctionMeta(
@@ -1670,7 +1670,7 @@ HOGQL_AGGREGATIONS: dict[str, HogQLFunctionMeta] = {
             ((IntegerType(),), IntegerType()),    # MAX(Integer) return Integer
             ((FloatType(),), FloatType()),        # MAX(Float) return Float
             ((StringType(),), StringType()),      # MAX(String) return String
-        ]
+        ],
     ),
     "maxIf": HogQLFunctionMeta("maxIf", 2, 2, aggregate=True),
     "sum": HogQLFunctionMeta("sum", 1, 1, aggregate=True, case_sensitive=False),


### PR DESCRIPTION
## Problem

When using toDate(MIN(timestamp)) or similar aggregate + date conversion combinations, users get this error:
```Illegal type DateTime64(6, 'UTC') of first argument of function toDateOrNull. Conversion functions with postfix 'OrZero' or 'OrNull' should take String argument```

## Changes
Added signatures to min and max aggregations in `posthog/hogql/functions/mapping.py`

## How did you test this code?
Didn't test here, just added signatures

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
