### PR TITLE
fix(cdp): Name in the alpha warning

### DIFF
--- a/frontend/src/scenes/hog-functions/configuration/HogFunctionConfiguration.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/HogFunctionConfiguration.tsx
@@ -33,6 +33,7 @@ import { HogFunctionIconEditable } from './HogFunctionIcon'
 import { HogFunctionTest } from './HogFunctionTest'
 import { HogFunctionCode } from './components/HogFunctionCode'
 import { HogFunctionTemplateOptions } from './components/HogFunctionTemplateOptions'
+import { humanizeHogFunctionType } from '../hog-function-utils'
 
 export interface HogFunctionConfigurationProps {
     templateId?: string | null
@@ -172,9 +173,9 @@ export function HogFunctionConfiguration({ templateId, id, logicKey }: HogFuncti
                     <div>
                         <LemonBanner type="warning">
                             <p>
-                                This destination is currently in an experimental state. For many cases this will work
-                                just fine but for others there may be unexpected issues and we do not offer official
-                                customer support for it in these cases.
+                                This {humanizeHogFunctionType(type)} is currently in an experimental state. For many
+                                cases this will work just fine but for others there may be unexpected issues and we do
+                                not offer official customer support for it in these cases.
                             </p>
                             {['template-reddit-conversions-api', 'template-snapchat-ads'].includes(
                                 templateId ?? hogFunction?.template?.id ?? ''


### PR DESCRIPTION
## Changes

* Fixes the alpha warning label to use the right name

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
