### PR TITLE
fix(data-warehouse): Soft delete schemas that no longer exist in upstream

### DIFF
--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -56,6 +56,7 @@
                               e."$group_0" as aggregation_target,
                               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               person.person_props as person_props,
+                              person.pmat_email as pmat_email,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -79,6 +80,7 @@
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
                          (SELECT id,
+                                 argMax(pmat_email, version) as pmat_email,
                                  argMax(properties, version) as person_props
                           FROM person
                           WHERE team_id = 99999
@@ -95,7 +97,7 @@
                          AND event IN ['step one', 'step three', 'step two']
                          AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-10 23:59:59', 'UTC')
-                         AND ((replaceRegexpAll(JSONExtractRaw(person_props, 'email'), '^"|"$', '') ILIKE '%g0%'
+                         AND (("pmat_email" ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(e.properties, 'distinct_id'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(group_properties_0, 'name'), '^"|"$', '') ILIKE '%g0%'

--- a/posthog/temporal/data_imports/workflow_activities/sync_new_schemas.py
+++ b/posthog/temporal/data_imports/workflow_activities/sync_new_schemas.py
@@ -50,7 +50,7 @@ def sync_new_schemas_activity(inputs: SyncNewSchemasActivityInputs) -> None:
 
     # TODO: this could cause a race condition where each schema worker creates the missing schema
 
-    schemas_created = sync_old_schemas_with_new_schemas(
+    schemas_created, schemas_deleted = sync_old_schemas_with_new_schemas(
         schemas_to_sync,
         source_id=inputs.source_id,
         team_id=inputs.team_id,
@@ -60,3 +60,8 @@ def sync_new_schemas_activity(inputs: SyncNewSchemasActivityInputs) -> None:
         logger.info(f"Added new schemas: {', '.join(schemas_created)}")
     else:
         logger.info("No new schemas to create")
+
+    if len(schemas_deleted) > 0:
+        logger.info(f"Deleted schemas: {', '.join(schemas_deleted)}")
+    else:
+        logger.info("No schemas to delete")

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -2602,6 +2602,7 @@ async def test_postgres_deleting_schemas_with_pre_synced_data(team, postgres_con
     # Because table_1 has already been synced and we hold data for it, we dont delete the schema
     assert len(schemas) == 2
 
-    # The schema with the deleted upstream table should now have "should_sync" updated to False
+    # The schema with the deleted upstream table should now have "should_sync" updated to False and status set to completed
     synced_schema = await ExternalDataSchema.objects.aget(id=inputs.external_data_schema_id)
     assert synced_schema.should_sync is False
+    assert synced_schema.status == ExternalDataSchema.Status.COMPLETED

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -2481,3 +2481,127 @@ async def test_pipeline_mb_chunk_size(team, zendesk_brands):
     # Returning two items should cause the pipeline to process each item individually
 
     assert mock_process_pa_table.call_count == 2
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_postgres_deleting_schemas(team, postgres_config, postgres_connection):
+    await postgres_connection.execute(
+        "CREATE TABLE IF NOT EXISTS {schema}.table_1 (id integer)".format(schema=postgres_config["schema"])
+    )
+    await postgres_connection.execute(
+        "INSERT INTO {schema}.table_1 (id) VALUES (1)".format(schema=postgres_config["schema"])
+    )
+    await postgres_connection.execute(
+        "CREATE TABLE IF NOT EXISTS {schema}.table_2 (id integer)".format(schema=postgres_config["schema"])
+    )
+    await postgres_connection.commit()
+
+    _, inputs = await _run(
+        team=team,
+        schema_name="table_1",
+        table_name="postgres_table_1",
+        source_type="Postgres",
+        job_inputs={
+            "host": postgres_config["host"],
+            "port": postgres_config["port"],
+            "database": postgres_config["database"],
+            "user": postgres_config["user"],
+            "password": postgres_config["password"],
+            "schema": postgres_config["schema"],
+            "ssh_tunnel_enabled": "False",
+        },
+        mock_data_response=[],
+    )
+
+    @sync_to_async
+    def get_schemas():
+        schemas = ExternalDataSchema.objects.filter(source_id=inputs.external_data_source_id, deleted=False)
+
+        return list(schemas)
+
+    schemas = await get_schemas()
+    assert len(schemas) == 2
+
+    # Drop the table we've not synced yet
+    await postgres_connection.execute("DROP TABLE {schema}.table_2".format(schema=postgres_config["schema"]))
+    await postgres_connection.commit()
+
+    await _execute_run(str(uuid.uuid4()), inputs, [])
+
+    schemas = await get_schemas()
+
+    # It should have soft deleted the unsynced table
+    assert len(schemas) == 1
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_postgres_deleting_schemas_with_pre_synced_data(team, postgres_config, postgres_connection):
+    await postgres_connection.execute(
+        "CREATE TABLE IF NOT EXISTS {schema}.table_1 (id integer)".format(schema=postgres_config["schema"])
+    )
+    await postgres_connection.execute(
+        "INSERT INTO {schema}.table_1 (id) VALUES (1)".format(schema=postgres_config["schema"])
+    )
+    await postgres_connection.execute(
+        "CREATE TABLE IF NOT EXISTS {schema}.table_2 (id integer)".format(schema=postgres_config["schema"])
+    )
+    await postgres_connection.execute(
+        "INSERT INTO {schema}.table_2 (id) VALUES (1)".format(schema=postgres_config["schema"])
+    )
+    await postgres_connection.commit()
+
+    # Sync both tables
+    _, inputs = await _run(
+        team=team,
+        schema_name="table_1",
+        table_name="postgres_table_1",
+        source_type="Postgres",
+        job_inputs={
+            "host": postgres_config["host"],
+            "port": postgres_config["port"],
+            "database": postgres_config["database"],
+            "user": postgres_config["user"],
+            "password": postgres_config["password"],
+            "schema": postgres_config["schema"],
+            "ssh_tunnel_enabled": "False",
+        },
+        mock_data_response=[],
+    )
+
+    @sync_to_async
+    def get_schemas():
+        schemas = ExternalDataSchema.objects.filter(source_id=inputs.external_data_source_id, deleted=False)
+
+        return list(schemas)
+
+    schemas = await get_schemas()
+    assert len(schemas) == 2
+
+    # Drop the table that we've already synced
+    await postgres_connection.execute("DROP TABLE {schema}.table_1".format(schema=postgres_config["schema"]))
+    await postgres_connection.commit()
+
+    # Sync the second table - this will trigger `sync_new_schemas_activity`
+    unsynced_schema_ids = [s.id for s in schemas if s.id != inputs.external_data_schema_id]
+    assert len(unsynced_schema_ids) == 1
+    unsynced_schema_id = unsynced_schema_ids[0]
+    await _execute_run(
+        str(uuid.uuid4()),
+        ExternalDataWorkflowInputs(
+            team_id=inputs.team_id,
+            external_data_source_id=inputs.external_data_source_id,
+            external_data_schema_id=unsynced_schema_id,  # the schema id of the second table
+            billable=inputs.billable,
+        ),
+        [],
+    )
+
+    schemas = await get_schemas()
+    # Because table_1 has already been synced and we hold data for it, we dont delete the schema
+    assert len(schemas) == 2
+
+    # The schema with the deleted upstream table should now have "should_sync" updated to False
+    synced_schema = await ExternalDataSchema.objects.aget(id=inputs.external_data_schema_id)
+    assert synced_schema.should_sync is False

--- a/posthog/warehouse/models/external_data_schema.py
+++ b/posthog/warehouse/models/external_data_schema.py
@@ -348,6 +348,7 @@ def sync_old_schemas_with_new_schemas(
             deleted_schemas.append(schema)
         else:
             s.should_sync = False
+            s.status = ExternalDataSchema.Status.COMPLETED
             s.save()
 
     return schemas_to_create, deleted_schemas

--- a/posthog/warehouse/models/external_data_schema.py
+++ b/posthog/warehouse/models/external_data_schema.py
@@ -327,16 +327,30 @@ def get_all_schemas_for_source_id(source_id: str, team_id: int):
     return list(ExternalDataSchema.objects.exclude(deleted=True).filter(team_id=team_id, source_id=source_id).all())
 
 
-def sync_old_schemas_with_new_schemas(new_schemas: list[str], source_id: str, team_id: int) -> list[str]:
+def sync_old_schemas_with_new_schemas(
+    new_schemas: list[str], source_id: str, team_id: int
+) -> tuple[list[str], list[str]]:
     old_schemas = get_all_schemas_for_source_id(source_id=source_id, team_id=team_id)
     old_schemas_names = [schema.name for schema in old_schemas]
 
     schemas_to_create = [schema for schema in new_schemas if schema not in old_schemas_names]
 
+    schemas_to_possibly_delete = [schema for schema in old_schemas_names if schema not in new_schemas]
+    deleted_schemas: list[str] = []
+
     for schema in schemas_to_create:
         ExternalDataSchema.objects.create(name=schema, team_id=team_id, source_id=source_id, should_sync=False)
 
-    return schemas_to_create
+    for schema in schemas_to_possibly_delete:
+        s = ExternalDataSchema.objects.get(team_id=team_id, name=schema, source_id=source_id)
+        if s.table_id is None:
+            s.soft_delete()
+            deleted_schemas.append(schema)
+        else:
+            s.should_sync = False
+            s.save()
+
+    return schemas_to_create, deleted_schemas
 
 
 def sync_frequency_to_sync_frequency_interval(frequency: str) -> timedelta | None:


### PR DESCRIPTION
## Problem
- If a table no longer exists upstream in a customers DB, then it will always show as "error" on the sources page
- From https://posthoghelp.zendesk.com/agent/tickets/35669 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/37336)

## Changes
- If we hold no data for the deleted table, then soft delete the schema from our system
- If we do hold data for the table, dont delete it, but do set should_run to false and update the status to completed

## How did you test this code?
Added unit tests 