### PR TITLE
chore: add project creation limit enforcement and tests

### DIFF
--- a/ee/api/test/test_team.py
+++ b/ee/api/test/test_team.py
@@ -105,9 +105,9 @@ def team_enterprise_api_test_factory():  # type: ignore
             response_2_data = response_2.json()
             self.assertEqual(
                 response_2_data.get("detail"),
-                "You must upgrade your PostHog plan to be able to create and manage more environments per project."
+                "You have reached the maximum limit of allowed environments for your current plan. Upgrade your plan to be able to create and manage more environments."
                 if self.client_class is not EnvironmentToProjectRewriteClient
-                else "You must upgrade your PostHog plan to be able to create and manage more projects.",
+                else "You have reached the maximum limit of allowed projects for your current plan. Upgrade your plan to be able to create and manage more projects.",
             )
             self.assertEqual(response_2_data.get("type"), "authentication_error")
             self.assertEqual(response_2_data.get("code"), "permission_denied")

--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -829,7 +829,7 @@ class PremiumMultiProjectPermission(BasePermission):
                 # We have a hard limit of MAX_ALLOWED_PROJECTS_PER_ORG projects per organization
                 # We don't want to block updates if a customer is already over the max allowed
                 if current_non_demo_project_count >= MAX_ALLOWED_PROJECTS_PER_ORG and view.action == "create":
-                    self.message = f"You have reached the maximum limit of {MAX_ALLOWED_PROJECTS_PER_ORG} projects per organization. Contact support for more if you'd like access to more projects."
+                    self.message = f"You have reached the maximum limit of {MAX_ALLOWED_PROJECTS_PER_ORG} projects per organization. Contact support if you'd like access to more projects."
                     return False
                 return True
             # Check current limit against allowed limit

--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -829,7 +829,7 @@ class PremiumMultiProjectPermission(BasePermission):
                 # We have a hard limit of MAX_ALLOWED_PROJECTS_PER_ORG projects per organization
                 # We don't want to block updates if a customer is already over the max allowed
                 if current_non_demo_project_count >= MAX_ALLOWED_PROJECTS_PER_ORG and view.action == "create":
-                    self.message = f"You have reached the maximum limit of {MAX_ALLOWED_PROJECTS_PER_ORG} projects per organization."
+                    self.message = f"You have reached the maximum limit of {MAX_ALLOWED_PROJECTS_PER_ORG} projects per organization. Contact support for more if you'd like access to more projects."
                     return False
                 return True
             # Check current limit against allowed limit

--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -817,12 +817,18 @@ class PremiumMultiProjectPermission(BasePermission):
             if organization.teams.filter(is_demo=True).count() > 0:
                 return False
 
+        MAX_ALLOWED_PROJECTS_PER_ORG = 1000
+
         current_non_demo_project_count = organization.teams.exclude(is_demo=True).distinct("project_id").count()
         projects_feature = organization.get_available_feature(AvailableFeature.ORGANIZATIONS_PROJECTS)
+
         if projects_feature:
             allowed_project_count = projects_feature.get("limit")
             # If allowed_project_count is None then the user is allowed unlimited projects
             if allowed_project_count is None:
+                # We have a hard limit of 1000 projects per organization
+                if current_non_demo_project_count >= MAX_ALLOWED_PROJECTS_PER_ORG:
+                    return False
                 return True
             # Check current limit against allowed limit
             if current_non_demo_project_count >= allowed_project_count:

--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -58,7 +58,7 @@ from posthog.utils import (
 )
 from posthog.api.team import TEAM_CONFIG_FIELDS_SET
 
