### PR TITLE
fix(devex): build products in vite command

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,7 +45,7 @@
         "format": "cd .. && oxlint --fix --fix-suggestions --fix-dangerously --quiet && pnpm prettier -w \"./{cypress,products,frontend/src}/**/*.{js,mjs,ts,tsx,json,yaml,yml,css,scss}\"",
         "visualize-toolbar-bundle": "pnpm exec esbuild-visualizer --metadata ./toolbar-esbuild-meta.json --filename=toolbar-esbuild-bundle-visualization.html",
         "check-toolbar-csp-eval": "node ./bin/check-toolbar-csp-eval.mjs",
-        "start-vite": "concurrently -n VITE,TYPEGEN,TAILWIND -c green,blue,yellow  \"vite --host 0.0.0.0\" \"${SKIP_TYPEGEN:-pnpm run typegen:watch}\" \"pnpm watch:tailwind\""
+        "start-vite": "pnpm build:products && concurrently -n VITE,TYPEGEN,TAILWIND -c green,blue,yellow  \"vite --host 0.0.0.0\" \"${SKIP_TYPEGEN:-pnpm run typegen:watch}\" \"pnpm watch:tailwind\""
     },
     "dependencies": {
         "@babel/runtime": "^7.24.0",


### PR DESCRIPTION
## Problem
When running the local dev environment, we need to build the products folder first before serving the frontend. This is implemented in the old flow but missing in the new Vite based flow.

## Changes
- Add `build:products` step in `start-vite`

## How did you test this code?
Locally
