### PR TITLE
fix: Only re enable if not forcefully disabled

### DIFF
--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
@@ -815,10 +815,7 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
             (s) => [s.configuration, s.hogFunction],
             (configuration, hogFunction) => {
                 const hogState = hogFunction?.status?.state ?? 0
-                return (
-                    configuration?.enabled &&
-                    (hogState === HogWatcherState.overflowed || hogState === HogWatcherState.disabled)
-                )
+                return configuration?.enabled && hogState === HogWatcherState.disabled
             },
         ],
 

--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
@@ -44,6 +44,7 @@ import {
     HogFunctionTemplateType,
     HogFunctionType,
     HogFunctionTypeType,
+    HogWatcherState,
     PersonType,
     PipelineNodeTab,
     PipelineStage,
@@ -813,7 +814,11 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
         willReEnableOnSave: [
             (s) => [s.configuration, s.hogFunction],
             (configuration, hogFunction) => {
-                return configuration?.enabled && (hogFunction?.status?.state ?? 0) >= 3
+                const hogState = hogFunction?.status?.state ?? 0
+                return (
+                    configuration?.enabled &&
+                    (hogState === HogWatcherState.overflowed || hogState === HogWatcherState.disabled)
+                )
             },
         ],
 

--- a/posthog/api/hog_function.py
+++ b/posthog/api/hog_function.py
@@ -374,10 +374,7 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
         # Standard update
         res: HogFunction = super().update(instance, validated_data)
 
-        if res.enabled and res.status.get("state", 0) in (
-            HogFunctionState.DISABLED.value,
-            HogFunctionState.DEGRADED.value,
-        ):
+        if res.enabled and res.status.get("state", 0) == HogFunctionState.DISABLED.value:
             res.set_function_status(HogFunctionState.DEGRADED.value)
 
         return res

--- a/posthog/api/hog_function.py
+++ b/posthog/api/hog_function.py
@@ -374,7 +374,10 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
         # Standard update
         res: HogFunction = super().update(instance, validated_data)
 
-        if res.enabled and res.status.get("state", 0) >= HogFunctionState.DISABLED.value:
+        if res.enabled and res.status.get("state", 0) in (
+            HogFunctionState.DISABLED.value,
+            HogFunctionState.DEGRADED.value,
+        ):
             res.set_function_status(HogFunctionState.DEGRADED.value)
 
         return res

--- a/posthog/api/test/test_hog_function.py
+++ b/posthog/api/test/test_hog_function.py
@@ -12,7 +12,7 @@ from posthog.api.test.test_hog_function_templates import MOCK_NODE_TEMPLATES
 from posthog.cdp.templates.hog_function_template import sync_template_to_db
 from posthog.constants import AvailableFeature
 from posthog.models.action.action import Action
-from posthog.models.hog_functions.hog_function import DEFAULT_STATE, HogFunction
+from posthog.models.hog_functions.hog_function import DEFAULT_STATE, HogFunction, HogFunctionState
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, QueryMatchingTest
 from posthog.cdp.templates.slack.template_slack import template as template_slack
 from posthog.api.hog_function import MAX_HOG_CODE_SIZE_BYTES, MAX_TRANSFORMATIONS_PER_TEAM
@@ -984,7 +984,7 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             with patch("posthog.plugins.plugin_server_api.requests.patch") as mock_patch:
                 mock_get.return_value.status_code = status.HTTP_200_OK
                 mock_get.return_value.json.return_value = {
-                    "state": 4,
+                    "state": HogFunctionState.DISABLED.value,
                     "tokens": 0,
                 }
 
@@ -997,7 +997,7 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 )
                 id = response.json()["id"]
 
-                assert response.json()["status"]["state"] == 4
+                assert response.json()["status"]["state"] == HogFunctionState.DISABLED.value
 
                 self.client.patch(
                     f"/api/projects/{self.team.id}/hog_functions/{response.json()['id']}/",


### PR DESCRIPTION
## Problem

The API allows re-enabling if automatically disabled for example once someone has fixed the issue. but this shouldn't happen if forcefully degraded / disabled

## Changes

* Only do it and show the button if disabled

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
