### PR TITLE
chore: change expression for materialized columns to DEFAULT

### DIFF
--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -56,6 +56,7 @@
                               e."$group_0" as aggregation_target,
                               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               person.person_props as person_props,
+                              person.pmat_email as pmat_email,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -79,6 +80,7 @@
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
                          (SELECT id,
+                                 argMax(pmat_email, version) as pmat_email,
                                  argMax(properties, version) as person_props
                           FROM person
                           WHERE team_id = 99999
@@ -95,7 +97,7 @@
                          AND event IN ['step one', 'step three', 'step two']
                          AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-10 23:59:59', 'UTC')
-                         AND ((replaceRegexpAll(JSONExtractRaw(person_props, 'email'), '^"|"$', '') ILIKE '%g0%'
+                         AND (("pmat_email" ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(e.properties, 'distinct_id'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(group_properties_0, 'name'), '^"|"$', '') ILIKE '%g0%'

--- a/ee/tasks/materialized_columns.py
+++ b/ee/tasks/materialized_columns.py
@@ -1,42 +1,12 @@
 from collections.abc import Iterator
-from dataclasses import dataclass
 from celery.utils.log import get_task_logger
-from clickhouse_driver import Client
 
-from ee.clickhouse.materialized_columns.columns import MaterializedColumn, tables as table_infos
+from ee.clickhouse.materialized_columns.columns import MaterializedColumn
 from posthog.clickhouse.client import sync_execute
 from posthog.settings import CLICKHOUSE_DATABASE
-from posthog.clickhouse.cluster import get_cluster
 from posthog.clickhouse.materialized_columns import ColumnName, TablesWithMaterializedColumns
 
 logger = get_task_logger(__name__)
-
-
-@dataclass
-class MarkMaterializedTask:
-    table: str
-    column: MaterializedColumn
-
-    def execute(self, client: Client) -> None:
-        expression, parameters = self.column.get_expression_and_parameters()
-        client.execute(
-            f"ALTER TABLE {self.table} MODIFY COLUMN {self.column.name} {self.column.type} MATERIALIZED {expression}",
-            parameters,
-        )
-
-
-def mark_all_materialized() -> None:
-    cluster = get_cluster()
-
-    for table_name, column in get_materialized_columns_with_default_expression():
-        table_info = table_infos[table_name]
-        table_info.map_data_nodes(
-            cluster,
-            MarkMaterializedTask(
-                table_info.data_table,
-                column,
-            ).execute,
-        ).result()
 
 
 def get_materialized_columns_with_default_expression() -> Iterator[tuple[str, MaterializedColumn]]:

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -26,7 +26,6 @@ from posthog.tasks.tasks import (
     clear_clickhouse_deleted_person,
     clickhouse_clear_removed_data,
     clickhouse_errors_count,
-    clickhouse_mark_all_materialized,
     clickhouse_materialize_columns,
     clickhouse_mutation_count,
     clickhouse_part_count,
@@ -292,12 +291,6 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
                 materialize_columns_crontab,
                 clickhouse_materialize_columns.s(),
                 name="clickhouse materialize columns",
-            )
-
-            sender.add_periodic_task(
-                crontab(hour="*/4", minute="0"),
-                clickhouse_mark_all_materialized.s(),
-                name="clickhouse mark all columns as materialized",
             )
 
         sender.add_periodic_task(crontab(hour="*", minute="55"), schedule_all_subscriptions.s())

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -746,17 +746,6 @@ def clickhouse_materialize_columns() -> None:
             materialize_properties_task()
 
 
-@shared_task(ignore_result=True)
-def clickhouse_mark_all_materialized() -> None:
-    if recompute_materialized_columns_enabled():
-        try:
-            from ee.tasks.materialized_columns import mark_all_materialized
-        except ImportError:
-            pass
-        else:
-            mark_all_materialized()
-
-
 @shared_task(ignore_result=True, queue=CeleryQueue.USAGE_REPORTS.value)
 def send_org_usage_reports() -> None:
     from posthog.tasks.usage_report import send_all_org_usage_reports


### PR DESCRIPTION
## Problem

We are switching to a dedicated ingestion layer. To get the most out of it, we need to compute values in there. Materialized columns do not allow us to do so, as they are computed when data is inserted, and we cannot explicitly insert values in them.

## Changes

Change materialized columns so they use a `DEFAULT` expression instead of a `MATERIALIZED` one.

This PR also removes unneeded code that changed a column temporarily from `MATERIALIZED` to `DEFAULT` to run the materialization, as we are declaring the column with `DEFAULT` from the beginning.

## How did you test this code?

Ran / updated unit tests.
Made a test with the ingestion layer, ensuring we can properly insert values into the default columns as we expect.
