### PR TITLE
feat(crm): Add template to group notebooks

### DIFF
--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_groups.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_groups.ambr
@@ -88,3 +88,92 @@
   ORDER BY group_key
   '''
 # ---
+# name: GroupsViewSetTestCase.test_related_groups
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT DISTINCT pdi.person_id
+  FROM events e
+  JOIN
+    (SELECT distinct_id,
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 99999
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) pdi on e.distinct_id = pdi.distinct_id
+  WHERE team_id = 99999
+    AND timestamp > '2021-02-09T00:00:00.000000'
+    AND timestamp < '2021-05-10T00:00:00.000000'
+    AND $group_0 = '0::0'
+  '''
+# ---
+# name: GroupsViewSetTestCase.test_related_groups.1
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT DISTINCT $group_1 AS group_key
+  FROM events e
+  JOIN
+    (SELECT group_key
+     FROM groups
+     WHERE team_id = 99999
+       AND group_type_index = 1
+     GROUP BY group_key) groups ON $group_1 = groups.group_key
+  WHERE team_id = 99999
+    AND timestamp > '2021-02-09T00:00:00.000000'
+    AND timestamp < '2021-05-10T00:00:00.000000'
+    AND group_key != ''
+    AND $group_0 = '0::0'
+  ORDER BY group_key
+  '''
+# ---
+# name: GroupsViewSetTestCase.test_related_groups_person
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT DISTINCT $group_0 AS group_key
+  FROM events e
+  JOIN
+    (SELECT distinct_id,
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 99999
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) pdi on e.distinct_id = pdi.distinct_id
+  JOIN
+    (SELECT group_key
+     FROM groups
+     WHERE team_id = 99999
+       AND group_type_index = 0
+     GROUP BY group_key) groups ON $group_0 = groups.group_key
+  WHERE team_id = 99999
+    AND timestamp > '2021-02-09T00:00:00.000000'
+    AND timestamp < '2021-05-10T00:00:00.000000'
+    AND group_key != ''
+    AND pdi.person_id = '01795392-cc00-0003-7dc7-67a694604d72'
+  ORDER BY group_key
+  '''
+# ---
+# name: GroupsViewSetTestCase.test_related_groups_person.1
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT DISTINCT $group_1 AS group_key
+  FROM events e
+  JOIN
+    (SELECT distinct_id,
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 99999
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) pdi on e.distinct_id = pdi.distinct_id
+  JOIN
+    (SELECT group_key
+     FROM groups
+     WHERE team_id = 99999
+       AND group_type_index = 1
+     GROUP BY group_key) groups ON $group_1 = groups.group_key
+  WHERE team_id = 99999
+    AND timestamp > '2021-02-09T00:00:00.000000'
+    AND timestamp < '2021-05-10T00:00:00.000000'
+    AND group_key != ''
+    AND pdi.person_id = '01795392-cc00-0003-7dc7-67a694604d72'
+  ORDER BY group_key
+  '''
+# ---

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -29,7 +29,7 @@ from unittest.mock import patch
 PATH = "ee.clickhouse.views.groups"
 
 
-class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
+class GroupsViewSetTestCase(ClickhouseTestMixin, APIBaseTest):
     maxDiff = None
 
     @freeze_time("2021-05-02")
@@ -217,6 +217,14 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
             },
         )
         self.assertEqual(1, Notebook.objects.filter(team=self.team).count())
+
+        # Test default notebook content structure
+        notebook = relationships.first().notebook
+        self.assertIsNotNone(notebook.content)
+        self.assertEqual(notebook.content[0]["type"], "heading")
+        self.assertEqual(notebook.content[0]["attrs"]["level"], 1)
+        self.assertEqual(notebook.content[0]["content"][0]["text"], "Mr. Krabs Notes")
+        self.assertEqual(notebook.content[1]["type"], "text")
 
     @freeze_time("2021-05-02")
     def test_retrieve_group_with_notebook(self):

--- a/ee/hogai/session_summaries/session_group/summary_notebooks.py
+++ b/ee/hogai/session_summaries/session_group/summary_notebooks.py
@@ -1,7 +1,16 @@
 from datetime import datetime
-from typing import Any
 
 from posthog.models.notebook.notebook import Notebook
+from posthog.models.notebook.util import (
+    TipTapNode,
+    TipTapContent,
+    create_heading_with_text,
+    create_text_content,
+    create_bullet_list,
+    create_paragraph_with_content,
+    create_paragraph_with_text,
+    create_empty_paragraph,
+)
 from posthog.models.user import User
 from posthog.models.team import Team
 from ee.hogai.session_summaries.session_group.patterns import (
@@ -9,11 +18,6 @@ from ee.hogai.session_summaries.session_group.patterns import (
     EnrichedSessionGroupSummaryPattern,
     PatternAssignedEventSegmentContext,
 )
-import uuid
-
-# Type aliases for TipTap editor nodes
-TipTapNode = dict[str, Any]
-TipTapContent = list[TipTapNode]
 
 
 def create_summary_notebook(
@@ -43,10 +47,10 @@ def _generate_notebook_content_from_summary(
         return {
             "type": "doc",
             "content": [
-                _create_heading_with_text(f"Session Summaries Report - {project_name}", 1),
-                _create_empty_paragraph(),
-                _create_paragraph_with_text("No patterns found."),
-                _create_paragraph_with_text(f"Sessions covered: {', '.join(session_ids)}"),
+                create_heading_with_text(f"Session Summaries Report - {project_name}", 1),
+                create_empty_paragraph(),
+                create_paragraph_with_text("No patterns found."),
+                create_paragraph_with_text(f"Sessions covered: {', '.join(session_ids)}"),
             ],
         }
 
@@ -58,10 +62,10 @@ def _generate_notebook_content_from_summary(
     content = []
 
     # Title
-    content.append(_create_heading_with_text(f"Session Summaries Report - {project_name}", 1))
+    content.append(create_heading_with_text(f"Session Summaries Report - {project_name}", 1))
     # Issues to review summary
     session_text = "session" if total_sessions == 1 else "sessions"
-    content.append(_create_heading_with_text(f"📊 Issues to review ({total_sessions} {session_text} scope)", 2))
+    content.append(create_heading_with_text(f"📊 Issues to review ({total_sessions} {session_text} scope)", 2))
     # Summary table
     table_content = _create_summary_table(patterns_sorted, total_sessions)
     content.extend(table_content)
@@ -70,14 +74,14 @@ def _generate_notebook_content_from_summary(
     # Pattern details
     for pattern in patterns_sorted:
         pattern_content = _create_pattern_section(pattern=pattern, total_sessions=total_sessions, team_id=team_id)
-        content.append(_create_empty_paragraph())
+        content.append(create_empty_paragraph())
         content.extend(pattern_content)
 
     content.extend(
         [
-            _create_empty_paragraph(),
+            create_empty_paragraph(),
             _create_line_separator(),
-            _create_paragraph_with_text(f"Sessions covered: {', '.join(session_ids)}"),
+            create_paragraph_with_text(f"Sessions covered: {', '.join(session_ids)}"),
         ]
     )
 
@@ -96,79 +100,9 @@ def _milliseconds_to_timestamp(milliseconds: int) -> str:
     return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
 
 
-def _sanitize_text_content(text: str) -> str:
-    """Sanitize text content to ensure it's valid for TipTap editor."""
-    if not text or not text.strip():
-        raise ValueError("Empty text should not be passed to create heading or paragraph")
-    return text.strip()
-
-
-def _create_empty_paragraph() -> TipTapNode:
-    """Create a paragraph node with no content to add spacing."""
-    return {"type": "paragraph"}
-
-
 def _create_line_separator() -> TipTapNode:
     """Create a line separator node."""
     return {"type": "horizontalRule"}
-
-
-def _create_paragraph_with_text(text: str, marks: list[dict[str, Any]] | None = None) -> TipTapNode:
-    """Create a paragraph node with sanitized text content and optional marks."""
-    content_node: dict[str, Any] = {"type": "text", "text": _sanitize_text_content(text)}
-    if marks:
-        content_node["marks"] = marks
-    return {
-        "type": "paragraph",
-        "content": [content_node],
-    }
-
-
-def _create_heading_with_text(text: str, level: int) -> TipTapNode:
-    """Create a heading node with sanitized text content."""
-    heading_id = str(uuid.uuid4())
-    return {
-        "type": "heading",
-        "attrs": {"id": heading_id, "level": level, "data-toc-id": heading_id},
-        "content": [{"type": "text", "text": _sanitize_text_content(text)}],
-    }
-
-
-def _create_text_content(text: str, is_bold: bool = False, is_italic: bool = False) -> TipTapNode:
-    """Create a text node with optional marks."""
-    node: dict[str, Any] = {"type": "text", "text": text}
-    marks = []
-    if is_bold:
-        marks.append({"type": "bold"})
-    if is_italic:
-        marks.append({"type": "italic"})
-    if marks:
-        node["marks"] = marks
-    return node
-
-
-def _create_paragraph_with_content(content: TipTapContent) -> TipTapNode:
-    """Create a paragraph node with a list of content items."""
-    return {
-        "type": "paragraph",
-        "content": content,
-    }
-
-
-def _create_bullet_list(items: list[str] | list[TipTapContent] | TipTapContent) -> TipTapNode:
-    """Create a bullet list with list items. Items can be strings or content arrays."""
-    list_items = []
-    for item in items:
-        if isinstance(item, str):
-            list_items.append({"type": "listItem", "content": [_create_paragraph_with_text(item)]})
-        elif isinstance(item, list):
-            # item is already a content array (could be paragraph + nested list)
-            list_items.append({"type": "listItem", "content": item})
-        else:
-            # item is a single content node
-            list_items.append({"type": "listItem", "content": [_create_paragraph_with_content([item])]})
-
-    return {"type": "bulletList", "content": list_items}
 
 
 def _create_summary_table(patterns: list[EnrichedSessionGroupSummaryPattern], total_sessions: int) -> TipTapContent:
@@ -192,14 +126,14 @@ def _create_summary_table(patterns: list[EnrichedSessionGroupSummaryPattern], to
 
         # Create a formatted item for each pattern
         pattern_info = [
-            _create_text_content(f"{pattern.pattern_name} - ", is_bold=True),
-            _create_text_content(f"{severity_icon} {severity_text} - "),
-            _create_text_content(f"{sessions_percentage} ({sessions_affected}) sessions - "),
-            _create_text_content(f"{failure_percentage} failure rate"),
+            create_text_content(f"{pattern.pattern_name} - ", is_bold=True),
+            create_text_content(f"{severity_icon} {severity_text} - "),
+            create_text_content(f"{sessions_percentage} ({sessions_affected}) sessions - "),
+            create_text_content(f"{failure_percentage} failure rate"),
         ]
         table_items.append(pattern_info)
 
-    content.append(_create_bullet_list(table_items))
+    content.append(create_bullet_list(table_items))
 
     return content
 
@@ -211,9 +145,9 @@ def _create_pattern_section(
     content = []
 
     # Pattern header
-    content.append(_create_heading_with_text(pattern.pattern_name, 2))
+    content.append(create_heading_with_text(pattern.pattern_name, 2))
     # Pattern description
-    content.append(_create_paragraph_with_text(pattern.pattern_description))
+    content.append(create_paragraph_with_text(pattern.pattern_description))
 
     # Pattern stats
     stats = pattern.stats
@@ -222,42 +156,42 @@ def _create_pattern_section(
     success_percentage = f"{stats.segments_success_ratio * 100:.0f}%"
     success_count = int(stats.segments_success_ratio * stats.occurences)
     severity_text = pattern.severity.value if hasattr(pattern.severity, "value") else pattern.severity
-    content.append(_create_empty_paragraph())
+    content.append(create_empty_paragraph())
     content.append(
-        _create_paragraph_with_content(
-            [_create_text_content("How severe it is: ", is_bold=True), _create_text_content(severity_text.title())]
+        create_paragraph_with_content(
+            [create_text_content("How severe it is: ", is_bold=True), create_text_content(severity_text.title())]
         )
     )
     content.append(
-        _create_paragraph_with_content(
+        create_paragraph_with_content(
             [
-                _create_text_content("How many sessions affected: ", is_bold=True),
-                _create_text_content(f"{sessions_percentage} ({sessions_affected} out of {total_sessions})"),
+                create_text_content("How many sessions affected: ", is_bold=True),
+                create_text_content(f"{sessions_percentage} ({sessions_affected} out of {total_sessions})"),
             ]
         )
     )
     content.append(
-        _create_paragraph_with_content(
+        create_paragraph_with_content(
             [
-                _create_text_content("How often users succeed, despite the pattern: ", is_bold=True),
-                _create_text_content(f"{success_percentage} ({success_count} out of {stats.occurences})"),
+                create_text_content("How often users succeed, despite the pattern: ", is_bold=True),
+                create_text_content(f"{success_percentage} ({success_count} out of {stats.occurences})"),
             ]
         )
     )
 
     # Detection indicators
-    content.append(_create_empty_paragraph())
+    content.append(create_empty_paragraph())
     content.append(
-        _create_paragraph_with_content(
-            [_create_text_content("🔍 "), _create_text_content("How we detect this:", is_bold=True)]
+        create_paragraph_with_content(
+            [create_text_content("🔍 "), create_text_content("How we detect this:", is_bold=True)]
         )
     )
     # Convert indicators to bullet list
-    content.append(_create_bullet_list(pattern.indicators))
+    content.append(create_bullet_list(pattern.indicators))
 
     # Examples section
-    content.append(_create_empty_paragraph())
-    content.append(_create_heading_with_text("Examples", 3))
+    content.append(create_empty_paragraph())
+    content.append(create_heading_with_text("Examples", 3))
     # TODO: Decide if to limit examples (or create some sort of collapsible section in notebooks)
     events_to_show = pattern.events
     for event_data in events_to_show:
@@ -298,21 +232,21 @@ def _create_example_section(event_data: PatternAssignedEventSegmentContext, team
         }
     )
     # Quick summary
-    content.append(_create_heading_with_text("Quick summary", 5))
+    content.append(create_heading_with_text("Quick summary", 5))
     quick_summary_items = [
-        [_create_text_content("What user was doing: ", is_bold=True), _create_text_content(event_data.segment_name)],
+        [create_text_content("What user was doing: ", is_bold=True), create_text_content(event_data.segment_name)],
         [
-            _create_text_content("What confirmed the pattern: ", is_bold=True),
-            _create_text_content(event_data.target_event.description),
+            create_text_content("What confirmed the pattern: ", is_bold=True),
+            create_text_content(event_data.target_event.description),
         ],
         [
-            _create_text_content("Where it happened: ", is_bold=True),
-            _create_text_content(event_data.target_event.current_url),
+            create_text_content("Where it happened: ", is_bold=True),
+            create_text_content(event_data.target_event.current_url),
         ],
     ]
-    content.append(_create_bullet_list(quick_summary_items))
+    content.append(create_bullet_list(quick_summary_items))
     # Outcome section
-    content.append(_create_heading_with_text("Outcome", 5))
+    content.append(create_heading_with_text("Outcome", 5))
     outcome_items = []
     # What happened before
     if event_data.previous_events_in_segment:
@@ -323,15 +257,15 @@ def _create_example_section(event_data: PatternAssignedEventSegmentContext, team
 
         # Create list item with paragraph and nested bullet list as content
         prev_events_content = [
-            _create_paragraph_with_content([_create_text_content("What happened before:", is_bold=True)]),
-            _create_bullet_list(prev_events_list),
+            create_paragraph_with_content([create_text_content("What happened before:", is_bold=True)]),
+            create_bullet_list(prev_events_list),
         ]
         outcome_items.append(prev_events_content)
     else:
         outcome_items.append(
             [
-                _create_text_content("What happened before: ", is_bold=True),
-                _create_text_content("Nothing, start of the segment"),
+                create_text_content("What happened before: ", is_bold=True),
+                create_text_content("Nothing, start of the segment"),
             ]
         )
 
@@ -344,15 +278,15 @@ def _create_example_section(event_data: PatternAssignedEventSegmentContext, team
 
         # Create list item with paragraph and nested bullet list as content
         next_events_content = [
-            _create_paragraph_with_content([_create_text_content("What happened after:", is_bold=True)]),
-            _create_bullet_list(next_events_list),
+            create_paragraph_with_content([create_text_content("What happened after:", is_bold=True)]),
+            create_bullet_list(next_events_list),
         ]
         outcome_items.append(next_events_content)
     else:
         outcome_items.append(
             [
-                _create_text_content("What happened after: ", is_bold=True),
-                _create_text_content("Nothing, end of the segment"),
+                create_text_content("What happened after: ", is_bold=True),
+                create_text_content("Nothing, end of the segment"),
             ]
         )
 
@@ -360,11 +294,11 @@ def _create_example_section(event_data: PatternAssignedEventSegmentContext, team
     outcome_status = "Success" if event_data.segment_success else "Failure"
     outcome_items.append(
         [
-            _create_text_content("What's the outcome: ", is_bold=True),
-            _create_text_content(f"{outcome_status}. {event_data.segment_outcome}"),
+            create_text_content("What's the outcome: ", is_bold=True),
+            create_text_content(f"{outcome_status}. {event_data.segment_outcome}"),
         ]
     )
 
-    content.append(_create_bullet_list(outcome_items))
+    content.append(create_bullet_list(outcome_items))
 
     return content

--- a/posthog/models/notebook/util.py
+++ b/posthog/models/notebook/util.py
@@ -1,0 +1,77 @@
+import uuid
+from typing import Any
+
+
+# Type aliases for TipTap editor nodes
+TipTapNode = dict[str, Any]
+TipTapContent = list[TipTapNode]
+
+
+def create_bullet_list(items: list[str] | list[TipTapContent] | TipTapContent) -> TipTapNode:
+    """Create a bullet list with list items. Items can be strings or content arrays."""
+    list_items = []
+    for item in items:
+        if isinstance(item, str):
+            list_items.append({"type": "listItem", "content": [create_paragraph_with_text(item)]})
+        elif isinstance(item, list):
+            # item is already a content array (could be paragraph + nested list)
+            list_items.append({"type": "listItem", "content": item})
+        else:
+            # item is a single content node
+            list_items.append({"type": "listItem", "content": [create_paragraph_with_content([item])]})
+
+    return {"type": "bulletList", "content": list_items}
+
+
+def create_heading_with_text(text: str, level: int) -> TipTapNode:
+    """Create a heading node with sanitized text content."""
+    heading_id = str(uuid.uuid4())
+    return {
+        "type": "heading",
+        "attrs": {"id": heading_id, "level": level, "data-toc-id": heading_id},
+        "content": [{"type": "text", "text": sanitize_text_content(text)}],
+    }
+
+
+def create_paragraph_with_text(text: str, marks: list[dict[str, Any]] | None = None) -> TipTapNode:
+    """Create a paragraph node with sanitized text content and optional marks."""
+    content_node: dict[str, Any] = {"type": "text", "text": sanitize_text_content(text)}
+    if marks:
+        content_node["marks"] = marks
+    return {
+        "type": "paragraph",
+        "content": [content_node],
+    }
+
+
+def create_paragraph_with_content(content: TipTapContent) -> TipTapNode:
+    """Create a paragraph node with a list of content items."""
+    return {
+        "type": "paragraph",
+        "content": content,
+    }
+
+
+def create_text_content(text: str, is_bold: bool = False, is_italic: bool = False) -> TipTapNode:
+    """Create a text node with optional marks."""
+    node: dict[str, Any] = {"type": "text", "text": text}
+    marks = []
+    if is_bold:
+        marks.append({"type": "bold"})
+    if is_italic:
+        marks.append({"type": "italic"})
+    if marks:
+        node["marks"] = marks
+    return node
+
+
+def create_empty_paragraph() -> TipTapNode:
+    """Create a paragraph node with no content to add spacing."""
+    return {"type": "paragraph"}
+
+
+def sanitize_text_content(text: str) -> str:
+    """Sanitize text content to ensure it's valid for TipTap editor."""
+    if not text or not text.strip():
+        raise ValueError("Empty text should not be passed to create heading or paragraph")
+    return text.strip()


### PR DESCRIPTION
## Problem
Users were facing a blank page when accessing notebook tab, which wasn't a great experience.


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Related to https://github.com/PostHog/posthog/issues/36460
## Changes
Added template content in the notebook, so folks can have a rough idea about how to use it.

@sortafreel reused some of the functions you wrote for session summary. Moved the shared ones into `/models/notebook/utils`
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
<img width="1579" height="961" alt="image" src="https://github.com/user-attachments/assets/af9c5d5e-674b-4677-8667-5da0f1a7e226" />

## How did you test this code?
Unit tests + 👁️ 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
