### PR TITLE
fix(experiments): update last refresh time periodically.

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/Info.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Info.tsx
@@ -12,6 +12,7 @@ import { urls } from 'scenes/urls'
 
 import { ExperimentStatsMethod, ProgressStatus } from '~/types'
 
+import { usePeriodicRerender } from 'lib/hooks/usePeriodicRerender'
 import { CONCLUSION_DISPLAY_CONFIG } from '../constants'
 import { experimentLogic } from '../experimentLogic'
 import { getExperimentStatus } from '../experimentsLogic'
@@ -19,6 +20,47 @@ import { modalsLogic } from '../modalsLogic'
 import { StatusTag } from './components'
 import { ExperimentDates } from './ExperimentDates'
 import { StatsMethodModal } from './StatsMethodModal'
+
+export const ExperimentLastRefresh = ({
+    isRefreshing,
+    lastRefresh,
+    onClick,
+}: {
+    isRefreshing: boolean
+    lastRefresh: string
+    onClick: () => void
+}): JSX.Element => {
+    usePeriodicRerender(15000) // Re-render every 15 seconds for up-to-date last refresh time
+
+    return (
+        <div className="block">
+            <div className="text-xs font-semibold uppercase tracking-wide">Last refreshed</div>
+            <div className="inline-flex deprecated-space-x-2">
+                <span
+                    className={`${
+                        lastRefresh
+                            ? dayjs().diff(dayjs(lastRefresh), 'hours') > 12
+                                ? 'text-danger'
+                                : dayjs().diff(dayjs(lastRefresh), 'hours') > 6
+                                  ? 'text-warning'
+                                  : ''
+                            : ''
+                    }`}
+                >
+                    {isRefreshing ? 'Loading…' : lastRefresh ? dayjs(lastRefresh).fromNow() : 'a while ago'}
+                </span>
+                <LemonButton
+                    type="secondary"
+                    size="xsmall"
+                    onClick={onClick}
+                    data-attr="refresh-experiment"
+                    icon={<IconRefresh />}
+                    tooltip="Refresh experiment results"
+                />
+            </div>
+        </div>
+    )
+}
 
 export function Info(): JSX.Element {
     const {
@@ -131,38 +173,11 @@ export function Info(): JSX.Element {
                 <div className="flex flex-col">
                     <div className="inline-flex deprecated-space-x-8">
                         {experiment.start_date && (
-                            <div className="block">
-                                <div className="text-xs font-semibold uppercase tracking-wide">Last refreshed</div>
-                                <div className="inline-flex deprecated-space-x-2">
-                                    <span
-                                        className={`${
-                                            lastRefresh
-                                                ? dayjs().diff(dayjs(lastRefresh), 'hours') > 12
-                                                    ? 'text-danger'
-                                                    : dayjs().diff(dayjs(lastRefresh), 'hours') > 6
-                                                      ? 'text-warning'
-                                                      : ''
-                                                : ''
-                                        }`}
-                                    >
-                                        {primaryMetricsResultsLoading || secondaryMetricsResultsLoading
-                                            ? 'Loading…'
-                                            : lastRefresh
-                                              ? dayjs(lastRefresh).fromNow()
-                                              : 'a while ago'}
-                                    </span>
-                                    <LemonButton
-                                        type="secondary"
-                                        size="xsmall"
-                                        onClick={() => {
-                                            refreshExperimentResults(true)
-                                        }}
-                                        data-attr="refresh-experiment"
-                                        icon={<IconRefresh />}
-                                        tooltip="Refresh experiment results"
-                                    />
-                                </div>
-                            </div>
+                            <ExperimentLastRefresh
+                                isRefreshing={primaryMetricsResultsLoading || secondaryMetricsResultsLoading}
+                                lastRefresh={lastRefresh}
+                                onClick={() => refreshExperimentResults(true)}
+                            />
                         )}
                         <ExperimentDates />
                         <div className="block">


### PR DESCRIPTION
## Problem

With the recent changes to the Results Breakdown to synchronize the refresh dates, the insight computed time gets updated periodically, while the experiment's refresh time does not.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We extract the last refresh label, time, and refresh button into a separate React component so we can use an interval provided by `usePeriodicRerender` to refresh the experiment's last refresh human-readable interval.
This was necessary to avoid refreshing the whole DOM of the page.

| Last Refresh... refresh |
| - |
| ![after](https://github.com/user-attachments/assets/a07cd94d-034a-4eec-95dc-2dc3bc4d9713) |


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/65ff41a8-0c76-4459-af40-01507750ee5e)
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
