### PR TITLE
feat(experiments): add `RatioStatistic` and tests

### DIFF
--- a/products/experiments/stats/bayesian/method.py
+++ b/products/experiments/stats/bayesian/method.py
@@ -7,22 +7,23 @@ and difference types.
 """
 
 from dataclasses import dataclass
-from typing import Optional, Any, Union
+from typing import Any, Optional
 
 from ..shared.enums import DifferenceType
 from ..shared.statistics import (
-    SampleMeanStatistic,
     ProportionStatistic,
+    RatioStatistic,
+    SampleMeanStatistic,
     StatisticError,
 )
-from .priors import GaussianPrior
 from .enums import PriorType
+from .priors import GaussianPrior
 from .tests import (
+    BayesianGaussianTest,
+    BayesianMeanTest,
+    BayesianProportionTest,
     BayesianResult,
     BayesianTest,
-    BayesianGaussianTest,
-    BayesianProportionTest,
-    BayesianMeanTest,
 )
 
 
@@ -121,9 +122,9 @@ class BayesianMethod:
 
     def run_test(
         self,
-        treatment_stat: Union[SampleMeanStatistic, ProportionStatistic],
-        control_stat: Union[SampleMeanStatistic, ProportionStatistic],
-        prior: Optional[GaussianPrior] = None,
+        treatment_stat: SampleMeanStatistic | ProportionStatistic | RatioStatistic,
+        control_stat: SampleMeanStatistic | ProportionStatistic | RatioStatistic,
+        prior: GaussianPrior | None = None,
         **kwargs,
     ) -> BayesianResult:
         """

--- a/products/experiments/stats/bayesian/tests.py
+++ b/products/experiments/stats/bayesian/tests.py
@@ -9,22 +9,23 @@ and risk assessments.
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Union
+
 import numpy as np
 
+from ..shared.enums import DifferenceType
 from ..shared.statistics import (
-    SampleMeanStatistic,
     ProportionStatistic,
+    RatioStatistic,
+    SampleMeanStatistic,
     StatisticError,
 )
-from ..shared.enums import DifferenceType
-
 from .priors import GaussianPrior
 from .utils import (
     calculate_effect_size_and_variance,
     calculate_posterior,
+    calculate_risk,
     chance_to_win,
     credible_interval,
-    calculate_risk,
     validate_inputs,
 )
 
