### PR TITLE
feat(cdp): Support degraded state for hog function api

### DIFF
--- a/plugin-server/src/cdp/consumers/cdp-source-webhooks.consumer.test.ts
+++ b/plugin-server/src/cdp/consumers/cdp-source-webhooks.consumer.test.ts
@@ -193,7 +193,7 @@ describe('SourceWebhooksConsumer', () => {
             })
         })
 
-        describe('degraded functions', () => {
+        describe('hogwatcher', () => {
             it('should return a degraded response if the function is degraded', async () => {
                 await api['cdpSourceWebhooksConsumer']['hogWatcher'].forceStateChange(
                     hogFunction,
@@ -213,6 +213,20 @@ describe('SourceWebhooksConsumer', () => {
                         functionId: hogFunction.id,
                     }),
                 ])
+            })
+
+            it('should return a disabled response if the function is disabled', async () => {
+                await api['cdpSourceWebhooksConsumer']['hogWatcher'].forceStateChange(
+                    hogFunction,
+                    HogWatcherState.disabled
+                )
+                const res = await doRequest({})
+                expect(res.status).toEqual(429)
+                expect(res.body).toEqual({
+                    error: 'Disabled',
+                })
+                expect(mockExecuteSpy).not.toHaveBeenCalled()
+                expect(mockQueueInvocationsSpy).not.toHaveBeenCalled()
             })
         })
     })

