### PR TITLE
feat(kafka): signal liveness when all brokers connected

### DIFF
--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -25,7 +25,7 @@ struct KafkaContext {
 impl rdkafka::ClientContext for KafkaContext {
     fn stats(&self, stats: rdkafka::Statistics) {
         // Signal liveness, as the main rdkafka loop is running and calling us
-        let brokers_up = stats.brokers.values().any(|broker| broker.state == "UP");
+        let brokers_up = stats.brokers.values().all(|broker| broker.state == "UP");
         if brokers_up {
             self.liveness.report_healthy_blocking();
         }

--- a/rust/common/kafka/src/kafka_producer.rs
+++ b/rust/common/kafka/src/kafka_producer.rs
@@ -20,9 +20,12 @@ impl From<HealthHandle> for KafkaContext {
 }
 
 impl rdkafka::ClientContext for KafkaContext {
-    fn stats(&self, _: rdkafka::Statistics) {
+    fn stats(&self, stats: rdkafka::Statistics) {
         // Signal liveness, as the main rdkafka loop is running and calling us
-        self.liveness.report_healthy_blocking();
+        let brokers_up = stats.brokers.values().all(|broker| broker.state == "UP");
+        if brokers_up {
+            self.liveness.report_healthy_blocking();
+        }
 
         // TODO: Take stats recording pieces that we want from `capture-rs`.
     }


### PR DESCRIPTION
## Problem

Only signal liveness from a pod if all connections to broker are up. If a pod can't write to a single broker, it shouldn't be receiving events, because any parititon in the broker it can't connect to will gum up the works.

## Changes

Adds a .all() check to the brokers being up.

## How did you test this code?

Gonna have to test in production
