### PR TITLE
fix(messaging): fix intercom eu endpoint key

### DIFF
--- a/posthog/cdp/templates/intercom/template_intercom.py
+++ b/posthog/cdp/templates/intercom/template_intercom.py
@@ -18,7 +18,7 @@ if (empty(inputs.email)) {
 
 let regions := {
     'US': 'api.intercom.io',
-    'EU': 'api.eu.intercom.io',
+    'Europe': 'api.eu.intercom.io',
     'AU': 'api.au.intercom.io',
 }
 


### PR DESCRIPTION
## Problem

The `app.region` in intercom's EU cloud will return `Europe` instead of `EU`
https://metabase.prod-eu.posthog.dev/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJkYXRhYmFzZSI6MzQsIm5hdGl2ZSI6eyJxdWVyeSI6IlNFTEVDVCBESVNUSU5DVCBjb25maWctPj4nYXBwLnJlZ2lvbicgRlJPTSBwb3N0aG9nX2ludGVncmF0aW9uIFdIRVJFIGtpbmQgPSAnaW50ZXJjb20nOyIsInRlbXBsYXRlLXRhZ3MiOnt9fX0sImRpc3BsYXkiOiJ0YWJsZSIsInBhcmFtZXRlcnMiOltdLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fX0=

https://posthoghelp.zendesk.com/agent/tickets/35469 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/37316)

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
