### PR TITLE
feat(max): Fanciful lively loader

### DIFF
--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -17,7 +17,6 @@ import {
     LemonInput,
     LemonSkeleton,
     ProfilePicture,
-    Spinner,
     Tooltip,
 } from '@posthog/lemon-ui'
 import clsx from 'clsx'
@@ -235,9 +234,12 @@ function MessageGroup({ messages, isFinal: isFinalGroup }: MessageGroupProps): J
                     } else if (isReasoningMessage(message)) {
                         return (
                             <MessageTemplate key={key} type="ai">
-                                <div className="flex items-center gap-1.5">
-                                    <Spinner className="text-xl" />
-                                    <span>{message.content}…</span>
+                                <div className="flex items-center gap-2">
+                                    <img
+                                        src="https://res.cloudinary.com/dmukukwp6/image/upload/loading_bdba47912e.gif"
+                                        className="size-7 -m-1" // At the "native" size-6 (24px), the icons are a tad too small
+                                    />
+                                    <span className="font-medium">{message.content}…</span>
                                 </div>
                                 {message.substeps?.map((substep, substepIndex) => (
                                     <MarkdownMessage


### PR DESCRIPTION
## Problem

We currently use `<Spinner />` for Max's "thinking" state, but it feels quite mechanical.

## Changes

We already use a much better "thinking" indicator in the Inkeep Max chat at posthog.com. It's [a gif](https://res.cloudinary.com/dmukukwp6/image/upload/loading_bdba47912e.gif" that we previously wanted to use as the general loader in the app, but found it too whimsical for most cases. It seems perfect for the use of LLM processing, which takes longer, has a variable duration, and is indeterministic in nature:

![maxxxx](https://github.com/user-attachments/assets/acf1dfd5-28a3-4ce6-9432-b67b6b751ee2)

Also made gave the thinking message `font-medium` to clearly separate from actual output.

## How did you test this code?

Worried about the stability of UI snapshots here out of the box, let's see how they behave.