### PR TITLE
fix(insight): add type casting to query metadata filler query

### DIFF
--- a/posthog/tasks/insight_query_metadata.py
+++ b/posthog/tasks/insight_query_metadata.py
@@ -12,6 +12,7 @@ logger = structlog.get_logger(__name__)
     ignore_result=True,
     queue=CeleryQueue.LONG_RUNNING.value,
     max_retries=1,
+    acks_late=True,
     reject_on_worker_lost=True,
     track_started=True,
     default_retry_delay=10 * 60,  # 10 minutes

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -354,7 +354,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
     )
 
     sender.add_periodic_task(
-        crontab(minute="0", hour="*/12"),
+        crontab(minute="0", hour="*/3"),
         fill_insights_missing_query_metadata.s(),
         name="fill insights missing query metadata",
     )


### PR DESCRIPTION
## Problem

The fill_insights_missing_query_metadata fails on production because of a query issue. [Logs](https://grafana.prod-us.posthog.dev/goto/93g0R0_Ng?orgId=1).

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Adds type casting to the query.
- Also adds back the `acks_late` previously removed in https://github.com/PostHog/posthog/pull/36413 because removing it did not help reduce the number of duplicate tasks. So I am adding that option back to the task in the hope that it at least helps improve the rate of tasks that are being run (still around half of the enqueued tasks are lost).
- Updates the schedule for running the back-fill task to every 3 hours (instead of every 12) because the number of failed Celery tasks are too high and it's better to run this filling job more often.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Schedule the task manually and confirm it runs.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
