### PR TITLE
chore(insight): delay metadata extraction task by 10 minutes

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -503,7 +503,10 @@ class InsightSerializer(InsightBasicSerializer):
         self.user_permissions.reset_insights_dashboard_cached_results()
 
         if not before_update or before_update.query != updated_insight.query:
-            query_meta_task = extract_insight_query_metadata.delay(insight_id=updated_insight.id)
+            query_meta_task = extract_insight_query_metadata.apply_async(
+                kwargs={"insight_id": updated_insight.id},
+                countdown=10 * 60,  # 10 minutes
+            )
             logger.warn(
                 "scheduled extract_insight_query_metadata",
                 insight_id=updated_insight.id,
@@ -1303,7 +1306,10 @@ class LegacyInsightViewSet(InsightViewSet):
 @mutable_receiver(post_save, sender=Insight)
 def schedule_query_metadata_extract(sender, instance: Insight, created: bool, **kwargs):
     if created:
-        query_meta_task = extract_insight_query_metadata.delay(insight_id=instance.pk)
+        query_meta_task = extract_insight_query_metadata.apply_async(
+            kwargs={"insight_id": instance.pk},
+            countdown=10 * 60,  # 10 minutes
+        )
         logger.warn(
             "scheduled extract_insight_query_metadata",
             insight_id=instance.id,

--- a/posthog/api/test/__snapshots__/test_insight.ambr
+++ b/posthog/api/test/__snapshots__/test_insight.ambr
@@ -794,8 +794,7 @@
          "posthog_team"."base_currency"
   FROM "posthog_dashboarditem"
   INNER JOIN "posthog_team" ON ("posthog_dashboarditem"."team_id" = "posthog_team"."id")
-  WHERE (NOT ("posthog_dashboarditem"."deleted")
-         AND "posthog_dashboarditem"."id" = 99999)
+  WHERE "posthog_dashboarditem"."id" = 99999
   LIMIT 21
   FOR
   UPDATE OF "posthog_dashboarditem"

--- a/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
@@ -870,8 +870,7 @@
          "posthog_team"."base_currency"
   FROM "posthog_dashboarditem"
   INNER JOIN "posthog_team" ON ("posthog_dashboarditem"."team_id" = "posthog_team"."id")
-  WHERE (NOT ("posthog_dashboarditem"."deleted")
-         AND "posthog_dashboarditem"."id" = 99999)
+  WHERE "posthog_dashboarditem"."id" = 99999
   LIMIT 21
   FOR
   UPDATE OF "posthog_dashboarditem"
@@ -1728,8 +1727,7 @@
          "posthog_team"."base_currency"
   FROM "posthog_dashboarditem"
   INNER JOIN "posthog_team" ON ("posthog_dashboarditem"."team_id" = "posthog_team"."id")
-  WHERE (NOT ("posthog_dashboarditem"."deleted")
-         AND "posthog_dashboarditem"."id" = 99999)
+  WHERE "posthog_dashboarditem"."id" = 99999
   LIMIT 21
   FOR
   UPDATE OF "posthog_dashboarditem"

--- a/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
+++ b/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
@@ -2481,8 +2481,7 @@
          "posthog_team"."base_currency"
   FROM "posthog_dashboarditem"
   INNER JOIN "posthog_team" ON ("posthog_dashboarditem"."team_id" = "posthog_team"."id")
-  WHERE (NOT ("posthog_dashboarditem"."deleted")
-         AND "posthog_dashboarditem"."id" = 99999)
+  WHERE "posthog_dashboarditem"."id" = 99999
   LIMIT 21
   FOR
   UPDATE OF "posthog_dashboarditem"
@@ -5733,8 +5732,7 @@
          "posthog_team"."base_currency"
   FROM "posthog_dashboarditem"
   INNER JOIN "posthog_team" ON ("posthog_dashboarditem"."team_id" = "posthog_team"."id")
-  WHERE (NOT ("posthog_dashboarditem"."deleted")
-         AND "posthog_dashboarditem"."id" = 99999)
+  WHERE "posthog_dashboarditem"."id" = 99999
   LIMIT 21
   FOR
   UPDATE OF "posthog_dashboarditem"
@@ -7589,8 +7587,7 @@
          "posthog_team"."base_currency"
   FROM "posthog_dashboarditem"
   INNER JOIN "posthog_team" ON ("posthog_dashboarditem"."team_id" = "posthog_team"."id")
-  WHERE (NOT ("posthog_dashboarditem"."deleted")
-         AND "posthog_dashboarditem"."id" = 99999)
+  WHERE "posthog_dashboarditem"."id" = 99999
   LIMIT 21
   FOR
   UPDATE OF "posthog_dashboarditem"
@@ -11304,8 +11301,7 @@
          "posthog_team"."base_currency"
   FROM "posthog_dashboarditem"
   INNER JOIN "posthog_team" ON ("posthog_dashboarditem"."team_id" = "posthog_team"."id")
-  WHERE (NOT ("posthog_dashboarditem"."deleted")
-         AND "posthog_dashboarditem"."id" = 99999)
+  WHERE "posthog_dashboarditem"."id" = 99999
   LIMIT 21
   FOR
   UPDATE OF "posthog_dashboarditem"
@@ -13339,8 +13335,7 @@
          "posthog_team"."base_currency"
   FROM "posthog_dashboarditem"
   INNER JOIN "posthog_team" ON ("posthog_dashboarditem"."team_id" = "posthog_team"."id")
-  WHERE (NOT ("posthog_dashboarditem"."deleted")
-         AND "posthog_dashboarditem"."id" = 99999)
+  WHERE "posthog_dashboarditem"."id" = 99999
   LIMIT 21
   FOR
   UPDATE OF "posthog_dashboarditem"

--- a/posthog/tasks/insight_query_metadata.py
+++ b/posthog/tasks/insight_query_metadata.py
@@ -15,6 +15,7 @@ logger = structlog.get_logger(__name__)
     acks_late=True,
     reject_on_worker_lost=True,
     track_started=True,
+    default_retry_delay=10 * 60,  # 10 minutes
 )
 def extract_insight_query_metadata(insight_id: str) -> None:
     try:
@@ -31,12 +32,6 @@ def extract_insight_query_metadata(insight_id: str) -> None:
             )
             insight.generate_query_metadata()
             insight.save(update_fields=["query_metadata"])
-    except Insight.DoesNotExist as e:
-        logger.exception(
-            "Failed to extract query metadata - insight does not exist", insight_id=insight_id, error=str(e)
-        )
-        # Don't retry for non-existent insights
-        return
     except Exception as e:
         logger.exception("Failed to extract query metadata for insight", insight_id=insight_id, error=str(e))
         raise

--- a/posthog/tasks/insight_query_metadata.py
+++ b/posthog/tasks/insight_query_metadata.py
@@ -25,7 +25,7 @@ def extract_insight_query_metadata(insight_id: str) -> None:
         )
         with transaction.atomic():
             insight = (
-                Insight.objects.select_for_update(of=("self",))
+                Insight.objects_including_soft_deleted.select_for_update(of=("self",))
                 .select_related("team")
                 .only("query", "query_metadata", "team")
                 .get(pk=insight_id)


### PR DESCRIPTION
## Problem

We get `insight not found` errors when the query_meta extraction tasks are run likely because of replication lag.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Delays the start of extraction task by 10 minutes and also adds a retry with another 10 minute delay if the insight still can't be found.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Create or update an insight and wait for the task to run in 10 mins.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
