### PR TITLE
feat(codeowners): Add workflow to auto assign codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,66 +1,6 @@
 # If a file is set here, then PRs will require that team's approval to get that code merged.
 
-# Surveys team owns all survey-related code
-frontend/src/scenes/settings/environment/SurveySettings.tsx @PostHog/team-surveys
-frontend/src/scenes/surveys/ @PostHog/team-surveys
-frontend/src/scenes/onboarding/sdks/surveys @PostHog/team-surveys
-ee/surveys @PostHog/team-surveys
-posthog/admin/admins/survey_admin.py @PostHog/team-surveys
-posthog/api/survey.py @PostHog/team-surveys
-posthog/api/test/test_survey.py @PostHog/team-surveys
-posthog/models/surveys/survey.py @PostHog/team-surveys
-posthog/tasks/stop_surveys_reached_target.py @PostHog/team-surveys
-posthog/tasks/update_survey_adaptive_sampling @PostHog/team-surveys
-posthog/tasks/update_survey_iteration @PostHog/team-surveys
-posthog/tasks/test/test_stop_surveys_reached_target.py @PostHog/team-surveys
-posthog/templates/surveys @PostHog/team-surveys
-
-# plugin server ownership is split between ingestion and messaging teams
-plugin-server/src/ @PostHog/team-ingestion @PostHog/team-messaging
-plugin-server/tests/ @PostHog/team-ingestion
-plugin-server/src/ingestion/ @PostHog/team-ingestion
-plugin-server/src/cdp/ @PostHog/team-messaging
-
-# ClickHouse team owns Clickhouse migrations
-posthog/clickhouse/migrations/** @PostHog/clickhouse
-
-# Web Analytics team owns web analytics code
-frontend/src/scenes/web-analytics/** @PostHog/web-analytics
-posthog/hogql_queries/web_analytics/** @PostHog/web-analytics
-frontend/src/toolbar/web-vitals/** @PostHog/web-analytics
-posthog/hogql/database/schema/sessions_v1.py @PostHog/web-analytics
-posthog/hogql/database/schema/sessions_v2.py @PostHog/web-analytics
-
-# Revenue Analytics team owns revenue analytics stuff
-# This is a single-person team - allow reviews from other teams
-# products/revenue_analytics/** @PostHog/team-revenue-analytics
-
 # Replay team...
 posthog/session_recordings/ @PostHog/team-replay
 ee/session_recordings/ @PostHog/team-replay
 ee/frontend/mobile-replay @PostHog/team-replay
-
-# Feature Flags team
-
-# Platform (the `/flags` and `/decide` endpoints + associated utils)
-rust/feature-flags/ @PostHog/team-feature-flags
-posthog/api/decide.py @PostHog/team-feature-flags
-posthog/models/flag_matching.py @PostHog/team-feature-flags
-
-# Feature Flags CRUD operations
-posthog/models/feature_flag/ @PostHog/team-feature-flags
-posthog/api/feature_flag.py @PostHog/team-feature-flags
-posthog/api/test/test_feature_flag_dependency_deletion.py @PostHog/team-feature-flags
-posthog/api/test/test_feature_flag_utils.py @PostHog/team-feature-flags
-posthog/api/test/test_feature_flag.py @PostHog/team-feature-flags
-posthog/test/test_feature_flag_analytics.py @PostHog/team-feature-flags
-posthog/test/test_feature_flag.py @PostHog/team-feature-flags
-
-# Cohorts
-posthog/api/cohort.py @PostHog/team-feature-flags
-posthog/models/cohort/ @PostHog/team-feature-flags
-frontend/src/scenes/cohorts/ @PostHog/team-feature-flags
-
-# Feature Flags frontend
-frontend/src/scenes/feature-flags/ @PostHog/team-feature-flags
-

--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -32,8 +32,7 @@ posthog/hogql/database/schema/sessions_v1.py @PostHog/web-analytics
 posthog/hogql/database/schema/sessions_v2.py @PostHog/web-analytics
 
 # Revenue Analytics team owns revenue analytics stuff
-# This is a single-person team - allow reviews from other teams
-# products/revenue_analytics/** @PostHog/team-revenue-analytics
+products/revenue_analytics/** @PostHog/team-revenue-analytics
 
 # Feature Flags team
 

--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -1,4 +1,4 @@
-# If a file is set here, then PRs will require that team's approval to get that code merged.
+# If a file is set here, then PRs will tag for the team's approval but will not block PRs.
 
 # Surveys team owns all survey-related code
 frontend/src/scenes/settings/environment/SurveySettings.tsx @PostHog/team-surveys
@@ -32,12 +32,8 @@ posthog/hogql/database/schema/sessions_v1.py @PostHog/web-analytics
 posthog/hogql/database/schema/sessions_v2.py @PostHog/web-analytics
 
 # Revenue Analytics team owns revenue analytics stuff
-products/revenue_analytics/** @PostHog/team-revenue-analytics
-
-# Replay team...
-posthog/session_recordings/ @PostHog/team-replay
-ee/session_recordings/ @PostHog/team-replay
-ee/frontend/mobile-replay @PostHog/team-replay
+# This is a single-person team - allow reviews from other teams
+# products/revenue_analytics/** @PostHog/team-revenue-analytics
 
 # Feature Flags team
 
@@ -63,5 +59,3 @@ frontend/src/scenes/cohorts/ @PostHog/team-feature-flags
 # Feature Flags frontend
 frontend/src/scenes/feature-flags/ @PostHog/team-feature-flags
 
-# Test
-posthog/warehouse/** @PostHog/team-data-warehouse

--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -1,0 +1,67 @@
+# If a file is set here, then PRs will require that team's approval to get that code merged.
+
+# Surveys team owns all survey-related code
+frontend/src/scenes/settings/environment/SurveySettings.tsx @PostHog/team-surveys
+frontend/src/scenes/surveys/ @PostHog/team-surveys
+frontend/src/scenes/onboarding/sdks/surveys @PostHog/team-surveys
+ee/surveys @PostHog/team-surveys
+posthog/admin/admins/survey_admin.py @PostHog/team-surveys
+posthog/api/survey.py @PostHog/team-surveys
+posthog/api/test/test_survey.py @PostHog/team-surveys
+posthog/models/surveys/survey.py @PostHog/team-surveys
+posthog/tasks/stop_surveys_reached_target.py @PostHog/team-surveys
+posthog/tasks/update_survey_adaptive_sampling @PostHog/team-surveys
+posthog/tasks/update_survey_iteration @PostHog/team-surveys
+posthog/tasks/test/test_stop_surveys_reached_target.py @PostHog/team-surveys
+posthog/templates/surveys @PostHog/team-surveys
+
+# plugin server ownership is split between ingestion and messaging teams
+plugin-server/src/ @PostHog/team-ingestion @PostHog/team-messaging
+plugin-server/tests/ @PostHog/team-ingestion
+plugin-server/src/ingestion/ @PostHog/team-ingestion
+plugin-server/src/cdp/ @PostHog/team-messaging
+
+# ClickHouse team owns Clickhouse migrations
+posthog/clickhouse/migrations/** @PostHog/clickhouse
+
+# Web Analytics team owns web analytics code
+frontend/src/scenes/web-analytics/** @PostHog/web-analytics
+posthog/hogql_queries/web_analytics/** @PostHog/web-analytics
+frontend/src/toolbar/web-vitals/** @PostHog/web-analytics
+posthog/hogql/database/schema/sessions_v1.py @PostHog/web-analytics
+posthog/hogql/database/schema/sessions_v2.py @PostHog/web-analytics
+
+# Revenue Analytics team owns revenue analytics stuff
+products/revenue_analytics/** @PostHog/team-revenue-analytics
+
+# Replay team...
+posthog/session_recordings/ @PostHog/team-replay
+ee/session_recordings/ @PostHog/team-replay
+ee/frontend/mobile-replay @PostHog/team-replay
+
+# Feature Flags team
+
+# Platform (the `/flags` and `/decide` endpoints + associated utils)
+rust/feature-flags/ @PostHog/team-feature-flags
+posthog/api/decide.py @PostHog/team-feature-flags
+posthog/models/flag_matching.py @PostHog/team-feature-flags
+
+# Feature Flags CRUD operations
+posthog/models/feature_flag/ @PostHog/team-feature-flags
+posthog/api/feature_flag.py @PostHog/team-feature-flags
+posthog/api/test/test_feature_flag_dependency_deletion.py @PostHog/team-feature-flags
+posthog/api/test/test_feature_flag_utils.py @PostHog/team-feature-flags
+posthog/api/test/test_feature_flag.py @PostHog/team-feature-flags
+posthog/test/test_feature_flag_analytics.py @PostHog/team-feature-flags
+posthog/test/test_feature_flag.py @PostHog/team-feature-flags
+
+# Cohorts
+posthog/api/cohort.py @PostHog/team-feature-flags
+posthog/models/cohort/ @PostHog/team-feature-flags
+frontend/src/scenes/cohorts/ @PostHog/team-feature-flags
+
+# Feature Flags frontend
+frontend/src/scenes/feature-flags/ @PostHog/team-feature-flags
+
+# Test
+posthog/warehouse/** @PostHog/team-data-warehouse

--- a/.github/scripts/assign-reviewers.js
+++ b/.github/scripts/assign-reviewers.js
@@ -54,7 +54,7 @@ function fileMatchesPattern(filePath, pattern) {
 
 function getChangedFiles() {
     try {
-        const output = execSync('git diff --name-only origin/main...HEAD', {
+        const output = execSync('git diff --name-only origin/master...HEAD', {
             encoding: 'utf8',
             stdio: ['pipe', 'pipe', 'ignore'],
         })

--- a/.github/scripts/assign-reviewers.js
+++ b/.github/scripts/assign-reviewers.js
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const { execSync } = require('child_process')
+
+function parseCodeowners(codeownersPath) {
+    if (!fs.existsSync(codeownersPath)) {
+        console.info('No CODEOWNERS file found')
+        return []
+    }
+
+    const content = fs.readFileSync(codeownersPath, 'utf8')
+    const rules = []
+
+    for (const line of content.split('\n')) {
+        const trimmed = line.trim()
+
+        if (!trimmed || trimmed.startsWith('#')) {
+            continue
+        }
+
+        const tokens = trimmed.split(/\s+/)
+        if (tokens.length < 2) {
+            continue
+        }
+
+        const pattern = tokens[0]
+        const owners = tokens.slice(1)
+
+        rules.push({ pattern, owners })
+    }
+
+    return rules
+}
+
+function globToRegex(pattern) {
+    let regex = pattern
+        .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+        .replace(/\*\*/g, '__DOUBLESTAR__')
+        .replace(/\*/g, '[^/]*')
+        .replace(/__DOUBLESTAR__/g, '.*')
+
+    if (pattern.endsWith('/')) {
+        regex = regex.slice(0, -1) + '.*'
+    }
+
+    return new RegExp(`^${regex}$`)
+}
+
+function fileMatchesPattern(filePath, pattern) {
+    const regex = globToRegex(pattern)
+    return regex.test(filePath)
+}
+
+function getChangedFiles() {
+    try {
+        const output = execSync('git diff --name-only origin/main...HEAD', {
+            encoding: 'utf8',
+            stdio: ['pipe', 'pipe', 'ignore'],
+        })
+
+        return output
+            .trim()
+            .split('\n')
+            .filter((file) => file.length > 0)
+    } catch (error) {
+        console.error('Failed to get changed files:', error.message)
+        return []
+    }
+}
+
+function parseOwners(owners) {
+    const teams = new Set()
+    const users = new Set()
+
+    for (const owner of owners) {
+        if (owner.startsWith('@PostHog/')) {
+            const teamName = owner.replace('@PostHog/', '')
+            teams.add(teamName)
+        } else if (owner.startsWith('@')) {
+            const username = owner.replace('@', '')
+            users.add(username)
+        }
+    }
+
+    return {
+        teams: Array.from(teams),
+        users: Array.from(users),
+    }
+}
+
+function getReviewersForChangedFiles() {
+    const codeownersPath = '.github/CODEOWNERS-soft'
+    const rules = parseCodeowners(codeownersPath)
+    const changedFiles = getChangedFiles()
+
+    console.info(`Found ${changedFiles.length} changed files:`)
+    changedFiles.forEach((file) => console.info(`  ${file}`))
+    console.info()
+
+    const allTeams = new Set()
+    const allUsers = new Set()
+
+    console.info('Processing CODEOWNERS rules...')
+
+    for (const rule of rules) {
+        const { pattern, owners } = rule
+        console.info(`Checking pattern: ${pattern}`)
+
+        let patternMatches = false
+
+        for (const file of changedFiles) {
+            if (fileMatchesPattern(file, pattern)) {
+                console.info(`  ✓ File ${file} matches pattern ${pattern}`)
+                patternMatches = true
+                break
+            }
+        }
+
+        if (patternMatches) {
+            const { teams, users } = parseOwners(owners)
+
+            console.info(`  Adding owners: ${owners.join(', ')}`)
+
+            teams.forEach((team) => {
+                allTeams.add(team)
+                console.info(`    Team: ${team}`)
+            })
+
+            users.forEach((user) => {
+                allUsers.add(user)
+                console.info(`    User: ${user}`)
+            })
+        }
+    }
+
+    return {
+        teams: Array.from(allTeams),
+        users: Array.from(allUsers),
+    }
+}
+
+async function assignReviewers(teams, users) {
+    const { GITHUB_TOKEN, GITHUB_REPOSITORY, PR_NUMBER } = process.env
+
+    if (!GITHUB_TOKEN || !GITHUB_REPOSITORY || !PR_NUMBER) {
+        throw new Error('Missing required environment variables: GITHUB_TOKEN, GITHUB_REPOSITORY, PR_NUMBER')
+    }
+
+    if (teams.length === 0 && users.length === 0) {
+        console.info('ℹ️  No reviewers to assign')
+        return
+    }
+
+    const payload = {}
+
+    if (users.length > 0) {
+        payload.reviewers = users
+    }
+
+    if (teams.length > 0) {
+        payload.team_reviewers = teams
+    }
+
+    console.info('Assigning reviewers with payload:', JSON.stringify(payload, null, 2))
+
+    try {
+        const response = await fetch(
+            `https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/requested_reviewers`,
+            {
+                method: 'POST',
+                headers: {
+                    Authorization: `token ${GITHUB_TOKEN}`,
+                    Accept: 'application/vnd.github.v3+json',
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(payload),
+            }
+        )
+
+        if (!response.ok) {
+            const errorText = await response.text()
+            throw new Error(`GitHub API error: ${response.status} ${response.statusText}\n${errorText}`)
+        }
+
+        console.info('✅ Reviewers assigned successfully')
+    } catch (error) {
+        console.error('Failed to assign reviewers:', error.message)
+        process.exit(1)
+    }
+}
+
+async function main() {
+    try {
+        const { teams, users } = getReviewersForChangedFiles()
+
+        console.info()
+        console.info(`Teams to add: ${teams.join(', ') || 'none'}`)
+        console.info(`Users to add: ${users.join(', ') || 'none'}`)
+        console.info()
+
+        await assignReviewers(teams, users)
+    } catch (error) {
+        console.error('Error:', error.message)
+        process.exit(1)
+    }
+}
+
+main()

--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -23,8 +23,8 @@ jobs:
               with:
                   node-version: '20'
 
-            - name: Fetch main branch
-              run: git fetch origin main
+            - name: Fetch master branch
+              run: git fetch origin master
 
             - name: Run reviewer assignment script
               env:

--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -1,0 +1,35 @@
+name: Auto Assign Reviewers
+
+on:
+    pull_request:
+        types: [opened, synchronize]
+
+permissions:
+    contents: read
+    pull-requests: write
+
+jobs:
+    assign-reviewers:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '20'
+
+            - name: Fetch main branch
+              run: git fetch origin main
+
+            - name: Run reviewer assignment script
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  GITHUB_REPOSITORY: ${{ github.repository }}
+              run: |
+                  node .github/scripts/assign-reviewers.js

--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -14,12 +14,12 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
               with:
                   fetch-depth: 0
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
               with:
                   node-version: '20'
 

--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
     assign-reviewers:
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-22.04'
 
         steps:
             - name: Checkout repository

--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -28,7 +28,7 @@ jobs:
 
             - name: Run reviewer assignment script
               env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
                   PR_NUMBER: ${{ github.event.pull_request.number }}
                   GITHUB_REPOSITORY: ${{ github.repository }}
               run: |

--- a/posthog/warehouse/types.py
+++ b/posthog/warehouse/types.py
@@ -24,7 +24,7 @@ class PartitionSettings(typing.NamedTuple):
 
     Attributes:
         partition_count: Total number of partitions.
-        partition_size: Number of rows to include per partition.
+        partition_size: Number of rows to include per partition...
     """
 
     partition_count: int

--- a/posthog/warehouse/types.py
+++ b/posthog/warehouse/types.py
@@ -24,7 +24,7 @@ class PartitionSettings(typing.NamedTuple):
 
     Attributes:
         partition_count: Total number of partitions.
-        partition_size: Number of rows to include per partition...
+        partition_size: Number of rows to include per partition.
     """
 
     partition_count: int


### PR DESCRIPTION
## Problem
- We use `CODEOWNERS` to request reviews for areas of the codebase that we own, this is great to get eyes on code changes that your team owns, but hard blocking the PR isn't the most "posthog" way of doing things
  - In the case of urgent PRs, we dont want codeowners to be a hard blocker
  - The same applies when a single-person team is on vacation

## Changes
- Rename `CODEOWNERS` to `CODEOWNERS-soft` 
- Add a github action (with a Node script) to assign reviewers to PRs from `CODEOWNERS-soft` 
- Add a new `CODEOWNERS` for keeping some session replay stuff as a hard block 
  - Although I would urge people not to make this a habit if it's not a critical path that needs reviewing 

