### PR TITLE
fix: temporal async slack for subscriptions

### DIFF
--- a/ee/tasks/subscriptions/__init__.py
+++ b/ee/tasks/subscriptions/__init__.py
@@ -12,6 +12,7 @@ from ee.tasks.subscriptions.email_subscriptions import send_email_subscription_r
 from ee.tasks.subscriptions.slack_subscriptions import (
     send_slack_subscription_report,
     send_slack_message_with_integration,
+    send_slack_message_with_integration_async,
     get_slack_integration_for_team,
 )
 from ee.tasks.subscriptions.subscription_utils import generate_assets
@@ -111,7 +112,7 @@ async def deliver_subscription_report_async(
                 SUBSCRIPTION_FAILURE.labels(destination="slack").inc()
                 return
 
-            send_slack_message_with_integration(
+            await send_slack_message_with_integration_async(
                 integration,
                 subscription,
                 assets,

--- a/ee/tasks/subscriptions/slack_subscriptions.py
+++ b/ee/tasks/subscriptions/slack_subscriptions.py
@@ -15,11 +15,9 @@ UTM_TAGS_BASE = "utm_source=posthog&utm_campaign=subscription_report"
 
 @dataclass
 class SlackMessageData:
-    """Data structure for Slack message with thread messages."""
-
     channel: str
     blocks: list[dict[str, Any]]
-    title: str  # This becomes the 'text' parameter in chat_postMessage
+    title: str
     thread_messages: list[dict[str, Any]] = field(default_factory=list)
 
 

--- a/ee/tasks/subscriptions/slack_subscriptions.py
+++ b/ee/tasks/subscriptions/slack_subscriptions.py
@@ -1,9 +1,11 @@
 import structlog
+from typing import Any
 from django.conf import settings
 
 from posthog.models.exported_asset import ExportedAsset
 from posthog.models.integration import Integration, SlackIntegration
 from posthog.models.subscription import Subscription
+from slack_sdk.web.async_client import AsyncWebClient
 
 logger = structlog.get_logger(__name__)
 
@@ -44,24 +46,20 @@ def send_slack_subscription_report(
     send_slack_message_with_integration(integration, subscription, assets, total_asset_count, is_new_subscription)
 
 
-def send_slack_message_with_integration(
-    integration: Integration,
+def _prepare_slack_message(
     subscription: Subscription,
     assets: list[ExportedAsset],
     total_asset_count: int,
     is_new_subscription: bool = False,
-) -> None:
-    """Send Slack message using provided integration. Pure function - no database operations."""
+) -> dict[str, Any]:
+    """Prepare Slack message content. Pure function with no side effects."""
     utm_tags = f"{UTM_TAGS_BASE}&utm_medium=slack"
 
     resource_info = subscription.resource_info
     if not resource_info:
         raise NotImplementedError("This type of subscription resource is not supported")
 
-    slack_integration = SlackIntegration(integration)
-
     channel = subscription.target_value.split("|")[0]
-
     first_asset, *other_assets = assets
 
     if is_new_subscription:
@@ -70,14 +68,10 @@ def send_slack_message_with_integration(
     else:
         title = f"Your subscription to the {resource_info.kind} *{resource_info.name}* is ready! 🎉"
 
-    blocks = []
-
-    blocks.extend(
-        [
-            {"type": "section", "text": {"type": "mrkdwn", "text": title}},
-            _block_for_asset(first_asset),
-        ]
-    )
+    blocks = [
+        {"type": "section", "text": {"type": "mrkdwn", "text": title}},
+        _block_for_asset(first_asset),
+    ]
 
     if other_assets:
         blocks.append(
@@ -108,21 +102,15 @@ def send_slack_message_with_integration(
         ]
     )
 
-    message_res = slack_integration.client.chat_postMessage(channel=channel, blocks=blocks, text=title)
+    # Prepare additional messages for thread
+    thread_messages = []
+    for asset in other_assets:
+        thread_messages.append({"blocks": [_block_for_asset(asset)]})
 
-    thread_ts = message_res.get("ts")
-
-    if thread_ts:
-        for asset in other_assets:
-            slack_integration.client.chat_postMessage(
-                channel=channel, thread_ts=thread_ts, blocks=[_block_for_asset(asset)]
-            )
-
-        if total_asset_count > len(assets):
-            slack_integration.client.chat_postMessage(
-                channel=channel,
-                thread_ts=thread_ts,
-                blocks=[
+    if total_asset_count > len(assets):
+        thread_messages.append(
+            {
+                "blocks": [
                     {
                         "type": "section",
                         "text": {
@@ -130,5 +118,61 @@ def send_slack_message_with_integration(
                             "text": f"Showing {len(assets)} of {total_asset_count} Insights. <{resource_info.url}?{utm_tags}|View the rest in PostHog>",
                         },
                     }
-                ],
+                ]
+            }
+        )
+
+    return {
+        "channel": channel,
+        "blocks": blocks,
+        "title": title,
+        "thread_messages": thread_messages,
+    }
+
+
+def send_slack_message_with_integration(
+    integration: Integration,
+    subscription: Subscription,
+    assets: list[ExportedAsset],
+    total_asset_count: int,
+    is_new_subscription: bool = False,
+) -> None:
+    """Send Slack message using provided integration (sync version)."""
+    message_data = _prepare_slack_message(subscription, assets, total_asset_count, is_new_subscription)
+    slack_integration = SlackIntegration(integration)
+
+    # Send main message
+    message_res = slack_integration.client.chat_postMessage(
+        channel=message_data["channel"], blocks=message_data["blocks"], text=message_data["title"]
+    )
+
+    thread_ts = message_res.get("ts")
+    if thread_ts:
+        # Send thread messages
+        for thread_msg in message_data["thread_messages"]:
+            slack_integration.client.chat_postMessage(
+                channel=message_data["channel"], thread_ts=thread_ts, **thread_msg
             )
+
+
+async def send_slack_message_with_integration_async(
+    integration: Integration,
+    subscription: Subscription,
+    assets: list[ExportedAsset],
+    total_asset_count: int,
+    is_new_subscription: bool = False,
+) -> None:
+    """Send Slack message using provided integration (async version)."""
+    message_data = _prepare_slack_message(subscription, assets, total_asset_count, is_new_subscription)
+    async_client = AsyncWebClient(integration.sensitive_config["access_token"])
+
+    # Send main message
+    message_res = await async_client.chat_postMessage(
+        channel=message_data["channel"], blocks=message_data["blocks"], text=message_data["title"]
+    )
+
+    thread_ts = message_res.get("ts")
+    if thread_ts:
+        # Send thread messages
+        for thread_msg in message_data["thread_messages"]:
+            await async_client.chat_postMessage(channel=message_data["channel"], thread_ts=thread_ts, **thread_msg)

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -3634,3 +3634,28 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["id"], accessible_insight.id)
         self.assertEqual(results[0]["short_id"], accessible_insight_short_id)
+
+    @patch("posthog.tasks.insight_query_metadata.extract_insight_query_metadata.apply_async")
+    def test_query_metadata_task_scheduled_consistently(self, mock_extract_task):
+        """Test that both creation and update paths schedule the same metadata extraction task"""
+        query = {"kind": "EventsQuery", "select": ["*"], "limit": 100}
+
+        # Test creation path (post_save signal)
+        mock_extract_task.reset_mock()
+        insight = Insight.objects.create(team=self.team, query=query, created_by=self.user)
+
+        # Should schedule task on creation
+        mock_extract_task.assert_called_once_with(kwargs={"insight_id": insight.id}, countdown=10 * 60)
+
+        # Test update path (API update method)
+        mock_extract_task.reset_mock()
+        new_query = {"kind": "EventsQuery", "select": ["event"], "limit": 50}
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/insights/{insight.id}", {"query": new_query}, format="json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Should schedule task on query change
+        mock_extract_task.assert_called_once_with(kwargs={"insight_id": insight.id}, countdown=10 * 60)

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -14,6 +14,8 @@ import requests
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework import status
+from slack_sdk.web.async_client import AsyncWebClient
+
 from posthog.exceptions_capture import capture_exception
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
@@ -563,6 +565,10 @@ class SlackIntegration:
     @property
     def client(self) -> WebClient:
         return WebClient(self.integration.sensitive_config["access_token"])
+
+    @property
+    def async_client(self) -> AsyncWebClient:
+        return AsyncWebClient(self.integration.sensitive_config["access_token"])
 
     def list_channels(self, should_include_private_channels: bool, authed_user: str) -> list[dict]:
         # NOTE: Annoyingly the Slack API has no search so we have to load all channels...


### PR DESCRIPTION
## Problem
Temporal slack messages aren't sending. The problem is likely with calling the sync client from the async context and not awaiting the response.

## Changes
Use the async slack client

## Testing
Async client currently only used for our team and feature-flagged. Relatively hard to test locally

