### PR TITLE
fix: make remaining expensive `FeatureFlagAdmin` field read-only

### DIFF
--- a/posthog/admin/admins/feature_flag_admin.py
+++ b/posthog/admin/admins/feature_flag_admin.py
@@ -17,6 +17,7 @@ class FeatureFlagAdmin(admin.ModelAdmin):
     list_select_related = ("team", "team__organization")
     search_fields = ("id", "key", "team__name", "team__organization__name")
     autocomplete_fields = ("team", "created_by", "last_modified_by")
+    readonly_fields = ("usage_dashboard",)
     ordering = ("-created_at",)
 
     @admin.display(description="Team")


### PR DESCRIPTION
When editable, displaying this field requires loading all possible rows from the `FeatureFlagDashboards` table. Follow up to #36344.
