### PR TITLE
chore: do not allow deleting feature flag if linked to a survey

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -615,7 +615,9 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                                                                   ? 'This feature flag is in use with an early access feature. Delete the early access feature to delete this flag'
                                                                   : (featureFlag.experiment_set?.length || 0) > 0
                                                                     ? 'This feature flag is linked to an experiment. Delete the experiment to delete this flag'
-                                                                    : null
+                                                                    : (featureFlag.surveys?.length || 0) > 0
+                                                                      ? 'This feature flag is linked to a survey. Delete the survey to delete this flag'
+                                                                      : null
                                                         }
                                                     >
                                                         {featureFlag.deleted ? 'Restore' : 'Delete'} feature flag

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -343,7 +343,9 @@ export function OverViewTab({
                                                   ? 'This feature flag is in use with an early access feature. Delete the early access feature to delete this flag'
                                                   : (featureFlag.experiment_set?.length || 0) > 0
                                                     ? 'This feature flag is linked to an experiment. Delete the experiment to delete this flag'
-                                                    : null
+                                                    : (featureFlag.surveys?.length || 0) > 0
+                                                      ? 'This feature flag is linked to a survey. Delete the survey to delete this flag'
+                                                      : null
                                         }
                                         fullWidth
                                     >


### PR DESCRIPTION
## Problem

you can delete a feature flag linked to a survey

## Changes

do now allow deleting a feature flag linked to a survey

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
