### PR TITLE
fix(frontend): Support ":" in scene URLs

### DIFF
--- a/frontend/src/initKea.ts
+++ b/frontend/src/initKea.ts
@@ -80,7 +80,7 @@ export function initKea({
             urlPatternOptions: {
                 // :TRICKY: What chars to allow in named segment values i.e. ":key"
                 // in "/url/:key". Default: "a-zA-Z0-9-_~ %".
-                segmentValueCharset: "a-zA-Z0-9-_~ %.@()!'|",
+                segmentValueCharset: "a-zA-Z0-9-_~ %.@()!'|:",
             },
             pathFromRoutesToWindow: (path) => {
                 return addProjectIdIfMissing(path)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1960,6 +1960,10 @@ importers:
       typescript:
         specifier: 5.2.2
         version: 5.2.2
+    devDependencies:
+      kea-test-utils:
+        specifier: '*'
+        version: 0.2.4(kea@3.1.6(react@18.2.0))
 
   products/logs:
     dependencies:

--- a/products/llm_observability/frontend/llmObservabilityTraceLogic.test.ts
+++ b/products/llm_observability/frontend/llmObservabilityTraceLogic.test.ts
@@ -1,0 +1,60 @@
+import { combineUrl, router } from 'kea-router'
+import { expectLogic } from 'kea-test-utils'
+import { MOCK_TEAM_ID } from 'lib/api.mock'
+import { addProjectIdIfMissing } from 'lib/utils/router-utils'
+import { urls } from 'scenes/urls'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { llmObservabilityTraceLogic } from './llmObservabilityTraceLogic'
+
+describe('llmObservabilityTraceLogic', () => {
+    let logic: ReturnType<typeof llmObservabilityTraceLogic.build>
+
+    beforeEach(async () => {
+        useMocks({
+            get: {
+                '/api/environments/:team_id/query/': { results: [] },
+            },
+        })
+        initKeaTests()
+        logic = llmObservabilityTraceLogic()
+        logic.mount()
+    })
+
+    it('properly loads trace scene when trace ID contains a colon', async () => {
+        const traceIdWithColon = 'session-summary:group:16-16:81008d53ff0a708b:da6c0390-409f-485c-aab3-5e910bcf8b33'
+        const traceUrl = combineUrl(urls.llmObservabilityTrace(traceIdWithColon))
+        const finalUrl = addProjectIdIfMissing(traceUrl.url, MOCK_TEAM_ID)
+
+        router.actions.push(finalUrl)
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(logic.values.traceId).toBe(traceIdWithColon)
+    })
+
+    it('properly loads trace scene when trace ID contains multiple colons', async () => {
+        const traceIdWithMultipleColons = 'namespace:trace:12345:abcdef:xyz'
+        const traceUrl = combineUrl(urls.llmObservabilityTrace(traceIdWithMultipleColons))
+
+        router.actions.push(addProjectIdIfMissing(traceUrl.url, MOCK_TEAM_ID))
+        await expectLogic(logic).toMatchValues({
+            traceId: traceIdWithMultipleColons,
+        })
+    })
+
+    it('handles trace ID with event and timestamp parameters', async () => {
+        const traceIdWithColon = 'session-summary:group:16-16:81008d53ff0a708b:da6c0390-409f-485c-aab3-5e910bcf8b33'
+        const eventId = 'event123'
+        const timestamp = '2024-01-01T00:00:00Z'
+        const traceUrl = combineUrl(urls.llmObservabilityTrace(traceIdWithColon, { event: eventId, timestamp }))
+
+        router.actions.push(addProjectIdIfMissing(traceUrl.url, MOCK_TEAM_ID))
+        await expectLogic(logic).toMatchValues({
+            traceId: traceIdWithColon,
+            eventId: eventId,
+            dateFrom: timestamp,
+        })
+    })
+})

--- a/products/llm_observability/package.json
+++ b/products/llm_observability/package.json
@@ -6,6 +6,9 @@
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.0"
     },
+    "devDependencies": {
+        "kea-test-utils": "*"
+    },
     "peerDependencies": {
         "@posthog/icons": "*",
         "@storybook/react": "*",


### PR DESCRIPTION
## Problem

URLs to LLM observability traces containing a colon `:` in their ID don't work:

`/llm-observability/traces/session-summary:group:16-16:81008d53ff0a708b:da6c0390-409f-485c-aab3-5e910bcf8b33`

In fact this URL doesn't even load the `LLMObservabilityTrace` scene, as `kea-router` under our current config doesn't consider the part after `/traces/` to be an `:id`.

## Changes

It looks like the allowed `segmentValueCharset` is defined in `initKea()`, and it didn't contain the colon. Now it does. Does this break anything? I don't think, but I would love to know if there was a reason to omit the colon specifically @thmsobrmlr.

## How did you test this code?

Got a new `llmObservabilityTraceLogic` test covering this (although the change is app-wide).