### PR TITLE
fix(insight alert): Clicking on new notification under CDP destination causes an error

### DIFF
--- a/frontend/src/lib/components/Alerts/constants.ts
+++ b/frontend/src/lib/components/Alerts/constants.ts
@@ -1,0 +1,3 @@
+export const INSIGHT_ALERT_FIRING_SUB_TEMPLATE_ID = 'insight-alert-firing'
+export const INSIGHT_ALERT_DESTINATION_LOGIC_KEY = 'insightAlertDestination'
+export const INSIGHT_ALERT_FIRING_EVENT_ID = '$insight_alert_firing'

--- a/frontend/src/lib/components/Alerts/constants.ts
+++ b/frontend/src/lib/components/Alerts/constants.ts
@@ -1,3 +1,0 @@
-export const INSIGHT_ALERT_FIRING_SUB_TEMPLATE_ID = 'insight-alert-firing'
-export const INSIGHT_ALERT_DESTINATION_LOGIC_KEY = 'insightAlertDestination'
-export const INSIGHT_ALERT_FIRING_EVENT_ID = '$insight_alert_firing'

--- a/frontend/src/lib/components/Alerts/views/AlertDestinationSelector.tsx
+++ b/frontend/src/lib/components/Alerts/views/AlertDestinationSelector.tsx
@@ -1,14 +1,11 @@
 import { LinkedHogFunctions } from 'scenes/hog-functions/list/LinkedHogFunctions'
 
 import { PropertyFilterType, PropertyOperator } from '~/types'
+import { INSIGHT_ALERT_FIRING_EVENT_ID, INSIGHT_ALERT_FIRING_SUB_TEMPLATE_ID } from '../constants'
 
 export interface AlertDestinationSelectorProps {
     alertId: string
 }
-
-export const INSIGHT_ALERT_DESTINATION_LOGIC_KEY = 'insightAlertDestination'
-export const INSIGHT_ALERT_FIRING_SUB_TEMPLATE_ID = 'insight-alert-firing'
-export const INSIGHT_ALERT_FIRING_EVENT_ID = '$insight_alert_firing'
 
 export function AlertDestinationSelector({ alertId }: AlertDestinationSelectorProps): JSX.Element {
     return (

--- a/frontend/src/lib/components/Alerts/views/AlertDestinationSelector.tsx
+++ b/frontend/src/lib/components/Alerts/views/AlertDestinationSelector.tsx
@@ -1,7 +1,7 @@
 import { LinkedHogFunctions } from 'scenes/hog-functions/list/LinkedHogFunctions'
 
 import { PropertyFilterType, PropertyOperator } from '~/types'
-import { INSIGHT_ALERT_FIRING_EVENT_ID, INSIGHT_ALERT_FIRING_SUB_TEMPLATE_ID } from '../constants'
+import { INSIGHT_ALERT_FIRING_EVENT_ID, INSIGHT_ALERT_FIRING_SUB_TEMPLATE_ID } from 'lib/constants'
 
 export interface AlertDestinationSelectorProps {
     alertId: string

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -415,3 +415,7 @@ export const TAILWIND_BREAKPOINTS = {
     xl: 1200,
     '2xl': 1600,
 }
+
+export const INSIGHT_ALERT_FIRING_SUB_TEMPLATE_ID = 'insight-alert-firing'
+export const INSIGHT_ALERT_DESTINATION_LOGIC_KEY = 'insightAlertDestination'
+export const INSIGHT_ALERT_FIRING_EVENT_ID = '$insight_alert_firing'

--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -1,4 +1,4 @@
-import { INSIGHT_ALERT_FIRING_SUB_TEMPLATE_ID } from 'lib/components/Alerts/views/AlertDestinationSelector'
+import { INSIGHT_ALERT_FIRING_SUB_TEMPLATE_ID } from 'lib/components/Alerts/constants'
 import {
     HogFunctionConfigurationContextId,
     HogFunctionSubTemplateIdType,

--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -1,4 +1,4 @@
-import { INSIGHT_ALERT_FIRING_SUB_TEMPLATE_ID } from 'lib/components/Alerts/constants'
+import { INSIGHT_ALERT_FIRING_SUB_TEMPLATE_ID } from 'lib/constants'
 import {
     HogFunctionConfigurationContextId,
     HogFunctionSubTemplateIdType,


### PR DESCRIPTION

## Problem

Closes #36140

## Changes

I suspect this is an issue of circular dependency, `AlertDestinationSelector` imports `LinkedHogFunctions`:

https://github.com/PostHog/posthog/blob/c0c17273dbc95382a7769adc0f7a5182fd939771/frontend/src/lib/components/Alerts/views/AlertDestinationSelector.tsx#L1

`LinkedHogFunctions` imports `HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES`:

https://github.com/PostHog/posthog/blob/db3e6a0df6c555330785b31e04f99952ae787c32/frontend/src/scenes/hog-functions/list/LinkedHogFunctions.tsx#L6

`HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES` then imports from the same file that `AlertDestinationSelector` is in: https://github.com/PostHog/posthog/blob/c0c17273dbc95382a7769adc0f7a5182fd939771/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts#L1

Moving the constants to separate `constants.ts` should fix it:


https://github.com/user-attachments/assets/0d223d90-aabd-4598-b320-86b28ef837e1



## How did you test this code?

Locally!

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
