### PR TITLE
fix: validate empty rule filters

### DIFF
--- a/products/error_tracking/frontend/configuration/rules/ErrorTrackingAutoAssignment.tsx
+++ b/products/error_tracking/frontend/configuration/rules/ErrorTrackingAutoAssignment.tsx
@@ -23,7 +23,15 @@ export function ErrorTrackingAutoAssignment(): JSX.Element {
                                     <ErrorTrackingRules.Operator rule={rule} editing={editing} />
                                     <div>filters match</div>
                                 </div>
-                                {!disabled && <ErrorTrackingRules.Actions rule={rule} editing={editing} />}
+                                {!disabled && (
+                                    <ErrorTrackingRules.Actions
+                                        rule={rule}
+                                        editing={editing}
+                                        validate={(rule) =>
+                                            rule.assignee ? undefined : 'You must choose an assignee for each rule.'
+                                        }
+                                    />
+                                )}
                             </div>
                             <LemonDivider className="my-0" />
                             <div className="p-2">


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C087FAT5FK5/p1754326500324749

## Changes

Rules can be saved as `{"type": "AND", "values": []}` which HogVM to return `Assignment rule returned Number(1), expected a boolean value`. We shouldn't let people create catch all rules