### PR TITLE
feat: for metrics replace path by route

### DIFF
--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -5448,7 +5448,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
                 "team_id": self.team.pk,
                 "scope": "burst",
                 "rate": "5/minute",
-                "path": f"/api/projects/TEAM_ID/feature_flags",
+                "path": "api/projects/TEAM_ID/feature_flags/",
                 "hashed_personal_api_key": hash_key_value(personal_api_key),
             },
         )

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -5448,7 +5448,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
                 "team_id": self.team.pk,
                 "scope": "burst",
                 "rate": "5/minute",
-                "path": "api/projects/TEAM_ID/feature_flags/",
+                "route": "/api/projects/TEAM_ID/feature_flags/",
                 "hashed_personal_api_key": hash_key_value(personal_api_key),
             },
         )

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -924,7 +924,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
                 "team_id": self.team.pk,
                 "scope": "burst",
                 "rate": "5/minute",
-                "route": "api/projects/TEAM_ID/feature_flags/",
+                "route": "/api/projects/TEAM_ID/feature_flags/",
                 "hashed_personal_api_key": hash_key_value(personal_api_key),
             },
         )
@@ -967,7 +967,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
                 "team_id": self.team.pk,
                 "scope": "persons",
                 "rate": "6/minute",
-                "path": f"/api/projects/TEAM_ID/persons/",
+                "route": "/api/projects/TEAM_ID/persons/",
                 "hashed_personal_api_key": hash_key_value(personal_api_key),
             },
         )

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -924,7 +924,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
                 "team_id": self.team.pk,
                 "scope": "burst",
                 "rate": "5/minute",
-                "path": f"/api/projects/TEAM_ID/feature_flags",
+                "route": "api/projects/TEAM_ID/feature_flags/",
                 "hashed_personal_api_key": hash_key_value(personal_api_key),
             },
         )

--- a/posthog/metrics.py
+++ b/posthog/metrics.py
@@ -18,6 +18,7 @@ This module holds common labels, metrics and helpers for Prometheus instrumentat
 
 # Common metric labels
 LABEL_PATH = "path"
+LABEL_ROUTE = "route_id"
 LABEL_RESOURCE_TYPE = "resource_type"
 LABEL_TEAM_ID = "team_id"
 

--- a/posthog/metrics.py
+++ b/posthog/metrics.py
@@ -18,7 +18,7 @@ This module holds common labels, metrics and helpers for Prometheus instrumentat
 
 # Common metric labels
 LABEL_PATH = "path"
-LABEL_ROUTE = "route_id"
+LABEL_ROUTE = "route"
 LABEL_RESOURCE_TYPE = "resource_type"
 LABEL_TEAM_ID = "team_id"
 

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -115,7 +115,7 @@ def replace_with_param_names(string, pattern):
     return compiled_pattern.sub(replacement_func, string)
 
 
