### PR TITLE
fix(insight): wrap insight metadata extraction in a transaction

### DIFF
--- a/posthog/tasks/insight_query_metadata.py
+++ b/posthog/tasks/insight_query_metadata.py
@@ -1,5 +1,6 @@
 import structlog
 from celery import shared_task
+from django.db import transaction
 
 from posthog.models import Insight
 from posthog.tasks.utils import CeleryQueue
@@ -10,14 +11,15 @@ logger = structlog.get_logger(__name__)
 @shared_task(ignore_result=True, queue=CeleryQueue.LONG_RUNNING.value, max_retries=1)
 def extract_insight_query_metadata(insight_id: str) -> None:
     try:
-        insight = (
-            Insight.objects.select_for_update(of=("self",))
-            .select_related("team")
-            .only("query", "query_metadata", "team")
-            .get(pk=insight_id)
-        )
-        insight.generate_query_metadata()
-        insight.save(update_fields=["query_metadata"])
+        with transaction.atomic():
+            insight = (
+                Insight.objects.select_for_update(of=("self",))
+                .select_related("team")
+                .only("query", "query_metadata", "team")
+                .get(pk=insight_id)
+            )
+            insight.generate_query_metadata()
+            insight.save(update_fields=["query_metadata"])
     except Insight.DoesNotExist as e:
         logger.exception(
             "Failed to extract query metadata - insight does not exist", insight_id=insight_id, error=str(e)


### PR DESCRIPTION
## Problem

The task to update query metadata (`posthog.tasks.insight_query_metadata.extract_insight_query_metadata`) is failing because of a missing transaction for select_for_update queries. [Check the logs here](https://grafana.prod-us.posthog.dev/goto/U4I1nqwHR?orgId=1).

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Wrap the select_for_update in a transaction when updating the insight's query_metadata

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Create or update an insight and confirm the query_metadata field is updated in the DB with no errors in the celery worker logs

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