--- a/plugin-server/src/cdp/consumers/cdp-source-webhooks.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-source-webhooks.consumer.ts
@@ -174,7 +174,6 @@ export class CdpSourceWebhooksConsumer extends CdpConsumerBase {
                     {},
                     {
                         finished: false,
-                        error: 'Function is degraded',
                         logs: [
                             {
                                 level: 'warn',

--- a/plugin-server/src/cdp/consumers/cdp-source-webhooks.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-source-webhooks.consumer.ts
@@ -6,6 +6,7 @@ import { logger } from '../../utils/logger'
 import { PromiseScheduler } from '../../utils/promise-scheduler'
 import { UUID, UUIDT } from '../../utils/utils'
 import { CyclotronJobQueue } from '../services/job-queue/job-queue'
+import { HogWatcherState } from '../services/monitoring/hog-watcher.service'
 import {
     CyclotronJobInvocationHogFunction,
     CyclotronJobInvocationResult,
@@ -90,7 +91,10 @@ export class CdpSourceWebhooksConsumer extends CdpConsumerBase {
         webhookId: string,
         req: express.Request
     ): Promise<CyclotronJobInvocationResult<CyclotronJobInvocationHogFunction>> {
-        const hogFunction = await this.getWebhook(webhookId)
+        const [hogFunction, hogFunctionState] = await Promise.all([
+            this.getWebhook(webhookId),
+            this.hogWatcher.getCachedEffectiveState(webhookId),
+        ])
 
         if (!hogFunction) {
             throw new SourceWebhookError(404, 'Not found')
@@ -145,34 +149,52 @@ export class CdpSourceWebhooksConsumer extends CdpConsumerBase {
             // TODO: Add error handling and logging
             const globalsWithInputs = await this.hogExecutor.buildInputsWithGlobals(hogFunction, globals)
 
-            // TODO: Do we want to use hogwatcher here as well?
             const invocation = createInvocation(globalsWithInputs, hogFunction)
-            // Run the initial step - this allows functions not using fetches to respond immediately
-            result = await this.hogExecutor.execute(invocation)
 
-            const addLog = createAddLogFunction(result.logs)
+            if (hogFunctionState?.state !== HogWatcherState.degraded) {
+                // Degraded functions are not executed immediately
+                await this.cyclotronJobQueue.queueInvocations([invocation])
 
-            // Queue any queued work here. This allows us to enable delayed work like fetching eventually without blocking the API.
-            if (!result.finished) {
-                await this.cyclotronJobQueue.queueInvocationResults([result])
+                result = createInvocationResult(
+                    invocation,
+                    {},
+                    {
+                        finished: false,
+                        error: 'Function is degraded',
+                        logs: [
+                            {
+                                level: 'warn',
+                                message: 'Function scheduled for future execution due to degraded state',
+                                timestamp: DateTime.now(),
+                            },
+                        ],
+                    }
+                )
+                result.execResult = {
+                    // TODO: Add support for a default response as an input
+                    httpResponse: {
+                        status: 200,
+                        body: '',
+                    },
+                }
+            } else {
+                // Run the initial step - this allows functions not using fetches to respond immediately
+                result = await this.hogExecutor.execute(invocation)
+
+                const addLog = createAddLogFunction(result.logs)
+
+                // Queue any queued work here. This allows us to enable delayed work like fetching eventually without blocking the API.
+                if (!result.finished) {
+                    await this.cyclotronJobQueue.queueInvocationResults([result])
+                }
+
+                const customHttpResponse = getCustomHttpResponse(result)
+                if (customHttpResponse) {
+                    const level = customHttpResponse.status >= 400 ? 'warn' : 'info'
+                    addLog(level, `Responded with response status - ${customHttpResponse.status}`)
+                }
             }
-
-            const customHttpResponse = getCustomHttpResponse(result)
-            if (customHttpResponse) {
-                const level = customHttpResponse.status >= 400 ? 'warn' : 'info'
-                addLog(level, `Responded with response status - ${customHttpResponse.status}`)
-            }
-
-            void this.promiseScheduler.schedule(
-                Promise.all([
-                    this.hogFunctionMonitoringService.queueInvocationResults([result]).then(() => {
-                        return this.hogFunctionMonitoringService.produceQueuedMessages()
-                    }),
-                    this.hogWatcher.observeResultsBuffered(result),
-                ])
-            )
         } catch (error) {
-            // TODO: Make this more robust
             logger.error('Error executing hog function', { error })
             result = createInvocationResult(
                 createInvocation({} as any, hogFunction),
@@ -183,15 +205,16 @@ export class CdpSourceWebhooksConsumer extends CdpConsumerBase {
                     logs: [{ level: 'error', message: error.message, timestamp: DateTime.now() }],
                 }
             )
-            void this.promiseScheduler.schedule(
-                Promise.all([
-                    this.hogFunctionMonitoringService.queueInvocationResults([result]).then(() => {
-                        return this.hogFunctionMonitoringService.produceQueuedMessages()
-                    }),
-                    this.hogWatcher.observeResultsBuffered(result),
-                ])
-            )
         }
+
+        void this.promiseScheduler.schedule(
+            Promise.all([
+                this.hogFunctionMonitoringService.queueInvocationResults([result]).then(() => {
+                    return this.hogFunctionMonitoringService.produceQueuedMessages()
+                }),
+                this.hogWatcher.observeResultsBuffered(result),
+            ])
+        )
 
         return result
     }

--- a/plugin-server/src/cdp/services/monitoring/hog-watcher.service.ts
+++ b/plugin-server/src/cdp/services/monitoring/hog-watcher.service.ts
@@ -111,6 +111,8 @@ export class HogWatcherService {
 
         this.lazyLoader = new LazyLoader({
             name: 'hog_watcher_lazy_loader',
+            refreshAge: 30_000, // Cache for 30 seconds
+            refreshJitterMs: 10_000,
             loader: async (ids) => await this.getPersistedStates(ids),
         })
     }

--- a/plugin-server/src/cdp/services/monitoring/hog-watcher.service.ts
+++ b/plugin-server/src/cdp/services/monitoring/hog-watcher.service.ts
@@ -1,5 +1,6 @@
 import { Counter } from 'prom-client'
 
+import { LazyLoader } from '~/utils/lazy-loader'
 import { logger } from '~/utils/logger'
 import { captureTeamEvent } from '~/utils/posthog'
 
@@ -74,6 +75,8 @@ const getPipelineResults = (res: PipelineResults, index: number, numOperations: 
 
 export class HogWatcherService {
     private costsMapping: HogFunctionTimingCosts
+    private lazyLoader: LazyLoader<HogWatcherFunctionState>
+
     private queuedResults: {
         results: CyclotronJobInvocationResult[]
         promise: Promise<void>
@@ -105,6 +108,11 @@ export class HogWatcherService {
                 )
             }
         }
+
+        this.lazyLoader = new LazyLoader({
+            name: 'hog_watcher_lazy_loader',
+            loader: async (ids) => await this.getPersistedStates(ids),
+        })
     }
 
     private async onStateChange({
@@ -203,6 +211,10 @@ export class HogWatcherService {
         return res[id]
     }
 
+    public async getCachedPersistedState(id: HogFunctionType['id']): Promise<HogWatcherFunctionState | null> {
+        return await this.lazyLoader.get(id)
+    }
+
     /**
      * Like getPersistedStates but returns the effective state (i.e. ignores forcefully set states)
      */
@@ -224,6 +236,15 @@ export class HogWatcherService {
     public async getEffectiveState(id: HogFunctionType['id']): Promise<HogWatcherFunctionState> {
         const res = await this.getEffectiveStates([id])
         return res[id]
+    }
+
+    public async getCachedEffectiveState(id: HogFunctionType['id']): Promise<HogWatcherFunctionState | null> {
+        const res = await this.lazyLoader.get(id)
+        if (!res) {
+            return null
+        }
+
+        return { state: effectiveState(res.state), tokens: res.tokens }
     }
 
     public async getAllFunctionStates(): Promise<Record<HogFunctionType['id'], HogWatcherFunctionState>> {


### PR DESCRIPTION
## Problem

The API is different to the consumer in that we will have per-event hits rather than big batches and response time is really important.

## Changes

* Adds a lazy loader for the hog watcher as a cached option
* Loads it in parallel with the function
* If degraded, schedules the job instead of running it

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
