### PR TITLE
feat: show tracing command on startup

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -35,6 +35,7 @@ elif [[ "$*" == *"--enable-tracing"* ]]; then
     export OTEL_TRACES_SAMPLER_ARG="1"
 else
     export OTEL_SDK_DISABLED="true"
+    echo "👉 To start with tracing enabled: bin/start --enable-tracing"
 fi
 
 if [ -f .env ]; then

--- a/bin/start
+++ b/bin/start
@@ -33,6 +33,7 @@ elif [[ "$*" == *"--enable-tracing"* ]]; then
     export OTEL_SDK_DISABLED="false"
     export OTEL_TRACES_SAMPLER="parentbased_traceidratio"
     export OTEL_TRACES_SAMPLER_ARG="1"
+    echo "👉 Tracing enabled, see http://localhost:16686 for Jaeger UI"
 else
     export OTEL_SDK_DISABLED="true"
     echo "👉 To start with tracing enabled: bin/start --enable-tracing"


### PR DESCRIPTION
## Problem

Missing doc for --enable-tracing to exist :D let's add it

## Changes

- show message when starting locally without tracing
- show message when tracing is enabled, pointing to jaeger locally 