### PR TITLE
feat(mm): reports the date range a managed migration failed on

### DIFF
--- a/rust/batch-import-worker/src/source/date_range_export.rs
+++ b/rust/batch-import-worker/src/source/date_range_export.rs
@@ -1052,7 +1052,7 @@ mod tests {
 
         let key = "2023-01-01T00:00:00+00:00_2023-01-01T01:00:00+00:00";
         let formatted = source.format_date_range_from_key(key).unwrap();
-        
+
         assert_eq!(formatted, "2023-01-01 00:00 UTC to 2023-01-01 01:00 UTC");
     }
 
@@ -1063,7 +1063,7 @@ mod tests {
 
         let key = "2023-12-31T23:30:00+00:00_2024-01-01T00:30:00+00:00";
         let formatted = source.format_date_range_from_key(key).unwrap();
-        
+
         assert_eq!(formatted, "2023-12-31 23:30 UTC to 2024-01-01 00:30 UTC");
     }
 
@@ -1074,7 +1074,7 @@ mod tests {
 
         let key = "invalid-key-format";
         let formatted = source.format_date_range_from_key(key);
-        
+
         assert!(formatted.is_none());
     }
 
@@ -1085,7 +1085,7 @@ mod tests {
 
         let key = "2023-06-15T12:00:00+00:00_2023-06-15T13:00:00+00:00";
         let date_range = source.get_date_range_for_key(key).unwrap();
-        
+
         assert_eq!(date_range, "2023-06-15 12:00 UTC to 2023-06-15 13:00 UTC");
     }
 
@@ -1105,7 +1105,9 @@ mod tests {
         assert!(source.format_date_range_from_key(invalid_key2).is_none());
 
         let invalid_date_key = "invalid-date_2023-01-01T01:00:00+00:00";
-        assert!(source.format_date_range_from_key(invalid_date_key).is_none());
+        assert!(source
+            .format_date_range_from_key(invalid_date_key)
+            .is_none());
     }
 
     #[tokio::test]

--- a/rust/batch-import-worker/src/source/mod.rs
+++ b/rust/batch-import-worker/src/source/mod.rs
@@ -28,4 +28,8 @@ pub trait DataSource: Sync + Send {
     async fn cleanup_after_job(&self) -> Result<(), Error> {
         Ok(())
     }
+
+    fn get_date_range_for_key(&self, _key: &str) -> Option<String> {
+        None
+    }
 }


### PR DESCRIPTION
## Problem

APIs that a managed migration are dependent on can be kind of flaky resulting in a migration failing part way through. In order for a customer to kick off another migration where the previous failed one left off they need to know what date was being processed when the job failed.

## Changes

Report the date range of the part that the job was processing when it failed in the User facing error message

## How did you test this code?

Unit tests

