### PR TITLE
chore: change web api docs to use feature preview

### DIFF
--- a/posthog/api/external_web_analytics/http.py
+++ b/posthog/api/external_web_analytics/http.py
@@ -86,7 +86,7 @@ class ExternalWebAnalyticsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, vi
     @action(methods=["GET"], detail=False)
     def overview(self, request: Request, **kwargs) -> Response:
         """
-        Get an overview of web analytics data including visitors, views, sessions, bounce rate, and session duration. This endpoint is in beta, please contact support to enable it for your team.
+        This endpoints is in Concept state, please join the <a href="https://app.posthog.com/settings/user-feature-previews#web-analytics-api">feature preview</a> to try it out when it's ready. Get an overview of web analytics data including visitors, views, sessions, bounce rate, and session duration.
         """
         self._can_use_external_web_analytics()
 
@@ -167,7 +167,7 @@ class ExternalWebAnalyticsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, vi
     @action(methods=["GET"], detail=False)
     def breakdown(self, request: Request, **kwargs) -> Response:
         """
-        Get a breakdown by a property (e.g. browser, device type, country, etc.). This endpoint is in beta, please contact support to enable it for your team.
+        This endpoints is in Concept state, please join the <a href="https://app.posthog.com/settings/user-feature-previews#web-analytics-api">feature preview</a> to try it out when it's ready. Get a breakdown by a property (e.g. browser, device type, country, etc.).
         """
         self._can_use_external_web_analytics()
 

--- a/posthog/api/external_web_analytics/http.py
+++ b/posthog/api/external_web_analytics/http.py
@@ -127,7 +127,7 @@ class ExternalWebAnalyticsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, vi
     @action(methods=["GET"], detail=False)
     def trend(self, request: Request, **kwargs) -> Response:
         """
-        Get trends for visitors, views, or sessions over time. This endpoint is in beta, please contact support to enable it for your team.
+        This endpoint is in Concept state, please join the <a href="https://app.posthog.com/settings/user-feature-previews#web-analytics-api">feature preview</a> to try it out when it's ready. Get trends for visitors, views, or sessions over time.
         """
         self._can_use_external_web_analytics()
 

--- a/posthog/api/external_web_analytics/http.py
+++ b/posthog/api/external_web_analytics/http.py
@@ -86,7 +86,7 @@ class ExternalWebAnalyticsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, vi
     @action(methods=["GET"], detail=False)
     def overview(self, request: Request, **kwargs) -> Response:
         """
-        This endpoints is in Concept state, please join the <a href="https://app.posthog.com/settings/user-feature-previews#web-analytics-api">feature preview</a> to try it out when it's ready. Get an overview of web analytics data including visitors, views, sessions, bounce rate, and session duration.
+        This endpoint is in Concept state, please join the <a href="https://app.posthog.com/settings/user-feature-previews#web-analytics-api">feature preview</a> to try it out when it's ready. Get an overview of web analytics data including visitors, views, sessions, bounce rate, and session duration.
         """
         self._can_use_external_web_analytics()
 

--- a/posthog/api/external_web_analytics/http.py
+++ b/posthog/api/external_web_analytics/http.py
@@ -167,7 +167,7 @@ class ExternalWebAnalyticsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, vi
     @action(methods=["GET"], detail=False)
     def breakdown(self, request: Request, **kwargs) -> Response:
         """
-        This endpoints is in Concept state, please join the <a href="https://app.posthog.com/settings/user-feature-previews#web-analytics-api">feature preview</a> to try it out when it's ready. Get a breakdown by a property (e.g. browser, device type, country, etc.).
+        This endpoint is in Concept state, please join the <a href="https://app.posthog.com/settings/user-feature-previews#web-analytics-api">feature preview</a> to try it out when it's ready. Get a breakdown by a property (e.g. browser, device type, country, etc.).
         """
         self._can_use_external_web_analytics()
 


### PR DESCRIPTION
## Problem

We said it was in beta, but people couldn't use it yet. This won't last long as we are about to enable it, but we already have some support tickets, so let's make it clear.

## Changes

- Say it is in Concept instead of beta as described in https://posthog.com/handbook/product/releasing-as-beta

## How did you test this code?

Checked generation

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
