### PR TITLE
fix(max): reset memory messages after a failure

### DIFF
--- a/ee/hogai/assistant.py
+++ b/ee/hogai/assistant.py
@@ -13,7 +13,6 @@ from langgraph.errors import GraphRecursionError
 from langgraph.graph.state import CompiledStateGraph
 from langgraph.types import StreamMode
 from posthoganalytics.ai.langchain.callbacks import CallbackHandler
-from posthog.exceptions_capture import capture_exception
 from pydantic import BaseModel
 
 from ee.hogai.graph import (
@@ -58,6 +57,7 @@ from ee.hogai.utils.types import (
 )
 from ee.models import Conversation
 from posthog.event_usage import report_user_action
+from posthog.exceptions_capture import capture_exception
 from posthog.models import Action, Team, User
 from posthog.schema import (
     AssistantEventType,

--- a/ee/hogai/utils/types.py
+++ b/ee/hogai/utils/types.py
@@ -106,31 +106,16 @@ PartialStateType = TypeVar("PartialStateType", bound=BaseModel)
 class BaseState(BaseModel):
     """Base state class with reset functionality."""
 
-    @staticmethod
-    def _get_ignored_reset_fields() -> set[str]:
-        """
-        Fields to ignore during state resets due to race conditions.
-        """
-        return set()
-
     @classmethod
     def get_reset_state(cls) -> Self:
         """Returns a new instance with all fields reset to their default values."""
-        ignored_fields = cls._get_ignored_reset_fields()
-        return cls(**{k: v.default for k, v in cls.model_fields.items() if k not in ignored_fields})
+        return cls(**{k: v.default for k, v in cls.model_fields.items()})
 
 
 class _SharedAssistantState(BaseState):
     """
     The state of the root node.
     """
-
-    @staticmethod
-    def _get_ignored_reset_fields() -> set[str]:
-        """
-        Fields to ignore during state resets due to race conditions.
-        """
-        return {"memory_collection_messages"}
 
     start_id: Optional[str] = Field(default=None)
     """


### PR DESCRIPTION
## Problem

We don't reset memory messages after a failure since we changed how the state is reset. Fixes [this exception](https://us.posthog.com/project/2/error_tracking/0197f9e0-0201-7901-bb7b-33ea9c13d7d2?timestamp=2025-08-06T21:11:31.266000-07:00). Related traces: [trace 1](https://us.posthog.com/project/2/llm-observability/traces/ea372978-9c14-4d17-a9c7-88091aac8a3c?event=a4b3559b-1813-40d7-a356-680262b58364&timestamp=2025-08-07T04:11:26Z) and [trace 2](https://us.posthog.com/project/2/llm-observability/traces/c67b3de7-c366-4250-bc82-a29f868e979b?event=9de1322e-7c2e-4469-b875-2e6430982e62&timestamp=2025-08-07T02:16:42Z).

## Changes

Since the initial problem was in the field's type, revert changes for the state reset method.

## How did you test this code?

Unit tests
