### PR TITLE
fix(data-warehouse): Fix useEffect dependency list

### DIFF
--- a/frontend/src/scenes/data-warehouse/external/forms/SourceForm.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SourceForm.tsx
@@ -242,7 +242,7 @@ export function SourceFormComponent({
                 setSourceConfigValue(['payload', input], jobInputs[input])
             }
         }
-    }, [JSON.stringify(jobInputs), setSourceConfigValue, jobInputs])
+    }, [JSON.stringify(jobInputs), setSourceConfigValue])
 
     const isUpdateMode = !!setSourceConfigValue
 


### PR DESCRIPTION
## Problem
- When updating a source config, the background polling would reset the config form, making it very hard to update the configs
- Looks like this was accientally updated in https://github.com/PostHog/posthog/pull/35594/files#diff-2e49e1e2b49234ccb0b0ce94542f7d7650ceee01844b2d4d22174f8dc189a7de but not reviewed by data warehouse
- Reported by https://posthoghelp.zendesk.com/agent/tickets/35650 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/37335)

## Changes
 - Fix the dependency list for a use effect call 
