### PR TITLE
fix: Don't tag reviewers on draft PRs

### DIFF
--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -2,7 +2,7 @@ name: Auto Assign Reviewers
 
 on:
     pull_request:
-        types: [opened, synchronize]
+        types: [opened, synchronize, ready_for_review]
 
 permissions:
     contents: read
@@ -11,6 +11,7 @@ permissions:
 jobs:
     assign-reviewers:
         runs-on: 'ubuntu-22.04'
+        if: github.event.pull_request.draft == false
 
         steps:
             - name: Checkout repository


### PR DESCRIPTION
## Problem

We are tagging reviewers on draft PRs that are, by definition, not ready for review. Moreover, we are not tagging reviewers when the PR switches from draft to ready.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

The solution is unfortunately not ideal: We can skip the job if the PR is a draft, but that still spawns a runner and charges us, even though nothing happens.

Also added `ready_for_review` in the event types so that this triggers when changing status.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
