### PR TITLE
feat: Log if batch export over SLA

### DIFF
--- a/products/batch_exports/backend/tests/temporal/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/conftest.py
@@ -149,7 +149,7 @@ def event_loop():
 @pytest_asyncio.fixture(autouse=True)
 async def configure_logger() -> None:
     """Configure logger when running in a Temporal activity environment."""
-    configure_logger_async()
+    configure_logger_async(cache_logger_on_first_use=False)
 
 
 @pytest.fixture

--- a/products/batch_exports/backend/tests/temporal/test_metrics.py
+++ b/products/batch_exports/backend/tests/temporal/test_metrics.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime as dt
 import uuid
 from unittest import mock
@@ -7,6 +8,7 @@ import pytest
 import pytest_asyncio
 import temporalio.client
 from django.conf import settings
+from structlog.testing import capture_logs
 from temporalio.common import RetryPolicy
 
 from posthog.batch_exports.service import (
@@ -20,6 +22,7 @@ from posthog.temporal.tests.utils.models import (
 from products.batch_exports.backend.temporal.destinations.postgres_batch_export import (
     PostgresBatchExportInputs,
 )
+from products.batch_exports.backend.temporal.metrics import SLAWaiter
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
 
@@ -149,3 +152,23 @@ async def test_interceptor_calls_histogram_metrics(
         expected_calls = [mock.call(1)] * number_of_add_calls
 
         assert mocked_meter.return_value.create_counter.return_value.add.mock_calls == expected_calls
+
+
+async def test_sla_waiter():
+    with capture_logs() as cap_logs:
+        async with SLAWaiter(name="test", sla=dt.timedelta(seconds=1)) as detector:
+            await asyncio.sleep(3)
+
+            assert detector.is_over_sla()
+
+    assert "%(name)s has been running longer than SLA of %(sla_seconds)ds" == cap_logs[0]["event"]
+    assert "test" == cap_logs[0]["name"]
+    assert 1 == cap_logs[0]["sla_seconds"]
+
+    with capture_logs() as cap_logs:
+        async with SLAWaiter(name="test", sla=dt.timedelta(seconds=3)) as detector:
+            await asyncio.sleep(1)
+
+            assert detector.is_over_sla() is False
+
+    assert not cap_logs


### PR DESCRIPTION
## Problem

Batch exports have an implicit SLA in their interval: Hourly batch exports should finish within the hour, 5 minute batch exports should finish within 5 minutes, and so on.

We track execution time currently, but there is no quick indication that we have exceeded SLA for a specific batch export, only aggregate metrics.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Print a log line when implicit SLA is exceeded. This is achieved by running a task that waits for the SLA duration. This task is cancelled if the workflow finishes before the SLA.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
