### PR TITLE
feat(max): filter by multiple properties in the actors taxonomy query

### DIFF
--- a/ee/hogai/graph/query_planner/toolkit.py
+++ b/ee/hogai/graph/query_planner/toolkit.py
@@ -311,15 +311,15 @@ class TaxonomyAgentToolkit:
         if entity == "session":
             return self._retrieve_session_properties(property_name)
         if entity == "person":
-            query = ActorsPropertyTaxonomyQuery(property=property_name, maxPropertyValues=25)
+            query = ActorsPropertyTaxonomyQuery(properties=[property_name], maxPropertyValues=25)
         elif entity == "event":
-            query = ActorsPropertyTaxonomyQuery(property=property_name, maxPropertyValues=50)
+            query = ActorsPropertyTaxonomyQuery(properties=[property_name], maxPropertyValues=50)
         else:
             group_index = next((group.group_type_index for group in self._groups if group.group_type == entity), None)
             if group_index is None:
                 return f"The entity {entity} does not exist in the taxonomy."
             query = ActorsPropertyTaxonomyQuery(
-                group_type_index=group_index, property=property_name, maxPropertyValues=25
+                groupTypeIndex=group_index, properties=[property_name], maxPropertyValues=25
             )
 
         try:
@@ -352,9 +352,14 @@ class TaxonomyAgentToolkit:
         if not response.results:
             return f"Property values for {property_name} do not exist in the taxonomy for the entity {entity}."
 
+        if isinstance(response.results, list):
+            unpacked_results = response.results[0]
+        else:
+            unpacked_results = response.results
+
         return self._format_property_values(
-            response.results.sample_values,
-            response.results.sample_count,
+            unpacked_results.sample_values,
+            unpacked_results.sample_count,
             format_as_string=property_definition.property_type in (PropertyType.String, PropertyType.Datetime),
         )
 

--- a/ee/hogai/graph/query_planner/toolkit.py
+++ b/ee/hogai/graph/query_planner/toolkit.py
@@ -356,6 +356,7 @@ class TaxonomyAgentToolkit:
         if not response.results:
             return f"Property values for {property_name} do not exist in the taxonomy for the entity {entity}."
 
+        # TRICKY. Remove when the toolkit supports multiple results.
         if isinstance(response.results, list):
             unpacked_results = response.results[0]
         else:

--- a/ee/hogai/graph/query_planner/toolkit.py
+++ b/ee/hogai/graph/query_planner/toolkit.py
@@ -6,10 +6,23 @@ from typing import Literal, Optional, Union, cast
 
 from pydantic import BaseModel, field_validator
 
+from ee.hogai.graph.taxonomy.tools import (
+    ask_user_for_help,
+    retrieve_action_properties,
+    retrieve_action_property_values,
+    retrieve_entity_properties,
+    retrieve_entity_property_values,
+    retrieve_event_properties,
+    retrieve_event_property_values,
+)
 from posthog.clickhouse.query_tagging import Product, tags_context
 from posthog.hogql.database.schema.channel_type import DEFAULT_CHANNEL_TYPES
-from posthog.hogql_queries.ai.actors_property_taxonomy_query_runner import ActorsPropertyTaxonomyQueryRunner
-from posthog.hogql_queries.ai.event_taxonomy_query_runner import EventTaxonomyQueryRunner
+from posthog.hogql_queries.ai.actors_property_taxonomy_query_runner import (
+    ActorsPropertyTaxonomyQueryRunner,
+)
+from posthog.hogql_queries.ai.event_taxonomy_query_runner import (
+    EventTaxonomyQueryRunner,
+)
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models import Action, Team
 from posthog.models.group_type_mapping import GroupTypeMapping
@@ -21,15 +34,6 @@ from posthog.schema import (
     EventTaxonomyQuery,
 )
 from posthog.taxonomy.taxonomy import CORE_FILTER_DEFINITIONS_BY_GROUP
-from ee.hogai.graph.taxonomy.tools import (
-    retrieve_action_properties,
-    retrieve_action_property_values,
-    retrieve_entity_properties,
-    retrieve_entity_property_values,
-    retrieve_event_properties,
-    retrieve_event_property_values,
-    ask_user_for_help,
-)
 
 MaxSupportedQueryKind = Literal["trends", "funnel", "retention", "sql"]
 
@@ -323,9 +327,9 @@ class TaxonomyAgentToolkit:
             )
 
         try:
-            if query.group_type_index is not None:
+            if query.groupTypeIndex is not None:
                 prop_type = PropertyDefinition.Type.GROUP
-                group_type_index = query.group_type_index
+                group_type_index = query.groupTypeIndex
             elif entity == "event":
                 prop_type = PropertyDefinition.Type.EVENT
                 group_type_index = None

--- a/ee/hogai/graph/taxonomy/toolkit.py
+++ b/ee/hogai/graph/taxonomy/toolkit.py
@@ -1,6 +1,20 @@
+from collections.abc import Iterable
+from functools import cached_property
+from typing import Optional, Union, cast
+from xml.etree import ElementTree as ET
+
+import yaml
+from langchain_core.agents import AgentAction
+from pydantic import BaseModel
+
+from posthog.clickhouse.query_tagging import Product, tags_context
 from posthog.hogql.database.schema.channel_type import DEFAULT_CHANNEL_TYPES
