### PR TITLE
fix: Partially remove support for `personal_api_key` in query param

### DIFF
--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -25,7 +25,6 @@ from posthog.models.personal_api_key import (
 )
 from posthog.models.sharing_configuration import SharingConfiguration
 from posthog.models.user import User
-from posthog.metrics import LABEL_TEAM_ID
 from django.contrib.auth.models import AnonymousUser
 from zxcvbn import zxcvbn
 
@@ -33,12 +32,6 @@ PERSONAL_API_KEY_QUERY_PARAM_COUNTER = Counter(
     "api_auth_personal_api_key_query_param",
     "Requests where the personal api key is specified in a query parameter",
     labelnames=["user_uuid"],
-)
-
-PROJECT_SECRET_API_KEY_QUERY_PARAM_COUNTER = Counter(
-    "api_auth_project_secret_api_key_query_param",
-    "Requests where the project secret api key is specified in a query parameter",
-    labelnames=[LABEL_TEAM_ID],
 )
 
 

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -32,7 +32,7 @@ from zxcvbn import zxcvbn
 PERSONAL_API_KEY_QUERY_PARAM_COUNTER = Counter(
     "api_auth_personal_api_key_query_param",
     "Requests where the personal api key is specified in a query parameter",
-    labelnames=["user_uuid", "extra_data"],
+    labelnames=["user_uuid"],
 )
 
 PROJECT_SECRET_API_KEY_QUERY_PARAM_COUNTER = Counter(
@@ -108,9 +108,6 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
             return data["personal_api_key"], "body"
         if "personal_api_key" in request.GET:
             return request.GET["personal_api_key"], "query string"
-        if extra_data and "personal_api_key" in extra_data:
-            # compatibility with /capture endpoint
-            return extra_data["personal_api_key"], "query string data"
         return None
 
     @classmethod
@@ -157,9 +154,7 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
             key_to_update.save(update_fields=["secure_value"])
 
         if source == "query string":
-            PERSONAL_API_KEY_QUERY_PARAM_COUNTER.labels(personal_api_key_object.user.uuid, False).inc()
-        elif source == "query string data":
-            PERSONAL_API_KEY_QUERY_PARAM_COUNTER.labels(personal_api_key_object.user.uuid, True).inc()
+            PERSONAL_API_KEY_QUERY_PARAM_COUNTER.labels(personal_api_key_object.user.uuid).inc()
 
         return personal_api_key_object
 


### PR DESCRIPTION
## Problem

Placing an API key in a query param is generally inadvisable as it's likely to be logged by middleware. This feature is still actively in use, but our prometheus metrics indicate the `extra_data` path is not in use, so we can remove that.

Related: #36150.

## Changes

Tbh I'm not even sure how to get a query param into `extra_data`.

## How did you test this code?

e2e tests exist for this
