### PR TITLE
fix: insights include all if admin logic

### DIFF
--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -178,8 +178,12 @@ class TeamAndOrgViewSetMixin(_GenericViewSet):  # TODO: Rename to include "Env" 
         include_all_if_admin = self.request.GET.get("admin_include_all") == "true"
 
         # Additionally "projects" is a special one where we always want to include all projects if you're an org admin
-        # "insights" is a special one where we always want to include all insights if you're an org admin because the insights retrieve uses a list call :|
-        if self.scope_object == "project" or self.scope_object == "insight":
+        if self.scope_object == "project":
+            include_all_if_admin = True
+
+        # "insights" are a special case where we want to use include_all_if_admin if listing with short_id because
+        # individual insights are retrieved
+        if self.scope_object == "insight" and self.request.GET.get("short_id") is not None:
             include_all_if_admin = True
 
         return self.user_access_control.filter_queryset_by_access_level(


### PR DESCRIPTION
## Changes

We currently don't list "none" access resources to admins. This is so private resources aren't discoverable. It was happening for insights because of some weird behaviour with how we load insights. This fixes it.

## How did you test this code?

Added some tests.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
