### PR TITLE
fix(max): SQL variables in queries

### DIFF
--- a/ee/hogai/graph/sql/mixins.py
+++ b/ee/hogai/graph/sql/mixins.py
@@ -1,13 +1,16 @@
 import asyncio
+from typing import cast
 
 from langchain_core.prompts import ChatPromptTemplate
 
 from ee.hogai.graph.mixins import AssistantContextMixin
 from ee.hogai.utils.warehouse import serialize_database_schema
+from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import Database, create_hogql_database
 from posthog.hogql.errors import ExposedHogQLError, NotImplementedError as HogQLNotImplementedError, ResolutionError
 from posthog.hogql.parser import parse_select
+from posthog.hogql.placeholders import find_placeholders, replace_placeholders
 from posthog.hogql.printer import print_ast
 from posthog.sync import database_sync_to_async
 
@@ -15,8 +18,8 @@ from ..schema_generator.parsers import PydanticOutputParserException
 from .prompts import (
     HOGQL_GENERATOR_SYSTEM_PROMPT,
     SQL_EXPRESSIONS_DOCS,
-    SQL_SUPPORTED_FUNCTIONS_DOCS,
     SQL_SUPPORTED_AGGREGATIONS_DOCS,
+    SQL_SUPPORTED_FUNCTIONS_DOCS,
 )
 
 
@@ -62,7 +65,17 @@ class HogQLGeneratorMixin(AssistantContextMixin):
         if query is None:
             raise PydanticOutputParserException(llm_output="", validation_message="Output is empty")
         try:
-            print_ast(parse_select(query), context=hogql_context, dialect="clickhouse")
+            parsed_query = parse_select(query, placeholders={})
+
+            # Replace placeholders with dummy values to compile the generated query.
+            finder = find_placeholders(parsed_query)
+            if finder.placeholder_fields or finder.has_filters:
+                dummy_placeholders = {str(field[0]): ast.Constant(value=1) for field in finder.placeholder_fields}
+                if finder.has_filters:
+                    dummy_placeholders["filters"] = ast.Constant(value=1)
+                parsed_query = cast(ast.SelectQuery, replace_placeholders(parsed_query, dummy_placeholders))
+
+            print_ast(parsed_query, context=hogql_context, dialect="clickhouse")
         except (ExposedHogQLError, HogQLNotImplementedError, ResolutionError) as err:
             err_msg = str(err)
             if err_msg.startswith("no viable alternative"):

--- a/ee/hogai/graph/sql/mixins.py
+++ b/ee/hogai/graph/sql/mixins.py
@@ -70,7 +70,9 @@ class HogQLGeneratorMixin(AssistantContextMixin):
             # Replace placeholders with dummy values to compile the generated query.
             finder = find_placeholders(parsed_query)
             if finder.placeholder_fields or finder.has_filters:
-                dummy_placeholders = {str(field[0]): ast.Constant(value=1) for field in finder.placeholder_fields}
+                dummy_placeholders: dict[str, ast.Expr] = {
+                    str(field[0]): ast.Constant(value=1) for field in finder.placeholder_fields
+                }
                 if finder.has_filters:
                     dummy_placeholders["filters"] = ast.Constant(value=1)
                 parsed_query = cast(ast.SelectQuery, replace_placeholders(parsed_query, dummy_placeholders))

--- a/ee/hogai/graph/sql/test/test_sql_mixins.py
+++ b/ee/hogai/graph/sql/test/test_sql_mixins.py
@@ -32,3 +32,10 @@ class TestSQLMixins(NonAtomicBaseTest):
         mixin = self._node
         database = await mixin._get_database()
         self.assertEqual(mixin._database_instance, database)
+
+    async def test_parses_queries_with_placeholders(self):
+        mixin = self._node
+        query = "SELECT properties FROM events WHERE {filters} AND {custom_filter}"
+        database = await mixin._get_database()
+        result = await mixin._parse_generated_hogql(query, mixin._get_default_hogql_context(database))
+        self.assertEqual(result, query)

--- a/products/data_warehouse/backend/max_tools.py
+++ b/products/data_warehouse/backend/max_tools.py
@@ -33,6 +33,7 @@ class HogQLGeneratorTool(HogQLGeneratorMixin, MaxTool):
     root_system_prompt_template: str = SQL_ASSISTANT_ROOT_SYSTEM_PROMPT
 
     async def _arun_impl(self, instructions: str) -> tuple[str, str]:
+        current_query: str | None = self.context.get("current_query", "")
         system_prompt = await self._construct_system_prompt()
 
         prompt = system_prompt + ChatPromptTemplate.from_messages(
@@ -49,7 +50,7 @@ class HogQLGeneratorTool(HogQLGeneratorMixin, MaxTool):
                 chain = prompt | merge_message_runs | self._model | self._parse_output
                 result: str = await chain.ainvoke(
                     {
-                        **self.context,
+                        "current_query": current_query,
                         "instructions": instructions,
                     }
                 )

--- a/products/data_warehouse/backend/test/test_max_tools.py
+++ b/products/data_warehouse/backend/test/test_max_tools.py
@@ -29,3 +29,28 @@ class TestDataWarehouseMaxTools(NonAtomicBaseTest):
             )
             result = await tool.ainvoke(tool_call.model_dump(), config)
             self.assertEqual(result.content, "```sql\nSELECT AVG(properties.$session_length) FROM events\n```")
+
+    async def test_generates_queries_with_placeholders(self):
+        config = {
+            "configurable": {
+                "team": self.team,
+                "user": self.user,
+                "contextual_tools": {"generate_hogql_query": {"current_query": "SELECT * FROM events WHERE {filters}"}},
+            },
+        }
+
+        with patch(
+            "products.data_warehouse.backend.max_tools.HogQLGeneratorTool._model",
+            return_value={"query": "SELECT properties FROM events WHERE {filters} AND {custom_filter}"},
+        ):
+            tool = HogQLGeneratorTool(team=self.team, user=self.user, state=AssistantState(messages=[]))
+            tool_call = AssistantToolCall(
+                id="1",
+                name="generate_hogql_query",
+                type="tool_call",
+                args={"instructions": "What are the properties for the variable {filters}?"},
+            )
+            result = await tool.ainvoke(tool_call.model_dump(), config)
+            self.assertEqual(
+                result.content, "```sql\nSELECT properties FROM events WHERE {filters} AND {custom_filter}\n```"
+            )


### PR DESCRIPTION
## Problem

Max doesn't parse SQL queries that have variables. `print_ast` only accepts queries that are ready for execution, so it fails if variables are undefined. [Trace](https://us.posthog.com/project/2/llm-observability/traces/0e7edaf4-e583-4fbb-b534-296f4115ec70?event=643bffb9-eeea-46b9-8d35-a56dca08a046&timestamp=2025-08-07T09:11:41Z).

## Changes

- Find placeholders and replace them with dummy values.

## How did you test this code?

Unit tests