@@ -111,8 +112,8 @@ class BayesianTest(ABC):
     @abstractmethod
     def run_test(
         self,
-        treatment_stat: Union[SampleMeanStatistic, ProportionStatistic],
-        control_stat: Union[SampleMeanStatistic, ProportionStatistic],
+        treatment_stat: SampleMeanStatistic | ProportionStatistic | RatioStatistic,
+        control_stat: SampleMeanStatistic | ProportionStatistic | RatioStatistic,
         prior: GaussianPrior,
         difference_type: DifferenceType = DifferenceType.RELATIVE,
         **kwargs,
@@ -150,8 +151,8 @@ class BayesianGaussianTest(BayesianTest):
 
     def run_test(
         self,
-        treatment_stat: Union[SampleMeanStatistic, ProportionStatistic],
-        control_stat: Union[SampleMeanStatistic, ProportionStatistic],
+        treatment_stat: SampleMeanStatistic | ProportionStatistic | RatioStatistic,
+        control_stat: SampleMeanStatistic | ProportionStatistic | RatioStatistic,
         prior: GaussianPrior,
         difference_type: DifferenceType = DifferenceType.RELATIVE,
         **kwargs,

--- a/products/experiments/stats/bayesian/tests.py
+++ b/products/experiments/stats/bayesian/tests.py
@@ -8,7 +8,6 @@ and risk assessments.
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Union
 
 import numpy as np
 
@@ -242,8 +241,8 @@ class BayesianProportionTest(BayesianTest):
 
     def run_test(
         self,
-        treatment_stat: Union[SampleMeanStatistic, ProportionStatistic],
-        control_stat: Union[SampleMeanStatistic, ProportionStatistic],
+        treatment_stat: SampleMeanStatistic | ProportionStatistic | RatioStatistic,
+        control_stat: SampleMeanStatistic | ProportionStatistic | RatioStatistic,
         prior: GaussianPrior,
         difference_type: DifferenceType = DifferenceType.RELATIVE,
         **kwargs,
@@ -324,8 +323,8 @@ class BayesianMeanTest(BayesianTest):
 
     def run_test(
         self,
-        treatment_stat: Union[SampleMeanStatistic, ProportionStatistic],
-        control_stat: Union[SampleMeanStatistic, ProportionStatistic],
+        treatment_stat: SampleMeanStatistic | ProportionStatistic | RatioStatistic,
+        control_stat: SampleMeanStatistic | ProportionStatistic | RatioStatistic,
         prior: GaussianPrior,
         difference_type: DifferenceType = DifferenceType.RELATIVE,
         **kwargs,

--- a/products/experiments/stats/bayesian/utils.py
+++ b/products/experiments/stats/bayesian/utils.py
@@ -5,20 +5,23 @@ This module provides fundamental Bayesian statistical calculations including
 posterior updates, credible intervals, probability calculations, and risk assessment.
 """
 
-from typing import Union
 import numpy as np
 from scipy.stats import norm, truncnorm
 
-from ..shared.statistics import SampleMeanStatistic, ProportionStatistic, StatisticError
 from ..shared.enums import DifferenceType
-from ..shared.utils import get_mean, get_variance, get_sample_size, validate_test_inputs
-
+from ..shared.statistics import (
+    ProportionStatistic,
+    RatioStatistic,
+    SampleMeanStatistic,
+    StatisticError,
+)
+from ..shared.utils import get_mean, get_sample_size, get_variance, validate_test_inputs
 from .priors import GaussianPrior
 
 
 def calculate_effect_size_and_variance(
-    treatment_stat: Union[SampleMeanStatistic, ProportionStatistic],
-    control_stat: Union[SampleMeanStatistic, ProportionStatistic],
+    treatment_stat: SampleMeanStatistic | ProportionStatistic | RatioStatistic,
+    control_stat: SampleMeanStatistic | ProportionStatistic | RatioStatistic,
     difference_type: DifferenceType,
 ) -> tuple[float, float]:
     """
@@ -274,8 +277,8 @@ def truncated_normal_mean(mu: float, sigma: float, lower_bound: float, upper_bou
 
 
 def validate_inputs(
-    treatment_stat: Union[SampleMeanStatistic, ProportionStatistic],
-    control_stat: Union[SampleMeanStatistic, ProportionStatistic],
+    treatment_stat: SampleMeanStatistic | ProportionStatistic | RatioStatistic,
+    control_stat: SampleMeanStatistic | ProportionStatistic | RatioStatistic,
 ) -> None:
     """
     Validate input statistics for Bayesian analysis.

--- a/products/experiments/stats/shared/statistics.py
+++ b/products/experiments/stats/shared/statistics.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Union
 
 import numpy as np
 
@@ -103,8 +102,8 @@ class RatioStatistic:
     """
 
     n: int  # Sample size
-    m_statistic: Union[SampleMeanStatistic, ProportionStatistic]  # Numerator statistic
-    d_statistic: Union[SampleMeanStatistic, ProportionStatistic]  # Denominator statistic
+    m_statistic: SampleMeanStatistic | ProportionStatistic  # Numerator statistic
+    d_statistic: SampleMeanStatistic | ProportionStatistic  # Denominator statistic
     m_d_sum_of_products: float  # Sum of products between numerator and denominator
 
     def __post_init__(self):

--- a/products/experiments/stats/shared/statistics.py
+++ b/products/experiments/stats/shared/statistics.py
@@ -103,7 +103,7 @@ class RatioStatistic:
     """
 
     n: int  # Sample size
-    m_statistic: Union[SampleMeanStatistic, ProportionStatistic]  # Numerator statisticdiag
+    m_statistic: Union[SampleMeanStatistic, ProportionStatistic]  # Numerator statistic
     d_statistic: Union[SampleMeanStatistic, ProportionStatistic]  # Denominator statistic
     m_d_sum_of_products: float  # Sum of products between numerator and denominator
 

--- a/products/experiments/stats/shared/statistics.py
+++ b/products/experiments/stats/shared/statistics.py
@@ -1,4 +1,6 @@
 from dataclasses import dataclass
+from typing import Union
+
 import numpy as np
 
 
@@ -89,6 +91,63 @@ class ProportionStatistic:
     @property
     def standard_error(self) -> float:
         """Standard error of proportion: SE = √(p(1-p)/n)"""
+        return np.sqrt(self.variance / self.n)
+
+
+@dataclass
+class RatioStatistic:
+    """
+    Statistics for ratio metrics (e.g., revenue per order, clicks per session).
+
+    Uses the delta method for variance approximation of ratios.
+    """
+
+    n: int  # Sample size
+    m_statistic: Union[SampleMeanStatistic, ProportionStatistic]  # Numerator statisticdiag
+    d_statistic: Union[SampleMeanStatistic, ProportionStatistic]  # Denominator statistic
+    m_d_sum_of_products: float  # Sum of products between numerator and denominator
+
+    def __post_init__(self):
+        """Validate inputs."""
+        if self.n <= 0:
+            raise InvalidStatisticError("Sample size must be positive")
+        if self.m_statistic.n != self.n or self.d_statistic.n != self.n:
+            raise InvalidStatisticError("All statistics must have same sample size")
+        d_mean = self.d_statistic.mean if hasattr(self.d_statistic, "mean") else self.d_statistic.proportion
+        if abs(d_mean) < 1e-10:
+            raise InvalidStatisticError("Denominator mean cannot be zero for ratio calculation")
+
+    @property
+    def ratio(self) -> float:
+        """Ratio estimate: R = Σm / Σd"""
+        m_sum = self.m_statistic.sum
+        d_sum = self.d_statistic.sum
+        return m_sum / d_sum
+
+    @property
+    def covariance(self) -> float:
+        """Sample covariance: Cov(M,D) = (sum_products - sum_m × sum_d / n) / (n-1)"""
+        if self.n == 1:
+            return 0.0
+        m_sum = self.m_statistic.sum
+        d_sum = self.d_statistic.sum
+        return (self.m_d_sum_of_products - m_sum * d_sum / self.n) / (self.n - 1)
+
+    @property
+    def variance(self) -> float:
+        """Delta method variance for ratio R = M/D"""
+        m_mean = self.m_statistic.mean if hasattr(self.m_statistic, "mean") else self.m_statistic.proportion
+        d_mean = self.d_statistic.mean if hasattr(self.d_statistic, "mean") else self.d_statistic.proportion
+        m_var = self.m_statistic.variance
+        d_var = self.d_statistic.variance
+        cov = self.covariance
+
+        # Delta method: Var(R) ≈ Var(M)/D² + M²Var(D)/D⁴ - 2M*Cov(M,D)/D³
+        return m_var / d_mean**2 + m_mean**2 * d_var / d_mean**4 - 2 * m_mean * cov / d_mean**3
+
+    @property
+    def standard_error(self) -> float:
+        """Standard error of the ratio: SE = √(Var(R)/n)"""
         return np.sqrt(self.variance / self.n)
 
 

--- a/products/experiments/stats/shared/statistics.py
+++ b/products/experiments/stats/shared/statistics.py
@@ -152,4 +152,4 @@ class RatioStatistic:
 
 
 # Type alias for any statistic type
-AnyStatistic = SampleMeanStatistic | ProportionStatistic
+AnyStatistic = SampleMeanStatistic | ProportionStatistic | RatioStatistic

--- a/products/experiments/stats/shared/utils.py
+++ b/products/experiments/stats/shared/utils.py
@@ -8,9 +8,10 @@ by both frequentist and Bayesian methods.
 import numpy as np
 
 from .statistics import (
-    SampleMeanStatistic,
-    ProportionStatistic,
     AnyStatistic,
+    ProportionStatistic,
+    RatioStatistic,
+    SampleMeanStatistic,
     StatisticError,
 )
 
@@ -21,6 +22,8 @@ def get_mean(statistic: AnyStatistic) -> float:
         return statistic.mean
     elif isinstance(statistic, ProportionStatistic):
         return statistic.proportion
+    elif isinstance(statistic, RatioStatistic):
+        return statistic.ratio
     else:
         raise StatisticError(f"Unknown statistic type: {type(statistic)}")
 

--- a/products/experiments/stats/tests/test_statistics.py
+++ b/products/experiments/stats/tests/test_statistics.py
@@ -1,0 +1,182 @@
+import numpy as np
+import pytest
+
+from ..shared.statistics import (
+    InvalidStatisticError,
+    ProportionStatistic,
+    RatioStatistic,
+    SampleMeanStatistic,
+)
+
+
+class TestSampleMeanStatistic:
+    """Tests for SampleMeanStatistic."""
+
+    def test_basic_calculations(self):
+        """Test basic mean and variance calculations."""
+        # Test case: [1, 2, 3, 4, 5]
+        stat = SampleMeanStatistic(n=5, sum=15, sum_squares=55)
+
+        assert stat.mean == 3.0
+        assert stat.variance == 2.5  # Sample variance
+        assert abs(stat.standard_error - np.sqrt(2.5 / 5)) < 1e-10
+
+    def test_single_observation(self):
+        """Test with single observation."""
+        stat = SampleMeanStatistic(n=1, sum=10, sum_squares=100)
+
+        assert stat.mean == 10.0
+        assert stat.variance == 0.0
+        assert stat.standard_error == 0.0
+
+    def test_zero_variance(self):
+        """Test with all identical values."""
+        # All values are 5: [5, 5, 5]
+        stat = SampleMeanStatistic(n=3, sum=15, sum_squares=75)
+
+        assert stat.mean == 5.0
+        assert stat.variance == 0.0
+        assert stat.standard_error == 0.0
+
+    def test_validation_errors(self):
+        """Test input validation."""
+        # Negative sample size
+        with pytest.raises(InvalidStatisticError):
+            SampleMeanStatistic(n=-1, sum=10, sum_squares=100)
+
+        # Zero sample size
+        with pytest.raises(InvalidStatisticError):
+            SampleMeanStatistic(n=0, sum=10, sum_squares=100)
+
+        # Invalid sum_squares (too small)
+        with pytest.raises(InvalidStatisticError):
+            SampleMeanStatistic(n=5, sum=15, sum_squares=40)  # 40 < 15²/5 = 45
+
+
+class TestProportionStatistic:
+    """Tests for ProportionStatistic."""
+
+    def test_basic_calculations(self):
+        """Test basic proportion calculations."""
+        stat = ProportionStatistic(n=100, sum=25)
+
+        assert stat.proportion == 0.25
+        assert stat.variance == 0.25 * 0.75  # p(1-p)
+        assert abs(stat.standard_error - np.sqrt(0.25 * 0.75 / 100)) < 1e-10
+
+    def test_extreme_proportions(self):
+        """Test with extreme proportions."""
+        # All successes
+        stat = ProportionStatistic(n=10, sum=10)
+        assert stat.proportion == 1.0
+        assert stat.variance == 0.0
+
+        # No successes
+        stat = ProportionStatistic(n=10, sum=0)
+        assert stat.proportion == 0.0
+        assert stat.variance == 0.0
+
+    def test_validation_errors(self):
+        """Test input validation."""
+        # Negative sample size
+        with pytest.raises(InvalidStatisticError):
+            ProportionStatistic(n=-1, sum=5)
+
+        # Negative successes
+        with pytest.raises(InvalidStatisticError):
+            ProportionStatistic(n=10, sum=-1)
+
+        # More successes than trials
+        with pytest.raises(InvalidStatisticError):
+            ProportionStatistic(n=10, sum=15)
+
+
+class TestRatioStatistic:
+    """Tests for RatioStatistic."""
+
+    def test_basic_calculations(self):
+        """Test basic ratio calculations."""
+        # Revenue per user: revenue=[10, 20, 30], users=[1, 1, 1]
+        numerator = SampleMeanStatistic(n=3, sum=60, sum_squares=1400)  # Revenue
+        denominator = SampleMeanStatistic(n=3, sum=3, sum_squares=3)  # Users
+
+        stat = RatioStatistic(
+            n=3,
+            m_statistic=numerator,
+            d_statistic=denominator,
+            m_d_sum_of_products=60,  # sum(revenue * users)
+        )
+
+        assert stat.ratio == 20.0  # 60 / 3
+
+        # Test covariance calculation
+        expected_cov = (60 - 60 * 3 / 3) / (3 - 1)  # Should be 0
+        assert abs(stat.covariance - expected_cov) < 1e-10
+
+    def test_with_proportion_denominator(self):
+        """Test ratio with proportion denominator (e.g., revenue per conversion)."""
+        revenue = SampleMeanStatistic(n=100, sum=500, sum_squares=5000)
+        conversions = ProportionStatistic(n=100, sum=20)  # 20% conversion rate
+
+        stat = RatioStatistic(
+            n=100,
+            m_statistic=revenue,
+            d_statistic=conversions,
+            m_d_sum_of_products=100,  # sum(revenue * conversion_indicator)
+        )
+
+        assert stat.ratio == 500 / 20  # Total revenue / total conversions
+
+    def test_validation_errors(self):
+        """Test input validation."""
+        numerator = SampleMeanStatistic(n=5, sum=25, sum_squares=125)
+        denominator = SampleMeanStatistic(n=5, sum=0, sum_squares=0)  # Zero denominator
+
+        # Zero denominator
+        with pytest.raises(InvalidStatisticError):
+            RatioStatistic(n=5, m_statistic=numerator, d_statistic=denominator, m_d_sum_of_products=0)
+
+        # Mismatched sample sizes
+        denominator_wrong_n = SampleMeanStatistic(n=3, sum=15, sum_squares=75)
+        with pytest.raises(InvalidStatisticError):
+            RatioStatistic(n=5, m_statistic=numerator, d_statistic=denominator_wrong_n, m_d_sum_of_products=0)
+
+
+class TestStatisticIntegration:
+    """Integration tests across statistic types."""
+
+    def test_mean_extraction(self):
+        """Test that all statistics can provide a mean value."""
+        sample_mean = SampleMeanStatistic(n=10, sum=50, sum_squares=300)
+        proportion = ProportionStatistic(n=100, sum=25)
+
+        assert hasattr(sample_mean, "mean")
+        assert hasattr(proportion, "proportion")
+
+        # Both should be usable in calculations
+        assert sample_mean.mean == 5.0
+        assert proportion.proportion == 0.25
+
+    def test_variance_extraction(self):
+        """Test that all statistics can provide variance."""
+        sample_mean = SampleMeanStatistic(n=10, sum=50, sum_squares=300)
+        proportion = ProportionStatistic(n=100, sum=25)
+
+        assert hasattr(sample_mean, "variance")
+        assert hasattr(proportion, "variance")
+
+        # Both should be non-negative
+        assert sample_mean.variance >= 0
+        assert proportion.variance >= 0
+
+    def test_standard_error_calculation(self):
+        """Test standard error calculations across types."""
+        sample_mean = SampleMeanStatistic(n=10, sum=50, sum_squares=300)
+        proportion = ProportionStatistic(n=100, sum=25)
+
+        # Standard error should be sqrt(variance / n)
+        expected_se_mean = np.sqrt(sample_mean.variance / sample_mean.n)
+        expected_se_prop = np.sqrt(proportion.variance / proportion.n)
+
+        assert abs(sample_mean.standard_error - expected_se_mean) < 1e-10
+        assert abs(proportion.standard_error - expected_se_prop) < 1e-10


### PR DESCRIPTION
## Changes
We have on our roadmap for Q3 to support ratio metrics. This is the first PR on that task.

* Add support for `RatioStatistic` in our stats module
* Add tests for frequentist and bayesian that uses a `RatioStatistic`

## How did you test this code?
* tests passes