### PR TITLE
fix(experiments): hide details dialog on single metric.

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -62,6 +62,22 @@ const ResultsTab = (): JSX.Element => {
 
     const hasLegacyResults = legacyPrimaryMetricsResults.some((result) => result != null)
 
+    /**
+     * Show a detailed results if:
+     * - there's a single primary metric
+     * - if the metric has insight results
+     * - if we have the minimum number of exposures
+     * - if it's the first primary metric (?)
+     *
+     * this is only for legacy experiments.
+     */
+    const showResultDetails =
+        hasSomeResults &&
+        hasMinimumExposureForResults &&
+        hasSinglePrimaryMetric &&
+        firstPrimaryMetric &&
+        firstPrimaryMetricResult
+
     return (
         <>
             {!experiment.start_date && !primaryMetricsResultsLoading && (
@@ -85,77 +101,64 @@ const ResultsTab = (): JSX.Element => {
             {isLegacyExperiment(experiment) || hasLegacyResults ? (
                 <>
                     <MetricsViewLegacy isSecondary={false} />
-                    {/**
-                     * Show a detailed results if:
-                     * - there's a single primary metric
-                     * - if the metric has insight results
-                     * - if we have the minimum number of exposures
-                     * - if it's the first primary metric (?)
-                     */}
-                    {hasSomeResults &&
-                        hasMinimumExposureForResults &&
-                        hasSinglePrimaryMetric &&
-                        firstPrimaryMetric &&
-                        firstPrimaryMetricResult && (
-                            <div>
-                                <div className="pb-4">
-                                    <SummaryTable metric={firstPrimaryMetric} metricIndex={0} isSecondary={false} />
-                                </div>
-                                {isLegacyExperimentQuery(firstPrimaryMetricResult) ? (
-                                    <>
-                                        <div className="flex justify-end">
-                                            <LegacyExploreButton result={firstPrimaryMetricResult} size="xsmall" />
-                                        </div>
-                                        <div className="pb-4">
-                                            <LegacyResultsQuery
-                                                result={firstPrimaryMetricResult || null}
-                                                showTable={true}
-                                            />
-                                        </div>
-                                    </>
-                                ) : (
-                                    /**
-                                     * altough we don't have a great typeguard here, we know that the result is a CachedExperimentQueryResponse
-                                     * because we're only showing results for experiment queries (legacy check)
-                                     */
-                                    <ResultsBreakdown
-                                        result={firstPrimaryMetricResult as CachedExperimentQueryResponse}
-                                        experiment={experiment}
-                                        metricIndex={0}
-                                        isPrimary={true}
-                                    >
-                                        {({
-                                            query,
-                                            breakdownResults,
-                                            breakdownResultsLoading,
-                                            exposureDifference,
-                                            breakdownLastRefresh,
-                                        }) => (
-                                            <div>
-                                                {breakdownResultsLoading && <ResultsBreakdownSkeleton />}
-                                                {query && breakdownResults && (
-                                                    <div>
-                                                        <div className="flex justify-end">
-                                                            <ExploreAsInsightButton query={query} />
-                                                        </div>
-                                                        <ResultsInsightInfoBanner
-                                                            exposureDifference={exposureDifference}
-                                                        />
-                                                        <div className="pb-4">
-                                                            <ResultsQuery
-                                                                query={query}
-                                                                breakdownResults={breakdownResults}
-                                                                breakdownLastRefresh={breakdownLastRefresh}
-                                                            />
-                                                        </div>
-                                                    </div>
-                                                )}
-                                            </div>
-                                        )}
-                                    </ResultsBreakdown>
-                                )}
+                    {showResultDetails && (
+                        <div>
+                            <div className="pb-4">
+                                <SummaryTable metric={firstPrimaryMetric} metricIndex={0} isSecondary={false} />
                             </div>
-                        )}
+                            {isLegacyExperimentQuery(firstPrimaryMetricResult) ? (
+                                <>
+                                    <div className="flex justify-end">
+                                        <LegacyExploreButton result={firstPrimaryMetricResult} size="xsmall" />
+                                    </div>
+                                    <div className="pb-4">
+                                        <LegacyResultsQuery
+                                            result={firstPrimaryMetricResult || null}
+                                            showTable={true}
+                                        />
+                                    </div>
+                                </>
+                            ) : (
+                                /**
+                                 * altough we don't have a great typeguard here, we know that the result is a CachedExperimentQueryResponse
+                                 * because we're only showing results for experiment queries (legacy check)
+                                 */
+                                <ResultsBreakdown
+                                    result={firstPrimaryMetricResult as CachedExperimentQueryResponse}
+                                    experiment={experiment}
+                                    metricIndex={0}
+                                    isPrimary={true}
+                                >
+                                    {({
+                                        query,
+                                        breakdownResults,
+                                        breakdownResultsLoading,
+                                        exposureDifference,
+                                        breakdownLastRefresh,
+                                    }) => (
+                                        <div>
+                                            {breakdownResultsLoading && <ResultsBreakdownSkeleton />}
+                                            {query && breakdownResults && (
+                                                <div>
+                                                    <div className="flex justify-end">
+                                                        <ExploreAsInsightButton query={query} />
+                                                    </div>
+                                                    <ResultsInsightInfoBanner exposureDifference={exposureDifference} />
+                                                    <div className="pb-4">
+                                                        <ResultsQuery
+                                                            query={query}
+                                                            breakdownResults={breakdownResults}
+                                                            breakdownLastRefresh={breakdownLastRefresh}
+                                                        />
+                                                    </div>
+                                                </div>
+                                            )}
+                                        </div>
+                                    )}
+                                </ResultsBreakdown>
+                            )}
+                        </div>
+                    )}
                     <MetricsViewLegacy isSecondary={true} />
                 </>
             ) : (

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -11,9 +11,9 @@ import { useChartColors } from '../shared/colors'
 import { MetricHeader } from '../shared/MetricHeader'
 import {
     formatDeltaPercent,
-    isSignificant,
-    isDeltaPositive,
     getNiceTickValues,
+    isDeltaPositive,
+    isSignificant,
     type ExperimentVariantResult,
 } from '../shared/utils'
 import { ChartCell } from './ChartCell'
@@ -46,7 +46,7 @@ interface MetricRowGroupProps {
     error?: any
     isLoading?: boolean
     hasMinimumExposureForResults?: boolean
-    shouldHideDetails?: boolean
+    showDetailsModal: boolean
 }
 
 export function MetricRowGroup({
@@ -64,7 +64,7 @@ export function MetricRowGroup({
     error,
     isLoading,
     hasMinimumExposureForResults = true,
-    shouldHideDetails = false,
+    showDetailsModal,
 }: MetricRowGroupProps): JSX.Element {
     const [isModalOpen, setIsModalOpen] = useState(false)
     const [tooltipState, setTooltipState] = useState<{
@@ -285,7 +285,7 @@ export function MetricRowGroup({
                         maxHeight: `${CELL_HEIGHT * totalRows}px`,
                     }}
                 >
-                    {!shouldHideDetails && (
+                    {showDetailsModal && (
                         <>
                             <div className="flex justify-end">
                                 <DetailsButton metric={metric} setIsModalOpen={setIsModalOpen} />

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -46,6 +46,7 @@ interface MetricRowGroupProps {
     error?: any
     isLoading?: boolean
     hasMinimumExposureForResults?: boolean
+    shouldHideDetails?: boolean
 }
 
 export function MetricRowGroup({
@@ -63,6 +64,7 @@ export function MetricRowGroup({
     error,
     isLoading,
     hasMinimumExposureForResults = true,
+    shouldHideDetails = false,
 }: MetricRowGroupProps): JSX.Element {
     const [isModalOpen, setIsModalOpen] = useState(false)
     const [tooltipState, setTooltipState] = useState<{
@@ -283,18 +285,22 @@ export function MetricRowGroup({
                         maxHeight: `${CELL_HEIGHT * totalRows}px`,
                     }}
                 >
-                    <div className="flex justify-end">
-                        <DetailsButton metric={metric} setIsModalOpen={setIsModalOpen} />
-                    </div>
-                    <DetailsModal
-                        isOpen={isModalOpen}
-                        onClose={() => setIsModalOpen(false)}
-                        metric={metric}
-                        result={result}
-                        experiment={experiment}
-                        metricIndex={metricIndex}
-                        isSecondary={isSecondary}
-                    />
+                    {!shouldHideDetails && (
+                        <>
+                            <div className="flex justify-end">
+                                <DetailsButton metric={metric} setIsModalOpen={setIsModalOpen} />
+                            </div>
+                            <DetailsModal
+                                isOpen={isModalOpen}
+                                onClose={() => setIsModalOpen(false)}
+                                metric={metric}
+                                result={result}
+                                experiment={experiment}
+                                metricIndex={metricIndex}
+                                isSecondary={isSecondary}
+                            />
+                        </>
+                    )}
                 </td>
 
                 {/* Chart (grid lines only for baseline) */}

--- a/frontend/src/scenes/experiments/MetricsView/new/Metrics.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/Metrics.tsx
@@ -8,8 +8,8 @@ import { ExperimentMetric } from '~/queries/schema/schema-general'
 import { EXPERIMENT_MAX_PRIMARY_METRICS, EXPERIMENT_MAX_SECONDARY_METRICS } from 'scenes/experiments/constants'
 import { experimentLogic } from '../../experimentLogic'
 import { AddPrimaryMetric, AddSecondaryMetric } from '../shared/AddMetric'
-import { ResultDetails } from './ResultDetails'
 import { MetricsTable } from './MetricsTable'
+import { ResultDetails } from './ResultDetails'
 
 export function Metrics({ isSecondary }: { isSecondary?: boolean }): JSX.Element {
     const {
@@ -45,6 +45,8 @@ export function Metrics({ isSecondary }: { isSecondary?: boolean }): JSX.Element
     if (sharedMetrics) {
         metrics = [...metrics, ...sharedMetrics]
     }
+
+    const showResultDetails = metrics.length === 1 && results[0] && hasMinimumExposureForResults && !isSecondary
 
     return (
         <div className="mb-4 -mt-2">
@@ -86,8 +88,9 @@ export function Metrics({ isSecondary }: { isSecondary?: boolean }): JSX.Element
                         errors={errors}
                         isSecondary={!!isSecondary}
                         getInsightType={getInsightType}
+                        showDetailsModal={!showResultDetails}
                     />
-                    {metrics.length === 1 && results[0] && hasMinimumExposureForResults && !isSecondary && (
+                    {showResultDetails && (
                         <div className="mt-4">
                             <ResultDetails
                                 metric={metrics[0] as ExperimentMetric}

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx
@@ -18,6 +18,7 @@ interface MetricsTableProps {
     errors: any[]
     isSecondary: boolean
     getInsightType: (metric: ExperimentMetric | ExperimentTrendsQuery | ExperimentFunnelsQuery) => InsightType
+    showDetailsModal?: boolean
 }
 
 export function MetricsTable({
@@ -26,6 +27,7 @@ export function MetricsTable({
     errors,
     isSecondary,
     getInsightType,
+    showDetailsModal = true,
 }: MetricsTableProps): JSX.Element {
     const {
         experiment,
@@ -83,14 +85,6 @@ export function MetricsTable({
 
                         const isLoading = !result && !error && !!experiment.start_date
 
-                        // Hide details button/modal when ResultsBreakdown is shown for single primary funnel metrics
-                        const shouldHideDetails =
-                            !isSecondary &&
-                            metrics.length === 1 &&
-                            metric.metric_type === 'funnel' &&
-                            result &&
-                            hasMinimumExposureForResults
-
                         return (
                             <MetricRowGroup
                                 key={metricIndex}
@@ -111,7 +105,7 @@ export function MetricsTable({
                                 error={error}
                                 isLoading={isLoading}
                                 hasMinimumExposureForResults={hasMinimumExposureForResults}
-                                shouldHideDetails={shouldHideDetails}
+                                showDetailsModal={showDetailsModal}
                             />
                         )
                     })}

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx
@@ -1,8 +1,4 @@
 import { useActions, useValues } from 'kea'
-import { TableHeader } from './TableHeader'
-import { MetricRowGroup } from './MetricRowGroup'
-import { getVariantInterval, type ExperimentVariantResult } from '../shared/utils'
-import { experimentLogic } from '../../experimentLogic'
 import { EXPERIMENT_MAX_PRIMARY_METRICS, EXPERIMENT_MAX_SECONDARY_METRICS } from 'scenes/experiments/constants'
 import {
     ExperimentFunnelsQuery,
@@ -11,6 +7,10 @@ import {
     NewExperimentQueryResponse,
 } from '~/queries/schema/schema-general'
 import { InsightType } from '~/types'
+import { experimentLogic } from '../../experimentLogic'
+import { getVariantInterval, type ExperimentVariantResult } from '../shared/utils'
+import { MetricRowGroup } from './MetricRowGroup'
+import { TableHeader } from './TableHeader'
 
 interface MetricsTableProps {
     metrics: ExperimentMetric[]
@@ -83,6 +83,14 @@ export function MetricsTable({
 
                         const isLoading = !result && !error && !!experiment.start_date
 
+                        // Hide details button/modal when ResultsBreakdown is shown for single primary funnel metrics
+                        const shouldHideDetails =
+                            !isSecondary &&
+                            metrics.length === 1 &&
+                            metric.metric_type === 'funnel' &&
+                            result &&
+                            hasMinimumExposureForResults
+
                         return (
                             <MetricRowGroup
                                 key={metricIndex}
@@ -103,6 +111,7 @@ export function MetricsTable({
                                 error={error}
                                 isLoading={isLoading}
                                 hasMinimumExposureForResults={hasMinimumExposureForResults}
+                                shouldHideDetails={shouldHideDetails}
                             />
                         )
                     })}


### PR DESCRIPTION
## Problem

On the metric row, we show a _Details_ button that opens a dialog showing the results breakdown, but when the experiment has a single metric, we load the breakdown directly on the experiment page, so the dialog is redundant.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We hide the _Details_ button and dialog when the experiment has a single primary metric.

| Before | After |
| - | - |
| <img width="1330" height="984" alt="image" src="https://github.com/user-attachments/assets/09b579bd-7db9-4d44-8a96-10706a0d1aee" /> | <img width="1329" height="990" alt="image" src="https://github.com/user-attachments/assets/3be0e212-c429-48c1-82e0-a6ddf07e36d4" /> |


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/2b83794c-1e64-4db2-8834-a1ce8bab62b5)
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