-from posthog.hogql_queries.ai.actors_property_taxonomy_query_runner import ActorsPropertyTaxonomyQueryRunner
-from posthog.hogql_queries.ai.event_taxonomy_query_runner import EventTaxonomyQueryRunner
+from posthog.hogql_queries.ai.actors_property_taxonomy_query_runner import (
+    ActorsPropertyTaxonomyQueryRunner,
+)
+from posthog.hogql_queries.ai.event_taxonomy_query_runner import (
+    EventTaxonomyQueryRunner,
+)
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models import Action, Team
 from posthog.models.group_type_mapping import GroupTypeMapping
@@ -11,24 +25,16 @@ from posthog.schema import (
     CachedEventTaxonomyQueryResponse,
     EventTaxonomyQuery,
 )
-from xml.etree import ElementTree as ET
-from posthog.clickhouse.query_tagging import Product, tags_context
-from langchain_core.agents import AgentAction
-from typing import Union
-from functools import cached_property
-from typing import Optional, cast
-from collections.abc import Iterable
-from pydantic import BaseModel
-import yaml
-from .tools import TaxonomyTool
+from posthog.taxonomy.taxonomy import CORE_FILTER_DEFINITIONS_BY_GROUP
+
 from .tools import (
+    TaxonomyTool,
+    ask_user_for_help,
     retrieve_entity_properties,
     retrieve_entity_property_values,
     retrieve_event_properties,
     retrieve_event_property_values,
-    ask_user_for_help,
 )
-from posthog.taxonomy.taxonomy import CORE_FILTER_DEFINITIONS_BY_GROUP
 
 
 class TaxonomyToolNotFoundError(Exception):
@@ -325,21 +331,21 @@ class TaxonomyAgentToolkit:
         if entity == "session":
             return self._retrieve_session_properties(property_name)
         if entity == "person":
-            query = ActorsPropertyTaxonomyQuery(property=property_name, maxPropertyValues=25)
+            query = ActorsPropertyTaxonomyQuery(properties=[property_name], maxPropertyValues=25)
         elif entity == "event":
-            query = ActorsPropertyTaxonomyQuery(property=property_name, maxPropertyValues=50)
+            query = ActorsPropertyTaxonomyQuery(properties=[property_name], maxPropertyValues=50)
         else:
             group_index = next((group.group_type_index for group in self._groups if group.group_type == entity), None)
             if group_index is None:
                 return TaxonomyErrorMessages.entity_not_found(entity)
             query = ActorsPropertyTaxonomyQuery(
-                group_type_index=group_index, property=property_name, maxPropertyValues=25
+                groupTypeIndex=group_index, properties=[property_name], maxPropertyValues=25
             )
 
         try:
-            if query.group_type_index is not None:
+            if query.groupTypeIndex is not None:
                 prop_type = PropertyDefinition.Type.GROUP
-                group_type_index = query.group_type_index
+                group_type_index = query.groupTypeIndex
             elif entity == "event":
                 prop_type = PropertyDefinition.Type.EVENT
                 group_type_index = None
@@ -366,9 +372,14 @@ class TaxonomyAgentToolkit:
         if not response.results:
             return TaxonomyErrorMessages.property_values_not_found(property_name, entity)
 
+        if isinstance(response.results, list):
+            unpacked_results = response.results[0]
+        else:
+            unpacked_results = response.results
+
         return self._format_property_values(
-            response.results.sample_values,
-            response.results.sample_count,
+            unpacked_results.sample_values,
+            unpacked_results.sample_count,
             format_as_string=property_definition.property_type in (PropertyType.String, PropertyType.Datetime),
         )
 

--- a/ee/hogai/graph/taxonomy/toolkit.py
+++ b/ee/hogai/graph/taxonomy/toolkit.py
@@ -372,6 +372,7 @@ class TaxonomyAgentToolkit:
         if not response.results:
             return TaxonomyErrorMessages.property_values_not_found(property_name, entity)
 
