### PR TITLE
fix(query): Allow setting of `dataNodeLogicKey` in query's context to reload query programmatically 

### DIFF
--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -140,7 +140,7 @@ export function DataTable({
     const vizKey = insightVizDataNodeKey(insightProps)
     const dataNodeLogicProps: DataNodeLogicProps = {
         query: query.source,
-        key: vizKey,
+        key: context?.dataNodeLogicKey ?? vizKey,
         cachedResults: cachedResults,
         dataNodeCollectionId: context?.insightProps?.dataNodeCollectionId || dataKey,
         refresh: context?.refresh,

--- a/frontend/src/queries/types.ts
+++ b/frontend/src/queries/types.ts
@@ -42,6 +42,8 @@ export interface QueryContext<Q extends QuerySchema = QuerySchema> {
     formatNumbers?: boolean
     /** Custom column features to pass down to the DataTable */
     columnFeatures?: ColumnFeature[]
+    /** Key to be used in dataNodeLogic so that we can find the dataNodeLogic */
+    dataNodeLogicKey?: string
 }
 
 export type QueryContextColumnTitleComponent = ComponentType<{

--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -32,6 +32,7 @@ import { Query } from '~/queries/Query/Query'
 
 import { IconCopy, IconTrash } from '@posthog/icons'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+import { createCohortDataNodeLogicKey } from './cohortUtils'
 const RESOURCE_TYPE = 'cohort'
 
 export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
@@ -42,6 +43,7 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
     const isNewCohort = cohort.id === 'new' || cohort.id === undefined
     const { featureFlags } = useValues(featureFlagLogic)
     const newSceneLayout = featureFlags[FEATURE_FLAGS.NEW_SCENE_LAYOUT]
+    const dataNodeLogicKey = createCohortDataNodeLogicKey(cohort.id)
 
     if (cohortMissing) {
         return <NotFound object="cohort" />
@@ -370,7 +372,11 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
                                 <Query
                                     query={query}
                                     setQuery={setQuery}
-                                    context={{ refresh: 'force_blocking', fileNameForExport: cohort.name }}
+                                    context={{
+                                        refresh: 'force_blocking',
+                                        fileNameForExport: cohort.name,
+                                        dataNodeLogicKey: dataNodeLogicKey,
+                                    }}
                                 />
                             )}
                         </div>

--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -11,6 +11,7 @@ import {
     applyAllCriteriaGroup,
     applyAllNestedCriteria,
     cleanCriteria,
+    createCohortDataNodeLogicKey,
     createCohortFormData,
     isCohortCriteriaGroup,
     validateGroup,
@@ -34,6 +35,7 @@ import {
 } from '~/types'
 
 import type { cohortEditLogicType } from './cohortEditLogicType'
+import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 
 export type CohortLogicProps = {
     id?: CohortType['id']
@@ -267,6 +269,12 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                         toastId: `cohort-saved-${key}`,
                     })
                     actions.checkIfFinishedCalculating(cohort)
+                    if (cohort.id !== 'new') {
+                        const mountedDataNodeLogic = dataNodeLogic.findMounted({
+                            key: createCohortDataNodeLogicKey(cohort.id),
+                        })
+                        mountedDataNodeLogic?.actions.loadData('force_blocking')
+                    }
                     return processCohort(cohort)
                 },
                 onCriteriaChange: ({ newGroup, id }) => {

--- a/frontend/src/scenes/cohorts/cohortUtils.tsx
+++ b/frontend/src/scenes/cohorts/cohortUtils.tsx
@@ -499,6 +499,10 @@ export function criteriaToHumanSentence(
     return <>{words}</>
 }
 
+export function createCohortDataNodeLogicKey(cohortId: number | 'new'): string {
+    return `cohort_${cohortId}_persons`
+}
+
 export const COHORT_MATCHING_DAYS = {
     '1': 'day',
     '7': 'week',


### PR DESCRIPTION
## Problem

Currently, when we upload a csv to a static cohort, the query is not updated with the latest result:


https://github.com/user-attachments/assets/e105a7fc-04d5-4743-a7e5-938eb9c25d6c


## Changes

Updated `query.context` to now have an optional key called `dataNodeLogicKey`, so that other components can look for the specific `dataNodeLogic` and trigger a reload if they want. 

This is the same behavior as pressing the reload button. 


https://github.com/user-attachments/assets/4fa2f906-d543-4b6e-9a4f-49eb1ece5e41



## How did you test this code?

Locally!

1) Create a CSV file with a distinct ID
2) Go to a static cohort that does not have that distinct ID uploaded
3) Upload the CSV file
4) You should see the new person in the query table without having to reload

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
