### PR TITLE
fix: don't load large related tables on Admin

### DIFF
--- a/posthog/admin/admins/batch_imports.py
+++ b/posthog/admin/admins/batch_imports.py
@@ -44,6 +44,7 @@ class BatchImportAdmin(admin.ModelAdmin):
     list_filter = ("status", "created_at")
     search_fields = ("id", "status_message", "team__name")
     readonly_fields = ("id", "created_at", "updated_at", "state", "import_config")
+    autocomplete_fields = ("team",)
     fieldsets = (
         (None, {"fields": ("team", "created_by_id", "status", "status_message")}),
         (

--- a/posthog/admin/admins/data_color_theme_admin.py
+++ b/posthog/admin/admins/data_color_theme_admin.py
@@ -12,6 +12,7 @@ class DataColorThemeAdmin(admin.ModelAdmin):
         "team_link",
     )
     readonly_fields = ("team",)
+    autocomplete_fields = ("created_by", "project")
 
     @admin.display(description="Team")
     def team_link(self, data_color_theme: DataColorTheme):

--- a/posthog/admin/admins/data_warehouse_table_admin.py
+++ b/posthog/admin/admins/data_warehouse_table_admin.py
@@ -20,6 +20,7 @@ class DataWarehouseTableAdmin(admin.ModelAdmin):
     list_select_related = ("team", "team__organization")
     search_fields = ("id", "name", "team__name", "team__organization__name")
     autocomplete_fields = ("team", "created_by")
+    readonly_fields = ("credential", "external_data_source")
     ordering = ("-created_at",)
 
     @admin.display(description="Team")

--- a/posthog/admin/admins/feature_flag_admin.py
+++ b/posthog/admin/admins/feature_flag_admin.py
@@ -16,7 +16,7 @@ class FeatureFlagAdmin(admin.ModelAdmin):
     list_display_links = ("id", "key")
     list_select_related = ("team", "team__organization")
     search_fields = ("id", "key", "team__name", "team__organization__name")
-    autocomplete_fields = ("team", "created_by")
+    autocomplete_fields = ("team", "created_by", "last_modified_by")
     ordering = ("-created_at",)
 
     @admin.display(description="Team")

--- a/posthog/admin/admins/group_type_mapping_admin.py
+++ b/posthog/admin/admins/group_type_mapping_admin.py
@@ -15,7 +15,7 @@ class GroupTypeMappingAdmin(admin.ModelAdmin):
     )
     list_select_related = ("team", "team__organization")
     search_fields = ("name_singular", "team__name", "team__organization__name")
-    readonly_fields = ("team", "project", "group_type", "group_type_index")
+    readonly_fields = ("team", "project", "group_type", "group_type_index", "detail_dashboard")
 
     @admin.display(description="Team")
     def team_link(self, group_type_mapping: GroupTypeMapping):

--- a/posthog/admin/admins/person_distinct_id_admin.py
+++ b/posthog/admin/admins/person_distinct_id_admin.py
@@ -9,3 +9,5 @@ class PersonDistinctIdAdmin(admin.ModelAdmin):
     list_display = ("id", "team", "distinct_id", "version")
     list_filter = ("version",)
     search_fields = ("id", "distinct_id")
+    readonly_fields = ("person",)
+    autocomplete_fields = ("team",)

--- a/posthog/admin/admins/survey_admin.py
+++ b/posthog/admin/admins/survey_admin.py
@@ -17,6 +17,7 @@ class SurveyAdmin(admin.ModelAdmin):
     list_select_related = ("team", "team__organization")
     search_fields = ("id", "name", "team__name", "team__organization__name")
     autocomplete_fields = ("team", "created_by")
+    readonly_fields = ("linked_flag", "targeting_flag", "internal_targeting_flag", "internal_response_sampling_flag")
     ordering = ("-created_at",)
 
     def get_form(self, request, obj=None, change=False, **kwargs):

--- a/products/links/backend/admin.py
+++ b/products/links/backend/admin.py
@@ -10,6 +10,7 @@ class LinkAdmin(admin.ModelAdmin):
     list_filter = ("team", "created_at", "updated_at")
     search_fields = ("id", "redirect_url", "team__name")
     readonly_fields = ("id", "created_at", "updated_at")
+    autocomplete_fields = ("team",)
     fieldsets = (
         (None, {"fields": ("id", "redirect_url", "short_link_domain", "short_code", "team")}),
         ("Dates", {"fields": ("created_at", "updated_at")}),


### PR DESCRIPTION
## Problem

By default, Django Admin loads all rows in a model's related tables and adds them to a select dropdown. This creates extremely slow Admin pages, in some cases timing out. It also adds a massive amount of info to the DOM.

## Changes

For models that implement `ModelAdmin`, we can autocomplete their values to prevent loading all rows. Models that don't yet implement `ModelAdmin` are instead displayed read-only.

## How did you test this code?

Manually!