+        # TRICKY. Remove when the toolkit supports multiple results.
         if isinstance(response.results, list):
             unpacked_results = response.results[0]
         else:

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -81,7 +81,7 @@
         "ActorsPropertyTaxonomyQuery": {
             "additionalProperties": false,
             "properties": {
-                "group_type_index": {
+                "groupTypeIndex": {
                     "$ref": "#/definitions/integer"
                 },
                 "kind": {
@@ -95,8 +95,11 @@
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
                 },
-                "property": {
-                    "type": "string"
+                "properties": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
                 },
                 "response": {
                     "$ref": "#/definitions/ActorsPropertyTaxonomyQueryResponse"
@@ -109,7 +112,7 @@
                     "type": "number"
                 }
             },
-            "required": ["kind", "property"],
+            "required": ["kind", "properties"],
             "type": "object"
         },
         "ActorsPropertyTaxonomyQueryResponse": {
@@ -137,7 +140,17 @@
                     "description": "The date range used for the query"
                 },
                 "results": {
-                    "$ref": "#/definitions/ActorsPropertyTaxonomyResponse"
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ActorsPropertyTaxonomyResponse"
+                        },
+                        {
+                            "items": {
+                                "$ref": "#/definitions/ActorsPropertyTaxonomyResponse"
+                            },
+                            "type": "array"
+                        }
+                    ]
                 },
                 "timings": {
                     "description": "Measured timings for different parts of the query generation process",
@@ -2537,7 +2550,17 @@
                     "description": "The date range used for the query"
                 },
                 "results": {
-                    "$ref": "#/definitions/ActorsPropertyTaxonomyResponse"
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ActorsPropertyTaxonomyResponse"
+                        },
+                        {
+                            "items": {
+                                "$ref": "#/definitions/ActorsPropertyTaxonomyResponse"
+                            },
+                            "type": "array"
+                        }
+                    ]
                 },
                 "timezone": {
                     "type": "string"
@@ -19951,7 +19974,17 @@
                             "description": "The date range used for the query"
                         },
                         "results": {
-                            "$ref": "#/definitions/ActorsPropertyTaxonomyResponse"
+                            "anyOf": [
+                                {
+                                    "$ref": "#/definitions/ActorsPropertyTaxonomyResponse"
+                                },
+                                {
+                                    "items": {
+                                        "$ref": "#/definitions/ActorsPropertyTaxonomyResponse"
+                                    },
+                                    "type": "array"
+                                }
+                            ]
                         },
                         "timings": {
                             "description": "Measured timings for different parts of the query generation process",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -3026,12 +3026,14 @@ export interface ActorsPropertyTaxonomyResponse {
 
 export interface ActorsPropertyTaxonomyQuery extends DataNode<ActorsPropertyTaxonomyQueryResponse> {
     kind: NodeKind.ActorsPropertyTaxonomyQuery
-    property: string
-    group_type_index?: integer
+    properties: string[]
+    groupTypeIndex?: integer
     maxPropertyValues?: integer
 }
 
-export type ActorsPropertyTaxonomyQueryResponse = AnalyticsQueryResponseBase<ActorsPropertyTaxonomyResponse>
+export type ActorsPropertyTaxonomyQueryResponse = AnalyticsQueryResponseBase<
+    ActorsPropertyTaxonomyResponse | ActorsPropertyTaxonomyResponse[]
+>
 
 export type CachedActorsPropertyTaxonomyQueryResponse = CachedQueryResponse<ActorsPropertyTaxonomyQueryResponse>
 

--- a/posthog/hogql_queries/ai/actors_property_taxonomy_query_runner.py
+++ b/posthog/hogql_queries/ai/actors_property_taxonomy_query_runner.py
@@ -103,7 +103,10 @@ class ActorsPropertyTaxonomyQueryRunner(TaxonomyCacheMixin, QueryRunner):
 
     def _get_subquery(self) -> ast.SelectQuery:
         inner_props_array = ast.Array(
-            exprs=[ast.Field(chain=["properties", p]) for p in self.query.properties[: self.MAX_PROPERTY_LIMIT]]
+            exprs=[
+                ast.Call(name="toString", args=[ast.Field(chain=["properties", p])])
+                for p in self.query.properties[: self.MAX_PROPERTY_LIMIT]
+            ]
         )
 
         return ast.SelectQuery(

--- a/posthog/hogql_queries/ai/actors_property_taxonomy_query_runner.py
+++ b/posthog/hogql_queries/ai/actors_property_taxonomy_query_runner.py
@@ -13,6 +13,8 @@ from posthog.schema import (
 
 
 class ActorsPropertyTaxonomyQueryRunner(TaxonomyCacheMixin, QueryRunner):
+    MAX_PROPERTY_LIMIT = 200
+
     query: ActorsPropertyTaxonomyQuery
     response: ActorsPropertyTaxonomyQueryResponse
     cached_response: CachedActorsPropertyTaxonomyQueryResponse
@@ -30,26 +32,26 @@ class ActorsPropertyTaxonomyQueryRunner(TaxonomyCacheMixin, QueryRunner):
             limit_context=self.limit_context,
         )
 
-        results = (
-            {
-                "sample_values": response.results[0][0],
-                "sample_count": response.results[0][1],
-            }
-            if response.results
-            else {
-                "sample_values": [],
-                "sample_count": 0,
-            }
-        )
+        # Map results by prop_index (1-based from arrayEnumerate) back to input order
+        num_props = len(self.query.properties)
+        results_by_index: list[dict] = [{"sample_values": [], "sample_count": 0} for _ in range(num_props)]
+
+        for sample_values, sample_count, prop_index in response.results or []:
+            idx = int(prop_index) - 1
+            if 0 <= idx < num_props:
+                results_by_index[idx] = {
+                    "sample_values": sample_values,
+                    "sample_count": sample_count,
+                }
 
         return ActorsPropertyTaxonomyQueryResponse(
-            results=results,
+            results=results_by_index,
             timings=response.timings,
             hogql=hogql,
             modifiers=self.modifiers,
         )
 
-    def to_query(self) -> ast.SelectQuery | ast.SelectSetQuery:
+    def to_query(self) -> ast.SelectQuery:
         query = ast.SelectQuery(
             select=[
                 ast.Call(
@@ -58,15 +60,18 @@ class ActorsPropertyTaxonomyQueryRunner(TaxonomyCacheMixin, QueryRunner):
                     params=[ast.Constant(value=self.query.maxPropertyValues or 5)],
                 ),
                 ast.Call(name="count", args=[]),
+                ast.Field(chain=["prop_index"]),
             ],
             select_from=ast.JoinExpr(table=self._get_subquery()),
+            group_by=[ast.Field(chain=["prop_index"])],
+            order_by=[ast.OrderExpr(expr=ast.Field(chain=["prop_index"]), order="ASC")],
         )
 
         return query
 
     @property
     def _actor_type(self) -> str:
-        if self.query.group_type_index is not None:
+        if self.query.groupTypeIndex is not None:
             return "group"
         return "person"
 
@@ -76,10 +81,10 @@ class ActorsPropertyTaxonomyQueryRunner(TaxonomyCacheMixin, QueryRunner):
             return "persons"
         return "groups"
 
-    def _subquery_filter(self) -> Optional[ast.Expr]:
+    def _subquery_filter(self, *, field_name: str = "prop") -> Optional[ast.Expr]:
         field_filter = ast.Call(
             name="isNotNull",
-            args=[ast.Field(chain=["prop"])],
+            args=[ast.Field(chain=[field_name])],
         )
 
         if self._actor_type == "group":
@@ -89,7 +94,7 @@ class ActorsPropertyTaxonomyQueryRunner(TaxonomyCacheMixin, QueryRunner):
                     ast.CompareOperation(
                         left=ast.Field(chain=["index"]),
                         op=ast.CompareOperationOp.Eq,
-                        right=ast.Constant(value=self.query.group_type_index),
+                        right=ast.Constant(value=self.query.groupTypeIndex),
                     ),
                 ]
             )
@@ -97,11 +102,22 @@ class ActorsPropertyTaxonomyQueryRunner(TaxonomyCacheMixin, QueryRunner):
         return field_filter
 
     def _get_subquery(self) -> ast.SelectQuery:
-        query = ast.SelectQuery(
-            select=[ast.Alias(expr=ast.Field(chain=["properties", self.query.property]), alias="prop")],
+        inner_props_array = ast.Array(
+            exprs=[ast.Field(chain=["properties", p]) for p in self.query.properties[: self.MAX_PROPERTY_LIMIT]]
+        )
+
+        return ast.SelectQuery(
+            select=[
+                ast.Field(chain=["prop_index"]),
+                ast.Alias(alias="prop", expr=ast.Call(name="toString", args=[ast.Field(chain=["prop_value"])])),
+            ],
             distinct=True,
             select_from=ast.JoinExpr(table=ast.Field(chain=[self._origin])),
-            where=self._subquery_filter(),
+            where=self._subquery_filter(field_name="prop_value"),
             order_by=[ast.OrderExpr(expr=ast.Field(chain=["created_at"]), order="DESC")],
+            array_join_op="ARRAY JOIN",
+            array_join_list=[
+                ast.Alias(alias="prop_index", expr=ast.Call(name="arrayEnumerate", args=[inner_props_array])),
+                ast.Alias(alias="prop_value", expr=inner_props_array),
+            ],
         )
-        return query

--- a/posthog/hogql_queries/ai/test/__snapshots__/test_actors_property_taxonomy_query_runner.ambr
+++ b/posthog/hogql_queries/ai/test/__snapshots__/test_actors_property_taxonomy_query_runner.ambr
@@ -16,8 +16,8 @@
         WHERE equals(groups.team_id, 99999)
         GROUP BY groups.group_type_index,
                  groups.group_key) AS groups ARRAY
-     JOIN arrayEnumerate([groups.properties___industry]) AS prop_index,
-          [groups.properties___industry] AS prop_value
+     JOIN arrayEnumerate([toString(groups.properties___industry)]) AS prop_index,
+          [toString(groups.properties___industry)] AS prop_value
      WHERE and(isNotNull(prop_value), ifNull(equals(groups.index, 0), 0))
      ORDER BY groups.created_at DESC)
   GROUP BY prop_index
