### PR TITLE
chore: add survey empty state viewed event

### DIFF
--- a/frontend/src/scenes/surveys/Surveys.tsx
+++ b/frontend/src/scenes/surveys/Surveys.tsx
@@ -115,6 +115,10 @@ function Surveys(): JSX.Element {
     const { user } = useValues(userLogic)
     const shouldShowEmptyState = !dataLoading && surveys.length === 0
 
+    if (shouldShowEmptyState) {
+        posthog.capture('surveys_empty_state_viewed')
+    }
+
     return (
         <div>
             <PageHeader


### PR DESCRIPTION
## Problem

I have no idea of knowing how many people are seeing the survey empty states experience atm, and when surveys are launched.

## Changes

Add events when survey empty state is viewed and when a survey is launched. I'll use those to build the funnel to see how many people we're losing in the empty states for existing customers