### PR TITLE
chore(crm): Move group notebook to a dedicated tab

### DIFF
--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -38,6 +38,7 @@ import {
 import { GroupOverview } from './GroupOverview'
 import { RelatedGroups } from './RelatedGroups'
 import { NotebookNodeType } from 'scenes/notebooks/types'
+import { GroupNotebookCard } from './cards/GroupNotebookCard'
 
 interface GroupSceneProps {
     groupTypeIndex?: string
@@ -117,6 +118,15 @@ export function Group(): JSX.Element {
                         label: <span data-attr="groups-overview-tab">Overview</span>,
                         content: <GroupOverview groupData={groupData} />,
                     },
+                    ...(featureFlags[FEATURE_FLAGS.CRM_ITERATION_ONE] && groupData.notebook
+                        ? [
+                              {
+                                  key: 'notebook',
+                                  label: <span data-attr="groups-notebook-tab">Notebook</span>,
+                                  content: <GroupNotebookCard shortId={groupData.notebook} />,
+                              },
+                          ]
+                        : []),
                     {
                         key: PersonsTabType.PROPERTIES,
                         label: <span data-attr="groups-properties-tab">Properties</span>,

--- a/frontend/src/scenes/groups/GroupOverview.tsx
+++ b/frontend/src/scenes/groups/GroupOverview.tsx
@@ -1,45 +1,15 @@
 import { useValues } from 'kea'
 import { capitalizeFirstLetter } from 'lib/utils'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { Group } from '~/types'
 
 import { GroupDashboardCard } from './cards/GroupDashboardCard'
-import { GroupNotebookCard } from './cards/GroupNotebookCard'
 import { GroupPeopleCard } from './cards/GroupPeopleCard'
 import { GroupPropertiesCard } from './cards/GroupPropertiesCard'
 import { groupLogic } from './groupLogic'
 
 export function GroupOverview({ groupData }: { groupData: Group }): JSX.Element {
     const { groupTypeName } = useValues(groupLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
-
-    if (featureFlags[FEATURE_FLAGS.CRM_ITERATION_ONE] && groupData.notebook) {
-        return (
-            <div className="flex flex-col gap-4">
-                <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 items-stretch">
-                    <div className="col-span-1 order-1">
-                        <GroupNotebookCard shortId={groupData.notebook} />
-                    </div>
-                    <div className="col-span-1 flex flex-col gap-4 order-2">
-                        <div>
-                            <h2>{capitalizeFirstLetter(groupTypeName)} properties</h2>
-                            <GroupPropertiesCard groupData={groupData} />
-                        </div>
-                        <div>
-                            <h2>Related people</h2>
-                            <GroupPeopleCard groupData={groupData} />
-                        </div>
-                    </div>
-                </div>
-                <div>
-                    <h2>Insights</h2>
-                    <GroupDashboardCard />
-                </div>
-            </div>
-        )
-    }
 
     return (
         <div className="flex flex-col gap-4">

--- a/frontend/src/scenes/groups/cards/GroupNotebookCard.tsx
+++ b/frontend/src/scenes/groups/cards/GroupNotebookCard.tsx
@@ -8,16 +8,14 @@ interface GroupNotebookCardProps {
 
 export function GroupNotebookCard({ shortId }: GroupNotebookCardProps): JSX.Element {
     return (
-        <div className="flex flex-col gap-2 h-full min-h-80">
-            <div className="flex-1 relative">
-                <div className="absolute inset-0 overflow-y-auto">
-                    <Notebook shortId={shortId} editable={true} initialAutofocus="end" />
-                </div>
-            </div>
+        <div className="flex flex-col gap-2">
             <div className="flex justify-end">
                 <LemonButton type="secondary" size="small" to={urls.notebook(shortId)}>
                     Open notebook
                 </LemonButton>
+            </div>
+            <div className="flex-1">
+                <Notebook shortId={shortId} editable={true} initialAutofocus="end" />
             </div>
         </div>
     )


### PR DESCRIPTION
## Problem
Moved group notebook from overview to its own tab
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
### Before
<img width="4064" height="2334" alt="image" src="https://github.com/user-attachments/assets/2d12f4d0-fb3d-401b-bde9-fe350238389d" />

### After
<img width="1604" height="951" alt="image" src="https://github.com/user-attachments/assets/aee47c78-f9ab-4fc4-8712-11e46f3311e7" />

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
