### PR TITLE
chore: fix and improve bin/start --minimal

### DIFF
--- a/bin/mprocs-minimal.yaml
+++ b/bin/mprocs-minimal.yaml
@@ -10,7 +10,7 @@ procs:
         autostart: false
 
     plugin-server:
-        shell: 'bin/check_kafka_clickhouse_up && ./bin/plugin-server'
+        shell: 'bin/check_postgres_up && bin/check_kafka_clickhouse_up && SESSION_RECORDING_V2_METADATA_SWITCHOVER=1970-01-01 ./bin/plugin-server'
 
     frontend:
         shell: 'bin/check_kafka_clickhouse_up && ./bin/start-frontend'

--- a/bin/mprocs-minimal.yaml
+++ b/bin/mprocs-minimal.yaml
@@ -1,6 +1,8 @@
 procs:
     backend:
         shell: 'uv sync --active && bin/check_kafka_clickhouse_up && python manage.py migrate && ./bin/start-backend'
+        env:
+            POSTHOG_USE_VITE: '1'
 
     celery-worker:
         shell: 'uv sync --active && bin/check_kafka_clickhouse_up && ./bin/start-celery worker'
@@ -13,7 +15,9 @@ procs:
         shell: 'bin/check_postgres_up && bin/check_kafka_clickhouse_up && SESSION_RECORDING_V2_METADATA_SWITCHOVER=1970-01-01 ./bin/plugin-server'
 
     frontend:
-        shell: 'bin/check_kafka_clickhouse_up && ./bin/start-frontend'
+        shell: './bin/start-frontend-vite'
+        env:
+            POSTHOG_USE_VITE: '1'
 
     docker-compose:
         # docker-compose makes sure the stack is up, and then follows its logs - but doesn't tear down on exit for speed

--- a/docker-compose.dev-minimal.yml
+++ b/docker-compose.dev-minimal.yml
@@ -118,14 +118,6 @@ services:
             - 'host.docker.internal:host-gateway'
         depends_on:
             - kafka
-            - zookeeper
-
-    zookeeper:
-        extends:
-            file: docker-compose.base.yml
-            service: zookeeper
-        ports:
-            - '2181:2181'
 
     kafka:
         extends:
@@ -133,8 +125,6 @@ services:
             service: kafka
         ports:
             - '9092:9092'
-        depends_on:
-            - zookeeper
 
     objectstorage:
         extends:


### PR DESCRIPTION
## Changes
* use the new vite setup for the frontend (a lot less resource usage with this, esbuild is heavy)
* remove zookeeper (not needed with redpanda as kafka replacement)
* sync plugin server start command from upstream

## How did you test this code?
* Ran it and verified that the dev env came up healty
