### PR TITLE
fix: Add Max tool name back

### DIFF
--- a/frontend/src/scenes/max/MaxTool.tsx
+++ b/frontend/src/scenes/max/MaxTool.tsx
@@ -87,14 +87,14 @@ export function MaxTool({
                         !isMaxOpen ? (
                             <>
                                 <IconSparkles className="mr-1.5" />
-                                {name} with Max
+                                {definition.name} with Max
                             </>
                         ) : (
                             <>
                                 Max can use this tool
                                 <br />
                                 {icon || <IconWrench />}
-                                <i className="ml-1.5">{name}</i>
+                                <i className="ml-1.5">{definition.name}</i>
                             </>
                         )
                     }


### PR DESCRIPTION
Max tool name is always blank because we're using `name` rather than `definition.name` :).

`name` is not defined on this component, but it's a global variable on the DOM, it will almost always return undefined: https://developer.mozilla.org/en-US/docs/Web/API/HTMLObjectElement/name

<img width="145" height="113" alt="image" src="https://github.com/user-attachments/assets/cbd58dfb-ac10-40cf-a832-7e41475cfe22" />