### PR TITLE
fix(flags): Rename to `project_api_key`

### DIFF
--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -426,10 +426,10 @@ class TeamAndOrgViewSetMixin(_GenericViewSet):  # TODO: Rename to include "Env" 
     def _get_team_from_request(self) -> Optional["Team"]:
         team_found = None
 
-        # Special case for project_api_token in the request body.
+        # Special case for project_api_key in the request body.
         # This ensures we can route deterministically to the correct team for URLs with @current as the team_id.
         # See https://github.com/PostHog/posthog/issues/35303 for more context.
-        token = self._get_explicit_project_api_token() or get_token(None, self.request)
+        token = self._get_explicit_project_api_key() or get_token(None, self.request)
 
         if token:
             team = Team.objects.get_team_from_token(token)
@@ -440,13 +440,13 @@ class TeamAndOrgViewSetMixin(_GenericViewSet):  # TODO: Rename to include "Env" 
 
         return team_found
 
-    def _get_explicit_project_api_token(self) -> Optional[str]:
+    def _get_explicit_project_api_key(self) -> Optional[str]:
         if (
             self.request.method in ("POST", "PUT", "PATCH")
             and hasattr(self.request, "data")
             and isinstance(self.request.data, dict)
         ):
-            return self.request.data.get("project_api_token")
+            return self.request.data.get("project_api_key")
         return None
 
     @cached_property

--- a/posthog/api/test/test_routing.py
+++ b/posthog/api/test/test_routing.py
@@ -117,7 +117,7 @@ class TestTeamAndOrgViewSetMixin(APIBaseTest):
 
 
 class TestTeamAndOrgViewSetMixinProjectApiToken(APIBaseTest):
-    """Test the _get_explicit_project_api_token and _get_team_from_request methods."""
+    """Test the _get_explicit_project_api_key and _get_team_from_request methods."""
 
     def setUp(self):
         super().setUp()
@@ -125,71 +125,71 @@ class TestTeamAndOrgViewSetMixinProjectApiToken(APIBaseTest):
         self.viewset = FooViewSet()
 
     @patch("posthog.api.test.test_routing.FooViewSet.request", create=True)
-    def test_get_explicit_project_api_token_with_dict_data(self, mock_request):
-        """Test _get_explicit_project_api_token returns token when request.data is a dict with project_api_token."""
+    def test_get_explicit_project_api_key_with_dict_data(self, mock_request):
+        """Test _get_explicit_project_api_key returns token when request.data is a dict with project_api_key."""
         mock_request.method = "POST"
-        mock_request.data = {"project_api_token": "test_token", "other_data": "value"}
+        mock_request.data = {"project_api_key": "test_token", "other_data": "value"}
         self.viewset.request = mock_request
 
-        result = self.viewset._get_explicit_project_api_token()
+        result = self.viewset._get_explicit_project_api_key()
         self.assertEqual(result, "test_token")
 
     @patch("posthog.api.test.test_routing.FooViewSet.request", create=True)
-    def test_get_explicit_project_api_token_with_dict_data_no_token(self, mock_request):
-        """Test _get_explicit_project_api_token returns None when request.data is a dict without project_api_token."""
+    def test_get_explicit_project_api_key_with_dict_data_no_token(self, mock_request):
+        """Test _get_explicit_project_api_key returns None when request.data is a dict without project_api_key."""
         mock_request.method = "POST"
         mock_request.data = {"other_data": "value"}
         self.viewset.request = mock_request
 
-        result = self.viewset._get_explicit_project_api_token()
+        result = self.viewset._get_explicit_project_api_key()
         self.assertIsNone(result)
 
     @patch("posthog.api.test.test_routing.FooViewSet.request", create=True)
-    def test_get_explicit_project_api_token_with_list_data(self, mock_request):
-        """Test _get_explicit_project_api_token returns None when request.data is a list (bulk operations)."""
+    def test_get_explicit_project_api_key_with_list_data(self, mock_request):
+        """Test _get_explicit_project_api_key returns None when request.data is a list (bulk operations)."""
         mock_request.method = "POST"
-        mock_request.data = [{"project_api_token": "test_token"}]
+        mock_request.data = [{"project_api_key": "test_token"}]
         self.viewset.request = mock_request
 
