### PR TITLE
fix: remove Roll button from PersonalAPIKey list view

### DIFF
--- a/posthog/admin/admins/personal_api_key_admin.py
+++ b/posthog/admin/admins/personal_api_key_admin.py
@@ -31,7 +31,7 @@ class PersonalAPIKeyAdmin(admin.ModelAdmin):
         "user",
         "roll_action",
     )
-    list_display = ("id", "label", "mask_value", "user_link", "created_at", "last_used_at", "scopes", "roll_action")
+    list_display = ("id", "label", "mask_value", "user_link", "created_at", "last_used_at", "scopes")
     list_display_links = ("id", "label")
     list_select_related = ("user",)
     search_fields = ("id", "user__email", "scopes")


### PR DESCRIPTION
Follow up to #36339. This field accidentally snuck in to the list view, which I decided against. It's still accessible on the individual Personal API Key page.
