### PR TITLE
chore: remove Explore tab to avoid duplication

### DIFF
--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -27,9 +27,6 @@ import { AndOrFilterSelect } from '~/queries/nodes/InsightViz/PropertyGroupFilte
 import { NodeKind } from '~/queries/schema/schema-general'
 import { RecordingUniversalFilters, ReplayTabs, SidePanelTab, UniversalFiltersGroup } from '~/types'
 
-import { ReplayActiveHoursHeatMap } from '../components/ReplayActiveHoursHeatMap'
-import { ReplayActiveScreensTable } from '../components/ReplayActiveScreensTable'
-import { ReplayActiveUsersTable } from '../components/ReplayActiveUsersTable'
 import { playerSettingsLogic, TimestampFormat } from '../player/playerSettingsLogic'
 import { playlistLogic } from '../playlist/playlistLogic'
 import { createPlaylist, updatePlaylist } from '../playlist/playlistUtils'
@@ -510,20 +507,6 @@ export const RecordingsUniversalFiltersEmbed = ({
             ),
             content: <SavedFilters setFilters={setFilters} />,
             'data-attr': 'session-recordings-saved-tab',
-        },
-        {
-            key: 'explore',
-            label: <div className="px-2">Explore</div>,
-            content: (
-                <div className="flex flex-col gap-2 w-full pb-2">
-                    <div className="flex flex-row gap-2 w-full">
-                        <ReplayActiveUsersTable />
-                        <ReplayActiveScreensTable />
-                    </div>
-                    <ReplayActiveHoursHeatMap />
-                </div>
-            ),
-            'data-attr': 'session-recordings-explore-tab',
         },
     ]
 


### PR DESCRIPTION
We have the same feature, "Figure out what to watch", in the main tabs and in the "Explore" section of the Filters tab.

According to this insight ([link](https://us.posthog.com/project/2/insights/7IYmcsie)), most users access it via the "Figure out what to watch" tab, so keeping it only there makes sense.

To avoid duplication, let's remove it from the Explore tab.