### PR TITLE
fix: Remove support for `secret_api_key` in the query string

### DIFF
--- a/posthog/api/test/test_authentication.py
+++ b/posthog/api/test/test_authentication.py
@@ -1004,19 +1004,15 @@ class TestProjectSecretAPIKeyAuthentication(APIBaseTest):
         self.assertIsInstance(user, ProjectSecretAPIKeyUser)
         self.assertEqual(user.team, self.team)
 
-    def test_authenticate_with_valid_secret_api_key_in_query_string(self):
-        # Simulate a request with a valid secret API key
+    def test_authenticate_with_secret_api_key_in_query_string_not_supported(self):
+        # Query string authentication should not be supported for security reasons
         wsgi_request = self.factory.get(f"/?secret_api_key={self.team.secret_api_token}")
         request = Request(wsgi_request)  # Wrap the WSGIRequest in a DRF Request
 
         authenticator = ProjectSecretAPIKeyAuthentication()
         result = authenticator.authenticate(request)
-        assert result is not None
-        user, _ = result
 
-        self.assertIsNotNone(user)
-        self.assertIsInstance(user, ProjectSecretAPIKeyUser)
-        self.assertEqual(user.team, self.team)
+        self.assertIsNone(result)
 
     def test_authenticate_with_invalid_secret_api_key(self):
         # Simulate a request with an invalid secret API key

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -3140,15 +3140,6 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
 
         response = self.client.get(
             f"/api/feature_flag/local_evaluation",
-            data={"secret_api_key": secret_api_key},
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        response = self.client.get(f"/api/feature_flag/local_evaluation?secret_api_key={secret_api_key}")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        response = self.client.get(
-            f"/api/feature_flag/local_evaluation",
             HTTP_AUTHORIZATION=f"Bearer {secret_api_key}",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -214,12 +214,12 @@ class ProjectSecretAPIKeyAuthentication(authentication.BaseAuthentication):
     def find_secret_api_token(
         cls,
         request: Union[HttpRequest, Request],
-    ) -> Optional[tuple[str, str]]:
+    ) -> Optional[str]:
         """Try to find project secret API key in request and return it"""
         if "HTTP_AUTHORIZATION" in request.META:
             authorization_match = re.match(rf"^{cls.keyword}\s+(phs_[a-zA-Z0-9]+)$", request.META["HTTP_AUTHORIZATION"])
             if authorization_match:
-                return authorization_match.group(1).strip(), "header"
+                return authorization_match.group(1).strip()
 
         # Wrap HttpRequest in DRF Request if needed
         if not isinstance(request, Request):
@@ -228,17 +228,16 @@ class ProjectSecretAPIKeyAuthentication(authentication.BaseAuthentication):
         data = request.data
 
         if data and "secret_api_key" in data:
-            return data["secret_api_key"], "body"
+            return data["secret_api_key"]
 
         return None
 
     def authenticate(self, request: Union[HttpRequest, Request]) -> Optional[tuple[Any, None]]:
-        secret_api_token_with_source = self.find_secret_api_token(request)
+        secret_api_token = self.find_secret_api_token(request)
 
-        if not secret_api_token_with_source:
+        if not secret_api_token:
             return None
 
-        secret_api_token, source = secret_api_token_with_source
         # get the team from the secret api key
         try:
             Team = apps.get_model(app_label="posthog", model_name="Team")
@@ -246,9 +245,6 @@ class ProjectSecretAPIKeyAuthentication(authentication.BaseAuthentication):
 
             if team is None:
                 return None
-
-            if source == "query":
-                PROJECT_SECRET_API_KEY_QUERY_PARAM_COUNTER.labels(team.id).inc()
 
             # Secret api keys are not associated with a user, so we create a ProjectSecretAPIKeyUser
             # and attach the team. The team is the important part here.

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -206,7 +206,6 @@ class ProjectSecretAPIKeyAuthentication(authentication.BaseAuthentication):
     Only the first key candidate found in the request is tried, and the order is:
     1. Request Authorization header of type Bearer.
     2. Request body.
-    3. Request query string.
     """
 
     keyword = "Bearer"
@@ -230,9 +229,6 @@ class ProjectSecretAPIKeyAuthentication(authentication.BaseAuthentication):
 
         if data and "secret_api_key" in data:
             return data["secret_api_key"], "body"
-
-        if "secret_api_key" in request.GET:
-            return request.GET["secret_api_key"], "query"
 
         return None
 


### PR DESCRIPTION
## Problem

It's not a good idea to put sensitive information in the query string where it can be cached by browsers, proxies, etc.

See this discussion for more context: https://posthog.slack.com/archives/C02E3BKC78F/p1753312954817879

## Changes

Removed the option to retrieve `secret_api_key` from the query string.

## How did you test this code?

Unit tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
