### PR TITLE
feat(messaging): add message category selector to action config panel

### DIFF
--- a/plugin-server/src/cdp/services/messaging/recipient-preferences.service.test.ts
+++ b/plugin-server/src/cdp/services/messaging/recipient-preferences.service.test.ts
@@ -309,10 +309,8 @@ describe('RecipientPreferencesService', () => {
                     template_id: 'template-twilio',
                     message_category_id: categoryId,
                     inputs: {
-                        sms: {
-                            value: { to: toNumber },
-                        },
-                    },
+                        to_number: toNumber,
+                    } as any,
                 },
                 created_at: Date.now(),
                 updated_at: Date.now(),

--- a/products/messaging/frontend/Campaigns/hogflows/HogFlowEditorDetailsPanel.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/HogFlowEditorDetailsPanel.tsx
@@ -67,71 +67,74 @@ export function HogFlowEditorDetailsPanel(): JSX.Element | null {
                 {Step?.renderConfiguration(selectedNode)}
             </ScrollableShadows>
 
-            <LemonDivider className="my-0" />
-
             {isOptOutEligibleAction(action) && (
-                <div className="flex flex-col p-2">
-                    <LemonLabel htmlFor="Message category" className="flex gap-2 justify-between items-center">
-                        <span>Message category</span>
-                        <div className="flex gap-2">
-                            {!categoriesLoading && !categories.length && (
-                                <LemonButton
-                                    to={urls.messaging('opt-outs')}
-                                    targetBlank
-                                    type="secondary"
-                                    icon={<IconExternal />}
-                                >
-                                    Configure
-                                </LemonButton>
-                            )}
-                            <CategorySelect
-                                onChange={(categoryId) => {
-                                    setCampaignAction(action.id, {
-                                        ...action,
-                                        config: {
-                                            ...action.config,
-                                            message_category_id: categoryId,
-                                        },
-                                    } as Extract<HogFlowAction, { type: 'function_email' | 'function_sms' }>)
-                                }}
-                                value={action.config.message_category_id}
-                            />
-                        </div>
-                    </LemonLabel>
-                </div>
+                <>
+                    <LemonDivider className="my-0" />
+                    <div className="flex flex-col p-2">
+                        <LemonLabel htmlFor="Message category" className="flex gap-2 justify-between items-center">
+                            <span>Message category</span>
+                            <div className="flex gap-2">
+                                {!categoriesLoading && !categories.length && (
+                                    <LemonButton
+                                        to={urls.messaging('opt-outs')}
+                                        targetBlank
+                                        type="secondary"
+                                        icon={<IconExternal />}
+                                    >
+                                        Configure
+                                    </LemonButton>
+                                )}
+                                <CategorySelect
+                                    onChange={(categoryId) => {
+                                        setCampaignAction(action.id, {
+                                            ...action,
+                                            config: {
+                                                ...action.config,
+                                                message_category_id: categoryId,
+                                            },
+                                        } as Extract<HogFlowAction, { type: 'function_email' | 'function_sms' }>)
+                                    }}
+                                    value={action.config.message_category_id}
+                                />
+                            </div>
+                        </LemonLabel>
+                    </div>
+                </>
             )}
 
-            <LemonDivider className="my-0" />
             {!['trigger', 'exit'].includes(action.type) && (
-                <div className="flex flex-col p-2">
-                    <LemonLabel htmlFor="conditions" className="flex gap-2 justify-between items-center">
-                        <span>Conditions</span>
-                        <LemonSwitch
-                            id="conditions"
-                            checked={!!action.filters}
-                            onChange={(checked) =>
-                                setCampaignAction(action.id, {
-                                    ...action,
-                                    filters: checked ? {} : null,
-                                })
-                            }
-                        />
-                    </LemonLabel>
-
-                    {action.filters && (
-                        <>
-                            <p className="mb-0">
-                                Add conditions to the step. If these conditions aren't met, the user will skip this step
-                                and continue to the next one.
-                            </p>
-                            <HogFlowFilters
-                                filters={action.filters ?? {}}
-                                setFilters={(filters) => setCampaignAction(action.id, { ...action, filters })}
-                                buttonCopy="Add filter conditions"
+                <>
+                    <LemonDivider className="my-0" />
+                    <div className="flex flex-col p-2">
+                        <LemonLabel htmlFor="conditions" className="flex gap-2 justify-between items-center">
+                            <span>Conditions</span>
+                            <LemonSwitch
+                                id="conditions"
+                                checked={!!action.filters}
+                                onChange={(checked) =>
+                                    setCampaignAction(action.id, {
+                                        ...action,
+                                        filters: checked ? {} : null,
+                                    })
+                                }
                             />
-                        </>
-                    )}
-                </div>
+                        </LemonLabel>
+
+                        {action.filters && (
+                            <>
+                                <p className="mb-0">
+                                    Add conditions to the step. If these conditions aren't met, the user will skip this
+                                    step and continue to the next one.
+                                </p>
+                                <HogFlowFilters
+                                    filters={action.filters ?? {}}
+                                    setFilters={(filters) => setCampaignAction(action.id, { ...action, filters })}
+                                    buttonCopy="Add filter conditions"
+                                />
+                            </>
+                        )}
+                    </div>
+                </>
             )}
         </div>
     )

