### PR TITLE
fix: bin/start --minimal don't autostart beat and replay

### DIFF
--- a/bin/mprocs-minimal.yaml
+++ b/bin/mprocs-minimal.yaml
@@ -7,6 +7,7 @@ procs:
 
     celery-beat:
         shell: 'uv sync --active && bin/check_kafka_clickhouse_up && ./bin/start-celery beat'
+        autostart: false
 
     plugin-server:
         shell: 'bin/check_kafka_clickhouse_up && ./bin/plugin-server'
@@ -35,6 +36,7 @@ procs:
             bin/check_postgres_up && \
             bin/check_kafka_clickhouse_up && \
             bin/start-rust-service capture-replay
+        autostart: false
 
     migrate-clickhouse:
         # These migrations are not in the `backend` service, because they typically aren't blocking for backend startup,


### PR DESCRIPTION
## Changes
Celery beat and capture-replay are not required to run the stack for most development tasks, so don't start them to save some resources.

## How did you test this code?
* ran it