### PR TITLE
fix: remove OTP models from Admin and hide sensitive TOTP fields

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -44,6 +44,7 @@ ee/tasks/subscriptions/email_subscriptions.py:0: error: Item "None" of "User | N
 ee/tasks/subscriptions/email_subscriptions.py:0: error: Item "None" of "datetime | None" has no attribute "isoformat"  [union-attr]
 ee/tasks/subscriptions/email_subscriptions.py:0: error: Item "None" of "datetime | None" has no attribute "strftime"  [union-attr]
 ee/tasks/subscriptions/slack_subscriptions.py:0: error: Item "None" of "datetime | None" has no attribute "strftime"  [union-attr]
+ee/urls.py:0: error: Module "django.contrib.admin.sites" has no attribute "NotRegistered"  [attr-defined]
 posthog/admin/admins/plugin_admin.py:0: error: Item "None" of "Organization | None" has no attribute "name"  [union-attr]
 posthog/admin/admins/plugin_admin.py:0: error: Item "None" of "Organization | None" has no attribute "pk"  [union-attr]
 posthog/admin/admins/plugin_config_admin.py:0: error: Item "None" of "Team | None" has no attribute "name"  [union-attr]

--- a/posthog/admin/inlines/totp_device_inline.py
+++ b/posthog/admin/inlines/totp_device_inline.py
@@ -5,3 +5,5 @@ from django_otp.plugins.otp_totp.models import TOTPDevice
 class TOTPDeviceInline(admin.TabularInline):
     model = TOTPDevice
     extra = 0
+    # only include non-sensitive fields
+    fields = ("name", "confirmed", "throttling_failure_timestamp", "throttling_failure_count", "last_used_at")


### PR DESCRIPTION
## Problem

These models are sensitive and don't need to be exposed to staff.

## Changes

OTP models are no longer available. OTP devices can still be viewed and deleted on User Admin, but cannot otherwise be modified.

<img width="1099" height="298" alt="Screenshot 2025-08-08 at 09 51 52" src="https://github.com/user-attachments/assets/e9fcb6a2-d152-41f4-b73d-d8eb15610c62" />

## How did you test this code?

Manually!