### PR TITLE
feat(msg): try table partitioning by team

### DIFF
--- a/plugin-server/src/cdp/consumers/cdp-aggregation-writer.consumer.test.ts
+++ b/plugin-server/src/cdp/consumers/cdp-aggregation-writer.consumer.test.ts
@@ -133,7 +133,7 @@ describe('CdpAggregationWriterConsumer', () => {
             // Verify person performed events in database (should be deduplicated)
             const personResult = await hub.postgres.query(
                 PostgresUse.COUNTERS_RW,
-                'SELECT * FROM person_performed_events WHERE team_id = $1 ORDER BY event_name',
+                'SELECT * FROM person_performed_events_partitioned WHERE team_id = $1 ORDER BY event_name',
                 [team.id],
                 'test-read-person-events'
             )
@@ -153,7 +153,7 @@ describe('CdpAggregationWriterConsumer', () => {
             // Verify behavioural events in database (should be aggregated)
             const behaviouralResult = await hub.postgres.query(
                 PostgresUse.COUNTERS_RW,
-                'SELECT * FROM behavioural_filter_matched_events WHERE team_id = $1 ORDER BY filter_hash',
+                'SELECT * FROM behavioural_filter_matched_events_partitioned WHERE team_id = $1 ORDER BY filter_hash',
                 [team.id],
                 'test-read-behavioural-events'
             )
@@ -190,7 +190,7 @@ describe('CdpAggregationWriterConsumer', () => {
             // Verify no records were written
             const personResult = await hub.postgres.query(
                 PostgresUse.COUNTERS_RW,
-                'SELECT COUNT(*) as count FROM person_performed_events WHERE team_id = $1',
+                'SELECT COUNT(*) as count FROM person_performed_events_partitioned WHERE team_id = $1',
                 [team.id],
                 'test-count-person-events'
             )
@@ -198,7 +198,7 @@ describe('CdpAggregationWriterConsumer', () => {
 
             const behaviouralResult = await hub.postgres.query(
                 PostgresUse.COUNTERS_RW,
-                'SELECT COUNT(*) as count FROM behavioural_filter_matched_events WHERE team_id = $1',
+                'SELECT COUNT(*) as count FROM behavioural_filter_matched_events_partitioned WHERE team_id = $1',
                 [team.id],
                 'test-count-behavioural-events'
             )
@@ -236,7 +236,7 @@ describe('CdpAggregationWriterConsumer', () => {
             // Verify the counter was incremented correctly
             const result = await hub.postgres.query(
                 PostgresUse.COUNTERS_RW,
-                'SELECT * FROM behavioural_filter_matched_events WHERE team_id = $1 AND filter_hash = $2',
+                'SELECT * FROM behavioural_filter_matched_events_partitioned WHERE team_id = $1 AND filter_hash = $2',
                 [team.id, 'hash123'],
                 'test-read-upserted-events'
             )
@@ -263,7 +263,7 @@ describe('CdpAggregationWriterConsumer', () => {
             // Verify only one record exists
             const result = await hub.postgres.query(
                 PostgresUse.COUNTERS_RW,
-                'SELECT * FROM person_performed_events WHERE team_id = $1 AND person_id = $2 AND event_name = $3',
+                'SELECT * FROM person_performed_events_partitioned WHERE team_id = $1 AND person_id = $2 AND event_name = $3',
                 [team.id, personId, 'pageview'],
                 'test-read-duplicate-person-events'
             )
@@ -293,7 +293,7 @@ describe('CdpAggregationWriterConsumer', () => {
             // Verify person events were written
             const personResult = await hub.postgres.query(
                 PostgresUse.COUNTERS_RW,
-                'SELECT * FROM person_performed_events WHERE team_id = $1 AND person_id = $2 ORDER BY event_name',
+                'SELECT * FROM person_performed_events_partitioned WHERE team_id = $1 AND person_id = $2 ORDER BY event_name',
                 [team.id, personId],
                 'test-read-person-only-events'
             )
@@ -304,7 +304,7 @@ describe('CdpAggregationWriterConsumer', () => {
             // Verify no behavioral events were written
             const behavioralResult = await hub.postgres.query(
                 PostgresUse.COUNTERS_RW,
-                'SELECT * FROM behavioural_filter_matched_events WHERE team_id = $1',
+                'SELECT * FROM behavioural_filter_matched_events_partitioned WHERE team_id = $1',
                 [team.id],
                 'test-read-no-behavioral-events'
             )
@@ -338,7 +338,7 @@ describe('CdpAggregationWriterConsumer', () => {
             // Verify behavioral events were written
             const behavioralResult = await hub.postgres.query(
                 PostgresUse.COUNTERS_RW,
-                'SELECT * FROM behavioural_filter_matched_events WHERE team_id = $1 AND person_id = $2 ORDER BY filter_hash',
+                'SELECT * FROM behavioural_filter_matched_events_partitioned WHERE team_id = $1 AND person_id = $2 ORDER BY filter_hash',
                 [team.id, personId],
                 'test-read-behavioral-only-events'
             )
@@ -351,7 +351,7 @@ describe('CdpAggregationWriterConsumer', () => {
             // Verify no person events were written
             const personResult = await hub.postgres.query(
                 PostgresUse.COUNTERS_RW,
-                'SELECT * FROM person_performed_events WHERE team_id = $1 AND person_id = $2',
+                'SELECT * FROM person_performed_events_partitioned WHERE team_id = $1 AND person_id = $2',
                 [team.id, personId],
                 'test-read-no-person-events'
             )
@@ -383,7 +383,7 @@ describe('CdpAggregationWriterConsumer', () => {
             // Verify events were written with cleaned names
             const result = await hub.postgres.query(
                 PostgresUse.COUNTERS_RW,
-                'SELECT event_name FROM person_performed_events WHERE team_id = $1 AND person_id = $2 ORDER BY event_name',
+                'SELECT event_name FROM person_performed_events_partitioned WHERE team_id = $1 AND person_id = $2 ORDER BY event_name',
                 [team.id, personId],
                 'test-read-cleaned-events'
             )
@@ -413,7 +413,7 @@ describe('CdpAggregationWriterConsumer', () => {
                 {
                     type: 'person-performed-event',
                     personId: validPersonId2,
-                    eventName: "event$with$dollars$and$1=1'); DROP TABLE person_performed_events; --", // SQL injection attempt
+                    eventName: "event$with$dollars$and$1=1'); DROP TABLE person_performed_events_partitioned; --", // SQL injection attempt
                     teamId: team.id,
                 },
             ]
@@ -431,7 +431,7 @@ describe('CdpAggregationWriterConsumer', () => {
                     type: 'behavioural-filter-match-event',
                     teamId: team.id,
                     personId: validPersonId2,
-                    filterHash: "hash'); DELETE FROM behavioural_filter_matched_events; --",
+                    filterHash: "hash'); DELETE FROM behavioural_filter_matched_events_partitioned; --",
                     date: '2023-12-01',
                     counter: 1,
                 },
@@ -443,14 +443,14 @@ describe('CdpAggregationWriterConsumer', () => {
             // Verify person events were written correctly with special characters preserved
             const personResult = await hub.postgres.query(
                 PostgresUse.COUNTERS_RW,
-                'SELECT * FROM person_performed_events WHERE team_id = $1 ORDER BY event_name',
+                'SELECT * FROM person_performed_events_partitioned WHERE team_id = $1 ORDER BY event_name',
                 [team.id],
                 'test-read-special-char-person-events'
             )
 
             expect(personResult.rows).toHaveLength(2)
             expect(personResult.rows[0].event_name).toBe(
-                "event$with$dollars$and$1=1'); DROP TABLE person_performed_events; --"
+                "event$with$dollars$and$1=1'); DROP TABLE person_performed_events_partitioned; --"
             )
             expect(personResult.rows[1].event_name).toBe(problematicEventName)
             expect(personResult.rows[1].person_id).toBe(validPersonId1)
@@ -458,7 +458,7 @@ describe('CdpAggregationWriterConsumer', () => {
             // Verify behavioral events were written correctly with special characters preserved
             const behavioralResult = await hub.postgres.query(
                 PostgresUse.COUNTERS_RW,
-                'SELECT * FROM behavioural_filter_matched_events WHERE team_id = $1 ORDER BY person_id',
+                'SELECT * FROM behavioural_filter_matched_events_partitioned WHERE team_id = $1 ORDER BY person_id',
                 [team.id],
                 'test-read-special-char-behavioral-events'
             )
@@ -468,7 +468,7 @@ describe('CdpAggregationWriterConsumer', () => {
             expect(behavioralResult.rows[0].filter_hash).toBe(problematicFilterHash)
             expect(behavioralResult.rows[1].person_id).toBe(validPersonId2)
             expect(behavioralResult.rows[1].filter_hash).toBe(
-                "hash'); DELETE FROM behavioural_filter_matched_events; --"
+                "hash'); DELETE FROM behavioural_filter_matched_events_partitioned; --"
             )
 
             // Verify tables still exist (SQL injection attempt failed)
@@ -476,7 +476,7 @@ describe('CdpAggregationWriterConsumer', () => {
                 PostgresUse.COUNTERS_RW,
                 `SELECT EXISTS (
                     SELECT FROM information_schema.tables 
-                    WHERE table_name = 'behavioural_filter_matched_events'
+                    WHERE table_name = 'behavioural_filter_matched_events_partitioned'
                 ) as table_exists`,
                 [],
                 'test-check-table-exists'

--- a/plugin-server/src/cdp/consumers/cdp-aggregation-writer.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-aggregation-writer.consumer.ts
@@ -121,7 +121,7 @@ export class CdpAggregationWriterConsumer extends CdpConsumerBase {
         paramOffset: number
     ): { cte: string; params: any[] } {
         const cte = `person_inserts AS (
-            INSERT INTO person_performed_events (team_id, person_id, event_name)
+            INSERT INTO person_performed_events_partitioned (team_id, person_id, event_name)
             SELECT * FROM unnest($${paramOffset}::int[], $${paramOffset + 1}::uuid[], $${paramOffset + 2}::text[])
             ON CONFLICT (team_id, person_id, event_name) DO NOTHING
             RETURNING 1
@@ -142,10 +142,10 @@ export class CdpAggregationWriterConsumer extends CdpConsumerBase {
         paramOffset: number
     ): { cte: string; params: any[] } {
         const cte = `behavioural_inserts AS (
-            INSERT INTO behavioural_filter_matched_events (team_id, person_id, filter_hash, date, counter)
+            INSERT INTO behavioural_filter_matched_events_partitioned (team_id, person_id, filter_hash, date, counter)
             SELECT * FROM unnest($${paramOffset}::int[], $${paramOffset + 1}::uuid[], $${paramOffset + 2}::text[], $${paramOffset + 3}::date[], $${paramOffset + 4}::int[])
             ON CONFLICT (team_id, person_id, filter_hash, date) 
-            DO UPDATE SET counter = behavioural_filter_matched_events.counter + EXCLUDED.counter
+            DO UPDATE SET counter = behavioural_filter_matched_events_partitioned.counter + EXCLUDED.counter
             RETURNING 1
         )`
 

--- a/plugin-server/src/migrations/002_partition_counters_tables.js
+++ b/plugin-server/src/migrations/002_partition_counters_tables.js
@@ -1,0 +1,74 @@
+exports.up = (pgm) => {
+    // Create partitioned table structure for person_performed_events
+    pgm.sql(`
+        CREATE TABLE person_performed_events_partitioned (
+            team_id INTEGER NOT NULL,
+            person_id UUID NOT NULL,
+            event_name TEXT NOT NULL,
+            created_at TIMESTAMP DEFAULT NOW()
+        ) PARTITION BY HASH (team_id)
+    `)
+
+    // Create partitions (100 partitions for hash)
+    pgm.sql(`
+        DO $$
+        BEGIN
+            FOR i IN 0..99 LOOP
+                EXECUTE format('CREATE TABLE person_performed_events_p%s PARTITION OF person_performed_events_partitioned 
+                                FOR VALUES WITH (modulus 100, remainder %s)', i, i);
+            END LOOP;
+        END $$
+    `)
+
+    // Add constraints to partitioned table (automatically inherited by partitions)
+    pgm.addConstraint('person_performed_events_partitioned', 'person_performed_events_partitioned_unique', {
+        unique: ['team_id', 'person_id', 'event_name'],
+    })
+
+    // Create partitioned table structure for behavioural_filter_matched_events
+    pgm.sql(`
+        CREATE TABLE behavioural_filter_matched_events_partitioned (
+            team_id INTEGER NOT NULL,
+            person_id UUID NOT NULL,
+            filter_hash TEXT NOT NULL,
+            date DATE NOT NULL,
+            counter INTEGER NOT NULL DEFAULT 0,
+            created_at TIMESTAMP DEFAULT NOW()
+        ) PARTITION BY HASH (team_id)
+    `)
+
+    // Create partitions (100 partitions for hash)
+    pgm.sql(`
+        DO $$
+        BEGIN
+            FOR i IN 0..99 LOOP
+                EXECUTE format('CREATE TABLE behavioural_filter_matched_events_p%s PARTITION OF behavioural_filter_matched_events_partitioned 
+                                FOR VALUES WITH (modulus 100, remainder %s)', i, i);
+            END LOOP;
+        END $$
+    `)
+
+    // Add constraints to partitioned table (automatically inherited by partitions)
+    pgm.addConstraint(
+        'behavioural_filter_matched_events_partitioned',
+        'behavioural_filter_matched_events_partitioned_unique',
+        {
+            unique: ['team_id', 'person_id', 'filter_hash', 'date'],
+        }
+    )
+
+    // Create indexes on partitioned tables (automatically inherited by partitions)
+    pgm.createIndex('person_performed_events_partitioned', ['team_id', 'person_id'], {
+        name: 'idx_person_performed_events_partitioned_team_person',
+    })
+
+    pgm.createIndex('behavioural_filter_matched_events_partitioned', ['team_id', 'person_id'], {
+        name: 'idx_behavioural_filter_partitioned_team_person',
+    })
+}
+
+exports.down = (pgm) => {
+    // Drop partitioned tables and all their partitions
+    pgm.dropTable('behavioural_filter_matched_events_partitioned', { cascade: true })
+    pgm.dropTable('person_performed_events_partitioned', { cascade: true })
+}

--- a/plugin-server/tests/helpers/sql.ts
+++ b/plugin-server/tests/helpers/sql.ts
@@ -573,7 +573,7 @@ export async function fetchPostgresDistinctIdsForPerson(db: DB, personId: string
 export async function resetCountersDatabase(db: PostgresRouter): Promise<void> {
     await db.query(
         PostgresUse.COUNTERS_RW,
-        'TRUNCATE TABLE person_performed_events, behavioural_filter_matched_events',
+        'TRUNCATE TABLE person_performed_events_partitioned, behavioural_filter_matched_events_partitioned',
         undefined,
         'reset-counters-db'
     )


### PR DESCRIPTION
## Problem

Massive I/O bottleneck (108+ AAS IO wait) due to single giant index spanning billions of rows.

Potential Solution: Hash partition tables by team_id into 100 partitions.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

  Benefits:
  - 100x smaller indexes per partition 

  Changes:
  - Added migration to create partitioned tables
  - Updated consumer to write to *_partitioned tables
  - No logic changes, just table name updates

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
