### PR TITLE
feat(crm): Display complex structures with json viewer

### DIFF
--- a/frontend/src/lib/components/PropertiesTable/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable/PropertiesTable.tsx
@@ -29,6 +29,8 @@ import { PROPERTY_FILTER_TYPE_TO_TAXONOMIC_FILTER_GROUP_TYPE } from '../Property
 import { PropertyKeyInfo } from '../PropertyKeyInfo'
 import { TaxonomicFilterGroupType } from '../TaxonomicFilter/types'
 import { JSONViewer } from '../JSONViewer'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 
 type HandledType = 'string' | 'number' | 'bigint' | 'boolean' | 'undefined' | 'null'
 type Type = HandledType | 'symbol' | 'object' | 'function'
@@ -225,6 +227,7 @@ export function PropertiesTable({
     const { hidePostHogPropertiesInTable, hideNullValues } = useValues(userPreferencesLogic)
     const { setHidePostHogPropertiesInTable, setHideNullValues } = useActions(userPreferencesLogic)
     const { isCloudOrDev } = useValues(preflightLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     const objectProperties = useMemo(() => {
         if (!properties || Array.isArray(properties) || !isObject(properties)) {
@@ -338,10 +341,25 @@ export function PropertiesTable({
                                     const arrayItem = item[1]
                                     const isComplexStructure =
                                         Array.isArray(arrayItem) || (isObject(arrayItem) && arrayItem !== null)
+                                    if (!featureFlags[FEATURE_FLAGS.TOGGLE_PROPERTY_ARRAYS]) {
+                                        return (
+                                            <PropertiesTable
+                                                type={type}
+                                                properties={item[1]}
+                                                nestingLevel={nestingLevel + 1}
+                                                useDetectedPropertyType={
+                                                    ['$set', '$set_once'].some((s) => s === rootKey)
+                                                        ? false
+                                                        : useDetectedPropertyType
+                                                }
+                                            />
+                                        )
+                                    }
 
                                     if (isComplexStructure) {
                                         return <JSONViewer src={arrayItem} collapsed={true} />
                                     }
+
                                     return (
                                         <ValueDisplay
                                             type={type}
@@ -397,7 +415,7 @@ export function PropertiesTable({
                 render: function Value(_, item: any): JSX.Element {
                     const isComplexStructure = Array.isArray(item[1]) || (isObject(item[1]) && item[1] !== null)
 
-                    if (isComplexStructure) {
+                    if (isComplexStructure && featureFlags[FEATURE_FLAGS.TOGGLE_PROPERTY_ARRAYS]) {
                         return <JSONViewer src={item[1]} collapsed={true} />
                     }
                     return (

--- a/frontend/src/lib/components/PropertiesTable/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable/PropertiesTable.tsx
@@ -28,6 +28,7 @@ import { CopyToClipboardInline } from '../CopyToClipboard'
 import { PROPERTY_FILTER_TYPE_TO_TAXONOMIC_FILTER_GROUP_TYPE } from '../PropertyFilters/utils'
 import { PropertyKeyInfo } from '../PropertyKeyInfo'
 import { TaxonomicFilterGroupType } from '../TaxonomicFilter/types'
+import { JSONViewer } from '../JSONViewer'
 
 type HandledType = 'string' | 'number' | 'bigint' | 'boolean' | 'undefined' | 'null'
 type Type = HandledType | 'symbol' | 'object' | 'function'
@@ -334,10 +335,17 @@ export function PropertiesTable({
                                 ),
                                 fullWidth: true,
                                 render: function Value(_, item: any): JSX.Element {
+                                    const arrayItem = item[1]
+                                    const isComplexStructure =
+                                        Array.isArray(arrayItem) || (isObject(arrayItem) && arrayItem !== null)
+
+                                    if (isComplexStructure) {
+                                        return <JSONViewer src={arrayItem} collapsed={true} />
+                                    }
                                     return (
-                                        <PropertiesTable
+                                        <ValueDisplay
                                             type={type}
-                                            properties={item[1]}
+                                            value={arrayItem}
                                             nestingLevel={nestingLevel + 1}
                                             useDetectedPropertyType={
                                                 ['$set', '$set_once'].some((s) => s === rootKey)
@@ -387,6 +395,11 @@ export function PropertiesTable({
                 key: 'value',
                 title: 'Value',
                 render: function Value(_, item: any): JSX.Element {
+                    const isComplexStructure = Array.isArray(item[1]) || (isObject(item[1]) && item[1] !== null)
+
+                    if (isComplexStructure) {
+                        return <JSONViewer src={item[1]} collapsed={true} />
+                    }
                     return (
                         <PropertiesTable
                             type={type}

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -222,6 +222,7 @@ export const FEATURE_FLAGS = {
     SUPPORT_FORM_IN_ONBOARDING: 'support-form-in-onboarding', // owner: @joshsny #team-growth
     CRM_BLOCKING_QUERIES: 'crm-blocking-queries', // owner: @danielbachhuber #team-crm
     CRM_ITERATION_ONE: 'crm-iteration-one', // owner: @danielbachhuber #team-crm
+    TOGGLE_PROPERTY_ARRAYS: 'toggle-property-arrays', // owner: @arthurdedeus #team-crm
     RECORDINGS_SIMILAR_RECORDINGS: 'recordings-similar-recordings', // owner: @veryayskiy #team-replay
     RECORDINGS_BLOBBY_V2_REPLAY: 'recordings-blobby-v2-replay', // owner: @pl #team-cdp
     RECORDINGS_BLOBBY_V2_LTS_REPLAY: 'use-blob-v2-lts', // owner: @pauldambra #team-replay


### PR DESCRIPTION
## Problem
When groups have json or array properties, the properties tab becomes difficult to use, having to scroll down a lot to navigate. This PR addresses that by rendering json/array objects with `JSONViewer`.


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
_All changes are feature flagged by `crm-iteration-one` flag_
- Implement `JSONViewer` component to render complex objects in `PropertiesTable`
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
### Before
<img width="1560" height="1024" alt="image" src="https://github.com/user-attachments/assets/dbdf36f8-e5e1-45b0-8509-e2427bbc0af0" />

### After
<img width="1604" height="1068" alt="image" src="https://github.com/user-attachments/assets/238b7122-452d-4f2b-a8c3-67b6793721c6" />
<img width="1604" height="1068" alt="image" src="https://github.com/user-attachments/assets/a76893f5-8b64-481a-af89-4ae537a2c6ce" />

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
