### PR TITLE
fix(sql-editor): Dont render a blank monaco editor

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -910,7 +910,7 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
 
                 actions.setTabs(newModels)
 
-                if (activeModelUri) {
+                if (activeModelUri && newModels.length) {
                     const uri = props.monaco?.Uri.parse(activeModelUri)
                     const activeModel = props.monaco?.editor
                         .getModels()


### PR DESCRIPTION
## Problem
- If there are no saved models in the indexedDB, then we show a blank SQL editor 
- reported here: https://posthoghelp.zendesk.com/agent/tickets/35856 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/37347)

## Changes
- Skip the logic block that tries to reload from the indexedDB and create the empty tab

I somehow lost all my local state when recreating this, not really so sure how 😢 but something a bit fishy seems up with the editor and the multiTabLogic 