### PR TITLE
fix(flags): Deterministic project selection for the `remote_config` endpoint

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1491,7 +1491,7 @@ class FeatureFlagViewSet(
         )
 
     @action(
-        methods=["GET"],
+        methods=["GET", "POST"],
         detail=True,
         required_scopes=["feature_flag:read"],
         authentication_classes=[TemporaryTokenAuthentication, ProjectSecretAPIKeyAuthentication],

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -1320,6 +1320,44 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json(), '{"test": true}')
 
+    def test_remote_config_with_secret_api_key_prevents_cross_team_access(self):
+        # Create two teams with different secret keys
+        self.team.rotate_secret_token_and_save(user=self.user, is_impersonated_session=False)
+        other_team = Team.objects.create(
+            organization=self.organization, api_token="phc_other_team_token", name="Other Team"
+        )
+        other_team.rotate_secret_token_and_save(user=self.user, is_impersonated_session=False)
+
+        # Create a flag in the other team
+        FeatureFlag.objects.create(
+            team=other_team,
+            key="other-team-flag",
+            name="Other Team Flag",
+            active=True,
+            filters={
+                "groups": [
+                    {
+                        "properties": [],
+                        "rollout_percentage": 100,
+                    }
+                ],
+                "payloads": {"true": '{"other_team": true}'},
+            },
+            is_remote_configuration=True,
+        )
+
+        self.client.logout()
+
+        # Try to access other team's flag using this team's secret key + other team's project_api_key in body
+        response = self.client.post(
+            f"/api/projects/{other_team.id}/feature_flags/other-team-flag/remote_config",
+            data={"project_api_key": other_team.api_token},  # Other team's project key in body
+            HTTP_AUTHORIZATION=f"Bearer {self.team.secret_api_token}",  # This team's secret key
+        )
+
+        # Should be forbidden due to team mismatch
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
     def test_remote_config_returns_not_found_for_unknown_flag(self):
         response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/nonexistent_key/remote_config")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/posthog/api/test/test_routing.py
+++ b/posthog/api/test/test_routing.py
@@ -1,10 +1,11 @@
 import pytest
-
+from unittest.mock import Mock, patch
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from django.test import override_settings
 from django.urls import include, path
 from rest_framework import viewsets
+from rest_framework.test import APIRequestFactory
 from posthog.api.annotation import AnnotationSerializer
 from posthog.api.routing import DefaultRouterPlusPlus
 from posthog.models.annotation import Annotation
@@ -113,3 +114,141 @@ class TestTeamAndOrgViewSetMixin(APIBaseTest):
         assert (
             str(e.value) == "Method get_object is protected and should not be overridden. Use safely_get_object instead"
         )