-MAX_ALLOWED_PROJECTS_PER_ORG = 1000
+MAX_ALLOWED_PROJECTS_PER_ORG = 1500
 
 
 class ProjectSerializer(serializers.ModelSerializer):

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -994,7 +994,7 @@ def validate_team_attrs(
 class PremiumMultiEnvironmentPermission(BasePermission):
     """Require user to have all necessary premium features on their plan for create access to the endpoint."""
 
-    message = "You must upgrade your PostHog plan to be able to create and manage more environments per project."
+    message = "You have reached the maximum limit of allowed environments for your current plan. Upgrade your plan to be able to create and manage more environments."
 
     def has_permission(self, request: request.Request, view) -> bool:
         if view.action not in CREATE_ACTIONS:

--- a/posthog/api/test/test_project.py
+++ b/posthog/api/test/test_project.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch, MagicMock
 from posthog.api.test.test_team import EnvironmentToProjectRewriteClient, team_api_test_factory
-from posthog.models.organization import Organization
+from posthog.constants import AvailableFeature
+from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+from posthog.models.project import Project
 from posthog.models.utils import generate_random_token_personal
 from rest_framework import status
 
@@ -33,3 +36,153 @@ class TestProjectAPI(team_api_test_factory()):  # type: ignore
             {team_in_other_org.project.id},
             "Only the project belonging to the scoped organization should be listed, the other one should be excluded",
         )
