### PR TITLE
chore(flags): clean traces

### DIFF
--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -70,9 +70,6 @@ pub fn calculate_hash(prefix: &str, hashed_identifier: &str, salt: &str) -> Resu
 #[instrument(skip_all, fields(
     team_id = %team_id,
     distinct_id = %distinct_id,
-    person_query_ms = tracing::field::Empty,
-    cohort_query_ms = tracing::field::Empty,
-    group_query_ms = tracing::field::Empty,
     cohort_ids = ?static_cohort_ids,
     group_type_indexes = ?group_type_indexes,
     group_keys = ?group_keys
@@ -97,7 +94,13 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
         ),
     ];
     let conn_timer = common_metrics::timing_guard(FLAG_DB_CONNECTION_TIME, &labels);
+    let conn_acquisition_start = Instant::now();
     let mut conn = reader.as_ref().get_connection().await?;
+    let conn_acquisition_duration = conn_acquisition_start.elapsed();
+    info!(
+        conn_acquisition_ms = conn_acquisition_duration.as_millis(),
+        "Database connection acquired"
+    );
     conn_timer.fin();
 
     // First query: Get person data from the distinct_id (person_id and person_properties)
@@ -131,7 +134,6 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
     person_query_timer.fin();
 
     let person_query_duration = person_query_start.elapsed();
-    tracing::Span::current().record("person_query_ms", person_query_duration.as_millis());
 
     if person_query_duration.as_millis() > 500 {
         warn!(
@@ -177,7 +179,6 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
             cohort_timer.fin();
 
             let cohort_query_duration = cohort_query_start.elapsed();
-            tracing::Span::current().record("cohort_query_ms", cohort_query_duration.as_millis());
 
             if cohort_query_duration.as_millis() > 200 {
                 warn!(
@@ -269,7 +270,6 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
         group_query_timer.fin();
 
         let group_query_duration = group_query_start.elapsed();
-        tracing::Span::current().record("group_query_ms", group_query_duration.as_millis());
 
         if group_query_duration.as_millis() > 300 {
             warn!(

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -97,7 +97,7 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
     let conn_acquisition_start = Instant::now();
     let conn_result = reader.as_ref().get_connection().await;
     let conn_acquisition_duration = conn_acquisition_start.elapsed();
-    
+
     let mut conn = match conn_result {
         Ok(conn) => {
             info!(


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Turns out that otel tracing shows logs, so I don't need to add query durations to the tags. 

e.g. 
<img width="1288" height="235" alt="Screenshot 2025-08-12 at 11 10 46 PM" src="https://github.com/user-attachments/assets/fd41a460-fe93-480e-b02d-d161160e881d" />

https://traces.prod-us.posthog.dev/trace/2fd0b0caa78de406002c39be2324daff
## Changes

Remove query duration from tags and add a log for connection time

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