--- a/products/messaging/frontend/Campaigns/hogflows/hogFlowEditorLogic.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/hogFlowEditorLogic.tsx
@@ -23,6 +23,7 @@ import { StepViewNodeHandle } from './steps/types'
 import type { HogFlow, HogFlowAction, HogFlowActionNode } from './types'
 import type { DragEvent } from 'react'
 import { getSmartStepPath } from './steps/SmartEdge'
+import { optOutCategoriesLogic } from '../../OptOuts/optOutCategoriesLogic'
 
 const getEdgeId = (edge: HogFlow['edges'][number]): string => `${edge.from}->${edge.to} ${edge.index ?? ''}`.trim()
 
@@ -33,10 +34,17 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
     path((key) => ['scenes', 'hogflows', 'hogFlowEditorLogic', key]),
     key((props) => `${props.id}`),
     connect((props: CampaignLogicProps) => ({
-        values: [campaignLogic(props), ['campaign', 'edgesByActionId']],
+        values: [
+            campaignLogic(props),
+            ['campaign', 'edgesByActionId'],
+            optOutCategoriesLogic(),
+            ['categories', 'categoriesLoading'],
+        ],
         actions: [
             campaignLogic(props),
             ['setCampaignInfo', 'setCampaignActionConfig', 'setCampaignAction', 'setCampaignActionEdges'],
+            optOutCategoriesLogic(),
+            ['loadCategories'],
         ],
     })),
     actions({

--- a/products/messaging/frontend/Campaigns/hogflows/steps/HogFlowSteps.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/steps/HogFlowSteps.tsx
@@ -26,7 +26,6 @@ export const HogFlowSteps: Partial<{
     function_webhook: StepFunctionWebhook,
     function_sms: StepFunctionSms,
     function_slack: StepFunctionSlack,
-    // function: StepFunction,
 } as const
 
 // Type-safe accessor that preserves the key type

--- a/products/messaging/frontend/Campaigns/hogflows/steps/types.ts
+++ b/products/messaging/frontend/Campaigns/hogflows/steps/types.ts
@@ -179,3 +179,9 @@ export const HogFlowActionSchema = z.discriminatedUnion('type', [
         }),
     }),
 ])
+
+export const isOptOutEligibleAction = (
+    action: HogFlowAction
+): action is Extract<HogFlowAction, { type: 'function_email' | 'function_sms' }> => {
+    return ['function_email', 'function_sms'].includes(action.type)
+}