+
+    def test_cannot_create_second_demo_project(self):
+        # Create first demo project
+        Project.objects.create_with_team(
+            organization=self.organization, name="First Demo", initiating_user=self.user, team_fields={"is_demo": True}
+        )
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+
+        # Try to create second demo project
+        response = self.client.post("/api/projects/", {"name": "Second Demo", "is_demo": True})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(
+            response.json()["detail"],
+            "You must upgrade your PostHog plan to be able to create and manage more projects.",
+        )
+
+    def test_project_creation_without_feature(self):
+        # Organization without the ORGANIZATIONS_PROJECTS feature (has 1 project already)
+        self.organization.available_product_features = []
+        self.organization.save()
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+
+        response = self.client.post("/api/projects/", {"name": "New Project"})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(
+            response.json()["detail"],
+            "You must upgrade your PostHog plan to be able to create and manage more projects.",
+        )
+
+    def test_project_creation_with_limited_feature(self):
+        # Set project limit to 2
+        self.organization.available_product_features = [
+            {
+                "key": AvailableFeature.ORGANIZATIONS_PROJECTS,
+                "name": "Projects",
+                "limit": 2,
+            }
+        ]
+        self.organization.save()
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+
+        # Can create one more project (already have 1)
+        response = self.client.post("/api/projects/", {"name": "Second Project"})
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # Cannot create third project
+        response = self.client.post("/api/projects/", {"name": "Third Project"})
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(
+            response.json()["detail"],
+            "You must upgrade your PostHog plan to be able to create and manage more projects.",
+        )
+
+    def test_project_creation_with_unlimited_feature(self):
+        # Set unlimited projects
+        self.organization.available_product_features = [
+            {
+                "key": AvailableFeature.ORGANIZATIONS_PROJECTS,
+                "name": "Projects",
+                "limit": None,  # unlimited
+            }
+        ]
+        self.organization.save()
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+
+        # Can create multiple projects
+        for i in range(5):
+            response = self.client.post("/api/projects/", {"name": f"Project {i}"})
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    @patch("posthog.models.organization.Organization.teams")
+    def test_hard_limit_1000_projects(self, mock_teams):
+        # Set unlimited projects
+        self.organization.available_product_features = [
+            {
+                "key": AvailableFeature.ORGANIZATIONS_PROJECTS,
+                "name": "Projects",
+                "limit": None,  # unlimited
+            }
+        ]
+        self.organization.save()
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+
+        # Mock the teams queryset to return a count of 1000 non-demo projects
+        mock_qs = MagicMock()
+        mock_qs.exclude.return_value.distinct.return_value.count.return_value = 1000
+        mock_teams.return_value = mock_qs
+        mock_teams.exclude.return_value.distinct.return_value.count.return_value = 1000
+
+        # Should not be able to create another project
+        response = self.client.post("/api/projects/", {"name": "Project 1001"})
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(
+            response.json()["detail"],
+            "You must upgrade your PostHog plan to be able to create and manage more projects.",
+        )
+
+    def test_demo_projects_not_counted_toward_limit(self):
+        # Set project limit to 2
+        self.organization.available_product_features = [
+            {
+                "key": AvailableFeature.ORGANIZATIONS_PROJECTS,
+                "name": "Projects",
+                "limit": 2,
+            }
+        ]
+        self.organization.save()
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+
+        # Create a demo project (doesn't count toward limit)
+        Project.objects.create_with_team(
+            organization=self.organization,
+            name="Demo Project",
+            initiating_user=self.user,
+            team_fields={"is_demo": True},
+        )
+
+        # Can still create 2 regular projects (demo doesn't count)
+        response = self.client.post("/api/projects/", {"name": "Regular Project 1"})
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # Can't create third regular project (limit reached)
+        response = self.client.post("/api/projects/", {"name": "Regular Project 2"})
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_update_project_allowed_regardless_of_limits(self):
+        # Set project limit to 1 (already have 1)
+        self.organization.available_product_features = [
+            {
+                "key": AvailableFeature.ORGANIZATIONS_PROJECTS,
+                "name": "Projects",
+                "limit": 1,
+            }
+        ]
+        self.organization.save()
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+
+        # Should be able to update existing project even at limit
+        response = self.client.patch(f"/api/projects/{self.project.id}/", {"name": "Updated Name"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["name"], "Updated Name")

--- a/posthog/api/test/test_project.py
+++ b/posthog/api/test/test_project.py
@@ -137,7 +137,7 @@ class TestProjectAPI(team_api_test_factory()):  # type: ignore
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(
             response.json()["detail"],
-            "You have reached the maximum limit of allowed projects for your current plan. Upgrade your plan to be able to create and manage more projects.",
+            "You have reached the maximum limit of 1000 projects per organization. Contact support for more if you'd like access to more projects.",
         )
 
     def test_demo_projects_not_counted_toward_limit(self):

--- a/posthog/api/test/test_project.py
+++ b/posthog/api/test/test_project.py
@@ -137,7 +137,7 @@ class TestProjectAPI(team_api_test_factory()):  # type: ignore
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(
             response.json()["detail"],
-            "You have reached the maximum limit of 1500 projects per organization. Contact support for more if you'd like access to more projects.",
+            "You have reached the maximum limit of 1500 projects per organization. Contact support if you'd like access to more projects.",
         )
 
     def test_demo_projects_not_counted_toward_limit(self):

--- a/posthog/api/test/test_project.py
+++ b/posthog/api/test/test_project.py
@@ -51,7 +51,7 @@ class TestProjectAPI(team_api_test_factory()):  # type: ignore
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(
             response.json()["detail"],
-            "You must upgrade your PostHog plan to be able to create and manage more projects.",
+            "You have reached the maximum limit of allowed projects for your current plan. Upgrade your plan to be able to create and manage more projects.",
         )
 
     def test_project_creation_without_feature(self):
@@ -66,7 +66,7 @@ class TestProjectAPI(team_api_test_factory()):  # type: ignore
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(
             response.json()["detail"],
-            "You must upgrade your PostHog plan to be able to create and manage more projects.",
+            "You have reached the maximum limit of allowed projects for your current plan. Upgrade your plan to be able to create and manage more projects.",
         )
 
     def test_project_creation_with_limited_feature(self):
@@ -91,7 +91,7 @@ class TestProjectAPI(team_api_test_factory()):  # type: ignore
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(
             response.json()["detail"],
-            "You must upgrade your PostHog plan to be able to create and manage more projects.",
+            "You have reached the maximum limit of allowed projects for your current plan. Upgrade your plan to be able to create and manage more projects.",
         )
 
     def test_project_creation_with_unlimited_feature(self):
@@ -137,7 +137,7 @@ class TestProjectAPI(team_api_test_factory()):  # type: ignore
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(
             response.json()["detail"],
-            "You must upgrade your PostHog plan to be able to create and manage more projects.",
+            "You have reached the maximum limit of allowed projects for your current plan. Upgrade your plan to be able to create and manage more projects.",
         )
 
     def test_demo_projects_not_counted_toward_limit(self):

--- a/posthog/api/test/test_project.py
+++ b/posthog/api/test/test_project.py
@@ -113,7 +113,7 @@ class TestProjectAPI(team_api_test_factory()):  # type: ignore
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     @patch("posthog.models.organization.Organization.teams")
-    def test_hard_limit_1000_projects(self, mock_teams):
+    def test_hard_limit_projects(self, mock_teams):
         # Set unlimited projects
         self.organization.available_product_features = [
             {
@@ -126,18 +126,18 @@ class TestProjectAPI(team_api_test_factory()):  # type: ignore
         self.organization_membership.level = OrganizationMembership.Level.ADMIN
         self.organization_membership.save()
 
-        # Mock the teams queryset to return a count of 1000 non-demo projects
+        # Mock the teams queryset to return a count of 1500 non-demo projects
         mock_qs = MagicMock()
-        mock_qs.exclude.return_value.distinct.return_value.count.return_value = 1000
+        mock_qs.exclude.return_value.distinct.return_value.count.return_value = 1500
         mock_teams.return_value = mock_qs
-        mock_teams.exclude.return_value.distinct.return_value.count.return_value = 1000
+        mock_teams.exclude.return_value.distinct.return_value.count.return_value = 1500
 
         # Should not be able to create another project
         response = self.client.post("/api/projects/", {"name": "Project 1001"})
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(
             response.json()["detail"],
-            "You have reached the maximum limit of 1000 projects per organization. Contact support for more if you'd like access to more projects.",
+            "You have reached the maximum limit of 1500 projects per organization. Contact support for more if you'd like access to more projects.",
         )
 
     def test_demo_projects_not_counted_toward_limit(self):

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -207,9 +207,9 @@ def team_api_test_factory():
             response_data = response.json()
             self.assertEqual(
                 response_data.get("detail"),
-                "You must upgrade your PostHog plan to be able to create and manage more environments per project."
+                "You have reached the maximum limit of allowed environments for your current plan. Upgrade your plan to be able to create and manage more environments."
                 if self.client_class is not EnvironmentToProjectRewriteClient
-                else "You must upgrade your PostHog plan to be able to create and manage more projects.",
+                else "You have reached the maximum limit of allowed projects for your current plan. Upgrade your plan to be able to create and manage more projects.",
             )
             self.assertEqual(response_data.get("type"), "authentication_error")
             self.assertEqual(response_data.get("code"), "permission_denied")
@@ -221,9 +221,9 @@ def team_api_test_factory():
             response_data = response.json()
             self.assertEqual(
                 response_data.get("detail"),
-                "You must upgrade your PostHog plan to be able to create and manage more environments per project."
+                "You have reached the maximum limit of allowed environments for your current plan. Upgrade your plan to be able to create and manage more environments."
                 if self.client_class is not EnvironmentToProjectRewriteClient
-                else "You must upgrade your PostHog plan to be able to create and manage more projects.",
+                else "You have reached the maximum limit of allowed projects for your current plan. Upgrade your plan to be able to create and manage more projects.",
             )
             self.assertEqual(response_data.get("type"), "authentication_error")
             self.assertEqual(response_data.get("code"), "permission_denied")
@@ -1722,9 +1722,9 @@ class TestTeamAPI(team_api_test_factory()):  # type: ignore
         response_data = response.json()
         self.assertEqual(
             response_data.get("detail"),
-            "You must upgrade your PostHog plan to be able to create and manage more environments per project."
+            "You have reached the maximum limit of allowed environments for your current plan. Upgrade your plan to be able to create and manage more environments."
             if self.client_class is not EnvironmentToProjectRewriteClient
-            else "You must upgrade your PostHog plan to be able to create and manage more projects.",
+            else "You have reached the maximum limit of allowed projects for your current plan. Upgrade your plan to be able to create and manage more projects.",
         )
         self.assertEqual(response_data.get("type"), "authentication_error")
         self.assertEqual(response_data.get("code"), "permission_denied")


### PR DESCRIPTION
## Changes

Enforces a hard limit of 1500 non-demo projects per organization and improves logic for project creation limits based on feature flags. Adds comprehensive tests to verify project creation behavior under various feature and limit scenarios, including demo project handling and update permissions.

## How did you test this code?

Added tests - also added some others for the `PremiumMultiProjectPermission` class.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
