### PR TITLE
feat: extra metrics to livestream, bump to go1.24.6

### DIFF
--- a/.github/workflows/ci-livestream.yml
+++ b/.github/workflows/ci-livestream.yml
@@ -16,7 +16,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
               with:
-                  go-version: 1.22
+                  go-version: 1.24
 
             - name: Run tests
               run: cd livestream && go test -v

--- a/livestream/Dockerfile
+++ b/livestream/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.4 AS builder
+FROM golang:1.24.6 AS builder
 WORKDIR /code
 COPY go.sum go.mod ./
 RUN go mod download -x

--- a/livestream/events/kafka.go
+++ b/livestream/events/kafka.go
@@ -185,3 +185,7 @@ func (c *PostHogKafkaConsumer) Close() {
 	}
 	close(c.incoming)
 }
+
+func (c *PostHogKafkaConsumer) IncomingRatio() float64 {
+	return float64(len(c.incoming)) / float64(cap(c.incoming))
+}

--- a/livestream/handlers/handlers.go
+++ b/livestream/handlers/handlers.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/posthog/posthog/livestream/auth"
@@ -111,9 +112,12 @@ func StreamEventsHandler(log echo.Logger, subChan chan events.Subscription, filt
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.Header().Set("Cache-Control", "no-cache")
 		w.Header().Set("Connection", "keep-alive")
-
+		timeout := time.After(30 * time.Minute)
 		for {
 			select {
+			case <-timeout:
+				log.Debug("SSE connection to be terminated after timeout")
+				return nil
 			case <-c.Request().Context().Done():
 				log.Debugf("SSE client disconnected, ip: %v", c.RealIP())
 				return nil

--- a/livestream/metrics/metrics.go
+++ b/livestream/metrics/metrics.go
@@ -39,7 +39,7 @@ var (
 		Help: "How much of stats queue is used",
 	})
 	SubQueue = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "livestream_sub_queue_ratio",
+		Name: "livestream_sub_queue_use_ratio",
 		Help: "How much of sub queue is used (a connection create subscription)",
 	})
 	UnSubQueue = promauto.NewGauge(prometheus.GaugeOpts{

--- a/livestream/metrics/metrics.go
+++ b/livestream/metrics/metrics.go
@@ -25,4 +25,25 @@ var (
 		Name: "livestream_ph_events_total",
 		Help: "The total number of handled PostHog events, less than or equal to consumed",
 	})
+
+	IncomingQueue = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "livestream_incoming_queue_use_ratio",
+		Help: "How much of incoming queue is used",
+	})
+	EventQueue = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "livestream_event_queue_use_ratio",
+		Help: "How much of parsed event queue is used",
+	})
+	StatsQueue = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "livestream_stats_queue_use_ratio",
+		Help: "How much of stats queue is used",
+	})
+	SubQueue = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "livestream_sub_queue_ratio",
+		Help: "How much of sub queue is used (a connection create subscription)",
+	})
+	UnSubQueue = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "livestream_unsub_queue_use_ratio",
+		Help: "How much of unsub queue is used (disconnecting removes subscription)",
+	})
 )


### PR DESCRIPTION
## Problem

We don't now what is causing livestream bottlenecks

## Changes

Add metrics to monitor internal queues.