### PR TITLE
fix: Enable text wrapping for long funnel step descriptors

### DIFF
--- a/frontend/src/scenes/funnels/FunnelBarHorizontal/FunnelBarHorizontal.scss
+++ b/frontend/src/scenes/funnels/FunnelBarHorizontal/FunnelBarHorizontal.scss
@@ -100,8 +100,11 @@ $glyph_height: 23px; // Based on .funnel-step-glyph
 
             .funnel-step-title {
                 font-weight: bold;
-
-                @extend %mixin-text-ellipsis;
+                max-width: calc(100% - 8px);
+                overflow: hidden;
+                word-wrap: break-word;
+                word-break: break-word;
+                white-space: normal;
             }
 
             button {
@@ -123,9 +126,7 @@ $glyph_height: 23px; // Based on .funnel-step-glyph
             position: relative;
             height: 100%;
             background: var(--color-accent);
-            transition:
-                width 0.2s ease,
-                height 0.2s ease;
+            transition: width 0.2s ease, height 0.2s ease;
 
             &.first {
                 border-radius: var(--radius) 0 0 4px;

--- a/frontend/src/scenes/funnels/FunnelBarHorizontal/FunnelBarHorizontal.scss
+++ b/frontend/src/scenes/funnels/FunnelBarHorizontal/FunnelBarHorizontal.scss
@@ -102,8 +102,7 @@ $glyph_height: 23px; // Based on .funnel-step-glyph
                 font-weight: bold;
                 max-width: calc(100% - 8px);
                 overflow: hidden;
-                word-wrap: break-word;
-                word-break: break-word;
+                overflow-wrap: break-word;
                 white-space: normal;
             }
 

--- a/frontend/src/scenes/funnels/FunnelBarHorizontal/FunnelBarHorizontal.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarHorizontal/FunnelBarHorizontal.tsx
@@ -77,7 +77,7 @@ export function FunnelBarHorizontal({
                                     {funnelsFilter?.funnelOrderType === StepOrderValue.UNORDERED ? (
                                         <span>Completed {step.order + 1} steps</span>
                                     ) : (
-                                        <EntityFilterInfo filter={getActionFilterFromFunnelStep(step)} />
+                                        <EntityFilterInfo filter={getActionFilterFromFunnelStep(step)} allowWrap />
                                     )}
                                 </div>
                                 {funnelsFilter?.funnelOrderType !== StepOrderValue.UNORDERED &&

--- a/frontend/src/scenes/funnels/FunnelBarVertical/FunnelBarVertical.scss
+++ b/frontend/src/scenes/funnels/FunnelBarVertical/FunnelBarVertical.scss
@@ -111,8 +111,7 @@
 
 .StepBar__backdrop {
     height: 100%;
-    background:
-        repeating-linear-gradient(
+    background: repeating-linear-gradient(
             -22.5deg,
             transparent,
             transparent 0.5rem,
@@ -172,7 +171,6 @@
 
 .StepLegend {
     height: 100%;
-    white-space: nowrap;
     border-left: 1px solid var(--color-border-primary);
 
     > .LemonRow {

--- a/frontend/src/scenes/funnels/FunnelBarVertical/StepLegend.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarVertical/StepLegend.tsx
@@ -62,7 +62,7 @@ export function StepLegend({ step, stepIndex, showTime, showPersonsModal }: Step
                     hasAvailableFeature(AvailableFeature.PATHS_ADVANCED) && <FunnelStepMore stepIndex={stepIndex} />
                 }
             >
-                <EntityFilterInfo filter={getActionFilterFromFunnelStep(step)} />
+                <EntityFilterInfo filter={getActionFilterFromFunnelStep(step)} allowWrap />
             </LemonRow>
             <LemonRow
                 icon={<IconTrendingFlat />}


### PR DESCRIPTION
### Problem

- Funnels with long descriptors were not wrapping text properly, requiring users to scroll horizontally to see subsequent query steps. This created a poor user experience when funnel step names were longer than the available space.

fix: #36259

### Changes

- **Horizontal funnel**: Added `allowWrap` prop to `EntityFilterInfo` component and replaced text-ellipsis mixin with proper text wrapping styles
- **Vertical funnel**: Added `allowWrap` prop to `EntityFilterInfo` component and removed `white-space: nowrap` from `.StepLegend` class

- The changes enable text wrapping for long funnel step descriptors in both horizontal and vertical funnel visualizations, eliminating the need for horizontal scrolling.

### How did you test this code?

- Verified that long funnel step names now wrap properly instead of being truncated with ellipsis
- Tested both horizontal and vertical funnel layouts
- Confirmed that the layout remains responsive and readable with wrapped text
- Checked that existing functionality is preserved for shorter step names