### PR TITLE
chore: `bin/start --minimal` add --no-restart-loop to plugin-server

### DIFF
--- a/bin/mprocs-minimal.yaml
+++ b/bin/mprocs-minimal.yaml
@@ -12,7 +12,7 @@ procs:
         autostart: false
 
     plugin-server:
-        shell: 'bin/check_postgres_up && bin/check_kafka_clickhouse_up && SESSION_RECORDING_V2_METADATA_SWITCHOVER=1970-01-01 ./bin/plugin-server'
+        shell: 'bin/check_postgres_up && bin/check_kafka_clickhouse_up && SESSION_RECORDING_V2_METADATA_SWITCHOVER=1970-01-01 ./bin/plugin-server --no-restart-loop'
 
     frontend:
         shell: './bin/start-frontend-vite'


### PR DESCRIPTION
## Problem
The `node` process for plugin-server keeps running after exiting mprocs.

The script does have a trap handler when using `--no-restart-loop` flag that properly kills the child process, but in the default mode with the restart loop, there's no such handler.

## Changes
Add the `--no-restart-loop` to plugin-server such that it is killed when exiting mprocs.


## How did you test this code?
- exited mprocs and verified that the plugin-server was terminated
