### PR TITLE
feat(crm): Show group-exclusive notebook in group details

### DIFF
--- a/frontend/src/scenes/groups/GroupOverview.tsx
+++ b/frontend/src/scenes/groups/GroupOverview.tsx
@@ -15,12 +15,12 @@ export function GroupOverview({ groupData }: { groupData: Group }): JSX.Element 
     const { groupTypeName } = useValues(groupLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 
-    if (featureFlags[FEATURE_FLAGS.CRM_ITERATION_ONE]) {
+    if (featureFlags[FEATURE_FLAGS.CRM_ITERATION_ONE] && groupData.notebook) {
         return (
             <div className="flex flex-col gap-4">
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 items-stretch">
                     <div className="col-span-1 order-1">
-                        <GroupNotebookCard />
+                        <GroupNotebookCard shortId={groupData.notebook} />
                     </div>
                     <div className="col-span-1 flex flex-col gap-4 order-2">
                         <div>

--- a/frontend/src/scenes/groups/cards/GroupNotebookCard.tsx
+++ b/frontend/src/scenes/groups/cards/GroupNotebookCard.tsx
@@ -2,9 +2,11 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Notebook } from 'scenes/notebooks/Notebook/Notebook'
 import { urls } from 'scenes/urls'
 
-export function GroupNotebookCard(): JSX.Element {
-    // TODO: hardcoded as scratchpad temporarily until the backend relationship between groups and notebooks is created
-    const shortId = 'scratchpad'
+interface GroupNotebookCardProps {
+    shortId: string
+}
+
+export function GroupNotebookCard({ shortId }: GroupNotebookCardProps): JSX.Element {
     return (
         <div className="flex flex-col gap-2 h-full min-h-80">
             <div className="flex-1 relative">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3673,10 +3673,11 @@ export interface GroupType {
 export type GroupTypeProperties = Record<number, Array<PersonProperty>>
 
 export interface Group {
-    group_type_index: GroupTypeIndex
-    group_key: string
     created_at: string
+    group_key: string
+    group_type_index: GroupTypeIndex
     group_properties: Record<string, any>
+    notebook: string | null
 }
 
 export interface UserInterviewType {

--- a/posthog/api/notebook.py
+++ b/posthog/api/notebook.py
@@ -245,7 +245,7 @@ class NotebookSerializer(NotebookMinimalSerializer):
 )
 class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidDestroyModel, viewsets.ModelViewSet):
     scope_object = "notebook"
-    queryset = Notebook.objects.filter(visibility=Notebook.Visibility.DEFAULT)
+    queryset = Notebook.objects.all()
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ["short_id"]
     lookup_field = "short_id"

--- a/posthog/api/test/notebooks/__snapshots__/test_notebook.ambr
+++ b/posthog/api/test/notebooks/__snapshots__/test_notebook.ambr
@@ -387,8 +387,7 @@
   INNER JOIN "posthog_team" ON ("posthog_notebook"."team_id" = "posthog_team"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_notebook"."created_by_id" = "posthog_user"."id")
   LEFT OUTER JOIN "posthog_user" T5 ON ("posthog_notebook"."last_modified_by_id" = T5."id")
-  WHERE ("posthog_notebook"."visibility" = 'default'
-         AND "posthog_team"."project_id" = 99999
+  WHERE ("posthog_team"."project_id" = 99999
          AND "posthog_notebook"."short_id" = '00000000')
   LIMIT 21
   '''


### PR DESCRIPTION
## Problem
Closes https://github.com/PostHog/posthog/issues/35894
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Link `GroupNotebookCard` with the actual group notebook, by passing in the notebook short_id
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
<img width="4064" height="2334" alt="image" src="https://github.com/user-attachments/assets/a6c6db4f-9473-4eb5-9dd5-569871c81494" />

## How did you test this code?
- Opened group details
- Checked embeded notebook was not a draft
- Wrote a note
- Refreshed the page, checked notes persisted
- Opened group notebook in a new tab
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
