### PR TITLE
fix(devex): scene panel resizing fixes + nits

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
@@ -9,6 +9,7 @@ import { resizerLogic, ResizerLogicProps } from 'lib/components/Resizer/resizerL
 import { useEffect, useRef } from 'react'
 import { NotebookPanel } from 'scenes/notebooks/NotebookPanel/NotebookPanel'
 import { userLogic } from 'scenes/userLogic'
+import { sceneLayoutLogic } from '~/layout/scenes/sceneLayoutLogic'
 
 import { ErrorBoundary } from '~/layout/ErrorBoundary'
 import {
@@ -135,6 +136,8 @@ export function SidePanel(): JSX.Element | null {
     }
 
     const { desiredSize, isResizeInProgress } = useValues(resizerLogic(resizerLogicProps))
+    const { setSceneWidth } = useActions(sceneLayoutLogic)
+    const { sceneContainerRef } = useValues(sceneLayoutLogic)
 
     useEffect(() => {
         setSidePanelAvailable(true)
@@ -142,6 +145,13 @@ export function SidePanel(): JSX.Element | null {
             setSidePanelAvailable(false)
         }
     }, [setSidePanelAvailable])
+
+    // Trigger scene width recalculation when SidePanel size changes
+    useEffect(() => {
+        if (sceneContainerRef?.current) {
+            setSceneWidth(sceneContainerRef.current.offsetWidth)
+        }
+    }, [desiredSize, sidePanelOpen, setSceneWidth, sceneContainerRef])
 
     if (!visibleTabs.length) {
         return null

--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
@@ -136,7 +136,7 @@ export function SidePanel(): JSX.Element | null {
     }
 
     const { desiredSize, isResizeInProgress } = useValues(resizerLogic(resizerLogicProps))
-    const { setSceneWidth } = useActions(sceneLayoutLogic)
+    const { setSceneContainerRect } = useActions(sceneLayoutLogic)
     const { sceneContainerRef } = useValues(sceneLayoutLogic)
 
     useEffect(() => {
@@ -149,9 +149,9 @@ export function SidePanel(): JSX.Element | null {
     // Trigger scene width recalculation when SidePanel size changes
     useEffect(() => {
         if (sceneContainerRef?.current) {
-            setSceneWidth(sceneContainerRef.current.offsetWidth)
+            setSceneContainerRect(sceneContainerRef.current.getBoundingClientRect())
         }
-    }, [desiredSize, sidePanelOpen, setSceneWidth, sceneContainerRef])
+    }, [desiredSize, sidePanelOpen, setSceneContainerRect, sceneContainerRef])
 
     if (!visibleTabs.length) {
         return null

--- a/frontend/src/layout/scenes/SceneHeader.tsx
+++ b/frontend/src/layout/scenes/SceneHeader.tsx
@@ -92,18 +92,18 @@ export function SceneHeader({ className }: { className?: string }): JSX.Element 
                                 }
                                 icon={<IconInfo className="text-primary" />}
                                 tooltip={
-                                    scenePanelIsRelative
-                                        ? 'Force close info panel'
-                                        : scenePanelOpen
-                                          ? 'Close info panel'
-                                          : 'Open info panel'
+                                    !scenePanelOpen
+                                        ? 'Open info panel'
+                                        : scenePanelIsRelative
+                                          ? 'Force close info panel'
+                                          : 'Close info panel'
                                 }
                                 aria-label={
-                                    scenePanelIsRelative
-                                        ? 'Force close info panel'
-                                        : scenePanelOpen
-                                          ? 'Close info panel'
-                                          : 'Open info panel'
+                                    !scenePanelOpen
+                                        ? 'Open info panel'
+                                        : scenePanelIsRelative
+                                          ? 'Force close info panel'
+                                          : 'Close info panel'
                                 }
                                 active={scenePanelOpen}
                                 size="small"

--- a/frontend/src/layout/scenes/SceneLayout.tsx
+++ b/frontend/src/layout/scenes/SceneLayout.tsx
@@ -166,18 +166,18 @@ export function SceneLayout({ children, className, layoutConfig }: SceneLayoutPr
                                                 : setScenePanelOpen(false)
                                         }
                                         tooltip={
-                                            scenePanelIsRelative
-                                                ? 'Force close info panel'
-                                                : scenePanelOpen
-                                                  ? 'Close info panel'
-                                                  : 'Open info panel'
+                                            !scenePanelOpen
+                                                ? 'Open info panel'
+                                                : scenePanelIsRelative
+                                                  ? 'Force close info panel'
+                                                  : 'Close info panel'
                                         }
                                         aria-label={
-                                            scenePanelIsRelative
-                                                ? 'Force close info panel'
-                                                : scenePanelOpen
-                                                  ? 'Close info panel'
-                                                  : 'Open info panel'
+                                            !scenePanelOpen
+                                                ? 'Open info panel'
+                                                : scenePanelIsRelative
+                                                  ? 'Force close info panel'
+                                                  : 'Close info panel'
                                         }
                                     >
                                         <IconX className="size-4" />

--- a/frontend/src/layout/scenes/SceneLayout.tsx
+++ b/frontend/src/layout/scenes/SceneLayout.tsx
@@ -39,8 +39,8 @@ export function ScenePanel({ children }: { children: React.ReactNode }): JSX.Ele
     )
 }
 
-export function ScenePanelDivider(): JSX.Element {
-    return <LemonDivider className="-mx-2 my-2 w-[calc(100%+1rem)]" />
+export function ScenePanelDivider({ className }: { className?: string }): JSX.Element {
+    return <LemonDivider className={cn('-mx-2 my-2 w-[calc(100%+1rem)]', className)} />
 }
 
 // Should be first!
@@ -49,7 +49,7 @@ export const ScenePanelCommonActions = ({ children }: { children: React.ReactNod
         <>
             <div
                 className={cn(
-                    'flex flex-col gap-2 h-[var(--scene-layout-header-height)] py-1 border-b border-primary -mx-2 px-2 mb-2'
+                    'flex flex-col gap-2 min-h-[var(--scene-layout-header-height)] py-2 border-b border-primary -mx-2 px-2 mb-2'
                 )}
             >
                 {children}

--- a/frontend/src/layout/scenes/SceneLayout.tsx
+++ b/frontend/src/layout/scenes/SceneLayout.tsx
@@ -35,7 +35,7 @@ export function ScenePanel({ children }: { children: React.ReactNode }): JSX.Ele
         <>
             {children &&
                 scenePanelElement &&
-                createPortal(<div className="flex flex-col gap-px pt-4">{children}</div>, scenePanelElement)}
+                createPortal(<div className="flex flex-col gap-px">{children}</div>, scenePanelElement)}
         </>
     )
 }
@@ -45,17 +45,16 @@ export function ScenePanelDivider(): JSX.Element {
 }
 
 // Should be first!
-export const ScenePanelCommonActions = ({
-    children,
-    isFirst = true,
-}: {
-    children: React.ReactNode
-    isFirst?: boolean
-}): JSX.Element => {
+export const ScenePanelCommonActions = ({ children }: { children: React.ReactNode }): JSX.Element => {
     return (
         <>
-            <div className={cn('flex flex-col gap-2', { '-mt-2': isFirst })}>{children}</div>
-            <ScenePanelDivider />
+            <div
+                className={cn(
+                    'flex flex-col gap-2 h-[var(--scene-layout-header-height)] py-1 border-b border-primary -mx-2 px-2 mb-2'
+                )}
+            >
+                {children}
+            </div>
         </>
     )
 }
@@ -145,7 +144,7 @@ export function SceneLayout({ children, className, layoutConfig }: SceneLayoutPr
             <div
                 className={cn('relative min-h-screen', {
                     block: layoutConfig?.layout === 'app-raw-no-header',
-                    flex: scenePanelIsPresent && scenePanelIsRelative && scenePanelOpen,
+                    // flex: scenePanelIsPresent && scenePanelIsRelative && scenePanelOpen,
                 })}
             >
                 <div
@@ -177,11 +176,9 @@ export function SceneLayout({ children, className, layoutConfig }: SceneLayoutPr
                     <>
                         <div
                             className={cn(
-                                'scene-layout__content-panel order-2 bg-surface-secondary flex flex-col overflow-hidden row-span-2 col-span-2 row-start-1 col-start-2 top-0 h-screen min-w-0',
+                                'scene-layout__content-panel order-2 fixed left-[calc(var(--scene-layout-outer-right)-var(--scene-layout-panel-width))] bg-surface-secondary flex flex-col overflow-hidden row-span-2 col-span-2 row-start-1 col-start-2 top-0 h-screen min-w-0',
                                 {
                                     hidden: !scenePanelOpen,
-                                    'fixed left-[calc(var(--scene-layout-outer-right)-var(--scene-layout-panel-width)-1px)]':
-                                        !scenePanelIsRelative && scenePanelOpen,
                                 }
                             )}
                         >

--- a/frontend/src/layout/scenes/SceneLayout.tsx
+++ b/frontend/src/layout/scenes/SceneLayout.tsx
@@ -5,14 +5,13 @@ import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableSh
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { Label, LabelProps } from 'lib/ui/Label/Label'
 import { cn } from 'lib/utils/css-classes'
-import React, { PropsWithChildren, useEffect, useRef, useState } from 'react'
+import React, { PropsWithChildren, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { SceneConfig } from 'scenes/sceneTypes'
+import { SceneTabs } from '~/layout/scenes/SceneTabs'
 import { SceneHeader } from './SceneHeader'
 import './SceneLayout.css'
 import { sceneLayoutLogic } from './sceneLayoutLogic'
-import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
-import { SceneTabs } from '~/layout/scenes/SceneTabs'
 
 type SceneLayoutProps = {
     children: React.ReactNode
@@ -90,39 +89,9 @@ export function ScenePanelLabel({ children, title, ...props }: PropsWithChildren
 export function SceneLayout({ children, className, layoutConfig }: SceneLayoutProps): JSX.Element {
     const { registerScenePanelElement, setScenePanelOpen, setSceneContainerRef, setForceScenePanelClosedWhenRelative } =
         useActions(sceneLayoutLogic)
-    const { scenePanelIsPresent, scenePanelOpen, useSceneTabs, scenePanelIsRelative } = useValues(sceneLayoutLogic)
+    const { scenePanelIsPresent, scenePanelOpen, useSceneTabs, scenePanelIsRelative, sceneContainerRect } =
+        useValues(sceneLayoutLogic)
     const sceneLayoutContainer = useRef<HTMLDivElement>(null)
-    const [outerRight, setOuterRight] = useState<number>(0)
-
-    useOnMountEffect(() => {
-        const updateOuterRight = (): void => {
-            if (sceneLayoutContainer.current) {
-                setOuterRight(sceneLayoutContainer.current.getBoundingClientRect().right)
-            }
-        }
-
-        // Update on mount
-        updateOuterRight()
-
-        // Watch for window resize
-        window.addEventListener('resize', updateOuterRight)
-
-        // Watch for container size changes
-        let resizeObserver: ResizeObserver | null = null
-        if (sceneLayoutContainer.current) {
-            resizeObserver = new ResizeObserver(() => {
-                updateOuterRight()
-            })
-            resizeObserver.observe(sceneLayoutContainer.current)
-        }
-
-        return () => {
-            window.removeEventListener('resize', updateOuterRight)
-            if (resizeObserver) {
-                resizeObserver.disconnect()
-            }
-        }
-    })
 
     // Set container ref so we can measure the width of the scene layout in logic
     useEffect(() => {
@@ -137,7 +106,7 @@ export function SceneLayout({ children, className, layoutConfig }: SceneLayoutPr
             ref={sceneLayoutContainer}
             style={
                 {
-                    '--scene-layout-outer-right': outerRight + 'px',
+                    '--scene-layout-rect-right': sceneContainerRect?.right + 'px',
                 } as React.CSSProperties
             }
         >
@@ -176,7 +145,7 @@ export function SceneLayout({ children, className, layoutConfig }: SceneLayoutPr
                     <>
                         <div
                             className={cn(
-                                'scene-layout__content-panel order-2 fixed left-[calc(var(--scene-layout-outer-right)-var(--scene-layout-panel-width))] bg-surface-secondary flex flex-col overflow-hidden row-span-2 col-span-2 row-start-1 col-start-2 top-0 h-screen min-w-0',
+                                'scene-layout__content-panel order-2 fixed left-[calc(var(--scene-layout-rect-right)-var(--scene-layout-panel-width))] bg-surface-secondary flex flex-col overflow-hidden row-span-2 col-span-2 row-start-1 col-start-2 top-0 h-screen min-w-0',
                                 {
                                     hidden: !scenePanelOpen,
                                 }

--- a/frontend/src/layout/scenes/SceneLayout.tsx
+++ b/frontend/src/layout/scenes/SceneLayout.tsx
@@ -102,12 +102,26 @@ export function SceneLayout({ children, className, layoutConfig }: SceneLayoutPr
             }
         }
 
-        // Update on mount and when window resizes
+        // Update on mount
         updateOuterRight()
+
+        // Watch for window resize
         window.addEventListener('resize', updateOuterRight)
+
+        // Watch for container size changes
+        let resizeObserver: ResizeObserver | null = null
+        if (sceneLayoutContainer.current) {
+            resizeObserver = new ResizeObserver(() => {
+                updateOuterRight()
+            })
+            resizeObserver.observe(sceneLayoutContainer.current)
+        }
 
         return () => {
             window.removeEventListener('resize', updateOuterRight)
+            if (resizeObserver) {
+                resizeObserver.disconnect()
+            }
         }
     })
 
@@ -131,6 +145,7 @@ export function SceneLayout({ children, className, layoutConfig }: SceneLayoutPr
             <div
                 className={cn('relative min-h-screen', {
                     block: layoutConfig?.layout === 'app-raw-no-header',
+                    flex: scenePanelIsPresent && scenePanelIsRelative && scenePanelOpen,
                 })}
             >
                 <div
@@ -162,9 +177,11 @@ export function SceneLayout({ children, className, layoutConfig }: SceneLayoutPr
                     <>
                         <div
                             className={cn(
-                                'scene-layout__content-panel order-2 bg-surface-secondary flex flex-col overflow-hidden row-span-2 col-span-2 row-start-1 col-start-2 top-0 h-screen min-w-0 fixed left-[calc(var(--scene-layout-outer-right)-var(--scene-layout-panel-width)-1px)]',
+                                'scene-layout__content-panel order-2 bg-surface-secondary flex flex-col overflow-hidden row-span-2 col-span-2 row-start-1 col-start-2 top-0 h-screen min-w-0',
                                 {
                                     hidden: !scenePanelOpen,
+                                    'fixed left-[calc(var(--scene-layout-outer-right)-var(--scene-layout-panel-width)-1px)]':
+                                        !scenePanelIsRelative && scenePanelOpen,
                                 }
                             )}
                         >

--- a/frontend/src/layout/scenes/sceneLayoutLogic.tsx
+++ b/frontend/src/layout/scenes/sceneLayoutLogic.tsx
@@ -2,6 +2,7 @@ import { actions, connect, kea, path, reducers, selectors, listeners, afterMount
 import type { sceneLayoutLogicType } from './sceneLayoutLogicType'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+
 import React from 'react'
 
 export type SceneLayoutContainerRef = React.RefObject<HTMLElement> | null
@@ -100,13 +101,26 @@ export const sceneLayoutLogic = kea<sceneLayoutLogicType>([
         }
         cache.handleResize = handleResize
 
+        // Watch for window resize
         if (typeof window !== 'undefined') {
             window.addEventListener('resize', handleResize)
+        }
+
+        // Watch for container size changes
+        const containerRef = values.sceneContainerRef
+        if (containerRef?.current && typeof ResizeObserver !== 'undefined') {
+            cache.resizeObserver = new ResizeObserver(() => {
+                handleResize()
+            })
+            cache.resizeObserver.observe(containerRef.current)
         }
     }),
     beforeUnmount(({ cache }) => {
         if (typeof window !== 'undefined' && cache.handleResize) {
             window.removeEventListener('resize', cache.handleResize)
+        }
+        if (cache.resizeObserver) {
+            cache.resizeObserver.disconnect()
         }
     }),
 ])

--- a/frontend/src/layout/scenes/sceneLayoutLogic.tsx
+++ b/frontend/src/layout/scenes/sceneLayoutLogic.tsx
@@ -17,9 +17,9 @@ export const sceneLayoutLogic = kea<sceneLayoutLogicType>([
         registerScenePanelElement: (element: HTMLElement | null) => ({ element }),
         setScenePanelIsPresent: (active: boolean) => ({ active }),
         setScenePanelOpen: (open: boolean) => ({ open }),
-        setSceneWidth: (width: number) => ({ width }),
         setForceScenePanelClosedWhenRelative: (closed: boolean) => ({ closed }),
         setSceneContainerRef: (ref: SceneLayoutContainerRef) => ({ ref }),
+        setSceneContainerRect: (rect: DOMRect) => ({ rect }),
     }),
     reducers({
         scenePanelElement: [
@@ -40,12 +40,6 @@ export const sceneLayoutLogic = kea<sceneLayoutLogicType>([
                 setScenePanelOpen: (_, { open }) => open,
             },
         ],
-        sceneWidth: [
-            0,
-            {
-                setSceneWidth: (_, { width }) => width,
-            },
-        ],
         forceScenePanelClosedWhenRelative: [
             false,
             { persist: true },
@@ -59,12 +53,20 @@ export const sceneLayoutLogic = kea<sceneLayoutLogicType>([
                 setSceneContainerRef: (_, { ref }) => ref,
             },
         ],
+        // Rect might not be the best for our use case right now, but this will be helpful in the future
+        sceneContainerRect: [
+            null as DOMRect | null,
+            {
+                setSceneContainerRect: (_, { rect }) => rect,
+            },
+        ],
     }),
     selectors({
         useSceneTabs: [(s) => [s.featureFlags], (featureFlags) => !!featureFlags[FEATURE_FLAGS.SCENE_TABS]],
         scenePanelIsRelative: [
-            (s) => [s.sceneWidth],
-            (sceneWidth) => sceneWidth >= SCENE_WIDTH_WHERE_RELATIVE_PANEL_IS_OPEN,
+            (s) => [s.sceneContainerRect],
+            (sceneContainerRect) =>
+                sceneContainerRect && sceneContainerRect.width >= SCENE_WIDTH_WHERE_RELATIVE_PANEL_IS_OPEN,
         ],
         scenePanelOpen: [
             (s) => [s.scenePanelIsRelative, s.forceScenePanelClosedWhenRelative, s.scenePanelOpenManual],
@@ -72,13 +74,7 @@ export const sceneLayoutLogic = kea<sceneLayoutLogicType>([
                 scenePanelIsRelative ? !forceScenePanelClosedWhenRelative : scenePanelOpenManual,
         ],
     }),
-    listeners(({ actions, values }) => ({
-        updateSceneWidth: () => {
-            const containerRef = values.sceneContainerRef
-            if (containerRef?.current) {
-                actions.setSceneWidth(containerRef.current.offsetWidth)
-            }
-        },
+    listeners(({ actions, values, cache }) => ({
         setScenePanelOpen: ({ open }) => {
             // When trying to open a relative panel that's force closed, reset the force closed state
             if (open && values.scenePanelIsRelative && values.forceScenePanelClosedWhenRelative) {
@@ -86,9 +82,25 @@ export const sceneLayoutLogic = kea<sceneLayoutLogicType>([
             }
         },
         setSceneContainerRef: ({ ref }) => {
+            // Clean up old ResizeObserver
+            if (cache.resizeObserver) {
+                cache.resizeObserver.disconnect()
+                cache.resizeObserver = null
+            }
+
             // Measure width immediately when container ref is set
             if (ref?.current) {
-                actions.setSceneWidth(ref.current.offsetWidth)
+                actions.setSceneContainerRect(ref.current.getBoundingClientRect())
+
+                // Set up new ResizeObserver for the new container
+                if (typeof ResizeObserver !== 'undefined') {
+                    cache.resizeObserver = new ResizeObserver(() => {
+                        if (ref?.current) {
+                            actions.setSceneContainerRect(ref.current.getBoundingClientRect())
+                        }
+                    })
+                    cache.resizeObserver.observe(ref.current)
+                }
             }
         },
     })),
@@ -96,7 +108,7 @@ export const sceneLayoutLogic = kea<sceneLayoutLogicType>([
         const handleResize = (): void => {
             const containerRef = values.sceneContainerRef
             if (containerRef?.current) {
-                actions.setSceneWidth(containerRef.current.offsetWidth)
+                actions.setSceneContainerRect(containerRef.current.getBoundingClientRect())
             }
         }
         cache.handleResize = handleResize
@@ -104,15 +116,6 @@ export const sceneLayoutLogic = kea<sceneLayoutLogicType>([
         // Watch for window resize
         if (typeof window !== 'undefined') {
             window.addEventListener('resize', handleResize)
-        }
-
-        // Watch for container size changes
-        const containerRef = values.sceneContainerRef
-        if (containerRef?.current && typeof ResizeObserver !== 'undefined') {
-            cache.resizeObserver = new ResizeObserver(() => {
-                handleResize()
-            })
-            cache.resizeObserver.observe(containerRef.current)
         }
     }),
     beforeUnmount(({ cache }) => {

--- a/frontend/src/lib/components/Scenes/SceneCommonButtons.tsx
+++ b/frontend/src/lib/components/Scenes/SceneCommonButtons.tsx
@@ -48,14 +48,14 @@ export function SceneCommonButtons({
     const { openSidePanel } = useActions(sidePanelLogic)
 
     return (
-        <div className="flex gap-1 flex-wrap h-full items-center">
+        <div className="grid grid-cols-2 gap-1">
             {favorite && (
                 <ButtonPrimitive
                     onClick={favorite.onClick}
                     tooltip={favorite.active ? 'Remove from favorites' : 'Add to favorites'}
                     active={favorite.active}
-                    className="justify-center flex-1"
                     menuItem
+                    className="justify-center"
                 >
                     {favorite.active ? <IconStarFilled className="text-warning" /> : <IconStar />}
                     Favorite
@@ -71,8 +71,8 @@ export function SceneCommonButtons({
                         openSidePanel(SidePanelTab.Discussion)
                     }}
                     tooltip="Comment"
-                    className="justify-center"
                     menuItem
+                    className="justify-center"
                 >
                     <IconComment />
                     Comment
@@ -80,7 +80,13 @@ export function SceneCommonButtons({
             )}
 
             {share && (
-                <ButtonPrimitive onClick={share.onClick} tooltip="Share" fullWidth className="justify-center" menuItem>
+                <ButtonPrimitive
+                    onClick={share.onClick}
+                    tooltip="Share"
+                    data-attr={`${dataAttrKey}-share`}
+                    menuItem
+                    className="justify-center"
+                >
                     <IconShare />
                     Share
                 </ButtonPrimitive>
@@ -90,9 +96,9 @@ export function SceneCommonButtons({
                 <ButtonPrimitive
                     onClick={duplicate.onClick}
                     tooltip="Duplicate this resource"
-                    className="justify-center flex-1"
-                    menuItem
                     data-attr={`${dataAttrKey}-duplicate`}
+                    menuItem
+                    className="justify-center"
                 >
                     <IconCopy />
                     Duplicate
@@ -104,9 +110,9 @@ export function SceneCommonButtons({
                     onClick={pinned.onClick}
                     tooltip={pinned.active ? 'Unpin' : 'Pin'}
                     active={pinned.active}
-                    className="justify-center flex-1"
-                    menuItem
                     data-attr={`${dataAttrKey}-pin`}
+                    menuItem
+                    className="justify-center"
                 >
                     {pinned.active ? <IconPinFilled className="text-warning" /> : <IconPin />}
                     Pin
@@ -118,9 +124,9 @@ export function SceneCommonButtons({
                     onClick={fullscreen.onClick}
                     tooltip={fullscreen.active ? 'Exit fullscreen' : 'Fullscreen'}
                     active={fullscreen.active}
-                    className="justify-center flex-1"
-                    menuItem
                     data-attr={`${dataAttrKey}-fullscreen`}
+                    menuItem
+                    className="justify-center"
                 >
                     <IconExpand45 />
                     Fullscreen
@@ -132,9 +138,9 @@ export function SceneCommonButtons({
                     onClick={recordings.onClick}
                     to={recordings.to}
                     tooltip="View recordings"
-                    className="justify-center flex-1"
                     buttonProps={{
                         menuItem: true,
+                        className: 'justify-center',
                     }}
                     data-attr={`${dataAttrKey}-view-recordings`}
                 >

--- a/frontend/src/lib/components/Scenes/SceneCommonButtons.tsx
+++ b/frontend/src/lib/components/Scenes/SceneCommonButtons.tsx
@@ -48,7 +48,7 @@ export function SceneCommonButtons({
     const { openSidePanel } = useActions(sidePanelLogic)
 
     return (
-        <div className="flex gap-1 flex-wrap">
+        <div className="flex gap-1 flex-wrap h-full items-center">
             {favorite && (
                 <ButtonPrimitive
                     onClick={favorite.onClick}
@@ -71,7 +71,6 @@ export function SceneCommonButtons({
                         openSidePanel(SidePanelTab.Discussion)
                     }}
                     tooltip="Comment"
-                    fullWidth
                     className="justify-center"
                     menuItem
                 >

--- a/products/error_tracking/frontend/ErrorTrackingIssueScenePanel.tsx
+++ b/products/error_tracking/frontend/ErrorTrackingIssueScenePanel.tsx
@@ -42,7 +42,6 @@ export const ErrorTrackingIssueScenePanel = (): JSX.Element | null => {
                 onSave={updateDescription}
                 dataAttrKey={RESOURCE_TYPE}
             />
-            <SceneActivityIndicator at={issue.first_seen} prefix="First seen" />
 
             <IssueStatusSelect status={issue.status} onChange={updateStatus} />
             <IssueAssigneeSelect
@@ -51,23 +50,27 @@ export const ErrorTrackingIssueScenePanel = (): JSX.Element | null => {
                 disabled={issue.status != 'active'}
             />
             <IssueExternalReference />
+            <SceneActivityIndicator at={issue.first_seen} prefix="First seen" />
 
-            <ScenePanelDivider />
+            {/* Add a div here to break out of the gap-2 */}
+            <div>
+                <ScenePanelDivider className="mb-0" />
 
-            <ScenePanelCommonActions>
-                <SceneCommonButtons
-                    comment
-                    share={{
-                        onClick: () => {
-                            void copyToClipboard(
-                                window.location.origin + urls.errorTrackingIssue(issue.id),
-                                'issue link'
-                            )
-                        },
-                    }}
-                    dataAttrKey={RESOURCE_TYPE}
-                />
-            </ScenePanelCommonActions>
+                <ScenePanelCommonActions>
+                    <SceneCommonButtons
+                        comment
+                        share={{
+                            onClick: () => {
+                                void copyToClipboard(
+                                    window.location.origin + urls.errorTrackingIssue(issue.id),
+                                    'issue link'
+                                )
+                            },
+                        }}
+                        dataAttrKey={RESOURCE_TYPE}
+                    />
+                </ScenePanelCommonActions>
+            </div>
         </div>
     ) : null
 }
@@ -83,7 +86,7 @@ const IssueStatusSelect = ({
         <ScenePanelLabel title="Status">
             <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                    <ButtonPrimitive fullWidth className="flex justify-between">
+                    <ButtonPrimitive fullWidth className="flex justify-between" variant="panel" menuItem>
                         <StatusIndicator status={status} withTooltip={true} />
                         <DropdownMenuOpenIndicator />
                     </ButtonPrimitive>
@@ -135,6 +138,7 @@ const IssueAssigneeSelect = ({
                         disabled={disabled}
                         className="flex justify-between"
                         data-state={isOpen ? 'open' : 'closed'}
+                        variant="panel"
                     >
                         <div className="flex items-center">
                             <AssigneeIconDisplay assignee={anyAssignee} size="small" />

--- a/products/error_tracking/frontend/ErrorTrackingIssueScenePanel.tsx
+++ b/products/error_tracking/frontend/ErrorTrackingIssueScenePanel.tsx
@@ -54,7 +54,7 @@ export const ErrorTrackingIssueScenePanel = (): JSX.Element | null => {
 
             <ScenePanelDivider />
 
-            <ScenePanelCommonActions isFirst={false}>
+            <ScenePanelCommonActions>
                 <SceneCommonButtons
                     comment
                     share={{

--- a/products/error_tracking/frontend/components/ExternalReferences.tsx
+++ b/products/error_tracking/frontend/components/ExternalReferences.tsx
@@ -1,4 +1,4 @@
-import { LemonDialog, LemonInput, LemonSkeleton, LemonTextArea, Link } from '@posthog/lemon-ui'
+import { LemonDialog, LemonInput, LemonTextArea, Link } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 
 import { ErrorTrackingRelationalIssue } from '~/queries/schema/schema-general'
@@ -18,6 +18,7 @@ import {
     DropdownMenuTrigger,
 } from 'lib/ui/DropdownMenu/DropdownMenu'
 import { IconPlus } from '@posthog/icons'
+import { WrappingLoadingSkeleton } from 'lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton'
 
 const ERROR_TRACKING_INTEGRATIONS: IntegrationKind[] = ['linear', 'github']
 
@@ -29,7 +30,13 @@ export const ExternalReferences = (): JSX.Element | null => {
     const { getIntegrationsByKind, integrationsLoading } = useValues(integrationsLogic)
 
     if (!issue || integrationsLoading) {
-        return <LemonSkeleton />
+        return (
+            <WrappingLoadingSkeleton fullWidth>
+                <ButtonPrimitive menuItem aria-hidden>
+                    Loading
+                </ButtonPrimitive>
+            </WrappingLoadingSkeleton>
+        )
     }
 
     const errorTrackingIntegrations = getIntegrationsByKind(ERROR_TRACKING_INTEGRATIONS)
@@ -92,8 +99,12 @@ export const ExternalReferences = (): JSX.Element | null => {
 
 function SetupIntegrationsButton(): JSX.Element {
     return (
-        <Link to={urls.errorTrackingConfiguration({ tab: 'error-tracking-integrations' })}>
-            <ButtonPrimitive fullWidth>Setup integrations</ButtonPrimitive>
+        <Link
+            to={urls.errorTrackingConfiguration({ tab: 'error-tracking-integrations' })}
+            buttonProps={{ variant: 'panel', fullWidth: true, menuItem: true }}
+            tooltip="Go to integrations configuration"
+        >
+            Setup integrations
         </Link>
     )
 }


### PR DESCRIPTION
## Problems
* ScenePanel didn't move with the outer edge when we opened the SidePanel opened
* ScenePanel toggle tooltips weren't reflecting reality
* SceneCommonActions + buttons style fixes
* Error tracking button style fixes 

![2025-08-07 11 41 07](https://github.com/user-attachments/assets/b9e3d7b7-7469-4449-86f0-85492d125f47)
![2025-08-07 11 45 23](https://github.com/user-attachments/assets/ed2a9512-1218-47e2-a27c-0420f5021939)

## Changes
* Moved resizing observer and calculating SceneLayout width into SceneLayoutLogic (using `getBoundingRect()` (for future purposes)
* Fix ScenePanel toggle tooltips to match intended action
* updated SceneCommonActions styles 
* updated ErrorTracking's SceneCommonActions implementations to match the rest
* updated ErrorTracking's scene panel button styles to match the rest  

![2025-08-07 11 40 22](https://github.com/user-attachments/assets/a963065c-add1-4851-abb1-0fe72e0532e2)
![2025-08-07 11 46 13](https://github.com/user-attachments/assets/7b815533-b2d5-4804-a738-a1df351c5242)


## How did you test this code?
Locally, tested all implementations
