### PR TITLE
feat(ux): refactor sceneLogic and a whole bunch of scenes

### DIFF
--- a/frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.tsx
+++ b/frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.tsx
@@ -27,7 +27,7 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType>([
             preflightLogic,
             ['preflight'],
             sceneLogic,
-            ['sceneConfig', 'activeScene'],
+            ['sceneConfig', 'activeSceneId'],
             userLogic,
             ['user', 'otherOrganizations'],
             organizationLogic,
@@ -77,7 +77,7 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType>([
                 // this every time it's rendered. Caching will happen within the scene's breadcrumb selector.
                 (state, props): Breadcrumb[] => {
                     const activeSceneLogic = sceneLogic.selectors.activeSceneLogic(state, props)
-                    const activeScene = s.activeScene(state, props)
+                    const activeSceneId = s.activeSceneId(state, props)
 
                     if (activeSceneLogic && 'breadcrumbs' in activeSceneLogic.selectors) {
                         try {
@@ -91,9 +91,9 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType>([
                         }
                     }
 
-                    if (activeScene) {
+                    if (activeSceneId) {
                         const sceneConfig = s.sceneConfig(state, props)
-                        return [{ name: sceneConfig?.name ?? identifierToHuman(activeScene), key: activeScene }]
+                        return [{ name: sceneConfig?.name ?? identifierToHuman(activeSceneId), key: activeSceneId }]
                     }
                     return []
                 },
@@ -124,10 +124,18 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType>([
             { equalityCheck: objectsEqual },
         ],
         appBreadcrumbs: [
-            (s) => [s.preflight, s.sceneConfig, s.activeScene, s.user, s.currentProject, s.currentTeam, s.featureFlags],
-            (preflight, sceneConfig, activeScene, user, currentProject, currentTeam, featureFlags) => {
+            (s) => [
+                s.preflight,
+                s.sceneConfig,
+                s.activeSceneId,
+                s.user,
+                s.currentProject,
+                s.currentTeam,
+                s.featureFlags,
+            ],
+            (preflight, sceneConfig, activeSceneId, user, currentProject, currentTeam, featureFlags) => {
                 const breadcrumbs: Breadcrumb[] = []
-                if (!activeScene || !sceneConfig) {
+                if (!activeSceneId || !sceneConfig) {
                     return breadcrumbs
                 }
                 // User

--- a/frontend/src/layout/scenes/SceneTabContextMenu.tsx
+++ b/frontend/src/layout/scenes/SceneTabContextMenu.tsx
@@ -3,19 +3,11 @@ import { useActions, useValues } from 'kea'
 import { sceneLogic, SceneTab } from '~/scenes/sceneLogic'
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from 'lib/ui/ContextMenu/ContextMenu'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
-import { IconCopy, IconX, IconChevronRight, IconChevronLeft, IconExternal } from '@posthog/icons'
+import { IconCopy, IconX, IconChevronRight, IconChevronLeft, IconExternal, IconPencil } from '@posthog/icons'
 
 export function SceneTabContextMenu({ tab, children }: { tab: SceneTab; children: React.ReactElement }): JSX.Element {
     const { tabs } = useValues(sceneLogic)
-    const { setTabs, removeTab, cloneTab } = useActions(sceneLogic)
-
-    const duplicateTab = (): void => {
-        cloneTab(tab)
-    }
-
-    const closeThis = (): void => {
-        removeTab(tab)
-    }
+    const { setTabs, removeTab, duplicateTab, renameTab } = useActions(sceneLogic)
 
     const openInNewWindow = (): void => {
         const fullUrl = `${window.location.origin}${tab.pathname}${tab.search}${tab.hash}`
@@ -43,8 +35,13 @@ export function SceneTabContextMenu({ tab, children }: { tab: SceneTab; children
             <ContextMenuTrigger>{children}</ContextMenuTrigger>
             <ContextMenuContent>
                 <ContextMenuItem asChild>
-                    <ButtonPrimitive menuItem onClick={duplicateTab}>
+                    <ButtonPrimitive menuItem onClick={() => duplicateTab(tab)}>
                         <IconCopy /> Duplicate tab
+                    </ButtonPrimitive>
+                </ContextMenuItem>
+                <ContextMenuItem asChild>
+                    <ButtonPrimitive menuItem onClick={() => renameTab(tab)}>
+                        <IconPencil /> Rename tab
                     </ButtonPrimitive>
                 </ContextMenuItem>
                 <ContextMenuItem asChild>
@@ -53,7 +50,7 @@ export function SceneTabContextMenu({ tab, children }: { tab: SceneTab; children
                     </ButtonPrimitive>
                 </ContextMenuItem>
                 <ContextMenuItem asChild>
-                    <ButtonPrimitive menuItem onClick={closeThis}>
+                    <ButtonPrimitive menuItem onClick={() => removeTab(tab)}>
                         <IconX /> Close tab
                     </ButtonPrimitive>
                 </ContextMenuItem>

--- a/frontend/src/layout/scenes/SceneTabs.tsx
+++ b/frontend/src/layout/scenes/SceneTabs.tsx
@@ -99,7 +99,7 @@ interface SceneTabProps {
 
 function SceneTabComponent({ tab, className, isDragging }: SceneTabProps): JSX.Element {
     const canRemoveTab = true
-    const { clickOnTab, removeTab } = useActions(sceneLogic)
+    const { clickOnTab, removeTab, renameTab } = useActions(sceneLogic)
     return (
         <Link
             onClick={(e) => {
@@ -107,6 +107,13 @@ function SceneTabComponent({ tab, className, isDragging }: SceneTabProps): JSX.E
                 e.preventDefault()
                 if (!isDragging) {
                     clickOnTab(tab)
+                }
+            }}
+            onDoubleClick={(e) => {
+                e.stopPropagation()
+                e.preventDefault()
+                if (!isDragging) {
+                    renameTab(tab)
                 }
             }}
             to={isDragging ? undefined : `${tab.pathname}${tab.search}${tab.hash}`}
@@ -120,7 +127,9 @@ function SceneTabComponent({ tab, className, isDragging }: SceneTabProps): JSX.E
                 className
             )}
         >
-            <div className="flex-grow text-left whitespace-pre">{tab.title}</div>
+            <div className={cn('flex-grow text-left whitespace-pre', tab.customTitle && 'italic')}>
+                {tab.customTitle || tab.title}
+            </div>
             {canRemoveTab && (
                 <ButtonPrimitive
                     onClick={(e) => {

--- a/frontend/src/lib/KeaDevTools.tsx
+++ b/frontend/src/lib/KeaDevTools.tsx
@@ -54,9 +54,9 @@ function displayName(logic: BuiltLogic): string {
 /** size metric → used for a subtle tint & node size */
 function logicSize(logic: BuiltLogic): number {
     const c = Math.max(0, Object.keys((logic as any)?.connections || {}).length - 1)
-    const a = Object.keys((logic as any).actions || {}).length
-    const s = Object.keys((logic as any).selectors || {}).length
-    const v = Object.keys((logic as any).values || {}).length
+    const a = Object.keys((logic as any)?.actions || {}).length
+    const s = Object.keys((logic as any)?.selectors || {}).length
+    const v = Object.keys((logic as any)?.values || {}).length
     return c + a + s + v
 }
 
@@ -429,8 +429,6 @@ function GraphTab({
                         b.vx -= rx
                         b.vy -= ry
                     }
-
-                    // hard non-overlap
                     const minD = a.size + b.size + COLLISION_PAD
                     if (dist < minD) {
                         const overlap = minD - dist

--- a/frontend/src/lib/KeaDevTools.tsx
+++ b/frontend/src/lib/KeaDevTools.tsx
@@ -38,24 +38,22 @@ function compactJSON(x: unknown) {
 /* ---------- naming ---------- */
 
 function displayName(logic: BuiltLogic): string {
-    const parts = logic.pathString.split('.')
+    if (!logic || !logic.path || !logic.path.length) {
+        return 'Unknown logic'
+    }
+    const parts = logic.path
     const hasKey = typeof logic.key !== 'undefined'
 
     if (hasKey && parts.length >= 2) {
-        const keyStr = String((logic as any).key)
-        const keyIndex = parts.lastIndexOf(keyStr)
-        if (keyIndex > 0) {
-            const name = parts[keyIndex - 1]
-            return `${name}.${keyStr}`
-        }
+        return parts.slice(-2).map(String).join('.') // remove 'kea' and 'logic' from the path
     }
 
-    return parts[parts.length - 1]
+    return String(parts[parts.length - 1] || 'Unknown logic')
 }
 
 /** size metric → used for a subtle tint & node size */
 function logicSize(logic: BuiltLogic): number {
-    const c = Math.max(0, Object.keys((logic as any).connections || {}).length - 1)
+    const c = Math.max(0, Object.keys((logic as any)?.connections || {}).length - 1)
     const a = Object.keys((logic as any).actions || {}).length
     const s = Object.keys((logic as any).selectors || {}).length
     const v = Object.keys((logic as any).values || {}).length

--- a/frontend/src/lib/lemon-ui/Link/Link.tsx
+++ b/frontend/src/lib/lemon-ui/Link/Link.tsx
@@ -26,6 +26,7 @@ export type LinkProps = Pick<React.HTMLProps<HTMLAnchorElement>, 'target' | 'cla
     disableDocsPanel?: boolean
     preventClick?: boolean
     onClick?: (event: React.MouseEvent<HTMLElement>) => void
+    onDoubleClick?: (event: React.MouseEvent<HTMLElement>) => void
     onMouseDown?: (event: React.MouseEvent<HTMLElement>) => void
     onMouseEnter?: (event: React.MouseEvent<HTMLElement>) => void
     onMouseLeave?: (event: React.MouseEvent<HTMLElement>) => void

--- a/frontend/src/lib/logic/scene-plugin/tabAwareActionToUrl.ts
+++ b/frontend/src/lib/logic/scene-plugin/tabAwareActionToUrl.ts
@@ -1,0 +1,38 @@
+import { BuiltLogic, Logic } from 'kea'
+import { ActionToUrlPayload } from 'kea-router/lib/types'
+import { sceneLogic } from 'scenes/sceneLogic'
+import { combineUrl, router, actionToUrl } from 'kea-router'
+
+export const tabAwareActionToUrl = <L extends Logic = Logic>(
+    input: ActionToUrlPayload<L> | ((logic: BuiltLogic<L>) => ActionToUrlPayload<L>)
+) => {
+    return (logic: BuiltLogic<L>) => {
+        const finalInput = typeof input === 'function' ? input(logic) : input
+        const newPayload = Object.fromEntries(
+            Object.entries(finalInput).map(([k, v]) => [
+                k,
+                (payload: Record<string, any>): any => {
+                    if (v) {
+                        const response = v(payload)
+                        if (sceneLogic.values.activeTabId === logic.props.tabId) {
+                            return response
+                        }
+                        // If we want to change the URL, but we're inactive, just update the tab value
+                        sceneLogic.actions.setTabs(
+                            sceneLogic.values.tabs.map((tab) => {
+                                if (tab.id === logic.props.tabId) {
+                                    const { pathname, search, hash } = router.values.location
+                                    const { url } = combineUrl(pathname, search, hash)
+                                    return { ...tab, url }
+                                }
+                                return tab
+                            })
+                        )
+                        return undefined
+                    }
+                },
+            ])
+        )
+        actionToUrl(newPayload)(logic)
+    }
+}

--- a/frontend/src/lib/logic/scene-plugin/tabAwareScene.ts
+++ b/frontend/src/lib/logic/scene-plugin/tabAwareScene.ts
@@ -1,0 +1,13 @@
+import { BuiltLogic, key, Logic } from 'kea'
+
+export const tabAwareScene = <L extends Logic = Logic>() => {
+    return (logic: BuiltLogic<L>) => {
+        // add a tab-based key if none present
+        key((props) => {
+            if (!props.tabId) {
+                throw new Error('Tab-aware scene logic must have a tabId prop')
+            }
+            return props.tabId
+        })(logic)
+    }
+}

--- a/frontend/src/lib/logic/scene-plugin/tabAwareUrlToAction.ts
+++ b/frontend/src/lib/logic/scene-plugin/tabAwareUrlToAction.ts
@@ -1,0 +1,23 @@
+import { BuiltLogic, Logic } from 'kea'
+import { UrlToActionPayload } from 'kea-router/lib/types'
+import { sceneLogic } from 'scenes/sceneLogic'
+import { urlToAction } from 'kea-router'
+
+export const tabAwareUrlToAction = <L extends Logic = Logic>(
+    input: UrlToActionPayload<L> | ((logic: BuiltLogic<L>) => UrlToActionPayload<L>)
+) => {
+    return (logic: BuiltLogic<L>) => {
+        const finalInput = typeof input === 'function' ? input(logic) : input
+        const newPayload = Object.fromEntries(
+            Object.entries(finalInput).map(([k, v]) => [
+                k,
+                (params: any, searchParams: any, hashParams: any, payload: any, previousLocation: any): any => {
+                    if (sceneLogic.values.activeTabId === logic.props.tabId) {
+                        return v(params, searchParams, hashParams, payload, previousLocation)
+                    }
+                },
+            ])
+        )
+        urlToAction(newPayload)(logic)
+    }
+}

--- a/frontend/src/lib/logic/scene-plugin/useAttachedLogic.ts
+++ b/frontend/src/lib/logic/scene-plugin/useAttachedLogic.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react'
+import { BuiltLogic, Logic, LogicWrapper, useMountedLogic } from 'kea'
+
+/**
+ * Attach a logic to another logic. The logics stay connected even if the React component unmounts.
+ * The only way to detach them is to unmount the "attachTo" logic. If there are no other connections,
+ * the "logic" will be unmounted as well.
+ * */
+export function useAttachedLogic(logic: BuiltLogic<Logic>, attachTo?: BuiltLogic<Logic> | LogicWrapper<Logic>): void {
+    if (!attachTo) {
+        // We're breaking the rules of hooks here...
+        // You should not change the attachTo prop from undefined to defined
+        return
+    }
+    const builtAttachTo = useMountedLogic(attachTo) // eslint-disable-line react-hooks/rules-of-hooks
+    useEffect(() => {
+        if (attachTo && builtAttachTo) {
+            // connect(logic)(builtAttachTo)
+            // logic.mount()
+            // beforeUnmount(() => {
+            //     // debugger
+            //     unmount()
+            // })(builtAttachTo)
+        }
+    }, [attachTo, builtAttachTo]) // eslint-disable-line react-hooks/rules-of-hooks
+}

--- a/frontend/src/queries/Query/Query.tsx
+++ b/frontend/src/queries/Query/Query.tsx
@@ -135,6 +135,7 @@ export function Query<Q extends Node>(props: QueryProps<Q>): JSX.Element | null 
     } else if (isDataVisualizationNode(query)) {
         component = (
             <DataTableVisualization
+                attachTo={props.attachTo}
                 query={query}
                 setQuery={setQuery as unknown as (query: DataVisualizationNode) => void}
                 cachedResults={props.cachedResults}
@@ -145,10 +146,19 @@ export function Query<Q extends Node>(props: QueryProps<Q>): JSX.Element | null 
             />
         )
     } else if (isSavedInsightNode(query)) {
-        component = <SavedInsight query={query} context={queryContext} readOnly={readOnly} embedded={embedded} />
+        component = (
+            <SavedInsight
+                attachTo={props.attachTo}
+                query={query}
+                context={queryContext}
+                readOnly={readOnly}
+                embedded={embedded}
+            />
+        )
     } else if (isInsightVizNode(query)) {
         component = (
             <InsightViz
+                attachTo={props.attachTo}
                 query={query}
                 setQuery={setQuery as unknown as (query: InsightVizNode) => void}
                 context={queryContext}
@@ -195,7 +205,7 @@ export function Query<Q extends Node>(props: QueryProps<Q>): JSX.Element | null 
     } else if (isCalendarHeatmapQuery(query)) {
         component = <WebActiveHoursHeatmap query={query} context={queryContext} cachedResults={props.cachedResults} />
     } else {
-        component = <DataNode query={query} cachedResults={props.cachedResults} />
+        component = <DataNode attachTo={props.attachTo} query={query} cachedResults={props.cachedResults} />
     }
 
     return (

--- a/frontend/src/queries/Query/Query.tsx
+++ b/frontend/src/queries/Query/Query.tsx
@@ -47,6 +47,7 @@ import {
     isWebVitalsPathBreakdownQuery,
     isWebVitalsQuery,
 } from '../utils'
+import { BuiltLogic, Logic, LogicWrapper } from 'kea'
 
 export interface QueryProps<Q extends Node> {
     /** An optional key to identify the query */
@@ -73,6 +74,8 @@ export interface QueryProps<Q extends Node> {
     variablesOverride?: Record<string, HogQLVariable> | null
     /** Passed down if implemented by the query type to e.g. set data attr on a LemonTable in a data table */
     dataAttr?: string
+    /** Attach ourselves to another logic */
+    attachTo?: BuiltLogic<Logic> | LogicWrapper<Logic>
 }
 
 export function Query<Q extends Node>(props: QueryProps<Q>): JSX.Element | null {
@@ -118,6 +121,8 @@ export function Query<Q extends Node>(props: QueryProps<Q>): JSX.Element | null 
     if (isDataTableNode(query)) {
         component = (
             <DataTable
+                attachTo={props.attachTo}
+                key={props.uniqueKey}
                 query={query}
                 setQuery={setQuery as unknown as (query: DataTableNode) => void}
                 context={queryContext}

--- a/frontend/src/queries/hooks/useDebouncedQuery.ts
+++ b/frontend/src/queries/hooks/useDebouncedQuery.ts
@@ -16,7 +16,8 @@ export function useDebouncedQuery<T extends Node = Node, V extends string = stri
     const queryRef = useRef(query)
     useEffect(() => {
         queryRef.current = query
-    }, [query])
+        setLocalValue(getValueFromQuery(query))
+    }, [query, getValueFromQuery])
 
     const timeoutRef = useRef<number>()
     const onChange = (newValue: V): void => {

--- a/frontend/src/queries/hooks/useDebouncedQuery.ts
+++ b/frontend/src/queries/hooks/useDebouncedQuery.ts
@@ -16,7 +16,6 @@ export function useDebouncedQuery<T extends Node = Node, V extends string = stri
     const queryRef = useRef(query)
     useEffect(() => {
         queryRef.current = query
-        setLocalValue(getValueFromQuery(query))
     }, [query, getValueFromQuery])
 
     const timeoutRef = useRef<number>()

--- a/frontend/src/queries/nodes/DataNode/DataNode.tsx
+++ b/frontend/src/queries/nodes/DataNode/DataNode.tsx
@@ -1,4 +1,4 @@
-import { useValues } from 'kea'
+import { BuiltLogic, Logic, LogicWrapper, useValues } from 'kea'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 import { CodeEditor } from 'lib/monaco/CodeEditor'
 import { useState } from 'react'
@@ -7,6 +7,7 @@ import { AutoSizer } from 'react-virtualized/dist/es/AutoSizer'
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { OpenEditorButton } from '~/queries/nodes/Node/OpenEditorButton'
 import { AnyResponseType, DataNode as DataNodeType, DataTableNode } from '~/queries/schema/schema-general'
+import { useAttachedLogic } from 'lib/logic/scene-plugin/useAttachedLogic'
 
 interface DataNodeProps {
     query: DataNodeType
@@ -14,6 +15,7 @@ interface DataNodeProps {
     /* Cached Results are provided when shared or exported,
     the data node logic becomes read only implicitly */
     cachedResults?: AnyResponseType
+    attachTo?: BuiltLogic<Logic> | LogicWrapper<Logic>
 }
 
 let uniqueNode = 0
@@ -23,6 +25,8 @@ export function DataNode(props: DataNodeProps): JSX.Element {
     const [key] = useState(() => `DataNode.${uniqueNode++}`)
     const logic = dataNodeLogic({ ...props, key, cachedResults: props.cachedResults, dataNodeCollectionId: key })
     const { response, responseLoading, responseErrorObject } = useValues(logic)
+
+    useAttachedLogic(logic, props.attachTo)
 
     return (
         <div className="relative">

--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -130,7 +130,7 @@ function addTags<T extends Record<string, any>>(query: DataNode<T>): DataNode<T>
     // find the currently mounted scene logic to get the active scene, but don't use the kea connect()
     // method to do this as we don't want to mount the sceneLogic if it isn't already mounted
     const mountedSceneLogic = sceneLogic.findMounted()
-    const activeScene = mountedSceneLogic?.values.activeScene
+    const activeScene = mountedSceneLogic?.values.activeSceneId
 
     const tags = query.tags ? { ...query.tags } : {}
     if (!tags.scene && activeScene) {

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -1,7 +1,7 @@
 import './DataTable.scss'
 
 import clsx from 'clsx'
-import { BindLogic, useActions, useValues } from 'kea'
+import { BindLogic, BuiltLogic, Logic, LogicWrapper, useActions, useValues } from 'kea'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TaxonomicPopover } from 'lib/components/TaxonomicPopover/TaxonomicPopover'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
@@ -77,6 +77,7 @@ import { GroupsSearch } from '../GroupsQuery/GroupsSearch'
 import { DataTableOpenEditor } from './DataTableOpenEditor'
 import { createMarketingAnalyticsOrderBy } from 'scenes/web-analytics/tabs/marketing-analytics/frontend/logic/utils'
 import { groupViewLogic } from 'scenes/groups/groupViewLogic'
+import { useAttachedLogic } from 'lib/logic/scene-plugin/useAttachedLogic'
 
 export enum ColumnFeature {
     canSort = 'canSort',
@@ -102,6 +103,7 @@ interface DataTableProps {
      Set a data-attr on the LemonTable component
     */
     dataAttr?: string
+    attachTo?: BuiltLogic<Logic> | LogicWrapper<Logic>
 }
 
 const eventGroupTypes = [
@@ -122,6 +124,7 @@ export function DataTable({
     cachedResults,
     readOnly,
     dataAttr,
+    attachTo,
 }: DataTableProps): JSX.Element {
     const [uniqueNodeKey] = useState(() => uniqueNode++)
     const [dataKey] = useState(() => `DataNode.${uniqueKey || uniqueNodeKey}`)
@@ -178,6 +181,9 @@ export function DataTable({
     const { dataTableRows, columnsInQuery, columnsInResponse, queryWithDefaults, canSort, sourceFeatures } = useValues(
         dataTableLogic(dataTableLogicProps)
     )
+
+    useAttachedLogic(builtDataNodeLogic, attachTo)
+    useAttachedLogic(dataTableLogic(dataTableLogicProps), attachTo)
 
     const {
         showActions,

--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
@@ -1,7 +1,7 @@
 import { IconGear } from '@posthog/icons'
 import { LemonButton, LemonDivider } from '@posthog/lemon-ui'
 import clsx from 'clsx'
-import { BindLogic, useActions, useValues } from 'kea'
+import { BindLogic, BuiltLogic, Logic, LogicWrapper, useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { ExportButton } from 'lib/components/ExportButton/ExportButton'
 import { useCallback, useState } from 'react'
@@ -34,9 +34,10 @@ import { TableDisplay } from './Components/TableDisplay'
 import { AddVariableButton } from './Components/Variables/AddVariableButton'
 import { variableModalLogic } from './Components/Variables/variableModalLogic'
 import { VariablesForInsight } from './Components/Variables/Variables'
-import { variablesLogic } from './Components/Variables/variablesLogic'
+import { variablesLogic, VariablesLogicProps } from './Components/Variables/variablesLogic'
 import { dataVisualizationLogic, DataVisualizationLogicProps } from './dataVisualizationLogic'
 import { displayLogic } from './displayLogic'
+import { useAttachedLogic } from 'lib/logic/scene-plugin/useAttachedLogic'
 
 export interface DataTableVisualizationProps {
     uniqueKey?: string | number
@@ -50,6 +51,7 @@ export interface DataTableVisualizationProps {
     exportContext?: ExportContext
     /** Dashboard variables to override the ones in the query */
     variablesOverride?: Record<string, HogQLVariable> | null
+    attachTo?: BuiltLogic<Logic> | LogicWrapper<Logic>
 }
 
 let uniqueNode = 0
@@ -62,6 +64,7 @@ export function DataTableVisualization({
     cachedResults,
     readOnly,
     variablesOverride,
+    attachTo,
 }: DataTableVisualizationProps): JSX.Element {
     const [key] = useState(`DataVisualizationNode.${uniqueKey ?? uniqueNode++}`)
     const insightProps: InsightLogicProps<DataVisualizationNode> = context?.insightProps || {
@@ -100,27 +103,27 @@ export function DataTableVisualization({
 
     const { loadData } = useActions(dataVisualizationLogic(dataVisualizationLogicProps))
 
+    const variablesLogicProps: VariablesLogicProps = {
+        key: dataVisualizationLogicProps.key,
+        readOnly: readOnly ?? false,
+        dashboardId: insightProps.dashboardId,
+        sourceQuery: query,
+        setQuery: setQuery,
+        onUpdate: (query: DataVisualizationNode) => {
+            loadData(shouldQueryBeAsync(query.source) ? 'force_async' : 'force_blocking', undefined, query.source)
+        },
+    }
+
+    useAttachedLogic(dataNodeLogic(dataNodeLogicProps), attachTo)
+    useAttachedLogic(dataVisualizationLogic(dataVisualizationLogicProps), attachTo)
+    useAttachedLogic(displayLogic({ key: dataVisualizationLogicProps.key }), attachTo)
+    useAttachedLogic(variablesLogic(variablesLogicProps), attachTo)
+
     return (
         <BindLogic logic={dataNodeLogic} props={dataNodeLogicProps}>
             <BindLogic logic={dataVisualizationLogic} props={dataVisualizationLogicProps}>
                 <BindLogic logic={displayLogic} props={{ key: dataVisualizationLogicProps.key }}>
-                    <BindLogic
-                        logic={variablesLogic}
-                        props={{
-                            key: dataVisualizationLogicProps.key,
-                            readOnly: readOnly ?? false,
-                            dashboardId: insightProps.dashboardId,
-                            sourceQuery: query,
-                            setQuery: setQuery,
-                            onUpdate: (query: DataVisualizationNode) => {
-                                loadData(
-                                    shouldQueryBeAsync(query.source) ? 'force_async' : 'force_blocking',
-                                    undefined,
-                                    query.source
-                                )
-                            },
-                        }}
-                    >
+                    <BindLogic logic={variablesLogic} props={variablesLogicProps}>
                         <BindLogic logic={variableModalLogic} props={{ key: dataVisualizationLogicProps.key }}>
                             <InternalDataTableVisualization
                                 uniqueKey={key}

--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
@@ -7,7 +7,6 @@ import { ExportButton } from 'lib/components/ExportButton/ExportButton'
 import { useCallback, useState } from 'react'
 import { InsightErrorState, StatelessInsightLoadingState } from 'scenes/insights/EmptyStates'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
-import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { HogQLBoldNumber } from 'scenes/insights/views/BoldNumber/BoldNumber'
 import { urls } from 'scenes/urls'
 
@@ -22,7 +21,7 @@ import {
 } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 import { shouldQueryBeAsync } from '~/queries/utils'
-import { ChartDisplayType, ExportContext, ExporterFormat, InsightLogicProps } from '~/types'
+import { ChartDisplayType, ExportContext, ExporterFormat, InsightLogicProps, ItemMode } from '~/types'
 
 import { dataNodeLogic, DataNodeLogicProps } from '../DataNode/dataNodeLogic'
 import { DateRange } from '../DataNode/DateRange'
@@ -74,7 +73,7 @@ export function DataTableVisualization({
 
     const vizKey = insightVizDataNodeKey(insightProps)
     const dataNodeCollectionId = insightVizDataCollectionId(insightProps, key)
-    const { insightMode } = useValues(insightSceneLogic)
+    const insightMode = context?.insightMode || ItemMode.View
     const dataVisualizationLogicProps: DataVisualizationLogicProps = {
         key: vizKey,
         query,

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -242,7 +242,7 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
             themeLogic,
             ['isDarkModeOn'],
             sceneLogic,
-            ['activeScene'],
+            ['activeSceneId'],
         ],
         actions: [
             dataNodeLogic({
@@ -603,12 +603,12 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
             },
         ],
         presetChartHeight: [
-            (state, props) => [props.key, state.dashboardId, state.activeScene],
-            (key, dashboardId, activeScene) => {
-                // Key for SQL editor based visiaulizations
-                const sqlEditorScene = activeScene === Scene.SQLEditor
+            (state, props) => [props.key, state.dashboardId, state.activeSceneId],
+            (key, dashboardId, activeSceneId) => {
+                // Key for SQL editor based visualizations
+                const sqlEditorScene = activeSceneId === Scene.SQLEditor
 
-                if (activeScene === Scene.Insight) {
+                if (activeSceneId === Scene.Insight) {
                     return true
                 }
 

--- a/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
@@ -1,11 +1,10 @@
 import './InsightViz.scss'
 
 import clsx from 'clsx'
-import { BindLogic, useValues } from 'kea'
+import { BindLogic } from 'kea'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useState } from 'react'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 
@@ -83,7 +82,7 @@ export function InsightViz({
         variablesOverride,
     }
 
-    const { insightMode } = useValues(insightSceneLogic)
+    const insightMode = context?.insightMode ?? ItemMode.View
 
     const isFunnels = isFunnelsQuery(query.source)
     const isHorizontalAlways = useFeatureFlag('INSIGHT_HORIZONTAL_CONTROLS')

--- a/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
@@ -1,7 +1,7 @@
 import './InsightViz.scss'
 
 import clsx from 'clsx'
-import { BindLogic } from 'kea'
+import { BindLogic, BuiltLogic, Logic, LogicWrapper } from 'kea'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useState } from 'react'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -18,6 +18,7 @@ import { dataNodeLogic, DataNodeLogicProps } from '../DataNode/dataNodeLogic'
 import { EditorFilters } from './EditorFilters'
 import { InsightVizDisplay } from './InsightVizDisplay'
 import { getCachedResults } from './utils'
+import { useAttachedLogic } from 'lib/logic/scene-plugin/useAttachedLogic'
 
 /** The key for the dataNodeLogic mounted by an InsightViz for insight of insightProps */
 export const insightVizDataNodeKey = (insightProps: InsightLogicProps<any>): string => {
@@ -38,6 +39,7 @@ type InsightVizProps = {
     inSharedMode?: boolean
     filtersOverride?: DashboardFilter | null
     variablesOverride?: Record<string, HogQLVariable> | null
+    attachTo?: BuiltLogic<Logic> | LogicWrapper<Logic>
 }
 
 let uniqueNode = 0
@@ -52,6 +54,7 @@ export function InsightViz({
     inSharedMode,
     filtersOverride,
     variablesOverride,
+    attachTo,
 }: InsightVizProps): JSX.Element {
     const [key] = useState(() => `InsightViz.${uniqueKey || uniqueNode++}`)
     const insightProps =
@@ -112,6 +115,13 @@ export function InsightViz({
             inSharedMode={inSharedMode}
         />
     )
+
+    if (!attachTo) {
+    }
+
+    useAttachedLogic(dataNodeLogic(dataNodeLogicProps), attachTo)
+    useAttachedLogic(insightLogic(insightProps), attachTo)
+    useAttachedLogic(insightVizDataLogic(insightProps), attachTo)
 
     return (
         <ErrorBoundary exceptionProps={{ feature: 'InsightViz' }}>

--- a/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
@@ -237,6 +237,7 @@ export function InsightVizDisplay({
                                 : undefined
                         }
                         canCheckUncheckSeries={canEditInsight}
+                        insightMode={insightMode}
                     />
                 </>
             )

--- a/frontend/src/queries/nodes/PersonsNode/PersonsSearch.tsx
+++ b/frontend/src/queries/nodes/PersonsNode/PersonsSearch.tsx
@@ -42,7 +42,7 @@ export function PersonsSearch({ query, setQuery }: PersonSearchProps): JSX.Eleme
         <div className="flex items-center gap-2">
             <LemonInput
                 type="search"
-                value={value}
+                value={value ?? ''}
                 placeholder={`Search for ${labels[target].label}`}
                 data-attr="persons-search"
                 disabled={!setQuery}

--- a/frontend/src/queries/nodes/SavedInsight/SavedInsight.tsx
+++ b/frontend/src/queries/nodes/SavedInsight/SavedInsight.tsx
@@ -1,4 +1,4 @@
-import { useValues } from 'kea'
+import { BuiltLogic, Logic, LogicWrapper, useValues } from 'kea'
 import { LoadingBar } from 'lib/lemon-ui/LoadingBar'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -7,18 +7,23 @@ import { Query } from '~/queries/Query/Query'
 import { SavedInsightNode } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 import { InsightLogicProps } from '~/types'
+import { useAttachedLogic } from 'lib/logic/scene-plugin/useAttachedLogic'
 
 interface InsightProps {
     query: SavedInsightNode
     context?: QueryContext
     embedded?: boolean
     readOnly?: boolean
+    attachTo?: BuiltLogic<Logic> | LogicWrapper<Logic>
 }
 
-export function SavedInsight({ query: propsQuery, context, embedded, readOnly }: InsightProps): JSX.Element {
+export function SavedInsight({ query: propsQuery, context, embedded, readOnly, attachTo }: InsightProps): JSX.Element {
     const insightProps: InsightLogicProps = { dashboardItemId: propsQuery.shortId }
     const { insight, insightLoading } = useValues(insightLogic(insightProps))
     const { query: dataQuery } = useValues(insightDataLogic(insightProps))
+
+    useAttachedLogic(insightLogic(insightProps), attachTo)
+    useAttachedLogic(insightDataLogic(insightProps), attachTo)
 
     if (insightLoading) {
         return (

--- a/frontend/src/queries/types.ts
+++ b/frontend/src/queries/types.ts
@@ -8,7 +8,7 @@ import {
     QuerySchema,
     RefreshType,
 } from '~/queries/schema/schema-general'
-import { InsightLogicProps, TrendResult } from '~/types'
+import { InsightLogicProps, ItemMode, TrendResult } from '~/types'
 import { ColumnFeature } from './nodes/DataTable/DataTable'
 
 /** Pass custom metadata to queries. Used for e.g. custom columns in the DataTable. */
@@ -21,6 +21,8 @@ export interface QueryContext<Q extends QuerySchema = QuerySchema> {
     /* Adds help and examples to the query editor component */
     showQueryHelp?: boolean
     insightProps?: InsightLogicProps<Q>
+    /** Are we editing or viewing the insight */
+    insightMode?: ItemMode
     emptyStateHeading?: string
     emptyStateDetail?: string | JSX.Element
     renderEmptyStateAsSkeleton?: boolean

--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -141,15 +141,21 @@ function AppScene(): JSX.Element | null {
     let sceneElement: JSX.Element
     if (activeLoadedScene?.component) {
         const { component: SceneComponent } = activeLoadedScene
-        sceneElement = <SceneComponent user={user} {...sceneParamsWithTabId} />
+        sceneElement = (
+            <SceneComponent key={`tab-${sceneParamsWithTabId.tabId}`} user={user} {...sceneParamsWithTabId} />
+        )
     } else {
         sceneElement = <SpinnerOverlay sceneLevel visible={showingDelayedSpinner} />
     }
 
     const wrappedSceneElement = (
-        <ErrorBoundary key={activeSceneId} exceptionProps={{ feature: activeSceneId }}>
+        <ErrorBoundary key={`error-${sceneParamsWithTabId.tabId}`} exceptionProps={{ feature: activeSceneId }}>
             {activeLoadedScene?.logic ? (
-                <BindLogic logic={activeLoadedScene.logic} props={sceneParamsWithTabId}>
+                <BindLogic
+                    key={`bind-${sceneParamsWithTabId.tabId}`}
+                    logic={activeLoadedScene.logic}
+                    props={sceneParamsWithTabId}
+                >
                     {sceneElement}
                 </BindLogic>
             ) : (

--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -98,11 +98,11 @@ export function App(): JSX.Element | null {
     return <SpinnerOverlay sceneLevel visible={showingDelayedSpinner} />
 }
 
-function LoadedSceneLogic({ scene }: { scene: LoadedScene }): null {
+function LoadedSceneLogic({ scene, tabId }: { scene: LoadedScene; tabId: string }): null {
     if (!scene.logic) {
         throw new Error('Loading scene without a logic')
     }
-    useMountedLogic(scene.logic(scene.paramsToProps?.(scene.sceneParams)))
+    useMountedLogic(scene.logic({ tabId, ...scene.paramsToProps?.(scene.sceneParams) }))
     return null
 }
 
@@ -113,7 +113,7 @@ function LoadedSceneLogics(): JSX.Element {
             {Object.entries(loadedScenes)
                 .filter(([, { logic }]) => !!logic)
                 .map(([key, loadedScene]) => (
-                    <LoadedSceneLogic key={key} scene={loadedScene} />
+                    <LoadedSceneLogic key={key} scene={loadedScene} tabId={loadedScene.tabId} />
                 ))}
         </>
     )
@@ -122,7 +122,8 @@ function LoadedSceneLogics(): JSX.Element {
 function AppScene(): JSX.Element | null {
     useMountedLogic(breadcrumbsLogic)
     const { user } = useValues(userLogic)
-    const { activeScene, activeLoadedScene, sceneParams, params, loadedScenes, sceneConfig } = useValues(sceneLogic)
+    const { activeScene, activeLoadedScene, activeTabId, sceneParams, params, loadedScenes, sceneConfig } =
+        useValues(sceneLogic)
     const { showingDelayedSpinner } = useValues(appLogic)
     const { isDarkModeOn } = useValues(themeLogic)
 
@@ -141,7 +142,7 @@ function AppScene(): JSX.Element | null {
     let sceneElement: JSX.Element
     if (activeScene && activeScene in loadedScenes) {
         const { component: SceneComponent } = loadedScenes[activeScene]
-        sceneElement = <SceneComponent user={user} {...params} />
+        sceneElement = <SceneComponent user={user} {...params} tabId={activeTabId} />
     } else {
         sceneElement = <SpinnerOverlay sceneLevel visible={showingDelayedSpinner} />
     }
@@ -149,7 +150,13 @@ function AppScene(): JSX.Element | null {
     const wrappedSceneElement = (
         <ErrorBoundary key={activeScene} exceptionProps={{ feature: activeScene }}>
             {activeLoadedScene?.logic ? (
-                <BindLogic logic={activeLoadedScene.logic} props={activeLoadedScene.paramsToProps?.(sceneParams) || {}}>
+                <BindLogic
+                    logic={activeLoadedScene.logic}
+                    props={{
+                        tabId: activeLoadedScene.tabId,
+                        ...activeLoadedScene.paramsToProps?.(sceneParams),
+                    }}
+                >
                     {sceneElement}
                 </BindLogic>
             ) : (

--- a/frontend/src/scenes/actions/actionEditLogic.tsx
+++ b/frontend/src/scenes/actions/actionEditLogic.tsx
@@ -45,7 +45,7 @@ export const actionEditLogic = kea<actionEditLogicType>([
             tagsModel,
             ['loadTags'],
         ],
-        values: [sceneLogic, ['activeScene']],
+        values: [sceneLogic, ['activeSceneId']],
     })),
     actions({
         setAction: (action: Partial<ActionType>, options: SetActionProps = { merge: true }) => ({

--- a/frontend/src/scenes/activity/ActivityScene.tsx
+++ b/frontend/src/scenes/activity/ActivityScene.tsx
@@ -1,76 +1,40 @@
-import { actions, kea, path, reducers, selectors, useActions, useValues } from 'kea'
-import { urlToAction } from 'kea-router'
+import { useActions, useValues } from 'kea'
 import { PageHeader } from 'lib/components/PageHeader'
-import { LemonTab, LemonTabs } from 'lib/lemon-ui/LemonTabs'
-import { capitalizeFirstLetter } from 'lib/utils'
-import { Scene, SceneExport } from 'scenes/sceneTypes'
+import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
+import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
-import { ActivityTab, Breadcrumb } from '~/types'
+import { ActivityTab } from '~/types'
 
-import type { activitySceneLogicType } from './ActivitySceneType'
 import { EventsScene } from './explore/EventsScene'
 import { LiveEventsTable } from './live/LiveEventsTable'
-
-const ACTIVITY_TABS: LemonTab<ActivityTab>[] = [
-    {
-        key: ActivityTab.ExploreEvents,
-        label: 'Explore',
-        content: <EventsScene />,
-        link: urls.activity(ActivityTab.ExploreEvents),
-    },
-    {
-        key: ActivityTab.LiveEvents,
-        label: 'Live',
-        content: <LiveEventsTable />,
-        link: urls.activity(ActivityTab.LiveEvents),
-    },
-]
-
-const activitySceneLogic = kea<activitySceneLogicType>([
-    path(['scenes', 'events', 'activitySceneLogic']),
-    actions({
-        setTab: (tab: ActivityTab) => ({ tab }),
-    }),
-    reducers({
-        tab: [
-            ActivityTab.ExploreEvents as ActivityTab,
-            {
-                setTab: (_, { tab }) => tab,
-            },
-        ],
-    }),
-    selectors({
-        breadcrumbs: [
-            (s) => [s.tab],
-            (tab): Breadcrumb[] => [
-                {
-                    key: Scene.Activity,
-                    name: `Activity`,
-                    path: urls.activity(),
-                },
-                {
-                    key: tab,
-                    name: capitalizeFirstLetter(tab),
-                },
-            ],
-        ],
-    }),
-    urlToAction(({ actions }) => ({
-        [urls.activity(':tab')]: ({ tab }) => {
-            actions.setTab(tab as ActivityTab)
-        },
-    })),
-])
+import { activitySceneLogic } from 'scenes/activity/activitySceneLogic'
 
 export function ActivityScene(): JSX.Element {
-    const { tab } = useValues(activitySceneLogic)
+    const { tab, tabId } = useValues(activitySceneLogic)
     const { setTab } = useActions(activitySceneLogic)
 
     return (
         <>
             <PageHeader tabbedPage />
-            <LemonTabs activeKey={tab} onChange={(t) => setTab(t)} tabs={ACTIVITY_TABS} />
+            <LemonTabs
+                activeKey={tab}
+                onChange={(t) => setTab(t)}
+                tabs={[
+                    {
+                        key: ActivityTab.ExploreEvents,
+                        label: 'Explore',
+                        content: <EventsScene tabId={tabId} />,
+                        link: urls.activity(ActivityTab.ExploreEvents),
+                    },
+                    {
+                        key: ActivityTab.LiveEvents,
+                        label: 'Live',
+                        content: <LiveEventsTable tabId={tabId} />,
+                        link: urls.activity(ActivityTab.LiveEvents),
+                    },
+                ]}
+            />
         </>
     )
 }

--- a/frontend/src/scenes/activity/activitySceneLogic.ts
+++ b/frontend/src/scenes/activity/activitySceneLogic.ts
@@ -1,0 +1,46 @@
+import { actions, kea, path, reducers, selectors } from 'kea'
+import type { activitySceneLogicType } from 'scenes/activity/ActivitySceneType'
+import { tabAwareScene } from 'lib/logic/scene-plugin/tabAwareScene'
+import { ActivityTab, Breadcrumb } from '~/types'
+import { Scene } from 'scenes/sceneTypes'
+import { urls } from 'scenes/urls'
+import { capitalizeFirstLetter } from 'lib/utils'
+import { tabAwareUrlToAction } from 'lib/logic/scene-plugin/tabAwareUrlToAction'
+
+export const activitySceneLogic = kea<activitySceneLogicType>([
+    path(['scenes', 'events', 'activitySceneLogic']),
+    tabAwareScene(),
+    actions({
+        setTab: (tab: ActivityTab) => ({ tab }),
+    }),
+    reducers({
+        tab: [
+            ActivityTab.ExploreEvents as ActivityTab,
+            {
+                setTab: (_, { tab }) => tab,
+            },
+        ],
+    }),
+    selectors({
+        breadcrumbs: [
+            (s) => [s.tab],
+            (tab): Breadcrumb[] => [
+                {
+                    key: Scene.Activity,
+                    name: `Activity`,
+                    path: urls.activity(),
+                },
+                {
+                    key: tab,
+                    name: capitalizeFirstLetter(tab),
+                },
+            ],
+        ],
+        tabId: [() => [(_, props) => props.tabId], (tabId): string => tabId],
+    }),
+    tabAwareUrlToAction(({ actions }) => ({
+        [urls.activity(':tab')]: ({ tab }) => {
+            actions.setTab(tab as ActivityTab)
+        },
+    })),
+])

--- a/frontend/src/scenes/activity/explore/EventsScene.tsx
+++ b/frontend/src/scenes/activity/explore/EventsScene.tsx
@@ -4,13 +4,19 @@ import { QueryFeature } from '~/queries/nodes/DataTable/queryFeatures'
 import { Query } from '~/queries/Query/Query'
 
 import { eventsSceneLogic } from './eventsSceneLogic'
+import { activitySceneLogic } from 'scenes/activity/activitySceneLogic'
+import { useAttachedLogic } from 'lib/logic/scene-plugin/useAttachedLogic'
 
-export function EventsScene(): JSX.Element {
-    const { query } = useValues(eventsSceneLogic)
-    const { setQuery } = useActions(eventsSceneLogic)
+export function EventsScene({ tabId }: { tabId: string }): JSX.Element {
+    const { query } = useValues(eventsSceneLogic({ tabId }))
+    const { setQuery } = useActions(eventsSceneLogic({ tabId }))
+
+    useAttachedLogic(eventsSceneLogic({ tabId }), activitySceneLogic)
 
     return (
         <Query
+            attachTo={eventsSceneLogic({ tabId })}
+            uniqueKey={`events-scene-${tabId}`}
             query={query}
             setQuery={setQuery}
             context={{

--- a/frontend/src/scenes/activity/explore/eventsSceneLogic.tsx
+++ b/frontend/src/scenes/activity/explore/eventsSceneLogic.tsx
@@ -1,6 +1,5 @@
 import equal from 'fast-deep-equal'
 import { actions, connect, kea, path, reducers, selectors } from 'kea'
-import { actionToUrl, urlToAction } from 'kea-router'
 import { UrlToActionPayload } from 'kea-router/lib/types'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -14,9 +13,13 @@ import { Node } from '~/queries/schema/schema-general'
 import { ActivityTab } from '~/types'
 
 import type { eventsSceneLogicType } from './eventsSceneLogicType'
+import { tabAwareScene } from 'lib/logic/scene-plugin/tabAwareScene'
+import { tabAwareUrlToAction } from 'lib/logic/scene-plugin/tabAwareUrlToAction'
+import { tabAwareActionToUrl } from 'lib/logic/scene-plugin/tabAwareActionToUrl'
 
 export const eventsSceneLogic = kea<eventsSceneLogicType>([
     path(['scenes', 'events', 'eventsSceneLogic']),
+    tabAwareScene(),
     connect(() => ({ values: [teamLogic, ['currentTeam'], featureFlagLogic, ['featureFlags']] })),
 
     actions({ setQuery: (query: Node) => ({ query }) }),
@@ -32,7 +35,7 @@ export const eventsSceneLogic = kea<eventsSceneLogicType>([
         ],
         query: [(s) => [s.savedQuery, s.defaultQuery], (savedQuery, defaultQuery) => savedQuery || defaultQuery],
     }),
-    actionToUrl(({ values }) => ({
+    tabAwareActionToUrl(({ values }) => ({
         setQuery: () => [
             urls.activity(ActivityTab.ExploreEvents),
             {},
@@ -41,7 +44,7 @@ export const eventsSceneLogic = kea<eventsSceneLogicType>([
         ],
     })),
 
-    urlToAction(({ actions, values }) => {
+    tabAwareUrlToAction(({ actions, values }) => {
         const eventsQueryHandler: UrlToActionPayload[keyof UrlToActionPayload] = (_, __, { q: queryParam }): void => {
             if (!equal(queryParam, values.query)) {
                 // nothing in the URL

--- a/frontend/src/scenes/activity/live/LiveEventsTable.tsx
+++ b/frontend/src/scenes/activity/live/LiveEventsTable.tsx
@@ -13,6 +13,8 @@ import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 
 import { EventCopyLinkButton } from '~/queries/nodes/DataTable/EventRowActions'
 import type { LiveEvent } from '~/types'
+import { useAttachedLogic } from 'lib/logic/scene-plugin/useAttachedLogic'
+import { activitySceneLogic } from 'scenes/activity/activitySceneLogic'
 
 const columns: LemonTableColumns<LiveEvent> = [
     {
@@ -66,9 +68,11 @@ const columns: LemonTableColumns<LiveEvent> = [
     },
 ]
 
-export function LiveEventsTable(): JSX.Element {
-    const { events, stats, streamPaused, filters } = useValues(liveEventsTableLogic)
-    const { pauseStream, resumeStream, setFilters } = useActions(liveEventsTableLogic)
+export function LiveEventsTable({ tabId }: { tabId: string }): JSX.Element {
+    const { events, stats, streamPaused, filters } = useValues(liveEventsTableLogic.build({ tabId }))
+    const { pauseStream, resumeStream, setFilters } = useActions(liveEventsTableLogic.build({ tabId }))
+
+    useAttachedLogic(liveEventsTableLogic.build({ tabId }), activitySceneLogic)
 
     return (
         <div data-attr="manage-events-table">

--- a/frontend/src/scenes/activity/live/liveEventsTableLogic.tsx
+++ b/frontend/src/scenes/activity/live/liveEventsTableLogic.tsx
@@ -7,16 +7,19 @@ import { teamLogic } from 'scenes/teamLogic'
 import type { LiveEvent } from '~/types'
 
 import type { liveEventsTableLogicType } from './liveEventsTableLogicType'
+import { tabAwareScene } from 'lib/logic/scene-plugin/tabAwareScene'
 
 const ERROR_TOAST_ID = 'live-stream-error'
 
 export interface LiveEventsTableProps {
-    showLiveStreamErrorToast: boolean
+    showLiveStreamErrorToast?: boolean
+    tabId?: string
 }
 
 export const liveEventsTableLogic = kea<liveEventsTableLogicType>([
     path(['scenes', 'activity', 'live-events', 'liveEventsTableLogic']),
     props({} as LiveEventsTableProps),
+    tabAwareScene(),
     connect(() => ({
         values: [teamLogic, ['currentTeam']],
     })),

--- a/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
@@ -1,6 +1,6 @@
 import Fuse from 'fuse.js'
 import { actions, connect, kea, path, reducers, selectors } from 'kea'
-import { actionToUrl, router, urlToAction } from 'kea-router'
+import { router } from 'kea-router'
 import { Sorting } from 'lib/lemon-ui/LemonTable/sorting'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { objectClean } from 'lib/utils'
@@ -10,6 +10,9 @@ import { dashboardsModel } from '~/models/dashboardsModel'
 import { DashboardBasicType } from '~/types'
 
 import type { dashboardsLogicType } from './dashboardsLogicType'
+import { tabAwareUrlToAction } from 'lib/logic/scene-plugin/tabAwareUrlToAction'
+import { tabAwareScene } from 'lib/logic/scene-plugin/tabAwareScene'
+import { tabAwareActionToUrl } from 'lib/logic/scene-plugin/tabAwareActionToUrl'
 
 export enum DashboardsTab {
     All = 'all',
@@ -38,6 +41,7 @@ export type DashboardFuse = Fuse<DashboardBasicType> // This is exported for kea
 
 export const dashboardsLogic = kea<dashboardsLogicType>([
     path(['scenes', 'dashboard', 'dashboardsLogic']),
+    tabAwareScene(),
     connect(() => ({ values: [userLogic, ['user'], featureFlagLogic, ['featureFlags']] })),
     actions({
         setCurrentTab: (tab: DashboardsTab) => ({ tab }),
@@ -116,7 +120,7 @@ export const dashboardsLogic = kea<dashboardsLogicType>([
             },
         ],
     }),
-    actionToUrl(({ values }) => ({
+    tabAwareActionToUrl(({ values }) => ({
         setCurrentTab: () => {
             const tab = values.currentTab === DashboardsTab.All ? undefined : values.currentTab
             if (router.values.searchParams['tab'] === tab) {
@@ -126,7 +130,7 @@ export const dashboardsLogic = kea<dashboardsLogicType>([
             router.actions.push(router.values.location.pathname, { ...router.values.searchParams, tab })
         },
     })),
-    urlToAction(({ actions }) => ({
+    tabAwareUrlToAction(({ actions }) => ({
         '/dashboard': (_, searchParams) => {
             const tab = searchParams['tab'] || DashboardsTab.All
             actions.setCurrentTab(tab)

--- a/frontend/src/scenes/data-warehouse/editor/editorSceneLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/editorSceneLogic.tsx
@@ -74,7 +74,7 @@ export const editorSceneLogic = kea<editorSceneLogicType>([
     connect(() => ({
         values: [
             sceneLogic,
-            ['activeScene', 'sceneParams'],
+            ['activeSceneId', 'sceneParams'],
             dataWarehouseViewsLogic,
             ['dataWarehouseSavedQueries', 'dataWarehouseSavedQueryMapById', 'initialDataWarehouseSavedQueryLoading'],
             databaseTableListLogic,
@@ -344,9 +344,9 @@ export const editorSceneLogic = kea<editorSceneLogicType>([
             },
         ],
         activeListItemKey: [
-            (s) => [s.activeScene, s.sceneParams],
-            (activeScene, sceneParams): [string, number] | null => {
-                return activeScene === Scene.SQLEditor && sceneParams.params.id
+            (s) => [s.activeSceneId, s.sceneParams],
+            (activeSceneId, sceneParams): [string, number] | null => {
+                return activeSceneId === Scene.SQLEditor && sceneParams.params.id
                     ? ['saved-queries', parseInt(sceneParams.params.id)]
                     : null
             },

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -22,7 +22,7 @@ import { featureFlagsLogic } from 'scenes/feature-flags/featureFlagsLogic'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { projectLogic } from 'scenes/projectLogic'
-import { sceneLogic } from 'scenes/sceneLogic'
+
 import { Scene } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
@@ -292,8 +292,6 @@ export const experimentLogic = kea<experimentLogicType>([
             ['currentProjectId'],
             groupsModel,
             ['aggregationLabel', 'groupTypes', 'showGroupsOptions'],
-            sceneLogic,
-            ['activeScene'],
             featureFlagLogic,
             ['featureFlags'],
             holdoutsLogic,

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -19,15 +19,16 @@ import { insightLogic } from './insightLogic'
 import { InsightsNav } from './InsightNav/InsightsNav'
 export interface InsightSceneProps {
     insightId: InsightShortId | 'new'
+    tabId: string
 }
 
-export function Insight({ insightId }: InsightSceneProps): JSX.Element | null {
+export function Insight({ insightId, tabId }: InsightSceneProps): JSX.Element | null {
     // insightSceneLogic
     const { insightMode, insight, filtersOverride, variablesOverride, freshQuery } = useValues(insightSceneLogic)
 
     // insightLogic
     const logic = insightLogic({
-        dashboardItemId: insightId || 'new',
+        dashboardItemId: insightId || `new-${tabId}`,
         // don't use cached insight if we have filtersOverride
         cachedInsight:
             (isObject(filtersOverride) || isObject(variablesOverride)) && insight?.short_id === insightId
@@ -102,6 +103,7 @@ export function Insight({ insightId }: InsightSceneProps): JSX.Element | null {
                         showQueryEditor: actuallyShowQueryEditor,
                         showQueryHelp: insightMode === ItemMode.Edit && !containsHogQLQuery(query),
                         insightProps,
+                        insightMode,
                     }}
                     filtersOverride={filtersOverride}
                     variablesOverride={variablesOverride}

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -51,11 +51,11 @@ import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { InsightSaveButton } from 'scenes/insights/InsightSaveButton'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
-import { insightsApi } from 'scenes/insights/utils/api'
+
 import { NotebookSelectButton } from 'scenes/notebooks/NotebookSelectButton/NotebookSelectButton'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { projectLogic } from 'scenes/projectLogic'
-import { savedInsightsLogic } from 'scenes/saved-insights/savedInsightsLogic'
+
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 import {
@@ -111,7 +111,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
     )
 
     // savedInsightsLogic
-    const { duplicateInsight, loadInsights } = useActions(savedInsightsLogic)
+    // const { duplicateInsight, loadInsights } = useActions(savedInsightsLogic)
 
     // insightDataLogic
     const { query, queryChanged, showQueryEditor, showDebugPanel, hogQL, exportContext } = useValues(
@@ -152,15 +152,15 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
         // We do not want to duplicate the dashboard filters that might be included in this insight
         // Ideally we would store those separately and be able to remove them on duplicate or edit, but current we merge them
         // irreversibly in apply_dashboard_filters and return that to the front-end
-        if (insight.short_id) {
-            const cleanInsight = await insightsApi.getByShortId(insight.short_id)
-            if (cleanInsight) {
-                duplicateInsight(cleanInsight, true)
-                return
-            }
-        }
-        // Fallback to original behavior if load failed
-        duplicateInsight(insight as QueryBasedInsightModel, true)
+        // if (insight.short_id) {
+        //     const cleanInsight = await insightsApi.getByShortId(insight.short_id)
+        //     if (cleanInsight) {
+        //         duplicateInsight(cleanInsight, true)
+        //         return
+        //     }
+        // }
+        // // Fallback to original behavior if load failed
+        // duplicateInsight(insight as QueryBasedInsightModel, true)
     }
 
     return (
@@ -514,7 +514,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                                             object: insight as QueryBasedInsightModel,
                                                             endpoint: `projects/${currentProjectId}/insights`,
                                                             callback: () => {
-                                                                loadInsights()
+                                                                // loadInsights()
                                                                 push(urls.savedInsights())
                                                             },
                                                         })
@@ -860,7 +860,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                                     object: insight as QueryBasedInsightModel,
                                                     endpoint: `projects/${currentProjectId}/insights`,
                                                     callback: () => {
-                                                        loadInsights()
+                                                        // loadInsights()
                                                         push(urls.savedInsights())
                                                     },
                                                 })

--- a/frontend/src/scenes/insights/InsightScene.tsx
+++ b/frontend/src/scenes/insights/InsightScene.tsx
@@ -1,4 +1,4 @@
-import { useValues, BindLogic } from 'kea'
+import { useValues } from 'kea'
 import { router } from 'kea-router'
 import { NotFound } from 'lib/components/NotFound'
 import { useEffect } from 'react'
@@ -15,11 +15,8 @@ export interface InsightSceneProps {
     tabId?: string
 }
 
-export function InsightScene({ tabId }: InsightSceneProps = {}): JSX.Element {
-    if (!tabId) {
-        throw new Error("No tabId in InsightScene's props")
-    }
-    const { insightId, insight, insightLogicRef, insightMode } = useValues(insightSceneLogic({ tabId }))
+export function InsightScene(): JSX.Element {
+    const { insightId, insight, insightLogicRef, insightMode } = useValues(insightSceneLogic)
 
     useEffect(() => {
         // Redirect data viz nodes to the sql editor
@@ -36,26 +33,14 @@ export function InsightScene({ tabId }: InsightSceneProps = {}): JSX.Element {
             insight?.short_id &&
             (insight?.query?.kind !== NodeKind.DataVisualizationNode || insightMode !== ItemMode.Edit))
     ) {
-        return (
-            <BindLogic logic={insightSceneLogic} props={{ tabId }}>
-                <Insight insightId={insightId} tabId={tabId} />
-            </BindLogic>
-        )
+        return <Insight insightId={insightId} attachTo={insightSceneLogic} />
     }
 
     if (insightLogicRef?.logic?.values?.insightLoading) {
-        return (
-            <BindLogic logic={insightSceneLogic} props={{ tabId }}>
-                <InsightSkeleton />
-            </BindLogic>
-        )
+        return <InsightSkeleton />
     }
 
-    return (
-        <BindLogic logic={insightSceneLogic} props={{ tabId }}>
-            <NotFound object="insight" />
-        </BindLogic>
-    )
+    return <NotFound object="insight" />
 }
 
 export const scene: SceneExport = {

--- a/frontend/src/scenes/insights/insightDataLogic.tsx
+++ b/frontend/src/scenes/insights/insightDataLogic.tsx
@@ -1,9 +1,9 @@
 import { actions, connect, kea, key, listeners, path, props, propsChanged, reducers, selectors } from 'kea'
-import { actionToUrl, router } from 'kea-router'
+import {} from 'kea-router'
 import { objectsEqual } from 'lib/utils'
 import { DATAWAREHOUSE_EDITOR_ITEM_ID } from 'scenes/data-warehouse/utils'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
-import { Scene } from 'scenes/sceneTypes'
+
 import { filterTestAccountsDefaultsLogic } from 'scenes/settings/environment/filterTestAccountDefaultsLogic'
 
 import { examples } from '~/queries/examples'
@@ -20,9 +20,9 @@ import { teamLogic } from '../teamLogic'
 import type { insightDataLogicType } from './insightDataLogicType'
 import { insightDataTimingLogic } from './insightDataTimingLogic'
 import { insightLogic } from './insightLogic'
-import { insightSceneLogic } from './insightSceneLogic'
+
 import { insightUsageLogic } from './insightUsageLogic'
-import { crushDraftQueryForLocalStorage, crushDraftQueryForURL, isQueryTooLarge } from './utils'
+import { crushDraftQueryForLocalStorage, isQueryTooLarge } from './utils'
 import { compareQuery } from './utils/queryUtils'
 
 export const insightDataLogic = kea<insightDataLogicType>([
@@ -34,8 +34,8 @@ export const insightDataLogic = kea<insightDataLogicType>([
         values: [
             insightLogic,
             ['insight', 'savedInsight'],
-            insightSceneLogic,
-            ['insightId', 'insightMode', 'activeScene'],
+            // insightSceneLogic({ tabId: props.tabId }),
+            // ['insightId', 'insightMode', 'activeScene'],
             teamLogic,
             ['currentTeamId'],
             dataNodeLogic({
@@ -219,14 +219,14 @@ export const insightDataLogic = kea<insightDataLogicType>([
             if (!query || !values.queryChanged) {
                 return
             }
-            // only run on insight scene
-            if (insightSceneLogic.values.activeScene !== Scene.Insight) {
-                return
-            }
-            // don't save for saved insights
-            if (insightSceneLogic.values.insightId !== 'new') {
-                return
-            }
+            // // only run on insight scene
+            // if (insightSceneLogic.values.activeScene !== Scene.Insight) {
+            //     return
+            // }
+            // // don't save for saved insights
+            // if (insightSceneLogic.values.insightId !== 'new') {
+            //     return
+            // }
 
             if (isQueryTooLarge(query)) {
                 localStorage.removeItem(`draft-query-${values.currentTeamId}`)
@@ -243,25 +243,25 @@ export const insightDataLogic = kea<insightDataLogicType>([
             actions.setQuery(props.cachedInsight.query)
         }
     }),
-    actionToUrl(({ values }) => ({
-        setQuery: ({ query }) => {
-            if (
-                values.queryChanged &&
-                insightSceneLogic.values.activeScene === Scene.Insight &&
-                insightSceneLogic.values.insightId === 'new'
-            ) {
-                // query is changed and we are in edit mode
-                return [
-                    router.values.currentLocation.pathname,
-                    {
-                        ...router.values.currentLocation.searchParams,
-                    },
-                    {
-                        ...router.values.currentLocation.hashParams,
-                        q: crushDraftQueryForURL(query),
-                    },
-                ]
-            }
-        },
-    })),
+    // actionToUrl(({ values }) => ({
+    //     setQuery: ({ query }) => {
+    //         if (
+    //             values.queryChanged &&
+    //             insightSceneLogic.values.activeScene === Scene.Insight &&
+    //             insightSceneLogic.values.insightId === 'new'
+    //         ) {
+    //             // query is changed and we are in edit mode
+    //             return [
+    //                 router.values.currentLocation.pathname,
+    //                 {
+    //                     ...router.values.currentLocation.searchParams,
+    //                 },
+    //                 {
+    //                     ...router.values.currentLocation.hashParams,
+    //                     q: crushDraftQueryForURL(query),
+    //                 },
+    //             ]
+    //         }
+    //     },
+    // })),
 ])

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -81,7 +81,7 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
             featureFlagLogic,
             ['featureFlags'],
             sceneLogic,
-            ['activeScene'],
+            ['activeSceneId'],
         ],
         actions: [tagsModel, ['loadTags']],
         logic: [eventUsageLogic, dashboardsModel],
@@ -384,8 +384,8 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
             },
         ],
         supportsCreatingExperiment: [
-            (s) => [s.insight, s.activeScene],
-            (insight: QueryBasedInsightModel, activeScene: Scene) =>
+            (s) => [s.insight, s.activeSceneId],
+            (insight: QueryBasedInsightModel, activeSceneId: Scene) =>
                 insight?.query &&
                 isValidQueryForExperiment(insight.query) &&
                 ![
@@ -393,7 +393,7 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                     Scene.Experiments,
                     Scene.ExperimentsSharedMetric,
                     Scene.ExperimentsSharedMetrics,
-                ].includes(activeScene),
+                ].includes(activeSceneId),
         ],
         isUsingPathsV1: [(s) => [s.featureFlags], (featureFlags) => !featureFlags[FEATURE_FLAGS.PATHS_V2]],
         isUsingPathsV2: [(s) => [s.featureFlags], (featureFlags) => featureFlags[FEATURE_FLAGS.PATHS_V2]],

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -58,7 +58,13 @@ export const createEmptyInsight = (
 
 export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType>([
     props({} as InsightLogicProps),
-    key(keyForInsightLogicProps('new')),
+    key((props) => {
+        const key = keyForInsightLogicProps('new')(props)
+        if (key === 'new') {
+            throw new Error('Cannot initialize insightLogic with a key of "new". Please provide a unique key.')
+        }
+        return key
+    }),
     path((key) => ['scenes', 'insights', 'insightLogic', key]),
     connect(() => ({
         values: [

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -187,7 +187,19 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
     }),
     selectors(() => ({
         insightSelector: [(s) => [s.insightLogicRef], (insightLogicRef) => insightLogicRef?.logic.selectors.insight],
-        insight: [(s) => [(state, props) => s.insightSelector?.(state, props)?.(state, props)], (insight) => insight],
+        insight: [
+            (s) => [
+                (state, props) => {
+                    try {
+                        return s.insightSelector?.(state, props)?.(state, props)
+                    } catch {
+                        // Not mounted yet
+                        return null
+                    }
+                },
+            ],
+            (insight) => insight,
+        ],
         breadcrumbs: [
             (s) => [s.insightLogicRef, s.insight, s.dashboardId, s.dashboardName, (_, { tabId }) => tabId],
             (insightLogicRef, insight, dashboardId, dashboardName, tabId): Breadcrumb[] => {

--- a/frontend/src/scenes/insights/insightUsageLogic.ts
+++ b/frontend/src/scenes/insights/insightUsageLogic.ts
@@ -11,7 +11,7 @@ import { Node } from '~/queries/schema/schema-general'
 import { InsightLogicProps } from '~/types'
 
 import { insightLogic } from './insightLogic'
-import { insightSceneLogic } from './insightSceneLogic'
+
 import type { insightUsageLogicType } from './insightUsageLogicType'
 import { keyForInsightLogicProps } from './sharedUtils'
 
@@ -50,13 +50,16 @@ export const insightUsageLogic = kea<insightUsageLogicType>([
     listeners(({ actions, values }) => ({
         onQueryChange: async ({ query }, breakpoint) => {
             // We only want to report direct views on the insights page.
-            if (
-                !insightSceneLogic.isMounted() ||
-                insightSceneLogic.values.activeScene !== 'Insight' ||
-                insightSceneLogic.values.insight?.short_id !== values.insight?.short_id
-            ) {
-                return
-            }
+            // if (
+            //     !props.tabId ||
+            //     !insightSceneLogic({tabId: props.tabId}).isMounted() ||
+            //     insightSceneLogic({tabId: props.tabId}).values.activeScene !== 'Insight' ||
+            //     insightSceneLogic({tabId: props.tabId}).values.insight?.short_id !== values.insight?.short_id
+            // ) {
+            //     return
+            // }
+            // TODO
+            return
 
             // Report the insight being viewed to our '/viewed' endpoint. Used for "recently viewed insights".
             if (values.insight.id) {

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -581,7 +581,7 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
                 actions.setTimedOutQueryId(queryId)
                 const tags = {
                     kind: values.querySource?.kind,
-                    scene: sceneLogic.isMounted() ? sceneLogic.values.scene : null,
+                    scene: sceneLogic.isMounted() ? sceneLogic.values.activeSceneId : null,
                 }
                 posthog.capture('insight timeout message shown', tags)
             }

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -6,7 +6,6 @@ import { COUNTRY_CODE_TO_LONG_NAME } from 'lib/utils/geography/country'
 import { compare as compareFn } from 'natural-orderby'
 import { useMemo } from 'react'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { formatBreakdownLabel } from 'scenes/insights/utils'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 import { IndexedTrendResult } from 'scenes/trends/types'
@@ -57,6 +56,11 @@ export interface InsightsTableProps {
      * @default false
      */
     isMainInsightView?: boolean
+    /**
+     * Insight mode, which is overridden by the insightLogic, so it can be ignored here.
+     * @default ItemMode.View
+     */
+    insightMode?: ItemMode
 }
 
 export function InsightsTable({
@@ -67,8 +71,8 @@ export function InsightsTable({
     seriesNameTooltip,
     canCheckUncheckSeries = true,
     isMainInsightView = false,
+    insightMode = ItemMode.View,
 }: InsightsTableProps): JSX.Element {
-    const { insightMode } = useValues(insightSceneLogic)
     const { insightProps, isInDashboardContext, insight } = useValues(insightLogic)
     const {
         insightDataLoading,

--- a/frontend/src/scenes/max/maxContextLogic.ts
+++ b/frontend/src/scenes/max/maxContextLogic.ts
@@ -60,7 +60,7 @@ export const maxContextLogic = kea<maxContextLogicType>([
             // insightSceneLogic,
             // ['filtersOverride', 'variablesOverride'],
             sceneLogic,
-            ['activeScene', 'activeSceneLogic', 'activeLoadedScene'],
+            ['activeSceneId', 'activeSceneLogic', 'activeLoadedScene'],
         ],
         actions: [router, ['locationChanged']],
     })),

--- a/frontend/src/scenes/max/maxContextLogic.ts
+++ b/frontend/src/scenes/max/maxContextLogic.ts
@@ -4,10 +4,10 @@ import { router } from 'kea-router'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { objectsEqual } from 'lib/utils'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
+
 import { sceneLogic } from 'scenes/sceneLogic'
 
-import { DashboardFilter, HogQLVariable } from '~/queries/schema/schema-general'
+import {} from '~/queries/schema/schema-general'
 import { ActionType, DashboardType, EventDefinition, InsightShortId, QueryBasedInsightModel } from '~/types'
 
 import type { maxContextLogicType } from './maxContextLogicType'
@@ -57,8 +57,8 @@ export const maxContextLogic = kea<maxContextLogicType>([
     path(['scenes', 'max', 'maxContextLogic']),
     connect(() => ({
         values: [
-            insightSceneLogic,
-            ['filtersOverride', 'variablesOverride'],
+            // insightSceneLogic,
+            // ['filtersOverride', 'variablesOverride'],
             sceneLogic,
             ['activeScene', 'activeSceneLogic', 'activeLoadedScene'],
         ],
@@ -455,17 +455,17 @@ export const maxContextLogic = kea<maxContextLogicType>([
                 s.contextDashboards,
                 s.contextEvents,
                 s.contextActions,
-                s.filtersOverride,
-                s.variablesOverride,
+                // s.filtersOverride,
+                // s.variablesOverride,
             ],
             (
                 hasData: boolean,
                 contextInsights: MaxInsightContext[],
                 contextDashboards: MaxDashboardContext[],
                 contextEvents: MaxEventContext[],
-                contextActions: MaxActionContext[],
-                filtersOverride: DashboardFilter,
-                variablesOverride: Record<string, HogQLVariable> | null
+                contextActions: MaxActionContext[]
+                // filtersOverride: DashboardFilter,
+                // variablesOverride: Record<string, HogQLVariable> | null
             ): MaxUIContext | null => {
                 const context: MaxUIContext = {}
 
@@ -494,13 +494,13 @@ export const maxContextLogic = kea<maxContextLogicType>([
                 }
 
                 // Add global filters and variables override if present
-                if (filtersOverride) {
-                    context.filters_override = filtersOverride
-                }
-
-                if (variablesOverride) {
-                    context.variables_override = variablesOverride
-                }
+                // if (filtersOverride) {
+                //     context.filters_override = filtersOverride
+                // }
+                //
+                // if (variablesOverride) {
+                //     context.variables_override = variablesOverride
+                // }
 
                 // Deduplicate dashboards by ID
                 if (context.dashboards) {

--- a/frontend/src/scenes/max/maxGlobalLogic.tsx
+++ b/frontend/src/scenes/max/maxGlobalLogic.tsx
@@ -53,7 +53,7 @@ export const maxGlobalLogic = kea<maxGlobalLogicType>([
             organizationLogic,
             ['currentOrganization'],
             sceneLogic,
-            ['scene', 'sceneConfig'],
+            ['sceneId', 'sceneConfig'],
             featureFlagLogic,
             ['featureFlags'],
         ],
@@ -90,7 +90,7 @@ export const maxGlobalLogic = kea<maxGlobalLogicType>([
                             const NAVIGATION_TIMEOUT = 1000 // 1 second timeout
                             const startTime = performance.now()
                             const checkPathname = (): void => {
-                                if (sceneLogic.values.activeScene === routes[url]?.[0]) {
+                                if (sceneLogic.values.activeSceneId === routes[url]?.[0]) {
                                     resolve()
                                 } else if (performance.now() - startTime > NAVIGATION_TIMEOUT) {
                                     reject(new Error('Navigation timeout'))
@@ -163,18 +163,18 @@ export const maxGlobalLogic = kea<maxGlobalLogicType>([
     selectors({
         showFloatingMax: [
             (s) => [
-                s.scene,
+                s.sceneId,
                 s.sceneConfig,
                 s.isFloatingMaxExpanded,
                 sidePanelLogic.selectors.sidePanelOpen,
                 sidePanelLogic.selectors.selectedTab,
                 s.featureFlags,
             ],
-            (scene, sceneConfig, isFloatingMaxExpanded, sidePanelOpen, selectedTab, featureFlags) =>
+            (sceneId, sceneConfig, isFloatingMaxExpanded, sidePanelOpen, selectedTab, featureFlags) =>
                 sceneConfig &&
                 !sceneConfig.onlyUnauthenticated &&
                 sceneConfig.layout !== 'plain' &&
-                !(scene === Scene.Max && !isFloatingMaxExpanded) && // In the full Max scene, and Max is not intentionally in floating mode (i.e. expanded)
+                !(sceneId === Scene.Max && !isFloatingMaxExpanded) && // In the full Max scene, and Max is not intentionally in floating mode (i.e. expanded)
                 !(sidePanelOpen && selectedTab === SidePanelTab.Max) && // The Max side panel is open
                 featureFlags[FEATURE_FLAGS.ARTIFICIAL_HOG] &&
                 featureFlags[FEATURE_FLAGS.FLOATING_ARTIFICIAL_HOG],

--- a/frontend/src/scenes/onboarding/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/onboardingLogic.tsx
@@ -60,7 +60,7 @@ export const onboardingLogic = kea<onboardingLogicType>([
     props({} as OnboardingLogicProps),
     path(['scenes', 'onboarding', 'onboardingLogic']),
     // connect this so we start collecting live events the whole time during onboarding
-    connect(liveEventsTableLogic({ showLiveStreamErrorToast: false })),
+    connect(liveEventsTableLogic({ tabId: 'onboarding', showLiveStreamErrorToast: false })),
     connect(() => ({
         values: [
             billingLogic,

--- a/frontend/src/scenes/onboarding/sdks/OnboardingLiveEvents.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingLiveEvents.tsx
@@ -40,7 +40,7 @@ const columns: LemonTableColumns<LiveEvent> = [
 ]
 
 export function OnboardingLiveEvents(): JSX.Element | null {
-    const { events } = useValues(liveEventsTableLogic)
+    const { events } = useValues(liveEventsTableLogic({ tabId: 'onboarding' }))
 
     if (events.length === 0) {
         return null

--- a/frontend/src/scenes/onboarding/sdks/sdksLogic.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdksLogic.tsx
@@ -47,7 +47,7 @@ export const sdksLogic = kea<sdksLogicType>([
         values: [
             onboardingLogic,
             ['productKey'],
-            liveEventsTableLogic,
+            liveEventsTableLogic({ tabId: 'sdks' }),
             ['eventHosts'],
             featureFlagLogic,
             ['featureFlags'],

--- a/frontend/src/scenes/persons/PersonsScene.tsx
+++ b/frontend/src/scenes/persons/PersonsScene.tsx
@@ -18,9 +18,12 @@ export const scene: SceneExport = {
 }
 
 export function PersonsScene({ tabId }: { tabId?: string } = {}): JSX.Element {
-    const { query } = useValues(personsSceneLogic({ tabId }))
-    const { setQuery } = useActions(personsSceneLogic({ tabId }))
-    const { resetDeletedDistinctId } = useAsyncActions(personsSceneLogic({ tabId }))
+    if (!tabId) {
+        // TODO: why and how is this empty?????
+    }
+    const { query } = useValues(personsSceneLogic)
+    const { setQuery } = useActions(personsSceneLogic)
+    const { resetDeletedDistinctId } = useAsyncActions(personsSceneLogic)
     const { currentTeam } = useValues(teamLogic)
 
     return (

--- a/frontend/src/scenes/persons/PersonsScene.tsx
+++ b/frontend/src/scenes/persons/PersonsScene.tsx
@@ -17,10 +17,10 @@ export const scene: SceneExport = {
     logic: personsSceneLogic,
 }
 
-export function PersonsScene(): JSX.Element {
-    const { query } = useValues(personsSceneLogic)
-    const { setQuery } = useActions(personsSceneLogic)
-    const { resetDeletedDistinctId } = useAsyncActions(personsSceneLogic)
+export function PersonsScene({ tabId }: { tabId?: string } = {}): JSX.Element {
+    const { query } = useValues(personsSceneLogic({ tabId }))
+    const { setQuery } = useActions(personsSceneLogic({ tabId }))
+    const { resetDeletedDistinctId } = useAsyncActions(personsSceneLogic({ tabId }))
     const { currentTeam } = useValues(teamLogic)
 
     return (
@@ -60,6 +60,8 @@ export function PersonsScene(): JSX.Element {
                 }
             />
             <Query
+                uniqueKey={`persons-query-${tabId}`}
+                attachTo={personsSceneLogic({ tabId })}
                 query={query}
                 setQuery={setQuery}
                 context={{

--- a/frontend/src/scenes/persons/personsSceneLogic.ts
+++ b/frontend/src/scenes/persons/personsSceneLogic.ts
@@ -6,9 +6,11 @@ import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
 import { DataTableNode, NodeKind } from '~/queries/schema/schema-general'
 
 import type { personsSceneLogicType } from './personsSceneLogicType'
-import { actionToUrl, urlToAction } from 'kea-router'
 import { urls } from 'scenes/urls'
 import equal from 'fast-deep-equal'
+import { tabAwareScene } from 'lib/logic/scene-plugin/tabAwareScene'
+import { tabAwareUrlToAction } from 'lib/logic/scene-plugin/tabAwareUrlToAction'
+import { tabAwareActionToUrl } from 'lib/logic/scene-plugin/tabAwareActionToUrl'
 
 const defaultQuery = {
     kind: NodeKind.DataTableNode,
@@ -22,6 +24,7 @@ const defaultQuery = {
 
 export const personsSceneLogic = kea<personsSceneLogicType>([
     path(['scenes', 'persons', 'personsSceneLogic']),
+    tabAwareScene(),
 
     actions({
         setQuery: (query: DataTableNode) => ({ query }),
@@ -38,7 +41,7 @@ export const personsSceneLogic = kea<personsSceneLogicType>([
         },
     }),
 
-    actionToUrl(({ values }) => ({
+    tabAwareActionToUrl(({ values }) => ({
         setQuery: () => [
             urls.persons(),
             {},
@@ -47,7 +50,7 @@ export const personsSceneLogic = kea<personsSceneLogicType>([
         ],
     })),
 
-    urlToAction(({ actions, values }) => ({
+    tabAwareUrlToAction(({ actions, values }) => ({
         [urls.persons()]: (_, __, { q: queryParam }): void => {
             if (!equal(queryParam, values.query)) {
                 // nothing in the URL

--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
@@ -1,6 +1,6 @@
 import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
-import { actionToUrl, router, urlToAction } from 'kea-router'
+import { router } from 'kea-router'
 import api, { CountedPaginatedResponse } from 'lib/api'
 import { AlertType } from 'lib/components/Alerts/types'
 import { dayjs } from 'lib/dayjs'
@@ -24,6 +24,9 @@ import { InsightModel, LayoutView, QueryBasedInsightModel, SavedInsightsTabs } f
 
 import { teamLogic } from '../teamLogic'
 import type { savedInsightsLogicType } from './savedInsightsLogicType'
+import { tabAwareScene } from 'lib/logic/scene-plugin/tabAwareScene'
+import { tabAwareUrlToAction } from 'lib/logic/scene-plugin/tabAwareUrlToAction'
+import { tabAwareActionToUrl } from 'lib/logic/scene-plugin/tabAwareActionToUrl'
 
 export const INSIGHTS_PER_PAGE = 30
 
@@ -66,8 +69,9 @@ export function cleanFilters(values: Partial<SavedInsightFilters>): SavedInsight
 
 export const savedInsightsLogic = kea<savedInsightsLogicType>([
     path(['scenes', 'saved-insights', 'savedInsightsLogic']),
+    tabAwareScene(),
     connect(() => ({
-        values: [teamLogic, ['currentTeamId'], sceneLogic, ['activeScene']],
+        values: [teamLogic, ['currentTeamId'], sceneLogic, ['activeSceneId']],
         logic: [eventUsageLogic],
     })),
     actions({
@@ -128,7 +132,7 @@ export const savedInsightsLogic = kea<savedInsightsLogicType>([
 
                 // scroll to top if the page changed, except if changed via back/forward
                 if (
-                    sceneLogic.findMounted()?.values.activeScene === Scene.SavedInsights &&
+                    sceneLogic.findMounted()?.values.activeSceneId === Scene.SavedInsights &&
                     router.values.lastMethod !== 'POP' &&
                     values.insights.filters?.page !== filters.page
                 ) {
@@ -332,7 +336,7 @@ export const savedInsightsLogic = kea<savedInsightsLogicType>([
             }
         },
     })),
-    actionToUrl(({ values }) => {
+    tabAwareActionToUrl(({ values }) => {
         const changeUrl = ():
             | [
                   string,
@@ -344,7 +348,7 @@ export const savedInsightsLogic = kea<savedInsightsLogicType>([
               ]
             | void => {
             const currentScene = sceneLogic.findMounted()?.values
-            if (currentScene?.activeScene === Scene.SavedInsights) {
+            if (currentScene?.activeSceneId === Scene.SavedInsights) {
                 const nextValues = cleanFilters(values.filters)
                 const urlValues = cleanFilters(router.values.searchParams)
                 if (!objectsEqual(nextValues, urlValues)) {
@@ -362,7 +366,7 @@ export const savedInsightsLogic = kea<savedInsightsLogicType>([
             setLayoutView: changeUrl,
         }
     }),
-    urlToAction(({ actions, values }) => ({
+    tabAwareUrlToAction(({ actions, values }) => ({
         [urls.savedInsights()]: async (
             _,
             { alert_id, ...searchParams }, // search params,

--- a/frontend/src/scenes/sceneLogic.test.tsx
+++ b/frontend/src/scenes/sceneLogic.test.tsx
@@ -35,7 +35,7 @@ describe('sceneLogic', () => {
     it('has preloaded some scenes', async () => {
         const preloadedScenes = [Scene.Error404, Scene.ErrorNetwork, Scene.ErrorProjectUnavailable]
         await expectLogic(logic).toMatchValues({
-            loadedScenes: truth(
+            exportedScenes: truth(
                 (obj: Record<string, any>) =>
                     Object.keys(obj).filter((key) => preloadedScenes.includes(key as Scene)).length === 3
             ),
@@ -77,13 +77,13 @@ describe('sceneLogic', () => {
 
         await expectLogic(logic).delay(1)
 
-        expect(logic.values.loadedScenes).toMatchObject({
+        expect(logic.values.exportedScenes).toMatchObject({
             [Scene.DataManagement]: expectedAnnotation,
         })
         router.actions.push(urls.settings('user'))
         await expectLogic(logic).delay(1)
 
-        expect(logic.values.loadedScenes).toMatchObject({
+        expect(logic.values.exportedScenes).toMatchObject({
             [Scene.DataManagement]: expectedAnnotation,
             [Scene.Settings]: expectedSettings,
         })

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -232,20 +232,23 @@ export const sceneLogic = kea<sceneLogicType>([
                 },
                 duplicateTab: (state, { tab }) => {
                     const idx = state.findIndex((t) => t === tab || t.id === tab.id)
-                    const base = state.map((t) => (t.active ? { ...t, active: false } : t))
                     const source = idx !== -1 ? state[idx] : tab
 
                     const cloned: SceneTab = {
-                        ...source,
                         id: generateTabId(),
-                        active: true,
+                        pathname: source.pathname,
+                        search: source.search,
+                        hash: source.hash,
+                        title: source.title,
+                        customTitle: source.customTitle,
+                        active: false,
                     }
 
                     if (idx === -1) {
                         // If for some reason we didn't find the tab, just append
-                        return [...base, cloned]
+                        return [...state, cloned]
                     }
-                    return [...base.slice(0, idx + 1), cloned, ...base.slice(idx + 1)]
+                    return [...state.slice(0, idx + 1), cloned, ...state.slice(idx + 1)]
                 },
                 renameTab: (state, { tab }) => {
                     const newName = prompt('Rename tab', tab.customTitle || tab.title)

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -55,7 +55,7 @@ const getPersistedTabs: () => SceneTab[] | null = () => {
     }
     return null
 }
-const generateTabId = (): string => crypto?.randomUUID?.() || `${Date.now()}-${Math.random()}`
+const generateTabId = (): string => crypto?.randomUUID?.()?.split('-')?.pop() || `${Date.now()}-${Math.random()}`
 
 export const productUrlMapping: Partial<Record<ProductKey, string[]>> = {
     [ProductKey.SESSION_REPLAY]: [urls.replay()],

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -503,7 +503,7 @@ export const sceneLogic = kea<sceneLogicType>([
         },
         locationChanged: ({ pathname, search, hash, routerState, method }) => {
             pathname = addProjectIdIfMissing(pathname)
-            if (routerState?.tabs && method !== 'PUSH') {
+            if (routerState?.tabs && method === 'POP') {
                 actions.setTabs(routerState.tabs)
                 return
             }

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -172,7 +172,8 @@ export const sceneLogic = kea<sceneLogicType>([
         activateTab: (tab: SceneTab) => ({ tab }),
         clickOnTab: (tab: SceneTab) => ({ tab }),
         reorderTabs: (activeId: string, overId: string) => ({ activeId, overId }),
-        cloneTab: (tab: SceneTab) => ({ tab }),
+        duplicateTab: (tab: SceneTab) => ({ tab }),
+        renameTab: (tab: SceneTab) => ({ tab }),
     }),
     reducers({
         // We store all state in "tabs". This allows us to have multiple tabs open, each with its own scene and parameters.
@@ -229,7 +230,7 @@ export const sceneLogic = kea<sceneLogicType>([
                     }
                     return arrayMove(state, oldIndex, newIndex)
                 },
-                cloneTab: (state, { tab }) => {
+                duplicateTab: (state, { tab }) => {
                     const idx = state.findIndex((t) => t === tab || t.id === tab.id)
                     const base = state.map((t) => (t.active ? { ...t, active: false } : t))
                     const source = idx !== -1 ? state[idx] : tab
@@ -245,6 +246,20 @@ export const sceneLogic = kea<sceneLogicType>([
                         return [...base, cloned]
                     }
                     return [...base.slice(0, idx + 1), cloned, ...base.slice(idx + 1)]
+                },
+                renameTab: (state, { tab }) => {
+                    const newName = prompt('Rename tab', tab.customTitle || tab.title)
+                    if (newName === null) {
+                        return state // User cancelled
+                    }
+                    return state.map((t) =>
+                        t.id === tab.id
+                            ? {
+                                  ...t,
+                                  customTitle: newName.trim() === '' ? undefined : newName.trim(),
+                              }
+                            : t
+                    )
                 },
                 setScene: (state, { sceneId, sceneKey, tabId, params }) => {
                     return state.map((tab) =>

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -146,6 +146,7 @@ export interface SceneTab {
     hash: string
     title: string
     active: boolean
+    customTitle?: string
 
     sceneId?: string
     sceneKey?: string

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -139,6 +139,19 @@ export interface LoadedScene extends SceneExport {
     sceneParams: SceneParams
 }
 
+export interface SceneTab {
+    id: string
+    pathname: string
+    search: string
+    hash: string
+    title: string
+    active: boolean
+
+    sceneId?: string
+    sceneKey?: string
+    sceneParams?: SceneParams
+}
+
 export interface SceneParams {
     params: Record<string, any>
     searchParams: Record<string, any>

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -135,6 +135,7 @@ export interface SceneExport {
 
 export interface LoadedScene extends SceneExport {
     id: string
+    tabId?: string
     sceneParams: SceneParams
 }
 

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -2,7 +2,7 @@ import { combineUrl } from 'kea-router'
 import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { getDefaultEventsSceneQuery } from 'scenes/activity/explore/defaults'
-import { LoadedScene, Params, Scene, SceneConfig } from 'scenes/sceneTypes'
+import { Params, Scene, SceneConfig, SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
 import { Error404 as Error404Component } from '~/layout/Error404'
@@ -25,26 +25,18 @@ import { BillingSectionId } from './billing/types'
 
 export const emptySceneParams = { params: {}, searchParams: {}, hashParams: {} }
 
-export const preloadedScenes: Record<string, LoadedScene> = {
+export const preloadedScenes: Record<string, SceneExport> = {
     [Scene.Error404]: {
-        id: Scene.Error404,
         component: Error404Component,
-        sceneParams: emptySceneParams,
     },
     [Scene.ErrorAccessDenied]: {
-        id: Scene.ErrorAccessDenied,
         component: ErrorAccessDeniedComponent,
-        sceneParams: emptySceneParams,
     },
     [Scene.ErrorNetwork]: {
-        id: Scene.ErrorNetwork,
         component: ErrorNetworkComponent,
-        sceneParams: emptySceneParams,
     },
     [Scene.ErrorProjectUnavailable]: {
-        id: Scene.ErrorProjectUnavailable,
         component: ErrorProjectUnavailableComponent,
-        sceneParams: emptySceneParams,
     },
 }
 

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistSceneLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistSceneLogic.ts
@@ -44,7 +44,7 @@ export const sessionRecordingsPlaylistSceneLogic = kea<sessionRecordingsPlaylist
     props({} as SessionRecordingsPlaylistLogicProps),
     key((props) => props.shortId),
     connect(() => ({
-        values: [cohortsModel, ['cohortsById'], sceneLogic, ['activeScene']],
+        values: [cohortsModel, ['cohortsById'], sceneLogic, ['activeSceneId']],
         actions: [sessionRecordingEventUsageLogic, ['reportRecordingPlaylistCreated']],
     })),
     actions({
@@ -161,7 +161,7 @@ export const sessionRecordingsPlaylistSceneLogic = kea<sessionRecordingsPlaylist
     beforeUnload(({ values, actions }) => ({
         enabled: (newLocation) => {
             const response =
-                values.activeScene === Scene.ReplayPlaylist &&
+                values.activeSceneId === Scene.ReplayPlaylist &&
                 values.hasChanges &&
                 removeProjectIdIfPresent(newLocation?.pathname ?? '') !==
                     removeProjectIdIfPresent(router.values.location.pathname) &&

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -1,7 +1,6 @@
 import { LemonButton } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { BoldNumber } from 'scenes/insights/views/BoldNumber'
 import { InsightsTable } from 'scenes/insights/views/InsightsTable/InsightsTable'
 import { WorldMap } from 'scenes/insights/views/WorldMap'
@@ -20,7 +19,7 @@ interface Props {
 }
 
 export function TrendInsight({ view, context, embedded, inSharedMode }: Props): JSX.Element {
-    const { insightMode } = useValues(insightSceneLogic)
+    const insightMode = context?.insightMode || ItemMode.View
     const { insightProps, showPersonsModal: insightLogicShowPersonsModal } = useValues(insightLogic)
     const showPersonsModal = insightLogicShowPersonsModal && !inSharedMode
 


### PR DESCRIPTION
Almost everything from this PR has been merged into master in the subsequent PRs:

- https://github.com/PostHog/posthog/pull/36634
- https://github.com/PostHog/posthog/pull/36639
- https://github.com/PostHog/posthog/pull/36655
- https://github.com/PostHog/posthog/pull/36656

The only missing part is everything that has to do with `insightSceneLogic`. While it will need a bit of a rework, I'll keep this PR open/draft until it's done.

------

## Problem

We want tabs. Our logics don't want tabs. One side has got to give.

## Changes

- Refactor `sceneLogic` to be tabs-first.
- Add hooks and kea logic builders to make using tabs easy
- WIP

## How did you test this code?

WIP. Still lots to do.