### PR TITLE
chore(max): Final query generation fixes

### DIFF
--- a/ee/hogai/eval/eval_trends.py
+++ b/ee/hogai/eval/eval_trends.py
@@ -385,7 +385,7 @@ Query kind:
 - Trends
     - single series (EventsNode) with math = total
     - dateRange: { date_from: “2025-01-01”, date_to: “2025-01-31” }
-    - display: BoldNumber (to show a single total count)
+    - display: ActionsLineGraph (to have the requested number for the month, but also see any trends)
 """,
             query=AssistantTrendsQuery(
                 dateRange={"date_from": "2025-01-01", "date_to": "2025-01-31"},

--- a/ee/hogai/eval/eval_trends.py
+++ b/ee/hogai/eval/eval_trends.py
@@ -18,6 +18,393 @@ from .conftest import MaxEval
 from .scorers import PlanAndQueryOutput, PlanCorrectness, QueryAndPlanAlignment, QueryKindSelection, TimeRangeRelevancy
 
 
+TRENDS_CASES = [
+    EvalCase(
+        input="Show the $pageview trend",
+        expected=PlanAndQueryOutput(
+            plan="""
+Events:
+- $pageview
+    - math operation: total count
+""",
+            query=AssistantTrendsQuery(
+                dateRange={"date_from": "-30d", "date_to": None},
+                filterTestAccounts=True,
+                interval="day",
+                trendsFilter=AssistantTrendsFilter(
+                    display="ActionsLineGraph",
+                    showLegend=True,
+                ),
+                series=[
+                    AssistantTrendsEventsNode(
+                        event="$pageview",
+                        math="total",
+                        properties=None,
+                    )
+                ],
+            ),
+        ),
+    ),
+    EvalCase(
+        input="What is our MAU?",
+        expected=PlanAndQueryOutput(
+            plan="""
+Events:
+- All events
+    - math operation: unique users
+
+Time period: last 30 days
+No interval
+""",
+            query=AssistantTrendsQuery(
+                dateRange={"date_from": "-30d", "date_to": None},
+                filterTestAccounts=True,
+                trendsFilter=AssistantTrendsFilter(
+                    display="BoldNumber",
+                    showLegend=True,
+                ),
+                series=[
+                    AssistantTrendsEventsNode(
+                        event=None,
+                        math="dau",  # "dau" name is a legacy misnomer, it actually just means "unique users"
+                        properties=None,
+                    )
+                ],
+            ),
+        ),
+    ),
+    EvalCase(
+        input="can you compare how many Chrome vs Safari users uploaded a file in the last 30d?",
+        expected=PlanAndQueryOutput(
+            plan="""
+Events:
+- uploaded_file
+    - math operation: unique users
+    - property filter 1:
+        - entity: event
+        - property name: $browser
+        - property type: String
+        - operator: equals
+        - property value: Chrome
+- uploaded_file
+    - math operation: unique users
+    - property filter 1:
+        - entity: event
+        - property name: $browser
+        - property type: String
+        - operator: equals
+        - property value: Safari
+""",
+            query=AssistantTrendsQuery(
+                dateRange={"date_from": "-30d", "date_to": None},
+                filterTestAccounts=True,
+                interval="day",
+                trendsFilter=AssistantTrendsFilter(
+                    display="ActionsLineGraph",
+                    showLegend=True,
+                ),
+                breakdownFilter=AssistantTrendsBreakdownFilter(
+                    breakdowns=[
+                        AssistantGenericMultipleBreakdownFilter(
+                            property="$browser",
+                            type=AssistantEventMultipleBreakdownFilterType.EVENT,
+                        )
+                    ]
+                ),
+                series=[
+                    AssistantTrendsEventsNode(
+                        event="uploaded_file",
+                        math="total",
+                        properties=[
+                            {
+                                "key": "$browser",
+                                "value": ["Chrome", "Safari"],
+                                "operator": "exact",
+                                "type": "event",
+                            },
+                        ],
+                    )
+                ],
+            ),
+        ),
+    ),
+    EvalCase(
+        input="i want to see a ratio of identify divided by page views",
+        expected=PlanAndQueryOutput(
+            plan="""
+Events:
+- $identify
+    - math operation: total count
+- $pageview
+    - math operation: total count
+
+Formula:
+`A/B`, where `A` is the total count of `$identify` and `B` is the total count of `$pageview`
+""",
+            query=AssistantTrendsQuery(
+                dateRange={"date_from": "-30d", "date_to": None},
+                filterTestAccounts=True,
+                interval="day",
+                trendsFilter=AssistantTrendsFilter(display="ActionsLineGraph", showLegend=True, formulas=["A/B"]),
+                series=[
+                    AssistantTrendsEventsNode(
+                        event="$identify",
+                        math="total",
+                        properties=None,
+                    ),
+                    AssistantTrendsEventsNode(
+                        event="$pageview",
+                        math="total",
+                        properties=None,
+                    ),
+                ],
+            ),
+        ),
+    ),
+    EvalCase(
+        input="what is our average session duration?",
+        expected=PlanAndQueryOutput(
+            plan="""
+Events:
+- All Events
+    - math operation: average by `$session_duration`
+""",
+            query=AssistantTrendsQuery(
+                dateRange={"date_from": "-30d", "date_to": None},
+                filterTestAccounts=True,
+                interval="day",
+                trendsFilter=AssistantTrendsFilter(
+                    display="ActionsLineGraph",
+                    showLegend=True,
+                ),
+                series=[
+                    AssistantTrendsEventsNode(
+                        event="$all_events",
+                        math="avg",
+                        math_property="$session_duration",
+                        properties=None,
+                    )
+                ],
+            ),
+        ),
+    ),
+    EvalCase(
+        input="how many $pageviews with unique sessions did we have?",
+        expected=PlanAndQueryOutput(
+            plan="""
+Events:
+- $pageview
+    - math operation: unique sessions
+
+Time period: last month
+Time interval: day
+""",
+            query=AssistantTrendsQuery(
+                dateRange={"date_from": "-30d", "date_to": None},
+                filterTestAccounts=True,
+                interval="day",
+                trendsFilter=AssistantTrendsFilter(
+                    display="ActionsLineGraph",
+                    showLegend=True,
+                ),
+                series=[
+                    AssistantTrendsEventsNode(
+                        event="$pageview",
+                        math="unique_session",
+                        properties=None,
+                    )
+                ],
+            ),
+        ),
+    ),
+    EvalCase(
+        input="How often do users view the website in this January?",
+        expected=PlanAndQueryOutput(
+            plan="""
+Events:
+- $pageview
+    - math operation: total count
+
+Time period: this January
+Time interval: day
+""",
+            query=AssistantTrendsQuery(
+                dateRange={
+                    "date_from": f"{datetime.now().year}-01-01",
+                    "date_to": f"{datetime.now().year}-01-31",
+                },
+                filterTestAccounts=True,
+                interval="day",
+                trendsFilter=AssistantTrendsFilter(
+                    display="ActionsLineGraph",
+                    showLegend=True,
+                ),
+                series=[
+                    AssistantTrendsEventsNode(
+                        event="$pageview",
+                        math="total",
+                        properties=None,
+                    )
+                ],
+            ),
+        ),
+    ),
+    EvalCase(
+        input="How many paid bill events have occurred with amount more than 20 usd in this January?",
+        expected=PlanAndQueryOutput(
+            plan="""
+Events:
+- paid_bill
+    - math operation: total count
+    - property filter 1:
+        - entity: event
+        - property name: amount_usd
+        - property type: Numeric
+        - operator: greater than
+        - property value: 20
+
+Time period: this January
+Time interval: day
+""",
+            query=AssistantTrendsQuery(
+                dateRange={
+                    "date_from": f"{datetime.now().year}-01-01",
+                    "date_to": f"{datetime.now().year}-01-31",
+                },
+                filterTestAccounts=True,
+                interval="day",
+                trendsFilter=AssistantTrendsFilter(
+                    display="ActionsLineGraph",
+                    showLegend=True,
+                ),
+                series=[
+                    AssistantTrendsEventsNode(
+                        event="paid_bill",
+                        math="total",
+                        properties=[
+                            {
+                                "key": "amount_usd",
+                                "value": 20,
+                                "operator": "gt",
+                                "type": "event",
+                            },
+                        ],
+                    )
+                ],
+            ),
+        ),
+    ),
+    EvalCase(
+        input="on hedgebox.net, what is the % of mac os x users",
+        expected=PlanAndQueryOutput(
+            plan="""
+Events:
+- All events
+    - math operation: unique users
+    - property filter 1:
+        - entity: event
+        - property name: $host
+        - property type: String
+        - operator: equals
+        - property value: hedgebox.net
+- All events
+    - math operation: unique users
+    - property filter 1:
+        - entity: event
+        - property name: $host
+        - property type: String
+        - operator: equals
+        - property value: hedgebox.net
+    - property filter 2:
+        - entity: event
+        - property name: $os
+        - property type: String
+        - operator: equals
+        - property value: Mac OS X
+
+Formula:
+`B/A * 100`, where `A` is total unique users on hedgebox.net and `B` is unique users on hedgebox.net with Mac OS X
+""",
+            query=AssistantTrendsQuery(
+                dateRange={"date_from": "-30d", "date_to": None},
+                filterTestAccounts=True,
+                interval="day",
+                trendsFilter=AssistantTrendsFilter(display="BoldNumber", showLegend=True, formulas=["B/A * 100"]),
+                series=[
+                    AssistantTrendsEventsNode(
+                        event=None,
+                        math="dau",
+                        properties=[
+                            {
+                                "key": "$host",
+                                "value": "hedgebox.net",
+                                "operator": "icontains",
+                                "type": "event",
+                            },
+                        ],
+                    ),
+                    AssistantTrendsEventsNode(
+                        event=None,
+                        math="dau",
+                        properties=[
+                            {
+                                "key": "$host",
+                                "value": "hedgebox.net",
+                                "operator": "icontains",
+                                "type": "event",
+                            },
+                            {
+                                "key": "$os",
+                                "value": "Mac OS X",
+                                "operator": "exact",
+                                "type": "event",
+                            },
+                        ],
+                    ),
+                ],
+            ),
+        ),
+    ),
+    # Specific, uppercase event to use, which doesn't exist in the actual data (but the user quotes it specifically anyway)
+    EvalCase(
+        input="How many 'Onboarding Completed' events have we had in January 2025?",
+        expected=PlanAndQueryOutput(
+            plan="""
+Logic:
+- Scan the events table for records where the event name exactly equals “Onboarding Completed”.
+- Restrict to those with timestamp ≥ 2025-01-01 00:00:00 and ≤ 2025-01-31 23:59:59.
+- Aggregate by counting the total number of matching rows.
+
+Sources:
+- events
+    - filter: event = “Onboarding Completed”
+    - filter: timestamp between “2025-01-01” and “2025-01-31”
+    - aggregation: COUNT(*)
+
+Query kind:
+- Trends
+    - single series (EventsNode) with math = total
+    - dateRange: { date_from: “2025-01-01”, date_to: “2025-01-31” }
+    - display: BoldNumber (to show a single total count)
+""",
+            query=AssistantTrendsQuery(
+                dateRange={"date_from": "2025-01-01", "date_to": "2025-01-31"},
+                filterTestAccounts=True,
+                interval="day",
+                trendsFilter=AssistantTrendsFilter(display="ActionsLineGraph"),
+                series=[
+                    AssistantTrendsEventsNode(
+                        event="Onboarding Completed",
+                        math="total",
+                        properties=None,
+                    )
+                ],
+            ),
+        ),
+    ),
+]
+
+
 @pytest.mark.django_db
 async def eval_trends(call_root_for_insight_generation, pytestconfig):
     await MaxEval(
@@ -71,357 +458,6 @@ async def eval_trends(call_root_for_insight_generation, pytestconfig):
             ),
             TimeRangeRelevancy(query_kind=NodeKind.TRENDS_QUERY),
         ],
-        data=[
-            EvalCase(
-                input="Show the $pageview trend",
-                expected=PlanAndQueryOutput(
-                    plan="""
-Events:
-- $pageview
-    - math operation: total count
-""",
-                    query=AssistantTrendsQuery(
-                        dateRange={"date_from": "-30d", "date_to": None},
-                        filterTestAccounts=True,
-                        interval="day",
-                        trendsFilter=AssistantTrendsFilter(
-                            display="ActionsLineGraph",
-                            showLegend=True,
-                        ),
-                        series=[
-                            AssistantTrendsEventsNode(
-                                event="$pageview",
-                                math="total",
-                                properties=None,
-                            )
-                        ],
-                    ),
-                ),
-            ),
-            EvalCase(
-                input="What is our MAU?",
-                expected=PlanAndQueryOutput(
-                    plan="""
-Events:
-- All events
-    - math operation: unique users
-
-Time period: last 30 days
-No interval
-""",
-                    query=AssistantTrendsQuery(
-                        dateRange={"date_from": "-30d", "date_to": None},
-                        filterTestAccounts=True,
-                        trendsFilter=AssistantTrendsFilter(
-                            display="BoldNumber",
-                            showLegend=True,
-                        ),
-                        series=[
-                            AssistantTrendsEventsNode(
-                                event=None,
-                                math="dau",  # "dau" name is a legacy misnomer, it actually just means "unique users"
-                                properties=None,
-                            )
-                        ],
-                    ),
-                ),
-            ),
-            EvalCase(
-                input="can you compare how many Chrome vs Safari users uploaded a file in the last 30d?",
-                expected=PlanAndQueryOutput(
-                    plan="""
-Events:
-- uploaded_file
-    - math operation: unique users
-    - property filter 1:
-        - entity: event
-        - property name: $browser
-        - property type: String
-        - operator: equals
-        - property value: Chrome
-- uploaded_file
-    - math operation: unique users
-    - property filter 1:
-        - entity: event
-        - property name: $browser
-        - property type: String
-        - operator: equals
-        - property value: Safari
-""",
-                    query=AssistantTrendsQuery(
-                        dateRange={"date_from": "-30d", "date_to": None},
-                        filterTestAccounts=True,
-                        interval="day",
-                        trendsFilter=AssistantTrendsFilter(
-                            display="ActionsLineGraph",
-                            showLegend=True,
-                        ),
-                        breakdownFilter=AssistantTrendsBreakdownFilter(
-                            breakdowns=[
-                                AssistantGenericMultipleBreakdownFilter(
-                                    property="$browser",
-                                    type=AssistantEventMultipleBreakdownFilterType.EVENT,
-                                )
-                            ]
-                        ),
-                        series=[
-                            AssistantTrendsEventsNode(
-                                event="uploaded_file",
-                                math="total",
-                                properties=[
-                                    {
-                                        "key": "$browser",
-                                        "value": ["Chrome", "Safari"],
-                                        "operator": "exact",
-                                        "type": "event",
-                                    },
-                                ],
-                            )
-                        ],
-                    ),
-                ),
-            ),
-            EvalCase(
-                input="i want to see a ratio of identify divided by page views",
-                expected=PlanAndQueryOutput(
-                    plan="""
-Events:
-- $identify
-    - math operation: total count
-- $pageview
-    - math operation: total count
-
-Formula:
-`A/B`, where `A` is the total count of `$identify` and `B` is the total count of `$pageview`
-""",
-                    query=AssistantTrendsQuery(
-                        dateRange={"date_from": "-30d", "date_to": None},
-                        filterTestAccounts=True,
-                        interval="day",
-                        trendsFilter=AssistantTrendsFilter(
-                            display="ActionsLineGraph", showLegend=True, formulas=["A/B"]
-                        ),
-                        series=[
-                            AssistantTrendsEventsNode(
-                                event="$identify",
-                                math="total",
-                                properties=None,
-                            ),
-                            AssistantTrendsEventsNode(
-                                event="$pageview",
-                                math="total",
-                                properties=None,
-                            ),
-                        ],
-                    ),
-                ),
-            ),
-            EvalCase(
-                input="what is our average session duration?",
-                expected=PlanAndQueryOutput(
-                    plan="""
-Events:
-- All Events
-    - math operation: average by `$session_duration`
-""",
-                    query=AssistantTrendsQuery(
-                        dateRange={"date_from": "-30d", "date_to": None},
-                        filterTestAccounts=True,
-                        interval="day",
-                        trendsFilter=AssistantTrendsFilter(
-                            display="ActionsLineGraph",
-                            showLegend=True,
-                        ),
-                        series=[
-                            AssistantTrendsEventsNode(
-                                event="$all_events",
-                                math="avg",
-                                math_property="$session_duration",
-                                properties=None,
-                            )
-                        ],
-                    ),
-                ),
-            ),
-            EvalCase(
-                input="how many $pageviews with unique sessions did we have?",
-                expected=PlanAndQueryOutput(
-                    plan="""
-Events:
-- $pageview
-    - math operation: unique sessions
-
-Time period: last month
-Time interval: day
-""",
-                    query=AssistantTrendsQuery(
-                        dateRange={"date_from": "-30d", "date_to": None},
-                        filterTestAccounts=True,
-                        interval="day",
-                        trendsFilter=AssistantTrendsFilter(
-                            display="ActionsLineGraph",
-                            showLegend=True,
-                        ),
-                        series=[
-                            AssistantTrendsEventsNode(
-                                event="$pageview",
-                                math="unique_session",
-                                properties=None,
-                            )
-                        ],
-                    ),
-                ),
-            ),
-            EvalCase(
-                input="How often do users view the website in this January?",
-                expected=PlanAndQueryOutput(
-                    plan="""
-Events:
-- $pageview
-    - math operation: total count
-
-Time period: this January
-Time interval: day
-""",
-                    query=AssistantTrendsQuery(
-                        dateRange={
-                            "date_from": f"{datetime.now().year}-01-01",
-                            "date_to": f"{datetime.now().year}-01-31",
-                        },
-                        filterTestAccounts=True,
-                        interval="day",
-                        trendsFilter=AssistantTrendsFilter(
-                            display="ActionsLineGraph",
-                            showLegend=True,
-                        ),
-                        series=[
-                            AssistantTrendsEventsNode(
-                                event="$pageview",
-                                math="total",
-                                properties=None,
-                            )
-                        ],
-                    ),
-                ),
-            ),
-            EvalCase(
-                input="How many paid bill events have occurred with amount more than 20 usd in this January?",
-                expected=PlanAndQueryOutput(
-                    plan="""
-Events:
-- paid_bill
-    - math operation: total count
-    - property filter 1:
-        - entity: event
-        - property name: amount_usd
-        - property type: Numeric
-        - operator: greater than
-        - property value: 20
-
-Time period: this January
-Time interval: day
-""",
-                    query=AssistantTrendsQuery(
-                        dateRange={
-                            "date_from": f"{datetime.now().year}-01-01",
-                            "date_to": f"{datetime.now().year}-01-31",
-                        },
-                        filterTestAccounts=True,
-                        interval="day",
-                        trendsFilter=AssistantTrendsFilter(
-                            display="ActionsLineGraph",
-                            showLegend=True,
-                        ),
-                        series=[
-                            AssistantTrendsEventsNode(
-                                event="paid_bill",
-                                math="total",
-                                properties=[
-                                    {
-                                        "key": "amount_usd",
-                                        "value": 20,
-                                        "operator": "gt",
-                                        "type": "event",
-                                    },
-                                ],
-                            )
-                        ],
-                    ),
-                ),
-            ),
-            EvalCase(
-                input="on hedgebox.net, what is the % of mac os x users",
-                expected=PlanAndQueryOutput(
-                    plan="""
-Events:
-- All events
-    - math operation: unique users
-    - property filter 1:
-        - entity: event
-        - property name: $host
-        - property type: String
-        - operator: equals
-        - property value: hedgebox.net
-- All events
-    - math operation: unique users
-    - property filter 1:
-        - entity: event
-        - property name: $host
-        - property type: String
-        - operator: equals
-        - property value: hedgebox.net
-    - property filter 2:
-        - entity: event
-        - property name: $os
-        - property type: String
-        - operator: equals
-        - property value: Mac OS X
-
-Formula:
-`B/A * 100`, where `A` is total unique users on hedgebox.net and `B` is unique users on hedgebox.net with Mac OS X
-""",
-                    query=AssistantTrendsQuery(
-                        dateRange={"date_from": "-30d", "date_to": None},
-                        filterTestAccounts=True,
-                        interval="day",
-                        trendsFilter=AssistantTrendsFilter(
-                            display="BoldNumber", showLegend=True, formulas=["B/A * 100"]
-                        ),
-                        series=[
-                            AssistantTrendsEventsNode(
-                                event=None,
-                                math="dau",
-                                properties=[
-                                    {
-                                        "key": "$host",
-                                        "value": "hedgebox.net",
-                                        "operator": "icontains",
-                                        "type": "event",
-                                    },
-                                ],
-                            ),
-                            AssistantTrendsEventsNode(
-                                event=None,
-                                math="dau",
-                                properties=[
-                                    {
-                                        "key": "$host",
-                                        "value": "hedgebox.net",
-                                        "operator": "icontains",
-                                        "type": "event",
-                                    },
-                                    {
-                                        "key": "$os",
-                                        "value": "Mac OS X",
-                                        "operator": "exact",
-                                        "type": "event",
-                                    },
-                                ],
-                            ),
-                        ],
-                    ),
-                ),
-            ),
-        ],
+        data=TRENDS_CASES,
         pytestconfig=pytestconfig,
     )

--- a/ee/hogai/graph/funnels/prompts.py
+++ b/ee/hogai/graph/funnels/prompts.py
@@ -17,6 +17,7 @@ Follow this instruction to create a query:
 * Determine if the user wants to filter out internal and test users. If the user didn't specify, filter out internal and test users by default.
 * Determine if you need to apply a sampling factor, different layout, bin count,  etc. Only specify those if the user has explicitly asked.
 * Use your judgment if there are any other parameters that the user might want to adjust that aren't listed here.
+* In the output, preserve the plan's casing of events, properties, and values.
 
 The user might want to receive insights about groups. A group aggregates events based on entities, such as organizations or sellers. The user might provide a list of group names and their numeric indexes. Instead of a group's name, always use its numeric index.
 

--- a/ee/hogai/graph/funnels/prompts.py
+++ b/ee/hogai/graph/funnels/prompts.py
@@ -4,7 +4,7 @@ Act as an expert product manager. Your task is to generate a JSON schema of funn
 Follow this instruction to create a query:
 * Build series according to the series sequence and filters in the plan. Properties can be of multiple types: String, Numeric, Bool, and DateTime. A property can be an array of those types and only has a single type.
 * Apply the exclusion steps and breakdown according to the plan.
-* When evaluating filter operators, replace the `equals` or `doesn't equal` operators with `contains` or `doesn't contain` if the query value is likely a personal name, company name, or any other name-sensitive term where letter casing matters. For instance, if the value is ‘John Doe’ or ‘Acme Corp’, replace `equals` with `contains` and change the value to lowercase from `John Doe` to `john doe` or  `Acme Corp` to `acme corp`.
+* When evaluating property filter operators, replace the `equals` or `doesn't equal` operators with `contains` or `doesn't contain` if the query value is likely a personal name, company name, or any other name-sensitive term where letter casing matters. For instance, if the value is ‘John Doe’ or ‘Acme Corp’, replace `equals` with `contains` and change the value to lowercase from `John Doe` to `john doe` or `Acme Corp` to `acme corp`. Do not apply this to event names, as they are strictly case-sensitive!
 * Determine what metric the user seeks from the funnel and choose the correct funnel type.
 * Determine the funnel order type, aggregation type, and visualization type that will answer the user's question in the best way. Use the provided defaults.
 * Determine the window interval and unit. Use the provided defaults.
@@ -13,7 +13,6 @@ Follow this instruction to create a query:
 * Determine if the user wants to filter out internal and test users. If the user didn't specify, filter out internal and test users by default.
 * Determine if you need to apply a sampling factor, different layout, bin count,  etc. Only specify those if the user has explicitly asked.
 * Use your judgment if there are any other parameters that the user might want to adjust that aren't listed here.
-* In the output, preserve the plan's casing of events, properties, and values.
 
 The user might want to receive insights about groups. A group aggregates events based on entities, such as organizations or sellers. The user might provide a list of group names and their numeric indexes. Instead of a group's name, always use its numeric index.
 

--- a/ee/hogai/graph/funnels/prompts.py
+++ b/ee/hogai/graph/funnels/prompts.py
@@ -1,10 +1,6 @@
 FUNNEL_SYSTEM_PROMPT = """
 Act as an expert product manager. Your task is to generate a JSON schema of funnel insights. You will be given a generation plan describing a series sequence, filters, exclusion steps, and breakdown. Use the plan and following instructions to create a correct query answering the user's question.
 
