### PR TITLE
feat(cohorts): capture client errors when cohort creation fails

### DIFF
--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -265,7 +265,6 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                                 is_static: cohort.is_static,
                             })
                             posthog.captureException(error, {
-                                // Context explains what we were doing when error occurred
                                 cohort_operation: 'Cohort creation failed unexpectedly',
                                 // Cohort context (most valuable)
                                 cohort_name: cohort.name,

--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -255,6 +255,34 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                         }
                     } catch (error: any) {
                         breakpoint()
+
+                        // Only capture exception if we don't have proper error details
+                        // This indicates an unexpected failure (network, timeout, etc.)
+                        if (!error.detail) {
+                            posthog.captureException(new Error('Cohort creation failed unexpectedly'), {
+                                // Cohort context (most valuable)
+                                cohort_name: cohort.name,
+                                is_static: cohort.is_static,
+                                operation_type: cohort.id === 'new' ? 'create' : 'update',
+                                has_csv: !!cohortFormData.get?.('csv'),
+                                file_size: cohortFormData.get?.('csv')?.size,
+
+                                // Error context
+                                error_status: error.status,
+                                error_status_text: error.statusText,
+                                error_message: error.message,
+                                error_name: error.name,
+                                error_type: typeof error,
+
+                                // Browser context
+                                user_agent: navigator.userAgent.substring(0, 100),
+                                is_online: navigator.onLine,
+
+                                // Request context
+                                timestamp: new Date().toISOString(),
+                            })
+                        }
+
                         lemonToast.error(error.detail || 'Failed to save cohort')
                         return values.cohort
                     }

--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -6,6 +6,7 @@ import api from 'lib/api'
 import { ENTITY_MATCH_TYPE } from 'lib/constants'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import posthog from 'posthog-js'
 import { NEW_COHORT, NEW_CRITERIA, NEW_CRITERIA_GROUP } from 'scenes/cohorts/CohortFilters/constants'
 import {
     applyAllCriteriaGroup,
@@ -271,7 +272,10 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                                 is_static: cohort.is_static,
                                 operation_type: cohort.id === 'new' ? 'create' : 'update',
                                 has_csv: !!cohortFormData.get?.('csv'),
-                                file_size: cohortFormData.get?.('csv')?.size,
+                                file_size: (() => {
+                                    const csvFile = cohortFormData.get?.('csv')
+                                    return csvFile instanceof File ? csvFile.size : undefined
+                                })(),
 
                                 // Error context
                                 error_status: error.status,

--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -259,13 +259,14 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                         // Only capture exception if we don't have proper error details
                         // This indicates an unexpected failure (network, timeout, etc.)
                         if (!error.detail) {
-                            const contextualError = new Error('Cohort creation failed unexpectedly')
                             console.error('Cohort creation failed unexpectedly:', error, {
                                 cohort_name: cohort.name,
                                 operation_type: cohort.id === 'new' ? 'create' : 'update',
                                 is_static: cohort.is_static,
                             })
-                            posthog.captureException(contextualError, {
+                            posthog.captureException(error, {
+                                // Context explains what we were doing when error occurred
+                                cohort_operation: 'Cohort creation failed unexpectedly',
                                 // Cohort context (most valuable)
                                 cohort_name: cohort.name,
                                 is_static: cohort.is_static,

--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -259,7 +259,13 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                         // Only capture exception if we don't have proper error details
                         // This indicates an unexpected failure (network, timeout, etc.)
                         if (!error.detail) {
-                            posthog.captureException(new Error('Cohort creation failed unexpectedly'), {
+                            const contextualError = new Error('Cohort creation failed unexpectedly')
+                            console.error('Cohort creation failed unexpectedly:', error, {
+                                cohort_name: cohort.name,
+                                operation_type: cohort.id === 'new' ? 'create' : 'update',
+                                is_static: cohort.is_static,
+                            })
+                            posthog.captureException(contextualError, {
                                 // Cohort context (most valuable)
                                 cohort_name: cohort.name,
                                 is_static: cohort.is_static,


### PR DESCRIPTION
Call `captureException` when `error.detail` is missing, indicating unexpected failures like network issues, timeouts, or infrastructure problems. These are errors that were possibly NOT logged on the server.

## Problem

Saving a cohort sometimes fails with the message "Failed to save cohort". Unfortunately, that's not all that helpful. There's nothing in the client or server logs. This indicates that the `error.detail` was empty. This could indicate an error that happens in between the client and server since we couldn't find any server logs.

See ticket: https://posthoghelp.zendesk.com/agent/tickets/35862 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/38080)

## Changes

When `error.detail` is empty, we call `posthog.captureException()` and we log the error to the console.

## How did you test this code?

Manually.

<img width="504" height="189" alt="Screenshot 2025-08-11 at 3 20 55 PM" src="https://github.com/user-attachments/assets/9c138536-b64e-4990-9ab3-2c68cc1c067b" />


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
