### PR TITLE
fix: Bump elasticsearch image in docker-compose.base

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -325,7 +325,7 @@ services:
             - discovery.type=single-node
             - ES_JAVA_OPTS=-Xms256m -Xmx256m
             - xpack.security.enabled=false
-        image: elasticsearch:7.16.2
+        image: elasticsearch:7.17.27
         expose:
             - 9200
         volumes:


### PR DESCRIPTION
## Problem

Starting from the linux kernel 6.12, cgroups v1 has been removed by default, and it's only available by modifying a kernel setting. 

JVM 17 supports both cgroups v1 and cgroups v2, but there's a bug that was fixed in later versions of JVM 17: [bugs.openjdk.org/browse/JDK-8287073](https://bugs.openjdk.org/browse/JDK-8287073).

Elasticsearch depends on JVM, so now that the runners have updated their kernel we must bump the image to get the bugfix.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Bump elasticsearch image.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
