### PR TITLE
fix(devex): show panel on bigger screens, fixes

### DIFF
--- a/frontend/src/layout/scenes/SceneHeader.tsx
+++ b/frontend/src/layout/scenes/SceneHeader.tsx
@@ -98,6 +98,13 @@ export function SceneHeader({ className }: { className?: string }): JSX.Element 
                                           ? 'Close info panel'
                                           : 'Open info panel'
                                 }
+                                aria-label={
+                                    scenePanelIsRelative
+                                        ? 'Force close info panel'
+                                        : scenePanelOpen
+                                          ? 'Close info panel'
+                                          : 'Open info panel'
+                                }
                                 active={scenePanelOpen}
                                 size="small"
                             />

--- a/frontend/src/layout/scenes/SceneHeader.tsx
+++ b/frontend/src/layout/scenes/SceneHeader.tsx
@@ -28,8 +28,14 @@ export function SceneHeader({ className }: { className?: string }): JSX.Element 
     const { showLayoutNavBar } = useActions(panelLayoutLogic)
     const { isLayoutNavbarVisibleForMobile } = useValues(panelLayoutLogic)
     const { projectTreeRefEntry } = useValues(projectTreeDataLogic)
-    const { scenePanelOpen, scenePanelIsPresent, useSceneTabs } = useValues(sceneLayoutLogic)
-    const { setScenePanelOpen } = useActions(sceneLayoutLogic)
+    const {
+        scenePanelOpen,
+        scenePanelIsPresent,
+        useSceneTabs,
+        scenePanelIsRelative,
+        forceScenePanelClosedWhenRelative,
+    } = useValues(sceneLayoutLogic)
+    const { setScenePanelOpen, setForceScenePanelClosedWhenRelative } = useActions(sceneLayoutLogic)
 
     const effectiveBreadcrumbs = useSceneTabs ? breadcrumbs.slice(1) : breadcrumbs
     return effectiveBreadcrumbs.length || projectTreeRefEntry ? (
@@ -75,17 +81,27 @@ export function SceneHeader({ className }: { className?: string }): JSX.Element 
                     <div className="flex gap-1 items-center shrink-0 pr-px">
                         <div className="contents" ref={setActionsContainer} />
 
+                        <TopBarSettingsButton buttonProps={{ size: 'small', icon: <IconGear /> }} />
+
                         {scenePanelIsPresent && (
                             <LemonButton
-                                onClick={() => setScenePanelOpen(!scenePanelOpen)}
+                                onClick={() =>
+                                    scenePanelIsRelative
+                                        ? setForceScenePanelClosedWhenRelative(!forceScenePanelClosedWhenRelative)
+                                        : setScenePanelOpen(!scenePanelOpen)
+                                }
                                 icon={<IconInfo className="text-primary" />}
-                                tooltip={scenePanelOpen ? 'Close info panel' : 'Open info panel'}
+                                tooltip={
+                                    scenePanelIsRelative
+                                        ? 'Force close info panel'
+                                        : scenePanelOpen
+                                          ? 'Close info panel'
+                                          : 'Open info panel'
+                                }
                                 active={scenePanelOpen}
                                 size="small"
                             />
                         )}
-
-                        <TopBarSettingsButton buttonProps={{ size: 'small', icon: <IconGear /> }} />
                     </div>
                 </div>
             </div>

--- a/frontend/src/layout/scenes/SceneLayout.tsx
+++ b/frontend/src/layout/scenes/SceneLayout.tsx
@@ -165,8 +165,6 @@ export function SceneLayout({ children, className, layoutConfig }: SceneLayoutPr
                                 'scene-layout__content-panel order-2 bg-surface-secondary flex flex-col overflow-hidden row-span-2 col-span-2 row-start-1 col-start-2 top-0 h-screen min-w-0 fixed left-[calc(var(--scene-layout-outer-right)-var(--scene-layout-panel-width)-1px)]',
                                 {
                                     hidden: !scenePanelOpen,
-                                    'fixed left-[calc(var(--scene-layout-outer-right)-var(--scene-layout-panel-width)-1px)]':
-                                        scenePanelIsRelative,
                                 }
                             )}
                         >
@@ -184,7 +182,20 @@ export function SceneLayout({ children, className, layoutConfig }: SceneLayoutPr
                                                 ? setForceScenePanelClosedWhenRelative(true)
                                                 : setScenePanelOpen(false)
                                         }
-                                        tooltip={scenePanelIsRelative ? 'Force close info panel' : undefined}
+                                        tooltip={
+                                            scenePanelIsRelative
+                                                ? 'Force close info panel'
+                                                : scenePanelOpen
+                                                  ? 'Close info panel'
+                                                  : 'Open info panel'
+                                        }
+                                        aria-label={
+                                            scenePanelIsRelative
+                                                ? 'Force close info panel'
+                                                : scenePanelOpen
+                                                  ? 'Close info panel'
+                                                  : 'Open info panel'
+                                        }
                                     >
                                         <IconX className="size-4" />
                                     </ButtonPrimitive>
@@ -205,6 +216,7 @@ export function SceneLayout({ children, className, layoutConfig }: SceneLayoutPr
                                 onClick={() => {
                                     setScenePanelOpen(false)
                                 }}
+                                aria-hidden="true"
                                 className="z-[var(--z-top-navigation-under)] fixed inset-0 w-screen h-screen bg-fill-highlight-100"
                             />
                         )}

