### PR TITLE
chore(insight): add cron task to fill missing query metadata

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -502,7 +502,7 @@ class InsightSerializer(InsightBasicSerializer):
 
         self.user_permissions.reset_insights_dashboard_cached_results()
 
-        if not before_update or before_update.query != updated_insight.query:
+        if not before_update or before_update.query != updated_insight.query or updated_insight.query_metadata is None:
             query_meta_task = extract_insight_query_metadata.apply_async(
                 kwargs={"insight_id": updated_insight.id},
                 countdown=10 * 60,  # 10 minutes

--- a/posthog/tasks/insight_query_metadata.py
+++ b/posthog/tasks/insight_query_metadata.py
@@ -40,14 +40,21 @@ def extract_insight_query_metadata(insight_id: int) -> None:
 @shared_task(ignore_result=True, queue=CeleryQueue.LONG_RUNNING.value, expires=60 * 60)
 def fill_insights_missing_query_metadata() -> None:
     from datetime import timedelta
-    from django.db.models import Q
+    from django.db.models import Q, F
     from django.db.models.functions import Now
 
     one_day_ago = Now() - timedelta(days=1)
 
     insights = Insight.objects_including_soft_deleted.filter(
-        (Q(query_metadata__isnull=True) | Q(query_metadata={}))
-        & (Q(created_at__gte=one_day_ago) | Q(last_modified_at__gte=one_day_ago))
+        # Insights with no metadata or empty metadata
+        ((Q(query_metadata__isnull=True) | Q(query_metadata={})) & Q(last_modified_at__gte=one_day_ago))
+        |
+        # Insights with outdated metadata
+        (
+            Q(query_metadata__isnull=False)
+            & Q(query_metadata__has_key="updated_at")
+            & Q(last_modified_at__gt=F("query_metadata__updated_at"))
+        )
     ).only("id")
 
     for insight in insights.iterator(chunk_size=100):

--- a/posthog/tasks/insight_query_metadata.py
+++ b/posthog/tasks/insight_query_metadata.py
@@ -47,7 +47,7 @@ def fill_insights_missing_query_metadata() -> None:
 
     insights = Insight.objects_including_soft_deleted.filter(
         (Q(query_metadata__isnull=True) | Q(query_metadata={}))
-        & (Q(created_at__gte=one_day_ago) | Q(last_modified_at_gte=one_day_ago))
+        & (Q(created_at__gte=one_day_ago) | Q(last_modified_at__gte=one_day_ago))
     ).only("id")
 
     for insight in insights.iterator(chunk_size=100):

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -13,6 +13,7 @@ from posthog.tasks.alerts.checks import (
     checks_cleanup_task,
     reset_stuck_alerts_task,
 )
+from posthog.tasks.insight_query_metadata import fill_insights_missing_query_metadata
 from posthog.tasks.integrations import refresh_integrations
 from posthog.tasks.periodic_digest.periodic_digest import send_all_periodic_digest_reports
 from posthog.tasks.email import send_hog_functions_daily_digest
@@ -350,4 +351,10 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         crontab(hour="0", minute=str(randrange(0, 40))),
         sync_all_remote_configs.s(),
         name="sync all remote configs",
+    )
+
+    sender.add_periodic_task(
+        crontab(minute="0", hour="*/12"),
+        fill_insights_missing_query_metadata.s(),
+        name="fill insights missing query metadata",
     )


### PR DESCRIPTION
## Problem

If `extract_insight_query_metadata` task would fail for any reason we did not have a way to go back and fill missing query_metadata for insights

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

This adds a cron job to check for insights that are missing `query_metadata` (or outdated) and schedule the `extract_insight_query_metadata` task for them again. The task will run every 12 hours.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Manually invoke the `fill_insights_missing_query_metadata` task and let it run. Confirm that the missing query_metadata is filled for insights.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
