### PR TITLE
feat(msg): add person performed events consumer

### DIFF
--- a/plugin-server/src/capabilities.ts
+++ b/plugin-server/src/capabilities.ts
@@ -22,6 +22,7 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
                 cdpCyclotronWorker: true,
                 cdpCyclotronWorkerHogFlow: true,
                 cdpBehaviouralEvents: true,
+                cdpPersonPerformedEvents: true,
                 cdpApi: true,
             }
 
@@ -35,6 +36,7 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
                 cdpCyclotronWorker: true,
                 // cdpCyclotronWorkerHogFlow: true,
                 cdpBehaviouralEvents: true,
+                cdpPersonPerformedEvents: true,
                 cdpApi: true,
             }
 

--- a/plugin-server/src/cdp/consumers/cdp-person-performed-events.consumer.test.ts
+++ b/plugin-server/src/cdp/consumers/cdp-person-performed-events.consumer.test.ts
@@ -1,0 +1,278 @@
+import { getFirstTeam, resetTestDatabase } from '../../../tests/helpers/sql'
+import { CdpPersonPerformedEvent, Hub, Team } from '../../types'
+import { closeHub, createHub } from '../../utils/db/hub'
+import { CdpPersonPerformedEventsConsumer } from './cdp-person-performed-events.consumer'
+
+class TestableCdpPersonPerformedEventsConsumer extends CdpPersonPerformedEventsConsumer {
+    // Expose protected methods for testing
+    public async testProcessEvent(event: CdpPersonPerformedEvent) {
+        return this.processEvent(event)
+    }
+
+    public testDeduplicateEvents(events: CdpPersonPerformedEvent[]) {
+        return this.deduplicateEvents(events)
+    }
+
+    public testGetCacheKey(event: CdpPersonPerformedEvent) {
+        return this.getCacheKey(event)
+    }
+
+    public testEvictCacheEntries() {
+        return this.evictCacheEntries()
+    }
+
+    public getCacheSize() {
+        return this.deduplicationCache.size
+    }
+
+    public clearCache() {
+        this.deduplicationCache.clear()
+    }
+
+    public setCacheSize(size: number) {
+        this.maxCacheSize = size
+    }
+
+    public setCacheEvictionBatchSize(size: number) {
+        this.cacheEvictionBatchSize = size
+    }
+}
+
+jest.setTimeout(10_000)
+
+describe('CdpPersonPerformedEventsConsumer', () => {
+    let processor: TestableCdpPersonPerformedEventsConsumer
+    let hub: Hub
+    let team: Team
+
+    beforeEach(async () => {
+        await resetTestDatabase()
+        hub = await createHub()
+        team = await getFirstTeam(hub)
+        processor = new TestableCdpPersonPerformedEventsConsumer(hub)
+    })
+
+    afterEach(async () => {
+        await closeHub(hub)
+    })
+
+    describe('message parsing', () => {
+        it('should parse valid person performed event messages', async () => {
+            const personId = '550e8400-e29b-41d4-a716-446655440000'
+            const eventName = '$pageview'
+            const messages = [
+                {
+                    value: Buffer.from(
+                        JSON.stringify({
+                            teamId: team.id,
+                            personId,
+                            eventName,
+                        } as CdpPersonPerformedEvent)
+                    ),
+                } as any,
+            ]
+
+            // Parse messages
+            const events = await processor._parseKafkaBatch(messages)
+
+            // Verify parsed events
+            expect(events).toHaveLength(1)
+            expect(events[0]).toEqual({
+                teamId: team.id,
+                personId,
+                eventName,
+            })
+        })
+
+        it('should handle malformed JSON gracefully', async () => {
+            const messages = [
+                {
+                    value: Buffer.from('invalid json'),
+                } as any,
+                {
+                    value: Buffer.from(
+                        JSON.stringify({
+                            teamId: team.id,
+                            personId: '550e8400-e29b-41d4-a716-446655440000',
+                            eventName: '$pageview',
+                        })
+                    ),
+                } as any,
+            ]
+
+            // Parse messages should not throw
+            const events = await processor._parseKafkaBatch(messages)
+
+            // Verify only valid message was parsed
+            expect(events).toHaveLength(1)
+            expect(events[0].eventName).toBe('$pageview')
+        })
+    })
+
+    describe('event processing', () => {
+        it('should process person performed events without errors', async () => {
+            const event: CdpPersonPerformedEvent = {
+                teamId: team.id,
+                personId: '550e8400-e29b-41d4-a716-446655440000',
+                eventName: '$pageview',
+            }
+
+            // Process event should not throw
+            await expect(processor.testProcessEvent(event)).resolves.not.toThrow()
+        })
+
+        it('should process batch of events', async () => {
+            const events: CdpPersonPerformedEvent[] = [
+                {
+                    teamId: team.id,
+                    personId: '550e8400-e29b-41d4-a716-446655440000',
+                    eventName: '$pageview',
+                },
+                {
+                    teamId: team.id,
+                    personId: '550e8400-e29b-41d4-a716-446655440001',
+                    eventName: '$identify',
+                },
+                {
+                    teamId: 999,
+                    personId: '550e8400-e29b-41d4-a716-446655440002',
+                    eventName: 'custom_event',
+                },
+            ]
+
+            // Process batch should not throw
+            await expect(processor.processBatch(events)).resolves.not.toThrow()
+        })
+
+        it('should handle empty batch', async () => {
+            const events: CdpPersonPerformedEvent[] = []
+
+            // Process empty batch should not throw
+            await expect(processor.processBatch(events)).resolves.not.toThrow()
+        })
+    })
+
+    describe('deduplication cache', () => {
+        it('should generate consistent cache keys', () => {
+            const event: CdpPersonPerformedEvent = {
+                teamId: 123,
+                personId: '550e8400-e29b-41d4-a716-446655440000',
+                eventName: '$pageview',
+            }
+
+            const key1 = processor.testGetCacheKey(event)
+            const key2 = processor.testGetCacheKey(event)
+
+            expect(key1).toBe(key2)
+            expect(key1).toBe('123:550e8400-e29b-41d4-a716-446655440000:$pageview')
+        })
+
+        it('should deduplicate identical events', () => {
+            const event: CdpPersonPerformedEvent = {
+                teamId: team.id,
+                personId: '550e8400-e29b-41d4-a716-446655440000',
+                eventName: '$pageview',
+            }
+
+            // First batch with same event twice
+            const events = [event, { ...event }]
+            const deduplicatedEvents = processor.testDeduplicateEvents(events)
+
+            // Should only return one event (first occurrence)
+            expect(deduplicatedEvents).toHaveLength(1)
+            expect(processor.getCacheSize()).toBe(1)
+        })
+
+        it('should not deduplicate different events', () => {
+            const events: CdpPersonPerformedEvent[] = [
+                {
+                    teamId: team.id,
+                    personId: '550e8400-e29b-41d4-a716-446655440000',
+                    eventName: '$pageview',
+                },
+                {
+                    teamId: team.id,
+                    personId: '550e8400-e29b-41d4-a716-446655440001',
+                    eventName: '$pageview',
+                },
+                {
+                    teamId: team.id,
+                    personId: '550e8400-e29b-41d4-a716-446655440000',
+                    eventName: '$identify',
+                },
+            ]
+
+            const deduplicatedEvents = processor.testDeduplicateEvents(events)
+
+            // All events should be unique
+            expect(deduplicatedEvents).toHaveLength(3)
+            expect(processor.getCacheSize()).toBe(3)
+        })
+
+        it('should track cache hits and misses', () => {
+            const event: CdpPersonPerformedEvent = {
+                teamId: team.id,
+                personId: '550e8400-e29b-41d4-a716-446655440000',
+                eventName: '$pageview',
+            }
+
+            // First deduplication - should be cache miss
+            processor.testDeduplicateEvents([event])
+
+            // Second deduplication with same event - should be cache hit
+            const deduplicatedEvents = processor.testDeduplicateEvents([event])
+
+            expect(deduplicatedEvents).toHaveLength(0) // Event was duplicate
+        })
+
+        it('should evict cache entries when limit is reached', () => {
+            // Set a small cache size for testing
+            processor.setCacheSize(3)
+            processor.setCacheEvictionBatchSize(1)
+
+            const events: CdpPersonPerformedEvent[] = [
+                { teamId: team.id, personId: 'person1', eventName: 'event1' },
+                { teamId: team.id, personId: 'person2', eventName: 'event2' },
+                { teamId: team.id, personId: 'person3', eventName: 'event3' },
+            ]
+
+            // Fill up the cache
+            processor.testDeduplicateEvents(events)
+            expect(processor.getCacheSize()).toBe(3)
+
+            // Add one more event, should trigger eviction
+            const newEvent = { teamId: team.id, personId: 'person4', eventName: 'event4' }
+            processor.testDeduplicateEvents([newEvent])
+
+            // Cache should still be at max size (3)
+            expect(processor.getCacheSize()).toBe(3)
+        })
+
+        it('should process mixed batch with duplicates and new events', async () => {
+            const event1: CdpPersonPerformedEvent = {
+                teamId: team.id,
+                personId: '550e8400-e29b-41d4-a716-446655440000',
+                eventName: '$pageview',
+            }
+            const event2: CdpPersonPerformedEvent = {
+                teamId: team.id,
+                personId: '550e8400-e29b-41d4-a716-446655440001',
+                eventName: '$identify',
+            }
+
+            // Process first batch
+            await processor.processBatch([event1, event2])
+            expect(processor.getCacheSize()).toBe(2)
+
+            // Process second batch with one duplicate and one new event
+            const event3: CdpPersonPerformedEvent = {
+                teamId: team.id,
+                personId: '550e8400-e29b-41d4-a716-446655440002',
+                eventName: 'custom_event',
+            }
+
+            await processor.processBatch([event1, event3]) // event1 is duplicate
+            expect(processor.getCacheSize()).toBe(3) // Should have event1, event2, event3
+        })
+    })
+})

