### PR TITLE
chore(insight): log metadata extraction task scheduling for insights

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -430,7 +430,7 @@ class InsightSerializer(InsightBasicSerializer):
 
         # schedule the insight query metadata extraction
         query_meta_task = extract_insight_query_metadata.delay(insight_id=insight.id)
-        logger.info(
+        logger.warn(
             "scheduled extract_insight_query_metadata",
             insight_id=insight.id,
             task_id=query_meta_task.id,
@@ -510,7 +510,7 @@ class InsightSerializer(InsightBasicSerializer):
 
         if not before_update or before_update.query != updated_insight.query:
             query_meta_task = extract_insight_query_metadata.delay(insight_id=updated_insight.id)
-            logger.info(
+            logger.warn(
                 "scheduled extract_insight_query_metadata",
                 insight_id=updated_insight.id,
                 task_id=query_meta_task.id,

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -429,7 +429,13 @@ class InsightSerializer(InsightBasicSerializer):
         )
 
         # schedule the insight query metadata extraction
-        extract_insight_query_metadata.delay(insight_id=insight.id)
+        query_meta_task = extract_insight_query_metadata.delay(insight_id=insight.id)
+        logger.info(
+            "scheduled extract_insight_query_metadata",
+            insight_id=insight.id,
+            task_id=query_meta_task.id,
+            trigger="create_insight",
+        )
 
         if dashboards is not None:
             for dashboard in Dashboard.objects.filter(id__in=[d.id for d in dashboards]).all():
@@ -503,7 +509,13 @@ class InsightSerializer(InsightBasicSerializer):
         self.user_permissions.reset_insights_dashboard_cached_results()
 
         if not before_update or before_update.query != updated_insight.query:
-            extract_insight_query_metadata.delay(insight_id=updated_insight.id)
+            query_meta_task = extract_insight_query_metadata.delay(insight_id=updated_insight.id)
+            logger.info(
+                "scheduled extract_insight_query_metadata",
+                insight_id=updated_insight.id,
+                task_id=query_meta_task.id,
+                trigger="update_insight",
+            )
 
         return updated_insight
 

--- a/posthog/tasks/insight_query_metadata.py
+++ b/posthog/tasks/insight_query_metadata.py
@@ -18,7 +18,7 @@ logger = structlog.get_logger(__name__)
 )
 def extract_insight_query_metadata(insight_id: str) -> None:
     try:
-        logger.info(
+        logger.warn(
             "Extracting query metadata for insight",
             insight_id=insight_id,
         )


### PR DESCRIPTION
Adding some logs to check if the query metadata extraction tasks are being enqueued after the insight is created/updated.