### PR TITLE
fix(hogql): Handle array values when `expr` was tweaked

### DIFF
--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -815,6 +815,29 @@ class TestProperty(BaseTest):
         self.assertEqual(compare_op_2.left.chain, ["foobars", "properties", "$feature/test"])
         self.assertEqual(compare_op_2.right.value, "test")
 
+    def test_revenue_analytics_property(self):
+        self.assertEqual(
+            self._property_to_expr(
+                {"type": "revenue_analytics", "key": "product", "value": ["Product A"], "operator": "exact"},
+                scope="revenue_analytics",
+            ),
+            self._parse_expr("revenue_analytics_product.name = 'Product A'"),
+        )
+
+    def test_revenue_analytics_property_multiple_values(self):
+        self.assertEqual(
+            self._property_to_expr(
+                {
+                    "type": "revenue_analytics",
+                    "key": "product",
+                    "value": ["Product A", "Product C"],
+                    "operator": "exact",
+                },
+                scope="revenue_analytics",
+            ),
+            self._parse_expr("revenue_analytics_product.name IN ('Product A', 'Product C')"),
+        )
+
     def test_property_to_expr_event_metadata(self):
         self.assertEqual(
             self._property_to_expr(

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -37,7 +37,9 @@ class TestProperty(BaseTest):
         self,
         property: Union[PropertyGroup, Property, HogQLPropertyFilter, dict, list],
         team: Optional[Team] = None,
-        scope: Optional[Literal["event", "person", "group"]] = None,
+        scope: Optional[
+            Literal["event", "person", "group", "session", "replay", "replay_entity", "revenue_analytics"]
+        ] = None,
     ):
         return clear_locations(property_to_expr(property, team=team or self.team, scope=scope or "event"))
 

--- a/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_metrics_query_runner.ambr
+++ b/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_metrics_query_runner.ambr
@@ -1379,6 +1379,219 @@
                        allow_experimental_join_condition=1
   '''
 # ---
+# name: TestRevenueAnalyticsMetricsQueryRunner.test_with_multiple_products_filter
+  '''
+  SELECT subquery.breakdown_by AS breakdown_by,
+         subquery.period_start AS period_start,
+         sum(subquery.subscription_count) AS subscription_count,
+         sum(subquery.new_subscription_count) AS new_subscription_count,
+         sum(subquery.churned_subscription_count) AS churned_subscription_count,
+         countIf(subquery.customer_id, ifNull(greaterOrEquals(subquery.subscription_count, 1), 0)) AS customer_count,
+         countIf(subquery.customer_id, subquery.is_new_customer) AS new_customer_count,
+         countIf(subquery.customer_id, subquery.is_churned_customer) AS churned_customer_count,
+         ifNull(if(or(isNull(customer_count), ifNull(equals(customer_count, 0), 0)), 0, divide(sum(subquery.revenue), customer_count)), 0) AS arpu,
+         multiIf(ifNull(equals(customer_count, 0), 0), 0, ifNull(equals(churned_customer_count, 0), 0), NaN, divide(arpu, divide(churned_customer_count, customer_count))) AS ltv
+  FROM
+    (SELECT revenue_analytics_subscription.source_label AS breakdown_by,
+            revenue_analytics_subscription.customer_id AS customer_id,
+            toStartOfMonth(parseDateTime64BestEffortOrNull(arrayJoin(['2024-11-01 00:00:00', '2024-12-01 00:00:00', '2025-01-01 00:00:00', '2025-02-01 00:00:00', '2025-03-01 00:00:00', '2025-04-01 00:00:00', '2025-05-01 00:00:00']), 6, 'UTC')) AS period_start,
+            countIf(DISTINCT revenue_analytics_subscription.id, and(ifNull(lessOrEquals(toStartOfMonth(revenue_analytics_subscription.started_at), period_start), 0), or(isNull(revenue_analytics_subscription.ended_at), ifNull(greaterOrEquals(toStartOfMonth(revenue_analytics_subscription.ended_at), period_start), 0)))) AS subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, and(ifNull(lessOrEquals(toStartOfMonth(revenue_analytics_subscription.started_at), date_add(period_start, toIntervalMonth(-1))), 0), or(isNull(revenue_analytics_subscription.ended_at), ifNull(greaterOrEquals(toStartOfMonth(revenue_analytics_subscription.ended_at), date_add(period_start, toIntervalMonth(-1))), 0)))) AS prev_subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(revenue_analytics_subscription.started_at), period_start), isNull(toStartOfMonth(revenue_analytics_subscription.started_at))
+                                                                       and isNull(period_start))) AS new_subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(revenue_analytics_subscription.ended_at), period_start), isNull(toStartOfMonth(revenue_analytics_subscription.ended_at))
+                                                                       and isNull(period_start))) AS churned_subscription_count,
+            and(ifNull(equals(prev_subscription_count, 0), 0), ifNull(greater(subscription_count, 0), 0)) AS is_new_customer,
+            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, subscription_count), isNull(churned_subscription_count)
+                                                                          and isNull(subscription_count))) AS is_churned_customer,
+            sumIf(revenue_analytics_invoice_item.amount, ifNull(equals(toStartOfMonth(revenue_analytics_invoice_item.timestamp), period_start), isNull(toStartOfMonth(revenue_analytics_invoice_item.timestamp))
+                                                                and isNull(period_start))) AS revenue
+     FROM
+       (SELECT `stripe.posthog_test.subscription_revenue_view`.id AS id,
+               `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
+               `stripe.posthog_test.subscription_revenue_view`.plan_id AS plan_id,
+               `stripe.posthog_test.subscription_revenue_view`.product_id AS product_id,
+               `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
+               `stripe.posthog_test.subscription_revenue_view`.status AS status,
+               `stripe.posthog_test.subscription_revenue_view`.started_at AS started_at,
+               `stripe.posthog_test.subscription_revenue_view`.ended_at AS ended_at,
+               `stripe.posthog_test.subscription_revenue_view`.current_period_start AS current_period_start,
+               `stripe.posthog_test.subscription_revenue_view`.current_period_end AS current_period_end,
+               `stripe.posthog_test.subscription_revenue_view`.metadata AS metadata
+        FROM
+          (SELECT posthog_test_stripe_subscription.id AS id,
+                  'stripe.posthog_test' AS source_label,
+                  JSONExtractString(posthog_test_stripe_subscription.plan, 'id') AS plan_id,
+                  JSONExtractString(posthog_test_stripe_subscription.plan, 'product') AS product_id,
+                  posthog_test_stripe_subscription.customer AS customer_id,
+                  posthog_test_stripe_subscription.status AS status,
+                  parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_subscription.created), 6, 'UTC') AS started_at,
+                  parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_subscription.ended_at), 6, 'UTC') AS ended_at,
+                  parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_subscription.current_period_start), 6, 'UTC') AS current_period_start,
+                  parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_subscription.current_period_end), 6, 'UTC') AS current_period_end,
+                  posthog_test_stripe_subscription.metadata AS metadata
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_subscriptions/posthog_test_stripe_subscription/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `plan` String, `status` String, `created` DateTime, `customer` String, `ended_at` DateTime, `metadata` String, `current_period_end` DateTime, `current_period_start` DateTime') AS posthog_test_stripe_subscription) AS `stripe.posthog_test.subscription_revenue_view`) AS revenue_analytics_subscription
+     LEFT JOIN
+       (SELECT `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.id AS id,
+               `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.invoice_item_id AS invoice_item_id,
+               `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.source_label AS source_label,
+               `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.timestamp AS timestamp,
+               `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.created_at AS created_at,
+               `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.is_recurring AS is_recurring,
+               `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.product_id AS product_id,
+               `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.customer_id AS customer_id,
+               `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.invoice_id AS invoice_id,
+               `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.subscription_id AS subscription_id,
+               `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.session_id AS session_id,
+               `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.event_name AS event_name,
+               `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.coupon AS coupon,
+               `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.coupon_id AS coupon_id,
+               `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.original_currency AS original_currency,
+               `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.original_amount AS original_amount,
+               `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+               `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.currency_aware_divider AS currency_aware_divider,
+               `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.currency_aware_amount AS currency_aware_amount,
+               `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.currency AS currency,
+               `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.amount AS amount
+        FROM
+          (SELECT toString(events.uuid) AS id,
+                  toString(events.uuid) AS invoice_item_id,
+                  'revenue_analytics.events.purchase' AS source_label,
+                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                  timestamp AS created_at,
+                  0 AS is_recurring,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'product'), ''), 'null'), '^"|"$', '') AS product_id,
+                  toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
+                  NULL AS invoice_id,
+                  NULL AS subscription_id,
+                  toString(events.`$session_id`) AS session_id,
+                  events.event AS event_name,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'coupon'), ''), 'null'), '^"|"$', '') AS coupon,
+                  coupon AS coupon_id,
+                  upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                  1 AS enable_currency_aware_divider,
+                  if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                  divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                  'GBP' AS currency,
+                  if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+           FROM events
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+           WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+           ORDER BY timestamp DESC) AS `revenue_analytics.events.purchase.invoice_item_events_revenue_view`
+        UNION ALL SELECT `stripe.posthog_test.invoice_item_revenue_view`.id AS id,
+                         `stripe.posthog_test.invoice_item_revenue_view`.invoice_item_id AS invoice_item_id,
+                         `stripe.posthog_test.invoice_item_revenue_view`.source_label AS source_label,
+                         `stripe.posthog_test.invoice_item_revenue_view`.timestamp AS timestamp,
+                         `stripe.posthog_test.invoice_item_revenue_view`.created_at AS created_at,
+                         `stripe.posthog_test.invoice_item_revenue_view`.is_recurring AS is_recurring,
+                         `stripe.posthog_test.invoice_item_revenue_view`.product_id AS product_id,
+                         `stripe.posthog_test.invoice_item_revenue_view`.customer_id AS customer_id,
+                         `stripe.posthog_test.invoice_item_revenue_view`.invoice_id AS invoice_id,
+                         `stripe.posthog_test.invoice_item_revenue_view`.subscription_id AS subscription_id,
+                         `stripe.posthog_test.invoice_item_revenue_view`.session_id AS session_id,
+                         `stripe.posthog_test.invoice_item_revenue_view`.event_name AS event_name,
+                         `stripe.posthog_test.invoice_item_revenue_view`.coupon AS coupon,
+                         `stripe.posthog_test.invoice_item_revenue_view`.coupon_id AS coupon_id,
+                         `stripe.posthog_test.invoice_item_revenue_view`.original_currency AS original_currency,
+                         `stripe.posthog_test.invoice_item_revenue_view`.original_amount AS original_amount,
+                         `stripe.posthog_test.invoice_item_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                         `stripe.posthog_test.invoice_item_revenue_view`.currency_aware_divider AS currency_aware_divider,
+                         `stripe.posthog_test.invoice_item_revenue_view`.currency_aware_amount AS currency_aware_amount,
+                         `stripe.posthog_test.invoice_item_revenue_view`.currency AS currency,
+                         `stripe.posthog_test.invoice_item_revenue_view`.amount AS amount
+        FROM
+          (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                  invoice.invoice_item_id AS invoice_item_id,
+                  'stripe.posthog_test' AS source_label,
+                  addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                  invoice.created_at AS created_at,
+                  ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                  invoice.product_id AS product_id,
+                  invoice.customer_id AS customer_id,
+                  invoice.id AS invoice_id,
+                  invoice.subscription_id AS subscription_id,
+                  NULL AS session_id,
+                  NULL AS event_name,
+                  JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                  JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                  upper(invoice.currency) AS original_currency,
+                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                  in(original_currency,
+                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                    'GBP' AS currency,
+                    divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+           FROM
+             (SELECT posthog_test_stripe_invoice.id AS id,
+                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                     posthog_test_stripe_invoice.customer AS customer_id,
+                     posthog_test_stripe_invoice.subscription AS subscription_id,
+                     posthog_test_stripe_invoice.discount AS discount,
+                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                     JSONExtractString(data, 'id') AS invoice_item_id,
+                     JSONExtractString(data, 'amount') AS amount_captured,
+                     JSONExtractString(data, 'currency') AS currency,
+                     JSONExtractString(data, 'price', 'product') AS product_id,
+                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                     greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                     arrayJoin(range(0, period_months)) AS month_index,
+                     ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`) AS revenue_analytics_invoice_item ON equals(revenue_analytics_subscription.id, revenue_analytics_invoice_item.subscription_id)
+     LEFT JOIN
+       (SELECT `revenue_analytics.events.purchase.product_events_revenue_view`.id AS id,
+               `revenue_analytics.events.purchase.product_events_revenue_view`.source_label AS source_label,
+               `revenue_analytics.events.purchase.product_events_revenue_view`.name AS name
+        FROM
+          (SELECT product_id AS id,
+                  'revenue_analytics.events.purchase' AS source_label,
+                  product_id AS name
+           FROM
+             (SELECT DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'product'), ''), 'null'), '^"|"$', '') AS product_id
+              FROM events
+              WHERE and(equals(events.team_id, 99999), 1))
+           ORDER BY id ASC) AS `revenue_analytics.events.purchase.product_events_revenue_view`
+        UNION ALL SELECT `stripe.posthog_test.product_revenue_view`.id AS id,
+                         `stripe.posthog_test.product_revenue_view`.source_label AS source_label,
+                         `stripe.posthog_test.product_revenue_view`.name AS name
+        FROM
+          (SELECT posthog_test_stripe_product.id AS id,
+                  'stripe.posthog_test' AS source_label,
+                  posthog_test_stripe_product.name AS name
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_products/posthog_test_stripe_product/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `type` String, `active` UInt8, `images` String, `object` String, `created` DateTime, `features` String, `livemode` UInt8, `metadata` String, `tax_code` String, `attributes` String, `updated_at` DateTime, `description` String, `default_price_id` String') AS posthog_test_stripe_product) AS `stripe.posthog_test.product_revenue_view`) AS revenue_analytics_product ON equals(revenue_analytics_subscription.product_id, revenue_analytics_product.id)
+     WHERE in(revenue_analytics_product.name,
+              tuple('Product A', 'Product C'))
+     GROUP BY revenue_analytics_subscription.customer_id,
+              breakdown_by,
+              period_start
+     ORDER BY revenue_analytics_subscription.customer_id ASC, breakdown_by ASC, period_start ASC) AS subquery
+  GROUP BY subquery.breakdown_by,
+           subquery.period_start
+  ORDER BY subquery.breakdown_by ASC,
+           subquery.period_start ASC,
+           subscription_count DESC,
+           customer_count DESC
+  LIMIT 10000 SETTINGS readonly=2,
+                       max_execution_time=60,
+                       allow_experimental_object_type=1,
+                       format_csv_allow_double_quotes=1,
+                       max_ast_elements=4000000,
+                       max_expanded_ast_elements=4000000,
+                       max_bytes_before_external_group_by=0,
+                       transform_null_in=1,
+                       optimize_min_equality_disjunction_chain_length=4294967295,
+                       allow_experimental_join_condition=1
+  '''
+# ---
 # name: TestRevenueAnalyticsMetricsQueryRunner.test_with_product_filter
   '''
   SELECT subquery.breakdown_by AS breakdown_by,

--- a/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_overview_query_runner.ambr
+++ b/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_overview_query_runner.ambr
@@ -1153,3 +1153,158 @@
                      allow_experimental_join_condition=1
   '''
 # ---
+# name: TestRevenueAnalyticsOverviewQueryRunner.test_with_property_filter_multiple_values
+  '''
+  SELECT accurateCastOrNull(sum(revenue_analytics_invoice_item.amount), 'Decimal64(10)') AS revenue,
+         count(DISTINCT revenue_analytics_invoice_item.customer_id) AS paying_customer_count,
+         if(ifNull(equals(paying_customer_count, 0), 0), 0, ifNull(divideDecimal(revenue, accurateCastOrNull(paying_customer_count, 'Decimal64(10)')), 0)) AS avg_revenue_per_customer
+  FROM
+    (SELECT `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.id AS id,
+            `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.invoice_item_id AS invoice_item_id,
+            `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.source_label AS source_label,
+            `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.timestamp AS timestamp,
+            `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.created_at AS created_at,
+            `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.is_recurring AS is_recurring,
+            `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.product_id AS product_id,
+            `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.customer_id AS customer_id,
+            `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.invoice_id AS invoice_id,
+            `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.subscription_id AS subscription_id,
+            `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.session_id AS session_id,
+            `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.event_name AS event_name,
+            `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.coupon AS coupon,
+            `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.coupon_id AS coupon_id,
+            `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.original_currency AS original_currency,
+            `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.original_amount AS original_amount,
+            `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+            `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.currency_aware_divider AS currency_aware_divider,
+            `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.currency_aware_amount AS currency_aware_amount,
+            `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.currency AS currency,
+            `revenue_analytics.events.purchase.invoice_item_events_revenue_view`.amount AS amount
+     FROM
+       (SELECT toString(events.uuid) AS id,
+               toString(events.uuid) AS invoice_item_id,
+               'revenue_analytics.events.purchase' AS source_label,
+               toTimeZone(events.timestamp, 'UTC') AS timestamp,
+               timestamp AS created_at,
+               0 AS is_recurring,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'product'), ''), 'null'), '^"|"$', '') AS product_id,
+               toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
+               NULL AS invoice_id,
+               NULL AS subscription_id,
+               toString(events.`$session_id`) AS session_id,
+               events.event AS event_name,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'coupon'), ''), 'null'), '^"|"$', '') AS coupon,
+               coupon AS coupon_id,
+               upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+               accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+               1 AS enable_currency_aware_divider,
+               if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+               divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+               'GBP' AS currency,
+               if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+        ORDER BY timestamp DESC) AS `revenue_analytics.events.purchase.invoice_item_events_revenue_view`
+     UNION ALL SELECT `stripe.posthog_test.invoice_item_revenue_view`.id AS id,
+                      `stripe.posthog_test.invoice_item_revenue_view`.invoice_item_id AS invoice_item_id,
+                      `stripe.posthog_test.invoice_item_revenue_view`.source_label AS source_label,
+                      `stripe.posthog_test.invoice_item_revenue_view`.timestamp AS timestamp,
+                      `stripe.posthog_test.invoice_item_revenue_view`.created_at AS created_at,
+                      `stripe.posthog_test.invoice_item_revenue_view`.is_recurring AS is_recurring,
+                      `stripe.posthog_test.invoice_item_revenue_view`.product_id AS product_id,
+                      `stripe.posthog_test.invoice_item_revenue_view`.customer_id AS customer_id,
+                      `stripe.posthog_test.invoice_item_revenue_view`.invoice_id AS invoice_id,
+                      `stripe.posthog_test.invoice_item_revenue_view`.subscription_id AS subscription_id,
+                      `stripe.posthog_test.invoice_item_revenue_view`.session_id AS session_id,
+                      `stripe.posthog_test.invoice_item_revenue_view`.event_name AS event_name,
+                      `stripe.posthog_test.invoice_item_revenue_view`.coupon AS coupon,
+                      `stripe.posthog_test.invoice_item_revenue_view`.coupon_id AS coupon_id,
+                      `stripe.posthog_test.invoice_item_revenue_view`.original_currency AS original_currency,
+                      `stripe.posthog_test.invoice_item_revenue_view`.original_amount AS original_amount,
+                      `stripe.posthog_test.invoice_item_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                      `stripe.posthog_test.invoice_item_revenue_view`.currency_aware_divider AS currency_aware_divider,
+                      `stripe.posthog_test.invoice_item_revenue_view`.currency_aware_amount AS currency_aware_amount,
+                      `stripe.posthog_test.invoice_item_revenue_view`.currency AS currency,
+                      `stripe.posthog_test.invoice_item_revenue_view`.amount AS amount
+     FROM
+       (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+               invoice.invoice_item_id AS invoice_item_id,
+               'stripe.posthog_test' AS source_label,
+               addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+               invoice.created_at AS created_at,
+               ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+               invoice.product_id AS product_id,
+               invoice.customer_id AS customer_id,
+               invoice.id AS invoice_id,
+               invoice.subscription_id AS subscription_id,
+               NULL AS session_id,
+               NULL AS event_name,
+               JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+               JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+               upper(invoice.currency) AS original_currency,
+               accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+               in(original_currency,
+                  ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                 if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                 divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                 'GBP' AS currency,
+                 divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+        FROM
+          (SELECT posthog_test_stripe_invoice.id AS id,
+                  parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                  posthog_test_stripe_invoice.customer AS customer_id,
+                  posthog_test_stripe_invoice.subscription AS subscription_id,
+                  posthog_test_stripe_invoice.discount AS discount,
+                  arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                  JSONExtractString(data, 'id') AS invoice_item_id,
+                  JSONExtractString(data, 'amount') AS amount_captured,
+                  JSONExtractString(data, 'currency') AS currency,
+                  JSONExtractString(data, 'price', 'product') AS product_id,
+                  fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                  fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                  greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                  arrayJoin(range(0, period_months)) AS month_index,
+                  ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.overview_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+           WHERE posthog_test_stripe_invoice.paid) AS invoice) AS `stripe.posthog_test.invoice_item_revenue_view`) AS revenue_analytics_invoice_item
+  LEFT JOIN
+    (SELECT `revenue_analytics.events.purchase.product_events_revenue_view`.id AS id,
+            `revenue_analytics.events.purchase.product_events_revenue_view`.source_label AS source_label,
+            `revenue_analytics.events.purchase.product_events_revenue_view`.name AS name
+     FROM
+       (SELECT product_id AS id,
+               'revenue_analytics.events.purchase' AS source_label,
+               product_id AS name
+        FROM
+          (SELECT DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'product'), ''), 'null'), '^"|"$', '') AS product_id
+           FROM events
+           WHERE and(equals(events.team_id, 99999), 1))
+        ORDER BY id ASC) AS `revenue_analytics.events.purchase.product_events_revenue_view`
+     UNION ALL SELECT `stripe.posthog_test.product_revenue_view`.id AS id,
+                      `stripe.posthog_test.product_revenue_view`.source_label AS source_label,
+                      `stripe.posthog_test.product_revenue_view`.name AS name
+     FROM
+       (SELECT posthog_test_stripe_product.id AS id,
+               'stripe.posthog_test' AS source_label,
+               posthog_test_stripe_product.name AS name
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.overview_query_runner.stripe_products/posthog_test_stripe_product/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `type` String, `active` UInt8, `images` String, `object` String, `created` DateTime, `features` String, `livemode` UInt8, `metadata` String, `tax_code` String, `attributes` String, `updated_at` DateTime, `description` String, `default_price_id` String') AS posthog_test_stripe_product) AS `stripe.posthog_test.product_revenue_view`) AS revenue_analytics_product ON equals(revenue_analytics_invoice_item.product_id, revenue_analytics_product.id)
+  WHERE and(and(ifNull(greaterOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-04-30 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_invoice_item.timestamp, assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), 0)), in(revenue_analytics_product.name, tuple('Product A', 'Product C')))
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1
+  '''
+# ---

--- a/products/revenue_analytics/backend/hogql_queries/test/test_revenue_analytics_overview_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/test/test_revenue_analytics_overview_query_runner.py
@@ -226,6 +226,30 @@ class TestRevenueAnalyticsOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
+    def test_with_property_filter_multiple_values(self):
+        results = self._run_revenue_analytics_overview_query(
+            properties=[
+                RevenueAnalyticsPropertyFilter(
+                    key="product",
+                    operator=PropertyOperator.EXACT,
+                    value=["Product A", "Product C"],
+                )
+            ]
+        ).results
+
+        self.assertEqual(
+            results,
+            [
+                RevenueAnalyticsOverviewItem(
+                    key=RevenueAnalyticsOverviewItemKey.REVENUE, value=Decimal("133.9132683333")
+                ),
+                RevenueAnalyticsOverviewItem(key=RevenueAnalyticsOverviewItemKey.PAYING_CUSTOMER_COUNT, value=2),
+                RevenueAnalyticsOverviewItem(
+                    key=RevenueAnalyticsOverviewItemKey.AVG_REVENUE_PER_CUSTOMER, value=Decimal("66.9566341666")
+                ),
+            ],
+        )
+
     def test_with_events_data(self):
         s1 = str(uuid7("2023-12-02"))
         s2 = str(uuid7("2024-01-03"))


### PR DESCRIPTION
We had a weird dormant bug here where we were using the raw `field` inside the code that handles array `value`s rather than using the prepared `expr`. `expr` is only different than `field` for some (but not all) revenue analytics, error tracking, session replay and virtual property queries hence why we've never noticed that we were not using the correct field - seldom used queries in comparison to product analytics and/or custom SQL.

The bug would reproduce by us not taking into consideration the expr mapping which meant Revenue Analytics would fail to find the correct fields - and similarly for the other mappings.

This is easily fixed by using `expr` over `field` on the `ast.CompareOperation` creation. I changed some other names to make this clearer - and also make it less easy to miss in the future.

Added a couple tests all around to make this regression-proof (almost).

See https://posthoghelp.zendesk.com/agent/tickets/35058 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/37667)
