### PR TITLE
fix: Handle fix_definition_project_ids failures gracefully

### DIFF
--- a/posthog/management/commands/fix_definition_project_ids.py
+++ b/posthog/management/commands/fix_definition_project_ids.py
@@ -320,17 +320,11 @@ class Command(BaseCommand):
 
                 # Print failed record IDs
                 if self.failed_records["EventDefinition"]:
-                    self.stdout.write(
-                        f"\nFailed EventDefinition IDs: {[r['id'] for r in self.failed_records['EventDefinition']]}"
-                    )
+                    self.stdout.write(f"\nFailed EventDefinition IDs: {self.failed_records['EventDefinition']}")
                 if self.failed_records["PropertyDefinition"]:
-                    self.stdout.write(
-                        f"Failed PropertyDefinition IDs: {[r['id'] for r in self.failed_records['PropertyDefinition']]}"
-                    )
+                    self.stdout.write(f"Failed PropertyDefinition IDs: {self.failed_records['PropertyDefinition']}")
                 if self.failed_records["GroupTypeMapping"]:
-                    self.stdout.write(
-                        f"Failed GroupTypeMapping IDs: {[r['id'] for r in self.failed_records['GroupTypeMapping']]}"
-                    )
+                    self.stdout.write(f"Failed GroupTypeMapping IDs: {self.failed_records['GroupTypeMapping']}")
 
             if total_updated > 0:
                 self.stdout.write(self.style.SUCCESS(f"\n✓ Successfully aligned {total_updated} definition records"))

--- a/posthog/management/commands/fix_definition_project_ids.py
+++ b/posthog/management/commands/fix_definition_project_ids.py
@@ -1,5 +1,5 @@
 from django.core.management.base import BaseCommand
-from django.db import transaction, models
+from django.db import transaction, models, IntegrityError
 from django.db.models import Count
 from posthog.models import EventDefinition, PropertyDefinition, GroupTypeMapping
 from posthog.storage.environments_rollback_storage import get_all_rollback_organization_ids
@@ -19,6 +19,8 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         self.dry_run = options["dry_run"]
         self.batch_size = options["batch_size"]
+
+        self.failed_records = {"EventDefinition": [], "PropertyDefinition": [], "GroupTypeMapping": []}
 
         self.stdout.write(self.style.SUCCESS("Starting definition project_id alignment process"))
 
@@ -109,8 +111,11 @@ class Command(BaseCommand):
             with transaction.atomic():
                 for event_def in batch_records:
                     event_def.project_id = event_def.team.project_id
