### PR TITLE
feat(activity-logs): Add AlertConfiguration as a tracked scope

### DIFF
--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lib/components/ActivityLog/humanizeActivity'
 import { ACTIVITY_PAGE_SIZE } from 'lib/constants'
 import { PaginationManual } from 'lib/lemon-ui/PaginationControl'
+import { alertConfigurationActivityDescriber } from 'scenes/alerts/activityDescriptions'
 import { annotationActivityDescriber } from 'scenes/annotations/activityDescriptions'
 import { cohortActivityDescriber } from 'scenes/cohorts/activityDescriptions'
 import { dataManagementActivityDescriber } from 'scenes/data-management/dataManagementDescribers'
@@ -40,6 +41,8 @@ import type { activityLogLogicType } from './activityLogLogicType'
  * **/
 export const describerFor = (logItem?: ActivityLogItem): Describer | undefined => {
     switch (logItem?.scope) {
+        case ActivityScope.ALERT_CONFIGURATION:
+            return alertConfigurationActivityDescriber
         case ActivityScope.ANNOTATION:
             return annotationActivityDescriber
         case ActivityScope.FEATURE_FLAG:

--- a/frontend/src/lib/components/ActivityLog/humanizeActivity.tsx
+++ b/frontend/src/lib/components/ActivityLog/humanizeActivity.tsx
@@ -131,7 +131,17 @@ const NO_PLURAL_SCOPES: ActivityScope[] = [
     ActivityScope.PROPERTY_DEFINITION,
 ]
 
+const SCOPE_DISPLAY_NAMES: Partial<Record<ActivityScope, { singular: string; plural: string }>> = {
+    [ActivityScope.ALERT_CONFIGURATION]: { singular: 'Alert', plural: 'Alerts' },
+}
+
 export function humanizeScope(scope: ActivityScope | string, singular = false): string {
+    const customName = SCOPE_DISPLAY_NAMES[scope as ActivityScope]
+    if (customName) {
+        return singular ? customName.singular : customName.plural
+    }
+
+    // Default behavior: split camelCase and add plural 's'
     let output = scope.split(/(?=[A-Z])/).join(' ')
 
     if (!singular && !NO_PLURAL_SCOPES.includes(scope as ActivityScope)) {

--- a/frontend/src/scenes/alerts/activityDescriptions.tsx
+++ b/frontend/src/scenes/alerts/activityDescriptions.tsx
@@ -49,9 +49,11 @@ export function alertConfigurationActivityDescriber(
             return {
                 description: (
                     <>
-                        <strong>{userNameForLogItem(logItem)}</strong> added {logItem?.detail?.context?.subscriber_name}{' '}
-                        ({logItem?.detail?.context?.subscriber_email}) as a subscriber for alert{' '}
-                        {formattedName(logItem?.detail?.context?.alert_name)}
+                        <strong>{userNameForLogItem(logItem)}</strong> added{' '}
+                        <strong>
+                            {logItem?.detail?.context?.subscriber_name} ({logItem?.detail?.context?.subscriber_email})
+                        </strong>{' '}
+                        as a subscriber for alert {formattedName(logItem?.detail?.context?.alert_name)}
                         {contextDesc}
                     </>
                 ),
@@ -77,8 +79,10 @@ export function alertConfigurationActivityDescriber(
                 description: (
                     <>
                         <strong>{userNameForLogItem(logItem)}</strong> removed{' '}
-                        {logItem?.detail?.context?.subscriber_name} ({logItem?.detail?.context?.subscriber_email}) as a
-                        subscriber from alert {formattedName(logItem?.detail?.context?.alert_name)}
+                        <strong>
+                            {logItem?.detail?.context?.subscriber_name} ({logItem?.detail?.context?.subscriber_email})
+                        </strong>{' '}
+                        as a subscriber from alert {formattedName(logItem?.detail?.context?.alert_name)}
                         {contextDesc}
                     </>
                 ),

--- a/frontend/src/scenes/alerts/activityDescriptions.tsx
+++ b/frontend/src/scenes/alerts/activityDescriptions.tsx
@@ -44,6 +44,20 @@ export function alertConfigurationActivityDescriber(
 
     if (logItem.activity == 'created') {
         const contextDesc = getContextDescription(logItem?.detail?.context)
+
+        if (logItem.detail?.type === 'alert_subscription_change') {
+            return {
+                description: (
+                    <>
+                        <strong>{userNameForLogItem(logItem)}</strong> added {logItem?.detail?.context?.subscriber_name}{' '}
+                        ({logItem?.detail?.context?.subscriber_email}) as a subscriber for alert{' '}
+                        {formattedName(logItem?.detail?.context?.alert_name)}
+                        {contextDesc}
+                    </>
+                ),
+            }
+        }
+
         return {
             description: (
                 <>
@@ -56,8 +70,22 @@ export function alertConfigurationActivityDescriber(
     }
 
     if (logItem.activity == 'deleted') {
-        const displayName = logItem.detail.name || 'Alert Configuration'
         const contextDesc = getContextDescription(logItem?.detail?.context)
+
+        if (logItem.detail?.type === 'alert_subscription_change') {
+            return {
+                description: (
+                    <>
+                        <strong>{userNameForLogItem(logItem)}</strong> removed{' '}
+                        {logItem?.detail?.context?.subscriber_name} ({logItem?.detail?.context?.subscriber_email}) as a
+                        subscriber from alert {formattedName(logItem?.detail?.context?.alert_name)}
+                        {contextDesc}
+                    </>
+                ),
+            }
+        }
+
+        const displayName = logItem.detail.name || 'Alert Configuration'
         return {
             description: (
                 <>
@@ -76,7 +104,7 @@ export function alertConfigurationActivityDescriber(
                 description: (
                     <>
                         <strong>{userNameForLogItem(logItem)}</strong> updated the <strong>threshold</strong> for alert{' '}
-                        {formattedName(logItem?.detail.name)}
+                        {formattedName(logItem?.detail?.context?.alert_name)}
                         {contextDesc}
                     </>
                 ),

--- a/frontend/src/scenes/alerts/activityDescriptions.tsx
+++ b/frontend/src/scenes/alerts/activityDescriptions.tsx
@@ -1,0 +1,98 @@
+import {
+    ActivityLogItem,
+    defaultDescriber,
+    HumanizedChange,
+    userNameForLogItem,
+} from 'lib/components/ActivityLog/humanizeActivity'
+import { Link } from 'lib/lemon-ui/Link'
+import { urls } from 'scenes/urls'
+
+const formattedName = (name?: string | null): string | JSX.Element => {
+    const displayName = name
+
+    return <strong>{displayName}</strong>
+}
+
+const getContextDescription = (context: any): JSX.Element | null => {
+    if (!context) {
+        return null
+    }
+
+    if (context.insight_id && context.insight_short_id) {
+        return (
+            <>
+                {' '}
+                for insight{' '}
+                <Link to={urls.insightView(context.insight_short_id)}>
+                    {context.insight_name || context.insight_short_id}
+                </Link>
+            </>
+        )
+    }
+
+    return null
+}
+
+export function alertConfigurationActivityDescriber(
+    logItem: ActivityLogItem,
+    asNotification?: boolean
+): HumanizedChange {
+    if (logItem.scope != 'AlertConfiguration') {
+        console.error('alert configuration describer received a non-alert-configuration activity')
+        return { description: null }
+    }
+
+    if (logItem.activity == 'created') {
+        const contextDesc = getContextDescription(logItem?.detail?.context)
+        return {
+            description: (
+                <>
+                    <strong>{userNameForLogItem(logItem)}</strong> created the alert{' '}
+                    {formattedName(logItem?.detail.name)}
+                    {contextDesc}
+                </>
+            ),
+        }
+    }
+
+    if (logItem.activity == 'deleted') {
+        const displayName = logItem.detail.name || 'Alert Configuration'
+        const contextDesc = getContextDescription(logItem?.detail?.context)
+        return {
+            description: (
+                <>
+                    <strong>{userNameForLogItem(logItem)}</strong> deleted the alert: {displayName}
+                    {contextDesc}
+                </>
+            ),
+        }
+    }
+
+    if (logItem.activity == 'updated') {
+        const contextDesc = getContextDescription(logItem?.detail?.context)
+
+        if (logItem.detail?.type === 'threshold_change') {
+            return {
+                description: (
+                    <>
+                        <strong>{userNameForLogItem(logItem)}</strong> updated the <strong>threshold</strong> for alert{' '}
+                        {formattedName(logItem?.detail.name)}
+                        {contextDesc}
+                    </>
+                ),
+            }
+        }
+
+        return {
+            description: (
+                <>
+                    <strong>{userNameForLogItem(logItem)}</strong> updated the alert{' '}
+                    {formattedName(logItem?.detail.name)}
+                    {contextDesc}
+                </>
+            ),
+        }
+    }
+
+    return defaultDescriber(logItem, asNotification, formattedName(logItem?.detail.name))
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4494,6 +4494,7 @@ export type PromptFlag = {
 // Should be kept in sync with "posthog/models/activity_logging/activity_log.py"
 export enum ActivityScope {
     ACTION = 'Action',
+    ALERT_CONFIGURATION = 'AlertConfiguration',
     ANNOTATION = 'Annotation',
     FEATURE_FLAG = 'FeatureFlag',
     PERSON = 'Person',

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -1,3 +1,5 @@
+import dataclasses
+from typing import Optional
 from rest_framework import serializers, viewsets
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
@@ -19,6 +21,9 @@ from posthog.api.insight import InsightBasicSerializer
 from posthog.utils import relative_date_parse
 from zoneinfo import ZoneInfo
 from posthog.constants import AvailableFeature
+from posthog.models.activity_logging.activity_log import Detail, log_activity, changes_between, ActivityContextBase
+from posthog.models.signals import model_activity_signal
+from django.dispatch import receiver
 
 
 class ThresholdSerializer(serializers.ModelSerializer):
@@ -321,3 +326,64 @@ class ThresholdViewSet(TeamAndOrgViewSetMixin, viewsets.ReadOnlyModelViewSet):
     scope_object = "INTERNAL"
     queryset = Threshold.objects.all()
     serializer_class = ThresholdWithAlertSerializer
+
+
+@dataclasses.dataclass(frozen=True)
+class AlertConfigurationContext(ActivityContextBase):
+    insight_id: Optional[int] = None
+    insight_short_id: Optional[str] = None
+    insight_name: Optional[str] = None
+
+
+@receiver(model_activity_signal, sender=AlertConfiguration)
+def handle_alert_configuration_change(
+    sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
+):
+    log_activity(
+        organization_id=after_update.team.organization_id,
+        team_id=after_update.team_id,
+        user=user,
+        was_impersonated=was_impersonated,
+        item_id=after_update.id,
+        scope=scope,
+        activity=activity,
+        detail=Detail(
+            changes=changes_between(scope, previous=before_update, current=after_update),
+            name=after_update.name or f"Alert for {after_update.insight.name}",
+            context=AlertConfigurationContext(
+                insight_id=after_update.insight_id,
+                insight_short_id=after_update.insight.short_id,
+                insight_name=after_update.insight.name,
+            ),
+        ),
+    )
+
+
+@receiver(model_activity_signal, sender=Threshold)
+def handle_threshold_change(
+    sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
+):
+    alert_config = None
+    if hasattr(after_update, "alertconfiguration_set"):
+        alert_config = after_update.alertconfiguration_set.first()
+
+    if alert_config:
+        log_activity(
+            organization_id=alert_config.team.organization_id,
+            team_id=alert_config.team_id,
+            user=user,
+            was_impersonated=was_impersonated,
+            item_id=alert_config.id,
+            scope="AlertConfiguration",
+            activity=activity,
+            detail=Detail(
+                changes=changes_between("Threshold", previous=before_update, current=after_update),
+                type="threshold_change",
+                name=alert_config.name,
+                context=AlertConfigurationContext(
+                    insight_id=alert_config.insight_id,
+                    insight_short_id=alert_config.insight.short_id,
+                    insight_name=alert_config.insight.name,
+                ),
+            ),
+        )

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -331,17 +331,17 @@ class ThresholdViewSet(TeamAndOrgViewSetMixin, viewsets.ReadOnlyModelViewSet):
 
 @dataclasses.dataclass(frozen=True)
 class AlertConfigurationContext(ActivityContextBase):
-    insight_id: int = None
-    insight_short_id: str = None
+    insight_id: Optional[int] = None
+    insight_short_id: Optional[str] = None
     insight_name: Optional[str] = "Insight"
-    alert_id: int = None
+    alert_id: Optional[int] = None
     alert_name: Optional[str] = "Alert"
 
 
 @dataclasses.dataclass(frozen=True)
 class AlertSubscriptionContext(AlertConfigurationContext):
-    subscriber_name: str = None
-    subscriber_email: str = None
+    subscriber_name: Optional[str] = None
+    subscriber_email: Optional[str] = None
 
 
 @receiver(model_activity_signal, sender=AlertConfiguration)

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -24,6 +24,7 @@ from posthog.constants import AvailableFeature
 from posthog.models.activity_logging.activity_log import Detail, log_activity, changes_between, ActivityContextBase
 from posthog.models.signals import model_activity_signal
 from django.dispatch import receiver
+from django.db.models.signals import pre_delete
 
 
 class ThresholdSerializer(serializers.ModelSerializer):
@@ -330,9 +331,17 @@ class ThresholdViewSet(TeamAndOrgViewSetMixin, viewsets.ReadOnlyModelViewSet):
 
 @dataclasses.dataclass(frozen=True)
 class AlertConfigurationContext(ActivityContextBase):
-    insight_id: Optional[int] = None
-    insight_short_id: Optional[str] = None
-    insight_name: Optional[str] = None
+    insight_id: int = None
+    insight_short_id: str = None
+    insight_name: Optional[str] = "Insight"
+    alert_id: int = None
+    alert_name: Optional[str] = "Alert"
+
+
+@dataclasses.dataclass(frozen=True)
+class AlertSubscriptionContext(AlertConfigurationContext):
+    subscriber_name: str = None
+    subscriber_email: str = None
 
 
 @receiver(model_activity_signal, sender=AlertConfiguration)
@@ -379,11 +388,68 @@ def handle_threshold_change(
             detail=Detail(
                 changes=changes_between("Threshold", previous=before_update, current=after_update),
                 type="threshold_change",
-                name=alert_config.name,
                 context=AlertConfigurationContext(
                     insight_id=alert_config.insight_id,
                     insight_short_id=alert_config.insight.short_id,
                     insight_name=alert_config.insight.name,
+                    alert_name=alert_config.name,
+                ),
+            ),
+        )
+
+
+@receiver(model_activity_signal, sender=AlertSubscription)
+def handle_alert_subscription_change(before_update, after_update, activity, user, was_impersonated=False, **kwargs):
+    alert_config = after_update.alert_configuration
+
+    if alert_config:
+        log_activity(
+            organization_id=alert_config.team.organization_id,
+            team_id=alert_config.team_id,
+            user=user,
+            was_impersonated=was_impersonated,
+            item_id=alert_config.id,
+            scope="AlertConfiguration",
+            activity=activity,
+            detail=Detail(
+                changes=changes_between("AlertSubscription", previous=before_update, current=after_update),
+                type="alert_subscription_change",
+                context=AlertSubscriptionContext(
+                    insight_id=alert_config.insight_id,
+                    insight_short_id=alert_config.insight.short_id,
+                    insight_name=alert_config.insight.name,
+                    subscriber_name=after_update.user.get_full_name(),
+                    subscriber_email=after_update.user.email,
+                    alert_name=alert_config.name,
+                ),
+            ),
+        )
+
+
+@receiver(pre_delete, sender=AlertSubscription)
+def handle_alert_subscription_delete(sender, instance, **kwargs):
+    from posthog.models.activity_logging.model_activity import get_current_user, get_was_impersonated
+
+    alert_config = instance.alert_configuration
+
+    if alert_config:
+        log_activity(
+            organization_id=alert_config.team.organization_id,
+            team_id=alert_config.team_id,
+            user=get_current_user(),
+            was_impersonated=get_was_impersonated(),
+            item_id=alert_config.id,
+            scope="AlertConfiguration",
+            activity="deleted",
+            detail=Detail(
+                type="alert_subscription_change",
+                context=AlertSubscriptionContext(
+                    insight_id=alert_config.insight_id,
+                    insight_short_id=alert_config.insight.short_id,
+                    insight_name=alert_config.insight.name,
+                    subscriber_name=instance.user.get_full_name(),
+                    subscriber_email=instance.user.email,
+                    alert_name=alert_config.name,
                 ),
             ),
         )

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -63,10 +63,12 @@ ActivityScope = Literal[
     "Tag",
     "TaggedItem",
     "Subscription",
-    "AlertConfiguration",
     "PersonalAPIKey",
     "User",
     "Action",
+    "AlertConfiguration",
+    "Threshold",
+    "AlertSubscription",
 ]
 ChangeAction = Literal["changed", "created", "deleted", "merged", "split", "exported"]
 

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -432,7 +432,7 @@ def safely_get_field_value(instance: models.Model | None, field: str):
 
 
 def changes_between(
-    model_type: ActivityScope | str,
+    model_type: ActivityScope,
     previous: Optional[models.Model],
     current: Optional[models.Model],
 ) -> list[Change]:

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -138,6 +138,13 @@ class ActivityDetailEncoder(json.JSONEncoder):
                 "deleted": obj.deleted,
                 "active": obj.active,
             }
+        if hasattr(obj, "__class__") and obj.__class__.__name__ == "Insight":
+            return {
+                "id": obj.id,
+                "short_id": obj.short_id,
+                "name": obj.name,
+                "team_id": obj.team_id,
+            }
 
         return json.JSONEncoder.default(self, obj)
 

--- a/posthog/models/alert.py
+++ b/posthog/models/alert.py
@@ -3,6 +3,7 @@ from datetime import datetime, UTC, timedelta
 
 from django.db import models
 from django.core.exceptions import ValidationError
+from posthog.models.activity_logging.model_activity import ModelActivityMixin
 from posthog.schema_migrations.upgrade_manager import upgrade_query
 import pydantic
 
@@ -40,7 +41,7 @@ class Alert(models.Model):
     anomaly_condition = models.JSONField(default=dict)
 
 
-class Threshold(CreatedMetaFields, UUIDModel):
+class Threshold(ModelActivityMixin, CreatedMetaFields, UUIDModel):
     """
     Threshold holds the configuration for a threshold. This can either be attached to an alert, or used as a standalone
     object for other purposes.
@@ -65,7 +66,7 @@ class Threshold(CreatedMetaFields, UUIDModel):
                 raise ValidationError("Lower threshold must be less than upper threshold")
 
 
-class AlertConfiguration(CreatedMetaFields, UUIDModel):
+class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDModel):
     ALERTS_ALLOWED_ON_FREE_TIER = 2
 
     team = models.ForeignKey("Team", on_delete=models.CASCADE)

--- a/posthog/models/alert.py
+++ b/posthog/models/alert.py
@@ -128,7 +128,7 @@ class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDModel):
         super().save(*args, **kwargs)
 
 
-class AlertSubscription(CreatedMetaFields, UUIDModel):
+class AlertSubscription(ModelActivityMixin, CreatedMetaFields, UUIDModel):
     user = models.ForeignKey(
         "User",
         on_delete=models.CASCADE,

--- a/posthog/test/activity_logging/test_alert_activity_logging.py
+++ b/posthog/test/activity_logging/test_alert_activity_logging.py
@@ -1,0 +1,210 @@
+from posthog.models.activity_logging.activity_log import ActivityLog
+from posthog.test.activity_log_utils import ActivityLogTestHelper
+
+
+class TestAlertActivityLogging(ActivityLogTestHelper):
+    def test_alert_configuration_creation_activity_logging(self):
+        alert = self.create_alert_configuration("Test alert")
+
+        log = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="AlertConfiguration", item_id=str(alert["id"]), activity="created"
+        ).first()
+        assert log is not None
+        self.assertIsNotNone(log)
+        self.assertIsNotNone(log.detail)
+
+    def test_alert_configuration_update_activity_logging(self):
+        alert = self.create_alert_configuration("Original alert")
+
+        self.update_alert_configuration(alert["id"], {"name": "Updated alert"})
+
+        update_log = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="AlertConfiguration", item_id=str(alert["id"]), activity="updated"
+        ).first()
+
+        assert update_log is not None
+        self.assertIsNotNone(update_log)
+        self.assertIsNotNone(update_log.detail)
+
+    def test_alert_configuration_basic_context(self):
+        insight = self.create_insight("Test Insight for Alert")
+        alert = self.create_alert_configuration(
+            name="Alert with context",
+            insight=insight["id"],
+            config={"type": "TrendsAlertConfig", "series_index": 0},
+        )
+
+        log = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="AlertConfiguration", item_id=str(alert["id"]), activity="created"
+        ).first()
+
+        self.assertIsNotNone(log)
+        assert log is not None
+        self.assertIsNotNone(log.detail)
+        self.assertIsNotNone(log.detail.get("context"))
+
+        context = log.detail["context"]
+        self.assertEqual(context["insight_id"], insight["id"])
+        self.assertEqual(context["insight_short_id"], insight["short_id"])
+        self.assertEqual(context["insight_name"], insight["name"])
+
+    def test_alert_configuration_different_conditions(self):
+        insight = self.create_insight("Insight for Different Conditions")
+        alert1 = self.create_alert_configuration(
+            name="Alert with relative threshold",
+            insight=insight["id"],
+            threshold={"configuration": {"type": "percentage", "bounds": {"lower": 10, "upper": 90}}},
+            condition={"type": "relative_previous_period"},
+        )
+
+        log1 = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="AlertConfiguration", item_id=str(alert1["id"]), activity="created"
+        ).first()
+
+        self.assertIsNotNone(log1)
+        assert log1 is not None
+
+        alert2 = self.create_alert_configuration(
+            name="Alert with series index",
+            insight=insight["id"],
+            config={"type": "TrendsAlertConfig", "series_index": 1},
+        )
+
+        log2 = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="AlertConfiguration", item_id=str(alert2["id"]), activity="created"
+        ).first()
+
+        self.assertIsNotNone(log2)
+        assert log2 is not None
+        context2 = log2.detail["context"]
+        self.assertEqual(context2["insight_id"], insight["id"])
+
+    def test_alert_configuration_field_change_tracking(self):
+        alert = self.create_alert_configuration("Alert for field tracking", enabled=True, calculation_interval="daily")
+
+        # Test enabled field changes
+        self.update_alert_configuration(alert["id"], {"enabled": False})
+        disable_log = (
+            ActivityLog.objects.filter(
+                team_id=self.team.id, scope="AlertConfiguration", item_id=str(alert["id"]), activity="updated"
+            )
+            .order_by("-created_at")
+            .first()
+        )
+
+        changes = disable_log.detail.get("changes", [])
+        enabled_change = next((change for change in changes if change.get("field") == "enabled"), None)
+        self.assertIsNotNone(enabled_change)
+        self.assertEqual(enabled_change["action"], "changed")
+        self.assertTrue(enabled_change["before"])
+        self.assertFalse(enabled_change["after"])
+
+        # Test name field changes
+        self.update_alert_configuration(alert["id"], {"name": "Updated Alert Name"})
+        name_log = (
+            ActivityLog.objects.filter(
+                team_id=self.team.id, scope="AlertConfiguration", item_id=str(alert["id"]), activity="updated"
+            )
+            .order_by("-created_at")
+            .first()
+        )
+
+        changes = name_log.detail.get("changes", [])
+        name_change = next((change for change in changes if change.get("field") == "name"), None)
+        self.assertIsNotNone(name_change)
+        self.assertEqual(name_change["action"], "changed")
+        self.assertEqual(name_change["before"], "Alert for field tracking")
+        self.assertEqual(name_change["after"], "Updated Alert Name")
+
+        # Test calculation_interval field changes
+        self.update_alert_configuration(alert["id"], {"calculation_interval": "hourly"})
+        interval_log = (
+            ActivityLog.objects.filter(
+                team_id=self.team.id, scope="AlertConfiguration", item_id=str(alert["id"]), activity="updated"
+            )
+            .order_by("-created_at")
+            .first()
+        )
+
+        changes = interval_log.detail.get("changes", [])
+        interval_change = next((change for change in changes if change.get("field") == "calculation_interval"), None)
+        self.assertIsNotNone(interval_change)
+        self.assertEqual(interval_change["action"], "changed")
+        self.assertEqual(interval_change["before"], "daily")
+        self.assertEqual(interval_change["after"], "hourly")
+
+    def test_alert_configuration_threshold_update_logging(self):
+        alert = self.create_alert_configuration(
+            name="Alert for threshold update",
+            threshold={"configuration": {"type": "absolute", "bounds": {"lower": 100, "upper": 1000}}},
+        )
+
+        self.update_alert_configuration(alert["id"], {"name": "Updated Alert Name"})
+
+        update_log = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="AlertConfiguration", item_id=str(alert["id"]), activity="updated"
+        ).first()
+
+        self.assertIsNotNone(update_log)
+        assert update_log is not None
+        self.assertIsNotNone(update_log.detail)
+        self.assertIsNotNone(update_log.detail.get("context"))
+
+    def test_alert_configuration_activity_log_properties(self):
+        alert = self.create_alert_configuration("Test alert properties")
+
+        log = ActivityLog.objects.filter(
+            team_id=self.team.id, scope="AlertConfiguration", item_id=str(alert["id"]), activity="created"
+        ).first()
+
+        self.assertIsNotNone(log)
+        assert log is not None
+        self.assertEqual(log.scope, "AlertConfiguration")
+        self.assertEqual(log.activity, "created")
+        self.assertEqual(log.item_id, str(alert["id"]))
+        self.assertEqual(log.team_id, self.team.id)
+        self.assertEqual(log.organization_id, self.organization.id)
+        self.assertEqual(log.user, self.user)
+        self.assertFalse(log.was_impersonated or False)
+        self.assertFalse(log.is_system or False)
+
+        self.assertIsNotNone(log.detail)
+        detail = log.detail
+        self.assertEqual(detail["name"], alert["name"])
+        self.assertIsNotNone(detail.get("context"))
+        self.assertIsNotNone(detail.get("changes"))
+
+    def test_threshold_activity_logging(self):
+        alert = self.create_alert_configuration(
+            name="Alert with threshold",
+            threshold={"configuration": {"type": "absolute", "bounds": {"lower": 100, "upper": 500}}},
+        )
+
+        from posthog.models.alert import AlertConfiguration
+
+        alert_config = AlertConfiguration.objects.select_related("threshold").get(id=alert["id"])
+        threshold = alert_config.threshold
+        self.assertIsNotNone(threshold)
+        assert threshold is not None
+
+        threshold.configuration = {"type": "absolute", "bounds": {"lower": 200, "upper": 800}}
+        threshold.save(update_fields=["configuration"])
+
+        threshold_update_log = (
+            ActivityLog.objects.filter(
+                team_id=self.team.id, scope="AlertConfiguration", item_id=str(alert["id"]), activity="updated"
+            )
+            .order_by("-created_at")
+            .first()
+        )
+
+        self.assertIsNotNone(threshold_update_log)
+        assert threshold_update_log is not None
+        self.assertIsNotNone(threshold_update_log.detail)
+        self.assertEqual(threshold_update_log.detail.get("type"), "threshold_change")
+
+        changes = threshold_update_log.detail.get("changes", [])
+        config_change = next((change for change in changes if change.get("field") == "configuration"), None)
+        self.assertIsNotNone(config_change)
+        assert config_change is not None
+        self.assertEqual(config_change["action"], "changed")

--- a/posthog/test/activity_logging/test_alert_activity_logging.py
+++ b/posthog/test/activity_logging/test_alert_activity_logging.py
@@ -189,15 +189,9 @@ class TestAlertActivityLogging(ActivityLogTestHelper):
             threshold={"configuration": {"type": "absolute", "bounds": {"lower": 100, "upper": 500}}},
         )
 
-        from posthog.models.alert import AlertConfiguration
-
-        alert_config = AlertConfiguration.objects.select_related("threshold").get(id=alert["id"])
-        threshold = alert_config.threshold
-        self.assertIsNotNone(threshold)
-        assert threshold is not None
-
-        threshold.configuration = {"type": "absolute", "bounds": {"lower": 200, "upper": 800}}
-        threshold.save(update_fields=["configuration"])
+        self.update_alert_configuration(
+            alert["id"], {"threshold": {"configuration": {"type": "absolute", "bounds": {"lower": 200, "upper": 800}}}}
+        )
 
         threshold_update_log = (
             ActivityLog.objects.filter(


### PR DESCRIPTION
## Changes

- Adding logs for AlertConfigurations (i.e. insight alerts), Thresholds (i.e. alert thresholds which triggers the alert) and AlertSubscriptions (i.e. users subscribed to receive notifications when the alert fires).

- It would have been great to show these on the "Insights" and "This insight" selection in the Team Activity sidebar, but alas, that's making the code a bit convoluted which I'd like to avoid for now. Plan is to implement it as a separate scope for now, then do a separate pass to "combine" multiple scopes (Insight, AlertConfig, Thresholds, AlertSubs) into a single "grouped" scope on the FE.

<img width="496" height="673" alt="image" src="https://github.com/user-attachments/assets/dc2af56c-157f-47a5-b25f-2f8502e13e9a" />

## How did you test this code?

- Integration tests