### PR TITLE
feat(crm): Add usage metrics settings section

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -223,6 +223,7 @@ export const FEATURE_FLAGS = {
     SUPPORT_FORM_IN_ONBOARDING: 'support-form-in-onboarding', // owner: @joshsny #team-growth
     CRM_BLOCKING_QUERIES: 'crm-blocking-queries', // owner: @danielbachhuber #team-crm
     CRM_ITERATION_ONE: 'crm-iteration-one', // owner: @danielbachhuber #team-crm
+    CRM_USAGE_METRICS: 'crm-usage-metrics', // owner: @arthurdedeus #team-crm
     TOGGLE_PROPERTY_ARRAYS: 'toggle-property-arrays', // owner: @arthurdedeus #team-crm
     RECORDINGS_SIMILAR_RECORDINGS: 'recordings-similar-recordings', // owner: @veryayskiy #team-replay
     RECORDINGS_BLOBBY_V2_REPLAY: 'recordings-blobby-v2-replay', // owner: @pl #team-cdp

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -221,8 +221,7 @@ export const FEATURE_FLAGS = {
     WEB_ANALYTICS_PAGE_REPORTS: 'web-analytics-page-reports', // owner: @lricoy #team-web-analytics
     REVENUE_ANALYTICS: 'revenue-analytics-beta', // owner: @rafaeelaudibert #team-revenue-analytics
     SUPPORT_FORM_IN_ONBOARDING: 'support-form-in-onboarding', // owner: @joshsny #team-growth
-    CRM_BLOCKING_QUERIES: 'crm-blocking-queries', // owner: @danielbachhuber #team-crm
-    CRM_ITERATION_ONE: 'crm-iteration-one', // owner: @danielbachhuber #team-crm
+    CRM_ITERATION_ONE: 'crm-iteration-one', // owner: @arthurdedeus #team-crm
     CRM_USAGE_METRICS: 'crm-usage-metrics', // owner: @arthurdedeus #team-crm
     TOGGLE_PROPERTY_ARRAYS: 'toggle-property-arrays', // owner: @arthurdedeus #team-crm
     RECORDINGS_SIMILAR_RECORDINGS: 'recordings-similar-recordings', // owner: @veryayskiy #team-replay

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -91,6 +91,7 @@ import { UpdateEmailPreferences } from './user/UpdateEmailPreferences'
 import { UserDangerZone } from './user/UserDangerZone'
 import { UserDetails } from './user/UserDetails'
 import { FeaturePreviewsSettings } from './environment/FeaturePreviewsSettings'
+import { CRMUsageMetricsConfig } from './environment/CRMUsageMetricsConfig'
 
 export const SETTINGS_MAP: SettingSection[] = [
     // ENVIRONMENT
@@ -345,6 +346,12 @@ export const SETTINGS_MAP: SettingSection[] = [
                 id: 'group-analytics',
                 title: 'Group analytics',
                 component: <GroupAnalyticsConfig />,
+            },
+            {
+                id: 'crm-usage-metrics',
+                title: 'Usage metrics',
+                component: <CRMUsageMetricsConfig />,
+                flag: 'CRM_USAGE_METRICS',
             },
         ],
     },

--- a/frontend/src/scenes/settings/environment/CRMUsageMetricsConfig.tsx
+++ b/frontend/src/scenes/settings/environment/CRMUsageMetricsConfig.tsx
@@ -1,0 +1,235 @@
+import { IconEllipsis, IconPlus } from '@posthog/icons'
+import {
+    LemonButton,
+    LemonDialog,
+    LemonInput,
+    LemonSelect,
+    LemonTable,
+    LemonTableColumns,
+    LemonMenu,
+} from '@posthog/lemon-ui'
+import { Form } from 'kea-forms'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { LemonField } from 'lib/lemon-ui/LemonField'
+import { ActionFilter } from 'scenes/insights/filters/ActionFilter/ActionFilter'
+import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
+import { EntityTypes } from '~/types'
+import { crmUsageMetricsConfigLogic, UsageMetric } from './crmUsageMetricsConfigLogic'
+import { useActions, useValues } from 'kea'
+
+function CRMUsageMetricsTable(): JSX.Element {
+    const { usageMetrics, usageMetricsLoading } = useValues(crmUsageMetricsConfigLogic)
+    const { removeUsageMetric } = useActions(crmUsageMetricsConfigLogic)
+
+    const columns: LemonTableColumns<UsageMetric> = [
+        {
+            title: 'Name',
+            key: 'name',
+            dataIndex: 'name',
+        },
+        {
+            title: 'Format',
+            key: 'format',
+            dataIndex: 'format',
+        },
+        {
+            title: 'Interval',
+            key: 'interval',
+            dataIndex: 'interval',
+        },
+        {
+            title: 'Display',
+            key: 'display',
+            dataIndex: 'display',
+        },
+        {
+            title: '',
+            key: 'actions',
+            width: 24,
+            render: function Render(_, metric) {
+                return (
+                    <LemonMenu
+                        items={[
+                            {
+                                label: 'Edit',
+                                onClick: () => {
+                                    LemonDialog.open({
+                                        title: 'Edit usage metric',
+                                        description: (
+                                            <div>
+                                                <CRMUsageMetricsForm metric={metric} />
+                                            </div>
+                                        ),
+                                        primaryButton: {
+                                            htmlType: 'submit',
+                                            children: 'Save',
+                                            'data-attr': 'update-crm-usage-metric',
+                                            form: 'usageMetric',
+                                        },
+                                        secondaryButton: {
+                                            htmlType: 'button',
+                                            children: 'Cancel',
+                                            'data-attr': 'cancel-update-crm-usage-metric',
+                                        },
+                                    })
+                                },
+                            },
+                            {
+                                label: 'Delete',
+                                status: 'danger',
+                                onClick: () => {
+                                    LemonDialog.open({
+                                        title: 'Delete usage metric',
+                                        description: `Are you sure you want to delete "${metric.name}"? This action cannot be undone.`,
+                                        primaryButton: {
+                                            children: 'Delete',
+                                            status: 'danger',
+                                            onClick: () => removeUsageMetric(metric.id),
+                                        },
+                                        secondaryButton: {
+                                            children: 'Cancel',
+                                        },
+                                    })
+                                },
+                            },
+                        ]}
+                    >
+                        <LemonButton size="small" icon={<IconEllipsis />} />
+                    </LemonMenu>
+                )
+            },
+        },
+    ]
+
+    return <LemonTable columns={columns} dataSource={usageMetrics} loading={usageMetricsLoading} />
+}
+
+interface CRMUsageMetricsFormProps {
+    metric?: UsageMetric
+}
+
+function CRMUsageMetricsForm({ metric }: CRMUsageMetricsFormProps): JSX.Element {
+    const { resetUsageMetric, setIsEditing, setUsageMetricValues } = useActions(crmUsageMetricsConfigLogic)
+
+    if (metric) {
+        setUsageMetricValues(metric)
+    }
+
+    const handleCancelForm = (): void => {
+        resetUsageMetric()
+        setIsEditing(false)
+    }
+
+    return (
+        <Form id="usageMetric" logic={crmUsageMetricsConfigLogic} formKey="usageMetric" enableFormOnSubmit>
+            <div className="flex flex-col gap-2">
+                <div className="grid grid-cols-2 gap-2">
+                    <LemonField name="name" label="Name" help="This will be the title of the column in group list">
+                        <LemonInput placeholder="Events" />
+                    </LemonField>
+
+                    <LemonField name="interval" label="Interval">
+                        <LemonSelect
+                            options={[
+                                { value: '7d', label: '7d' },
+                                { value: '30d', label: '30d' },
+                                { value: '90d', label: '90d' },
+                            ]}
+                        />
+                    </LemonField>
+
+                    <LemonField name="format" label="Format">
+                        <LemonSelect
+                            options={[
+                                { value: 'currency', label: 'Currency' },
+                                { value: 'numeric', label: 'Numeric' },
+                            ]}
+                        />
+                    </LemonField>
+
+                    <LemonField name="display" label="Display">
+                        <LemonSelect
+                            options={[
+                                { value: 'number', label: 'Number' },
+                                { value: 'sparkline', label: 'Sparkline' },
+                            ]}
+                        />
+                    </LemonField>
+                </div>
+
+                <div className="grid grid-cols-1 gap-2">
+                    <LemonField
+                        name="events"
+                        label="Match events"
+                        help="The usage metric will take into account events matching any of the above."
+                    >
+                        <ActionFilter
+                            actionsTaxonomicGroupTypes={[TaxonomicFilterGroupType.Events]}
+                            addFilterDefaultOptions={{
+                                id: '$pageview',
+                                name: '$pageview',
+                                type: EntityTypes.EVENTS,
+                            }}
+                            bordered
+                            buttonCopy="Add event matcher"
+                            filters={{}}
+                            hideDuplicate
+                            hideRename
+                            mathAvailability={MathAvailability.None}
+                            propertiesTaxonomicGroupTypes={[
+                                TaxonomicFilterGroupType.EventProperties,
+                                TaxonomicFilterGroupType.EventMetadata,
+                            ]}
+                            propertyFiltersPopover
+                            setFilters={() => {}}
+                            showNestedArrow={false}
+                            typeKey="crm-usage-metrics"
+                        />
+                    </LemonField>
+                </div>
+                <div>
+                    {!metric && (
+                        <div className="flex gap-2 mt-2">
+                            <LemonButton
+                                type="primary"
+                                data-attr="save-crm-usage-metric"
+                                htmlType="submit"
+                                form="usageMetric"
+                            >
+                                Save
+                            </LemonButton>
+                            <LemonButton
+                                type="secondary"
+                                data-attr="cancel-crm-usage-metric"
+                                onClick={handleCancelForm}
+                            >
+                                Cancel
+                            </LemonButton>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </Form>
+    )
+}
+
+export function CRMUsageMetricsConfig(): JSX.Element {
+    const { isEditing } = useValues(crmUsageMetricsConfigLogic)
+    const { setIsEditing, resetUsageMetric } = useActions(crmUsageMetricsConfigLogic)
+
+    const handleAddMetric = (): void => {
+        resetUsageMetric()
+        setIsEditing(true)
+    }
+
+    return (
+        <div className="flex flex-col gap-2">
+            {!isEditing && (
+                <LemonButton onClick={handleAddMetric} icon={<IconPlus />}>
+                    Add metric
+                </LemonButton>
+            )}
+            {isEditing ? <CRMUsageMetricsForm /> : <CRMUsageMetricsTable />}
+        </div>
+    )
+}

--- a/frontend/src/scenes/settings/environment/crmUsageMetricsConfigLogic.ts
+++ b/frontend/src/scenes/settings/environment/crmUsageMetricsConfigLogic.ts
@@ -1,0 +1,127 @@
+import { actions, afterMount, connect, kea, listeners, path, reducers } from 'kea'
+import { forms } from 'kea-forms'
+import { groupsModel } from '~/models/groupsModel'
+
+import type { crmUsageMetricsConfigLogicType } from './crmUsageMetricsConfigLogicType'
+import { loaders } from 'kea-loaders'
+
+export interface UsageMetric {
+    id: string
+    name: string
+    format: string
+    interval: string
+    display: string
+    events: string[]
+}
+
+export interface NewUsageMetricFormData {
+    id?: string
+    name: string
+    format: string
+    interval: string
+    display: string
+    events: string[]
+}
+
+const NEW_USAGE_METRIC = {
+    format: 'numeric',
+    interval: '7d',
+    display: 'number',
+} as NewUsageMetricFormData
+
+export const crmUsageMetricsConfigLogic = kea<crmUsageMetricsConfigLogicType>([
+    path(['scenes', 'settings', 'environment', 'crmUsageMetricsConfigLogic']),
+    connect(() => ({
+        values: [groupsModel, ['groupTypes', 'groupTypesLoading']],
+    })),
+
+    actions(() => ({
+        setIsEditing: (isEditing: boolean) => ({ isEditing }),
+        addUsageMetric: (metric: NewUsageMetricFormData) => ({ metric }),
+        updateUsageMetric: (metric: NewUsageMetricFormData) => ({ metric }),
+        removeUsageMetric: (id: string) => ({ id }),
+    })),
+
+    reducers(() => ({
+        isEditing: [false, { setIsEditing: (_, { isEditing }) => isEditing }],
+    })),
+
+    forms(({ actions }) => ({
+        usageMetric: {
+            defaults: NEW_USAGE_METRIC,
+            errors: ({ name }) => ({
+                name: !name ? 'Name is required' : undefined,
+            }),
+            submit: (formData) => {
+                if (formData?.id) {
+                    actions.updateUsageMetric(formData)
+                } else {
+                    actions.addUsageMetric(formData)
+                }
+            },
+        },
+    })),
+
+    listeners(({ actions }) => ({
+        submitUsageMetricSuccess: () => {
+            actions.setIsEditing(false)
+            actions.resetUsageMetric()
+        },
+    })),
+
+    afterMount(({ actions }) => actions.loadUsageMetrics()),
+
+    loaders(({ values }) => ({
+        usageMetrics: [
+            [] as UsageMetric[],
+            {
+                loadUsageMetrics: async () => {
+                    // Mock API delay
+                    await new Promise((resolve) => setTimeout(resolve, 500))
+                    return [
+                        {
+                            id: '1',
+                            name: 'Events',
+                            format: 'numeric',
+                            display: 'number',
+                            interval: '7d',
+                            events: [],
+                        },
+                        {
+                            id: '2',
+                            name: 'Replay',
+                            format: 'numeric',
+                            display: 'sparkline',
+                            interval: '7d',
+                            events: [],
+                        },
+                    ] as UsageMetric[]
+                },
+                addUsageMetric: async ({ metric }) => {
+                    // Mock API delay
+                    await new Promise((resolve) => setTimeout(resolve, 300))
+                    const largestId = values.usageMetrics.reduce((max, m) => Math.max(max, parseInt(m.id, 10)), 0)
+                    const newId = (largestId + 1).toString() || '1'
+                    const newMetric = {
+                        id: newId,
+                        ...metric,
+                    }
+                    return [...values.usageMetrics, newMetric]
+                },
+                updateUsageMetric: async ({ metric }) => {
+                    // Mock API delay
+                    await new Promise((resolve) => setTimeout(resolve, 300))
+                    const updatedMetrics = values.usageMetrics.map((oldMetric) =>
+                        oldMetric.id === metric.id ? { ...oldMetric, ...metric } : oldMetric
+                    )
+                    return updatedMetrics
+                },
+                removeUsageMetric: async ({ id }) => {
+                    // Mock API delay
+                    await new Promise((resolve) => setTimeout(resolve, 300))
+                    return values.usageMetrics.filter((metric) => metric.id !== id)
+                },
+            },
+        ],
+    })),
+])

--- a/frontend/src/scenes/settings/types.ts
+++ b/frontend/src/scenes/settings/types.ts
@@ -70,6 +70,7 @@ export type SettingId =
     | 'internal-user-filtering'
     | 'data-theme'
     | 'correlation-analysis'
+    | 'crm-usage-metrics'
     | 'person-display-name'
     | 'path-cleaning'
     | 'datacapture'


### PR DESCRIPTION
## Problem
Building the UI to configure usage metrics. For now, it lives under CRM settings and is feature flagged by `crm-usage-metrics`.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Closes https://github.com/PostHog/posthog/issues/36446
## Changes
_New UI is hidden behind `crm-usage-metrics` feature flag_
- Create new settings section + logic to handle usage metrics CRUD
- Each group type has a different set of usage metrics
- `Events` part is not done yet. Need to figure out how we'll store this information (tbd after behavioral cohorts implements this)
- Currently showing dummy data, mocking API requests for CRUD operations
- Also cleaned up a stale crm feature flag

### Sidebar view
<img width="1604" height="951" alt="image" src="https://github.com/user-attachments/assets/930a63eb-5502-4ef8-9b7a-3ebc2775219e" />

### Fullscreen view
<img width="1604" height="951" alt="image" src="https://github.com/user-attachments/assets/643082d6-42fe-41f8-93fa-455a36cfa3cc" />

### Add metric form
<img width="1604" height="951" alt="image" src="https://github.com/user-attachments/assets/0e93c787-3331-4678-9f5f-e48bf28d4c39" />

<img width="1604" height="951" alt="image" src="https://github.com/user-attachments/assets/0c2b0640-debf-4fc9-a20b-74d79ac3f20f" />


### Ellipsis menu
<img width="1604" height="951" alt="image" src="https://github.com/user-attachments/assets/8d9f87b6-c3ca-40d2-ba89-3734c684afcb" />

### Table empty state
<img width="1604" height="951" alt="image" src="https://github.com/user-attachments/assets/f3703d96-6b20-46c7-aec7-e12c57bc69c7" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Poking around in the UI. Intend to add unit tests when integrating with the backend.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