-The project name is {{{project_name}}}. Current time is {{{project_datetime}}} in the project's timezone, {{{project_timezone}}}.
-
-Below is the additional context.
-
 Follow this instruction to create a query:
 * Build series according to the series sequence and filters in the plan. Properties can be of multiple types: String, Numeric, Bool, and DateTime. A property can be an array of those types and only has a single type.
 * Apply the exclusion steps and breakdown according to the plan.

--- a/ee/hogai/graph/retention/prompts.py
+++ b/ee/hogai/graph/retention/prompts.py
@@ -3,13 +3,12 @@ Act as an expert product manager. Your task is to generate a JSON schema of rete
 
 Follow this instruction to create a query:
 * Build the insight according to the plan. Properties can be of multiple types: String, Numeric, Bool, and DateTime. A property can be an array of those types and only has a single type.
-* When evaluating filter operators, replace the `equals` or `doesn't equal` operators with `contains` or `doesn't contain` if the query value is likely a personal name, company name, or any other name-sensitive term where letter casing matters. For instance, if the value is ‘John Doe' or ‘Acme Corp', replace `equals` with `contains` and change the value to lowercase from `John Doe` to `john doe` or  `Acme Corp` to `acme corp`.
+* When evaluating property filter operators, replace the `equals` or `doesn't equal` operators with `contains` or `doesn't contain` if the query value is likely a personal name, company name, or any other name-sensitive term where letter casing matters. For instance, if the value is ‘John Doe' or ‘Acme Corp', replace `equals` with `contains` and change the value to lowercase from `John Doe` to `john doe` or `Acme Corp` to `acme corp`. Do not apply this to event names, as they are strictly case-sensitive!
 * Determine the activation type that will answer the user's question in the best way. Use the provided defaults.
 * Use the time period as the retention period from the plan and determine the number of periods to look back.
 * Determine if the user wants to filter out internal and test users. If the user didn't specify, filter out internal and test users by default.
 * Determine if you need to apply a sampling factor. Only specify those if the user has explicitly asked.
 * Use your judgment if there are any other parameters that the user might want to adjust that aren't listed here.
