### PR TITLE
chore(max): add flag for autoreload of temporal worker

### DIFF
--- a/bin/mprocs-vite.yaml
+++ b/bin/mprocs-vite.yaml
@@ -38,7 +38,7 @@ procs:
 
     temporal-worker-max-ai:
         # added a sleep to give the docker stuff time to start
-        shell: 'bin/check_kafka_clickhouse_up && bin/check_temporal_up && python manage.py start_temporal_worker --task-queue max-ai-task-queue --metrics-port 8006'
+        shell: 'bin/check_kafka_clickhouse_up && bin/check_temporal_up && python manage.py start_temporal_worker --task-queue max-ai-task-queue --metrics-port 8006 --autoreload'
 
     dagster:
         shell: |-

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -34,7 +34,7 @@ procs:
 
     temporal-worker-max-ai:
         # added a sleep to give the docker stuff time to start
-        shell: 'bin/check_kafka_clickhouse_up && bin/check_temporal_up && python manage.py start_temporal_worker --task-queue max-ai-task-queue --metrics-port 8006'
+        shell: 'bin/check_kafka_clickhouse_up && bin/check_temporal_up && python manage.py start_temporal_worker --task-queue max-ai-task-queue --metrics-port 8006 --autoreload'
 
     dagster:
         shell: |-


### PR DESCRIPTION
## Problem
To improve the development lifecycle, we need to also have autoreloading upon changes in our temporal worker locally.
  Django's autoreload will automatically watch:
  - /posthog/posthog/temporal/ai/**/*.py
  - /posthog/ee/hogai/**/*.py
  - All imported dependencies and their files
  
## Changes
Added the flag `--autoreload` if the worker should be observing changes to files and dependencies

## How did you test this code?
Changed files locally, saw:
`2025-08-06T13:58:18.227759Z [info     ] AXES: blocking by IP only.     [axes.apps] pid=22235 tid=8407752448
2025-08-06T13:58:21.011908Z [info     ] Watching for file changes with StatReloader [django.utils.autoreload] pid=22235 tid=8407752448
2025-08-06T13:58:21.011995Z [info     ] Watching for file changes with StatReloader [django.utils.autoreload] pid=22235 tid=8407752448
2025-08-06 13:58:21 [info     ] Starting Temporal Worker       graceful_shutdown_timeout_seconds=None host=127.0.0.1 max_concurrent_activities=None max_concurrent_workflow_tasks=None namespace=default port=7233 task_queue=max-ai-task-queue
2025-08-06T13:59:46.667840Z [info     ] /Users/korita/posthog/ee/hogai/assistant.py changed, reloading. [django.utils.autoreload] pid=22235 tid=8407752448
2025-08-06T13:59:46.668333Z [info     ] /Users/korita/posthog/ee/hogai/assistant.py changed, reloading. [django.utils.autoreload] pid=22235 tid=8407752448
2025-08-06 13:59:50 [warning  ] ['️Environment variable DEBUG is set - PostHog is running in DEVELOPMENT MODE!', 'Be sure to unset DEBUG if this is supposed to be a PRODUCTION ENVIRONMENT!']
2`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
