### PR TITLE
chore: remove acks_late option from query metadata task

### DIFF
--- a/posthog/tasks/insight_query_metadata.py
+++ b/posthog/tasks/insight_query_metadata.py
@@ -12,7 +12,6 @@ logger = structlog.get_logger(__name__)
     ignore_result=True,
     queue=CeleryQueue.LONG_RUNNING.value,
     max_retries=1,
-    acks_late=True,
     reject_on_worker_lost=True,
     track_started=True,
     default_retry_delay=10 * 60,  # 10 minutes


### PR DESCRIPTION
## Problem

This task is being run multiple times for every insight. This isn't a problem by itself because it's idempotent but it's unnecessarily blocking the queue.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Removes the acks_late option so the task is removed from the queue once the worker has it. This increases the chance of the task being lost in case of OOM or other worker failures but we should be fine since we now have a reconciliation task that goes back and fixes things.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
