### PR TITLE
fix: remove Team from Links Admin filter list

### DIFF
--- a/products/links/backend/admin.py
+++ b/products/links/backend/admin.py
@@ -7,7 +7,7 @@ from posthog.models.link import Link
 
 class LinkAdmin(admin.ModelAdmin):
     list_display = ("id", "redirect_url_display", "team_link", "created_at", "updated_at")
-    list_filter = ("team", "created_at", "updated_at")
+    list_filter = ("created_at", "updated_at")
     search_fields = ("id", "redirect_url", "team__name")
     readonly_fields = ("id", "created_at", "updated_at")
     autocomplete_fields = ("team",)


### PR DESCRIPTION
## Problem

The filter list is loading all Teams in our database, which is incredibly slow.

This page takes tens of seconds to load for me: https://us.posthog.com/admin/posthog/link/

## Changes

The teams list is gone. Poof! It's too slow to ever be useful.