@@ -51,8 +51,8 @@
         WHERE equals(groups.team_id, 99999)
         GROUP BY groups.group_type_index,
                  groups.group_key) AS groups ARRAY
-     JOIN arrayEnumerate([groups.`properties___does not exist`]) AS prop_index,
-          [groups.`properties___does not exist`] AS prop_value
+     JOIN arrayEnumerate([toString(groups.`properties___does not exist`)]) AS prop_index,
+          [toString(groups.`properties___does not exist`)] AS prop_value
      WHERE and(isNotNull(prop_value), ifNull(equals(groups.index, 0), 0))
      ORDER BY groups.created_at DESC)
   GROUP BY prop_index
@@ -86,8 +86,8 @@
         WHERE equals(groups.team_id, 99999)
         GROUP BY groups.group_type_index,
                  groups.group_key) AS groups ARRAY
-     JOIN arrayEnumerate([groups.properties___employee_count]) AS prop_index,
-          [groups.properties___employee_count] AS prop_value
+     JOIN arrayEnumerate([toString(groups.properties___employee_count)]) AS prop_index,
+          [toString(groups.properties___employee_count)] AS prop_value
      WHERE and(isNotNull(prop_value), ifNull(equals(groups.index, 0), 0))
      ORDER BY groups.created_at DESC)
   GROUP BY prop_index
@@ -124,8 +124,8 @@
                                                        GROUP BY person.id
                                                        HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))
                                                        ORDER BY argMax(toTimeZone(person.created_at, 'UTC'), person.version) DESC))) SETTINGS optimize_aggregation_in_order=1) AS persons ARRAY
-     JOIN arrayEnumerate([persons.properties___age]) AS prop_index,
-          [persons.properties___age] AS prop_value
+     JOIN arrayEnumerate([toString(persons.properties___age)]) AS prop_index,
+          [toString(persons.properties___age)] AS prop_value
      WHERE isNotNull(prop_value)
      ORDER BY persons.created_at DESC)
   GROUP BY prop_index
@@ -162,8 +162,8 @@
                                                        GROUP BY person.id
                                                        HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))
                                                        ORDER BY argMax(toTimeZone(person.created_at, 'UTC'), person.version) DESC))) SETTINGS optimize_aggregation_in_order=1) AS persons ARRAY
-     JOIN arrayEnumerate([persons.properties___email]) AS prop_index,
-          [persons.properties___email] AS prop_value
+     JOIN arrayEnumerate([toString(persons.properties___email)]) AS prop_index,
+          [toString(persons.properties___email)] AS prop_value
      WHERE isNotNull(prop_value)
      ORDER BY persons.created_at DESC)
   GROUP BY prop_index
