### PR TITLE
chore(ci): env var to prevent kafka jvm from using cgroups

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -104,8 +104,7 @@ jobs:
             - name: Setup dependencies
               if: needs.changes.outputs.rust == 'true' && matrix.package == 'others'
               run: |
-                  export COMPOSE_LOG_LEVEL=DEBUG
-                  docker compose up kafka redis db echo_server objectstorage -d --wait
+                  docker compose up kafka redis db echo_server objectstorage -d --wait --verbose
                   docker compose up setup_test_db
                   echo "127.0.0.1 kafka clickhouse" | sudo tee -a /etc/hosts
 

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -104,7 +104,7 @@ jobs:
             - name: Setup dependencies
               if: needs.changes.outputs.rust == 'true' && matrix.package == 'others'
               run: |
-                  docker --log-level info compose up kafka redis db echo_server objectstorage -d --wait
+                  docker compose --log-level INFO up kafka redis db echo_server objectstorage -d --wait
                   docker compose up setup_test_db
                   echo "127.0.0.1 kafka clickhouse" | sudo tee -a /etc/hosts
 

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -104,10 +104,8 @@ jobs:
             - name: Setup dependencies
               if: needs.changes.outputs.rust == 'true' && matrix.package == 'others'
               run: |
-                  docker --log-level debug compose up kafka redis db echo_server objectstorage --wait
-                  docker compose logs kafka --timestamps
-                  docker compose ps -a
-                  docker inspect rust-kafka-1 | grep -A 10 Health
+                  docker --log-level debug compose up kafka redis db echo_server objectstorage -d
+                  timeout 60 docker compose logs -f --timestamps || true
                   docker compose up setup_test_db
                   echo "127.0.0.1 kafka clickhouse" | sudo tee -a /etc/hosts
 

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -104,7 +104,7 @@ jobs:
             - name: Setup dependencies
               if: needs.changes.outputs.rust == 'true' && matrix.package == 'others'
               run: |
-                  docker compose up kafka redis db echo_server objectstorage -d --wait
+                  docker --log-level info compose up kafka redis db echo_server objectstorage -d --wait
                   docker compose up setup_test_db
                   echo "127.0.0.1 kafka clickhouse" | sudo tee -a /etc/hosts
 

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -105,6 +105,9 @@ jobs:
               if: needs.changes.outputs.rust == 'true' && matrix.package == 'others'
               run: |
                   docker --log-level debug compose up kafka redis db echo_server objectstorage --wait
+                  docker compose logs kafka --timestamps
+                  docker compose ps -a
+                  docker inspect rust-kafka-1 | grep -A 10 Health
                   docker compose up setup_test_db
                   echo "127.0.0.1 kafka clickhouse" | sudo tee -a /etc/hosts
 

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -104,7 +104,8 @@ jobs:
             - name: Setup dependencies
               if: needs.changes.outputs.rust == 'true' && matrix.package == 'others'
               run: |
-                  docker compose --log-level INFO up kafka redis db echo_server objectstorage -d --wait
+                  export COMPOSE_LOG_LEVEL=DEBUG
+                  docker compose up kafka redis db echo_server objectstorage -d --wait
                   docker compose up setup_test_db
                   echo "127.0.0.1 kafka clickhouse" | sudo tee -a /etc/hosts
 

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -104,8 +104,7 @@ jobs:
             - name: Setup dependencies
               if: needs.changes.outputs.rust == 'true' && matrix.package == 'others'
               run: |
-                  docker --log-level debug compose up kafka redis db echo_server objectstorage -d
-                  timeout 60 docker compose logs -f --timestamps || true
+                  docker compose up kafka redis db echo_server objectstorage -d --wait
                   docker compose up setup_test_db
                   echo "127.0.0.1 kafka clickhouse" | sudo tee -a /etc/hosts
 

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -104,7 +104,7 @@ jobs:
             - name: Setup dependencies
               if: needs.changes.outputs.rust == 'true' && matrix.package == 'others'
               run: |
-                  docker compose up kafka redis db echo_server objectstorage -d --wait --verbose
+                  docker --log-level debug compose up kafka redis db echo_server objectstorage --wait
                   docker compose up setup_test_db
                   echo "127.0.0.1 kafka clickhouse" | sudo tee -a /etc/hosts
 

--- a/rust/common/kafka/src/kafka_consumer.rs
+++ b/rust/common/kafka/src/kafka_consumer.rs
@@ -137,7 +137,7 @@ impl SingleTopicConsumer {
                     let was_err = result.is_err();
                     results.push(result);
                     if was_err {
-                        break; // Early exit on error, since it might indicate a kafka error or something
+                        break; // Early exit on error, since it might indicate a kafka error or somethingz
                     }
                 }
             } => {}

--- a/rust/docker-compose.yml
+++ b/rust/docker-compose.yml
@@ -17,6 +17,7 @@ services:
             KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
             KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
             ALLOW_PLAINTEXT_LISTENER: 'true'
+            KAFKA_OPTS: -XX: -UseContainerSupport
         ports:
             - '9092:9092'
         healthcheck:

--- a/rust/docker-compose.yml
+++ b/rust/docker-compose.yml
@@ -17,7 +17,7 @@ services:
             KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
             KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
             ALLOW_PLAINTEXT_LISTENER: 'true'
-            KAFKA_OPTS: -XX: -UseContainerSupport
+            KAFKA_OPTS: -XX:-UseContainerSupport
         ports:
             - '9092:9092'
         healthcheck:


### PR DESCRIPTION
## Problem

Our rust tests were failing when trying to spin up a healthy kafka image within it's container. I believe this is related to a recent linux kernel upgrade that happened on our underlying CI containers (vended by depot). Similar to this [issue with the elastisearch image](https://github.com/PostHog/posthog/pull/36512).

## Changes

Added in an environment variable to stop the kafka service from trying to access whatever cgroup API went away with the linux kernel upgrade. The comment is to force an Rust Test dependency build.

## How did you test this code?

Ran the CI and it passed.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
