### PR TITLE
feat(dashboards): filter overrides for dashboards in the URL

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -25,8 +25,7 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 import { ErrorBoundary } from '~/layout/ErrorBoundary'
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { Query } from '~/queries/Query/Query'
-import { extractValidationError } from '~/queries/nodes/InsightViz/utils'
-import { HogQLVariable } from '~/queries/schema/schema-general'
+import { DashboardFilter, HogQLVariable } from '~/queries/schema/schema-general'
 import {
     DashboardBasicType,
     DashboardPlacement,
@@ -78,6 +77,8 @@ export interface InsightCardProps extends Resizeable {
     /** Priority for loading the insight, lower is earlier. */
     loadPriority?: number
     doNotLoad?: boolean
+    /** Dashboard filters to override the ones in the insight */
+    filtersOverride?: DashboardFilter
     /** Dashboard variables to override the ones in the insight */
     variablesOverride?: Record<string, HogQLVariable>
     /** Dashboard breakdown colors to override the ones in the insight */
@@ -117,6 +118,7 @@ function InsightCardInternal(
         placement,
         loadPriority,
         doNotLoad,
+        filtersOverride,
         variablesOverride,
         children,
         breakdownColorOverride: _breakdownColorOverride,
@@ -210,6 +212,7 @@ function InsightCardInternal(
                             showEditingControls={showEditingControls}
                             showDetailsControls={showDetailsControls}
                             moreButtons={moreButtons}
+                            filtersOverride={filtersOverride}
                             variablesOverride={variablesOverride}
                         />
                         <div className="InsightCard__viz">

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -25,6 +25,7 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 import { ErrorBoundary } from '~/layout/ErrorBoundary'
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { Query } from '~/queries/Query/Query'
+import { extractValidationError } from '~/queries/nodes/InsightViz/utils'
 import { DashboardFilter, HogQLVariable } from '~/queries/schema/schema-general'
 import {
     DashboardBasicType,

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -111,7 +111,7 @@ export function InsightMeta({
             topHeading={<TopHeading query={insight.query} lastRefresh={insight.last_refresh} />}
             content={
                 <InsightMetaContent
-                    link={urls.insightView(short_id, dashboardId, filtersOverride, variablesOverride)}
+                    link={urls.insightView(short_id, dashboardId, variablesOverride, filtersOverride)}
                     title={name}
                     fallbackTitle={summary}
                     description={insight.description}

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -51,6 +51,7 @@ interface InsightMetaProps
         | 'showEditingControls'
         | 'showDetailsControls'
         | 'moreButtons'
+        | 'filtersOverride'
         | 'variablesOverride'
     > {
     insight: QueryBasedInsightModel
@@ -63,6 +64,7 @@ export function InsightMeta({
     ribbonColor,
     dashboardId,
     updateColor,
+    filtersOverride,
     variablesOverride,
     removeFromDashboard,
     deleteWithUndo,
@@ -109,7 +111,7 @@ export function InsightMeta({
             topHeading={<TopHeading query={insight.query} lastRefresh={insight.last_refresh} />}
             content={
                 <InsightMetaContent
-                    link={urls.insightView(short_id, dashboardId, variablesOverride)}
+                    link={urls.insightView(short_id, dashboardId, filtersOverride, variablesOverride)}
                     title={name}
                     fallbackTitle={summary}
                     description={insight.description}

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -389,10 +389,14 @@ export function isNonEmptyObject(candidate: unknown): candidate is Record<string
 }
 
 // https://stackoverflow.com/questions/25421233/javascript-removing-undefined-fields-from-an-object
-export function objectClean<T extends Record<string | number | symbol, unknown>>(obj: T): T {
+export function objectClean<T extends Record<string | number | symbol, unknown>>(
+    obj: T,
+    options?: { removeNulls?: boolean }
+): T {
+    const { removeNulls = false } = options || {}
     const response = { ...obj }
     Object.keys(response).forEach((key) => {
-        if (response[key] === undefined) {
+        if (removeNulls ? response[key] == null : response[key] === undefined) {
             delete response[key]
         }
     })

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -67,6 +67,7 @@ export enum DashboardEventSource {
     DashboardHeaderSaveDashboard = 'dashboard_header_save_dashboard',
     DashboardHeaderDiscardChanges = 'dashboard_header_discard_changes',
     DashboardHeaderExitFullscreen = 'dashboard_header_exit_fullscreen',
+    DashboardHeaderOverridesBanner = 'dashboard_header_overrides_banner',
     Hotkey = 'hotkey',
     InputEnter = 'input_enter',
     Toast = 'toast',

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -3,7 +3,7 @@ import './Dashboard.scss'
 import clsx from 'clsx'
 import { BindLogic, useActions, useMountedLogic, useValues } from 'kea'
 
-import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
+import { LemonButton } from '@posthog/lemon-ui'
 
 import { AccessDenied } from 'lib/components/AccessDenied'
 import { NotFound } from 'lib/components/NotFound'

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -3,7 +3,7 @@ import './Dashboard.scss'
 import clsx from 'clsx'
 import { BindLogic, useActions, useMountedLogic, useValues } from 'kea'
 
-import { LemonButton } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
 
 import { AccessDenied } from 'lib/components/AccessDenied'
 import { NotFound } from 'lib/components/NotFound'
@@ -23,6 +23,7 @@ import { DashboardMode, DashboardPlacement, DashboardType, DataColorThemeModel, 
 
 import { AddInsightToDashboardModal } from './AddInsightToDashboardModal'
 import { DashboardHeader } from './DashboardHeader'
+import { DashboardOverridesBanner } from './DashboardOverridesBanner'
 import { EmptyDashboardComponent } from './EmptyDashboardComponent'
 
 interface DashboardProps {
@@ -121,6 +122,8 @@ function DashboardScene(): JSX.Element {
                 <EmptyDashboardComponent loading={itemsLoading} canEdit={canEditDashboard} />
             ) : (
                 <div>
+                    <DashboardOverridesBanner />
+
                     <div className="Dashboard_filters">
                         <div className="flex gap-2 justify-between">
                             {![

--- a/frontend/src/scenes/dashboard/DashboardEditBar.tsx
+++ b/frontend/src/scenes/dashboard/DashboardEditBar.tsx
@@ -26,6 +26,7 @@ export function DashboardEditBar(): JSX.Element {
         showEditBarApplyPopover,
         loadingPreview,
         cancellingPreview,
+        hasTemporaryFilters,
     } = useValues(dashboardLogic)
     const { setDates, setProperties, setBreakdownFilter, setDashboardMode, previewTemporaryFilters } =
         useActions(dashboardLogic)
@@ -51,7 +52,12 @@ export function DashboardEditBar(): JSX.Element {
             overlay={
                 <div className="flex items-center gap-2 m-1">
                     <LemonButton
-                        onClick={() => setDashboardMode(null, DashboardEventSource.DashboardHeaderDiscardChanges)}
+                        onClick={() =>
+                            setDashboardMode(
+                                hasTemporaryFilters ? dashboardMode : null,
+                                DashboardEventSource.DashboardHeaderDiscardChanges
+                            )
+                        }
                         loading={cancellingPreview}
                         type="secondary"
                         size="small"

--- a/frontend/src/scenes/dashboard/DashboardEditBar.tsx
+++ b/frontend/src/scenes/dashboard/DashboardEditBar.tsx
@@ -19,14 +19,13 @@ import { DashboardMode, InsightLogicProps } from '~/types'
 
 export function DashboardEditBar(): JSX.Element {
     const {
-        canAutoPreview,
         dashboard,
+        dashboardMode,
+        hasVariables,
+        effectiveEditBarFilters,
+        showEditBarApplyPopover,
         loadingPreview,
         cancellingPreview,
-        temporaryFilters,
-        dashboardMode,
-        filtersUpdated,
-        hasVariables,
     } = useValues(dashboardLogic)
     const { setDates, setProperties, setBreakdownFilter, setDashboardMode, previewTemporaryFilters } =
         useActions(dashboardLogic)
@@ -48,7 +47,7 @@ export function DashboardEditBar(): JSX.Element {
     return (
         // Only show preview button for large dashboards where we don't automatically preview filter changes */
         <Popover
-            visible={!canAutoPreview && filtersUpdated}
+            visible={showEditBarApplyPopover}
             overlay={
                 <div className="flex items-center gap-2 m-1">
                     <LemonButton
@@ -78,8 +77,8 @@ export function DashboardEditBar(): JSX.Element {
                 <div className={clsx('content-end', { 'h-[61px]': hasVariables })}>
                     <DateFilter
                         showCustom
-                        dateFrom={temporaryFilters.date_from}
-                        dateTo={temporaryFilters.date_to}
+                        dateFrom={effectiveEditBarFilters.date_from}
+                        dateTo={effectiveEditBarFilters.date_to}
                         onChange={(from_date, to_date) => {
                             if (dashboardMode !== DashboardMode.Edit) {
                                 setDashboardMode(DashboardMode.Edit, null)
@@ -103,7 +102,7 @@ export function DashboardEditBar(): JSX.Element {
                             setProperties(properties)
                         }}
                         pageKey={'dashboard_' + dashboard?.id}
-                        propertyFilters={temporaryFilters.properties}
+                        propertyFilters={effectiveEditBarFilters.properties}
                         taxonomicGroupTypes={[
                             TaxonomicFilterGroupType.EventProperties,
                             TaxonomicFilterGroupType.PersonProperties,
@@ -120,7 +119,7 @@ export function DashboardEditBar(): JSX.Element {
                     <BindLogic logic={insightLogic} props={insightProps}>
                         <TaxonomicBreakdownFilter
                             insightProps={insightProps}
-                            breakdownFilter={temporaryFilters.breakdown_filter}
+                            breakdownFilter={effectiveEditBarFilters.breakdown_filter}
                             isTrends={false}
                             showLabel={false}
                             updateBreakdownFilter={(breakdown_filter) => {

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -32,7 +32,7 @@ export function DashboardItems(): JSX.Element {
         highlightedInsightId,
         refreshStatus,
         itemsLoading,
-        temporaryFilters,
+        effectiveEditBarFilters,
         temporaryVariables,
         temporaryBreakdownColors,
         dataColorThemeId,
@@ -166,7 +166,7 @@ export function DashboardItems(): JSX.Element {
                                     }
                                     placement={placement}
                                     loadPriority={smLayout ? smLayout.y * 1000 + smLayout.x : undefined}
-                                    filtersOverride={temporaryFilters}
+                                    filtersOverride={effectiveEditBarFilters}
                                     variablesOverride={temporaryVariables}
                                     // :HACKY: The two props below aren't actually used in the component, but are needed to trigger a re-render
                                     breakdownColorOverride={temporaryBreakdownColors}

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -32,6 +32,7 @@ export function DashboardItems(): JSX.Element {
         highlightedInsightId,
         refreshStatus,
         itemsLoading,
+        temporaryFilters,
         temporaryVariables,
         temporaryBreakdownColors,
         dataColorThemeId,
@@ -165,6 +166,7 @@ export function DashboardItems(): JSX.Element {
                                     }
                                     placement={placement}
                                     loadPriority={smLayout ? smLayout.y * 1000 + smLayout.x : undefined}
+                                    filtersOverride={temporaryFilters}
                                     variablesOverride={temporaryVariables}
                                     // :HACKY: The two props below aren't actually used in the component, but are needed to trigger a re-render
                                     breakdownColorOverride={temporaryBreakdownColors}

--- a/frontend/src/scenes/dashboard/DashboardOverridesBanner.tsx
+++ b/frontend/src/scenes/dashboard/DashboardOverridesBanner.tsx
@@ -1,0 +1,44 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
+
+import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
+
+import { DashboardMode } from '~/types'
+
+import { dashboardLogic } from './dashboardLogic'
+
+export const DashboardOverridesBanner = (): JSX.Element | null => {
+    const { dashboardMode, temporaryFilters, cancellingPreview } = useValues(dashboardLogic)
+    const { setDashboardMode } = useActions(dashboardLogic)
+
+    if (dashboardMode === DashboardMode.Edit || Object.keys(temporaryFilters).length === 0) {
+        return null
+    }
+
+    return (
+        <LemonBanner type="info" className="mt-4 mb-2">
+            <div className="flex flex-row items-center justify-between gap-2">
+                <span>You are viewing this dashboard with filter overrides.</span>
+
+                <div className="flex gap-2">
+                    <LemonButton
+                        type="primary"
+                        onClick={() =>
+                            setDashboardMode(DashboardMode.Edit, DashboardEventSource.DashboardHeaderOverridesBanner)
+                        }
+                    >
+                        Edit dashboard
+                    </LemonButton>
+                    <LemonButton
+                        type="secondary"
+                        onClick={() => setDashboardMode(null, DashboardEventSource.DashboardHeaderDiscardChanges)}
+                        loading={cancellingPreview}
+                    >
+                        Discard overrides
+                    </LemonButton>
+                </div>
+            </div>
+        </LemonBanner>
+    )
+}

--- a/frontend/src/scenes/dashboard/DashboardOverridesBanner.tsx
+++ b/frontend/src/scenes/dashboard/DashboardOverridesBanner.tsx
@@ -32,7 +32,7 @@ export const DashboardOverridesBanner = (): JSX.Element | null => {
                     </LemonButton>
                     <LemonButton
                         type="secondary"
-                        onClick={() => setDashboardMode(null, DashboardEventSource.DashboardHeaderDiscardChanges)}
+                        onClick={() => setDashboardMode(null, DashboardEventSource.DashboardHeaderOverridesBanner)}
                         loading={cancellingPreview}
                     >
                         Discard overrides

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -333,28 +333,9 @@ describe('dashboardLogic', () => {
                 ],
                 breakdown_colors: [],
                 data_color_theme_id: null,
-                filters: {
-                    date_from: null,
-                    date_to: null,
-                    properties: [],
-                    breakdown_filter: null,
-                },
+                filters: {},
                 variables: {},
             })
-        })
-    })
-
-    describe('when the dashboard has filters', () => {
-        it('sets the filters reducer on load', async () => {
-            logic = dashboardLogic({ id: 11 })
-            logic.mount()
-
-            await expectLogic(logic)
-                .toFinishAllListeners()
-                .toNotHaveDispatchedActions(['setDates'])
-                .toMatchValues({
-                    filters: { date_from: '-24h', date_to: null, properties: [], breakdown_filter: null },
-                })
         })
     })
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -465,7 +465,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
             {
                 // have to reload dashboard when when cancelling preview
                 // and resetting filters
-                resetDashboardFilters: () => true,
+                loadDashboard: () => true,
                 loadDashboardSuccess: () => false,
                 loadDashboardFailure: () => false,
             },

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -74,6 +74,7 @@ import {
     parseURLVariables,
     runWithLimit,
 } from './dashboardUtils'
+import { isDashboardFilterEmpty } from 'scenes/insights/insightSceneLogic'
 
 export interface DashboardLogicProps {
     id: number
@@ -845,9 +846,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
         ],
         hasIntermittentFilters: [
             (s) => [s.intermittentFilters],
-            (intermittentFilters) =>
-                Object.keys(objectClean((intermittentFilters || {}) as Record<string, unknown>, { removeNulls: true }))
-                    .length > 0,
+            (intermittentFilters) => !isDashboardFilterEmpty(intermittentFilters),
         ],
         showEditBarApplyPopover: [
             (s) => [s.canAutoPreview, s.hasIntermittentFilters],
@@ -1644,10 +1643,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
             const { currentLocation } = router.values
 
             const urlFilters = parseURLFilters(currentLocation.searchParams)
-            const newUrlFilters: DashboardFilter = {
-                ...urlFilters,
-                ...values.intermittentFilters,
-            }
+            const newUrlFilters: DashboardFilter = combineDashboardFilters(urlFilters, values.intermittentFilters)
 
             const newSearchParams = {
                 ...currentLocation.searchParams,

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1640,6 +1640,95 @@ export const dashboardLogic = kea<dashboardLogicType>([
     })),
 
     actionToUrl(({ values }) => ({
+        previewTemporaryFilters: () => {
+            const { currentLocation } = router.values
+
+            const urlFilters = parseURLFilters(currentLocation.searchParams)
+            const newUrlFilters: DashboardFilter = {
+                ...urlFilters,
+                ...values.intermittentFilters,
+            }
+
+            const newSearchParams = {
+                ...currentLocation.searchParams,
+            }
+
+            return [
+                currentLocation.pathname,
+                { ...newSearchParams, ...encodeURLFilters(newUrlFilters) },
+                currentLocation.hashParams,
+            ]
+        },
+        setProperties: ({ properties }) => {
+            if (!values.canAutoPreview) {
+                return
+            }
+
+            const { currentLocation } = router.values
+
+            const urlFilters = parseURLFilters(currentLocation.searchParams)
+            const newUrlFilters: DashboardFilter = {
+                ...urlFilters,
+                properties,
+            }
+
+            const newSearchParams = {
+                ...currentLocation.searchParams,
+            }
+
+            return [
+                currentLocation.pathname,
+                { ...newSearchParams, ...encodeURLFilters(newUrlFilters) },
+                currentLocation.hashParams,
+            ]
+        },
+        setDates: ({ date_from, date_to }) => {
+            if (!values.canAutoPreview) {
+                return
+            }
+
+            const { currentLocation } = router.values
+
+            const urlFilters = parseURLFilters(currentLocation.searchParams)
+            const newUrlFilters: DashboardFilter = {
+                ...urlFilters,
+                date_from,
+                date_to,
+            }
+
+            const newSearchParams = {
+                ...currentLocation.searchParams,
+            }
+
+            return [
+                currentLocation.pathname,
+                { ...newSearchParams, ...encodeURLFilters(newUrlFilters) },
+                currentLocation.hashParams,
+            ]
+        },
+        setBreakdownFilter: ({ breakdown_filter }) => {
+            if (!values.canAutoPreview) {
+                return
+            }
+
+            const { currentLocation } = router.values
+
+            const urlFilters = parseURLFilters(currentLocation.searchParams)
+            const newUrlFilters: DashboardFilter = {
+                ...urlFilters,
+                breakdown_filter,
+            }
+
+            const newSearchParams = {
+                ...currentLocation.searchParams,
+            }
+
+            return [
+                currentLocation.pathname,
+                { ...newSearchParams, ...encodeURLFilters(newUrlFilters) },
+                currentLocation.hashParams,
+            ]
+        },
         overrideVariableValue: ({ variableId, value }) => {
             const { currentLocation } = router.values
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -67,11 +67,12 @@ import {
     DASHBOARD_MIN_REFRESH_INTERVAL_MINUTES,
     IS_TEST_MODE,
     MAX_TILES_FOR_AUTOPREVIEW,
-    QUERY_VARIABLES_KEY,
+    SEARCH_PARAM_QUERY_VARIABLES_KEY,
     combineDashboardFilters,
     encodeURLVariables,
     getInsightWithRetry,
     layoutsByTile,
+    parseURLFilters,
     parseURLVariables,
     runWithLimit,
 } from './dashboardUtils'
@@ -203,6 +204,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
             dataColorThemeId,
         }),
         resetDashboardFilters: () => true,
+        resetIntermittentFilters: () => true,
         previewTemporaryFilters: true,
         resetVariables: true,
         setInitialVariablesLoaded: (initialVariablesLoaded: boolean) => ({ initialVariablesLoaded }),
@@ -805,7 +807,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 },
             },
         ],
-        temporaryFilters: [
+        intermittentFilters: [
             {
                 date_from: null,
                 date_to: null,
@@ -1016,7 +1018,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 return (
                     dashboardLoading ||
                     Object.values(refreshStatus).some((s) => s.loading || s.queued) ||
-                    (QUERY_VARIABLES_KEY in router.values.searchParams && !initialVariablesLoaded)
+                    (SEARCH_PARAM_QUERY_VARIABLES_KEY in router.values.searchParams && !initialVariablesLoaded)
                 )
             },
         ],
@@ -1205,7 +1207,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     // the loadDashboardSuccess listener will initiate a refresh
                     actions.loadDashboardSuccess(props.dashboard)
                 } else {
-                    if (!(QUERY_VARIABLES_KEY in router.values.searchParams)) {
+                    if (!(SEARCH_PARAM_QUERY_VARIABLES_KEY in router.values.searchParams)) {
                         actions.loadDashboard({
                             action: DashboardLoadAction.InitialLoad,
                         })
@@ -1612,7 +1614,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 return
             }
 
-            if (QUERY_VARIABLES_KEY in router.values.searchParams) {
+            if (SEARCH_PARAM_QUERY_VARIABLES_KEY in router.values.searchParams) {
                 actions.loadDashboard({
                     action: DashboardLoadAction.InitialLoadWithVariables,
                 })
@@ -1753,7 +1755,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
         resetVariables: () => {
             const { currentLocation } = router.values
             const newSearchParams = { ...currentLocation.searchParams }
-            delete newSearchParams[QUERY_VARIABLES_KEY]
+            delete newSearchParams[SEARCH_PARAM_QUERY_VARIABLES_KEY]
             return [currentLocation.pathname, newSearchParams, currentLocation.hashParams]
         },
     })),

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -18,6 +18,7 @@ import { clearDOMTextSelection, getJSHeapMemory, shouldCancelQuery, toParams, uu
 import { DashboardEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { calculateLayouts } from 'scenes/dashboard/tileLayouts'
 import { dataThemeLogic } from 'scenes/dataThemeLogic'
+import { isDashboardFilterEmpty } from 'scenes/insights/insightSceneLogic'
 import { MaxContextInput, createMaxContextHelpers } from 'scenes/max/maxTypes'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
@@ -74,7 +75,6 @@ import {
     parseURLVariables,
     runWithLimit,
 } from './dashboardUtils'
-import { isDashboardFilterEmpty } from 'scenes/insights/insightSceneLogic'
 
 export interface DashboardLogicProps {
     id: number
@@ -1239,9 +1239,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
     })),
     listeners(({ actions, values, cache, props, sharedListeners }) => ({
         resetDashboardFilters: () => {
-            actions.setDates(values.filters.date_from ?? null, values.filters.date_to ?? null)
-            actions.setProperties(values.filters.properties ?? null)
-            actions.setBreakdownFilter(values.filters.breakdown_filter ?? null)
+            actions.setDates(values.dashboard?.filters.date_from ?? null, values.dashboard?.filters.date_to ?? null)
+            actions.setProperties(values.dashboard?.filters.properties ?? null)
+            actions.setBreakdownFilter(values.dashboard?.filters.breakdown_filter ?? null)
         },
         setRefreshError: sharedListeners.reportRefreshTiming,
         setRefreshStatuses: sharedListeners.reportRefreshTiming,

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -828,16 +828,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     ...state,
                     breakdown_filter: breakdown_filter || null,
                 }),
-                loadDashboardSuccess: (state, { dashboard }) =>
-                    dashboard
-                        ? {
-                              ...state,
-                              date_from: dashboard?.filters.date_from || null,
-                              date_to: dashboard?.filters.date_to || null,
-                              properties: dashboard?.filters.properties || [],
-                              breakdown_filter: dashboard?.filters.breakdown_filter || null,
-                          }
-                        : state,
                 resetIntermittentFilters: () => ({
                     date_from: null,
                     date_to: null,

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -838,6 +838,12 @@ export const dashboardLogic = kea<dashboardLogicType>([
                               breakdown_filter: dashboard?.filters.breakdown_filter || null,
                           }
                         : state,
+                resetIntermittentFilters: () => ({
+                    date_from: null,
+                    date_to: null,
+                    properties: null,
+                    breakdown_filter: null,
+                }),
             },
         ],
     })),

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -69,6 +69,7 @@ import {
     MAX_TILES_FOR_AUTOPREVIEW,
     SEARCH_PARAM_QUERY_VARIABLES_KEY,
     combineDashboardFilters,
+    encodeURLFilters,
     encodeURLVariables,
     getInsightWithRetry,
     layoutsByTile,
@@ -1585,17 +1586,17 @@ export const dashboardLogic = kea<dashboardLogicType>([
             actions.loadDashboard({ action: DashboardLoadAction.Preview })
         },
         setProperties: () => {
-            if ((values.dashboard?.tiles.length || 0) < MAX_TILES_FOR_AUTOPREVIEW) {
+            if (values.canAutoPreview) {
                 actions.loadDashboard({ action: DashboardLoadAction.Preview })
             }
         },
         setDates: () => {
-            if ((values.dashboard?.tiles.length || 0) < MAX_TILES_FOR_AUTOPREVIEW) {
+            if (values.canAutoPreview) {
                 actions.loadDashboard({ action: DashboardLoadAction.Preview })
             }
         },
         setBreakdownFilter: () => {
-            if ((values.dashboard?.tiles.length || 0) < MAX_TILES_FOR_AUTOPREVIEW) {
+            if (values.canAutoPreview) {
                 actions.loadDashboard({ action: DashboardLoadAction.Preview })
             }
         },

--- a/frontend/src/scenes/dashboard/dashboardUtils.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.ts
@@ -260,9 +260,7 @@ export const encodeURLFilters = (filters: DashboardFilter): Record<string, strin
     const encodedFilters: Record<string, string> = {}
 
     if (Object.keys(filters).length > 0) {
-        encodedFilters[SEARCH_PARAM_FILTERS_KEY] = JSON.stringify(
-            objectClean(filters as Record<string, unknown>, { removeNulls: true })
-        )
+        encodedFilters[SEARCH_PARAM_FILTERS_KEY] = JSON.stringify(objectClean(filters as Record<string, unknown>))
     }
 
     return encodedFilters
@@ -272,7 +270,7 @@ export function combineDashboardFilters(...filters: DashboardFilter[]): Dashboar
     return filters.reduce((combined, filter) => {
         Object.keys(filter).forEach((key) => {
             const value = (filter as Record<string, any>)[key]
-            if (value !== null && value !== undefined) {
+            if (value !== undefined) {
                 ;(combined as Record<string, any>)[key] = value
             }
         })

--- a/frontend/src/scenes/dashboard/dashboardUtils.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.ts
@@ -25,7 +25,8 @@ export const DASHBOARD_MIN_REFRESH_INTERVAL_MINUTES = 15
 
 export const IS_TEST_MODE = process.env.NODE_ENV === 'test'
 
-export const QUERY_VARIABLES_KEY = 'query_variables'
+export const SEARCH_PARAM_QUERY_VARIABLES_KEY = 'query_variables'
+export const SEARCH_PARAM_FILTERS_KEY = 'query_filters'
 
 /**
  * Once a dashboard has more tiles than this,
@@ -218,9 +219,9 @@ export async function getInsightWithRetry(
 export const parseURLVariables = (searchParams: Record<string, any>): Record<string, Partial<HogQLVariable>> => {
     const variables: Record<string, Partial<HogQLVariable>> = {}
 
-    if (searchParams[QUERY_VARIABLES_KEY]) {
+    if (searchParams[SEARCH_PARAM_QUERY_VARIABLES_KEY]) {
         try {
-            const parsedVariables = JSON.parse(searchParams[QUERY_VARIABLES_KEY])
+            const parsedVariables = JSON.parse(searchParams[SEARCH_PARAM_QUERY_VARIABLES_KEY])
             Object.assign(variables, parsedVariables)
         } catch (e) {
             console.error('Failed to parse query_variables from URL:', e)
@@ -234,7 +235,7 @@ export const encodeURLVariables = (variables: Record<string, string>): Record<st
     const encodedVariables: Record<string, string> = {}
 
     if (Object.keys(variables).length > 0) {
-        encodedVariables[QUERY_VARIABLES_KEY] = JSON.stringify(variables)
+        encodedVariables[SEARCH_PARAM_QUERY_VARIABLES_KEY] = JSON.stringify(variables)
     }
 
     return encodedVariables

--- a/frontend/src/scenes/dashboard/dashboardUtils.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.ts
@@ -4,7 +4,7 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import api, { ApiMethodOptions, getJSONOrNull } from 'lib/api'
 import { currentSessionId } from 'lib/internalMetrics'
-import { shouldCancelQuery, toParams } from 'lib/utils'
+import { objectClean, shouldCancelQuery, toParams } from 'lib/utils'
 
 import { getQueryBasedInsightModel } from '~/queries/nodes/InsightViz/utils'
 import { pollForResults } from '~/queries/query'
@@ -238,4 +238,43 @@ export const encodeURLVariables = (variables: Record<string, string>): Record<st
     }
 
     return encodedVariables
+}
+
+export const parseURLFilters = (searchParams: Record<string, any>): DashboardFilter => {
+    const filters: DashboardFilter = {}
+
+    if (searchParams[SEARCH_PARAM_FILTERS_KEY]) {
+        try {
+            const parsedFilters = JSON.parse(searchParams[SEARCH_PARAM_FILTERS_KEY])
+            Object.assign(filters, parsedFilters)
+        } catch (e) {
+            console.error(`Failed to parse ${SEARCH_PARAM_FILTERS_KEY} from URL:`, e)
+        }
+    }
+
+    return filters
+}
+
+export const encodeURLFilters = (filters: DashboardFilter): Record<string, string> => {
+    const encodedFilters: Record<string, string> = {}
+
+    if (Object.keys(filters).length > 0) {
+        encodedFilters[SEARCH_PARAM_FILTERS_KEY] = JSON.stringify(
+            objectClean(filters as Record<string, unknown>, { removeNulls: true })
+        )
+    }
+
+    return encodedFilters
+}
+
+export function combineDashboardFilters(...filters: DashboardFilter[]): DashboardFilter {
+    return filters.reduce((combined, filter) => {
+        Object.keys(filter).forEach((key) => {
+            const value = (filter as Record<string, any>)[key]
+            if (value !== null && value !== undefined) {
+                ;(combined as Record<string, any>)[key] = value
+            }
+        })
+        return combined
+    }, {} as DashboardFilter)
 }

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -41,7 +41,7 @@ import { parseDraftQueryFromLocalStorage, parseDraftQueryFromURL } from './utils
 const NEW_INSIGHT = 'new' as const
 export type InsightId = InsightShortId | typeof NEW_INSIGHT | null
 
-export function isDashboardFilterEmpty(filter: DashboardFilter | null): boolean {
+function isDashboardFilterEmpty(filter: DashboardFilter | null): boolean {
     return (
         !filter ||
         (filter.date_from == null &&

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -37,10 +37,6 @@ import { insightDataLogic } from './insightDataLogic'
 import { insightDataLogicType } from './insightDataLogicType'
 import type { insightSceneLogicType } from './insightSceneLogicType'
 import { parseDraftQueryFromLocalStorage, parseDraftQueryFromURL } from './utils'
-import api from 'lib/api'
-import { checkLatestVersionsOnQuery } from '~/queries/utils'
-
-import { MaxContextInput, createMaxContextHelpers } from 'scenes/max/maxTypes'
 
 const NEW_INSIGHT = 'new' as const
 export type InsightId = InsightShortId | typeof NEW_INSIGHT | null

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -37,6 +37,11 @@ import { insightDataLogic } from './insightDataLogic'
 import { insightDataLogicType } from './insightDataLogicType'
 import type { insightSceneLogicType } from './insightSceneLogicType'
 import { parseDraftQueryFromLocalStorage, parseDraftQueryFromURL } from './utils'
+import api from 'lib/api'
+import { checkLatestVersionsOnQuery } from '~/queries/utils'
+
+import { MaxContextInput, createMaxContextHelpers } from 'scenes/max/maxTypes'
+import { SEARCH_PARAM_FILTERS_KEY, SEARCH_PARAM_VARIABLES_KEY } from 'scenes/dashboard/dashboardUtils'
 
 const NEW_INSIGHT = 'new' as const
 export type InsightId = InsightShortId | typeof NEW_INSIGHT | null
@@ -44,10 +49,10 @@ export type InsightId = InsightShortId | typeof NEW_INSIGHT | null
 export function isDashboardFilterEmpty(filter: DashboardFilter | null): boolean {
     return (
         !filter ||
-        (filter.date_from === null &&
-            filter.date_to === null &&
-            (filter.properties === null || (Array.isArray(filter.properties) && filter.properties.length === 0)) &&
-            filter.breakdown_filter === null)
+        (filter.date_from == null &&
+            filter.date_to == null &&
+            (filter.properties == null || (Array.isArray(filter.properties) && filter.properties.length === 0)) &&
+            filter.breakdown_filter == null)
     )
 }
 
@@ -360,8 +365,8 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
             }
 
             const dashboardName = dashboardLogic.findMounted({ id: dashboard })?.values.dashboard?.name
-            const filtersOverride = dashboardLogic.findMounted({ id: dashboard })?.values.temporaryFilters
-            const variablesOverride = searchParams['variables_override']
+            const filtersOverride = searchParams[SEARCH_PARAM_FILTERS_KEY]
+            const variablesOverride = searchParams[SEARCH_PARAM_VARIABLES_KEY]
 
             if (
                 insightId !== values.insightId ||

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -41,7 +41,6 @@ import api from 'lib/api'
 import { checkLatestVersionsOnQuery } from '~/queries/utils'
 
 import { MaxContextInput, createMaxContextHelpers } from 'scenes/max/maxTypes'
-import { parseURLFilters, SEARCH_PARAM_FILTERS_KEY, SEARCH_PARAM_VARIABLES_KEY } from 'scenes/dashboard/dashboardUtils'
 
 const NEW_INSIGHT = 'new' as const
 export type InsightId = InsightShortId | typeof NEW_INSIGHT | null

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -41,7 +41,7 @@ import api from 'lib/api'
 import { checkLatestVersionsOnQuery } from '~/queries/utils'
 
 import { MaxContextInput, createMaxContextHelpers } from 'scenes/max/maxTypes'
-import { SEARCH_PARAM_FILTERS_KEY, SEARCH_PARAM_VARIABLES_KEY } from 'scenes/dashboard/dashboardUtils'
+import { parseURLFilters, SEARCH_PARAM_FILTERS_KEY, SEARCH_PARAM_VARIABLES_KEY } from 'scenes/dashboard/dashboardUtils'
 
 const NEW_INSIGHT = 'new' as const
 export type InsightId = InsightShortId | typeof NEW_INSIGHT | null
@@ -365,8 +365,8 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
             }
 
             const dashboardName = dashboardLogic.findMounted({ id: dashboard })?.values.dashboard?.name
-            const filtersOverride = searchParams[SEARCH_PARAM_FILTERS_KEY]
-            const variablesOverride = searchParams[SEARCH_PARAM_VARIABLES_KEY]
+            const filtersOverride = searchParams['filters_override']
+            const variablesOverride = searchParams['variables_override']
 
             if (
                 insightId !== values.insightId ||

--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -500,13 +500,7 @@ class DashboardSerializer(DashboardBasicSerializer):
 
     def get_filters(self, dashboard: Dashboard) -> dict:
         request = self.context.get("request")
-        if request:
-            filters_override = filters_override_requested_by_client(request)
-
-            if filters_override is not None:
-                return filters_override
-
-        return dashboard.filters
+        return filters_override_requested_by_client(request, dashboard)
 
     def get_variables(self, dashboard: Dashboard) -> dict | None:
         request = self.context.get("request")

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -664,7 +664,7 @@ class InsightSerializer(InsightBasicSerializer):
 
         dashboard: Optional[Dashboard] = self.context.get("dashboard")
         request: Optional[Request] = self.context.get("request")
-        dashboard_filters_override = filters_override_requested_by_client(request) if request else None
+        dashboard_filters_override = filters_override_requested_by_client(request, dashboard) if request else None
         dashboard_variables_override = variables_override_requested_by_client(
             request, dashboard, list(self.context["insight_variables"])
         )
@@ -731,7 +731,7 @@ class InsightSerializer(InsightBasicSerializer):
             try:
                 refresh_requested = refresh_requested_by_client(self.context["request"])
                 execution_mode = execution_mode_from_refresh(refresh_requested)
-                filters_override = filters_override_requested_by_client(self.context["request"])
+                filters_override = filters_override_requested_by_client(self.context["request"], dashboard)
                 variables_override = variables_override_requested_by_client(
                     self.context["request"], dashboard, list(self.context["insight_variables"])
                 )

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -383,7 +383,7 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 execution_mode=ExecutionMode.EXTENDED_CACHE_CALCULATE_ASYNC_IF_STALE,
                 team=self.team,
                 user=mock.ANY,
-                filters_override=None,
+                filters_override={},
                 variables_override={},
             )
 
@@ -397,7 +397,7 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
                 team=self.team,
                 user=mock.ANY,
-                filters_override=None,
+                filters_override={},
                 variables_override={},
             )
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -1155,16 +1155,19 @@ def cache_requested_by_client(request: Request) -> bool | str:
     return _request_has_key_set("use_cache", request)
 
 
-def filters_override_requested_by_client(request: Request) -> Optional[dict]:
-    raw_filters = request.query_params.get("filters_override")
+def filters_override_requested_by_client(request: Request, dashboard: Optional["Dashboard"]) -> Optional[dict]:
+    raw_filters_override_param = request.query_params.get("filters_override")
 
-    if raw_filters is not None:
+    request_filters = {}
+    dashboard_filters = dashboard.filters if dashboard else {}
+
+    if raw_filters_override_param is not None:
         try:
-            return json.loads(raw_filters)
+            request_filters = json.loads(raw_filters_override_param)
         except Exception:
             raise serializers.ValidationError({"filters_override": "Invalid JSON passed in filters_override parameter"})
 
-    return None
+    return {**dashboard_filters, **request_filters}
 
 
 def variables_override_requested_by_client(

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -1155,7 +1155,7 @@ def cache_requested_by_client(request: Request) -> bool | str:
     return _request_has_key_set("use_cache", request)
 
 
-def filters_override_requested_by_client(request: Request, dashboard: Optional["Dashboard"]) -> Optional[dict]:
+def filters_override_requested_by_client(request: Request, dashboard: Optional["Dashboard"]) -> dict:
     raw_filters_override_param = request.query_params.get("filters_override")
 
     request_filters = {}

--- a/products/product_analytics/manifest.tsx
+++ b/products/product_analytics/manifest.tsx
@@ -6,7 +6,7 @@ import { AlertType } from 'lib/components/Alerts/types'
 import { FEATURE_FLAGS, INSIGHT_VISUAL_ORDER } from 'lib/constants'
 import { urls } from 'scenes/urls'
 
-import { HogQLFilters, HogQLVariable, Node, NodeKind } from '~/queries/schema/schema-general'
+import { DashboardFilter, HogQLFilters, HogQLVariable, Node, NodeKind } from '~/queries/schema/schema-general'
 import { isDataTableNode, isDataVisualizationNode, isHogQLQuery } from '~/queries/utils'
 
 import { DashboardType, InsightShortId, InsightType, ProductManifest } from '../../frontend/src/types'
@@ -51,10 +51,12 @@ export const manifest: ProductManifest = {
             id: InsightShortId,
             dashboardId?: number,
             variablesOverride?: Record<string, HogQLVariable>
+            filtersOverride?: DashboardFilter
         ): string => {
             const params = [
                 { param: 'dashboard', value: dashboardId },
                 { param: 'variables_override', value: variablesOverride },
+                { param: 'filters_override', value: filtersOverride }
             ]
                 .filter((n) => Boolean(n.value))
                 .map((n) => `${n.param}=${encodeURIComponent(JSON.stringify(n.value))}`)

--- a/products/product_analytics/manifest.tsx
+++ b/products/product_analytics/manifest.tsx
@@ -50,13 +50,13 @@ export const manifest: ProductManifest = {
         insightView: (
             id: InsightShortId,
             dashboardId?: number,
-            variablesOverride?: Record<string, HogQLVariable>
+            variablesOverride?: Record<string, HogQLVariable>,
             filtersOverride?: DashboardFilter
         ): string => {
             const params = [
                 { param: 'dashboard', value: dashboardId },
                 { param: 'variables_override', value: variablesOverride },
-                { param: 'filters_override', value: filtersOverride }
+                { param: 'filters_override', value: filtersOverride },
             ]
                 .filter((n) => Boolean(n.value))
                 .map((n) => `${n.param}=${encodeURIComponent(JSON.stringify(n.value))}`)


### PR DESCRIPTION
## Problem

Users want to override filters with query parameters. This is also more consistent with how dashboard variables are implemented (they allow overriding in the URL, but don't have a preview mode, yet).

Closes https://github.com/PostHog/posthog/issues/19069.

## Changes

- Allows overriding filters in query parameters.
- Adds a banner when loading a dashboard with filter overrides:
  <img width="1107" height="737" alt="Screenshot 2025-08-20 at 10 59 52" src="https://github.com/user-attachments/assets/8a82a1d5-6b0d-415d-90e4-2c2861429b3d" />
  This is how overrides look for insights:
  <img width="1093" height="471" alt="Screenshot 2025-08-20 at 11 00 23" src="https://github.com/user-attachments/assets/3c39d9c5-b534-46d4-8d2a-84aceb7b4838" />

## How did you test this code?

Tested setting filters with few tiles (auto preview) and many tiles (manual preview), as well as loading a dashboard with filters from the URL.