### PR TITLE
fix(max): inkeep message limit

### DIFF
--- a/ee/hogai/graph/inkeep_docs/nodes.py
+++ b/ee/hogai/graph/inkeep_docs/nodes.py
@@ -39,7 +39,8 @@ class InkeepDocsNode(RootNode):  # Inheriting from RootNode to use the same mess
         )
 
     def _construct_messages(self, state: AssistantState) -> list[BaseMessage]:
-        messages: list[BaseMessage] = [LangchainSystemMessage(content=INKEEP_DOCS_SYSTEM_PROMPT)]
+        system_prompt = LangchainSystemMessage(content=INKEEP_DOCS_SYSTEM_PROMPT)
+        messages: list[BaseMessage] = []
         for message in super()._construct_messages(state):
             if message.content:
                 messages.append(message)
@@ -51,7 +52,7 @@ class InkeepDocsNode(RootNode):  # Inheriting from RootNode to use the same mess
         )
         if last_human_message_index is not None:
             messages = messages[: last_human_message_index + 1]
-        return messages
+        return [system_prompt] + messages[-29:]
 
     def _get_model(self):  # type: ignore
         return MaxChatOpenAI(

--- a/ee/hogai/graph/inkeep_docs/test/test_nodes.py
+++ b/ee/hogai/graph/inkeep_docs/test/test_nodes.py
@@ -165,3 +165,16 @@ class TestInkeepDocsNode(ClickhouseTestMixin, BaseTest):
             self.assertIsNotNone(first_message.id)
             self.assertIsNotNone(second_message.id)
             self.assertNotEqual(first_message.id, second_message.id)
+
+    def test_truncates_messages_after_limit(self):
+        """Inkeep accepts maximum 30 messages"""
+        node = InkeepDocsNode(self.team, self.user)
+        state = AssistantState(
+            messages=[HumanMessage(content=str(i)) for i in range(31)],
+            root_tool_call_id="test-id",
+        )
+        next_state = node._construct_messages(state)
+        self.assertEqual(len(next_state), 30)
+        self.assertEqual(next_state[0].type, "system")
+        self.assertEqual(next_state[1].content, "2")
+        self.assertEqual(next_state[-1].content, "30")


### PR DESCRIPTION
## Problem

Apparently, Inkeep has a message limit of 30 messages. If a request exceeds the limit, it throws 400.

## Changes

Truncate message history for Inkeep.

## How did you test this code?

Unit tests