### PR TITLE
fix: exc info

### DIFF
--- a/posthog/exceptions_capture.py
+++ b/posthog/exceptions_capture.py
@@ -29,25 +29,22 @@ def capture_exception(error=None, additional_properties=None):
 
     properties.update(celery_properties())
 
-    # logger.exception() uses sys.exc_info() internally, so we should check this first
     exc_info = sys.exc_info()
-    has_valid_exc_info = exc_info[0] is not None
 
     if api_key:
         uuid = posthog_capture_exception(error, properties=properties)
 
         # Only log if captured
         if uuid is not None:
-            if has_valid_exc_info:
-                logger.exception(error, event_id=uuid)
-            else:
-                logger.error(
-                    f"Exception captured: {error}",
-                    event_id=uuid,
-                    exception_type=type(error).__name__ if error else "None",
-                )
+            logger.error(
+                f"Exception captured: {error}",
+                event_id=uuid,
+                exception_type=type(error).__name__ if error else "None",
+                exc_info=exc_info,
+            )
     else:
-        if has_valid_exc_info:
-            logger.exception(error)
-        else:
-            logger.error(f"Exception captured: {error}", exception_type=type(error).__name__ if error else "None")
+        logger.error(
+            f"Exception captured: {error}",
+            exception_type=type(error).__name__ if error else "None",
+            exc_info=exc_info,
+        )

--- a/posthog/test/test_exceptions_capture.py
+++ b/posthog/test/test_exceptions_capture.py
@@ -1,0 +1,51 @@
+import uuid
+import json
+from unittest.mock import patch
+from django.test import TestCase
+from io import StringIO
+import structlog
+
+from posthog.exceptions_capture import capture_exception
+
+
+class TestExceptionsCapture(TestCase):
+    def _setup_structlog_capture(self):
+        """Configure structlog to capture output and return the StringIO buffer"""
+        output = StringIO()
+        structlog.configure(
+            processors=[structlog.processors.format_exc_info, structlog.processors.JSONRenderer()],
+            logger_factory=lambda *args: structlog.WriteLogger(output),
+            cache_logger_on_first_use=False,
+        )
+        return output
+
+    @patch("posthoganalytics.api_key", "test-key")
+    @patch("posthoganalytics.capture_exception")
+    def test_capture_exception_with_none_exc_info(self, mock_posthog_capture):
+        """Test that structlog handles exc_info=(None, None, None) gracefully"""
+        mock_posthog_capture.return_value = str(uuid.uuid4())
+        output = self._setup_structlog_capture()
+
+        test_exception = ValueError("Test error without context")
+        capture_exception(test_exception)
+
+        log_data = json.loads(output.getvalue().strip())
+        self.assertIn("Exception captured: Test error without context", log_data["event"])
+        self.assertEqual(log_data["exception"], "MISSING")
+
+    @patch("posthoganalytics.api_key", "test-key")
+    @patch("posthoganalytics.capture_exception")
+    def test_capture_exception_with_real_exc_info(self, mock_posthog_capture):
+        """Test that structlog properly formats real exception info"""
+        mock_posthog_capture.return_value = str(uuid.uuid4())
+        output = self._setup_structlog_capture()
+
+        try:
+            raise ValueError("Test error with context")
+        except ValueError as e:
+            capture_exception(e)
+
+        log_data = json.loads(output.getvalue().strip())
+        self.assertIn("Exception captured: Test error with context", log_data["event"])
+        self.assertIn("ValueError: Test error with context", log_data["exception"])
+        self.assertIn("Traceback", log_data["exception"])


### PR DESCRIPTION
## Problem
This PR did not fix the issues: https://github.com/PostHog/posthog/pull/36115

The problem is actually that the exc_info gets erased when we are in an async context, like in temporal, before it gets to the point in structlog where it attempts to process it.

## Changes
Pass it into the error logger instead of using the exception logger.

## How did you test this code?
Wrote a test of the new logging
