### PR TITLE
chore: Ignore explicit-module-boundary-types TS errors

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -73,12 +73,6 @@
                 "allowExpressions": true
             }
         ],
-        "@typescript-eslint/explicit-module-boundary-types": [
-            "error",
-            {
-                "allowArgumentsExplicitlyTypedAsAny": true
-            }
-        ],
         "curly": "error",
         "no-restricted-imports": [
             "error",
@@ -252,12 +246,6 @@
             "files": ["*.stories.tsx"],
             "rules": {
                 "react-hooks/rules-of-hooks": "off"
-            }
-        },
-        {
-            "files": ["*"],
-            "rules": {
-                "@typescript-eslint/explicit-module-boundary-types": "off"
             }
         }
     ]

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -253,6 +253,12 @@
             "rules": {
                 "react-hooks/rules-of-hooks": "off"
             }
+        },
+        {
+            "files": ["*"],
+            "rules": {
+                "@typescript-eslint/explicit-module-boundary-types": "off"
+            }
         }
     ]
 }


### PR DESCRIPTION
## Problem
After oxlint version upgrade from 1.8.0 -> 1.9.0, we get `Missing return type on function` TS errors 726 places in our code base. Seems like legit errors that for some reason was not captured in version 1.8.0

## Changes
Ignore the `explicit-module-boundary-types` errors.

## How did you test this code?
* Ran `oxlint --quiet`, no errors
* No red lines in vscode anymore