--- a/plugin-server/src/cdp/consumers/cdp-person-performed-events.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-person-performed-events.consumer.ts
@@ -9,26 +9,26 @@ import { parseJSON } from '../../utils/json-parse'
 import { logger } from '../../utils/logger'
 import { CdpConsumerBase } from './cdp-base.consumer'
 
-export const histogramPersonPerformedEventProcessing = new Histogram({
+const histogramPersonPerformedEventProcessing = new Histogram({
     name: 'cdp_person_performed_event_processing_duration_ms',
     help: 'Time spent processing person performed events',
     labelNames: ['step'],
     buckets: [1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500],
 })
 
-export const cacheOperationsTotal = new Counter({
+const cacheOperationsTotal = new Counter({
     name: 'cdp_person_performed_event_cache_operations_total',
     help: 'Total number of cache operations performed',
     labelNames: ['operation', 'outcome'],
 })
 
-export const cacheHitRateGauge = new Counter({
+const cacheHitRateGauge = new Counter({
     name: 'cdp_person_performed_event_cache_hit_rate_total',
     help: 'Total cache hits and misses for cache hit rate calculation',
     labelNames: ['type'],
 })
 
-export const cacheSizeGauge = new Gauge({
+const cacheSizeGauge = new Gauge({
     name: 'cdp_person_performed_event_cache_size',
     help: 'Current number of entries in cache',
 })

--- a/plugin-server/src/cdp/consumers/cdp-person-performed-events.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-person-performed-events.consumer.ts
@@ -1,0 +1,200 @@
+import { Message } from 'node-rdkafka'
+import { Counter, Gauge, Histogram } from 'prom-client'
+
+import { KAFKA_CDP_PERSON_PERFORMED_EVENT } from '../../config/kafka-topics'
+import { KafkaConsumer } from '../../kafka/consumer'
+import { runInstrumentedFunction } from '../../main/utils'
+import { CdpPersonPerformedEvent, Hub } from '../../types'
+import { parseJSON } from '../../utils/json-parse'
+import { logger } from '../../utils/logger'
+import { CdpConsumerBase } from './cdp-base.consumer'
+
+export const histogramPersonPerformedEventProcessing = new Histogram({
+    name: 'cdp_person_performed_event_processing_duration_ms',
+    help: 'Time spent processing person performed events',
+    labelNames: ['step'],
+    buckets: [1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500],
+})
+
+export const cacheOperationsTotal = new Counter({
+    name: 'cdp_person_performed_event_cache_operations_total',
+    help: 'Total number of cache operations performed',
+    labelNames: ['operation', 'outcome'],
+})
+
+export const cacheHitRateGauge = new Counter({
+    name: 'cdp_person_performed_event_cache_hit_rate_total',
+    help: 'Total cache hits and misses for cache hit rate calculation',
+    labelNames: ['type'],
+})
+
+export const cacheSizeGauge = new Gauge({
+    name: 'cdp_person_performed_event_cache_size',
+    help: 'Current number of entries in cache',
+})
+
+export class CdpPersonPerformedEventsConsumer extends CdpConsumerBase {
+    protected name = 'CdpPersonPerformedEventsConsumer'
+    protected kafkaConsumer: KafkaConsumer
+    protected deduplicationCache: Set<string> = new Set()
+    protected maxCacheSize: number = 100000 // Cache for ~100k unique events
+    protected cacheEvictionBatchSize: number = 10000 // Evict 10k entries when cache is full
+
+    constructor(hub: Hub, groupId: string = 'cdp-person-performed-events-consumer') {
+        super(hub)
+        this.kafkaConsumer = new KafkaConsumer({
+            groupId,
+            topic: KAFKA_CDP_PERSON_PERFORMED_EVENT,
+        })
+    }
+
+    public async processBatch(events: CdpPersonPerformedEvent[]): Promise<void> {
+        return await this.runInstrumented('processBatch', async () => {
+            if (!events.length) {
+                return
+            }
+
+            logger.debug('Processing person performed events batch', {
+                eventCount: events.length,
+                teamIds: [...new Set(events.map((e) => e.teamId))],
+                cacheSize: this.deduplicationCache.size,
+            })
+
+            // Time deduplication
+            const deduplicationTimer = histogramPersonPerformedEventProcessing
+                .labels({ step: 'deduplication' })
+                .startTimer()
+
+            // Deduplicate events before processing
+            const deduplicatedEvents = this.deduplicateEvents(events)
+            deduplicationTimer()
+
+            if (deduplicatedEvents.length === 0) {
+                logger.debug('All events in batch were duplicates')
+                return
+            }
+
+            // Time event processing
+            const eventProcessingTimer = histogramPersonPerformedEventProcessing
+                .labels({ step: 'event_processing' })
+                .startTimer()
+
+            await Promise.all(deduplicatedEvents.map((event) => this.processEvent(event)))
+            eventProcessingTimer()
+        })
+    }
+
+    protected deduplicateEvents(events: CdpPersonPerformedEvent[]): CdpPersonPerformedEvent[] {
+        const deduplicatedEvents: CdpPersonPerformedEvent[] = []
+
+        for (const event of events) {
+            const cacheKey = this.getCacheKey(event)
+
+            if (this.deduplicationCache.has(cacheKey)) {
+                cacheHitRateGauge.labels({ type: 'hit' }).inc()
+                cacheOperationsTotal.labels({ operation: 'lookup', outcome: 'hit' }).inc()
+            } else {
+                cacheHitRateGauge.labels({ type: 'miss' }).inc()
+                cacheOperationsTotal.labels({ operation: 'lookup', outcome: 'miss' }).inc()
+
+                // Check cache size and evict if necessary
+                if (this.deduplicationCache.size >= this.maxCacheSize) {
+                    this.evictCacheEntries()
+                }
+
+                // Add to cache and include in deduplicated events
+                this.deduplicationCache.add(cacheKey)
+                cacheSizeGauge.inc()
+                cacheOperationsTotal.labels({ operation: 'insert', outcome: 'success' }).inc()
+                deduplicatedEvents.push(event)
+            }
+        }
+
+        return deduplicatedEvents
+    }
+
+    protected getCacheKey(event: CdpPersonPerformedEvent): string {
+        return `${event.teamId}:${event.personId}:${event.eventName}`
+    }
+
+    protected evictCacheEntries(): void {
+        // Convert Set to Array, remove first N entries (FIFO eviction)
+        const cacheEntries = Array.from(this.deduplicationCache)
+        const entriesToEvict = cacheEntries.slice(0, this.cacheEvictionBatchSize)
+
+        entriesToEvict.forEach((entry) => {
+            this.deduplicationCache.delete(entry)
+            cacheSizeGauge.dec()
+        })
+
+        cacheOperationsTotal.labels({ operation: 'evict', outcome: 'success' }).inc(entriesToEvict.length)
+    }
+
+    protected async processEvent(event: CdpPersonPerformedEvent): Promise<void> {
+        try {
+            await Promise.resolve()
+            // TODO: Add postgres write logic here once analysis is done
+        } catch (error) {
+            logger.error('Error processing person performed event', {
+                teamId: event.teamId,
+                personId: event.personId,
+                eventName: event.eventName,
+                error,
+            })
+        }
+    }
+
+    // This consumer always parses from kafka
+    public async _parseKafkaBatch(messages: Message[]): Promise<CdpPersonPerformedEvent[]> {
+        return await this.runWithHeartbeat(() =>
+            runInstrumentedFunction({
+                statsKey: `cdpPersonPerformedEventsConsumer.handleEachBatch.parseKafkaMessages`,
+                func: () => {
+                    const events: CdpPersonPerformedEvent[] = []
+
+                    messages.forEach((message) => {
+                        try {
+                            const personPerformedEvent = parseJSON(message.value!.toString()) as CdpPersonPerformedEvent
+                            events.push(personPerformedEvent)
+                        } catch (e) {
+                            logger.error('Error parsing person performed event message', e)
+                        }
+                    })
+
+                    return Promise.resolve(events)
+                },
+            })
+        )
+    }
+
+    public async start(): Promise<void> {
+        await super.start()
+
+        logger.info('🚀', `Starting ${this.name}...`)
+
+        // Start consuming messages
+        await this.kafkaConsumer.connect(async (messages) => {
+            logger.info('🔁', `${this.name} - handling batch`, {
+                size: messages.length,
+            })
+
+            return await this.runInstrumented('handleEachBatch', async () => {
+                const events = await this._parseKafkaBatch(messages)
+                await this.processBatch(events)
+            })
+        })
+    }
+
+    public async stop(): Promise<void> {
+        logger.info('💤', `Stopping ${this.name}...`)
+        await this.kafkaConsumer.disconnect()
+
+        // IMPORTANT: super always comes last
+        await super.stop()
+        logger.info('💤', `${this.name} stopped!`)
+    }
+
+    public isHealthy() {
+        return this.kafkaConsumer.isHealthy()
+    }
+}

--- a/plugin-server/src/server.ts
+++ b/plugin-server/src/server.ts
@@ -15,6 +15,7 @@ import { CdpCyclotronWorkerHogFlow } from './cdp/consumers/cdp-cyclotron-worker-
 import { CdpEventsConsumer } from './cdp/consumers/cdp-events.consumer'
 import { CdpInternalEventsConsumer } from './cdp/consumers/cdp-internal-event.consumer'
 import { CdpLegacyEventsConsumer } from './cdp/consumers/cdp-legacy-event.consumer'
+import { CdpPersonPerformedEventsConsumer } from './cdp/consumers/cdp-person-performed-events.consumer'
 import { CdpPersonUpdatesConsumer } from './cdp/consumers/cdp-person-updates-consumer'
 import { defaultConfig } from './config/config'
 import {
@@ -269,6 +270,13 @@ export class PluginServer {
             if (capabilities.cdpBehaviouralEvents) {
                 serviceLoaders.push(async () => {
                     const worker = new CdpBehaviouralEventsConsumer(hub)
+                    await worker.start()
+                    return worker.service
+                })
+            }
+            if (capabilities.cdpPersonPerformedEvents) {
+                serviceLoaders.push(async () => {
+                    const worker = new CdpPersonPerformedEventsConsumer(hub)
                     await worker.start()
                     return worker.service
                 })

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -428,6 +428,7 @@ export interface PluginServerCapabilities {
     cdpCyclotronWorker?: boolean
     cdpCyclotronWorkerHogFlow?: boolean
     cdpBehaviouralEvents?: boolean
+    cdpPersonPerformedEvents?: boolean
     cdpApi?: boolean
     appManagementSingleton?: boolean
 }


### PR DESCRIPTION
## Problem

we want to see what the cache hit and miss rate is for before writing to pg to see if we can dial in the cache a bit more and see how memory consumption is to potentially even increase the cacheSize limit and the batch size overall

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- introduced consumer to consume from the new topic
- introduced caching pattern to evict at some point (FIFO)
- added metrics

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- added tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