--- a/frontend/src/layout/scenes/sceneLayoutLogic.tsx
+++ b/frontend/src/layout/scenes/sceneLayoutLogic.tsx
@@ -1,7 +1,13 @@
-import { actions, connect, kea, path, reducers, selectors } from 'kea'
+import { actions, connect, kea, path, reducers, selectors, listeners, afterMount, beforeUnmount } from 'kea'
 import type { sceneLayoutLogicType } from './sceneLayoutLogicType'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import React from 'react'
+
+export type SceneLayoutContainerRef = React.RefObject<HTMLElement> | null
+
+// This seems arbitrary, but it's the comfortable width to keep dashboard in a two column layout
+const SCENE_WIDTH_WHERE_RELATIVE_PANEL_IS_OPEN = 1358
 
 export const sceneLayoutLogic = kea<sceneLayoutLogicType>([
     path(['layout', 'scene-layout', 'sceneLayoutLogic']),
@@ -10,6 +16,9 @@ export const sceneLayoutLogic = kea<sceneLayoutLogicType>([
         registerScenePanelElement: (element: HTMLElement | null) => ({ element }),
         setScenePanelIsPresent: (active: boolean) => ({ active }),
         setScenePanelOpen: (open: boolean) => ({ open }),
+        setSceneWidth: (width: number) => ({ width }),
+        setForceScenePanelClosedWhenRelative: (closed: boolean) => ({ closed }),
+        setSceneContainerRef: (ref: SceneLayoutContainerRef) => ({ ref }),
     }),
     reducers({
         scenePanelElement: [
@@ -24,14 +33,80 @@ export const sceneLayoutLogic = kea<sceneLayoutLogicType>([
                 setScenePanelIsPresent: (_, { active }) => active,
             },
         ],
-        scenePanelOpen: [
+        scenePanelOpenManual: [
             false,
             {
                 setScenePanelOpen: (_, { open }) => open,
             },
         ],
+        sceneWidth: [
+            0,
+            {
+                setSceneWidth: (_, { width }) => width,
+            },
+        ],
+        forceScenePanelClosedWhenRelative: [
+            false,
+            { persist: true },
+            {
+                setForceScenePanelClosedWhenRelative: (_, { closed }) => closed,
+            },
+        ],
+        sceneContainerRef: [
+            null as SceneLayoutContainerRef,
+            {
+                setSceneContainerRef: (_, { ref }) => ref,
+            },
+        ],
     }),
     selectors({
         useSceneTabs: [(s) => [s.featureFlags], (featureFlags) => !!featureFlags[FEATURE_FLAGS.SCENE_TABS]],
+        scenePanelIsRelative: [
+            (s) => [s.sceneWidth],
+            (sceneWidth) => sceneWidth >= SCENE_WIDTH_WHERE_RELATIVE_PANEL_IS_OPEN,
+        ],
+        scenePanelOpen: [
+            (s) => [s.scenePanelIsRelative, s.forceScenePanelClosedWhenRelative, s.scenePanelOpenManual],
+            (scenePanelIsRelative, forceScenePanelClosedWhenRelative, scenePanelOpenManual) =>
+                scenePanelIsRelative ? !forceScenePanelClosedWhenRelative : scenePanelOpenManual,
+        ],
+    }),
+    listeners(({ actions, values }) => ({
+        updateSceneWidth: () => {
+            const containerRef = values.sceneContainerRef
+            if (containerRef?.current) {
+                actions.setSceneWidth(containerRef.current.offsetWidth)
+            }
+        },
+        setScenePanelOpen: ({ open }) => {
+            // When trying to open a relative panel that's force closed, reset the force closed state
+            if (open && values.scenePanelIsRelative && values.forceScenePanelClosedWhenRelative) {
+                actions.setForceScenePanelClosedWhenRelative(false)
+            }
+        },
+        setSceneContainerRef: ({ ref }) => {
+            // Measure width immediately when container ref is set
+            if (ref?.current) {
+                actions.setSceneWidth(ref.current.offsetWidth)
+            }
+        },
+    })),
+    afterMount(({ actions, cache, values }) => {
+        const handleResize = (): void => {
+            const containerRef = values.sceneContainerRef
+            if (containerRef?.current) {
+                actions.setSceneWidth(containerRef.current.offsetWidth)
+            }
+        }
+        cache.handleResize = handleResize
+
+        if (typeof window !== 'undefined') {
+            window.addEventListener('resize', handleResize)
+        }
+    }),
+    beforeUnmount(({ cache }) => {
+        if (typeof window !== 'undefined' && cache.handleResize) {
+            window.removeEventListener('resize', cache.handleResize)
+        }
     }),
 ])


### PR DESCRIPTION

## Problem
Scene panel should be shown at bigger screens when space permits
-> And be force closeable so people can get rid of it
Scene trigger button `( i )` should be the furthest right in the header

## Changes
* Scene panel now shown on bigger screens
* Can be forced closed (persisted so it doesn't get in the way again)
* Move trigger button to the right of settings button

#### Peristed force close, and can open again
![2025-08-04 15 27 50](https://github.com/user-attachments/assets/fd33bdf0-570d-4227-8ce9-d4b73fdfc486)

#### Normal behaviour at smaller screens
![2025-08-04 15 30 28](https://github.com/user-attachments/assets/3696b1c3-140d-4c8d-a21e-f0fea321fbf7)


## How did you test this code?
Clicking, shrinking screen sizes, refreshing etc.

