### PR TITLE
feat(web-analytics): add new hourly tables to hogql with accuracy check asset

### DIFF
--- a/dags/locations/web_analytics.py
+++ b/dags/locations/web_analytics.py
@@ -13,6 +13,7 @@ from dags import (
 defs = dagster.Definitions(
     assets=[
         web_preaggregated_team_selection.web_analytics_team_selection,
+        web_preaggregated_team_selection.web_analytics_team_selection_v2,
         web_preaggregated_daily.web_stats_daily,
         web_preaggregated_daily.web_bounces_daily,
         web_preaggregated_daily.web_stats_daily_export,
@@ -24,6 +25,10 @@ defs = dagster.Definitions(
     ],
     asset_checks=[
         web_preaggregated_asset_checks.web_analytics_accuracy_check,
+        web_preaggregated_asset_checks.web_analytics_team_selection_v2_has_data,
+        web_preaggregated_asset_checks.web_pre_aggregated_bounces_has_data,
+        web_preaggregated_asset_checks.web_pre_aggregated_stats_has_data,
+        web_preaggregated_asset_checks.web_analytics_v2_accuracy_check,
         web_preaggregated_asset_checks.stats_daily_has_data,
         web_preaggregated_asset_checks.stats_hourly_has_data,
         web_preaggregated_asset_checks.bounces_daily_has_data,
@@ -35,6 +40,7 @@ defs = dagster.Definitions(
         web_preaggregated_hourly.web_pre_aggregate_current_day_hourly_job,
         web_preaggregated_daily.web_pre_aggregate_daily_job,
         web_preaggregated_asset_checks.web_analytics_data_quality_job,
+        web_preaggregated_asset_checks.web_analytics_v2_data_quality_job,
         web_preaggregated_asset_checks.simple_data_checks_job,
         web_preaggregated.web_pre_aggregate_job,
     ],
@@ -42,6 +48,7 @@ defs = dagster.Definitions(
         web_preaggregated_daily.web_pre_aggregate_daily_schedule,
         web_preaggregated_hourly.web_pre_aggregate_current_day_hourly_schedule,
         web_preaggregated_asset_checks.web_analytics_weekly_data_quality_schedule,
+        web_preaggregated_asset_checks.web_analytics_v2_weekly_data_quality_schedule,
         web_preaggregated.web_pre_aggregate_historical_schedule,
         web_preaggregated.web_pre_aggregate_current_day_schedule,
     ],

--- a/dags/web_preaggregated.py
+++ b/dags/web_preaggregated.py
@@ -27,7 +27,7 @@ from posthog.models.web_preaggregated.sql import (
 MAX_PARTITIONS_PER_RUN_ENV_VAR = "DAGSTER_WEB_PREAGGREGATED_MAX_PARTITIONS_PER_RUN"
 max_partitions_per_run = int(os.getenv(MAX_PARTITIONS_PER_RUN_ENV_VAR, 14))
 backfill_policy_def = BackfillPolicy.multi_run(max_partitions_per_run=max_partitions_per_run)
-partition_def = DailyPartitionsDefinition(start_date="2024-01-01")
+partition_def = DailyPartitionsDefinition(start_date="2024-01-01", end_offset=1)
 
 
 def pre_aggregate_web_analytics_data(
@@ -87,7 +87,7 @@ def pre_aggregate_web_analytics_data(
     name="web_pre_aggregated_bounces",
     group_name="web_analytics_v2",
     config_schema=WEB_ANALYTICS_CONFIG_SCHEMA,
-    deps=["web_analytics_team_selection"],
+    deps=["web_analytics_team_selection_v2"],
     partitions_def=partition_def,
     backfill_policy=backfill_policy_def,
     metadata={"table": "web_pre_aggregated_bounces"},
@@ -111,7 +111,7 @@ def web_pre_aggregated_bounces(
     name="web_pre_aggregated_stats",
     group_name="web_analytics_v2",
     config_schema=WEB_ANALYTICS_CONFIG_SCHEMA,
-    deps=["web_analytics_team_selection"],
+    deps=["web_analytics_team_selection_v2"],
     partitions_def=partition_def,
     backfill_policy=backfill_policy_def,
     metadata={"table": "web_pre_aggregated_stats"},

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -101,6 +101,8 @@ from posthog.hogql.database.schema.web_analytics_preaggregated import (
     WebBouncesHourlyTable,
     WebStatsCombinedTable,
     WebBouncesCombinedTable,
+    WebPreAggregatedStatsTable,
+    WebPreAggregatedBouncesTable,
 )
 from posthog.hogql.errors import QueryError, ResolutionError
 from posthog.hogql.parser import parse_expr
@@ -160,6 +162,10 @@ class Database(BaseModel):
     web_bounces_hourly: WebBouncesHourlyTable = WebBouncesHourlyTable()
     web_stats_combined: WebStatsCombinedTable = WebStatsCombinedTable()
     web_bounces_combined: WebBouncesCombinedTable = WebBouncesCombinedTable()
+
+    # V2 Pre-aggregated tables (will replace the above tables after we backfill)
+    web_pre_aggregated_stats: WebPreAggregatedStatsTable = WebPreAggregatedStatsTable()
+    web_pre_aggregated_bounces: WebPreAggregatedBouncesTable = WebPreAggregatedBouncesTable()
 
     # Revenue analytics tables
     raw_persons_revenue_analytics: RawPersonsRevenueAnalyticsTable = RawPersonsRevenueAnalyticsTable()

--- a/posthog/hogql/database/schema/web_analytics_preaggregated.py
+++ b/posthog/hogql/database/schema/web_analytics_preaggregated.py
@@ -168,3 +168,33 @@ class WebBouncesCombinedTable(Table):
 
     def to_printed_hogql(self):
         return "web_bounces_combined"
+
+
+class WebPreAggregatedStatsTable(Table):
+    fields: dict[str, FieldOrTable] = {
+        **web_preaggregated_base_fields,
+        **web_preaggregated_base_aggregation_fields,
+        **SHARED_SCHEMA_FIELDS,
+        **WEB_STATS_SPECIFIC_FIELDS,
+    }
+
+    def to_printed_clickhouse(self, context):
+        return "web_pre_aggregated_stats"
+
+    def to_printed_hogql(self):
+        return "web_pre_aggregated_stats"
+
+
+class WebPreAggregatedBouncesTable(Table):
+    fields: dict[str, FieldOrTable] = {
+        **web_preaggregated_base_fields,
+        **web_preaggregated_base_aggregation_fields,
+        **SHARED_SCHEMA_FIELDS,
+        **WEB_BOUNCES_SPECIFIC_FIELDS,
+    }
+
+    def to_printed_clickhouse(self, context):
+        return "web_pre_aggregated_bounces"
+
+    def to_printed_hogql(self):
+        return "web_pre_aggregated_bounces"

--- a/posthog/hogql_queries/web_analytics/pre_aggregated/query_builder.py
+++ b/posthog/hogql_queries/web_analytics/pre_aggregated/query_builder.py
@@ -8,11 +8,22 @@ from posthog.hogql_queries.web_analytics.pre_aggregated.property_transformer imp
     PreAggregatedPropertyTransformer,
 )
 
+get_stats_table = lambda use_v2: "web_pre_aggregated_stats" if use_v2 else "web_stats_combined"
+get_bounces_table = lambda use_v2: "web_pre_aggregated_bounces" if use_v2 else "web_bounces_combined"
+
 
 class WebAnalyticsPreAggregatedQueryBuilder:
     def __init__(self, runner, supported_props_filters) -> None:
         self.runner = runner
         self.supported_props_filters = supported_props_filters
+
+    @property
+    def stats_table(self) -> str:
+        return get_stats_table(self.runner.use_v2_tables)
+
+    @property
+    def bounces_table(self) -> str:
+        return get_bounces_table(self.runner.use_v2_tables)
 
     def can_use_preaggregated_tables(self) -> bool:
         query = self.runner.query

--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -39,8 +39,9 @@ class WebStatsTableQueryRunner(WebAnalyticsQueryRunner):
     preaggregated_query_builder: StatsTablePreAggregatedQueryBuilder
     used_preaggregated_tables: bool
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, use_v2_tables: bool = False, **kwargs):
         super().__init__(*args, **kwargs)
+        self.use_v2_tables = use_v2_tables
         self.used_preaggregated_tables = False
         self.paginator = HogQLHasMorePaginator.from_limit_context(
             limit_context=LimitContext.QUERY,

--- a/posthog/hogql_queries/web_analytics/stats_table_pre_aggregated.py
+++ b/posthog/hogql_queries/web_analytics/stats_table_pre_aggregated.py
@@ -107,7 +107,9 @@ class StatsTablePreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder)
             GROUP BY `context.columns.breakdown_value`
             """,
                 placeholders={
-                    "bounce_table": "web_pre_aggregated_bounces" if self.use_v2_tables else "web_bounces_combined",
+                    "bounce_table": ast.Field(
+                        chain=["web_pre_aggregated_bounces" if self.use_v2_tables else "web_bounces_combined"]
+                    ),
                     "breakdown_value": ast.Call(
                         name="nullIf",
                         args=[self._apply_path_cleaning(ast.Field(chain=["entry_pathname"])), ast.Constant(value="")],
@@ -149,13 +151,16 @@ class StatsTablePreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder)
                 {views_tuple} as `context.columns.views`,
                 any(bounces.`context.columns.bounce_rate`) as `context.columns.bounce_rate`
             FROM
-                web_stats_combined
+                {stats_table}
             LEFT JOIN ({bounce_subquery}) bounces
                 ON {join_condition}
             WHERE and({filters}, {breakdown_value} IS NOT NULL)
             GROUP BY `context.columns.breakdown_value`
             """,
                 placeholders={
+                    "stats_table": ast.Field(
+                        chain=["web_pre_aggregated_stats" if self.use_v2_tables else "web_stats_combined"]
+                    ),
                     "breakdown_value": ast.Call(
                         name="nullIf",
                         args=[self._apply_path_cleaning(ast.Field(chain=["pathname"])), ast.Constant(value="")],
@@ -212,7 +217,9 @@ class StatsTablePreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder)
             GROUP BY `context.columns.breakdown_value`
             """,
                 placeholders={
-                    "stats_table": "web_pre_aggregated_stats" if self.use_v2_tables else "web_stats_combined",
+                    "stats_table": ast.Field(
+                        chain=["web_pre_aggregated_stats" if self.use_v2_tables else "web_stats_combined"]
+                    ),
                     "breakdown_field": self._get_breakdown_field(),
                     "visitors_tuple": self._period_comparison_tuple(
                         "persons_uniq_state", "uniqMergeIf", current_period_filter, previous_period_filter

--- a/posthog/hogql_queries/web_analytics/web_overview.py
+++ b/posthog/hogql_queries/web_analytics/web_overview.py
@@ -30,8 +30,9 @@ class WebOverviewQueryRunner(WebAnalyticsQueryRunner):
     cached_response: CachedWebOverviewQueryResponse
     preaggregated_query_builder: WebOverviewPreAggregatedQueryBuilder
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, use_v2_tables: bool = False, **kwargs):
         super().__init__(*args, **kwargs)
+        self.use_v2_tables = use_v2_tables
         self.preaggregated_query_builder = WebOverviewPreAggregatedQueryBuilder(self)
 
     def to_query(self) -> ast.SelectQuery:

--- a/posthog/hogql_queries/web_analytics/web_overview_pre_aggregated.py
+++ b/posthog/hogql_queries/web_analytics/web_overview_pre_aggregated.py
@@ -13,31 +13,35 @@ if TYPE_CHECKING:
 class WebOverviewPreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder):
     def __init__(self, runner: "WebOverviewQueryRunner") -> None:
         super().__init__(runner, supported_props_filters=WEB_OVERVIEW_SUPPORTED_PROPERTIES)
+        self.use_v2_tables = getattr(runner, "use_v2_tables", False)
 
     def get_query(self) -> ast.SelectQuery:
         previous_period_filter, current_period_filter = self.get_date_ranges()
 
+        # Choose table based on version
+        table_name = "web_pre_aggregated_bounces" if self.use_v2_tables else "web_bounces_combined"
+
         query = parse_select(
-            """
+            f"""
             SELECT
-                {unique_persons_current} AS unique_persons,
-                {unique_persons_previous} AS previous_unique_persons,
+                {{unique_persons_current}} AS unique_persons,
+                {{unique_persons_previous}} AS previous_unique_persons,
 
-                {pageviews_current} AS pageviews,
-                {pageviews_previous} AS previous_pageviews,
+                {{pageviews_current}} AS pageviews,
+                {{pageviews_previous}} AS previous_pageviews,
 
-                {unique_sessions_current} AS unique_sessions,
-                {unique_sessions_previous} AS previous_unique_sessions,
+                {{unique_sessions_current}} AS unique_sessions,
+                {{unique_sessions_previous}} AS previous_unique_sessions,
 
-                {avg_session_duration_current} AS avg_session_duration,
-                {avg_session_duration_previous} AS previous_avg_session_duration,
+                {{avg_session_duration_current}} AS avg_session_duration,
+                {{avg_session_duration_previous}} AS previous_avg_session_duration,
 
-                {bounce_rate_current} AS bounce_rate,
-                {bounce_rate_previous} AS previous_bounce_rate,
+                {{bounce_rate_current}} AS bounce_rate,
+                {{bounce_rate_previous}} AS previous_bounce_rate,
 
                 NULL AS revenue,
                 NULL AS previous_revenue
-        FROM web_bounces_combined
+        FROM {table_name}
         """,
             placeholders={
                 "unique_persons_current": self._uniq_merge_if("persons_uniq_state", current_period_filter),
@@ -63,7 +67,7 @@ class WebOverviewPreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder
 
         assert isinstance(query, ast.SelectQuery)
 
-        filters = self._get_filters(table_name="web_bounces_combined")
+        filters = self._get_filters(table_name=table_name)
         if filters:
             query.where = filters
 


### PR DESCRIPTION
## Problem

I was checking those tables directly on Clickhouse because, at first, I thought we could swap them internally, but it is too much trouble, let's make them accessible via hogql and check their accuracy results to make sure we can start using them all together.

## Changes

- Added the new tables to hogql
- Added a new asset check to verify the hourly tables accuracy

## How did you test this code?

Manually materializing the assets locally

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
