### PR TITLE
chore(crm): Do not show popover for person in people list

### DIFF
--- a/frontend/src/queries/nodes/DataTable/renderColumn.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumn.tsx
@@ -281,11 +281,13 @@ export function renderColumn(
 
         return <PersonDisplay {...displayProps} />
     } else if (key === 'person_display_name') {
+        // Hide the popover on people list only
+        const noPopover = isActorsQuery(query.source)
         const displayProps: PersonDisplayProps = {
             withIcon: true,
             person: { id: value.id },
             displayName: value.display_name,
-            noPopover: false,
+            noPopover,
         }
         return <PersonDisplay {...displayProps} />
     } else if (key === 'group' && typeof value === 'object') {

--- a/frontend/src/scenes/persons-management/PersonsManagementScene.test.tsx
+++ b/frontend/src/scenes/persons-management/PersonsManagementScene.test.tsx
@@ -142,30 +142,13 @@ describe('PersonsManagementScene', () => {
         const firstRow = rows[0]
         const personDisplayLink = within(firstRow).getByRole('link')
 
+        // clicking person display link should navigate to person page
         userEvent.click(personDisplayLink)
 
-        // Wait for the Popover to appear AND contain links
-        const popoverLink = await waitFor(() => {
-            const popover = document.querySelector('.Popover')
-            if (!popover) {
-                throw new Error('Popover not found')
-            }
-
-            // Make sure the links have loaded
-            const popoverLinks = popover.querySelectorAll('a.Link')
-            if (popoverLinks.length === 0) {
-                throw new Error('No links found in Popover')
-            }
-
-            // Return the last link ("View events" link)
-            return popoverLinks[popoverLinks.length - 1] as HTMLElement
-        })
-
-        userEvent.click(popoverLink)
-
-        // The user is anonymous, the "view events" link takes them to the explore page
         await waitFor(() => {
-            expect(router.values.location.pathname).toBe(`/project/${MOCK_TEAM_ID}/activity/explore`)
+            expect(router.values.location.pathname).toBe(
+                `/project/${MOCK_TEAM_ID}/persons/0257ab53-0816-55da-8919-73abbf36d5a9`
+            )
         })
     })
 })


### PR DESCRIPTION
## Problem
@veryayskiy pointed out and I've watched a few replays of people having a bad experience when trying to open person details page out of people list.

Currently, when you click a cell in Person column, it opens a popover. Then, from the popover, the user is able to navigate to person details. This adds an extra click + wait time for the popover to open.


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Closes https://github.com/PostHog/posthog/issues/36114
## Changes
Set `person` column to open person details on click, instead of opening the popover.

> [!WARNING]
> Please let me know of any places this change may affect, as the DataTable is used extensively.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

https://github.com/user-attachments/assets/8aef7b31-9a5b-44b7-b04e-5e02eac0844d


https://github.com/user-attachments/assets/6e5f65ea-3f3f-499d-9c4e-a5dd9e6b1ca7


## How did you test this code?
Navigated to places I've seen people column and confirmed the behavior didn't change. Places I've checked:
- /activity/explore -> clicking opens popover ✅ 
- /cohorts/:id -> clicking navigates to person details ✅ 
- insights person modal -> clicking opens popover ✅
- early_access_features/:id -> clicking navigates to person details ✅ 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
