### PR TITLE
fix: remove generated dashboards from the list endpoint

### DIFF
--- a/frontend/src/models/dashboardsModel.tsx
+++ b/frontend/src/models/dashboardsModel.tsx
@@ -93,9 +93,12 @@ export const dashboardsModel = kea<dashboardsModelType>([
                         // If user is anonymous (i.e. viewing a shared dashboard logged out), don't load authenticated stuff
                         return { count: 0, next: null, previous: null, results: [] }
                     }
-                    const dashboards: PaginatedResponse<DashboardType> = await api.get(
-                        url || `api/environments/${teamLogic.values.currentTeamId}/dashboards/?limit=2000`
-                    )
+
+                    let apiUrl =
+                        url ||
+                        `api/environments/${teamLogic.values.currentTeamId}/dashboards/?limit=2000&exclude_generated=true`
+
+                    const dashboards: PaginatedResponse<DashboardType> = await api.get(apiUrl)
 
                     return {
                         ...dashboards,

--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -15,6 +15,7 @@ from rest_framework.utils.serializer_helpers import ReturnDict
 from posthog.api.dashboards.dashboard_template_json_schema_parser import (
     DashboardTemplateCreationJSONSchemaParser,
 )
+from posthog.constants import GENERATED_DASHBOARD_PREFIX
 from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.models.insight_variable import InsightVariable
 from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
@@ -590,6 +591,10 @@ class DashboardsViewSet(
 
         # Add access level filtering for list actions
         queryset = self._filter_queryset_by_access_level(queryset)
+
+        # Filter out generated dashboards if requested (for list action only)
+        if self.action == "list" and self.request.query_params.get("exclude_generated") == "true":
+            queryset = queryset.exclude(name__startswith=GENERATED_DASHBOARD_PREFIX)
 
         return queryset
 

--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -307,6 +307,7 @@ class FlagRequestType(StrEnum):
 
 
 SURVEY_TARGETING_FLAG_PREFIX = "survey-targeting-"
+GENERATED_DASHBOARD_PREFIX = "Generated Dashboard"
 
 ENRICHED_DASHBOARD_INSIGHT_IDENTIFIER = "Feature Viewed"
 DATA_WAREHOUSE_TASK_QUEUE = "data-warehouse-task-queue"


### PR DESCRIPTION
## Problem
Dashboard list view is slow. Currently we filter out all generated dashboards on the front-end with this code:
```
        nameSortedDashboards: [
            () => [selectors.rawDashboards],
            (rawDashboards) => {
                return Object.values(rawDashboards)
                    .filter((dashboard) => !(dashboard.name ?? 'Untitled').startsWith(GENERATED_DASHBOARD_PREFIX))
                    .sort(nameCompareFunction)
            },
        ],
 ```
 
 We have about 1800 dashboards and 1200 of them are generated.

## Changes
Remove generated dashboards from the list endpoint

## How did you test this code?
Yolo
