### PR TITLE
fix: make expensive Survey admin field read-only

### DIFF
--- a/posthog/admin/admins/survey_admin.py
+++ b/posthog/admin/admins/survey_admin.py
@@ -20,6 +20,13 @@ class SurveyAdmin(admin.ModelAdmin):
     readonly_fields = ("linked_flag", "targeting_flag", "internal_targeting_flag", "internal_response_sampling_flag")
     ordering = ("-created_at",)
 
+    def get_readonly_fields(self, request, obj=None):
+        readonly_fields = list(super().get_readonly_fields(request, obj))
+        # only on individual change page
+        if obj:
+            readonly_fields.append("actions")
+        return readonly_fields
+
     def get_form(self, request, obj=None, change=False, **kwargs):
         form = super().get_form(request, obj, **kwargs)
         for field in [
@@ -33,7 +40,8 @@ class SurveyAdmin(admin.ModelAdmin):
             "current_iteration_start_date",
             "actions",
         ]:
-            form.base_fields[field].required = False
+            if field in form.base_fields:
+                form.base_fields[field].required = False
         return form
 
     @admin.display(description="Team")


### PR DESCRIPTION
The final extremely slow Admin field. This one was a little tricky because the field doesn't exist directly on the `Survey` model - it exists on the `SurveyActions` model.