@@ -200,8 +200,8 @@
                                                        GROUP BY person.id
                                                        HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))
                                                        ORDER BY argMax(toTimeZone(person.created_at, 'UTC'), person.version) DESC))) SETTINGS optimize_aggregation_in_order=1) AS persons ARRAY
-     JOIN arrayEnumerate([persons.`properties___does not exist`]) AS prop_index,
-          [persons.`properties___does not exist`] AS prop_value
+     JOIN arrayEnumerate([toString(persons.`properties___does not exist`)]) AS prop_index,
+          [toString(persons.`properties___does not exist`)] AS prop_value
      WHERE isNotNull(prop_value)
      ORDER BY persons.created_at DESC)
   GROUP BY prop_index
@@ -238,8 +238,8 @@
                                                        GROUP BY person.id
                                                        HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))
                                                        ORDER BY argMax(toTimeZone(person.created_at, 'UTC'), person.version) DESC))) SETTINGS optimize_aggregation_in_order=1) AS persons ARRAY
-     JOIN arrayEnumerate([persons.properties___age]) AS prop_index,
-          [persons.properties___age] AS prop_value
+     JOIN arrayEnumerate([toString(persons.properties___age)]) AS prop_index,
+          [toString(persons.properties___age)] AS prop_value
      WHERE isNotNull(prop_value)
      ORDER BY persons.created_at DESC)
   GROUP BY prop_index

--- a/posthog/hogql_queries/ai/test/__snapshots__/test_actors_property_taxonomy_query_runner.ambr
+++ b/posthog/hogql_queries/ai/test/__snapshots__/test_actors_property_taxonomy_query_runner.ambr
@@ -2,9 +2,11 @@
 # name: TestActorsPropertyTaxonomyQueryRunner.test_group_property_taxonomy_query_runner
   '''
   SELECT groupArray(5)(prop) AS `groupArray(5)(prop)`,
-         count() AS `count()`
+         count() AS `count()`,
+         prop_index AS prop_index
   FROM
-    (SELECT DISTINCT groups.properties___industry AS prop
+    (SELECT DISTINCT prop_index,
+                     toString(prop_value) AS prop
      FROM
        (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
                argMax(toTimeZone(groups.created_at, 'UTC'), toTimeZone(groups._timestamp, 'UTC')) AS created_at,
@@ -13,9 +15,13 @@
         FROM groups
         WHERE equals(groups.team_id, 99999)
         GROUP BY groups.group_type_index,
-                 groups.group_key) AS groups
-     WHERE and(isNotNull(prop), ifNull(equals(groups.index, 0), 0))
+                 groups.group_key) AS groups ARRAY
+     JOIN arrayEnumerate([groups.properties___industry]) AS prop_index,
+          [groups.properties___industry] AS prop_value
+     WHERE and(isNotNull(prop_value), ifNull(equals(groups.index, 0), 0))
      ORDER BY groups.created_at DESC)
+  GROUP BY prop_index
+  ORDER BY prop_index ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -31,9 +37,11 @@
 # name: TestActorsPropertyTaxonomyQueryRunner.test_group_property_taxonomy_query_runner.1
   '''
   SELECT groupArray(5)(prop) AS `groupArray(5)(prop)`,
-         count() AS `count()`
+         count() AS `count()`,
+         prop_index AS prop_index
   FROM
-    (SELECT DISTINCT groups.`properties___does not exist` AS prop
+    (SELECT DISTINCT prop_index,
+                     toString(prop_value) AS prop
      FROM
        (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'does not exist'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS `properties___does not exist`,
                argMax(toTimeZone(groups.created_at, 'UTC'), toTimeZone(groups._timestamp, 'UTC')) AS created_at,
@@ -42,9 +50,13 @@
         FROM groups
         WHERE equals(groups.team_id, 99999)
         GROUP BY groups.group_type_index,
-                 groups.group_key) AS groups
-     WHERE and(isNotNull(prop), ifNull(equals(groups.index, 0), 0))
+                 groups.group_key) AS groups ARRAY
+     JOIN arrayEnumerate([groups.`properties___does not exist`]) AS prop_index,
+          [groups.`properties___does not exist`] AS prop_value
+     WHERE and(isNotNull(prop_value), ifNull(equals(groups.index, 0), 0))
      ORDER BY groups.created_at DESC)
+  GROUP BY prop_index
+  ORDER BY prop_index ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -60,9 +72,11 @@
 # name: TestActorsPropertyTaxonomyQueryRunner.test_group_property_taxonomy_query_runner.2
   '''
   SELECT groupArray(5)(prop) AS `groupArray(5)(prop)`,
-         count() AS `count()`
+         count() AS `count()`,
+         prop_index AS prop_index
   FROM
-    (SELECT DISTINCT groups.properties___employee_count AS prop
+    (SELECT DISTINCT prop_index,
+                     toString(prop_value) AS prop
      FROM
        (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'employee_count'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___employee_count,
                argMax(toTimeZone(groups.created_at, 'UTC'), toTimeZone(groups._timestamp, 'UTC')) AS created_at,
@@ -71,9 +85,13 @@
         FROM groups
         WHERE equals(groups.team_id, 99999)
         GROUP BY groups.group_type_index,
-                 groups.group_key) AS groups
-     WHERE and(isNotNull(prop), ifNull(equals(groups.index, 0), 0))
+                 groups.group_key) AS groups ARRAY
+     JOIN arrayEnumerate([groups.properties___employee_count]) AS prop_index,
+          [groups.properties___employee_count] AS prop_value
+     WHERE and(isNotNull(prop_value), ifNull(equals(groups.index, 0), 0))
      ORDER BY groups.created_at DESC)
+  GROUP BY prop_index
+  ORDER BY prop_index ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -89,9 +107,11 @@
 # name: TestActorsPropertyTaxonomyQueryRunner.test_max_value_count
   '''
   SELECT groupArray(1)(prop) AS `groupArray(1)(prop)`,