-        result = self.viewset._get_explicit_project_api_token()
+        result = self.viewset._get_explicit_project_api_key()
         self.assertIsNone(result)
 
     @patch("posthog.api.test.test_routing.FooViewSet.request", create=True)
-    def test_get_explicit_project_api_token_with_get_request(self, mock_request):
-        """Test _get_explicit_project_api_token returns None for GET requests."""
+    def test_get_explicit_project_api_key_with_get_request(self, mock_request):
+        """Test _get_explicit_project_api_key returns None for GET requests."""
         mock_request.method = "GET"
-        mock_request.data = {"project_api_token": "test_token"}
+        mock_request.data = {"project_api_key": "test_token"}
         self.viewset.request = mock_request
 
-        result = self.viewset._get_explicit_project_api_token()
+        result = self.viewset._get_explicit_project_api_key()
         self.assertIsNone(result)
 
     @patch("posthog.api.test.test_routing.FooViewSet.request", create=True)
-    def test_get_explicit_project_api_token_no_data_attribute(self, mock_request):
-        """Test _get_explicit_project_api_token returns None when request has no data attribute."""
+    def test_get_explicit_project_api_key_no_data_attribute(self, mock_request):
+        """Test _get_explicit_project_api_key returns None when request has no data attribute."""
         mock_request.method = "POST"
         # Don't set data attribute to simulate missing data attribute
         delattr(mock_request, "data")
         self.viewset.request = mock_request
 
-        result = self.viewset._get_explicit_project_api_token()
+        result = self.viewset._get_explicit_project_api_key()
         self.assertIsNone(result)
 
     @patch("posthog.api.routing.get_token")
     @patch("posthog.models.team.team.Team.objects.get_team_from_token")
     def test_get_team_from_request_with_explicit_token(self, mock_get_team_from_token, mock_get_token):
-        """Test _get_team_from_request uses explicit project_api_token from request body when available."""
+        """Test _get_team_from_request uses explicit project_api_key from request body when available."""
         # Setup mocks
         mock_team = Mock()
         mock_get_team_from_token.return_value = mock_team
         mock_get_token.return_value = None  # Shouldn't be called when explicit token exists
 
-        # Create request with explicit project_api_token
-        request = self.factory.post("/test/", {"project_api_token": "explicit_token"})
+        # Create request with explicit project_api_key
+        request = self.factory.post("/test/", {"project_api_key": "explicit_token"})
         self.viewset.request = request
 
-        # Mock _get_explicit_project_api_token to return the token
-        with patch.object(self.viewset, "_get_explicit_project_api_token", return_value="explicit_token"):
+        # Mock _get_explicit_project_api_key to return the token
+        with patch.object(self.viewset, "_get_explicit_project_api_key", return_value="explicit_token"):
             result = self.viewset._get_team_from_request()
 
         # Verify result and calls
@@ -206,12 +206,12 @@ class TestTeamAndOrgViewSetMixinProjectApiToken(APIBaseTest):
         mock_get_team_from_token.return_value = mock_team
         mock_get_token.return_value = "fallback_token"
 
-        # Create request without explicit project_api_token
+        # Create request without explicit project_api_key
         request = self.factory.post("/test/", [{"data": "bulk_data"}], format="json")
         self.viewset.request = request
 
-        # Mock _get_explicit_project_api_token to return None (bulk request)
-        with patch.object(self.viewset, "_get_explicit_project_api_token", return_value=None):
+        # Mock _get_explicit_project_api_key to return None (bulk request)
+        with patch.object(self.viewset, "_get_explicit_project_api_key", return_value=None):
             result = self.viewset._get_team_from_request()
 
         # Verify result and calls


### PR DESCRIPTION
PR #36154 added deterministic routing using a new `project_api_token` parameter in the body. But I intended the parameter to match the existing `api_key` parameter, but with a`project_` prefix (aka `project_api_key`). In fact, I [implemented it that way in the posthog-python library](https://github.com/PostHog/posthog-python/pull/303).

## Problem

I confused myself and used the wrong name. Since this is a new parameter, it doesn't break anybody.

## Changes

Rename `project_api_token` to `project_api_key` as the key and in the method name.

## How did you test this code?

Unit tests.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
