### PR TITLE
fix(msg): parametrize pg query

### DIFF
--- a/plugin-server/src/cdp/consumers/cdp-aggregation-writer.consumer.test.ts
+++ b/plugin-server/src/cdp/consumers/cdp-aggregation-writer.consumer.test.ts
@@ -357,5 +357,93 @@ describe('CdpAggregationWriterConsumer', () => {
             )
             expect(personResult.rows).toHaveLength(0)
         })
+
+        it('should handle special characters that could cause PostgreSQL protocol errors', async () => {
+            // These special characters previously caused "invalid message format" errors
+            const validPersonId1 = '550e8400-e29b-41d4-a716-446655440002'
+            const validPersonId2 = '550e8400-e29b-41d4-a716-446655440003'
+            const problematicEventName = 'event\'with"quotes;and--comments/**/and\\backslash'
+            const problematicFilterHash = "hash'with;semicolon--comment"
+
+            const personEvents: PersonEventPayload[] = [
+                {
+                    type: 'person-performed-event',
+                    personId: validPersonId1,
+                    eventName: problematicEventName,
+                    teamId: team.id,
+                },
+                {
+                    type: 'person-performed-event',
+                    personId: validPersonId2,
+                    eventName: "event$with$dollars$and$1=1'); DROP TABLE person_performed_events; --", // SQL injection attempt
+                    teamId: team.id,
+                },
+            ]
+
+            const behavioralEvents: AggregatedBehaviouralEvent[] = [
+                {
+                    type: 'behavioural-filter-match-event',
+                    teamId: team.id,
+                    personId: validPersonId1,
+                    filterHash: problematicFilterHash,
+                    date: '2023-12-01',
+                    counter: 1,
+                },
+                {
+                    type: 'behavioural-filter-match-event',
+                    teamId: team.id,
+                    personId: validPersonId2,
+                    filterHash: "hash'); DELETE FROM behavioural_filter_matched_events; --",
+                    date: '2023-12-01',
+                    counter: 1,
+                },
+            ]
+
+            // This should NOT throw an error with parameterized queries
+            await processor['writeToPostgres'](personEvents, behavioralEvents)
+
+            // Verify person events were written correctly with special characters preserved
+            const personResult = await hub.postgres.query(
+                PostgresUse.COUNTERS_RW,
+                'SELECT * FROM person_performed_events WHERE team_id = $1 ORDER BY event_name',
+                [team.id],
+                'test-read-special-char-person-events'
+            )
+
+            expect(personResult.rows).toHaveLength(2)
+            expect(personResult.rows[0].event_name).toBe(
+                "event$with$dollars$and$1=1'); DROP TABLE person_performed_events; --"
+            )
+            expect(personResult.rows[1].event_name).toBe(problematicEventName)
+            expect(personResult.rows[1].person_id).toBe(validPersonId1)
+
+            // Verify behavioral events were written correctly with special characters preserved
+            const behavioralResult = await hub.postgres.query(
+                PostgresUse.COUNTERS_RW,
+                'SELECT * FROM behavioural_filter_matched_events WHERE team_id = $1 ORDER BY person_id',
+                [team.id],
+                'test-read-special-char-behavioral-events'
+            )
+
+            expect(behavioralResult.rows).toHaveLength(2)
+            expect(behavioralResult.rows[0].person_id).toBe(validPersonId1)
+            expect(behavioralResult.rows[0].filter_hash).toBe(problematicFilterHash)
+            expect(behavioralResult.rows[1].person_id).toBe(validPersonId2)
+            expect(behavioralResult.rows[1].filter_hash).toBe(
+                "hash'); DELETE FROM behavioural_filter_matched_events; --"
+            )
+
+            // Verify tables still exist (SQL injection attempt failed)
+            const tablesExist = await hub.postgres.query(
+                PostgresUse.COUNTERS_RW,
+                `SELECT EXISTS (
+                    SELECT FROM information_schema.tables 
+                    WHERE table_name = 'behavioural_filter_matched_events'
+                ) as table_exists`,
+                [],
+                'test-check-table-exists'
+            )
+            expect(tablesExist.rows[0].table_exists).toBe(true)
+        })
     })
 })

--- a/plugin-server/src/cdp/consumers/cdp-aggregation-writer.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-aggregation-writer.consumer.ts
@@ -172,6 +172,7 @@ export class CdpAggregationWriterConsumer extends CdpConsumerBase {
             return
         }
 
+        let query = ''
         try {
             const ctes: string[] = []
             const allParams: any[] = []
@@ -191,7 +192,7 @@ export class CdpAggregationWriterConsumer extends CdpConsumerBase {
             }
 
             // Build and execute the single combined query with parameters
-            const query = `WITH ${ctes.join(', ')} SELECT 1`
+            query = `WITH ${ctes.join(', ')} SELECT 1`
             await this.hub.postgres.query(PostgresUse.COUNTERS_RW, query, allParams, 'counters-batch-upsert')
         } catch (error: any) {
             logger.error('Failed to write to COUNTERS postgres', {

--- a/plugin-server/src/cdp/consumers/cdp-aggregation-writer.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-aggregation-writer.consumer.ts
@@ -193,8 +193,14 @@ export class CdpAggregationWriterConsumer extends CdpConsumerBase {
             // Build and execute the single combined query with parameters
             const query = `WITH ${ctes.join(', ')} SELECT 1`
             await this.hub.postgres.query(PostgresUse.COUNTERS_RW, query, allParams, 'counters-batch-upsert')
-        } catch (error) {
-            logger.error('Failed to write to COUNTERS postgres', { error })
+        } catch (error: any) {
+            logger.error('Failed to write to COUNTERS postgres', {
+                error: error.message,
+                errorCode: error.code,
+                query: query,
+                personEventsCount: personEvents.length,
+                behaviouralEventsCount: behaviouralEvents.length,
+            })
             throw error
         }
     }


### PR DESCRIPTION
## Problem

PostgreSQL "invalid message format" error in production due to unsafe SQL string concatenation with potential special characters in event names and person IDs.

Root Cause: Direct string interpolation into SQL queries can break when data contained quotes, backslashes, or SQL comment sequences, also .. this was vulnerable to SQL injection.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

 1. Replaced string concatenation with parameterized queries using PostgreSQL's unnest() function
 2. Before: Built SQL like VALUES ('${eventName}') - dangerous string concatenation
 3. After: Uses SELECT * FROM unnest($1::text[]) - passes arrays as parameters
 
 Key improvements:
  - Safety: Special characters handled at protocol level, SQL injection impossible
  - Performance: PostgreSQL optimizes unnest() for bulk inserts
  - Better logging: Added error diagnostics to track query failures

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- added test 
- other tests still passing

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
