### PR TITLE
fix(posthog): disable surveys for impersonated sessions in loadPostHogJS

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -21,6 +21,7 @@ export function loadPostHogJS(): void {
             bootstrap: window.POSTHOG_USER_IDENTITY_WITH_FLAGS ? window.POSTHOG_USER_IDENTITY_WITH_FLAGS : {},
             opt_in_site_apps: true,
             api_transport: 'fetch',
+            disable_surveys: window.IMPERSONATED_SESSION,
             before_send: (payload) => {
                 const win = window as WindowWithCypressCaptures
                 if (win.Cypress && payload) {


### PR DESCRIPTION
We don't wanna display surveys for ourselves when we're impersonating our users, let's just disable it
