### PR TITLE
fix: update billing limits check

### DIFF
--- a/frontend/src/scenes/billing/billingProductLogic.ts
+++ b/frontend/src/scenes/billing/billingProductLogic.ts
@@ -13,12 +13,11 @@ import {
     BillingPlanType,
     BillingProductV2AddonType,
     BillingProductV2Type,
-    BillingTierType,
     BillingType,
     SurveyEventName,
 } from '~/types'
 
-import { convertAmountToUsage, isAddonVisible } from './billing-utils'
+import { isAddonVisible } from './billing-utils'
 import { billingLogic } from './billingLogic'
 import type { billingProductLogicType } from './billingProductLogicType'
 import { BillingGaugeItemKind, BillingGaugeItemType } from './types'
@@ -491,7 +490,7 @@ export const billingProductLogic = kea<billingProductLogicType>([
             }
         },
     })),
-    forms(({ actions, props, values }) => ({
+    forms(({ actions, props }) => ({
         billingLimitInput: {
             errors: ({ input }) => ({
                 input:
@@ -502,22 +501,7 @@ export const billingProductLogic = kea<billingProductLogicType>([
                         : 'Please enter a whole number',
             }),
             submit: async ({ input }) => {
-                const addonTiers =
-                    'addons' in props.product
-                        ? props.product.addons
-                              ?.filter((addon: BillingProductV2AddonType) => addon.subscribed)
-                              ?.map((addon: BillingProductV2AddonType) => addon.tiers)
-                        : []
-
-                const productAndAddonTiers: BillingTierType[][] = [props.product.tiers, ...addonTiers].filter(
-                    Boolean
-                ) as BillingTierType[][]
-
-                const newAmountAsUsage = props.product.tiers
-                    ? convertAmountToUsage(`${input}`, productAndAddonTiers, values.billing?.discount_percent)
-                    : 0
-
-                if (props.product.current_usage && newAmountAsUsage < props.product.current_usage) {
+                if (props.product.current_amount_usd && input < props.product.current_amount_usd) {
                     LemonDialog.open({
                         maxWidth: '600px',
                         title: 'Billing limit warning',
@@ -538,7 +522,7 @@ export const billingProductLogic = kea<billingProductLogicType>([
                     return
                 }
 
-                if (props.product.projected_usage && newAmountAsUsage < props.product.projected_usage) {
+                if (props.product.projected_amount_usd && input < props.product.projected_amount_usd) {
                     LemonDialog.open({
                         maxWidth: '600px',
                         title: 'Billing limit warning',


### PR DESCRIPTION
## Problem

Customer complained he received an unexpected warning when trying to update the Billing Limits. He got the "The billing limit you set is below your current usage", which was not the case.

I was able to reproduce it locally. The issue was because we converted the new limit (unit: USD) to a volume, and then check if this new volume is higher than current usage. Converting from USD to volume is tricky in products with add-ons (since there could be many combinations of usage that convers to the same amount of USD, ie, the function is not bijective).

## Changes

Since the Billing API provides the current_amount in USD and the projected_amount in USD, we can use them to make the check/comparison directly, without converting any units.

## How did you test this code?

Locally, reproducing different scenarios on my local instance of PostHog with my local Billing setup.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
