### PR TITLE
fix(experiments): show product info empty sate when no results.

### DIFF
--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -47,7 +47,11 @@ const getExperimentDuration = (experiment: Experiment): number | undefined => {
           : undefined
 }
 
-const ExperimentsTable = (): JSX.Element => {
+const ExperimentsTable = ({
+    openDuplicateModal,
+}: {
+    openDuplicateModal: (experiment: Experiment) => void
+}): JSX.Element => {
     const { currentProjectId, experiments, experimentsLoading, tab, shouldShowEmptyState, filters, count, pagination } =
         useValues(experimentsLogic)
     const { loadExperiments, archiveExperiment, setExperimentsFilters } = useActions(experimentsLogic)
@@ -134,11 +138,7 @@ const ExperimentsTable = (): JSX.Element => {
                                 <LemonButton to={urls.experiment(`${experiment.id}`)} size="small" fullWidth>
                                     View
                                 </LemonButton>
-                                <LemonButton
-                                    onClick={() => setDuplicateModalExperiment(experiment)}
-                                    size="small"
-                                    fullWidth
-                                >
+                                <LemonButton onClick={() => openDuplicateModal(experiment)} size="small" fullWidth>
                                     Duplicate
                                 </LemonButton>
                                 <LemonButton
@@ -369,10 +369,9 @@ export function Experiments(): JSX.Element {
                             to="https://posthog.com/docs/experiments/installation?utm_medium=in-product&utm_campaign=new-experiment"
                             target="_blank"
                         >
-                            {' '}
-                            Visit the guide
-                        </Link>{' '}
-                        to learn more.
+                            &nbsp; Visit the guide
+                        </Link>
+                        &nbsp; to learn more.
                     </>
                 }
                 tabbedPage={true}
@@ -381,8 +380,16 @@ export function Experiments(): JSX.Element {
                 activeKey={tab}
                 onChange={(newKey) => setExperimentsTab(newKey)}
                 tabs={[
-                    { key: ExperimentsTabs.All, label: 'All experiments', content: <ExperimentsTable /> },
-                    { key: ExperimentsTabs.Archived, label: 'Archived experiments', content: <ExperimentsTable /> },
+                    {
+                        key: ExperimentsTabs.All,
+                        label: 'All experiments',
+                        content: <ExperimentsTable openDuplicateModal={setDuplicateModalExperiment} />,
+                    },
+                    {
+                        key: ExperimentsTabs.Archived,
+                        label: 'Archived experiments',
+                        content: <ExperimentsTable openDuplicateModal={setDuplicateModalExperiment} />,
+                    },
                     { key: ExperimentsTabs.Holdouts, label: 'Holdout groups', content: <Holdouts /> },
                     {
                         key: ExperimentsTabs.SharedMetrics,

--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -43,8 +43,8 @@ const getExperimentDuration = (experiment: Experiment): number | undefined => {
     return experiment.end_date
         ? dayjs(experiment.end_date).diff(dayjs(experiment.start_date), 'day')
         : experiment.start_date
-        ? dayjs().diff(dayjs(experiment.start_date), 'day')
-        : undefined
+          ? dayjs().diff(dayjs(experiment.start_date), 'day')
+          : undefined
 }
 
 const ExperimentsTableFilters = ({

--- a/frontend/src/scenes/experiments/experimentsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.ts
@@ -1,5 +1,4 @@
-import { LemonTagType } from '@posthog/lemon-ui'
-import { PaginationManual } from '@posthog/lemon-ui'
+import { LemonTagType, PaginationManual } from '@posthog/lemon-ui'
 import { actions, connect, events, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { actionToUrl, router, urlToAction } from 'kea-router'
@@ -37,6 +36,7 @@ const DEFAULT_FILTERS: ExperimentsFilters = {
     status: 'all',
     created_by_id: undefined,
     page: 1,
+    order: undefined,
 }
 
 export function getExperimentStatus(experiment: Experiment): ProgressStatus {
@@ -100,6 +100,9 @@ export const experimentsLogic = kea<experimentsLogicType>([
     }),
     listeners(({ actions }) => ({
         setExperimentsFilters: async (_, breakpoint) => {
+            /**
+             * this debounces the search input. Yeah, I know.
+             */
             await breakpoint(300)
             actions.loadExperiments()
         },
@@ -173,7 +176,7 @@ export const experimentsLogic = kea<experimentsLogicType>([
         shouldShowEmptyState: [
             (s) => [s.experimentsLoading, s.experiments, s.filters],
             (experimentsLoading, experiments, filters): boolean => {
-                return !experimentsLoading && experiments.results.length <= 0 && objectsEqual(filters, DEFAULT_FILTERS)
+                return !experimentsLoading && experiments.results.length === 0 && objectsEqual(filters, DEFAULT_FILTERS)
             },
         ],
         pagination: [


### PR DESCRIPTION
## Problem

> [!NOTE]
> This is a follow-up of #35308 

When the user has not seen the experiment's product intro, and there are no results on the experiment table, we are not showing the correct banner. Also, the table behaves in a slightly different way than the rest of the table views in the app.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

To show the correct product information component, we needed to update the default filters, so we passed down the correct empty state configuration to the `ProductIntroduction` component.
We also removed some checks to make the empty table behave like other table views in the app. Instead of hiding it, we show an empty message.

We also refactored the components on the page so that the mounting and unmounting of the tabs is controlled by the LemonTab component.

| Before | After |
| - | - |
| <img width="1601" height="1245" alt="image" src="https://github.com/user-attachments/assets/c9651cca-6461-4819-9606-705621321e00" /> | <img width="1601" height="1245" alt="image" src="https://github.com/user-attachments/assets/c63ec963-05a7-4732-8a44-5fb8d6b1fc4b" /> |

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/7fb17dd3-48a7-4f9c-9b17-1fc9bfcdb27a)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
…endent component.