### PR TITLE
fix(messaging): update google ads endpoint version

### DIFF
--- a/plugin-server/src/cdp/templates/_destinations/google_ads/google.template.test.ts
+++ b/plugin-server/src/cdp/templates/_destinations/google_ads/google.template.test.ts
@@ -67,7 +67,7 @@ describe('google template', () => {
               },
               "method": "POST",
               "type": "fetch",
-              "url": "https://googleads.googleapis.com/v18/customers/1231231234:uploadClickConversions",
+              "url": "https://googleads.googleapis.com/v21/customers/1231231234:uploadClickConversions",
             }
         `)
 
@@ -105,7 +105,7 @@ describe('google template', () => {
               },
               "method": "POST",
               "type": "fetch",
-              "url": "https://googleads.googleapis.com/v18/customers/1231231234:uploadClickConversions",
+              "url": "https://googleads.googleapis.com/v21/customers/1231231234:uploadClickConversions",
             }
         `)
 
@@ -144,7 +144,7 @@ describe('google template', () => {
               },
               "method": "POST",
               "type": "fetch",
-              "url": "https://googleads.googleapis.com/v18/customers/1231231234:uploadClickConversions",
+              "url": "https://googleads.googleapis.com/v21/customers/1231231234:uploadClickConversions",
             }
         `)
 

--- a/plugin-server/src/cdp/templates/_destinations/google_ads/google.template.ts
+++ b/plugin-server/src/cdp/templates/_destinations/google_ads/google.template.ts
@@ -1,7 +1,7 @@
 import { HogFunctionInputSchemaType } from '~/cdp/types'
 import { HogFunctionTemplate } from '~/cdp/types'
 
-// Based on https://developers.google.com/google-ads/api/reference/rpc/v18/ClickConversion
+// Based on https://developers.google.com/google-ads/api/reference/rpc/v21/ClickConversion
 
 const build_inputs = (): HogFunctionInputSchemaType[] => {
     return [
@@ -104,7 +104,7 @@ if (not empty(inputs.orderId)) {
     body.conversions[1].order_id := inputs.orderId
 }
 
-let res := fetch(f'https://googleads.googleapis.com/v18/customers/{splitByString('/', inputs.customerId)[1]}:uploadClickConversions', {
+let res := fetch(f'https://googleads.googleapis.com/v21/customers/{splitByString('/', inputs.customerId)[1]}:uploadClickConversions', {
     'method': 'POST',
     'headers': {
         'Authorization': f'Bearer {inputs.oauth.access_token}',


### PR DESCRIPTION
## Problem

Google Ads API v18 has been deprecated and will stop accepting requests starting August 20, 2025.

- [x] email customers on the old version to upgrade the template ([query](https://metabase.prod-eu.posthog.dev/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJkYXRhYmFzZSI6MzQsIm5hdGl2ZSI6eyJxdWVyeSI6IlNFTEVDVCB1LmVtYWlsXG5GUk9NIHBvc3Rob2dfaG9nZnVuY3Rpb24gaGZcbkpPSU4gcG9zdGhvZ191c2VyIHUgT04gaGYuY3JlYXRlZF9ieV9pZCA9IHUuaWRcbldIRVJFIGhmLnRlbXBsYXRlX2lkID0gJ3RlbXBsYXRlLWdvb2dsZS1hZHMnIFxuQU5EIGhmLmhvZzo6dGV4dCBMSUtFICcldjE4JSdcbkdST1VQIEJZIHUuZW1haWwiLCJ0ZW1wbGF0ZS10YWdzIjp7fX19LCJkaXNwbGF5IjoidGFibGUiLCJwYXJhbWV0ZXJzIjpbXSwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319))

## Changes

- update the api version

## How did you test this code?

tested with an api call