-* In the output, preserve the plan's casing of events, properties, and values.
 
 The user might want to receive insights about groups. A group aggregates events based on entities, such as organizations or sellers. The user might provide a list of group names and their numeric indexes. Instead of a group's name, always use its numeric index.
 

--- a/ee/hogai/graph/retention/prompts.py
+++ b/ee/hogai/graph/retention/prompts.py
@@ -12,6 +12,7 @@ Follow this instruction to create a query:
 * Determine if the user wants to filter out internal and test users. If the user didn't specify, filter out internal and test users by default.
 * Determine if you need to apply a sampling factor. Only specify those if the user has explicitly asked.
 * Use your judgment if there are any other parameters that the user might want to adjust that aren't listed here.
+* In the output, preserve the plan's casing of events, properties, and values.
 
 The user might want to receive insights about groups. A group aggregates events based on entities, such as organizations or sellers. The user might provide a list of group names and their numeric indexes. Instead of a group's name, always use its numeric index.
 

--- a/ee/hogai/graph/retention/prompts.py
+++ b/ee/hogai/graph/retention/prompts.py
@@ -1,8 +1,5 @@
 RETENTION_SYSTEM_PROMPT = """
 Act as an expert product manager. Your task is to generate a JSON schema of retention insights. You will be given a generation plan describing a target event or action, returning event or action, target/returning parameters, and filters. Use the plan and following instructions to create a correct query answering the user's question.
-The project name is {{{project_name}}}. Current time is {{{project_datetime}}} in the project's timezone, {{{project_timezone}}}.
-
-Below is the additional context.
 
 Follow this instruction to create a query:
 * Build the insight according to the plan. Properties can be of multiple types: String, Numeric, Bool, and DateTime. A property can be an array of those types and only has a single type.

--- a/ee/hogai/graph/shared_prompts.py
+++ b/ee/hogai/graph/shared_prompts.py
@@ -1,9 +1,3 @@
-PROJECT_ORG_USER_CONTEXT_PROMPT = """
-You are currently in project {{{project_name}}}, which is part of the {{{organization_name}}} organization.
-The user's name appears to be {{{user_full_name}}} ({{{user_email}}}). Feel free to use their first name when greeting. DO NOT use this name if it appears possibly fake.
-Current time in the project's timezone, {{{project_timezone}}}: {{{project_datetime}}}.
-""".strip()
-
 CORE_MEMORY_PROMPT = """
 You have access to the core memory about the user's company and product in the <core_memory> tag. Use this memory in your thinking.
 <core_memory>

