### PR TITLE
feat(crm): Improve group saved views UX

### DIFF
--- a/frontend/src/scenes/groups/Groups.tsx
+++ b/frontend/src/scenes/groups/Groups.tsx
@@ -122,6 +122,11 @@ export function Groups({ groupTypeIndex }: { groupTypeIndex: GroupTypeIndex }): 
                             placeholder="Enter view name"
                             value={groupViewName}
                             onChange={setGroupViewName}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter' && groupViewName.trim()) {
+                                    saveGroupView(window.location.href, groupTypeIndex)
+                                }
+                            }}
                             autoFocus
                         />
                     </div>

--- a/frontend/src/scenes/groups/groupViewLogic.ts
+++ b/frontend/src/scenes/groups/groupViewLogic.ts
@@ -3,6 +3,7 @@ import { actions, connect, kea, listeners, path, reducers } from 'kea'
 import posthog from 'posthog-js'
 import type { groupViewLogicType } from './groupViewLogicType'
 import { projectTreeDataLogic } from '~/layout/panel-layout/ProjectTree/projectTreeDataLogic'
+import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { FileSystemEntry } from '~/queries/schema/schema-general'
 import { GroupTypeIndex } from '~/types'
@@ -10,7 +11,14 @@ import { GroupTypeIndex } from '~/types'
 export const groupViewLogic = kea<groupViewLogicType>([
     path(['scenes', 'groups', 'groupView']),
     connect(() => ({
-        actions: [projectTreeDataLogic, ['addShortcutItem'], eventUsageLogic, ['reportGroupViewSaved']],
+        actions: [
+            projectTreeDataLogic,
+            ['addShortcutItem'],
+            eventUsageLogic,
+            ['reportGroupViewSaved'],
+            panelLayoutLogic,
+            ['setActivePanelIdentifier', 'showLayoutPanel', 'showLayoutNavBar'],
+        ],
     })),
     actions(() => ({
         setSaveGroupViewModalOpen: (isOpen: boolean) => ({ isOpen }),
@@ -53,6 +61,12 @@ export const groupViewLogic = kea<groupViewLogicType>([
                 } as FileSystemEntry)
                 actions.reportGroupViewSaved(groupTypeIndex, values.groupViewName)
                 actions.setSaveGroupViewModalOpen(false)
+
+                // Open the People tab in the left sidebar to show where the saved view is located
+                actions.setActivePanelIdentifier('People')
+                actions.showLayoutPanel(true)
+                actions.showLayoutNavBar(true)
+
                 lemonToast.success('Group view saved')
             } catch (error) {
                 posthog.captureException(error)

--- a/frontend/src/scenes/groups/groupsListLogic.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.ts
@@ -18,10 +18,6 @@ export interface GroupsListLogicProps {
 
 const INITIAL_SORTING = [] as string[]
 const INITIAL_GROUPS_FILTER = [] as GroupPropertyFilter[]
-const persistConfig = (groupTypeIndex: GroupTypeIndex): { persist: boolean; prefix: string } => ({
-    persist: true,
-    prefix: `${window.POSTHOG_APP_CONTEXT?.current_team?.id}__group_${groupTypeIndex}__`,
-})
 
 export const groupsListLogic = kea<groupsListLogicType>([
     props({} as GroupsListLogicProps),
@@ -42,7 +38,7 @@ export const groupsListLogic = kea<groupsListLogicType>([
         setQueryWasModified: (queryWasModified: boolean) => ({ queryWasModified }),
         setGroupFilters: (filters: GroupPropertyFilter[]) => ({ filters }),
     })),
-    reducers(({ props }) => ({
+    reducers(() => ({
         query: [
             (_: any, props: GroupsListLogicProps) =>
                 ({
@@ -61,7 +57,6 @@ export const groupsListLogic = kea<groupsListLogicType>([
         ],
         groupFilters: [
             INITIAL_GROUPS_FILTER,
-            persistConfig(props.groupTypeIndex),
             {
                 setGroupFilters: (_, { filters }) => filters,
                 setQuery: (state, { query }) => {
@@ -74,7 +69,6 @@ export const groupsListLogic = kea<groupsListLogicType>([
         ],
         sorting: [
             INITIAL_SORTING,
-            persistConfig(props.groupTypeIndex),
             {
                 setQuery: (state, { query }) => {
                     if (query.source.kind === NodeKind.GroupsQuery && query.source.orderBy !== undefined) {


### PR DESCRIPTION
## Problem
Saved views UX was a bit weird. LocalStorage persistence was making it look like it was stuck on a given view, where in reality it was getting the filters from storage.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Related to https://github.com/PostHog/posthog/issues/36460
## Changes
- Remove localStorage persistence of filters and ordering
- Open sidebar when saving a new view, showing where they are
- Save view when pressing enter while typing view name
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
manually
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
