### PR TITLE
chore(kafka): enables ssl failure logging

### DIFF
--- a/rust/common/kafka/src/kafka_consumer.rs
+++ b/rust/common/kafka/src/kafka_consumer.rs
@@ -53,7 +53,6 @@ impl SingleTopicConsumer {
             .set("group.id", consumer_config.kafka_consumer_group)
             // For debugging SSL issues with broker in production
             .set("debug", "security,broker,protocol")
-            .set("log_level", "7")
             .set(
                 "auto.offset.reset",
                 &consumer_config.kafka_consumer_offset_reset,

--- a/rust/common/kafka/src/kafka_consumer.rs
+++ b/rust/common/kafka/src/kafka_consumer.rs
@@ -51,6 +51,9 @@ impl SingleTopicConsumer {
             .set("bootstrap.servers", &common_config.kafka_hosts)
             .set("statistics.interval.ms", "10000")
             .set("group.id", consumer_config.kafka_consumer_group)
+            // For debugging SSL issues with broker in production
+            .set("debug", "security,ssl,broker,protocol")
+            .set("log_level", "7")
             .set(
                 "auto.offset.reset",
                 &consumer_config.kafka_consumer_offset_reset,

--- a/rust/common/kafka/src/kafka_consumer.rs
+++ b/rust/common/kafka/src/kafka_consumer.rs
@@ -52,7 +52,7 @@ impl SingleTopicConsumer {
             .set("statistics.interval.ms", "10000")
             .set("group.id", consumer_config.kafka_consumer_group)
             // For debugging SSL issues with broker in production
-            .set("debug", "security,ssl,broker,protocol")
+            .set("debug", "security,broker,protocol")
             .set("log_level", "7")
             .set(
                 "auto.offset.reset",

--- a/rust/common/kafka/src/kafka_producer.rs
+++ b/rust/common/kafka/src/kafka_producer.rs
@@ -49,6 +49,9 @@ pub async fn create_kafka_producer(
             "queue.buffering.max.kbytes",
             (config.kafka_producer_queue_mib * 1024).to_string(),
         )
+        // For debugging SSL issues with broker in production
+        .set("debug", "security,ssl,broker,protocol")
+        .set("log_level", "7")
         .set(
             "queue.buffering.max.messages",
             config.kafka_producer_queue_messages.to_string(),

--- a/rust/common/kafka/src/kafka_producer.rs
+++ b/rust/common/kafka/src/kafka_producer.rs
@@ -50,7 +50,7 @@ pub async fn create_kafka_producer(
             (config.kafka_producer_queue_mib * 1024).to_string(),
         )
         // For debugging SSL issues with broker in production
-        .set("debug", "security,ssl,broker,protocol")
+        .set("debug", "security,broker,protocol")
         .set("log_level", "7")
         .set(
             "queue.buffering.max.messages",

--- a/rust/common/kafka/src/kafka_producer.rs
+++ b/rust/common/kafka/src/kafka_producer.rs
@@ -51,7 +51,6 @@ pub async fn create_kafka_producer(
         )
         // For debugging SSL issues with broker in production
         .set("debug", "security,broker,protocol")
-        .set("log_level", "7")
         .set(
             "queue.buffering.max.messages",
             config.kafka_producer_queue_messages.to_string(),


### PR DESCRIPTION
## Problem

Would like to see more logs around why SSL connections from kafka clients are failing

## Changes

Adds a new client config to our kafka producers and consumers

## How did you test this code?

Hasn't been tested. Just the CI