+
+
+class TestTeamAndOrgViewSetMixinProjectApiToken(APIBaseTest):
+    """Test the _get_explicit_project_api_token and _get_team_from_request methods."""
+
+    def setUp(self):
+        super().setUp()
+        self.factory = APIRequestFactory()
+        self.viewset = FooViewSet()
+
+    @patch("posthog.api.test.test_routing.FooViewSet.request", create=True)
+    def test_get_explicit_project_api_token_with_dict_data(self, mock_request):
+        """Test _get_explicit_project_api_token returns token when request.data is a dict with project_api_token."""
+        mock_request.method = "POST"
+        mock_request.data = {"project_api_token": "test_token", "other_data": "value"}
+        self.viewset.request = mock_request
+
+        result = self.viewset._get_explicit_project_api_token()
+        self.assertEqual(result, "test_token")
+
+    @patch("posthog.api.test.test_routing.FooViewSet.request", create=True)
+    def test_get_explicit_project_api_token_with_dict_data_no_token(self, mock_request):
+        """Test _get_explicit_project_api_token returns None when request.data is a dict without project_api_token."""
+        mock_request.method = "POST"
+        mock_request.data = {"other_data": "value"}
+        self.viewset.request = mock_request
+
+        result = self.viewset._get_explicit_project_api_token()
+        self.assertIsNone(result)
+
+    @patch("posthog.api.test.test_routing.FooViewSet.request", create=True)
+    def test_get_explicit_project_api_token_with_list_data(self, mock_request):
+        """Test _get_explicit_project_api_token returns None when request.data is a list (bulk operations)."""
+        mock_request.method = "POST"
+        mock_request.data = [{"project_api_token": "test_token"}]
+        self.viewset.request = mock_request
+
+        result = self.viewset._get_explicit_project_api_token()
+        self.assertIsNone(result)
+
+    @patch("posthog.api.test.test_routing.FooViewSet.request", create=True)
+    def test_get_explicit_project_api_token_with_get_request(self, mock_request):
+        """Test _get_explicit_project_api_token returns None for GET requests."""
+        mock_request.method = "GET"
+        mock_request.data = {"project_api_token": "test_token"}
+        self.viewset.request = mock_request
+
+        result = self.viewset._get_explicit_project_api_token()
+        self.assertIsNone(result)
+
+    @patch("posthog.api.test.test_routing.FooViewSet.request", create=True)
+    def test_get_explicit_project_api_token_no_data_attribute(self, mock_request):
+        """Test _get_explicit_project_api_token returns None when request has no data attribute."""
+        mock_request.method = "POST"
+        # Don't set data attribute to simulate missing data attribute
+        delattr(mock_request, "data")
+        self.viewset.request = mock_request
+
+        result = self.viewset._get_explicit_project_api_token()
+        self.assertIsNone(result)
+
+    @patch("posthog.api.routing.get_token")
+    @patch("posthog.models.team.team.Team.objects.get_team_from_token")
+    def test_get_team_from_request_with_explicit_token(self, mock_get_team_from_token, mock_get_token):
+        """Test _get_team_from_request uses explicit project_api_token from request body when available."""
+        # Setup mocks
+        mock_team = Mock()
+        mock_get_team_from_token.return_value = mock_team
+        mock_get_token.return_value = None  # Shouldn't be called when explicit token exists
+
+        # Create request with explicit project_api_token
+        request = self.factory.post("/test/", {"project_api_token": "explicit_token"})
+        self.viewset.request = request
+
+        # Mock _get_explicit_project_api_token to return the token
+        with patch.object(self.viewset, "_get_explicit_project_api_token", return_value="explicit_token"):
+            result = self.viewset._get_team_from_request()
+
+        # Verify result and calls
+        self.assertEqual(result, mock_team)
+        mock_get_team_from_token.assert_called_once_with("explicit_token")
+        mock_get_token.assert_not_called()
+
+    @patch("posthog.api.routing.get_token")
+    @patch("posthog.models.team.team.Team.objects.get_team_from_token")
+    def test_get_team_from_request_fallback_to_get_token(self, mock_get_team_from_token, mock_get_token):
+        """Test _get_team_from_request falls back to get_token when no explicit token in request body."""
+        # Setup mocks
+        mock_team = Mock()
+        mock_get_team_from_token.return_value = mock_team
+        mock_get_token.return_value = "fallback_token"
+
+        # Create request without explicit project_api_token
+        request = self.factory.post("/test/", [{"data": "bulk_data"}], format="json")
+        self.viewset.request = request
+
+        # Mock _get_explicit_project_api_token to return None (bulk request)
+        with patch.object(self.viewset, "_get_explicit_project_api_token", return_value=None):
+            result = self.viewset._get_team_from_request()
+
+        # Verify result and calls
+        self.assertEqual(result, mock_team)
+        mock_get_team_from_token.assert_called_once_with("fallback_token")
+        mock_get_token.assert_called_once_with(None, request)
+
+    @patch("posthog.api.routing.get_token")
+    def test_get_team_from_request_no_token_found(self, mock_get_token):
+        """Test _get_team_from_request returns None when no token is found."""
+        # Setup mocks
+        mock_get_token.return_value = None
+
+        # Create request without any tokens
+        request = self.factory.get("/test/")
+        self.viewset.request = request
+
+        result = self.viewset._get_team_from_request()
+
+        # Verify result
+        self.assertIsNone(result)
+        mock_get_token.assert_called_once_with(None, request)
+
+    @patch("posthog.api.routing.get_token")
+    @patch("posthog.models.team.team.Team.objects.get_team_from_token")
+    def test_get_team_from_request_authentication_failed(self, mock_get_team_from_token, mock_get_token):
+        """Test _get_team_from_request raises AuthenticationFailed when token exists but team lookup fails."""
+        from rest_framework.exceptions import AuthenticationFailed
+
+        # Setup mocks
+        mock_get_team_from_token.return_value = None  # No team found for token
+        mock_get_token.return_value = "invalid_token"
+
+        # Create request
+        request = self.factory.post("/test/", {"other_data": "value"})
+        self.viewset.request = request
+
+        # Verify AuthenticationFailed is raised
+        with self.assertRaises(AuthenticationFailed):
+            self.viewset._get_team_from_request()


### PR DESCRIPTION
Adds a means for deterministic project selection when calling the `remote_config` endpoint.

## Problem

See #35303 for more context, but in-short, `remote_config` endpoint is accessed with a `GET` request to `/api/projects/@current/feature_flags/unencrypted-remote-config-setting/remote_config/`

When using a personal access token for authentication, this causes the request to route to whichever project the user the token belongs to last visited.

Fixes #35303 

## Changes

1. Update `remote_config` to support `POST` requests.
2. When a `POST` request occurs, look in the request body for `project_api_key` to override the `@current` token.
3. Update `ProjectSecretAPIKeyAuthentication` to validate that the token team and resolved team match.

The changes should be backwards compatible. So if somebody had a need for the project switching ability of the `@current` URL, they still get that behavior when making a GET request.

I'll update the SDKs to make a POST request and pass the project api token in the request body.

## How did you test this code?

Manually.
Unit Tests.

- [x] `GET` personal_api_key, no request body. Expect: returns last visited project
- [x] `GET` personal_api_key, api_key in request body. Expect: returns last visited project
- [x] `POST` personal_api_key, no request body. Expect: returns last visited project
- [x] `POST` personal_api_key, api_key in request body. Expect: returns project with api_key
- [x] `POST` personal_api_key, api_key for different project in request body. Expect: Auth error
- [x] `GET` secret_api_key, no request body. Expect: returns project associated with the key
- [x] `GET` secret_api_key, api_key in request body. Expect: returns project associated with the key
- [x] `POST` secret_api_key, no request body. Expect: returns project associated with the key
- [x] `POST` secret_api_key, api_key in request body. Expect: returns project associated with the key
- [x] `POST` secret_api_key, api_key for a different project in request body. Expect: Auth error

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Client SDKs that need to be updated

- [ ] `posthog-python` - https://github.com/PostHog/posthog-python/pull/303
- [ ] `posthog-dotnet`
- [ ] `posthog-go`
- [ ] `posthog-elixir`
- [ ] `posthog-node`
- [ ] `posthog-php`
- [ ] `posthog-ruby`
- [ ] `posthog-rust`