### PR TITLE
feat: use same visualization for both multiple and single choice

### DIFF
--- a/frontend/src/scenes/surveys/components/question-visualizations/SurveyQuestionVisualization.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/SurveyQuestionVisualization.tsx
@@ -14,7 +14,6 @@ import { SurveyQuestion, SurveyQuestionType } from '~/types'
 
 import { SCALE_LABELS } from '../../constants'
 import { NPSBreakdownSkeleton, RatingQuestionViz } from './RatingQuestionViz'
-import { SingleChoiceQuestionViz } from './SingleChoiceQuestionViz'
 
 interface Props {
     question: SurveyQuestion
@@ -98,38 +97,22 @@ function QuestionLoadingSkeleton({ question }: { question: SurveyQuestion }): JS
                 </>
             )
         case SurveyQuestionType.SingleChoice:
-            return (
-                <div className="h-80 overflow-y-auto border rounded pt-4 pb-2 flex">
-                    <div className="relative h-full w-80 flex items-center justify-center">
-                        <LemonSkeleton className="w-64 h-64 rounded-full" />
-                    </div>
-                    <div className="flex-1 flex flex-col justify-center space-y-3 px-6">
-                        {question.choices.map((choice, i) => (
-                            <div key={i} className="flex items-center gap-2">
-                                <LemonSkeleton className="w-3 h-3 rounded-full flex-shrink-0" />
-                                <span className="text-sm text-secondary font-semibold">{choice}</span>
-                                <LemonSkeleton className="w-8 h-4 flex-shrink-0" />
-                            </div>
-                        ))}
-                    </div>
-                </div>
-            )
         case SurveyQuestionType.MultipleChoice:
             return (
                 <div className="border rounded py-4 max-h-[600px] overflow-y-auto">
-                    <div className="flex flex-col gap-1">
+                    <div className="flex flex-col gap-3">
                         {question.choices.map((choice, i) => {
                             // Use decreasing widths to match typical survey result ordering
                             const barWidths = ['w-11/12', 'w-3/4', 'w-3/5', 'w-1/2', 'w-2/5']
                             const width = barWidths[i] || 'w-1/4'
                             return (
-                                <div key={i} className="flex items-center gap-4">
-                                    <div className="w-48 text-right text-xs text-secondary flex-shrink-0 truncate">
+                                <div key={i} className="flex items-center gap-6">
+                                    <div className="w-48 text-right text-sm text-secondary flex-shrink-0 truncate">
                                         {choice}
                                     </div>
                                     <div className="flex-1 flex items-center gap-2">
-                                        <LemonSkeleton className={`h-4 ${width}`} />
-                                        <LemonSkeleton className="w-6 h-4 flex-shrink-0" />
+                                        <LemonSkeleton className={`h-6 ${width}`} />
+                                        <LemonSkeleton className="w-6 h-6 flex-shrink-0" />
                                     </div>
                                 </div>
                             )
@@ -214,12 +197,10 @@ export function SurveyQuestionVisualization({ question, questionIndex }: Props):
                                 processedData={processedData}
                             />
                         )}
-                    {question.type === SurveyQuestionType.SingleChoice &&
-                        processedData.type === SurveyQuestionType.SingleChoice && (
-                            <SingleChoiceQuestionViz question={question} processedData={processedData} />
-                        )}
-                    {question.type === SurveyQuestionType.MultipleChoice &&
-                        processedData.type === SurveyQuestionType.MultipleChoice && (
+                    {(question.type === SurveyQuestionType.SingleChoice ||
+                        question.type === SurveyQuestionType.MultipleChoice) &&
+                        (processedData.type === SurveyQuestionType.SingleChoice ||
+                            processedData.type === SurveyQuestionType.MultipleChoice) && (
                             <MultipleChoiceQuestionViz responseData={processedData.data} />
                         )}
                     {question.type === SurveyQuestionType.Open && processedData.type === SurveyQuestionType.Open && (

--- a/frontend/src/scenes/surveys/surveyLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveyLogic.test.ts
@@ -1792,9 +1792,9 @@ describe('processResultsForSurveyQuestions', () => {
                 label: 'Yes',
                 value: 2,
                 isPredefined: true,
-                distinctId: 'user1',
+                distinctId: 'user3',
                 personProperties: undefined,
-                timestamp: '2024-01-15T10:00:00Z',
+                timestamp: '2024-01-15T10:30:00Z',
             })
             expect(dataMap.get('No')).toEqual({
                 label: 'No',
@@ -1845,9 +1845,9 @@ describe('processResultsForSurveyQuestions', () => {
                 label: 'A',
                 value: 2,
                 isPredefined: true,
-                distinctId: 'user1',
+                distinctId: 'user2',
                 personProperties: undefined,
-                timestamp: '2024-01-15T10:00:00Z',
+                timestamp: '2024-01-15T10:15:00Z',
             })
             expect(dataMap.get('B')).toEqual({
                 label: 'B',

--- a/frontend/src/scenes/surveys/surveyLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveyLogic.test.ts
@@ -1774,10 +1774,10 @@ describe('processResultsForSurveyQuestions', () => {
                 },
             ]
             const results = [
-                ['Yes'], // User 1: picked Yes for question 0
-                ['No'], // User 2: picked No for question 0
-                ['Yes'], // User 3: picked Yes for question 0
-                ['Custom answer'], // User 4: picked custom answer for question 0
+                ['Yes', '', 'user1', '2024-01-15T10:00:00Z'], // User 1: picked Yes for question 0
+                ['No', '', 'user2', '2024-01-15T10:15:00Z'], // User 2: picked No for question 0
+                ['Yes', '', 'user3', '2024-01-15T10:30:00Z'], // User 3: picked Yes for question 0
+                ['Custom answer', '', 'user4', '2024-01-15T10:45:00Z'], // User 4: picked custom answer for question 0
             ]
 
             const processed = processResultsForSurveyQuestions(questions, results)
@@ -1789,9 +1789,23 @@ describe('processResultsForSurveyQuestions', () => {
             // Check that all values exist (order may vary due to sorting)
             const dataMap = new Map(singleData.data.map((item) => [item.label, item]))
             expect(dataMap.get('Yes')).toEqual({ label: 'Yes', value: 2, isPredefined: true })
-            expect(dataMap.get('No')).toEqual({ label: 'No', value: 1, isPredefined: true })
+            expect(dataMap.get('No')).toEqual({
+                label: 'No',
+                value: 1,
+                isPredefined: true,
+                distinctId: 'user2',
+                personProperties: undefined,
+                timestamp: '2024-01-15T10:15:00Z',
+            })
             expect(dataMap.get('Maybe')).toEqual({ label: 'Maybe', value: 0, isPredefined: true })
-            expect(dataMap.get('Custom answer')).toEqual({ label: 'Custom answer', value: 1, isPredefined: false })
+            expect(dataMap.get('Custom answer')).toEqual({
+                label: 'Custom answer',
+                value: 1,
+                isPredefined: false,
+                distinctId: 'user4',
+                personProperties: undefined,
+                timestamp: '2024-01-15T10:45:00Z',
+            })
         })
     })
 

--- a/frontend/src/scenes/surveys/surveyLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveyLogic.test.ts
@@ -1788,7 +1788,14 @@ describe('processResultsForSurveyQuestions', () => {
 
             // Check that all values exist (order may vary due to sorting)
             const dataMap = new Map(singleData.data.map((item) => [item.label, item]))
-            expect(dataMap.get('Yes')).toEqual({ label: 'Yes', value: 2, isPredefined: true })
+            expect(dataMap.get('Yes')).toEqual({
+                label: 'Yes',
+                value: 2,
+                isPredefined: true,
+                distinctId: 'user1',
+                personProperties: undefined,
+                timestamp: '2024-01-15T10:00:00Z',
+            })
             expect(dataMap.get('No')).toEqual({
                 label: 'No',
                 value: 1,

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -335,12 +335,14 @@ function processChoiceQuestion(
         } else {
             // Multiple choice
             const choices = rawValue as string[]
-            total += 1
 
-            choices.forEach((choice) => {
-                const cleaned = choice.replace(/^['"]+|['"]+$/g, '')
-                countChoice(cleaned, counts, uniqueResponsePersonData, personData)
-            })
+            if (choices.length > 0) {
+                total += 1
+                choices.forEach((choice) => {
+                    const cleaned = choice.replace(/^['"]+|['"]+$/g, '')
+                    countChoice(cleaned, counts, uniqueResponsePersonData, personData)
+                })
+            }
         }
     })
 


### PR DESCRIPTION
 ## Problem

  We're building for researchers and product teams who analyze survey results to understand user feedback and make data-driven decisions. Currently, we have two separate visualizations for single choice and multiple choice questions:

  - **Single choice questions** use pie charts, which are suboptimal for research workflows - researchers need to quickly identify the highest-scoring responses and compare percentages, but pie charts require mental estimation of angles
  - **Multiple choice questions** use horizontal bar charts, which are much better for comparative analysis and recently received improvements (separate display of open-ended responses, explicit percentages)

  This creates inconsistency in the user experience and forces us to maintain two separate codebases for what is essentially the same data visualization need.

Closes https://github.com/PostHog/posthog/issues/34374

  ## Changes

  - **Unified visualization**: Both single choice and multiple choice questions now use the same horizontal bar chart visualization
  - **Improved single choice data processing**: Enhanced the `processSingleChoiceQuestion` function to track person data for unique responses, enabling the display of open-ended responses (previously only available for multiple choice)
  - **Removed duplicate code**: Eliminated `SingleChoiceQuestionViz` component entirely and updated the rendering logic to use `MultipleChoiceQuestionViz` for both question types
  - **Consistent loading states**: Updated skeleton loading states to match the unified bar chart design

  **Benefits for survey users:**
  - Faster comparative analysis with consistent horizontal bar charts
  - Better handling of longer response text
  - Unified mental model across all choice-based questions
  - Open-ended response display now available for single choice questions

Also fixes one issue:

- Make sure that, for equal open-ended responses, we're showing the person who responded last. Added tests to cover this

| Before | After |
|--------|--------|
| ![CleanShot 2025-08-04 at 20 00 41@2x](https://github.com/user-attachments/assets/b94926cb-2043-4747-b717-31a9505a2a1a) | ![CleanShot 2025-08-04 at 20 00 00@2x](https://github.com/user-attachments/assets/f01c309f-a9b6-48f8-be64-c9dfb7ff9c1a) | 

  ## How did you test this code?

Tested locally; unit tests for the calculations