### PR TITLE
feat(experiments): add experiment holdout activity logging.

### DIFF
--- a/ee/clickhouse/views/experiment_holdouts.py
+++ b/ee/clickhouse/views/experiment_holdouts.py
@@ -58,7 +58,7 @@ class ExperimentHoldoutSerializer(serializers.ModelSerializer):
 
         instance = super().create(validated_data)
         instance.filters = self._get_filters_with_holdout_id(instance.id, instance.filters)
-        instance.save()
+        instance.save(skip_activity_log=True)  # Skip activity logging for filters update
         return instance
 
     def update(self, instance: ExperimentHoldout, validated_data):

--- a/ee/clickhouse/views/experiment_saved_metrics.py
+++ b/ee/clickhouse/views/experiment_saved_metrics.py
@@ -1,13 +1,16 @@
 import pydantic
 from django.db.models.functions import Lower
+from django.db.models.signals import pre_delete
+from django.dispatch import receiver
 from rest_framework import serializers, viewsets
 from rest_framework.exceptions import ValidationError
-
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.tagged_item import TaggedItemSerializerMixin
 from posthog.models.experiment import ExperimentSavedMetric, ExperimentToSavedMetric
+from posthog.models.signals import model_activity_signal
+from posthog.models.activity_logging.activity_log import Detail, log_activity, changes_between
 from posthog.schema import (
     ExperimentFunnelMetric,
     ExperimentFunnelsQuery,
@@ -102,3 +105,40 @@ class ExperimentSavedMetricViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
     scope_object = "experiment"
     queryset = ExperimentSavedMetric.objects.prefetch_related("created_by").order_by(Lower("name")).all()
     serializer_class = ExperimentSavedMetricSerializer
+
+
+@receiver(model_activity_signal, sender=ExperimentSavedMetric)
+def handle_experiment_saved_metric_change(
+    sender, scope, before_update, after_update, activity, was_impersonated=False, **kwargs
+):
+    log_activity(
+        organization_id=after_update.team.organization_id,
+        team_id=after_update.team_id,
+        user=after_update.created_by
+        if activity == "created"
+        else getattr(after_update, "last_modified_by", after_update.created_by),
+        was_impersonated=was_impersonated,
+        item_id=after_update.id,
+        scope="Experiment",  # log under Experiment scope so it appears in experiment activity log
+        activity=activity,
+        detail=Detail(
+            # need to use ExperimentSavedMetric here for field exclusions..
+            changes=changes_between("ExperimentSavedMetric", previous=before_update, current=after_update),
+            name=after_update.name,
+            type="shared_metric",
+        ),
+    )
+
+
+@receiver(pre_delete, sender=ExperimentSavedMetric)
+def handle_experiment_saved_metric_delete(sender, instance, **kwargs):
+    log_activity(
+        organization_id=instance.team.organization_id,
+        team_id=instance.team_id,
+        user=getattr(instance, "last_modified_by", instance.created_by),
+        was_impersonated=False,
+        item_id=instance.id,
+        scope="Experiment",  # log under Experiment scope so it appears in experiment activity log
+        activity="deleted",
+        detail=Detail(name=instance.name, type="shared_metric"),
+    )

--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -2,7 +2,6 @@ from enum import Enum
 from typing import Any, Literal
 
 from django.db.models import Q, QuerySet
-from django.db.models.signals import pre_delete
 from django.dispatch import receiver
 from rest_framework import serializers, viewsets
 from rest_framework.exceptions import ValidationError
@@ -705,41 +704,4 @@ def handle_experiment_change(sender, scope, before_update, after_update, activit
         detail=Detail(
             changes=changes_between(scope, previous=before_update, current=after_update), name=after_update.name
         ),
-    )
-
-
-@receiver(model_activity_signal, sender=ExperimentSavedMetric)
-def handle_experiment_saved_metric_change(
-    sender, scope, before_update, after_update, activity, was_impersonated=False, **kwargs
-):
-    log_activity(
-        organization_id=after_update.team.organization_id,
-        team_id=after_update.team_id,
-        user=after_update.created_by
-        if activity == "created"
-        else getattr(after_update, "last_modified_by", after_update.created_by),
-        was_impersonated=was_impersonated,
-        item_id=after_update.id,
-        scope="Experiment",  # log under Experiment scope so it appears in experiment activity log
-        activity=activity,
-        detail=Detail(
-            # need to use ExperimentSavedMetric here for field exclusions...
-            changes=changes_between("ExperimentSavedMetric", previous=before_update, current=after_update),
-            name=after_update.name,
-            type="shared_metric",
-        ),
-    )
-
-
-@receiver(pre_delete, sender=ExperimentSavedMetric)
-def handle_experiment_saved_metric_delete(sender, instance, **kwargs):
-    log_activity(
-        organization_id=instance.team.organization_id,
-        team_id=instance.team_id,
-        user=getattr(instance, "last_modified_by", instance.created_by),
-        was_impersonated=False,
-        item_id=instance.id,
-        scope="Experiment",  # log under Experiment scope so it appears in experiment activity log
-        activity="deleted",
-        detail=Detail(name=instance.name, type="shared_metric"),
     )

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -43,6 +43,7 @@ ActivityScope = Literal[
     "Dashboard",
     "Replay",
     "Experiment",
+    "ExperimentHoldout",
     "ExperimentSavedMetric",
     "Survey",
     "EarlyAccessFeature",

--- a/posthog/models/experiment.py
+++ b/posthog/models/experiment.py
@@ -112,7 +112,7 @@ class Experiment(FileSystemSyncMixin, ModelActivityMixin, RootTeamMixin, models.
         )
 
 
-class ExperimentHoldout(RootTeamMixin, models.Model):
+class ExperimentHoldout(ModelActivityMixin, RootTeamMixin, models.Model):
     name = models.CharField(max_length=400)
     description = models.CharField(max_length=400, null=True, blank=True)
     team = models.ForeignKey("Team", on_delete=models.CASCADE)

--- a/posthog/models/experiment.py
+++ b/posthog/models/experiment.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from django.db import models
 from django.utils import timezone
 
@@ -125,7 +125,7 @@ class ExperimentHoldout(ModelActivityMixin, RootTeamMixin, models.Model):
     created_at = models.DateTimeField(default=timezone.now)
     updated_at = models.DateTimeField(auto_now=True)
 
-    def save(self, skip_activity_log=False, *args, **kwargs):
+    def save(self, *args: Any, skip_activity_log: bool = False, **kwargs: Any) -> None:
         if skip_activity_log:
             # Bypass ModelActivityMixin.save() and call Model.save() directly
             super(ModelActivityMixin, self).save(*args, **kwargs)

--- a/posthog/models/experiment.py
+++ b/posthog/models/experiment.py
@@ -125,6 +125,13 @@ class ExperimentHoldout(ModelActivityMixin, RootTeamMixin, models.Model):
     created_at = models.DateTimeField(default=timezone.now)
     updated_at = models.DateTimeField(auto_now=True)
 
+    def save(self, skip_activity_log=False, *args, **kwargs):
+        if skip_activity_log:
+            # Bypass ModelActivityMixin.save() and call Model.save() directly
+            super(ModelActivityMixin, self).save(*args, **kwargs)
+        else:
+            super().save(*args, **kwargs)
+
 
 class ExperimentSavedMetric(ModelActivityMixin, RootTeamMixin, models.Model):
     name = models.CharField(max_length=400)


### PR DESCRIPTION
## Problem

We are not logging activity for the `Holdouts` entity.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Updates the `ExperimentHoldout` model to use the `ModelActivityMixin`, and the `ExperimentHoldout` model serializer to handle the model change signals. These changes are added to the activity log, but are not shown in the client because we don't have a valid description component.

We also refactored the saved metric signal handling into the saved metric code module.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/766280d1-92d6-4242-9f13-5c5096d349e9)
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
