### PR TITLE
feat: support rolling Personal API Key from Admin

### DIFF
--- a/posthog/admin/admins/personal_api_key_admin.py
+++ b/posthog/admin/admins/personal_api_key_admin.py
@@ -1,20 +1,19 @@
 from django.contrib import admin
 from django.utils.html import format_html
-from django.urls import reverse
+from django.urls import reverse, path
+from django.http import HttpResponseNotAllowed
+from django.shortcuts import redirect
 
 from posthog.models import PersonalAPIKey
+from posthog.api.personal_api_key import PersonalAPIKeySerializer
+from posthog.tasks.email import send_personal_api_key_exposed
 
 
 class PersonalAPIKeyAdmin(admin.ModelAdmin):
-    list_display = (
-        "id",
-        "label",
-        "mask_value",
-        "user_link",
-        "created_at",
-        "last_used_at",
-        "scopes",
-    )
+    change_form_template = "admin/posthog/personal_api_key/change_form.html"
+
+    readonly_fields = ("roll_action",)
+    list_display = ("id", "label", "mask_value", "user_link", "created_at", "last_used_at", "scopes", "roll_action")
     list_display_links = ("id", "label")
     list_select_related = ("user",)
     search_fields = ("id", "user__email", "scopes")
@@ -28,3 +27,46 @@ class PersonalAPIKeyAdmin(admin.ModelAdmin):
             reverse("admin:posthog_user_change", args=[key.user.pk]),
             key.user.email,
         )
+
+    @admin.display(description="Roll Key")
+    def roll_action(self, personal_api_key: PersonalAPIKey):
+        if not personal_api_key or not personal_api_key.pk:
+            return ""
+        return format_html(
+            '<button type="submit" name="_roll" id="roll_key_button" class="button" '
+            'formmethod="post" formaction="{}" formnovalidate style="padding: 5px 10px; background-color: red;">Roll</button> '
+            '<input type="hidden" name="_roll_url" />',
+            reverse("admin:posthog_personalapikey_roll", args=[personal_api_key.pk]),
+        )
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom = [
+            path(
+                "<path:object_id>/roll/",
+                self.admin_site.admin_view(self.roll_view),
+                name="posthog_personalapikey_roll",
+            ),
+        ]
+        return custom + urls
+
+    def roll_view(self, request, object_id, *args, **kwargs):
+        personal_api_key = self.get_queryset(request).select_related("user").get(pk=object_id)
+        if not personal_api_key:
+            return redirect(reverse("admin:posthog_personalapikey_changelist"))
+        if request.method != "POST":
+            return HttpResponseNotAllowed(["POST"])
+
+        old_mask_value = personal_api_key.mask_value
+        url = request.POST.get("_roll_url", "")
+        more_info = ""
+        if url != "":
+            more_info = f"This key was detected at {url}."
+
+        serializer = PersonalAPIKeySerializer(instance=personal_api_key)
+        serializer.roll(personal_api_key)
+        self.log_change(request, personal_api_key, f"Rolled key.")
+        send_personal_api_key_exposed(personal_api_key.user.id, personal_api_key.id, old_mask_value, more_info)
+
+        self.message_user(request, f"Personal API key rolled and user notified.")
+        return redirect(reverse("admin:posthog_personalapikey_change", args=[personal_api_key.pk]))

--- a/posthog/admin/admins/personal_api_key_admin.py
+++ b/posthog/admin/admins/personal_api_key_admin.py
@@ -12,12 +12,30 @@ from posthog.tasks.email import send_personal_api_key_exposed
 class PersonalAPIKeyAdmin(admin.ModelAdmin):
     change_form_template = "admin/posthog/personal_api_key/change_form.html"
 
-    readonly_fields = ("roll_action",)
+    fields = (
+        "id",
+        "user",
+        "label",
+        "created_at",
+        "last_used_at",
+        "last_rolled_at",
+        "scopes",
+        "scoped_teams",
+        "scoped_organizations",
+        "team",
+        "roll_action",
+    )
+    readonly_fields = (
+        "id",
+        "team",
+        "user",
+        "roll_action",
+    )
     list_display = ("id", "label", "mask_value", "user_link", "created_at", "last_used_at", "scopes", "roll_action")
     list_display_links = ("id", "label")
     list_select_related = ("user",)
     search_fields = ("id", "user__email", "scopes")
-    autocomplete_fields = ("user",)
+    autocomplete_fields = ("user", "team")
     ordering = ("-created_at",)
 
     @admin.display(description="User")

--- a/posthog/email.py
+++ b/posthog/email.py
@@ -91,6 +91,7 @@ CUSTOMER_IO_TEMPLATE_ID_MAP = {
     "email_change_old_address": "36",
     "email_change_new_address": "37",
     "password_changed": "42",
+    "personal_api_key_exposed": "45",
 }
 
 

--- a/posthog/models/personal_api_key.py
+++ b/posthog/models/personal_api_key.py
@@ -62,3 +62,20 @@ class PersonalAPIKey(models.Model):
         null=True,
         blank=True,
     )
+
+
+def find_personal_api_key(token: str) -> tuple[PersonalAPIKey, str] | None:
+    for mode, iterations in PERSONAL_API_KEY_MODES_TO_TRY:
+        secure_value = hash_key_value(token, mode=mode, iterations=iterations)
+        try:
+            obj = (
+                PersonalAPIKey.objects.select_related("user")
+                .filter(user__is_active=True)
+                .get(secure_value=secure_value)
+            )
+            return obj, mode
+
+        except PersonalAPIKey.DoesNotExist:
+            pass
+
+    return None

