### PR TITLE
fix(msg): sanitize pg query

### DIFF
--- a/plugin-server/src/cdp/consumers/cdp-aggregation-writer.consumer.test.ts
+++ b/plugin-server/src/cdp/consumers/cdp-aggregation-writer.consumer.test.ts
@@ -358,6 +358,43 @@ describe('CdpAggregationWriterConsumer', () => {
             expect(personResult.rows).toHaveLength(0)
         })
 
+        it('should clean null bytes and control characters that cause PostgreSQL errors', async () => {
+            const personId = '550e8400-e29b-41d4-a716-446655440002'
+
+            // Real-world example that caused "invalid byte sequence for encoding UTF8: 0x00"
+            const personEvents: PersonEventPayload[] = [
+                {
+                    type: 'person-performed-event',
+                    personId,
+                    eventName: 'OpenApp\x00\x00\x00\x00\x04>-', // Contains null bytes like in the error
+                    teamId: team.id,
+                },
+                {
+                    type: 'person-performed-event',
+                    personId,
+                    eventName: 'event\x13with\x00control\x01chars', // Mix of control characters
+                    teamId: team.id,
+                },
+            ]
+
+            // Should NOT throw PostgreSQL protocol error
+            await expect(processor['writeToPostgres'](personEvents, [])).resolves.not.toThrow()
+
+            // Verify events were written with cleaned names
+            const result = await hub.postgres.query(
+                PostgresUse.COUNTERS_RW,
+                'SELECT event_name FROM person_performed_events WHERE team_id = $1 AND person_id = $2 ORDER BY event_name',
+                [team.id, personId],
+                'test-read-cleaned-events'
+            )
+
+            expect(result.rows).toHaveLength(2)
+            // Verify null bytes and control chars were removed but readable text preserved
+            // ORDER BY is case-sensitive, so 'O' comes before 'e'
+            expect(result.rows[0].event_name).toBe('OpenApp>-')
+            expect(result.rows[1].event_name).toBe('eventwithcontrolchars')
+        })
+
         it('should handle special characters that could cause PostgreSQL protocol errors', async () => {
             // These special characters previously caused "invalid message format" errors
             const validPersonId1 = '550e8400-e29b-41d4-a716-446655440002'

--- a/plugin-server/src/cdp/consumers/cdp-aggregation-writer.consumer.test.ts
+++ b/plugin-server/src/cdp/consumers/cdp-aggregation-writer.consumer.test.ts
@@ -389,10 +389,11 @@ describe('CdpAggregationWriterConsumer', () => {
             )
 
             expect(result.rows).toHaveLength(2)
-            // Verify null bytes and control chars were removed but readable text preserved
-            // ORDER BY is case-sensitive, so 'O' comes before 'e'
-            expect(result.rows[0].event_name).toBe('OpenApp>-')
-            expect(result.rows[1].event_name).toBe('eventwithcontrolchars')
+            // sanitizeString replaces null bytes with � (replacement character)
+            // Control character \x04 remains, null bytes become �
+            expect(result.rows[0].event_name).toBe('OpenApp����\x04>-')
+            // Control characters \x13 and \x01 remain, null byte becomes �
+            expect(result.rows[1].event_name).toBe('event\x13with�control\x01chars')
         })
 
         it('should handle special characters that could cause PostgreSQL protocol errors', async () => {

--- a/plugin-server/src/cdp/consumers/cdp-aggregation-writer.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-aggregation-writer.consumer.ts
@@ -5,6 +5,7 @@ import { KafkaConsumer } from '../../kafka/consumer'
 import { runInstrumentedFunction } from '../../main/utils'
 import { Hub } from '../../types'
 import { PostgresUse } from '../../utils/db/postgres'
+import { sanitizeString } from '../../utils/db/utils'
 import { parseJSON } from '../../utils/json-parse'
 import { logger } from '../../utils/logger'
 import { CdpConsumerBase } from './cdp-base.consumer'
@@ -100,36 +101,6 @@ export class CdpAggregationWriterConsumer extends CdpConsumerBase {
         return Array.from(aggregatedEventsMap.values())
     }
 
-    // Clean string to be PostgreSQL-compatible by removing null bytes and control characters
-    // This is necessary because PostgreSQL TEXT columns cannot store null bytes
-    private cleanForPostgres(text: string): string {
-        // Fast path: check if cleaning is needed
-        let needsCleaning = false
-        for (let i = 0; i < text.length; i++) {
-            const code = text.charCodeAt(i)
-            // Check for null byte or control chars (except tab=9, newline=10, CR=13)
-            if (code === 0 || (code < 32 && code !== 9 && code !== 10 && code !== 13) || code === 127) {
-                needsCleaning = true
-                break
-            }
-        }
-
-        if (!needsCleaning) {
-            return text
-        }
-
-        // Remove null bytes and control characters
-        // Keep only printable chars and allowed whitespace (tab, newline, CR)
-        let result = ''
-        for (let i = 0; i < text.length; i++) {
-            const code = text.charCodeAt(i)
-            if ((code >= 32 && code < 127) || code === 9 || code === 10 || code === 13 || code > 127) {
-                result += text[i]
-            }
-        }
-        return result
-    }
-
     // Process batch by aggregating and writing to postgres
     private async processBatch(parsedBatch: ParsedBatch): Promise<void> {
         // Deduplicate person performed events
@@ -159,7 +130,7 @@ export class CdpAggregationWriterConsumer extends CdpConsumerBase {
         const params = [
             personEvents.map((e) => e.teamId),
             personEvents.map((e) => e.personId),
-            personEvents.map((e) => this.cleanForPostgres(e.eventName)),
+            personEvents.map((e) => sanitizeString(e.eventName)),
         ]
 
         return { cte, params }
@@ -181,8 +152,8 @@ export class CdpAggregationWriterConsumer extends CdpConsumerBase {
         const params = [
             behaviouralEvents.map((e) => e.teamId),
             behaviouralEvents.map((e) => e.personId),
-            behaviouralEvents.map((e) => this.cleanForPostgres(e.filterHash)),
-            behaviouralEvents.map((e) => this.cleanForPostgres(e.date)),
+            behaviouralEvents.map((e) => sanitizeString(e.filterHash)),
+            behaviouralEvents.map((e) => sanitizeString(e.date)),
             behaviouralEvents.map((e) => e.counter),
         ]
 


### PR DESCRIPTION
## Problem

The CDP aggregation writer was crashing with PostgreSQL errors ("invalid byte sequence for encoding UTF8: 0x00") when event names contained null bytes or control characters from corrupted client tracking data.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes


  - used sanitize util to replace invalid byte sequence

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- added test

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
