### PR TITLE
docs: Update Golang code snippets for the "Feature" section

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentCodeSnippets.tsx
+++ b/frontend/src/scenes/experiments/ExperimentCodeSnippets.tsx
@@ -161,13 +161,14 @@ export function GolangSnippet({ flagKey, variant }: SnippetProps): JSX.Element {
     return (
         <>
             <CodeSnippet language={Language.Go} wrap>
-                {`experimentFlagValue, err := client.GetFeatureFlag(
-                    FeatureFlagPayload{
-                        Key:        '${flagKey}',
-                        DistinctId: "distinct-id",
-                    })
-
-if (experimentFlagValue == '${variant}' ) {
+                {`experimentFlagValue, err := client.GetFeatureFlag(posthog.FeatureFlagPayload{
+    Key:        '${flagKey}',
+    DistinctId: "distinct-id",
+})
+if err != nil {
+    // Handle error (e.g. capture error and fallback to default behaviour)
+}
+if experimentFlagValue == '${variant}' {
     // Do something differently for this user
 } else {
     // It's a good idea to let control variant always be the default behaviour,


### PR DESCRIPTION
## Problem

Whilst reading the documentation about feature flags and experiments, I noticed that some of the Go snippets were missing the `posthog.` import prefix and/or were ignoring error handling. In order to improve the potential first impressions / copyability of the code, I quickly updated them to help out future readers. 

The indentation adjustments are solely for the sake of aligning with the other code samples, I've included screenshots below to show how it renders, but happy to leave the indentation as is if that is your preferred style 😃 ! 

I've also noticed it was listed as an issue in the [Golang SDK](https://github.com/PostHog/posthog-go), therefore, this update also closes https://github.com/PostHog/posthog-go/issues/114.

I have also submitted PRs for fixes in the [posthog.com repo](https://github.com/PostHog/posthog.com), and the [posthog-go repo](https://github.com/PostHog/posthog-go) so everything is aligned:

- https://github.com/PostHog/posthog.com/pull/12407
- https://github.com/PostHog/posthog-go/pull/119

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

**Rendering of the feature-flag sample Go code:**
<img width="1177" height="1189" alt="Scherm­afbeelding 2025-08-10 om 19 50 59" src="https://github.com/user-attachments/assets/d1357a52-9d6c-4af2-bbf5-ef4e29003ded" />

**Rendering of the feature-flag sample Go code with local evaluation options enabled:**
<img width="1180" height="1187" alt="Scherm­afbeelding 2025-08-10 om 19 50 54" src="https://github.com/user-attachments/assets/08b1b868-4abe-4987-90d0-fae82f21c0ca" />

**Rendering of the experiment sample Go code:**
<img width="1183" height="1147" alt="Scherm­afbeelding 2025-08-10 om 19 48 38" src="https://github.com/user-attachments/assets/f8440345-ad89-4bb6-929c-3e21ac411518" />

## How did you test this code?

I ran the PostHog system locally in order to observe how the changes in documentation would render on the pages. Please refer to the screenshots above to see. 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
