### PR TITLE
fix(msg): exclude plugins from public api

### DIFF
--- a/posthog/api/hog_function_template.py
+++ b/posthog/api/hog_function_template.py
@@ -70,6 +70,8 @@ class PublicHogFunctionTemplateViewSet(
 
         if self.request.path.startswith("/api/public_hog_function_templates"):
             queryset = queryset.exclude(status="hidden")
+            # Exclude legacy templates that start with "plugin-"
+            queryset = queryset.exclude(template_id__startswith="plugin-")
 
         return queryset
 

--- a/posthog/api/hog_function_template.py
+++ b/posthog/api/hog_function_template.py
@@ -71,7 +71,8 @@ class PublicHogFunctionTemplateViewSet(
         if self.request.path.startswith("/api/public_hog_function_templates"):
             queryset = queryset.exclude(status="hidden")
             # Exclude legacy templates that start with "plugin-"
-            queryset = queryset.exclude(template_id__startswith="plugin-")
+            if "transformation" in types:
+                queryset = queryset.exclude(template_id__startswith="plugin-")
 
         return queryset
 

--- a/posthog/api/test/test_hog_function_templates.py
+++ b/posthog/api/test/test_hog_function_templates.py
@@ -173,10 +173,9 @@ class TestHogFunctionTemplates(ClickhouseTestMixin, APIBaseTest, QueryMatchingTe
         for template_item in response.json()["results"]:
             assert template_item["status"] != "hidden", f"Hidden template {template_item['id']} should not be returned"
 
-    def test_legacy_plugin_templates_are_excluded_from_public_api(self):
+    def test_legacy_transformation_templates_are_excluded_from_public_api(self):
         """Test that templates with IDs starting with 'plugin-' are excluded from public API"""
         self.client.logout()
-        # Request both destination and transformation types to ensure we test all templates
         response = self.client.get("/api/public_hog_function_templates/?types=transformation")
 
         assert response.status_code == status.HTTP_200_OK, response.json()


### PR DESCRIPTION
## Problem

legacy transformations are still returned from the public template api 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- do not return them

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- added tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
