### PR TITLE
fix(sharing): embedded url redirect

### DIFF
--- a/frontend/src/lib/utils/router-utils.ts
+++ b/frontend/src/lib/utils/router-utils.ts
@@ -13,6 +13,8 @@ const pathsWithoutProjectId = [
     'create-organization',
     'account',
     'oauth',
+    'shared',
+    'embedded',
 ]
 
 const projectIdentifierInUrlRegex = /^\/project\/(\d+|phc_)/


### PR DESCRIPTION
## Problem

Shared URLs like `http://localhost:8010/shared/N8U69iEsbPhAkGtKrZYd101Pp0IXrQ` would get a redirect that adds `/project/1` to the start.

## Changes

Put `shared` and `embedded` in a blocklist

## How did you test this code?

Opening `http://localhost:8010/shared/N8U69iEsbPhAkGtKrZYd101Pp0IXrQ` locally did not redirect anymore.