### PR TITLE
chore: open screenshot in replay for all

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -251,7 +251,6 @@ export const FEATURE_FLAGS = {
     USAGE_SPEND_DASHBOARDS: 'usage-spend-dashboards', // owner: @pawel-cebula #team-billing
     CDP_HOG_SOURCES: 'cdp-hog-sources', // owner #team-cdp
     CDP_PERSON_UPDATES: 'cdp-person-updates', // owner: #team-cdp
-    REPLAY_SCREENSHOT: 'replay-screenshot', // owner: @veryayskiy #team-replay
     SCREENSHOT_EDITOR: 'screenshot-editor', // owner: @veryayskiy #team-replay
     ACTIVITY_OR_EXPLORE: 'activity-or-explore', // owner: @pauldambra #team-replay
     LINEAGE_DEPENDENCY_VIEW: 'lineage-dependency-view', // owner: @phixMe #team-data-warehouse

--- a/frontend/src/scenes/session-recordings/player/player-meta/PlayerMetaBottomSettings.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/PlayerMetaBottomSettings.tsx
@@ -153,11 +153,11 @@ export function PlayerMetaBottomSettings({ size }: { size: PlayerMetaBreakpoints
                         />
                     </FlaggedFeature>
                     {noInspector ? null : (
-                        <FlaggedFeature match={true} flag={FEATURE_FLAGS.REPLAY_SCREENSHOT}>
+                        <>
                             <Screenshot />
-                        </FlaggedFeature>
+                            <InspectDOM />
+                        </>
                     )}
-                    {noInspector ? null : <InspectDOM />}
                     <PlayerInspectorButton />
                 </div>
             </div>


### PR DESCRIPTION
Now that the screenshot feature is more reliable and works as a Celery task, let's open it to every user.