--- a/products/messaging/frontend/OptOuts/CategorySelect.tsx
+++ b/products/messaging/frontend/OptOuts/CategorySelect.tsx
@@ -27,7 +27,6 @@ export const CategorySelect = ({
                         .map((category) => ({
                             label: category.name,
                             value: category.id,
-                            labelInMenu: <div className="flex items-center gap-2">{category.name}</div>,
                         })),
                 },
                 {
@@ -37,7 +36,6 @@ export const CategorySelect = ({
                         .map((category) => ({
                             label: category.name,
                             value: category.id,
-                            labelInMenu: <div className="flex items-center gap-2">{category.name}</div>,
                         })),
                 },
             ]}

--- a/products/messaging/frontend/OptOuts/CategorySelect.tsx
+++ b/products/messaging/frontend/OptOuts/CategorySelect.tsx
@@ -1,0 +1,47 @@
+import { useValues } from 'kea'
+import { optOutCategoriesLogic } from './optOutCategoriesLogic'
+import { LemonSelect } from '@posthog/lemon-ui'
+
+export const CategorySelect = ({
+    onChange,
+    value,
+}: {
+    onChange: (value: string) => void
+    value?: string
+}): JSX.Element => {
+    const { categories, categoriesLoading } = useValues(optOutCategoriesLogic())
+
+    return (
+        <LemonSelect
+            onChange={onChange}
+            value={value}
+            loading={categoriesLoading}
+            disabledReason={
+                !categoriesLoading && !categories.length && 'Configure message categories in the opt-outs section'
+            }
+            options={[
+                {
+                    title: 'Marketing',
+                    options: categories
+                        .filter((category) => category.category_type === 'marketing')
+                        .map((category) => ({
+                            label: category.name,
+                            value: category.id,
+                            labelInMenu: <div className="flex items-center gap-2">{category.name}</div>,
+                        })),
+                },
+                {
+                    title: 'Transactional',
+                    options: categories
+                        .filter((category) => category.category_type === 'transactional')
+                        .map((category) => ({
+                            label: category.name,
+                            value: category.id,
+                            labelInMenu: <div className="flex items-center gap-2">{category.name}</div>,
+                        })),
+                },
+            ]}
+            placeholder="Select message type"
+        />
+    )
+}

--- a/products/messaging/frontend/OptOuts/OptOutCategories.tsx
+++ b/products/messaging/frontend/OptOuts/OptOutCategories.tsx
@@ -8,7 +8,6 @@ import { useActions, useValues } from 'kea'
 import { optOutCategoriesLogic } from './optOutCategoriesLogic'
 import { OptOutList } from './OptOutList'
 import { NewCategoryModal } from './NewCategoryModal'
-import { capitalizeFirstLetter } from 'lib/utils'
 
 interface MessageCategory {
     id: string
@@ -50,7 +49,7 @@ export function OptOutCategories(): JSX.Element {
                                 <div className="text-xs text-muted">{category.description}</div>
                             </div>
                             <LemonTag type={category.category_type === 'marketing' ? 'success' : 'completion'}>
-                                {capitalizeFirstLetter(category.category_type)}
+                                {category.category_type.toUpperCase()}
                             </LemonTag>
                         </div>
                         <More

--- a/products/messaging/frontend/OptOuts/newCategoryLogic.ts
+++ b/products/messaging/frontend/OptOuts/newCategoryLogic.ts
@@ -37,7 +37,7 @@ export const newCategoryLogic = kea<newCategoryLogicType>([
         resetForm: true,
     }),
 
-    forms(({ props }: { props: CategoryLogicProps }) => ({
+    forms(({ actions, props }) => ({
         categoryForm: {
             defaults: props.category
                 ? {
@@ -71,6 +71,8 @@ export const newCategoryLogic = kea<newCategoryLogicType>([
                 }
                 // Reload categories in the parent logic
                 optOutCategoriesLogic.actions.loadCategories()
+
+                actions.resetForm()
 
                 // Trigger success callback if available
                 if (props.onSuccess) {

--- a/products/messaging/frontend/OptOuts/optOutCategoriesLogic.ts
+++ b/products/messaging/frontend/OptOuts/optOutCategoriesLogic.ts
@@ -1,4 +1,4 @@
-import { kea, path, actions, reducers, listeners } from 'kea'
+import { kea, path, actions, reducers, listeners, afterMount } from 'kea'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 
@@ -59,4 +59,8 @@ export const optOutCategoriesLogic = kea<optOutCategoriesLogicType>([
             }
         },
     })),
+
+    afterMount(({ actions }) => {
+        actions.loadCategories()
+    }),
 ])


### PR DESCRIPTION
## Problem

Users need a way to mark their emails and SMS messages as certain categories

## Changes


https://github.com/user-attachments/assets/8f25ae48-f0c2-4e8b-848a-eddf41a537cc

