### PR TITLE
fix: add format_exc_info back to async logger

### DIFF
--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -255,6 +255,7 @@ def configure_logger_async(
         structlog.stdlib.filter_by_level,
         structlog.stdlib.add_logger_name,
         structlog.stdlib.add_log_level,
+        structlog.processors.format_exc_info,  # Add this to match sync version and handle exc_info properly
         structlog.stdlib.PositionalArgumentsFormatter(),
         structlog.processors.CallsiteParameterAdder(
             {

--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -299,13 +299,11 @@ def configure_logger_async(
             put_in_queue = PutInLogQueueProcessor(log_queue)
             processors.append(put_in_queue)
 
-    # Add environment-specific processors
     if sys.stderr.isatty() or settings.TEST or settings.DEBUG:
         processors.extend(DEVELOPMENT_PROCESSORS)
     else:
         processors.extend(PRODUCTION_PROCESSORS)
 
-    # Add any extra processors
     if extra_processors:
         processors.extend(extra_processors)
 

--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -21,7 +21,6 @@ from posthog.kafka_client.topics import KAFKA_LOG_ENTRIES
 BACKGROUND_LOGGER_TASKS = set()
 EXTERNAL_LOGGER_NAME = "EXTERNAL"
 
-# Common processor configurations for temporal loggers
 BASE_PROCESSORS = [
     structlog.stdlib.filter_by_level,
     structlog.stdlib.add_logger_name,

--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -21,7 +21,7 @@ from posthog.kafka_client.topics import KAFKA_LOG_ENTRIES
 BACKGROUND_LOGGER_TASKS = set()
 EXTERNAL_LOGGER_NAME = "EXTERNAL"
 
-BASE_PROCESSORS = [
+BASE_PROCESSORS: list[structlog.types.Processor] = [
     structlog.stdlib.filter_by_level,
     structlog.stdlib.add_logger_name,
     structlog.stdlib.add_log_level,
@@ -38,12 +38,12 @@ BASE_PROCESSORS = [
     structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S.%f", utc=True),
 ]
 
-DEVELOPMENT_PROCESSORS = [
+DEVELOPMENT_PROCESSORS: list[structlog.types.Processor] = [
     EventRenamer("msg"),
     structlog.dev.ConsoleRenderer(event_key="msg"),
 ]
 
-PRODUCTION_PROCESSORS = [
+PRODUCTION_PROCESSORS: list[structlog.types.Processor] = [
     structlog.processors.dict_tracebacks,
     EventRenamer("msg"),
     structlog.processors.JSONRenderer(),

--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -25,7 +25,7 @@ BASE_PROCESSORS = [
     structlog.stdlib.filter_by_level,
     structlog.stdlib.add_logger_name,
     structlog.stdlib.add_log_level,
-    structlog.processors.format_exc_info,  # Required to prevent AttributeError with dict_tracebacks
+    structlog.processors.format_exc_info,
     structlog.stdlib.PositionalArgumentsFormatter(),
     structlog.processors.CallsiteParameterAdder(
         {

--- a/posthog/test/test_exceptions_capture.py
+++ b/posthog/test/test_exceptions_capture.py
@@ -1,5 +1,6 @@
 import uuid
 import json
+import sys
 from unittest.mock import patch
 from django.test import TestCase
 from io import StringIO
@@ -49,3 +50,23 @@ class TestExceptionsCapture(TestCase):
         self.assertIn("Exception captured: Test error with context", log_data["event"])
         self.assertIn("ValueError: Test error with context", log_data["exception"])
         self.assertIn("Traceback", log_data["exception"])
+
+    def test_temporal_async_logger_handles_none_exc_info(self):
+        """Test that temporal async logger handles exc_info=(None, None, None) without crashing."""
+        from posthog.temporal.common.logger import BASE_PROCESSORS, PRODUCTION_PROCESSORS
+
+        # Configure structlog with the temporal processor constants
+        processors = BASE_PROCESSORS + PRODUCTION_PROCESSORS
+
+        structlog.configure(
+            processors=processors,
+            logger_factory=structlog.stdlib.LoggerFactory(),
+            wrapper_class=structlog.stdlib.BoundLogger,
+            cache_logger_on_first_use=False,
+        )
+
+        logger = structlog.get_logger("temporal_test")
+
+        # This should work if BASE_PROCESSORS contains format_exc_info, fail if it doesn't
+        # because PRODUCTION_PROCESSORS contains dict_tracebacks which needs format_exc_info
+        logger.error("Test temporal logger", exc_info=sys.exc_info())

--- a/posthog/test/test_exceptions_capture.py
+++ b/posthog/test/test_exceptions_capture.py
@@ -22,20 +22,6 @@ class TestExceptionsCapture(TestCase):
 
     @patch("posthoganalytics.api_key", "test-key")
     @patch("posthoganalytics.capture_exception")
-    def test_capture_exception_with_none_exc_info(self, mock_posthog_capture):
-        """Test that structlog handles exc_info=(None, None, None) gracefully"""
-        mock_posthog_capture.return_value = str(uuid.uuid4())
-        output = self._setup_structlog_capture()
-
-        test_exception = ValueError("Test error without context")
-        capture_exception(test_exception)
-
-        log_data = json.loads(output.getvalue().strip())
-        self.assertIn("Exception captured: Test error without context", log_data["event"])
-        self.assertEqual(log_data["exception"], "MISSING")
-
-    @patch("posthoganalytics.api_key", "test-key")
-    @patch("posthoganalytics.capture_exception")
     def test_capture_exception_with_real_exc_info(self, mock_posthog_capture):
         """Test that structlog properly formats real exception info"""
         mock_posthog_capture.return_value = str(uuid.uuid4())


### PR DESCRIPTION
This PR removed format_exc_info from the async logger:
https://github.com/PostHog/posthog/pull/34698/files

@tomasfarias was there a specific reason for removing? also there is a lot of divergence between the async and sync logger - i don't really have context on what you're using it for in batch exports, but is there a way to bring them closer?

However, this is causing the following issue when calling logger.exception from Temporal.

Add it back. Write a test to verify the logger works. 

```
"  File \"/python-runtime/lib/python3.11/site-packages/temporalio/worker/_activity.py\", line 301, in _handle_start_activity_task
    result = await self._execute_activity(start, running_activity, task_token)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File \"/python-runtime/lib/python3.11/site-packages/temporalio/worker/_activity.py\", line 590, in _execute_activity
    return await impl.execute_activity(input)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File \"/python-runtime/lib/python3.11/site-packages/temporalio/contrib/opentelemetry.py\", line 296, in execute_activity
    return await super().execute_activity(input)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File \"/python-runtime/lib/python3.11/site-packages/temporalio/worker/_interceptor.py\", line 123, in execute_activity
    return await self.next.execute_activity(input)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File \"/code/posthog/temporal/common/posthog_client.py\", line 37, in execute_activity
    return await super().execute_activity(input)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File \"/python-runtime/lib/python3.11/site-packages/temporalio/worker/_interceptor.py\", line 123, in execute_activity
    return await self.next.execute_activity(input)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File \"/code/products/batch_exports/backend/temporal/metrics.py\", line 81, in execute_activity
    return await super().execute_activity(input)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File \"/python-runtime/lib/python3.11/site-packages/temporalio/worker/_interceptor.py\", line 123, in execute_activity
    return await self.next.execute_activity(input)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File \"/python-runtime/lib/python3.11/site-packages/temporalio/worker/_activity.py\", line 785, in execute_activity
    return await input.fn(*input.args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File \"/code/posthog/temporal/subscriptions/subscription_scheduling_workflow.py\", line 99, in deliver_subscription_report_activity
    await deliver_subscription_report_async(

  File \"/code/ee/tasks/subscriptions/__init__.py\", line 69, in deliver_subscription_report_async
    capture_exception(Exception(\"No assets are in this subscription\"), {\"subscription_id\": subscription.id})

  File \"/code/posthog/exceptions_capture.py\", line 39, in capture_exception
    logger.error(

  File \"/python-runtime/lib/python3.11/site-packages/structlog/stdlib.py\", line 200, in error
    return self._proxy_to_logger(\"error\", event, *args, **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File \"/python-runtime/lib/python3.11/site-packages/structlog/stdlib.py\", line 247, in _proxy_to_logger
    return super()._proxy_to_logger(method_name, event=event, **event_kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File \"/python-runtime/lib/python3.11/site-packages/structlog/_base.py\", line 222, in _proxy_to_logger
    args, kw = self._process_event(method_name, event, event_kw)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File \"/python-runtime/lib/python3.11/site-packages/structlog/_base.py\", line 171, in _process_event
    event_dict = proc(self._logger, method_name, event_dict)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File \"/python-runtime/lib/python3.11/site-packages/structlog/processors.py\", line 412, in __call__
    event_dict[\"exception\"] = self.format_exception(
                              ^^^^^^^^^^^^^^^^^^^^^^

  File \"/python-runtime/lib/python3.11/site-packages/structlog/tracebacks.py\", line 262, in __call__
    trace = extract(
            ^^^^^^^^

  File \"/python-runtime/lib/python3.11/site-packages/structlog/tracebacks.py\", line 156, in extract
    exc_type=safe_str(exc_type.__name__),
                      ^^^^^^^^^^^^^^^^^
                      ```