### PR TITLE
fix(max): problems with billing context

### DIFF
--- a/ee/hogai/graph/root/nodes.py
+++ b/ee/hogai/graph/root/nodes.py
@@ -326,10 +326,10 @@ class RootNode(RootNodeUIContextMixin):
         )
 
         ui_context = self._format_ui_context(self._get_ui_context(state), config)
-        has_billing_access, billing_context_prompt = self._get_billing_info(config)
+        should_add_billing_tool, billing_context_prompt = self._get_billing_info(config)
 
         chain = prompt | self._get_model(
-            state, config, extra_tools=["retrieve_billing_information"] if has_billing_access else []
+            state, config, extra_tools=["retrieve_billing_information"] if should_add_billing_tool else []
         )
 
         message = chain.invoke(
@@ -363,9 +363,9 @@ class RootNode(RootNodeUIContextMixin):
         )
 
     def _get_billing_info(self, config: RunnableConfig) -> tuple[bool, str]:
-        """Get billing information including access, prompt, and whether to include the tool.
+        """Get billing information including wheter to include the billing tool and the prompt.
         Returns:
-            Tuple[bool, str]: (has_access, prompt)
+            Tuple[bool, str]: (should_add_billing_tool, prompt)
         """
         has_billing_context = self._get_billing_context(config) is not None
 
@@ -382,7 +382,9 @@ class RootNode(RootNodeUIContextMixin):
             else ROOT_BILLING_CONTEXT_WITH_NO_ACCESS_PROMPT
         )
 
-        return has_access, prompt
+        should_add_billing_tool = has_access and has_billing_context
+
+        return should_add_billing_tool, prompt
 
     def _get_model(self, state: AssistantState, config: RunnableConfig, extra_tools: list[str] | None = None):
         if extra_tools is None:

--- a/ee/hogai/graph/root/prompts.py
+++ b/ee/hogai/graph/root/prompts.py
@@ -245,3 +245,9 @@ The user does not have admin access to view detailed billing information. They w
 In case the user asks to debug problems that relate to billing, suggest them to contact an admin.
 </billing_context>
 """.strip()
+
+ROOT_BILLING_CONTEXT_ERROR_PROMPT = """
+<billing_context>
+If the user asks about billing, their subscription, their usage, or their spending, suggest them to talk to PostHog support.
+</billing_context>
+""".strip()

--- a/posthog/temporal/ai/conversation.py
+++ b/posthog/temporal/ai/conversation.py
@@ -98,6 +98,7 @@ async def process_conversation_activity(inputs: AssistantConversationRunnerWorkf
         trace_id=inputs.trace_id,
         session_id=inputs.session_id,
         mode=inputs.mode,
+        billing_context=inputs.billing_context,
     )
 
     stream_key = get_conversation_stream_key(inputs.conversation_id)


### PR DESCRIPTION
## Problem
Bunch of problems would break Max's access to billing data.

## Changes
- Due to a wrong merge for some git conflicts, the `billing_context` was not sent to the `Assistant` class anymore
- The `/billing` endpoint actually only returns two fields (`active_product_features` and `product`), so the `BillingType` on the frontend was wrong, and this would crash the Pydantic serializer on the backend. I set all fields except for these two to optional, but the real fix would be to actually type the billing response on the frontend, use the schema generation to generate the related Python type, and use that in the `billing` endpoint to have a strongly typed internal API (although I understand this would still need to be kept in sync manually with the billing service)
- Add a small fallback prompt in case someone is an admin/owner and Max can't respond to billing questions
- Add information about the user's cloud deployment to the `MaxChatOpenAI` system prompt

## How did you test this code?
Locally talking to Max
