### PR TITLE
fix: remove expensive version list from PersonDistinctIdAdmin

### DIFF
--- a/posthog/admin/admins/person_distinct_id_admin.py
+++ b/posthog/admin/admins/person_distinct_id_admin.py
@@ -7,7 +7,6 @@ class PersonDistinctIdAdmin(admin.ModelAdmin):
     show_full_result_count = False  # prevent count() queries to show the no of filtered results
     paginator = NoCountPaginator  # prevent count() queries and return a fix page count instead
     list_display = ("id", "team", "distinct_id", "version")
-    list_filter = ("version",)
     search_fields = ("id", "distinct_id")
     readonly_fields = ("person",)
     autocomplete_fields = ("team",)


### PR DESCRIPTION
## Problem

This filter performs a full table scan to compute all DISTINCT values. I get a 504 when trying to load https://us.posthog.com/admin/posthog/persondistinctid/.

## Changes

The unique version list is gone from the changelist page. If this is needed, we can consider indexing this field (though that's likely inadvisable).