--- a/ee/hogai/graph/trends/prompts.py
+++ b/ee/hogai/graph/trends/prompts.py
@@ -16,6 +16,7 @@ Follow this instruction to create a query:
 * Determine if the user wants to use a sampling factor.
 * Determine if it's useful to show a legend, values of series, unitss, y-axis scale type, etc.
 * Use your judgment if there are any other parameters that the user might want to adjust that aren't listed here.
+* In the output, preserve the plan's casing of events, properties, and values.
 
 For trends queries, use an appropriate ChartDisplayType for the output. For example:
 - if the user wants to see dynamics in time like a line graph, use `ActionsLineGraph`.

--- a/ee/hogai/graph/trends/prompts.py
+++ b/ee/hogai/graph/trends/prompts.py
@@ -1,10 +1,6 @@
 TRENDS_SYSTEM_PROMPT = """
 Act as an expert product manager. Your task is to generate a JSON schema of trends insights. You will be given a generation plan describing series, filters, and breakdowns. Use the plan and following instructions to create a correct query answering the user's question.
 
-The project name is {{{project_name}}}. Current time is {{{project_datetime}}} in the project's timezone, {{{project_timezone}}.
-
-Below is the additional context.
-
 Follow this instruction to create a query:
 * Build series according to the plan. The plan includes series (event or action), math types, property filters, and breakdowns. Properties can be of multiple types: String, Numeric, Bool, and DateTime. A property can be an array of those types and only has a single type.
 * When evaluating filter operators, replace the `equals` or `doesn't equal` operators with `contains` or `doesn't contain` if the query value is likely a personal name, company name, or any other name-sensitive term where letter casing matters. For instance, if the value is 'John Doe' or 'Acme Corp', replace `equals` with `contains` and change the value to lowercase from `John Doe` to `john doe` or  `Acme Corp` to `acme corp`.

--- a/ee/hogai/graph/trends/prompts.py
+++ b/ee/hogai/graph/trends/prompts.py
@@ -3,7 +3,7 @@ Act as an expert product manager. Your task is to generate a JSON schema of tren
 
 Follow this instruction to create a query:
 * Build series according to the plan. The plan includes series (event or action), math types, property filters, and breakdowns. Properties can be of multiple types: String, Numeric, Bool, and DateTime. A property can be an array of those types and only has a single type.
-* When evaluating filter operators, replace the `equals` or `doesn't equal` operators with `contains` or `doesn't contain` if the query value is likely a personal name, company name, or any other name-sensitive term where letter casing matters. For instance, if the value is 'John Doe' or 'Acme Corp', replace `equals` with `contains` and change the value to lowercase from `John Doe` to `john doe` or  `Acme Corp` to `acme corp`.
+* When evaluating property filter operators, replace the `equals` or `doesn't equal` operators with `contains` or `doesn't contain` if the query value is likely a personal name, company name, or any other name-sensitive term where letter casing matters. For instance, if the value is 'John Doe' or 'Acme Corp', replace `equals` with `contains` and change the value to lowercase from `John Doe` to `john doe` or `Acme Corp` to `acme corp`. Do not apply this to event names, as they are strictly case-sensitive!
 * Determine a visualization type that will answer the user's question in the best way.
 * Determine if the user wants to name the series or use the default names.
 * Use the date range and the interval from the plan.
@@ -12,7 +12,6 @@ Follow this instruction to create a query:
 * Determine if the user wants to use a sampling factor.
 * Determine if it's useful to show a legend, values of series, unitss, y-axis scale type, etc.
 * Use your judgment if there are any other parameters that the user might want to adjust that aren't listed here.
-* In the output, preserve the plan's casing of events, properties, and values.
 
 For trends queries, use an appropriate ChartDisplayType for the output. For example:
 - if the user wants to see dynamics in time like a line graph, use `ActionsLineGraph`.


### PR DESCRIPTION
## Changes

A small set of Max insight generation fixes:
1. LLM taking an upper-cased event from the plan and making it lowercase in the final query (reported by a friend – [trace](https://us.posthog.com/project/2/llm-observability/traces/b9b44c32-5b53-47a7-a081-cb47453baeba?event=6de261e6-7f13-4f70-a245-3aa13e192c56&timestamp=2025-08-04T16%3A34%3A08Z))
2. Query generation prompt caching broken by dynamic project&time info still being at the start of prompt, instead of using MaxChatOpenAI injection

Added an eval case for the uppercasing – although it's hard to reproduce reliably.