-         count() AS `count()`
+         count() AS `count()`,
+         prop_index AS prop_index
   FROM
-    (SELECT DISTINCT persons.properties___age AS prop
+    (SELECT DISTINCT prop_index,
+                     toString(prop_value) AS prop
      FROM
        (SELECT person.id AS id,
                replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'age'), ''), 'null'), '^"|"$', '') AS properties___age,
@@ -103,9 +123,13 @@
                                                        WHERE equals(person.team_id, 99999)
                                                        GROUP BY person.id
                                                        HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))
-                                                       ORDER BY argMax(toTimeZone(person.created_at, 'UTC'), person.version) DESC))) SETTINGS optimize_aggregation_in_order=1) AS persons
-     WHERE isNotNull(prop)
+                                                       ORDER BY argMax(toTimeZone(person.created_at, 'UTC'), person.version) DESC))) SETTINGS optimize_aggregation_in_order=1) AS persons ARRAY
+     JOIN arrayEnumerate([persons.properties___age]) AS prop_index,
+          [persons.properties___age] AS prop_value
+     WHERE isNotNull(prop_value)
      ORDER BY persons.created_at DESC)
+  GROUP BY prop_index
+  ORDER BY prop_index ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -121,9 +145,11 @@
 # name: TestActorsPropertyTaxonomyQueryRunner.test_person_property_taxonomy_query_runner
   '''
   SELECT groupArray(5)(prop) AS `groupArray(5)(prop)`,
-         count() AS `count()`
+         count() AS `count()`,
+         prop_index AS prop_index
   FROM
-    (SELECT DISTINCT persons.properties___email AS prop
+    (SELECT DISTINCT prop_index,
+                     toString(prop_value) AS prop
      FROM
        (SELECT person.id AS id,
                replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
@@ -135,9 +161,13 @@
                                                        WHERE equals(person.team_id, 99999)
                                                        GROUP BY person.id
                                                        HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))
-                                                       ORDER BY argMax(toTimeZone(person.created_at, 'UTC'), person.version) DESC))) SETTINGS optimize_aggregation_in_order=1) AS persons
-     WHERE isNotNull(prop)
+                                                       ORDER BY argMax(toTimeZone(person.created_at, 'UTC'), person.version) DESC))) SETTINGS optimize_aggregation_in_order=1) AS persons ARRAY
+     JOIN arrayEnumerate([persons.properties___email]) AS prop_index,
+          [persons.properties___email] AS prop_value
+     WHERE isNotNull(prop_value)
      ORDER BY persons.created_at DESC)
+  GROUP BY prop_index
+  ORDER BY prop_index ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -153,9 +183,11 @@
 # name: TestActorsPropertyTaxonomyQueryRunner.test_person_property_taxonomy_query_runner.1
   '''
   SELECT groupArray(5)(prop) AS `groupArray(5)(prop)`,
-         count() AS `count()`
+         count() AS `count()`,
+         prop_index AS prop_index
   FROM
-    (SELECT DISTINCT persons.`properties___does not exist` AS prop
+    (SELECT DISTINCT prop_index,
+                     toString(prop_value) AS prop
      FROM
        (SELECT person.id AS id,
                replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'does not exist'), ''), 'null'), '^"|"$', '') AS `properties___does not exist`,
@@ -167,9 +199,13 @@
                                                        WHERE equals(person.team_id, 99999)
                                                        GROUP BY person.id
                                                        HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))
-                                                       ORDER BY argMax(toTimeZone(person.created_at, 'UTC'), person.version) DESC))) SETTINGS optimize_aggregation_in_order=1) AS persons
-     WHERE isNotNull(prop)
+                                                       ORDER BY argMax(toTimeZone(person.created_at, 'UTC'), person.version) DESC))) SETTINGS optimize_aggregation_in_order=1) AS persons ARRAY
+     JOIN arrayEnumerate([persons.`properties___does not exist`]) AS prop_index,
+          [persons.`properties___does not exist`] AS prop_value
+     WHERE isNotNull(prop_value)
      ORDER BY persons.created_at DESC)