--- a/posthog/templates/admin/posthog/personal_api_key/change_form.html
+++ b/posthog/templates/admin/posthog/personal_api_key/change_form.html
@@ -1,0 +1,23 @@
+{% extends "admin/change_form.html" %}
+{% load i18n %}
+
+{% block extrahead %}
+  {{ block.super }}
+
+  <script nonce="{{ request.admin_csp_nonce }}">
+    window.addEventListener("DOMContentLoaded", () => {
+        document.getElementById("roll_key_button")?.addEventListener("click", (event) => {
+            const url = window.prompt("Enter the URL where the key was exposed (optional). This will be included in the email sent to the user.");
+            if (url === null) {
+                // action was aborted
+                event.preventDefault();
+                return false;
+            }
+
+            const form = event.target.closest("form");
+            const urlField = form.querySelector('input[name="_roll_url"]');
+            urlField.value = url;
+        });
+    });
+  </script>
+{% endblock %}

--- a/posthog/templates/api_key_search/values.html
+++ b/posthog/templates/api_key_search/values.html
@@ -60,6 +60,9 @@
                             <th scope="col">
                                 <div class="text"><span>{% trans "Last Used" %}</span></div>
                             </th>
+                            <th scope="col">
+                                <div class="text"><span>{% trans "Last Rolled" %}</span></div>
+                            </th>
                         </tr>
                     </thead>
                     <tbody>
@@ -79,6 +82,7 @@
                             </td>
                             <td>{{ personal_api_key_object.created_at }}</td>
                             <td>{{ personal_api_key_object.last_used_at }}</td>
+                            <td>{{ personal_api_key_object.last_rolled_at }}</td>
                         </tr>
                     </tbody>
                 </table>

--- a/posthog/templates/api_key_search/values.html
+++ b/posthog/templates/api_key_search/values.html
@@ -101,7 +101,7 @@
                     <tbody>
                         <tr>
                             <td>
-                                Team Secret API Token
+                                Feature Flags Secure API Key
                                 {% if team_object_key_type == "backup" %}
                                 (Backup)
                                 {% endif %}

--- a/posthog/templates/email/personal_api_key_exposed.html
+++ b/posthog/templates/email/personal_api_key_exposed.html
@@ -1,0 +1,21 @@
+{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% block heading %}Personal API Key has been deactivated{% endblock %}
+{% block section %}
+<p>
+    Your Personal API Key <strong>{{ label }}</strong> with value <strong>{{ mask_value }}</strong> was publicly exposed.
+    {% if more_info %}{{ more_info }}{% endif %}
+</p>
+<p>
+    To protect your account, this key is no longer valid. You can reactivate this key by rolling it.
+</p>
+<div class="mb mt text-center">
+    <a class="button" href="{{ url }}">Roll your key</a>
+</div>
+
+<div class="mt">
+    <p>
+        If the button above doesn't work, paste this link into your browser:<br />
+        <a href="{{ url }}">{{ url }}</a>
+    </p>
+</div>
+{% endblock %} {% block preheader %}{{preheader}}{% endblock %}

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -167,7 +167,7 @@ urlpatterns = [
     opt_slash_path("_stats", stats),
     opt_slash_path("_preflight", preflight_check),
     re_path(r"^admin/redisvalues$", redis_values_view, name="redis_values"),
-    re_path(r"^admin/apikeysearch$", api_key_search_view, name="api_key_search"),
+    path(r"admin/apikeysearch", api_key_search_view, name="api_key_search"),
     # ee
     *ee_urlpatterns,
     # api

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -11,6 +11,7 @@ from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth import login
 from django.contrib.auth.decorators import login_required as base_login_required
 from django.db import DEFAULT_DB_ALIAS, connections
+from django.db.models import Q
 from django.db.migrations.executor import MigrationExecutor
 from django.http import HttpRequest, HttpResponse, HttpResponseNotAllowed, JsonResponse
 from django.shortcuts import redirect, render
@@ -286,15 +287,8 @@ def api_key_search_view(request: HttpRequest):
 
         try:
             # don't use the cache so that we can differentiate btwn the primary and the backup key
-            team_object = Team.objects.get(secret_api_token=query)
-            team_object_key_type = "primary"
-
-        except Team.DoesNotExist:
-            pass
-
-        try:
-            team_object = Team.objects.get(secret_api_token_backup=query)
-            team_object_key_type = "backup"
+            team_object = Team.objects.get(Q(secret_api_token=query) | Q(secret_api_token_backup=query))
+            team_object_key_type = "primary" if team_object.secret_api_token == query else "backup"
 
         except Team.DoesNotExist:
             pass


### PR DESCRIPTION
## Problem

PostHog staff sometimes come across a Personal API Key that was shared publicly online.

## Changes

Admin now provides a way to roll a Personal API Key. Staff can note the URL where the key was exposed, which will be included in the email sent to the user.

Much of this logic, include the email, will be reused by our GitHub Secrets Scanning integration.

<img width="754" height="639" alt="Screenshot 2025-08-07 at 15 31 20" src="https://github.com/user-attachments/assets/1e17f717-04ca-445e-834f-3b502d257c9e" />

<img width="350" height="435" alt="Screenshot 2025-08-07 at 15 31 41" src="https://github.com/user-attachments/assets/c6492dd6-2213-4bbf-9b32-e6a1f8636e49" />