-                    event_def.save(update_fields=["project_id"])
-                    updated_count += 1
+                    try:
+                        event_def.save(update_fields=["project_id"])
+                        updated_count += 1
+                    except IntegrityError:
+                        self.failed_records["EventDefinition"].append(event_def.id)
 
             if i + self.batch_size < len(all_misaligned_ids):
                 self.stdout.write(
@@ -119,7 +124,13 @@ class Command(BaseCommand):
 
         self.stdout.write(self.style.SUCCESS(f"✓ Updated {updated_count} EventDefinitions"))
 
-        return {"total": misaligned_count, "updated": updated_count}
+        failed_count = len(self.failed_records["EventDefinition"])
+        if failed_count > 0:
+            self.stdout.write(
+                self.style.WARNING(f"⚠ Failed to update {failed_count} EventDefinitions due to integrity errors")
+            )
+
+        return {"total": misaligned_count, "updated": updated_count, "failed": failed_count}
 
     def process_property_definitions(self):
         """Process PropertyDefinition records that need project_id alignment."""
@@ -173,8 +184,11 @@ class Command(BaseCommand):
             with transaction.atomic():
                 for property_def in batch_records:
                     property_def.project_id = property_def.team.project_id
-                    property_def.save(update_fields=["project_id"])
-                    updated_count += 1
+                    try:
+                        property_def.save(update_fields=["project_id"])
+                        updated_count += 1
+                    except IntegrityError:
+                        self.failed_records["PropertyDefinition"].append(property_def.id)
 
             if i + self.batch_size < len(all_misaligned_ids):
                 self.stdout.write(
@@ -183,7 +197,13 @@ class Command(BaseCommand):
 
         self.stdout.write(self.style.SUCCESS(f"✓ Updated {updated_count} PropertyDefinitions"))
 
-        return {"total": misaligned_count, "updated": updated_count}
+        failed_count = len(self.failed_records["PropertyDefinition"])
+        if failed_count > 0:
+            self.stdout.write(
+                self.style.WARNING(f"⚠ Failed to update {failed_count} PropertyDefinitions due to integrity errors")
+            )
+
+        return {"total": misaligned_count, "updated": updated_count, "failed": failed_count}
 
     def process_group_type_mappings(self):
         """Process GroupTypeMapping records that need project_id alignment."""
@@ -237,8 +257,11 @@ class Command(BaseCommand):
             with transaction.atomic():
                 for group_type_mapping in batch_records:
                     group_type_mapping.project_id = group_type_mapping.team.project_id
-                    group_type_mapping.save(update_fields=["project_id"])
-                    updated_count += 1
+                    try:
+                        group_type_mapping.save(update_fields=["project_id"])
+                        updated_count += 1
+                    except IntegrityError:
+                        self.failed_records["GroupTypeMapping"].append(group_type_mapping.id)
 
             if i + self.batch_size < len(all_misaligned_ids):
                 self.stdout.write(
@@ -247,13 +270,24 @@ class Command(BaseCommand):
 
         self.stdout.write(self.style.SUCCESS(f"✓ Updated {updated_count} GroupTypeMappings"))
 
-        return {"total": misaligned_count, "updated": updated_count}
+        failed_count = len(self.failed_records["GroupTypeMapping"])
+        if failed_count > 0:
+            self.stdout.write(
+                self.style.WARNING(f"⚠ Failed to update {failed_count} GroupTypeMappings due to integrity errors")
+            )
+
+        return {"total": misaligned_count, "updated": updated_count, "failed": failed_count}
 
     def print_summary(self, event_def_stats, property_def_stats, group_type_mapping_stats):
         """Print summary of changes made or that would be made."""
 
         total_found = event_def_stats["total"] + property_def_stats["total"] + group_type_mapping_stats["total"]
         total_updated = event_def_stats["updated"] + property_def_stats["updated"] + group_type_mapping_stats["updated"]
+        total_failed = (
+            event_def_stats.get("failed", 0)
+            + property_def_stats.get("failed", 0)
+            + group_type_mapping_stats.get("failed", 0)
+        )
 
         self.stdout.write("\n" + "=" * 50)
         self.stdout.write("SUMMARY")
@@ -273,6 +307,26 @@ class Command(BaseCommand):
             self.stdout.write(f"  - EventDefinitions: {event_def_stats['updated']}")
             self.stdout.write(f"  - PropertyDefinitions: {property_def_stats['updated']}")
             self.stdout.write(f"  - GroupTypeMappings: {group_type_mapping_stats['updated']}")
+
+            if total_failed > 0:
+                self.stdout.write(self.style.WARNING(f"\nTotal definitions failed: {total_failed}"))
+                self.stdout.write(f"  - EventDefinitions: {event_def_stats.get('failed', 0)}")
+                self.stdout.write(f"  - PropertyDefinitions: {property_def_stats.get('failed', 0)}")
+                self.stdout.write(f"  - GroupTypeMappings: {group_type_mapping_stats.get('failed', 0)}")
+
+                # Print failed record IDs
+                if self.failed_records["EventDefinition"]:
+                    self.stdout.write(
+                        f"\nFailed EventDefinition IDs: {[r['id'] for r in self.failed_records['EventDefinition']]}"
+                    )
+                if self.failed_records["PropertyDefinition"]:
+                    self.stdout.write(
+                        f"Failed PropertyDefinition IDs: {[r['id'] for r in self.failed_records['PropertyDefinition']]}"
+                    )
+                if self.failed_records["GroupTypeMapping"]:
+                    self.stdout.write(
+                        f"Failed GroupTypeMapping IDs: {[r['id'] for r in self.failed_records['GroupTypeMapping']]}"
+                    )
 
             if total_updated > 0:
                 self.stdout.write(self.style.SUCCESS(f"\n✓ Successfully aligned {total_updated} definition records"))

--- a/posthog/management/commands/fix_definition_project_ids.py
+++ b/posthog/management/commands/fix_definition_project_ids.py
@@ -20,7 +20,11 @@ class Command(BaseCommand):
         self.dry_run = options["dry_run"]
         self.batch_size = options["batch_size"]
 
-        self.failed_records = {"EventDefinition": [], "PropertyDefinition": [], "GroupTypeMapping": []}
+        self.failed_records: dict[str, list[int]] = {
+            "EventDefinition": [],
+            "PropertyDefinition": [],
+            "GroupTypeMapping": [],
+        }
 
         self.stdout.write(self.style.SUCCESS("Starting definition project_id alignment process"))
 


### PR DESCRIPTION
## Problem

- The `fix_definition_project_ids` command currently doesnt take into account the constraint violations when changing the project_id. 

## Changes

- In case of failure, gracefully pass and log the ID for future processing. Leave the old record as-is.

## How did you test this code?

- Manually