+  GROUP BY prop_index
+  ORDER BY prop_index ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -185,9 +221,11 @@
 # name: TestActorsPropertyTaxonomyQueryRunner.test_person_property_taxonomy_query_runner.2
   '''
   SELECT groupArray(5)(prop) AS `groupArray(5)(prop)`,
-         count() AS `count()`
+         count() AS `count()`,
+         prop_index AS prop_index
   FROM
-    (SELECT DISTINCT persons.properties___age AS prop
+    (SELECT DISTINCT prop_index,
+                     toString(prop_value) AS prop
      FROM
        (SELECT person.id AS id,
                replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'age'), ''), 'null'), '^"|"$', '') AS properties___age,
@@ -199,9 +237,13 @@
                                                        WHERE equals(person.team_id, 99999)
                                                        GROUP BY person.id
                                                        HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))
-                                                       ORDER BY argMax(toTimeZone(person.created_at, 'UTC'), person.version) DESC))) SETTINGS optimize_aggregation_in_order=1) AS persons
-     WHERE isNotNull(prop)
+                                                       ORDER BY argMax(toTimeZone(person.created_at, 'UTC'), person.version) DESC))) SETTINGS optimize_aggregation_in_order=1) AS persons ARRAY
+     JOIN arrayEnumerate([persons.properties___age]) AS prop_index,
+          [persons.properties___age] AS prop_value
+     WHERE isNotNull(prop_value)
      ORDER BY persons.created_at DESC)
+  GROUP BY prop_index
+  ORDER BY prop_index ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/ai/test/test_actors_property_taxonomy_query_runner.py
+++ b/posthog/hogql_queries/ai/test/test_actors_property_taxonomy_query_runner.py
@@ -34,29 +34,29 @@ class TestActorsPropertyTaxonomyQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         # regular person property
         results = ActorsPropertyTaxonomyQueryRunner(
-            team=self.team, query=ActorsPropertyTaxonomyQuery(property="email")
+            team=self.team, query=ActorsPropertyTaxonomyQuery(properties=["email"])
         ).calculate()
-        self.assertEqual(len(results.results.sample_values), 3)
+        self.assertEqual(len(results.results[0].sample_values), 3)
         self.assertEqual(
-            set(results.results.sample_values), {"person1@example.com", "person2@example.com", "person3@example.com"}
+            set(results.results[0].sample_values), {"person1@example.com", "person2@example.com", "person3@example.com"}
         )
-        self.assertEqual(results.results.sample_count, 3)
+        self.assertEqual(results.results[0].sample_count, 3)
 
         # does not exist
         results = ActorsPropertyTaxonomyQueryRunner(
-            team=self.team, query=ActorsPropertyTaxonomyQuery(property="does not exist")
+            team=self.team, query=ActorsPropertyTaxonomyQuery(properties=["does not exist"])
         ).calculate()
-        self.assertEqual(len(results.results.sample_values), 0)
-        self.assertEqual(results.results.sample_count, 0)
+        self.assertEqual(len(results.results[0].sample_values), 0)
+        self.assertEqual(results.results[0].sample_count, 0)
 
         # Ensure only distinct values are returned
         results = ActorsPropertyTaxonomyQueryRunner(
-            team=self.team, query=ActorsPropertyTaxonomyQuery(property="age")
+            team=self.team, query=ActorsPropertyTaxonomyQuery(properties=["age"])
         ).calculate()
-        self.assertEqual(len(results.results.sample_values), 1)
-        self.assertEqual(results.results.sample_count, 1)
+        self.assertEqual(len(results.results[0].sample_values), 1)
+        self.assertEqual(results.results[0].sample_count, 1)
         # Ensure the value is a string
-        self.assertEqual(results.results.sample_values[0], "30")
+        self.assertEqual(results.results[0].sample_values[0], "30")
 
     @snapshot_clickhouse_queries
     def test_group_property_taxonomy_query_runner(self):
@@ -84,29 +84,29 @@ class TestActorsPropertyTaxonomyQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         # regular group property
         results = ActorsPropertyTaxonomyQueryRunner(
-            team=self.team, query=ActorsPropertyTaxonomyQuery(property="industry", group_type_index=0)
+            team=self.team, query=ActorsPropertyTaxonomyQuery(properties=["industry"], groupTypeIndex=0)
         ).calculate()
-        self.assertEqual(len(results.results.sample_values), 3)
-        self.assertEqual(set(results.results.sample_values), {"tech", "energy", "ecommerce"})
-        self.assertEqual(results.results.sample_count, 3)
+        self.assertEqual(len(results.results[0].sample_values), 3)
+        self.assertEqual(set(results.results[0].sample_values), {"tech", "energy", "ecommerce"})
+        self.assertEqual(results.results[0].sample_count, 3)
 
         # does not exist
         results = ActorsPropertyTaxonomyQueryRunner(
             team=self.team,
-            query=ActorsPropertyTaxonomyQuery(property="does not exist", group_type_index=0),
+            query=ActorsPropertyTaxonomyQuery(properties=["does not exist"], groupTypeIndex=0),
         ).calculate()
-        self.assertEqual(len(results.results.sample_values), 0)
-        self.assertEqual(results.results.sample_count, 0)
+        self.assertEqual(len(results.results[0].sample_values), 0)
+        self.assertEqual(results.results[0].sample_count, 0)
 
         # Ensure only distinct values are returned
         results = ActorsPropertyTaxonomyQueryRunner(
             team=self.team,
-            query=ActorsPropertyTaxonomyQuery(property="employee_count", group_type_index=0),
+            query=ActorsPropertyTaxonomyQuery(properties=["employee_count"], groupTypeIndex=0),
         ).calculate()
-        self.assertEqual(len(results.results.sample_values), 1)
-        self.assertEqual(results.results.sample_count, 1)
+        self.assertEqual(len(results.results[0].sample_values), 1)
+        self.assertEqual(results.results[0].sample_count, 1)
         # Ensure the value is a string
-        self.assertEqual(results.results.sample_values[0], "30")
+        self.assertEqual(results.results[0].sample_values[0], "30")
 
     @snapshot_clickhouse_queries
     def test_max_value_count(self):
@@ -128,7 +128,45 @@ class TestActorsPropertyTaxonomyQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         # regular person property
         results = ActorsPropertyTaxonomyQueryRunner(
-            team=self.team, query=ActorsPropertyTaxonomyQuery(property="age", maxPropertyValues=1)
+            team=self.team, query=ActorsPropertyTaxonomyQuery(properties=["age"], maxPropertyValues=1)
         ).calculate()
-        self.assertEqual(len(results.results.sample_values), 1)
-        self.assertEqual(results.results.sample_count, 3)
+        self.assertEqual(len(results.results[0].sample_values), 1)
+        self.assertEqual(results.results[0].sample_count, 3)
+
+    def test_multiple_properties(self):
+        _create_person(
+            distinct_ids=["person1"],
+            properties={"age": 29},
+            team=self.team,
+        )
+        _create_person(
+            distinct_ids=["person2"],
+            properties={"age": 30, "name": "Person Two"},
+            team=self.team,
+        )
+        _create_person(
+            distinct_ids=["person3"],
+            properties={"age": 31},
+            team=self.team,
+        )
+
+        # regular person property
+        results = ActorsPropertyTaxonomyQueryRunner(
+            team=self.team, query=ActorsPropertyTaxonomyQuery(properties=["age", "name"], maxPropertyValues=10)
+        ).calculate()
+        self.assertIsInstance(results.results, list)
+        self.assertEqual(len(results.results), 2)
+        self.assertEqual(len(results.results[0].sample_values), 3)
+        self.assertEqual(results.results[0].sample_count, 3)
+        self.assertEqual(len(results.results[1].sample_values), 1)
+        self.assertEqual(results.results[1].sample_count, 1)
+        self.assertEqual(set(results.results[1].sample_values), {"Person Two"})
+
+        results = ActorsPropertyTaxonomyQueryRunner(
+            team=self.team, query=ActorsPropertyTaxonomyQuery(properties=["name"], maxPropertyValues=10)
+        ).calculate()
+        self.assertIsInstance(results.results, list)
+        self.assertEqual(len(results.results), 1)
+        self.assertEqual(len(results.results[0].sample_values), 1)
+        self.assertEqual(results.results[0].sample_count, 1)
+        self.assertEqual(set(results.results[0].sample_values), {"Person Two"})

--- a/posthog/hogql_queries/ai/test/test_actors_property_taxonomy_query_runner.py
+++ b/posthog/hogql_queries/ai/test/test_actors_property_taxonomy_query_runner.py
@@ -2,7 +2,8 @@ from django.test import override_settings
 
 from posthog.hogql_queries.ai.actors_property_taxonomy_query_runner import ActorsPropertyTaxonomyQueryRunner
 from posthog.models.group.util import create_group
-from posthog.models.group_type_mapping import GroupTypeMapping
+from posthog.models import GroupTypeMapping, PropertyDefinition
+from posthog.models.property_definition import PropertyType
 from posthog.schema import ActorsPropertyTaxonomyQuery
 from posthog.test.base import (
     APIBaseTest,
@@ -134,6 +135,8 @@ class TestActorsPropertyTaxonomyQueryRunner(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(results.results[0].sample_count, 3)
 
     def test_multiple_properties(self):
+        PropertyDefinition.objects.create(team=self.team, name="age", property_type=PropertyType.Numeric)
+
         _create_person(
             distinct_ids=["person1"],
             properties={"age": 29},

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5027,7 +5027,7 @@ class ActorsPropertyTaxonomyQueryResponse(BaseModel):
     resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
         default=None, description="The date range used for the query"
     )
-    results: ActorsPropertyTaxonomyResponse
+    results: Union[ActorsPropertyTaxonomyResponse, list[ActorsPropertyTaxonomyResponse]]
     timings: Optional[list[QueryTiming]] = Field(
         default=None, description="Measured timings for different parts of the query generation process"
     )
@@ -5618,7 +5618,7 @@ class CachedActorsPropertyTaxonomyQueryResponse(BaseModel):
     resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
         default=None, description="The date range used for the query"
     )
-    results: ActorsPropertyTaxonomyResponse
+    results: Union[ActorsPropertyTaxonomyResponse, list[ActorsPropertyTaxonomyResponse]]
     timezone: str
     timings: Optional[list[QueryTiming]] = Field(
         default=None, description="Measured timings for different parts of the query generation process"
@@ -9966,7 +9966,7 @@ class QueryResponseAlternative68(BaseModel):
     resolved_date_range: Optional[ResolvedDateRangeResponse] = Field(
         default=None, description="The date range used for the query"
     )
-    results: ActorsPropertyTaxonomyResponse
+    results: Union[ActorsPropertyTaxonomyResponse, list[ActorsPropertyTaxonomyResponse]]
     timings: Optional[list[QueryTiming]] = Field(
         default=None, description="Measured timings for different parts of the query generation process"
     )
@@ -10753,13 +10753,13 @@ class ActorsPropertyTaxonomyQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    group_type_index: Optional[int] = None
+    groupTypeIndex: Optional[int] = None
     kind: Literal["ActorsPropertyTaxonomyQuery"] = "ActorsPropertyTaxonomyQuery"
     maxPropertyValues: Optional[int] = None
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    property: str
+    properties: list[str]
     response: Optional[ActorsPropertyTaxonomyQueryResponse] = None
     tags: Optional[QueryLogTags] = None
     version: Optional[float] = Field(default=None, description="version of the node, used for schema migrations")


### PR DESCRIPTION
## Problem

The ActorsTaxonomyQueryRunner now accepts just a single property. We could slightly optimize data exports if we exported multiple properties simultaneously.

## Changes

Updated the query to accept multiple properties:
- Filter by them.
- Return the results in the same order as they were passed.
- Set the limit to 200. Let's see if it's not too many properties in real-world scenarios, but data says we're much below average.

## How did you test this code?

Unit tests and manual testing.