-def get_route_from_path(path: str) -> str:
+def get_route_from_path(path: str | None) -> str:
     """
     Extract a generic route identifier from a request path to avoid high cardinality
     in metrics. This uses Django's URL resolver to get the actual route pattern

--- a/posthog/test/test_rate_limit.py
+++ b/posthog/test/test_rate_limit.py
@@ -145,7 +145,7 @@ class TestUserAPI(APIBaseTest):
                 "team_id": self.team.pk,
                 "scope": "burst",
                 "rate": "5/minute",
-                "path": "/api/projects/TEAM_ID/feature_flags",
+                "route": "api/projects/TEAM_ID/feature_flags/",
                 "hashed_personal_api_key": self.hashed_personal_api_key,
             },
         )
@@ -181,7 +181,7 @@ class TestUserAPI(APIBaseTest):
                     "team_id": self.team.pk,
                     "scope": "sustained",
                     "rate": "5/hour",
-                    "path": "/api/projects/TEAM_ID/feature_flags",
+                    "route": "api/projects/TEAM_ID/feature_flags/",
                     "hashed_personal_api_key": self.hashed_personal_api_key,
                 },
             )
@@ -223,7 +223,7 @@ class TestUserAPI(APIBaseTest):
                 "team_id": self.team.pk,
                 "scope": "clickhouse_burst",
                 "rate": "5/minute",
-                "path": "/api/projects/TEAM_ID/events",
+                "route": "api/projects/TEAM_ID/events/",
                 "hashed_personal_api_key": self.hashed_personal_api_key,
             },
         )
@@ -256,7 +256,7 @@ class TestUserAPI(APIBaseTest):
                 "team_id": self.team.pk,
                 "scope": "burst",
                 "rate": "5/minute",
-                "path": f"/api/projects/TEAM_ID/feature_flags",
+                "route": "api/projects/TEAM_ID/feature_flags/",
                 "hashed_personal_api_key": self.hashed_personal_api_key,
             },
         )
@@ -335,7 +335,7 @@ class TestUserAPI(APIBaseTest):
                 "team_id": None,
                 "scope": "burst",
                 "rate": "5/minute",
-                "path": f"/api/organizations/ORG_ID/plugins",
+                "route": "api/organizations/ORG_ID/plugins/",
                 "hashed_personal_api_key": self.hashed_personal_api_key,
             },
         )
@@ -396,7 +396,7 @@ class TestUserAPI(APIBaseTest):
                 "team_id": None,
                 "scope": "burst",
                 "rate": "5/minute",
-                "path": "/api/login",
+                "route": "api/login/",
                 "hashed_personal_api_key": None,
             },
         )
@@ -607,7 +607,7 @@ class TestUserAPI(APIBaseTest):
             (
                 "/api/projects/123/feature_flags/",
                 "^api/projects/(?P<parent_lookup_project_id>[^/.]+)/feature_flags/?$",
-                "api/projects/PARENT_LOOKUP_PROJECT_ID/feature_flags/",
+                "api/projects/TEAM_ID/feature_flags/",
                 "Django route pattern with named regexp parameters",
             ),
             (
@@ -642,7 +642,8 @@ class TestUserAPI(APIBaseTest):
             ),
         ]
     )
-    def test_get_route_from_path(self, test_path, mock_route, expected_result, description):
+    @patch("posthog.rate_limit.statsd.incr")
+    def test_get_route_from_path(self, test_path, mock_route, expected_result, description, incr_mock):
         """Test that get_route_from_path correctly extracts and normalizes route patterns"""
         if test_path in ("", None):
             # Direct test for empty/None paths

--- a/posthog/test/test_rate_limit.py
+++ b/posthog/test/test_rate_limit.py
@@ -145,7 +145,7 @@ class TestUserAPI(APIBaseTest):
                 "team_id": self.team.pk,
                 "scope": "burst",
                 "rate": "5/minute",
-                "route": "api/projects/TEAM_ID/feature_flags/",
+                "route": "/api/projects/TEAM_ID/feature_flags/",
                 "hashed_personal_api_key": self.hashed_personal_api_key,
             },
         )
@@ -181,7 +181,7 @@ class TestUserAPI(APIBaseTest):
                     "team_id": self.team.pk,
                     "scope": "sustained",
                     "rate": "5/hour",
-                    "route": "api/projects/TEAM_ID/feature_flags/",
+                    "route": "/api/projects/TEAM_ID/feature_flags/",
                     "hashed_personal_api_key": self.hashed_personal_api_key,
                 },
             )
@@ -223,7 +223,7 @@ class TestUserAPI(APIBaseTest):
                 "team_id": self.team.pk,
                 "scope": "clickhouse_burst",
                 "rate": "5/minute",
-                "route": "api/projects/TEAM_ID/events/",
+                "route": "/api/projects/TEAM_ID/events/",
                 "hashed_personal_api_key": self.hashed_personal_api_key,
             },
         )
@@ -256,7 +256,7 @@ class TestUserAPI(APIBaseTest):
                 "team_id": self.team.pk,
                 "scope": "burst",
                 "rate": "5/minute",
-                "route": "api/projects/TEAM_ID/feature_flags/",
+                "route": "/api/projects/TEAM_ID/feature_flags/",
                 "hashed_personal_api_key": self.hashed_personal_api_key,
             },
         )
@@ -335,7 +335,7 @@ class TestUserAPI(APIBaseTest):
                 "team_id": None,
                 "scope": "burst",
                 "rate": "5/minute",
-                "route": "api/organizations/ORG_ID/plugins/",
+                "route": "/api/organizations/ORG_ID/plugins/",
                 "hashed_personal_api_key": self.hashed_personal_api_key,
             },
         )
@@ -396,7 +396,7 @@ class TestUserAPI(APIBaseTest):
                 "team_id": None,
                 "scope": "burst",
                 "rate": "5/minute",
-                "route": "api/login/",
+                "route": "/api/login/",
                 "hashed_personal_api_key": None,
             },
         )
@@ -601,13 +601,13 @@ class TestUserAPI(APIBaseTest):
             (
                 "/api/environments/123/query/abc-123-def/progress/",
                 "api/environments/<int:team_id>/query/<str:query_uuid>/progress/",
-                "api/environments/TEAM_ID/query/QUERY_UUID/progress/",
+                "/api/environments/TEAM_ID/query/QUERY_UUID/progress/",
                 "Django route pattern with int and str parameters",
             ),
             (
                 "/api/projects/123/feature_flags/",
                 "^api/projects/(?P<parent_lookup_project_id>[^/.]+)/feature_flags/?$",
-                "api/projects/TEAM_ID/feature_flags/",
+                "/api/projects/TEAM_ID/feature_flags/",
                 "Django route pattern with named regexp parameters",
             ),
             (


### PR DESCRIPTION
## Problem

we use path as label which leads to number of time series explosion

## Changes

use route in metrics, still gives us observability, but limits number of metrics
