### PR TITLE
refactor: Extract `ExternalDataSourceType` class

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -7299,19 +7299,8 @@
                     "type": "array"
                 },
                 "context": {
-                    "additionalProperties": false,
-                    "description": "Context for the table, used by components like ColumnConfigurator",
-                    "properties": {
-                        "eventDefinitionId": {
-                            "type": "string"
-                        },
-                        "type": {
-                            "enum": ["event_definition", "team_columns"],
-                            "type": "string"
-                        }
-                    },
-                    "required": ["type"],
-                    "type": "object"
+                    "$ref": "#/definitions/DataTableNodeViewPropsContext",
+                    "description": "Context for the table, used by components like ColumnConfigurator"
                 },
                 "embedded": {
                     "description": "Uses the embedded version of LemonTable",
@@ -8773,6 +8762,23 @@
             "required": ["kind", "source"],
             "type": "object"
         },
+        "DataTableNodeViewPropsContext": {
+            "additionalProperties": false,
+            "properties": {
+                "eventDefinitionId": {
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/DataTableNodeViewPropsContextType"
+                }
+            },
+            "required": ["type"],
+            "type": "object"
+        },
+        "DataTableNodeViewPropsContextType": {
+            "enum": ["event_definition", "team_columns"],
+            "type": "string"
+        },
         "DataVisualizationNode": {
             "additionalProperties": false,
             "properties": {
@@ -9342,12 +9348,15 @@
                     "type": "number"
                 },
                 "type": {
-                    "enum": ["posthog", "data_warehouse", "view", "batch_export", "materialized_view", "managed_view"],
-                    "type": "string"
+                    "$ref": "#/definitions/DatabaseSchemaTableType"
                 }
             },
             "required": ["type", "id", "name", "fields"],
             "type": "object"
+        },
+        "DatabaseSchemaTableType": {
+            "enum": ["posthog", "data_warehouse", "view", "batch_export", "materialized_view", "managed_view"],
+            "type": "string"
         },
         "DatabaseSchemaViewTable": {
             "additionalProperties": false,
@@ -9823,12 +9832,15 @@
                     ]
                 },
                 "type": {
-                    "enum": ["user", "role"],
-                    "type": "string"
+                    "$ref": "#/definitions/ErrorTrackingIssueAssigneeType"
                 }
             },
             "required": ["type", "id"],
             "type": "object"
+        },
+        "ErrorTrackingIssueAssigneeType": {
+            "enum": ["user", "role"],
+            "type": "string"
         },
         "ErrorTrackingIssueCorrelationQuery": {
             "additionalProperties": false,
@@ -21870,19 +21882,8 @@
                     "type": "boolean"
                 },
                 "context": {
-                    "additionalProperties": false,
-                    "description": "Context for the table, used by components like ColumnConfigurator",
-                    "properties": {
-                        "eventDefinitionId": {
-                            "type": "string"
-                        },
-                        "type": {
-                            "enum": ["event_definition", "team_columns"],
-                            "type": "string"
-                        }
-                    },
-                    "required": ["type"],
-                    "type": "object"
+                    "$ref": "#/definitions/DataTableNodeViewPropsContext",
+                    "description": "Context for the table, used by components like ColumnConfigurator"
                 },
                 "embedded": {
                     "description": "Query is embedded inside another bordered component",
@@ -22693,12 +22694,15 @@
                     "type": "boolean"
                 },
                 "type": {
-                    "enum": ["text", "email", "search", "url", "password", "time", "number", "textarea"],
-                    "type": "string"
+                    "$ref": "#/definitions/SourceFieldInputConfigType"
                 }
             },
             "required": ["type", "name", "label", "required", "placeholder"],
             "type": "object"
+        },
+        "SourceFieldInputConfigType": {
+            "enum": ["text", "email", "search", "url", "password", "time", "number", "textarea"],
+            "type": "string"
         },
         "SourceFieldOauthConfig": {
             "additionalProperties": false,
@@ -22744,8 +22748,7 @@
             "additionalProperties": false,
             "properties": {
                 "converter": {
-                    "enum": ["str_to_int", "str_to_bool", "str_to_optional_int"],
-                    "type": "string"
+                    "$ref": "#/definitions/SourceFieldSelectConfigConverter"
                 },
                 "defaultValue": {
                     "type": "string"
@@ -22788,6 +22791,10 @@
             },
             "required": ["type", "name", "label", "required", "defaultValue", "options"],
             "type": "object"
+        },
+        "SourceFieldSelectConfigConverter": {
+            "enum": ["str_to_int", "str_to_bool", "str_to_optional_int"],
+            "type": "string"
         },
         "SourceFieldSwitchGroupConfig": {
             "additionalProperties": false,
@@ -23348,6 +23355,10 @@
             ],
             "type": "string"
         },
+        "SurveyQuestionBranchingType": {
+            "enum": ["next_question", "end", "response_based", "specific_question"],
+            "type": "string"
+        },
         "SurveyQuestionDescriptionContentType": {
             "enum": ["html", "text"],
             "type": "string"
@@ -23368,8 +23379,7 @@
                             "type": "object"
                         },
                         "type": {
-                            "enum": ["next_question", "end", "response_based", "specific_question"],
-                            "type": "string"
+                            "$ref": "#/definitions/SurveyQuestionBranchingType"
                         }
                     },
                     "required": ["type"],

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -914,6 +914,13 @@ export interface DataVisualizationNode extends Node<never> {
     tableSettings?: TableSettings
 }
 
+export type DataTableNodeViewPropsContextType = 'event_definition' | 'team_columns'
+
+export interface DataTableNodeViewPropsContext {
+    type: DataTableNodeViewPropsContextType
+    eventDefinitionId?: string
+}
+
 interface DataTableNodeViewProps {
     /** Show with most visual options enabled. Used in scenes. */ full?: boolean
     /** Include an event filter above the table (EventsNode only) */
@@ -957,10 +964,7 @@ interface DataTableNodeViewProps {
     /** Uses the embedded version of LemonTable */
     embedded?: boolean
     /** Context for the table, used by components like ColumnConfigurator */
-    context?: {
-        type: 'event_definition' | 'team_columns'
-        eventDefinitionId?: string
-    }
+    context?: DataTableNodeViewPropsContext
 }
 
 // Saved insight node
@@ -2091,8 +2095,10 @@ export interface ErrorTrackingSceneToolOutput
     filterTestAccounts?: boolean
 }
 
+export type ErrorTrackingIssueAssigneeType = 'user' | 'role'
+
 export interface ErrorTrackingIssueAssignee {
-    type: 'user' | 'role'
+    type: ErrorTrackingIssueAssigneeType
     id: integer | string
 }
 
@@ -2777,8 +2783,16 @@ export interface DatabaseSchemaField {
     id?: string
 }
 
+export type DatabaseSchemaTableType =
+    | 'posthog'
+    | 'data_warehouse'
+    | 'view'
+    | 'batch_export'
+    | 'materialized_view'
+    | 'managed_view'
+
 export interface DatabaseSchemaTableCommon {
-    type: 'posthog' | 'data_warehouse' | 'view' | 'batch_export' | 'materialized_view' | 'managed_view'
+    type: DatabaseSchemaTableType
     id: string
     name: string
     fields: Record<string, DatabaseSchemaField>
@@ -3574,13 +3588,25 @@ export interface SourceFieldOauthConfig {
     kind: string
 }
 
+export type SourceFieldInputConfigType =
+    | 'text'
+    | 'email'
+    | 'search'
+    | 'url'
+    | 'password'
+    | 'time'
+    | 'number'
+    | 'textarea'
+
 export interface SourceFieldInputConfig {
-    type: 'text' | 'email' | 'search' | 'url' | 'password' | 'time' | 'number' | 'textarea'
+    type: SourceFieldInputConfigType
     name: string
     label: string
     required: boolean
     placeholder: string
 }
+
+export type SourceFieldSelectConfigConverter = 'str_to_int' | 'str_to_bool' | 'str_to_optional_int'
 
 export interface SourceFieldSelectConfig {
     type: 'select'
@@ -3589,7 +3615,7 @@ export interface SourceFieldSelectConfig {
     required: boolean
     defaultValue: string
     options: { label: string; value: string; fields?: SourceFieldConfig[] }[]
-    converter?: 'str_to_int' | 'str_to_bool' | 'str_to_optional_int'
+    converter?: SourceFieldSelectConfigConverter
 }
 
 export interface SourceFieldSwitchGroupConfig {

--- a/frontend/src/queries/schema/schema-surveys.ts
+++ b/frontend/src/queries/schema/schema-surveys.ts
@@ -30,6 +30,8 @@ export interface SurveyCreationSchema {
     enable_partial_responses?: boolean
 }
 
+export type SurveyQuestionBranchingType = 'next_question' | 'end' | 'response_based' | 'specific_question'
+
 // Question schema matching PostHog Survey model format
 export interface SurveyQuestionSchema {
     type: SurveyQuestionType
@@ -55,7 +57,7 @@ export interface SurveyQuestionSchema {
 
     // Branching logic
     branching?: {
-        type: 'next_question' | 'end' | 'response_based' | 'specific_question'
+        type: SurveyQuestionBranchingType
         responseValues?: Record<string, string | number>
         index?: number
     }

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -424,7 +424,7 @@ posthog/warehouse/data_load/service.py:0: error: Incompatible return value type 
 posthog/warehouse/data_load/service.py:0: error: Incompatible return value type (got "tuple[timedelta | None, timedelta]", expected "tuple[timedelta, timedelta]")  [return-value]
 posthog/warehouse/data_load/service.py:0: error: Unsupported operand types for >= ("timedelta" and "None")  [operator]
 posthog/warehouse/data_load/service.py:0: error: Unsupported operand types for >= ("timedelta" and "None")  [operator]
-posthog/warehouse/data_load/source_templates.py:0: error: Incompatible types in assignment (expression has type "str", variable has type "Type")  [assignment]
+posthog/warehouse/data_load/source_templates.py:0: error: Incompatible types in assignment (expression has type "str", variable has type "ExternalDataSourceType")  [assignment]
 posthog/warehouse/data_load/validate_schema.py:0: error: Argument "job_id" to "get_external_data_job" has incompatible type "str"; expected "UUID"  [arg-type]
 posthog/warehouse/data_load/validate_schema.py:0: error: Argument "job_id" to "get_external_data_job" has incompatible type "str"; expected "UUID"  [arg-type]
 posthog/warehouse/data_load/validate_schema.py:0: error: Argument 1 to "aget_schema_by_id" has incompatible type "UUID"; expected "str"  [arg-type]

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -36,6 +36,7 @@ from posthog.hogql.test.utils import pretty_print_in_tests
 from posthog.warehouse.models.external_data_schema import ExternalDataSchema
 from posthog.warehouse.models.external_data_source import ExternalDataSource
 from posthog.warehouse.models.join import DataWarehouseJoin
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 class TestDatabase(BaseTest, QueryMatchingTest):
@@ -230,7 +231,7 @@ class TestDatabase(BaseTest, QueryMatchingTest):
             source_id="source_id",
             connection_id="connection_id",
             status=ExternalDataSource.Status.COMPLETED,
-            source_type=ExternalDataSource.Type.STRIPE,
+            source_type=ExternalDataSourceType.STRIPE,
         )
         credentials = DataWarehouseCredential.objects.create(access_key="blah", access_secret="blah", team=self.team)
         warehouse_table = DataWarehouseTable.objects.create(
@@ -287,7 +288,7 @@ class TestDatabase(BaseTest, QueryMatchingTest):
             source_id="source_id_1",
             connection_id="connection_id_1",
             status=ExternalDataSource.Status.COMPLETED,
-            source_type=ExternalDataSource.Type.STRIPE,
+            source_type=ExternalDataSourceType.STRIPE,
         )
         credentials = DataWarehouseCredential.objects.create(access_key="blah", access_secret="blah", team=self.team)
         warehouse_table = DataWarehouseTable.objects.create(
@@ -320,7 +321,7 @@ class TestDatabase(BaseTest, QueryMatchingTest):
                 source_id=f"source_id_{i + 2}",
                 connection_id=f"connection_id_{i + 2}",
                 status=ExternalDataSource.Status.COMPLETED,
-                source_type=ExternalDataSource.Type.STRIPE,
+                source_type=ExternalDataSourceType.STRIPE,
             )
             warehouse_table = DataWarehouseTable.objects.create(
                 name=f"table_{i + 2}",
@@ -700,7 +701,7 @@ class TestDatabase(BaseTest, QueryMatchingTest):
                 source_id=f"source_id_{i}",
                 connection_id=f"connection_id_{i}",
                 status=ExternalDataSource.Status.COMPLETED,
-                source_type=ExternalDataSource.Type.STRIPE,
+                source_type=ExternalDataSourceType.STRIPE,
             )
             credentials = DataWarehouseCredential.objects.create(
                 access_key=f"blah-{i}", access_secret="blah", team=self.team
@@ -805,7 +806,7 @@ class TestDatabase(BaseTest, QueryMatchingTest):
         source = ExternalDataSource.objects.create(
             team=self.team,
             source_id="source_id",
-            source_type=ExternalDataSource.Type.STRIPE,
+            source_type=ExternalDataSourceType.STRIPE,
         )
         DataWarehouseTable.objects.create(
             name="stripe_table",

--- a/posthog/hogql/test/test_autocomplete.py
+++ b/posthog/hogql/test/test_autocomplete.py
@@ -19,6 +19,7 @@ from posthog.warehouse.models import ExternalDataSource
 from posthog.warehouse.models.credential import DataWarehouseCredential
 from posthog.warehouse.models.datawarehouse_saved_query import DataWarehouseSavedQuery
 from posthog.warehouse.models.table import DataWarehouseTable
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 class TestAutocomplete(ClickhouseTestMixin, APIBaseTest):
@@ -461,7 +462,7 @@ class TestAutocomplete(ClickhouseTestMixin, APIBaseTest):
 
     def test_autocomplete_warehouse_table_with_source_dot_notation(self):
         credentials = DataWarehouseCredential.objects.create(team=self.team, access_key="key", access_secret="secret")
-        source = ExternalDataSource.objects.create(team=self.team, source_type=ExternalDataSource.Type.STRIPE)
+        source = ExternalDataSource.objects.create(team=self.team, source_type=ExternalDataSourceType.STRIPE)
         DataWarehouseTable.objects.create(
             team=self.team,
             name="some_table",
@@ -478,7 +479,7 @@ class TestAutocomplete(ClickhouseTestMixin, APIBaseTest):
     def test_autocomplete_warehouse_table_with_source_and_prefix_dot_notation(self):
         credentials = DataWarehouseCredential.objects.create(team=self.team, access_key="key", access_secret="secret")
         source = ExternalDataSource.objects.create(
-            team=self.team, source_type=ExternalDataSource.Type.STRIPE, prefix="prefix"
+            team=self.team, source_type=ExternalDataSourceType.STRIPE, prefix="prefix"
         )
         DataWarehouseTable.objects.create(
             team=self.team,

--- a/posthog/migrations/0807_dwh_source_refactor.py
+++ b/posthog/migrations/0807_dwh_source_refactor.py
@@ -2,6 +2,7 @@
 
 from django.db import migrations
 from posthog.warehouse.models import ExternalDataSource as ExternalDataSourceModel
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 def forwards(apps, schema_editor):
@@ -9,13 +10,13 @@ def forwards(apps, schema_editor):
     all_sources = ExternalDataSource.objects.all()
 
     for source in all_sources:
-        source_type = ExternalDataSourceModel.Type(source.source_type)
+        source_type = ExternalDataSourceType(source.source_type)
         job_inputs = source.job_inputs
 
         if job_inputs is None:
             continue
 
-        if source_type == ExternalDataSourceModel.Type.BIGQUERY:
+        if source_type == ExternalDataSourceType.BIGQUERY:
             new_job_inputs = {
                 "pre_migration_job_inputs": job_inputs,
                 "key_file": {
@@ -37,7 +38,7 @@ def forwards(apps, schema_editor):
             }
             source.job_inputs = new_job_inputs
             source.save()
-        elif source_type == ExternalDataSourceModel.Type.MSSQL:
+        elif source_type == ExternalDataSourceType.MSSQL:
             new_job_inputs = {
                 "pre_migration_job_inputs": job_inputs,
                 "host": job_inputs.get("host", ""),
@@ -61,7 +62,7 @@ def forwards(apps, schema_editor):
             }
             source.job_inputs = new_job_inputs
             source.save()
-        elif source_type == ExternalDataSourceModel.Type.MYSQL:
+        elif source_type == ExternalDataSourceType.MYSQL:
             new_job_inputs = {
                 "pre_migration_job_inputs": job_inputs,
                 "host": job_inputs.get("host", ""),
@@ -86,7 +87,7 @@ def forwards(apps, schema_editor):
             }
             source.job_inputs = new_job_inputs
             source.save()
-        elif source_type == ExternalDataSourceModel.Type.POSTGRES:
+        elif source_type == ExternalDataSourceType.POSTGRES:
             new_job_inputs = {
                 "pre_migration_job_inputs": job_inputs,
                 "host": job_inputs.get("host", ""),
@@ -110,7 +111,7 @@ def forwards(apps, schema_editor):
             }
             source.job_inputs = new_job_inputs
             source.save()
-        elif source_type == ExternalDataSourceModel.Type.SNOWFLAKE:
+        elif source_type == ExternalDataSourceType.SNOWFLAKE:
             new_job_inputs = {
                 "pre_migration_job_inputs": job_inputs,
                 "account_id": job_inputs.get("account_id", ""),
@@ -128,7 +129,7 @@ def forwards(apps, schema_editor):
             }
             source.job_inputs = new_job_inputs
             source.save()
-        elif source_type == ExternalDataSourceModel.Type.VITALLY:
+        elif source_type == ExternalDataSourceType.VITALLY:
             new_job_inputs = {
                 "pre_migration_job_inputs": job_inputs,
                 "secret_token": job_inputs.get("secret_token", ""),
@@ -136,7 +137,7 @@ def forwards(apps, schema_editor):
             }
             source.job_inputs = new_job_inputs
             source.save()
-        elif source_type == ExternalDataSourceModel.Type.ZENDESK:
+        elif source_type == ExternalDataSourceType.ZENDESK:
             new_job_inputs = {
                 "pre_migration_job_inputs": job_inputs,
                 "subdomain": job_inputs.get("zendesk_subdomain", ""),

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -823,17 +823,9 @@ class DataColorToken(StrEnum):
     PRESET_15 = "preset-15"
 
 
-class Type(StrEnum):
+class DataTableNodeViewPropsContextType(StrEnum):
     EVENT_DEFINITION = "event_definition"
     TEAM_COLUMNS = "team_columns"
-
-
-class Context(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    eventDefinitionId: Optional[str] = None
-    type: Type
 
 
 class DataWarehouseEventsModifier(BaseModel):
@@ -885,7 +877,7 @@ class DatabaseSchemaSource(BaseModel):
     status: str
 
 
-class Type1(StrEnum):
+class DatabaseSchemaTableType(StrEnum):
     POSTHOG = "posthog"
     DATA_WAREHOUSE = "data_warehouse"
     VIEW = "view"
@@ -1050,7 +1042,7 @@ class ErrorTrackingIssueAggregations(BaseModel):
     volume_buckets: list[VolumeBucket]
 
 
-class Type2(StrEnum):
+class ErrorTrackingIssueAssigneeType(StrEnum):
     USER = "user"
     ROLE = "role"
 
@@ -2304,19 +2296,6 @@ class SamplingRate(BaseModel):
     numerator: float
 
 
-class Type3(StrEnum):
-    EVENT_DEFINITION = "event_definition"
-    TEAM_COLUMNS = "team_columns"
-
-
-class Context1(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    eventDefinitionId: Optional[str] = None
-    type: Type3
-
-
 class SessionAttributionGroupBy(StrEnum):
     CHANNEL_TYPE = "ChannelType"
     MEDIUM = "Medium"
@@ -2380,7 +2359,7 @@ class SourceFieldFileUploadJsonFormatConfig(BaseModel):
     keys: Union[str, list[str]]
 
 
-class Type4(StrEnum):
+class SourceFieldInputConfigType(StrEnum):
     TEXT = "text"
     EMAIL = "email"
     SEARCH = "search"
@@ -2389,17 +2368,6 @@ class Type4(StrEnum):
     TIME = "time"
     NUMBER = "number"
     TEXTAREA = "textarea"
-
-
-class SourceFieldInputConfig(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    label: str
-    name: str
-    placeholder: str
-    required: bool
-    type: Type4
 
 
 class SourceFieldOauthConfig(BaseModel):
@@ -2422,7 +2390,7 @@ class SourceFieldSSHTunnelConfig(BaseModel):
     type: Literal["ssh-tunnel"] = "ssh-tunnel"
 
 
-class Converter(StrEnum):
+class SourceFieldSelectConfigConverter(StrEnum):
     STR_TO_INT = "str_to_int"
     STR_TO_BOOL = "str_to_bool"
     STR_TO_OPTIONAL_INT = "str_to_optional_int"
@@ -2515,16 +2483,16 @@ class SurveyPosition(StrEnum):
     NEXT_TO_TRIGGER = "next_to_trigger"
 
 
-class SurveyQuestionDescriptionContentType(StrEnum):
-    HTML = "html"
-    TEXT = "text"
-
-
-class Type5(StrEnum):
+class SurveyQuestionBranchingType(StrEnum):
     NEXT_QUESTION = "next_question"
     END = "end"
     RESPONSE_BASED = "response_based"
     SPECIFIC_QUESTION = "specific_question"
+
+
+class SurveyQuestionDescriptionContentType(StrEnum):
+    HTML = "html"
+    TEXT = "text"
 
 
 class Branching(BaseModel):
@@ -2533,7 +2501,7 @@ class Branching(BaseModel):
     )
     index: Optional[float] = None
     responseValues: Optional[dict[str, Union[str, float]]] = None
-    type: Type5
+    type: SurveyQuestionBranchingType
 
 
 class Display1(StrEnum):
@@ -3419,6 +3387,14 @@ class CustomChannelRule(BaseModel):
     items: list[CustomChannelCondition]
 
 
+class DataTableNodeViewPropsContext(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    eventDefinitionId: Optional[str] = None
+    type: DataTableNodeViewPropsContextType
+
+
 class DataWarehousePersonPropertyFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -3489,7 +3465,7 @@ class DatabaseSchemaTableCommon(BaseModel):
     id: str
     name: str
     row_count: Optional[float] = None
-    type: Type1
+    type: DatabaseSchemaTableType
 
 
 class Day(RootModel[int]):
@@ -3521,7 +3497,7 @@ class ErrorTrackingIssueAssignee(BaseModel):
         extra="forbid",
     )
     id: Union[str, int]
-    type: Type2
+    type: ErrorTrackingIssueAssigneeType
 
 
 class ErrorTrackingIssueFilter(BaseModel):
@@ -4325,7 +4301,7 @@ class SavedInsightNode(BaseModel):
     allowSorting: Optional[bool] = Field(
         default=None, description="Can the user click on column headers to sort the table? (default: true)"
     )
-    context: Optional[Context1] = Field(
+    context: Optional[DataTableNodeViewPropsContext] = Field(
         default=None, description="Context for the table, used by components like ColumnConfigurator"
     )
     embedded: Optional[bool] = Field(default=None, description="Query is embedded inside another bordered component")
@@ -4524,6 +4500,17 @@ class SourceFieldFileUploadConfig(BaseModel):
     name: str
     required: bool
     type: Literal["file-upload"] = "file-upload"
+
+
+class SourceFieldInputConfig(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    label: str
+    name: str
+    placeholder: str
+    required: bool
+    type: SourceFieldInputConfigType
 
 
 class StickinessCriteria(BaseModel):
@@ -13438,7 +13425,7 @@ class DataTableNode(BaseModel):
     columns: Optional[list[str]] = Field(
         default=None, description="Columns shown in the table, unless the `source` provides them."
     )
-    context: Optional[Context] = Field(
+    context: Optional[DataTableNodeViewPropsContext] = Field(
         default=None, description="Context for the table, used by components like ColumnConfigurator"
     )
     embedded: Optional[bool] = Field(default=None, description="Uses the embedded version of LemonTable")
@@ -14188,7 +14175,7 @@ class SourceFieldSelectConfig(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    converter: Optional[Converter] = None
+    converter: Optional[SourceFieldSelectConfigConverter] = None
     defaultValue: str
     label: str
     name: str

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -70,6 +70,7 @@ from posthog.warehouse.models import (
     ExternalDataSource,
     ExternalDataSchema,
 )
+from posthog.warehouse.types import ExternalDataSourceType
 
 logger = structlog.get_logger(__name__)
 
@@ -1516,7 +1517,7 @@ class TestExternalDataSyncUsageReport(ClickhouseDestroyTablesMixin, TestCase, Cl
             source_id="source_id",
             connection_id="connection_id",
             status=ExternalDataSource.Status.COMPLETED,
-            source_type=ExternalDataSource.Type.STRIPE,
+            source_type=ExternalDataSourceType.STRIPE,
         )
 
         for _ in range(5):
@@ -1575,7 +1576,7 @@ class TestExternalDataSyncUsageReport(ClickhouseDestroyTablesMixin, TestCase, Cl
             source_id="source_id",
             connection_id="connection_id",
             status=ExternalDataSource.Status.COMPLETED,
-            source_type=ExternalDataSource.Type.STRIPE,
+            source_type=ExternalDataSourceType.STRIPE,
         )
 
         for _ in range(5):
@@ -1654,7 +1655,7 @@ class TestExternalDataSyncUsageReport(ClickhouseDestroyTablesMixin, TestCase, Cl
             source_id="source_id",
             connection_id="connection_id",
             status=ExternalDataSource.Status.COMPLETED,
-            source_type=ExternalDataSource.Type.STRIPE,
+            source_type=ExternalDataSourceType.STRIPE,
         )
 
         for _ in range(5):
@@ -1712,7 +1713,7 @@ class TestExternalDataSyncUsageReport(ClickhouseDestroyTablesMixin, TestCase, Cl
             source_id="source_id",
             connection_id="connection_id",
             status=ExternalDataSource.Status.COMPLETED,
-            source_type=ExternalDataSource.Type.STRIPE,
+            source_type=ExternalDataSourceType.STRIPE,
         )
 
         for _ in range(5):

--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -44,9 +44,9 @@ from posthog.warehouse.models import (
     DataWarehouseTable,
     ExternalDataJob,
     ExternalDataSchema,
-    ExternalDataSource,
 )
 from posthog.warehouse.models.external_data_schema import process_incremental_value
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 class PipelineNonDLT:
@@ -414,14 +414,14 @@ def supports_partial_data_loading(schema: ExternalDataSchema) -> bool:
     We should be able to roll this out to all source types but initially we only support it for Stripe so we can verify
     the approach.
     """
-    return schema.source.source_type == ExternalDataSource.Type.STRIPE
+    return schema.source.source_type == ExternalDataSourceType.STRIPE
 
 
 def _notify_revenue_analytics_that_sync_has_completed(schema: ExternalDataSchema, logger: FilteringBoundLogger) -> None:
     try:
         if (
             schema.name == STRIPE_CHARGE_RESOURCE_NAME
-            and schema.source.source_type == ExternalDataSource.Type.STRIPE
+            and schema.source.source_type == ExternalDataSourceType.STRIPE
             and schema.source.revenue_analytics_enabled
             and not schema.team.revenue_analytics_config.notified_first_sync
         ):

--- a/posthog/temporal/data_imports/pipelines/pipeline_sync.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_sync.py
@@ -22,8 +22,8 @@ from posthog.temporal.common.logger import bind_temporal_worker_logger_sync
 from posthog.warehouse.models.credential import get_or_create_datawarehouse_credential
 from posthog.warehouse.models.external_data_job import ExternalDataJob
 from posthog.warehouse.models.external_data_schema import ExternalDataSchema
-from posthog.warehouse.models.external_data_source import ExternalDataSource
 from posthog.warehouse.models.table import DataWarehouseTable
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 def _from_arrow_scalar(arrow_value: pyarrow.Scalar) -> Any:
@@ -47,7 +47,7 @@ class PipelineInputs:
     run_id: str
     schema_id: uuid.UUID
     dataset_name: str
-    job_type: ExternalDataSource.Type
+    job_type: ExternalDataSourceType
     team_id: int
 
 

--- a/posthog/temporal/data_imports/sources/README.md
+++ b/posthog/temporal/data_imports/sources/README.md
@@ -2,7 +2,7 @@
 
 Adding a new source should be pretty simple. We've refactored the sources so that you need to only add your source logic and update a minimal amount of other files. Below is a step-by-step guide:
 
-1. Add a new enum value to `ExternalDataSource.Type` (posthog/warehouse/models/external_data_source.py). The key should be fully capitalized and the value should be in pascal case.
+1. Add a new enum value to `ExternalDataSourceType` (posthog/warehouse/types.py). The key should be fully capitalized and the value should be in pascal case.
 2. Run django migrations - `DEBUG=1 ./bin/migrate`
 3. Add a new folder in `posthog/temporal/data_imports/sources` for your source, add a new file within this folder called `source.py` using the template below
 4. Define the fields you'd like to collect via the `get_source_config()` method. Look at the other sources in `posthog/temporal/data_imports/sources` for examples. More info on the type of fields available is below
@@ -15,7 +15,7 @@ Adding a new source should be pretty simple. We've refactored the sources so tha
 ```python
 from typing import cast
 from posthog.schema import (
-    ExternalDataSourceType,
+    ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
 )
 from posthog.temporal.data_imports.sources.common.base import BaseSource, FieldType
@@ -23,19 +23,19 @@ from posthog.temporal.data_imports.sources.common.config import Config
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
 from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
-from posthog.warehouse.models import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
 class TemplateSource(BaseSource[Config]): # Replace this after config generation
     @property
-    def source_type(self) -> ExternalDataSource.Type:
-        return ExternalDataSource.Type.SOURCE_TYPE # Replace this
+    def source_type(self) -> ExternalDataSourceType:
+        return ExternalDataSourceType.SOURCE_TYPE # Replace this
 
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
-            name=ExternalDataSourceType.SOURCE_TYPE, # Replace this
+            name=SchemaExternalDataSourceType.SOURCE_TYPE, # Replace this
             label="Template", # Replace this
             caption="",
             fields=cast(list[FieldType], []), # Add source fields here

--- a/posthog/temporal/data_imports/sources/bigquery/source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/source.py
@@ -1,12 +1,12 @@
 from datetime import datetime
 from typing import cast
 from posthog.schema import (
-    ExternalDataSourceType,
+    ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldFileUploadConfig,
     SourceFieldSwitchGroupConfig,
-    Type4,
+    SourceFieldInputConfigType,
     SourceFieldFileUploadJsonFormatConfig,
 )
 from posthog.temporal.data_imports.sources.common.base import BaseSource, FieldType
@@ -22,14 +22,14 @@ from posthog.temporal.data_imports.sources.bigquery.bigquery import (
 )
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
 from posthog.temporal.data_imports.sources.generated_configs import BigQuerySourceConfig
-from posthog.warehouse.models import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
 class BigQuerySource(BaseSource[BigQuerySourceConfig]):
     @property
-    def source_type(self) -> ExternalDataSource.Type:
-        return ExternalDataSource.Type.BIGQUERY
+    def source_type(self) -> ExternalDataSourceType:
+        return ExternalDataSourceType.BIGQUERY
 
     def get_schemas(self, config: BigQuerySourceConfig, team_id: int) -> list[SourceSchema]:
         bq_schemas = get_bigquery_schemas(
@@ -144,7 +144,7 @@ class BigQuerySource(BaseSource[BigQuerySourceConfig]):
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
-            name=ExternalDataSourceType.BIG_QUERY,
+            name=SchemaExternalDataSourceType.BIG_QUERY,
             caption="",
             fields=cast(
                 list[FieldType],
@@ -159,7 +159,11 @@ class BigQuerySource(BaseSource[BigQuerySourceConfig]):
                         required=True,
                     ),
                     SourceFieldInputConfig(
-                        name="dataset_id", label="Dataset ID", type=Type4.TEXT, required=True, placeholder=""
+                        name="dataset_id",
+                        label="Dataset ID",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="",
                     ),
                     SourceFieldSwitchGroupConfig(
                         name="temporary-dataset",
@@ -172,7 +176,7 @@ class BigQuerySource(BaseSource[BigQuerySourceConfig]):
                                 SourceFieldInputConfig(
                                     name="temporary_dataset_id",
                                     label="Dataset ID for temporary tables",
-                                    type=Type4.TEXT,
+                                    type=SourceFieldInputConfigType.TEXT,
                                     required=True,
                                     placeholder="",
                                 )
@@ -190,7 +194,7 @@ class BigQuerySource(BaseSource[BigQuerySourceConfig]):
                                 SourceFieldInputConfig(
                                     name="dataset_project_id",
                                     label="Project ID for dataset",
-                                    type=Type4.TEXT,
+                                    type=SourceFieldInputConfigType.TEXT,
                                     required=True,
                                     placeholder="",
                                 )

--- a/posthog/temporal/data_imports/sources/braze/source.py
+++ b/posthog/temporal/data_imports/sources/braze/source.py
@@ -1,24 +1,24 @@
 from typing import cast
 from posthog.schema import (
-    ExternalDataSourceType,
+    ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
 )
 from posthog.temporal.data_imports.sources.common.base import BaseSource, FieldType
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
 from posthog.temporal.data_imports.sources.generated_configs import BrazeSourceConfig
-from posthog.warehouse.models import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
 class BrazeSource(BaseSource[BrazeSourceConfig]):
     @property
-    def source_type(self) -> ExternalDataSource.Type:
-        return ExternalDataSource.Type.BRAZE
+    def source_type(self) -> ExternalDataSourceType:
+        return ExternalDataSourceType.BRAZE
 
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
-            name=ExternalDataSourceType.BRAZE,
+            name=SchemaExternalDataSourceType.BRAZE,
             label="Braze",
             caption="",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/chargebee/source.py
+++ b/posthog/temporal/data_imports/sources/chargebee/source.py
@@ -1,10 +1,10 @@
 import re
 from typing import cast
 from posthog.schema import (
-    ExternalDataSourceType,
+    ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
     SourceFieldInputConfig,
-    Type4,
+    SourceFieldInputConfigType,
 )
 from posthog.temporal.data_imports.sources.common.base import BaseSource, FieldType
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
@@ -17,14 +17,14 @@ from posthog.temporal.data_imports.sources.chargebee.settings import ENDPOINTS, 
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
 from posthog.temporal.data_imports.sources.common.utils import dlt_source_to_source_response
 from posthog.temporal.data_imports.sources.generated_configs import ChargebeeSourceConfig
-from posthog.warehouse.models import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
 class ChargebeeSource(BaseSource[ChargebeeSourceConfig]):
     @property
-    def source_type(self) -> ExternalDataSource.Type:
-        return ExternalDataSource.Type.CHARGEBEE
+    def source_type(self) -> ExternalDataSourceType:
+        return ExternalDataSourceType.CHARGEBEE
 
     def get_schemas(self, config: ChargebeeSourceConfig, team_id: int) -> list[SourceSchema]:
         return [
@@ -65,16 +65,24 @@ class ChargebeeSource(BaseSource[ChargebeeSourceConfig]):
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
-            name=ExternalDataSourceType.CHARGEBEE,
+            name=SchemaExternalDataSourceType.CHARGEBEE,
             caption="",
             fields=cast(
                 list[FieldType],
                 [
                     SourceFieldInputConfig(
-                        name="api_key", label="API key", type=Type4.TEXT, required=True, placeholder=""
+                        name="api_key",
+                        label="API key",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="",
                     ),
                     SourceFieldInputConfig(
-                        name="site_name", label="Site name (subdomain)", type=Type4.TEXT, required=True, placeholder=""
+                        name="site_name",
+                        label="Site name (subdomain)",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="",
                     ),
                 ],
             ),

--- a/posthog/temporal/data_imports/sources/common/base.py
+++ b/posthog/temporal/data_imports/sources/common/base.py
@@ -13,7 +13,7 @@ from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.generated_configs import get_config_for_source
 from posthog.temporal.data_imports.sources.common.config import Config
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
-from posthog.warehouse.models import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType
 
 ConfigType = TypeVar("ConfigType", bound=Config)
 
@@ -32,7 +32,7 @@ class BaseSource(ABC, Generic[ConfigType]):
 
     @property
     @abstractmethod
-    def source_type(self) -> ExternalDataSource.Type:
+    def source_type(self) -> ExternalDataSourceType:
         raise NotImplementedError()
 
     @property

--- a/posthog/temporal/data_imports/sources/common/registry.py
+++ b/posthog/temporal/data_imports/sources/common/registry.py
@@ -1,14 +1,14 @@
 from typing import TYPE_CHECKING
+from posthog.warehouse.types import ExternalDataSourceType
 
 if TYPE_CHECKING:
     from posthog.temporal.data_imports.sources.common.base import BaseSource
-    from posthog.warehouse.models import ExternalDataSource
 
 
 class SourceRegistry:
     """Registry for all available data warehouse sources"""
 
-    _sources: dict["ExternalDataSource.Type", "BaseSource"] = {}
+    _sources: dict[ExternalDataSourceType, "BaseSource"] = {}
 
     @classmethod
     def register(cls, source_class: type["BaseSource"]):
@@ -20,7 +20,7 @@ class SourceRegistry:
         return source_class
 
     @classmethod
-    def get_source(cls, source_type: "ExternalDataSource.Type") -> "BaseSource":
+    def get_source(cls, source_type: ExternalDataSourceType) -> "BaseSource":
         """Get a source instance by type"""
 
         if source_type not in cls._sources:
@@ -28,19 +28,19 @@ class SourceRegistry:
         return cls._sources[source_type]
 
     @classmethod
-    def get_all_sources(cls) -> dict["ExternalDataSource.Type", "BaseSource"]:
+    def get_all_sources(cls) -> dict[ExternalDataSourceType, "BaseSource"]:
         """Get all registered sources"""
 
         return cls._sources
 
     @classmethod
-    def is_registered(cls, source_type: "ExternalDataSource.Type") -> bool:
+    def is_registered(cls, source_type: ExternalDataSourceType) -> bool:
         """Check if a source type is registered"""
 
         return source_type in cls._sources
 
     @classmethod
-    def get_registered_types(cls) -> list["ExternalDataSource.Type"]:
+    def get_registered_types(cls) -> list[ExternalDataSourceType]:
         """Get all registered source types"""
 
         return list(cls._sources.keys())

--- a/posthog/temporal/data_imports/sources/common/test/__snapshots__/test_source_config_generator.ambr
+++ b/posthog/temporal/data_imports/sources/common/test/__snapshots__/test_source_config_generator.ambr
@@ -5,8 +5,8 @@
   # Do not edit manually - run `pnpm generate:source-configs` to regenerate.
   
   from posthog.temporal.data_imports.sources.common import config
-  from posthog.warehouse.models import ExternalDataSource
   from posthog.warehouse.models.ssh_tunnel import SSHTunnelConfig
+  from posthog.warehouse.types import ExternalDataSourceType
   from typing import Literal
   
   
@@ -41,30 +41,30 @@
       ssh_tunnel: SSHTunnelConfig | None = None
   
   
-  def get_config_for_source(source: ExternalDataSource.Type):
+  def get_config_for_source(source: ExternalDataSourceType):
       return {
-          ExternalDataSource.Type.BIGQUERY: BigQuerySourceConfig,
-          ExternalDataSource.Type.BRAZE: BrazeSourceConfig,
-          ExternalDataSource.Type.CHARGEBEE: ChargebeeSourceConfig,
-          ExternalDataSource.Type.DOIT: DoItSourceConfig,
-          ExternalDataSource.Type.GOOGLEADS: GoogleAdsSourceConfig,
-          ExternalDataSource.Type.GOOGLESHEETS: GoogleSheetsSourceConfig,
-          ExternalDataSource.Type.HUBSPOT: HubspotSourceConfig,
-          ExternalDataSource.Type.KLAVIYO: KlaviyoSourceConfig,
-          ExternalDataSource.Type.MSSQL: MSSQLSourceConfig,
-          ExternalDataSource.Type.MAILCHIMP: MailchimpSourceConfig,
-          ExternalDataSource.Type.MAILJET: MailjetSourceConfig,
-          ExternalDataSource.Type.METAADS: MetaAdsSourceConfig,
-          ExternalDataSource.Type.MONGODB: MongoDBSourceConfig,
-          ExternalDataSource.Type.MYSQL: MySQLSourceConfig,
-          ExternalDataSource.Type.POSTGRES: PostgresSourceConfig,
-          ExternalDataSource.Type.REDSHIFT: RedshiftSourceConfig,
-          ExternalDataSource.Type.SALESFORCE: SalesforceSourceConfig,
-          ExternalDataSource.Type.SNOWFLAKE: SnowflakeSourceConfig,
-          ExternalDataSource.Type.STRIPE: StripeSourceConfig,
-          ExternalDataSource.Type.TEMPORALIO: TemporalIOSourceConfig,
-          ExternalDataSource.Type.VITALLY: VitallySourceConfig,
-          ExternalDataSource.Type.ZENDESK: ZendeskSourceConfig,
+          ExternalDataSourceType.BIGQUERY: BigQuerySourceConfig,
+          ExternalDataSourceType.BRAZE: BrazeSourceConfig,
+          ExternalDataSourceType.CHARGEBEE: ChargebeeSourceConfig,
+          ExternalDataSourceType.DOIT: DoItSourceConfig,
+          ExternalDataSourceType.GOOGLEADS: GoogleAdsSourceConfig,
+          ExternalDataSourceType.GOOGLESHEETS: GoogleSheetsSourceConfig,
+          ExternalDataSourceType.HUBSPOT: HubspotSourceConfig,
+          ExternalDataSourceType.KLAVIYO: KlaviyoSourceConfig,
+          ExternalDataSourceType.MSSQL: MSSQLSourceConfig,
+          ExternalDataSourceType.MAILCHIMP: MailchimpSourceConfig,
+          ExternalDataSourceType.MAILJET: MailjetSourceConfig,
+          ExternalDataSourceType.METAADS: MetaAdsSourceConfig,
+          ExternalDataSourceType.MONGODB: MongoDBSourceConfig,
+          ExternalDataSourceType.MYSQL: MySQLSourceConfig,
+          ExternalDataSourceType.POSTGRES: PostgresSourceConfig,
+          ExternalDataSourceType.REDSHIFT: RedshiftSourceConfig,
+          ExternalDataSourceType.SALESFORCE: SalesforceSourceConfig,
+          ExternalDataSourceType.SNOWFLAKE: SnowflakeSourceConfig,
+          ExternalDataSourceType.STRIPE: StripeSourceConfig,
+          ExternalDataSourceType.TEMPORALIO: TemporalIOSourceConfig,
+          ExternalDataSourceType.VITALLY: VitallySourceConfig,
+          ExternalDataSourceType.ZENDESK: ZendeskSourceConfig,
       }[source]
   
   '''

--- a/posthog/temporal/data_imports/sources/common/test/test_source_config_generator.py
+++ b/posthog/temporal/data_imports/sources/common/test/test_source_config_generator.py
@@ -3,13 +3,13 @@ import pytest
 
 from posthog.management.commands.generate_source_configs import SourceConfigGenerator
 from posthog.schema import (
-    ExternalDataSourceType,
+    ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
     SourceFieldFileUploadJsonFormatConfig,
     SourceFieldInputConfig,
     SourceFieldSSHTunnelConfig,
     SourceFieldSwitchGroupConfig,
-    Type4,
+    SourceFieldInputConfigType,
     SourceFieldSelectConfig,
     Option,
     SourceFieldOauthConfig,
@@ -17,11 +17,11 @@ from posthog.schema import (
 )
 from posthog.temporal.data_imports.sources.common.base import FieldType
 from posthog.test.base import ClickhouseTestMixin
-from posthog.warehouse.models import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 class TestSourceConfigGenerator(ClickhouseTestMixin):
-    def _run(self, sources: dict[ExternalDataSource.Type, SourceConfig]) -> str:
+    def _run(self, sources: dict[ExternalDataSourceType, SourceConfig]) -> str:
         generator = SourceConfigGenerator()
         for name, config in sources.items():
             generator.generate_source_config(name, config)
@@ -30,7 +30,7 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
     @pytest.mark.usefixtures("unittest_snapshot")
     def test_source_config_types(self):
         config = SourceConfig(
-            name=ExternalDataSourceType.STRIPE,
+            name=SchemaExternalDataSourceType.STRIPE,
             caption="",
             fields=cast(
                 list[FieldType],
@@ -38,7 +38,7 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
                     SourceFieldInputConfig(
                         name="input_field",
                         label="input label",
-                        type=Type4.TEXT,
+                        type=SourceFieldInputConfigType.TEXT,
                         required=False,
                         placeholder="input placeholder",
                     ),
@@ -53,14 +53,14 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
                                 SourceFieldInputConfig(
                                     name="input_field_1",
                                     label="input label",
-                                    type=Type4.TEXT,
+                                    type=SourceFieldInputConfigType.TEXT,
                                     required=False,
                                     placeholder="input placeholder",
                                 ),
                                 SourceFieldInputConfig(
                                     name="input_field_2",
                                     label="input label",
-                                    type=Type4.TEXT,
+                                    type=SourceFieldInputConfigType.TEXT,
                                     required=False,
                                     placeholder="input placeholder",
                                 ),
@@ -89,7 +89,7 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
                                         SourceFieldInputConfig(
                                             name="option_1_input",
                                             label="option_1 label",
-                                            type=Type4.TEXT,
+                                            type=SourceFieldInputConfigType.TEXT,
                                             required=True,
                                             placeholder="option_1 placeholder",
                                         ),
@@ -105,7 +105,7 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
                                         SourceFieldInputConfig(
                                             name="option_2_input",
                                             label="option_2 label",
-                                            type=Type4.TEXT,
+                                            type=SourceFieldInputConfigType.TEXT,
                                             required=True,
                                             placeholder="option_2 placeholder",
                                         ),
@@ -128,11 +128,11 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
             ),
         )
 
-        assert self._run({ExternalDataSource.Type.STRIPE: config}) == self.snapshot
+        assert self._run({ExternalDataSourceType.STRIPE: config}) == self.snapshot
 
     def test_source_config_required(self):
         config = SourceConfig(
-            name=ExternalDataSourceType.STRIPE,
+            name=SchemaExternalDataSourceType.STRIPE,
             caption="",
             fields=cast(
                 list[FieldType],
@@ -140,7 +140,7 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
                     SourceFieldInputConfig(
                         name="input_field",
                         label="input label",
-                        type=Type4.TEXT,
+                        type=SourceFieldInputConfigType.TEXT,
                         required=True,
                         placeholder="input placeholder",
                     ),
@@ -148,13 +148,13 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
             ),
         )
 
-        output = self._run({ExternalDataSource.Type.STRIPE: config})
+        output = self._run({ExternalDataSourceType.STRIPE: config})
         assert "input_field: str" in output
         assert "input_field: str | None = None" not in output
 
     def test_source_config_not_required(self):
         config = SourceConfig(
-            name=ExternalDataSourceType.STRIPE,
+            name=SchemaExternalDataSourceType.STRIPE,
             caption="",
             fields=cast(
                 list[FieldType],
@@ -162,7 +162,7 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
                     SourceFieldInputConfig(
                         name="input_field",
                         label="input label",
-                        type=Type4.TEXT,
+                        type=SourceFieldInputConfigType.TEXT,
                         required=False,
                         placeholder="input placeholder",
                     ),
@@ -170,12 +170,12 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
             ),
         )
 
-        output = self._run({ExternalDataSource.Type.STRIPE: config})
+        output = self._run({ExternalDataSourceType.STRIPE: config})
         assert "input_field: str | None = None" in output
 
     def test_source_config_input_non_python_identifier(self):
         config = SourceConfig(
-            name=ExternalDataSourceType.STRIPE,
+            name=SchemaExternalDataSourceType.STRIPE,
             caption="",
             fields=cast(
                 list[FieldType],
@@ -183,7 +183,7 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
                     SourceFieldInputConfig(
                         name="input-field",  # dashes are not allowed in python identifiers
                         label="input label",
-                        type=Type4.TEXT,
+                        type=SourceFieldInputConfigType.TEXT,
                         required=True,
                         placeholder="input placeholder",
                     ),
@@ -191,12 +191,12 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
             ),
         )
 
-        output = self._run({ExternalDataSource.Type.STRIPE: config})
+        output = self._run({ExternalDataSourceType.STRIPE: config})
         assert 'input_field: str = config.value(alias="input-field")' in output
 
     def test_source_config_switch_group_non_python_identifier(self):
         config = SourceConfig(
-            name=ExternalDataSourceType.STRIPE,
+            name=SchemaExternalDataSourceType.STRIPE,
             caption="",
             fields=cast(
                 list[FieldType],
@@ -212,7 +212,7 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
                                 SourceFieldInputConfig(
                                     name="input-field-1",  # dashes are not allowed in python identifiers
                                     label="input label",
-                                    type=Type4.TEXT,
+                                    type=SourceFieldInputConfigType.TEXT,
                                     required=False,
                                     placeholder="input placeholder",
                                 ),
@@ -223,7 +223,7 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
             ),
         )
 
-        output = self._run({ExternalDataSource.Type.STRIPE: config})
+        output = self._run({ExternalDataSourceType.STRIPE: config})
         assert (
             'switch_group: StripeSwitchGroupConfig | None = config.value(alias="switch-group", default_factory=lambda: None)'
             in output
@@ -232,7 +232,7 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
 
     def test_source_config_file_upload_non_python_identifier(self):
         config = SourceConfig(
-            name=ExternalDataSourceType.STRIPE,
+            name=SchemaExternalDataSourceType.STRIPE,
             caption="",
             fields=cast(
                 list[FieldType],
@@ -247,7 +247,7 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
             ),
         )
 
-        output = self._run({ExternalDataSource.Type.STRIPE: config})
+        output = self._run({ExternalDataSourceType.STRIPE: config})
         assert 'file_upload: StripeFileUploadConfig = config.value(alias="file-upload")' in output
         assert "class StripeFileUploadConfig" in output
         assert "key_1: str" in output
@@ -255,7 +255,7 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
 
     def test_source_config_oauth_non_python_identifier(self):
         config = SourceConfig(
-            name=ExternalDataSourceType.STRIPE,
+            name=SchemaExternalDataSourceType.STRIPE,
             caption="",
             fields=cast(
                 list[FieldType],
@@ -270,7 +270,7 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
             ),
         )
 
-        output = self._run({ExternalDataSource.Type.STRIPE: config})
+        output = self._run({ExternalDataSourceType.STRIPE: config})
         assert (
             'oauth_integration_id: int = config.value(alias="oauth-integration-id", converter=config.str_to_int)'
             in output
@@ -278,7 +278,7 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
 
     def test_source_config_ssh_tunnel_non_python_identifier(self):
         config = SourceConfig(
-            name=ExternalDataSourceType.STRIPE,
+            name=SchemaExternalDataSourceType.STRIPE,
             caption="",
             fields=cast(
                 list[FieldType],
@@ -291,7 +291,7 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
             ),
         )
 
-        output = self._run({ExternalDataSource.Type.STRIPE: config})
+        output = self._run({ExternalDataSourceType.STRIPE: config})
         assert (
             'ssh_tunnel: SSHTunnelConfig | None = config.value(alias="ssh-tunnel", default_factory=lambda: None)'
             in output
@@ -299,7 +299,7 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
 
     def test_source_config_complex_select_non_python_identifier(self):
         config = SourceConfig(
-            name=ExternalDataSourceType.STRIPE,
+            name=SchemaExternalDataSourceType.STRIPE,
             caption="",
             fields=cast(
                 list[FieldType],
@@ -319,7 +319,7 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
                                         SourceFieldInputConfig(
                                             name="option-1-input",  # dashes are not allowed in python identifiers
                                             label="option_1 label",
-                                            type=Type4.TEXT,
+                                            type=SourceFieldInputConfigType.TEXT,
                                             required=True,
                                             placeholder="option_1 placeholder",
                                         ),
@@ -335,7 +335,7 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
                                         SourceFieldInputConfig(
                                             name="option-2-input",  # dashes are not allowed in python identifiers
                                             label="option_2 label",
-                                            type=Type4.TEXT,
+                                            type=SourceFieldInputConfigType.TEXT,
                                             required=True,
                                             placeholder="option_2 placeholder",
                                         ),
@@ -348,7 +348,7 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
             ),
         )
 
-        output = self._run({ExternalDataSource.Type.STRIPE: config})
+        output = self._run({ExternalDataSourceType.STRIPE: config})
         assert 'select_with_fields: StripeSelectWithFieldsConfig = config.value(alias="select-with-fields")' in output
         assert "class StripeSelectWithFieldsConfig(config.Config)" in output
         assert 'selection: Literal["option_1", "option_2"] = "option_1' in output
@@ -357,7 +357,7 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
 
     def test_source_config_simple_select_non_python_identifier(self):
         config = SourceConfig(
-            name=ExternalDataSourceType.STRIPE,
+            name=SchemaExternalDataSourceType.STRIPE,
             caption="",
             fields=cast(
                 list[FieldType],
@@ -373,14 +373,14 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
             ),
         )
 
-        output = self._run({ExternalDataSource.Type.STRIPE: config})
+        output = self._run({ExternalDataSourceType.STRIPE: config})
         assert (
             'select_with_options: Literal["1", "0"] = config.value(default="1", alias="select-with-options")' in output
         )
 
     def test_source_config_ssh_tunnel_reference(self):
         config = SourceConfig(
-            name=ExternalDataSourceType.STRIPE,
+            name=SchemaExternalDataSourceType.STRIPE,
             caption="",
             fields=cast(
                 list[FieldType],
@@ -390,30 +390,34 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
             ),
         )
 
-        output = self._run({ExternalDataSource.Type.STRIPE: config})
+        output = self._run({ExternalDataSourceType.STRIPE: config})
         assert "from posthog.warehouse.models.ssh_tunnel import SSHTunnelConfig" in output
         assert "ssh_tunnel: SSHTunnelConfig" in output
 
     def test_source_config_type_conversion(self):
         config = SourceConfig(
-            name=ExternalDataSourceType.STRIPE,
+            name=SchemaExternalDataSourceType.STRIPE,
             caption="",
             fields=cast(
                 list[FieldType],
                 [
                     SourceFieldInputConfig(
-                        name="int_value", label="int", type=Type4.NUMBER, required=True, placeholder="12345"
+                        name="int_value",
+                        label="int",
+                        type=SourceFieldInputConfigType.NUMBER,
+                        required=True,
+                        placeholder="12345",
                     ),
                 ],
             ),
         )
 
-        output = self._run({ExternalDataSource.Type.STRIPE: config})
+        output = self._run({ExternalDataSourceType.STRIPE: config})
         assert "int_value: int = config.value(converter=int)" in output
 
     def test_source_config_nested_class(self):
         config = SourceConfig(
-            name=ExternalDataSourceType.STRIPE,
+            name=SchemaExternalDataSourceType.STRIPE,
             caption="",
             fields=cast(
                 list[FieldType],
@@ -429,14 +433,14 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
                                 SourceFieldInputConfig(
                                     name="input_field_1",
                                     label="input label",
-                                    type=Type4.TEXT,
+                                    type=SourceFieldInputConfigType.TEXT,
                                     required=False,
                                     placeholder="input placeholder",
                                 ),
                                 SourceFieldInputConfig(
                                     name="input_field_2",
                                     label="input label",
-                                    type=Type4.TEXT,
+                                    type=SourceFieldInputConfigType.TEXT,
                                     required=False,
                                     placeholder="input placeholder",
                                 ),
@@ -447,6 +451,6 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
             ),
         )
 
-        output = self._run({ExternalDataSource.Type.STRIPE: config})
+        output = self._run({ExternalDataSourceType.STRIPE: config})
         assert "class StripeSwitchGroupConfig(config.Config):" in output
         assert "switch_group: StripeSwitchGroupConfig" in output

--- a/posthog/temporal/data_imports/sources/doit/source.py
+++ b/posthog/temporal/data_imports/sources/doit/source.py
@@ -1,9 +1,9 @@
 from typing import cast
 from posthog.schema import (
-    ExternalDataSourceType,
+    ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
     SourceFieldInputConfig,
-    Type4,
+    SourceFieldInputConfigType,
 )
 from posthog.temporal.data_imports.sources.doit.doit import doit_source, doit_list_reports, DOIT_INCREMENTAL_FIELDS
 from posthog.temporal.data_imports.sources.common.base import BaseSource, FieldType
@@ -11,14 +11,14 @@ from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
 from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
 from posthog.temporal.data_imports.sources.generated_configs import DoItSourceConfig
-from posthog.warehouse.models import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
 class DoItSource(BaseSource[DoItSourceConfig]):
     @property
-    def source_type(self) -> ExternalDataSource.Type:
-        return ExternalDataSource.Type.DOIT
+    def source_type(self) -> ExternalDataSourceType:
+        return ExternalDataSourceType.DOIT
 
     def get_schemas(self, config: DoItSourceConfig, team_id: int) -> list[SourceSchema]:
         reports = doit_list_reports(config)
@@ -47,14 +47,18 @@ class DoItSource(BaseSource[DoItSourceConfig]):
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
-            name=ExternalDataSourceType.DO_IT,
+            name=SchemaExternalDataSourceType.DO_IT,
             label="DoIt",
             caption="",
             fields=cast(
                 list[FieldType],
                 [
                     SourceFieldInputConfig(
-                        name="api_key", label="API key", type=Type4.TEXT, required=True, placeholder=""
+                        name="api_key",
+                        label="API key",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="",
                     )
                 ],
             ),

--- a/posthog/temporal/data_imports/sources/generated_configs.py
+++ b/posthog/temporal/data_imports/sources/generated_configs.py
@@ -2,8 +2,8 @@
 # Do not edit manually - run `pnpm generate:source-configs` to regenerate.
 
 from posthog.temporal.data_imports.sources.common import config
-from posthog.warehouse.models import ExternalDataSource
 from posthog.warehouse.models.ssh_tunnel import SSHTunnelConfig
+from posthog.warehouse.types import ExternalDataSourceType
 from typing import Literal
 
 
@@ -196,28 +196,28 @@ class ZendeskSourceConfig(config.Config):
     email_address: str
 
 
-def get_config_for_source(source: ExternalDataSource.Type):
+def get_config_for_source(source: ExternalDataSourceType):
     return {
-        ExternalDataSource.Type.BIGQUERY: BigQuerySourceConfig,
-        ExternalDataSource.Type.BRAZE: BrazeSourceConfig,
-        ExternalDataSource.Type.CHARGEBEE: ChargebeeSourceConfig,
-        ExternalDataSource.Type.DOIT: DoItSourceConfig,
-        ExternalDataSource.Type.GOOGLEADS: GoogleAdsSourceConfig,
-        ExternalDataSource.Type.GOOGLESHEETS: GoogleSheetsSourceConfig,
-        ExternalDataSource.Type.HUBSPOT: HubspotSourceConfig,
-        ExternalDataSource.Type.KLAVIYO: KlaviyoSourceConfig,
-        ExternalDataSource.Type.MSSQL: MSSQLSourceConfig,
-        ExternalDataSource.Type.MAILCHIMP: MailchimpSourceConfig,
-        ExternalDataSource.Type.MAILJET: MailjetSourceConfig,
-        ExternalDataSource.Type.METAADS: MetaAdsSourceConfig,
-        ExternalDataSource.Type.MONGODB: MongoDBSourceConfig,
-        ExternalDataSource.Type.MYSQL: MySQLSourceConfig,
-        ExternalDataSource.Type.POSTGRES: PostgresSourceConfig,
-        ExternalDataSource.Type.REDSHIFT: RedshiftSourceConfig,
-        ExternalDataSource.Type.SALESFORCE: SalesforceSourceConfig,
-        ExternalDataSource.Type.SNOWFLAKE: SnowflakeSourceConfig,
-        ExternalDataSource.Type.STRIPE: StripeSourceConfig,
-        ExternalDataSource.Type.TEMPORALIO: TemporalIOSourceConfig,
-        ExternalDataSource.Type.VITALLY: VitallySourceConfig,
-        ExternalDataSource.Type.ZENDESK: ZendeskSourceConfig,
+        ExternalDataSourceType.BIGQUERY: BigQuerySourceConfig,
+        ExternalDataSourceType.BRAZE: BrazeSourceConfig,
+        ExternalDataSourceType.CHARGEBEE: ChargebeeSourceConfig,
+        ExternalDataSourceType.DOIT: DoItSourceConfig,
+        ExternalDataSourceType.GOOGLEADS: GoogleAdsSourceConfig,
+        ExternalDataSourceType.GOOGLESHEETS: GoogleSheetsSourceConfig,
+        ExternalDataSourceType.HUBSPOT: HubspotSourceConfig,
+        ExternalDataSourceType.KLAVIYO: KlaviyoSourceConfig,
+        ExternalDataSourceType.MSSQL: MSSQLSourceConfig,
+        ExternalDataSourceType.MAILCHIMP: MailchimpSourceConfig,
+        ExternalDataSourceType.MAILJET: MailjetSourceConfig,
+        ExternalDataSourceType.METAADS: MetaAdsSourceConfig,
+        ExternalDataSourceType.MONGODB: MongoDBSourceConfig,
+        ExternalDataSourceType.MYSQL: MySQLSourceConfig,
+        ExternalDataSourceType.POSTGRES: PostgresSourceConfig,
+        ExternalDataSourceType.REDSHIFT: RedshiftSourceConfig,
+        ExternalDataSourceType.SALESFORCE: SalesforceSourceConfig,
+        ExternalDataSourceType.SNOWFLAKE: SnowflakeSourceConfig,
+        ExternalDataSourceType.STRIPE: StripeSourceConfig,
+        ExternalDataSourceType.TEMPORALIO: TemporalIOSourceConfig,
+        ExternalDataSourceType.VITALLY: VitallySourceConfig,
+        ExternalDataSourceType.ZENDESK: ZendeskSourceConfig,
     }[source]

--- a/posthog/temporal/data_imports/sources/google_ads/google_ads.py
+++ b/posthog/temporal/data_imports/sources/google_ads/google_ads.py
@@ -14,7 +14,7 @@ from google.ads.googleads.v19.services import types as ga_services
 from google.oauth2 import service_account
 from google.protobuf.json_format import MessageToJson
 
-from posthog.models import Integration
+from posthog.models.integration import Integration
 from posthog.temporal.data_imports.sources.google_ads.schemas import RESOURCE_SCHEMAS
 from posthog.temporal.data_imports.pipelines.helpers import incremental_type_to_initial_value
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse

--- a/posthog/temporal/data_imports/sources/google_ads/source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/source.py
@@ -1,10 +1,10 @@
 from typing import cast
 from posthog.schema import (
-    ExternalDataSourceType,
+    ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldOauthConfig,
-    Type4,
+    SourceFieldInputConfigType,
 )
 from posthog.temporal.data_imports.sources.common.base import BaseSource, FieldType
 from posthog.temporal.data_imports.sources.common.mixins import OAuthMixin
@@ -18,14 +18,14 @@ from posthog.temporal.data_imports.sources.google_ads.google_ads import (
 )
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
 from posthog.temporal.data_imports.sources.generated_configs import GoogleAdsSourceConfig
-from posthog.warehouse.models import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
 class GoogleAdsSource(BaseSource[GoogleAdsSourceConfig | GoogleAdsServiceAccountSourceConfig], OAuthMixin):
     @property
-    def source_type(self) -> ExternalDataSource.Type:
-        return ExternalDataSource.Type.GOOGLEADS
+    def source_type(self) -> ExternalDataSourceType:
+        return ExternalDataSourceType.GOOGLEADS
 
     # TODO: clean up google ads source to not have two auth config options
     def parse_config(self, job_inputs: dict) -> GoogleAdsSourceConfig | GoogleAdsServiceAccountSourceConfig:
@@ -75,7 +75,7 @@ class GoogleAdsSource(BaseSource[GoogleAdsSourceConfig | GoogleAdsServiceAccount
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
-            name=ExternalDataSourceType.GOOGLE_ADS,
+            name=SchemaExternalDataSourceType.GOOGLE_ADS,
             label="Google Ads",
             caption="Ensure you have granted PostHog access to your Google Ads account, learn how to do this in [the docs](https://posthog.com/docs/cdp/sources/google-ads).",
             betaSource=True,
@@ -83,7 +83,11 @@ class GoogleAdsSource(BaseSource[GoogleAdsSourceConfig | GoogleAdsServiceAccount
                 list[FieldType],
                 [
                     SourceFieldInputConfig(
-                        name="customer_id", label="Customer ID", type=Type4.TEXT, required=True, placeholder=""
+                        name="customer_id",
+                        label="Customer ID",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="",
                     ),
                     SourceFieldOauthConfig(
                         name="google_ads_integration_id", label="Google Ads account", required=True, kind="google-ads"

--- a/posthog/temporal/data_imports/sources/google_sheets/source.py
+++ b/posthog/temporal/data_imports/sources/google_sheets/source.py
@@ -1,10 +1,10 @@
 from typing import cast
 import gspread
 from posthog.schema import (
-    ExternalDataSourceType,
+    ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
     SourceFieldInputConfig,
-    Type4,
+    SourceFieldInputConfigType,
 )
 from posthog.temporal.data_imports.sources.google_sheets.google_sheets import (
     get_schemas as get_google_sheets_schemas,
@@ -17,14 +17,14 @@ from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
 from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
 from posthog.temporal.data_imports.sources.generated_configs import GoogleSheetsSourceConfig
-from posthog.warehouse.models import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
 class GoogleSheetsSource(BaseSource[GoogleSheetsSourceConfig]):
     @property
-    def source_type(self) -> ExternalDataSource.Type:
-        return ExternalDataSource.Type.GOOGLESHEETS
+    def source_type(self) -> ExternalDataSourceType:
+        return ExternalDataSourceType.GOOGLESHEETS
 
     def get_schemas(self, config: GoogleSheetsSourceConfig, team_id: int) -> list[SourceSchema]:
         sheets = get_google_sheets_schemas(config)
@@ -72,7 +72,7 @@ class GoogleSheetsSource(BaseSource[GoogleSheetsSourceConfig]):
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
-            name=ExternalDataSourceType.GOOGLE_SHEETS,
+            name=SchemaExternalDataSourceType.GOOGLE_SHEETS,
             label="Google Sheets",
             caption="Ensure you have granted PostHog access to your Google Sheet as instructed in the [documentation](https://posthog.com/docs/cdp/sources/google-sheets)",
             betaSource=True,
@@ -80,7 +80,11 @@ class GoogleSheetsSource(BaseSource[GoogleSheetsSourceConfig]):
                 list[FieldType],
                 [
                     SourceFieldInputConfig(
-                        name="spreadsheet_url", label="Spreadsheet URL", type=Type4.TEXT, required=True, placeholder=""
+                        name="spreadsheet_url",
+                        label="Spreadsheet URL",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="",
                     )
                 ],
             ),

--- a/posthog/temporal/data_imports/sources/hubspot/source.py
+++ b/posthog/temporal/data_imports/sources/hubspot/source.py
@@ -1,6 +1,6 @@
 from typing import cast
 from posthog.schema import (
-    ExternalDataSourceType,
+    ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
     SourceFieldOauthConfig,
 )
@@ -17,7 +17,7 @@ from posthog.temporal.data_imports.sources.hubspot.settings import (
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
 from posthog.temporal.data_imports.sources.common.utils import dlt_source_to_source_response
 from posthog.temporal.data_imports.sources.generated_configs import HubspotSourceConfig
-from posthog.warehouse.models import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 @config.config
@@ -29,13 +29,13 @@ class HubspotSourceOldConfig(config.Config):
 @SourceRegistry.register
 class HubspotSource(BaseSource[HubspotSourceConfig | HubspotSourceOldConfig], OAuthMixin):
     @property
-    def source_type(self) -> ExternalDataSource.Type:
-        return ExternalDataSource.Type.HUBSPOT
+    def source_type(self) -> ExternalDataSourceType:
+        return ExternalDataSourceType.HUBSPOT
 
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
-            name=ExternalDataSourceType.HUBSPOT,
+            name=SchemaExternalDataSourceType.HUBSPOT,
             caption="Select an existing Hubspot account to link to PostHog or create a new connection",
             fields=cast(
                 list[FieldType],

--- a/posthog/temporal/data_imports/sources/klaviyo/source.py
+++ b/posthog/temporal/data_imports/sources/klaviyo/source.py
@@ -1,24 +1,24 @@
 from typing import cast
 from posthog.schema import (
-    ExternalDataSourceType,
+    ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
 )
 from posthog.temporal.data_imports.sources.common.base import BaseSource, FieldType
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
 from posthog.temporal.data_imports.sources.generated_configs import KlaviyoSourceConfig
-from posthog.warehouse.models import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
 class KlaviyoSource(BaseSource[KlaviyoSourceConfig]):
     @property
-    def source_type(self) -> ExternalDataSource.Type:
-        return ExternalDataSource.Type.KLAVIYO
+    def source_type(self) -> ExternalDataSourceType:
+        return ExternalDataSourceType.KLAVIYO
 
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
-            name=ExternalDataSourceType.KLAVIYO,
+            name=SchemaExternalDataSourceType.KLAVIYO,
             label="Klaviyo",
             caption="",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/mailchimp/source.py
+++ b/posthog/temporal/data_imports/sources/mailchimp/source.py
@@ -1,24 +1,24 @@
 from typing import cast
 from posthog.schema import (
-    ExternalDataSourceType,
+    ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
 )
 from posthog.temporal.data_imports.sources.common.base import BaseSource, FieldType
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
 from posthog.temporal.data_imports.sources.generated_configs import MailchimpSourceConfig
-from posthog.warehouse.models import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
 class MailchimpSource(BaseSource[MailchimpSourceConfig]):
     @property
-    def source_type(self) -> ExternalDataSource.Type:
-        return ExternalDataSource.Type.MAILCHIMP
+    def source_type(self) -> ExternalDataSourceType:
+        return ExternalDataSourceType.MAILCHIMP
 
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
-            name=ExternalDataSourceType.MAILCHIMP,
+            name=SchemaExternalDataSourceType.MAILCHIMP,
             label="Mailchimp",
             caption="",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/mailjet/source.py
+++ b/posthog/temporal/data_imports/sources/mailjet/source.py
@@ -1,24 +1,24 @@
 from typing import cast
 from posthog.schema import (
-    ExternalDataSourceType,
+    ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
 )
 from posthog.temporal.data_imports.sources.common.base import BaseSource, FieldType
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
 from posthog.temporal.data_imports.sources.generated_configs import MailjetSourceConfig
-from posthog.warehouse.models import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
 class MailJetSource(BaseSource[MailjetSourceConfig]):
     @property
-    def source_type(self) -> ExternalDataSource.Type:
-        return ExternalDataSource.Type.MAILJET
+    def source_type(self) -> ExternalDataSourceType:
+        return ExternalDataSourceType.MAILJET
 
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
-            name=ExternalDataSourceType.MAILJET,
+            name=SchemaExternalDataSourceType.MAILJET,
             label="Mailjet",
             caption="",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/meta_ads/meta_ads.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/meta_ads.py
@@ -7,8 +7,7 @@ import typing
 import requests
 from dlt.common.normalizers.naming.snake_case import NamingConvention
 
-from posthog.models import Integration
-from posthog.models.integration import ERROR_TOKEN_REFRESH_FAILED, MetaAdsIntegration
+from posthog.models.integration import Integration, ERROR_TOKEN_REFRESH_FAILED, MetaAdsIntegration
 from posthog.temporal.data_imports.pipelines.pipeline.typings import PartitionFormat, PartitionMode, SourceResponse
 from posthog.temporal.data_imports.sources.generated_configs import MetaAdsSourceConfig
 from posthog.warehouse.types import IncrementalFieldType

--- a/posthog/temporal/data_imports/sources/meta_ads/source.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/source.py
@@ -1,10 +1,10 @@
 from typing import cast
 from posthog.schema import (
-    ExternalDataSourceType,
+    ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldOauthConfig,
-    Type4,
+    SourceFieldInputConfigType,
 )
 from posthog.temporal.data_imports.sources.common.base import BaseSource, FieldType
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
@@ -13,14 +13,14 @@ from posthog.temporal.data_imports.sources.meta_ads.meta_ads import meta_ads_sou
 from posthog.temporal.data_imports.sources.meta_ads.schemas import ENDPOINTS, INCREMENTAL_FIELDS
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
 from posthog.temporal.data_imports.sources.generated_configs import MetaAdsSourceConfig
-from posthog.warehouse.models import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
 class MetaAdsSource(BaseSource[MetaAdsSourceConfig]):
     @property
-    def source_type(self) -> ExternalDataSource.Type:
-        return ExternalDataSource.Type.METAADS
+    def source_type(self) -> ExternalDataSourceType:
+        return ExternalDataSourceType.METAADS
 
     def get_schemas(self, config: MetaAdsSourceConfig, team_id: int) -> list[SourceSchema]:
         return [
@@ -49,7 +49,7 @@ class MetaAdsSource(BaseSource[MetaAdsSourceConfig]):
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
-            name=ExternalDataSourceType.META_ADS,
+            name=SchemaExternalDataSourceType.META_ADS,
             label="Meta Ads",
             caption="Ensure you have granted PostHog access to your Meta Ads account, learn how to do this in the [documentation](https://posthog.com/docs/cdp/sources/meta-ads).",
             fields=cast(
@@ -58,7 +58,7 @@ class MetaAdsSource(BaseSource[MetaAdsSourceConfig]):
                     SourceFieldInputConfig(
                         name="account_id",
                         label="Account ID",
-                        type=Type4.TEXT,
+                        type=SourceFieldInputConfigType.TEXT,
                         required=True,
                         placeholder="",
                     ),

--- a/posthog/temporal/data_imports/sources/mongodb/source.py
+++ b/posthog/temporal/data_imports/sources/mongodb/source.py
@@ -1,10 +1,10 @@
 from typing import cast
 from posthog.exceptions_capture import capture_exception
 from posthog.schema import (
-    ExternalDataSourceType,
+    ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
     SourceFieldInputConfig,
-    Type4,
+    SourceFieldInputConfigType,
 )
 from posthog.temporal.data_imports.sources.common.base import BaseSource, FieldType
 from posthog.temporal.data_imports.sources.common.mixins import ValidateDatabaseHostMixin
@@ -18,14 +18,14 @@ from posthog.temporal.data_imports.sources.mongodb.mongo import (
     mongo_source,
 )
 from posthog.temporal.data_imports.sources.generated_configs import MongoDBSourceConfig
-from posthog.warehouse.models import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
 class MongoDBSource(BaseSource[MongoDBSourceConfig], ValidateDatabaseHostMixin):
     @property
-    def source_type(self) -> ExternalDataSource.Type:
-        return ExternalDataSource.Type.MONGODB
+    def source_type(self) -> ExternalDataSourceType:
+        return ExternalDataSourceType.MONGODB
 
     def get_schemas(self, config: MongoDBSourceConfig, team_id: int) -> list[SourceSchema]:
         mongo_schemas = get_mongo_schemas(config)
@@ -95,7 +95,7 @@ class MongoDBSource(BaseSource[MongoDBSourceConfig], ValidateDatabaseHostMixin):
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
-            name=ExternalDataSourceType.MONGO_DB,
+            name=SchemaExternalDataSourceType.MONGO_DB,
             label="MongoDB",
             caption="Enter your MongoDB connection string to automatically pull your MongoDB data into the PostHog Data warehouse.",
             betaSource=True,
@@ -105,7 +105,7 @@ class MongoDBSource(BaseSource[MongoDBSourceConfig], ValidateDatabaseHostMixin):
                     SourceFieldInputConfig(
                         name="connection_string",
                         label="Connection String",
-                        type=Type4.TEXT,
+                        type=SourceFieldInputConfigType.TEXT,
                         required=True,
                         placeholder="mongodb://username:password@host:port/database?authSource=admin",
                     )

--- a/posthog/temporal/data_imports/sources/mssql/source.py
+++ b/posthog/temporal/data_imports/sources/mssql/source.py
@@ -2,11 +2,11 @@ from typing import cast
 from sshtunnel import BaseSSHTunnelForwarderError
 from posthog.exceptions_capture import capture_exception
 from posthog.schema import (
-    ExternalDataSourceType,
+    ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldSSHTunnelConfig,
-    Type4,
+    SourceFieldInputConfigType,
 )
 from posthog.temporal.data_imports.sources.common.base import BaseSource, FieldType
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
@@ -19,8 +19,7 @@ from posthog.temporal.data_imports.sources.mssql.mssql import (
     filter_mssql_incremental_fields,
 )
 from posthog.temporal.data_imports.sources.generated_configs import MSSQLSourceConfig
-from posthog.warehouse.types import IncrementalField
-from posthog.warehouse.models import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType, IncrementalField
 
 MSSQLErrors = {
     "Login failed for user": "Login failed for database",
@@ -32,33 +31,55 @@ MSSQLErrors = {
 @SourceRegistry.register
 class MSSQLSource(BaseSource[MSSQLSourceConfig], SSHTunnelMixin, ValidateDatabaseHostMixin):
     @property
-    def source_type(self) -> ExternalDataSource.Type:
-        return ExternalDataSource.Type.MSSQL
+    def source_type(self) -> ExternalDataSourceType:
+        return ExternalDataSourceType.MSSQL
 
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
-            name=ExternalDataSourceType.MSSQL,
+            name=SchemaExternalDataSourceType.MSSQL,
             label="Microsoft SQL Server",
             caption="Enter your Microsoft SQL Server/Azure SQL Server credentials to automatically pull your SQL data into the PostHog Data warehouse.",
             fields=cast(
                 list[FieldType],
                 [
                     SourceFieldInputConfig(
-                        name="host", label="Host", type=Type4.TEXT, required=True, placeholder="localhost"
+                        name="host",
+                        label="Host",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="localhost",
                     ),
                     SourceFieldInputConfig(
-                        name="port", label="Port", type=Type4.NUMBER, required=True, placeholder="1433"
+                        name="port",
+                        label="Port",
+                        type=SourceFieldInputConfigType.NUMBER,
+                        required=True,
+                        placeholder="1433",
                     ),
                     SourceFieldInputConfig(
-                        name="database", label="Database", type=Type4.TEXT, required=True, placeholder="msdb"
+                        name="database",
+                        label="Database",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="msdb",
                     ),
-                    SourceFieldInputConfig(name="user", label="User", type=Type4.TEXT, required=True, placeholder="sa"),
                     SourceFieldInputConfig(
-                        name="password", label="Password", type=Type4.PASSWORD, required=True, placeholder=""
+                        name="user", label="User", type=SourceFieldInputConfigType.TEXT, required=True, placeholder="sa"
                     ),
                     SourceFieldInputConfig(
-                        name="schema", label="Schema", type=Type4.TEXT, required=True, placeholder="dbo"
+                        name="password",
+                        label="Password",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
+                    ),
+                    SourceFieldInputConfig(
+                        name="schema",
+                        label="Schema",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="dbo",
                     ),
                     SourceFieldSSHTunnelConfig(name="ssh_tunnel", label="Use SSH tunnel?"),
                 ],

--- a/posthog/temporal/data_imports/sources/mysql/source.py
+++ b/posthog/temporal/data_imports/sources/mysql/source.py
@@ -2,14 +2,14 @@ from typing import cast
 from sshtunnel import BaseSSHTunnelForwarderError
 from posthog.exceptions_capture import capture_exception
 from posthog.schema import (
-    ExternalDataSourceType,
+    ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldSelectConfig,
     SourceFieldSSHTunnelConfig,
-    Type4,
+    SourceFieldInputConfigType,
     Option,
-    Converter,
+    SourceFieldSelectConfigConverter,
 )
 from posthog.temporal.data_imports.sources.common.base import BaseSource, FieldType
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
@@ -22,48 +22,71 @@ from posthog.temporal.data_imports.sources.mysql.mysql import (
     filter_mysql_incremental_fields,
 )
 from posthog.temporal.data_imports.sources.generated_configs import MySQLSourceConfig
-from posthog.warehouse.models import ExternalDataSource
-from posthog.warehouse.types import IncrementalField
+from posthog.warehouse.types import ExternalDataSourceType, IncrementalField
 
 
 @SourceRegistry.register
 class MySQLSource(BaseSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabaseHostMixin):
     @property
-    def source_type(self) -> ExternalDataSource.Type:
-        return ExternalDataSource.Type.MYSQL
+    def source_type(self) -> ExternalDataSourceType:
+        return ExternalDataSourceType.MYSQL
 
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
-            name=ExternalDataSourceType.MY_SQL,
+            name=SchemaExternalDataSourceType.MY_SQL,
             caption="Enter your MySQL/MariaDB credentials to automatically pull your MySQL data into the PostHog Data warehouse.",
             fields=cast(
                 list[FieldType],
                 [
                     SourceFieldInputConfig(
-                        name="host", label="Host", type=Type4.TEXT, required=True, placeholder="localhost"
+                        name="host",
+                        label="Host",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="localhost",
                     ),
                     SourceFieldInputConfig(
-                        name="port", label="Port", type=Type4.NUMBER, required=True, placeholder="3306"
+                        name="port",
+                        label="Port",
+                        type=SourceFieldInputConfigType.NUMBER,
+                        required=True,
+                        placeholder="3306",
                     ),
                     SourceFieldInputConfig(
-                        name="database", label="Database", type=Type4.TEXT, required=True, placeholder="mysql"
+                        name="database",
+                        label="Database",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="mysql",
                     ),
                     SourceFieldInputConfig(
-                        name="user", label="User", type=Type4.TEXT, required=True, placeholder="mysql"
+                        name="user",
+                        label="User",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="mysql",
                     ),
                     SourceFieldInputConfig(
-                        name="password", label="Password", type=Type4.PASSWORD, required=True, placeholder=""
+                        name="password",
+                        label="Password",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
                     ),
                     SourceFieldInputConfig(
-                        name="schema", label="Schema", type=Type4.TEXT, required=True, placeholder="public"
+                        name="schema",
+                        label="Schema",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="public",
                     ),
                     SourceFieldSelectConfig(
                         name="using_ssl",
                         label="Use SSL?",
                         required=True,
                         defaultValue="true",
-                        converter=Converter.STR_TO_BOOL,
+                        converter=SourceFieldSelectConfigConverter.STR_TO_BOOL,
                         options=[Option(label="Yes", value="true"), Option(label="No", value="false")],
                     ),
                     SourceFieldSSHTunnelConfig(name="ssh_tunnel", label="Use SSH tunnel?"),

--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -4,11 +4,11 @@ from psycopg import OperationalError
 from sshtunnel import BaseSSHTunnelForwarderError
 from posthog.exceptions_capture import capture_exception
 from posthog.schema import (
-    ExternalDataSourceType,
+    ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldSSHTunnelConfig,
-    Type4,
+    SourceFieldInputConfigType,
 )
 from posthog.temporal.data_imports.sources.common.base import BaseSource, FieldType
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
@@ -22,8 +22,7 @@ from posthog.temporal.data_imports.sources.postgres.postgres import (
 )
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
 from posthog.temporal.data_imports.sources.generated_configs import PostgresSourceConfig
-from posthog.warehouse.types import IncrementalField
-from posthog.warehouse.models import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType, IncrementalField
 
 PostgresErrors = {
     "password authentication failed for user": "Invalid user or password",
@@ -37,13 +36,13 @@ PostgresErrors = {
 @SourceRegistry.register
 class PostgresSource(BaseSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDatabaseHostMixin):
     @property
-    def source_type(self) -> ExternalDataSource.Type:
-        return ExternalDataSource.Type.POSTGRES
+    def source_type(self) -> ExternalDataSourceType:
+        return ExternalDataSourceType.POSTGRES
 
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
-            name=ExternalDataSourceType.POSTGRES,
+            name=SchemaExternalDataSourceType.POSTGRES,
             caption="Enter your Postgres credentials to automatically pull your Postgres data into the PostHog Data warehouse",
             fields=cast(
                 list[FieldType],
@@ -51,27 +50,51 @@ class PostgresSource(BaseSource[PostgresSourceConfig], SSHTunnelMixin, ValidateD
                     SourceFieldInputConfig(
                         name="connection_string",
                         label="Connection string (optional)",
-                        type=Type4.TEXT,
+                        type=SourceFieldInputConfigType.TEXT,
                         required=False,
                         placeholder="postgresql://user:password@localhost:5432/database",
                     ),
                     SourceFieldInputConfig(
-                        name="host", label="Host", type=Type4.TEXT, required=True, placeholder="localhost"
+                        name="host",
+                        label="Host",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="localhost",
                     ),
                     SourceFieldInputConfig(
-                        name="port", label="Port", type=Type4.NUMBER, required=True, placeholder="5432"
+                        name="port",
+                        label="Port",
+                        type=SourceFieldInputConfigType.NUMBER,
+                        required=True,
+                        placeholder="5432",
                     ),
                     SourceFieldInputConfig(
-                        name="database", label="Database", type=Type4.TEXT, required=True, placeholder="postgres"
+                        name="database",
+                        label="Database",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="postgres",
                     ),
                     SourceFieldInputConfig(
-                        name="user", label="User", type=Type4.TEXT, required=True, placeholder="postgres"
+                        name="user",
+                        label="User",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="postgres",
                     ),
                     SourceFieldInputConfig(
-                        name="password", label="Password", type=Type4.PASSWORD, required=True, placeholder=""
+                        name="password",
+                        label="Password",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
                     ),
                     SourceFieldInputConfig(
-                        name="schema", label="Schema", type=Type4.TEXT, required=True, placeholder="public"
+                        name="schema",
+                        label="Schema",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="public",
                     ),
                     SourceFieldSSHTunnelConfig(name="ssh_tunnel", label="Use SSH tunnel?"),
                 ],

--- a/posthog/temporal/data_imports/sources/redshift/source.py
+++ b/posthog/temporal/data_imports/sources/redshift/source.py
@@ -1,24 +1,24 @@
 from typing import cast
 from posthog.schema import (
-    ExternalDataSourceType,
+    ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
 )
 from posthog.temporal.data_imports.sources.common.base import BaseSource, FieldType
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
 from posthog.temporal.data_imports.sources.generated_configs import RedshiftSourceConfig
-from posthog.warehouse.models import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
 class RedshiftSource(BaseSource[RedshiftSourceConfig]):
     @property
-    def source_type(self) -> ExternalDataSource.Type:
-        return ExternalDataSource.Type.REDSHIFT
+    def source_type(self) -> ExternalDataSourceType:
+        return ExternalDataSourceType.REDSHIFT
 
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
-            name=ExternalDataSourceType.REDSHIFT,
+            name=SchemaExternalDataSourceType.REDSHIFT,
             label="Redshift",
             caption="",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/salesforce/source.py
+++ b/posthog/temporal/data_imports/sources/salesforce/source.py
@@ -1,6 +1,6 @@
 from typing import cast
 from posthog.schema import (
-    ExternalDataSourceType,
+    ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
     SourceFieldOauthConfig,
 )
@@ -16,14 +16,14 @@ from posthog.temporal.data_imports.sources.salesforce.salesforce import (
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
 from posthog.temporal.data_imports.sources.common.utils import dlt_source_to_source_response
 from posthog.temporal.data_imports.sources.generated_configs import SalesforceSourceConfig
-from posthog.warehouse.models import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
 class SalesforceSource(BaseSource[SalesforceSourceConfig], OAuthMixin):
     @property
-    def source_type(self) -> ExternalDataSource.Type:
-        return ExternalDataSource.Type.SALESFORCE
+    def source_type(self) -> ExternalDataSourceType:
+        return ExternalDataSourceType.SALESFORCE
 
     def get_schemas(self, config: SalesforceSourceConfig, team_id: int) -> list[SourceSchema]:
         return [
@@ -39,7 +39,7 @@ class SalesforceSource(BaseSource[SalesforceSourceConfig], OAuthMixin):
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
-            name=ExternalDataSourceType.SALESFORCE,
+            name=SchemaExternalDataSourceType.SALESFORCE,
             caption="Select an existing Salesforce account to link to PostHog or create a new connection",
             fields=cast(
                 list[FieldType],

--- a/posthog/temporal/data_imports/sources/snowflake/source.py
+++ b/posthog/temporal/data_imports/sources/snowflake/source.py
@@ -2,11 +2,11 @@ from typing import cast
 from snowflake.connector.errors import DatabaseError, ForbiddenError, ProgrammingError
 from posthog.exceptions_capture import capture_exception
 from posthog.schema import (
-    ExternalDataSourceType,
+    ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldSelectConfig,
-    Type4,
+    SourceFieldInputConfigType,
     Option,
 )
 from posthog.temporal.data_imports.sources.common.base import BaseSource, FieldType
@@ -19,8 +19,7 @@ from posthog.temporal.data_imports.sources.snowflake.snowflake import (
     snowflake_source,
 )
 from posthog.temporal.data_imports.sources.generated_configs import SnowflakeSourceConfig
-from posthog.warehouse.types import IncrementalField
-from posthog.warehouse.models import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType, IncrementalField
 
 
 SnowflakeErrors = {
@@ -35,31 +34,35 @@ SnowflakeErrors = {
 @SourceRegistry.register
 class SnowflakeSource(BaseSource[SnowflakeSourceConfig]):
     @property
-    def source_type(self) -> ExternalDataSource.Type:
-        return ExternalDataSource.Type.SNOWFLAKE
+    def source_type(self) -> ExternalDataSourceType:
+        return ExternalDataSourceType.SNOWFLAKE
 
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
-            name=ExternalDataSourceType.SNOWFLAKE,
+            name=SchemaExternalDataSourceType.SNOWFLAKE,
             caption="Enter your Snowflake credentials to automatically pull your Snowflake data into the PostHog Data warehouse.",
             fields=cast(
                 list[FieldType],
                 [
                     SourceFieldInputConfig(
-                        name="account_id", label="Account id", type=Type4.TEXT, required=True, placeholder=""
+                        name="account_id",
+                        label="Account id",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="",
                     ),
                     SourceFieldInputConfig(
                         name="database",
                         label="Database",
-                        type=Type4.TEXT,
+                        type=SourceFieldInputConfigType.TEXT,
                         required=True,
                         placeholder="snowflake_sample_data",
                     ),
                     SourceFieldInputConfig(
                         name="warehouse",
                         label="Warehouse",
-                        type=Type4.TEXT,
+                        type=SourceFieldInputConfigType.TEXT,
                         required=True,
                         placeholder="COMPUTE_WAREHOUSE",
                     ),
@@ -78,14 +81,14 @@ class SnowflakeSource(BaseSource[SnowflakeSourceConfig]):
                                         SourceFieldInputConfig(
                                             name="user",
                                             label="Username",
-                                            type=Type4.TEXT,
+                                            type=SourceFieldInputConfigType.TEXT,
                                             required=True,
                                             placeholder="User1",
                                         ),
                                         SourceFieldInputConfig(
                                             name="password",
                                             label="Password",
-                                            type=Type4.PASSWORD,
+                                            type=SourceFieldInputConfigType.PASSWORD,
                                             required=True,
                                             placeholder="",
                                         ),
@@ -101,21 +104,21 @@ class SnowflakeSource(BaseSource[SnowflakeSourceConfig]):
                                         SourceFieldInputConfig(
                                             name="user",
                                             label="Username",
-                                            type=Type4.TEXT,
+                                            type=SourceFieldInputConfigType.TEXT,
                                             required=True,
                                             placeholder="User1",
                                         ),
                                         SourceFieldInputConfig(
                                             name="private_key",
                                             label="Private key",
-                                            type=Type4.TEXTAREA,
+                                            type=SourceFieldInputConfigType.TEXTAREA,
                                             required=True,
                                             placeholder="",
                                         ),
                                         SourceFieldInputConfig(
                                             name="passphrase",
                                             label="Passphrase",
-                                            type=Type4.PASSWORD,
+                                            type=SourceFieldInputConfigType.PASSWORD,
                                             required=False,
                                             placeholder="",
                                         ),
@@ -127,12 +130,16 @@ class SnowflakeSource(BaseSource[SnowflakeSourceConfig]):
                     SourceFieldInputConfig(
                         name="role",
                         label="Role (optional)",
-                        type=Type4.TEXT,
+                        type=SourceFieldInputConfigType.TEXT,
                         required=False,
                         placeholder="ACCOUNTADMIN",
                     ),
                     SourceFieldInputConfig(
-                        name="schema", label="Schema", type=Type4.TEXT, required=True, placeholder="public"
+                        name="schema",
+                        label="Schema",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="public",
                     ),
                 ],
             ),

--- a/posthog/temporal/data_imports/sources/stripe/source.py
+++ b/posthog/temporal/data_imports/sources/stripe/source.py
@@ -1,5 +1,10 @@
 from typing import cast
-from posthog.schema import ExternalDataSourceType, SourceConfig, SourceFieldInputConfig, Type4
+from posthog.schema import (
+    ExternalDataSourceType as SchemaExternalDataSourceType,
+    SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
+)
 from posthog.temporal.data_imports.sources.common.base import BaseSource, FieldType
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
 from posthog.temporal.data_imports.sources.common.schema import SourceSchema
@@ -15,19 +20,19 @@ from posthog.temporal.data_imports.sources.stripe.settings import (
 )
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
 from posthog.temporal.data_imports.sources.generated_configs import StripeSourceConfig
-from posthog.warehouse.models import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
 class StripeSource(BaseSource[StripeSourceConfig]):
     @property
-    def source_type(self) -> ExternalDataSource.Type:
-        return ExternalDataSource.Type.STRIPE
+    def source_type(self) -> ExternalDataSourceType:
+        return ExternalDataSourceType.STRIPE
 
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
-            name=ExternalDataSourceType.STRIPE,
+            name=SchemaExternalDataSourceType.STRIPE,
             caption="""Enter your Stripe credentials to automatically pull your Stripe data into the PostHog Data warehouse.
 
 You can find your account ID [in your Stripe dashboard](https://dashboard.stripe.com/settings/account), and create a secret key [here](https://dashboard.stripe.com/apikeys/create).
@@ -43,14 +48,14 @@ Currently, **read permissions are required** for the following resources:
                     SourceFieldInputConfig(
                         name="stripe_account_id",
                         label="Account id",
-                        type=Type4.TEXT,
+                        type=SourceFieldInputConfigType.TEXT,
                         required=False,
                         placeholder="stripe_account_id",
                     ),
                     SourceFieldInputConfig(
                         name="stripe_secret_key",
                         label="API key",
-                        type=Type4.PASSWORD,
+                        type=SourceFieldInputConfigType.PASSWORD,
                         required=True,
                         placeholder="rk_live_...",
                     ),

--- a/posthog/temporal/data_imports/sources/temporalio/source.py
+++ b/posthog/temporal/data_imports/sources/temporalio/source.py
@@ -1,9 +1,9 @@
 from typing import cast
 from posthog.schema import (
-    ExternalDataSourceType,
+    ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
     SourceFieldInputConfig,
-    Type4,
+    SourceFieldInputConfigType,
 )
 from posthog.temporal.data_imports.sources.common.base import BaseSource, FieldType
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
@@ -16,14 +16,14 @@ from posthog.temporal.data_imports.sources.temporalio.temporalio import (
 )
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
 from posthog.temporal.data_imports.sources.generated_configs import TemporalIOSourceConfig
-from posthog.warehouse.models import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
 class TemporalIOSource(BaseSource[TemporalIOSourceConfig]):
     @property
-    def source_type(self) -> ExternalDataSource.Type:
-        return ExternalDataSource.Type.TEMPORALIO
+    def source_type(self) -> ExternalDataSourceType:
+        return ExternalDataSourceType.TEMPORALIO
 
     def get_schemas(self, config: TemporalIOSourceConfig, team_id: int) -> list[SourceSchema]:
         return [
@@ -49,38 +49,50 @@ class TemporalIOSource(BaseSource[TemporalIOSourceConfig]):
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
-            name=ExternalDataSourceType.TEMPORAL_IO,
+            name=SchemaExternalDataSourceType.TEMPORAL_IO,
             label="Temporal.io",
             caption="",
             fields=cast(
                 list[FieldType],
                 [
-                    SourceFieldInputConfig(name="host", label="Host", type=Type4.TEXT, required=True, placeholder=""),
-                    SourceFieldInputConfig(name="port", label="Port", type=Type4.TEXT, required=True, placeholder=""),
                     SourceFieldInputConfig(
-                        name="namespace", label="Namespace", type=Type4.TEXT, required=True, placeholder=""
+                        name="host", label="Host", type=SourceFieldInputConfigType.TEXT, required=True, placeholder=""
                     ),
                     SourceFieldInputConfig(
-                        name="encryption_key", label="Encryption key", type=Type4.TEXT, required=False, placeholder=""
+                        name="port", label="Port", type=SourceFieldInputConfigType.TEXT, required=True, placeholder=""
+                    ),
+                    SourceFieldInputConfig(
+                        name="namespace",
+                        label="Namespace",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="",
+                    ),
+                    SourceFieldInputConfig(
+                        name="encryption_key",
+                        label="Encryption key",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=False,
+                        placeholder="",
                     ),
                     SourceFieldInputConfig(
                         name="server_client_root_ca",
                         label="Server client root CA",
-                        type=Type4.TEXTAREA,
+                        type=SourceFieldInputConfigType.TEXTAREA,
                         required=True,
                         placeholder="",
                     ),
                     SourceFieldInputConfig(
                         name="client_certificate",
                         label="Client certificate",
-                        type=Type4.TEXTAREA,
+                        type=SourceFieldInputConfigType.TEXTAREA,
                         required=True,
                         placeholder="",
                     ),
                     SourceFieldInputConfig(
                         name="client_private_key",
                         label="Client private key",
-                        type=Type4.TEXTAREA,
+                        type=SourceFieldInputConfigType.TEXTAREA,
                         required=True,
                         placeholder="",
                     ),

--- a/posthog/temporal/data_imports/sources/vitally/source.py
+++ b/posthog/temporal/data_imports/sources/vitally/source.py
@@ -1,11 +1,11 @@
 import re
 from typing import cast
 from posthog.schema import (
-    ExternalDataSourceType,
+    ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldSelectConfig,
-    Type4,
+    SourceFieldInputConfigType,
     Option,
 )
 from posthog.temporal.data_imports.sources.common.base import BaseSource, FieldType
@@ -22,14 +22,14 @@ from posthog.temporal.data_imports.sources.vitally.settings import (
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
 from posthog.temporal.data_imports.sources.common.utils import dlt_source_to_source_response
 from posthog.temporal.data_imports.sources.generated_configs import VitallySourceConfig
-from posthog.warehouse.models import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
 class VitallySource(BaseSource[VitallySourceConfig]):
     @property
-    def source_type(self) -> ExternalDataSource.Type:
-        return ExternalDataSource.Type.VITALLY
+    def source_type(self) -> ExternalDataSourceType:
+        return ExternalDataSourceType.VITALLY
 
     def get_schemas(self, config: VitallySourceConfig, team_id: int) -> list[SourceSchema]:
         return [
@@ -71,7 +71,7 @@ class VitallySource(BaseSource[VitallySourceConfig]):
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
-            name=ExternalDataSourceType.VITALLY,
+            name=SchemaExternalDataSourceType.VITALLY,
             caption="",
             fields=cast(
                 list[FieldType],
@@ -79,7 +79,7 @@ class VitallySource(BaseSource[VitallySourceConfig]):
                     SourceFieldInputConfig(
                         name="secret_token",
                         label="Secret token",
-                        type=Type4.TEXT,
+                        type=SourceFieldInputConfigType.TEXT,
                         required=True,
                         placeholder="sk_live_...",
                     ),
@@ -99,7 +99,7 @@ class VitallySource(BaseSource[VitallySourceConfig]):
                                         SourceFieldInputConfig(
                                             name="subdomain",
                                             label="Vitally subdomain",
-                                            type=Type4.TEXT,
+                                            type=SourceFieldInputConfigType.TEXT,
                                             required=True,
                                             placeholder="",
                                         )

--- a/posthog/temporal/data_imports/sources/zendesk/source.py
+++ b/posthog/temporal/data_imports/sources/zendesk/source.py
@@ -1,10 +1,10 @@
 import re
 from typing import cast
 from posthog.schema import (
-    ExternalDataSourceType,
+    ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
     SourceFieldInputConfig,
-    Type4,
+    SourceFieldInputConfigType,
 )
 from posthog.temporal.data_imports.sources.common.base import BaseSource, FieldType
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
@@ -19,14 +19,14 @@ from posthog.temporal.data_imports.sources.zendesk.zendesk import zendesk_source
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
 from posthog.temporal.data_imports.sources.common.utils import dlt_source_to_source_response
 from posthog.temporal.data_imports.sources.generated_configs import ZendeskSourceConfig
-from posthog.warehouse.models import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
 class ZendeskSource(BaseSource[ZendeskSourceConfig]):
     @property
-    def source_type(self) -> ExternalDataSource.Type:
-        return ExternalDataSource.Type.ZENDESK
+    def source_type(self) -> ExternalDataSourceType:
+        return ExternalDataSourceType.ZENDESK
 
     def get_schemas(self, config: ZendeskSourceConfig, team_id: int) -> list[SourceSchema]:
         return [
@@ -53,21 +53,29 @@ class ZendeskSource(BaseSource[ZendeskSourceConfig]):
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
-            name=ExternalDataSourceType.ZENDESK,
+            name=SchemaExternalDataSourceType.ZENDESK,
             caption="Enter your Zendesk API key to automatically pull your Zendesk support data into the PostHog Data warehouse.",
             fields=cast(
                 list[FieldType],
                 [
                     SourceFieldInputConfig(
-                        name="subdomain", label="Zendesk subdomain", type=Type4.TEXT, required=True, placeholder=""
+                        name="subdomain",
+                        label="Zendesk subdomain",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="",
                     ),
                     SourceFieldInputConfig(
-                        name="api_key", label="API key", type=Type4.TEXT, required=True, placeholder=""
+                        name="api_key",
+                        label="API key",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="",
                     ),
                     SourceFieldInputConfig(
                         name="email_address",
                         label="Zendesk email address",
-                        type=Type4.EMAIL,
+                        type=SourceFieldInputConfigType.EMAIL,
                         required=True,
                         placeholder="",
                     ),

--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -17,6 +17,7 @@ from posthog.temporal.data_imports.pipelines.pipeline_sync import PipelineInputs
 from posthog.temporal.data_imports.row_tracking import setup_row_tracking
 from posthog.warehouse.models import ExternalDataJob, ExternalDataSource
 from posthog.warehouse.models.external_data_schema import ExternalDataSchema, process_incremental_value
+from posthog.warehouse.types import ExternalDataSourceType
 
 from posthog.temporal.data_imports.sources import SourceRegistry
 
@@ -70,7 +71,7 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
 
         logger.debug("Running *SYNC* import_data")
 
-        source_type = ExternalDataSource.Type(model.pipeline.source_type)
+        source_type = ExternalDataSourceType(model.pipeline.source_type)
 
         job_inputs = PipelineInputs(
             source_id=inputs.source_id,

--- a/posthog/temporal/data_imports/workflow_activities/sync_new_schemas.py
+++ b/posthog/temporal/data_imports/workflow_activities/sync_new_schemas.py
@@ -9,6 +9,7 @@ from posthog.warehouse.models import (
     ExternalDataSource,
     sync_old_schemas_with_new_schemas,
 )
+from posthog.warehouse.types import ExternalDataSourceType
 
 from posthog.temporal.data_imports.sources import SourceRegistry
 
@@ -35,7 +36,7 @@ def sync_new_schemas_activity(inputs: SyncNewSchemasActivityInputs) -> None:
 
     source = ExternalDataSource.objects.get(team_id=inputs.team_id, id=inputs.source_id)
 
-    source_type_enum = ExternalDataSource.Type(source.source_type)
+    source_type_enum = ExternalDataSourceType(source.source_type)
     if SourceRegistry.is_registered(source_type_enum):
         if not source.job_inputs:
             return

--- a/posthog/temporal/tests/data_imports/test_bigquery_source.py
+++ b/posthog/temporal/tests/data_imports/test_bigquery_source.py
@@ -22,7 +22,7 @@ from posthog.warehouse.models.external_data_job import ExternalDataJob
 from posthog.warehouse.models.external_data_schema import ExternalDataSchema
 from posthog.warehouse.models.external_data_source import ExternalDataSource
 from posthog.warehouse.models.table import DataWarehouseTable
-from posthog.warehouse.types import IncrementalFieldType
+from posthog.warehouse.types import ExternalDataSourceType, IncrementalFieldType
 
 SKIP_IF_MISSING_GOOGLE_APPLICATION_CREDENTIALS = pytest.mark.skipif(
     "GOOGLE_APPLICATION_CREDENTIALS" not in os.environ,
@@ -239,7 +239,7 @@ def setup_bigquery(
         source_id="source_id",
         connection_id="connection_id",
         status=ExternalDataSource.Status.COMPLETED,
-        source_type=ExternalDataSource.Type.BIGQUERY,
+        source_type=ExternalDataSourceType.BIGQUERY,
         job_inputs={
             "dataset_id": bigquery_dataset.dataset_id,
             "temporary_dataset_id": None,

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -56,6 +56,7 @@ from posthog.warehouse.models import (
 from posthog.warehouse.models.external_data_job import get_latest_run_if_exists
 from posthog.warehouse.models.external_table_definitions import external_tables
 from posthog.warehouse.models.join import DataWarehouseJoin
+from posthog.warehouse.types import ExternalDataSourceType
 from posthog.temporal.data_imports.sources.stripe.constants import (
     BALANCE_TRANSACTION_RESOURCE_NAME as STRIPE_BALANCE_TRANSACTION_RESOURCE_NAME,
     CHARGE_RESOURCE_NAME as STRIPE_CHARGE_RESOURCE_NAME,
@@ -201,7 +202,7 @@ async def _run(
         team=team,
         status="running",
         source_type=source_type,
-        revenue_analytics_enabled=source_type == ExternalDataSource.Type.STRIPE,
+        revenue_analytics_enabled=source_type == ExternalDataSourceType.STRIPE,
         job_inputs=job_inputs,
     )
 

--- a/posthog/temporal/tests/data_imports/test_import_data.py
+++ b/posthog/temporal/tests/data_imports/test_import_data.py
@@ -13,6 +13,7 @@ from posthog.warehouse.models.external_data_schema import ExternalDataSchema
 from posthog.warehouse.models.external_data_source import ExternalDataSource
 from posthog.warehouse.models.ssh_tunnel import SSHTunnel
 from posthog.warehouse.models.table import DataWarehouseTable
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 def _setup(team: Team, job_inputs: dict[Any, Any]) -> ImportDataActivityInputs:
@@ -21,7 +22,7 @@ def _setup(team: Team, job_inputs: dict[Any, Any]) -> ImportDataActivityInputs:
         source_id="source_id",
         connection_id="connection_id",
         status=ExternalDataSource.Status.COMPLETED,
-        source_type=ExternalDataSource.Type.POSTGRES,
+        source_type=ExternalDataSourceType.POSTGRES,
         job_inputs=job_inputs,
     )
     credentials = DataWarehouseCredential.objects.create(access_key="blah", access_secret="blah", team=team)

--- a/posthog/test/test_migration_0807.py
+++ b/posthog/test/test_migration_0807.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from posthog.test.base import NonAtomicTestMigrations
 from posthog.warehouse.models import ExternalDataSource as ExternalDataSourceModel
+from posthog.warehouse.types import ExternalDataSourceType
 from posthog.temporal.data_imports.sources.generated_configs import (
     BigQuerySourceConfig,
     MSSQLSourceConfig,
@@ -31,7 +32,7 @@ class DWHSourceRefactorMigrationTest(NonAtomicTestMigrations):
 
         self.bigquery_source = ExternalDataSource.objects.create(
             team=self.team,
-            source_type=ExternalDataSourceModel.Type.BIGQUERY,
+            source_type=ExternalDataSourceType.BIGQUERY,
             job_inputs={
                 "token_uri": "token_uri",
                 "dataset_id": "dataset_id",
@@ -47,7 +48,7 @@ class DWHSourceRefactorMigrationTest(NonAtomicTestMigrations):
         )
         self.mssql_source = ExternalDataSource.objects.create(
             team=self.team,
-            source_type=ExternalDataSourceModel.Type.MSSQL,
+            source_type=ExternalDataSourceType.MSSQL,
             job_inputs={
                 "host": "host",
                 "port": "1433",
@@ -68,7 +69,7 @@ class DWHSourceRefactorMigrationTest(NonAtomicTestMigrations):
         )
         self.mysql_source = ExternalDataSource.objects.create(
             team=self.team,
-            source_type=ExternalDataSourceModel.Type.MYSQL,
+            source_type=ExternalDataSourceType.MYSQL,
             job_inputs={
                 "host": "host",
                 "port": "1433",
@@ -89,7 +90,7 @@ class DWHSourceRefactorMigrationTest(NonAtomicTestMigrations):
         )
         self.postgres_source = ExternalDataSource.objects.create(
             team=self.team,
-            source_type=ExternalDataSourceModel.Type.POSTGRES,
+            source_type=ExternalDataSourceType.POSTGRES,
             job_inputs={
                 "host": "host",
                 "port": "1433",
@@ -110,7 +111,7 @@ class DWHSourceRefactorMigrationTest(NonAtomicTestMigrations):
         )
         self.snowflake_source = ExternalDataSource.objects.create(
             team=self.team,
-            source_type=ExternalDataSourceModel.Type.SNOWFLAKE,
+            source_type=ExternalDataSourceType.SNOWFLAKE,
             job_inputs={
                 "role": "role",
                 "user": "user",
@@ -126,7 +127,7 @@ class DWHSourceRefactorMigrationTest(NonAtomicTestMigrations):
         )
         self.vitally_source = ExternalDataSource.objects.create(
             team=self.team,
-            source_type=ExternalDataSourceModel.Type.VITALLY,
+            source_type=ExternalDataSourceType.VITALLY,
             job_inputs={
                 "region": "US",
                 "subdomain": "subdomain",
@@ -135,7 +136,7 @@ class DWHSourceRefactorMigrationTest(NonAtomicTestMigrations):
         )
         self.zendesk_source = ExternalDataSource.objects.create(
             team=self.team,
-            source_type=ExternalDataSourceModel.Type.ZENDESK,
+            source_type=ExternalDataSourceType.ZENDESK,
             job_inputs={
                 "zendesk_api_key": "api_key",
                 "zendesk_subdomain": "subdomain",

--- a/posthog/warehouse/api/external_data_schema.py
+++ b/posthog/warehouse/api/external_data_schema.py
@@ -29,6 +29,7 @@ from posthog.warehouse.models.external_data_schema import (
     sync_frequency_to_sync_frequency_interval,
 )
 from posthog.warehouse.models.external_data_source import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType
 
 logger = structlog.get_logger(__name__)
 
@@ -305,7 +306,7 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, LogEntryMixin, viewsets.
         if not source.source_type:
             return Response(status=status.HTTP_400_BAD_REQUEST, data={"message": "Missing source type"})
 
-        source_type_enum = ExternalDataSource.Type(source.source_type)
+        source_type_enum = ExternalDataSourceType(source.source_type)
 
         new_source = SourceRegistry.get_source(source_type_enum)
         config = new_source.parse_config(source.job_inputs)

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -33,6 +33,7 @@ from posthog.warehouse.models import (
     ExternalDataSchema,
     ExternalDataSource,
 )
+from posthog.warehouse.types import ExternalDataSourceType
 
 logger = structlog.get_logger(__name__)
 
@@ -236,7 +237,7 @@ class ExternalDataSourceSerializers(serializers.ModelSerializer):
         """Update source ensuring we merge with existing job inputs to allow partial updates."""
         existing_job_inputs = instance.job_inputs
 
-        source_type_model = ExternalDataSource.Type(instance.source_type)
+        source_type_model = ExternalDataSourceType(instance.source_type)
         source = SourceRegistry.get_source(source_type_model)
 
         if existing_job_inputs:
@@ -346,7 +347,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 if isinstance(value, str):
                     payload[key] = value.strip()
 
-        source_type_model = ExternalDataSource.Type(source_type)
+        source_type_model = ExternalDataSourceType(source_type)
         source = SourceRegistry.get_source(source_type_model)
         is_valid, errors = source.validate_config(payload)
         if not is_valid:
@@ -525,7 +526,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 data={"message": "Missing required parameter: source_type"},
             )
 
-        source_type_model = ExternalDataSource.Type(source_type)
+        source_type_model = ExternalDataSourceType(source_type)
         source = SourceRegistry.get_source(source_type_model)
         is_valid, errors = source.validate_config(request.data)
         if not is_valid:

--- a/posthog/warehouse/api/test/test_external_data_schema.py
+++ b/posthog/warehouse/api/test/test_external_data_schema.py
@@ -19,6 +19,7 @@ from posthog.warehouse.api.test.utils import create_external_data_source_ok
 from posthog.warehouse.models import DataWarehouseTable
 from posthog.warehouse.models.external_data_schema import ExternalDataSchema
 from posthog.warehouse.models.external_data_source import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType
 
 pytestmark = [
     pytest.mark.django_db,
@@ -65,7 +66,7 @@ class TestExternalDataSchema(APIBaseTest):
 
     def test_incremental_fields_stripe(self):
         source = ExternalDataSource.objects.create(
-            team=self.team, source_type=ExternalDataSource.Type.STRIPE, job_inputs={"stripe_secret_key": "123"}
+            team=self.team, source_type=ExternalDataSourceType.STRIPE, job_inputs={"stripe_secret_key": "123"}
         )
         schema = ExternalDataSchema.objects.create(
             name="BalanceTransaction",
@@ -112,7 +113,7 @@ class TestExternalDataSchema(APIBaseTest):
 
     def test_incremental_fields_missing_table_name(self):
         source = ExternalDataSource.objects.create(
-            team=self.team, source_type=ExternalDataSource.Type.STRIPE, job_inputs={"stripe_secret_key": "123"}
+            team=self.team, source_type=ExternalDataSourceType.STRIPE, job_inputs={"stripe_secret_key": "123"}
         )
         schema = ExternalDataSchema.objects.create(
             name="Some_other_non_existent_table",
@@ -184,7 +185,7 @@ class TestExternalDataSchema(APIBaseTest):
 
     def test_update_schema_change_sync_type(self):
         source = ExternalDataSource.objects.create(
-            team=self.team, source_type=ExternalDataSource.Type.STRIPE, job_inputs={"stripe_secret_key": "123"}
+            team=self.team, source_type=ExternalDataSourceType.STRIPE, job_inputs={"stripe_secret_key": "123"}
         )
         schema = ExternalDataSchema.objects.create(
             name="BalanceTransaction",
@@ -212,7 +213,7 @@ class TestExternalDataSchema(APIBaseTest):
 
     def test_update_schema_change_sync_type_incremental_field(self):
         source = ExternalDataSource.objects.create(
-            team=self.team, source_type=ExternalDataSource.Type.STRIPE, job_inputs={"stripe_secret_key": "123"}
+            team=self.team, source_type=ExternalDataSourceType.STRIPE, job_inputs={"stripe_secret_key": "123"}
         )
         table = DataWarehouseTable.objects.create(team=self.team)
         schema = ExternalDataSchema.objects.create(

--- a/posthog/warehouse/api/test/test_log_entry.py
+++ b/posthog/warehouse/api/test/test_log_entry.py
@@ -15,6 +15,7 @@ from posthog.warehouse.models import (
     ExternalDataSchema,
     ExternalDataSource,
 )
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 def create_external_data_job_log_entry(
@@ -69,7 +70,7 @@ def external_data_resources(client, organization, team):
         source_id="source_id",
         connection_id="connection_id",
         status=ExternalDataSource.Status.COMPLETED,
-        source_type=ExternalDataSource.Type.STRIPE,
+        source_type=ExternalDataSourceType.STRIPE,
     )
     credentials = DataWarehouseCredential.objects.create(access_key="blah", access_secret="blah", team=team)
     warehouse_table = DataWarehouseTable.objects.create(

--- a/posthog/warehouse/api/test/test_view_link.py
+++ b/posthog/warehouse/api/test/test_view_link.py
@@ -3,6 +3,7 @@ from posthog.warehouse.models import DataWarehouseJoin, DataWarehouseTable
 from posthog.warehouse.models.credential import DataWarehouseCredential
 from posthog.warehouse.models.external_data_schema import ExternalDataSchema
 from posthog.warehouse.models.external_data_source import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 class TestViewLinkQuery(APIBaseTest):
@@ -42,7 +43,7 @@ class TestViewLinkQuery(APIBaseTest):
             source_id="source_id",
             connection_id="connection_id",
             status=ExternalDataSource.Status.COMPLETED,
-            source_type=ExternalDataSource.Type.STRIPE,
+            source_type=ExternalDataSourceType.STRIPE,
         )
         credentials = DataWarehouseCredential.objects.create(access_key="blah", access_secret="blah", team=self.team)
         warehouse_table = DataWarehouseTable.objects.create(

--- a/posthog/warehouse/data_load/source_templates.py
+++ b/posthog/warehouse/data_load/source_templates.py
@@ -1,8 +1,8 @@
 from django.db import close_old_connections
 from posthog.temporal.common.logger import bind_temporal_worker_logger_sync
-from posthog.warehouse.models.external_data_job import ExternalDataJob
-from posthog.warehouse.models.external_data_source import ExternalDataSource
 from posthog.warehouse.models.join import DataWarehouseJoin
+from posthog.warehouse.models.external_data_job import ExternalDataJob
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 def database_operations(team_id: int, table_prefix: str) -> None:
@@ -67,10 +67,10 @@ def create_warehouse_templates_for_source(team_id: int, run_id: str) -> None:
         .first()
     )
 
-    source: ExternalDataSource.Type = job.pipeline.source_type
+    source: ExternalDataSourceType = job.pipeline.source_type
 
     # Quick exit if this isn't the first sync, or a stripe source
-    if source != ExternalDataSource.Type.STRIPE or last_successful_job is not None:
+    if source != ExternalDataSourceType.STRIPE or last_successful_job is not None:
         logger.info(
             f"Create warehouse templates skipped for job {run_id}",
         )

--- a/posthog/warehouse/models/external_data_source.py
+++ b/posthog/warehouse/models/external_data_source.py
@@ -4,6 +4,7 @@ from uuid import UUID
 import structlog
 import temporalio
 from django.db import models
+from posthog.warehouse.types import ExternalDataSourceType
 
 from posthog.helpers.encrypted_fields import EncryptedJSONField
 from posthog.models.team import Team
@@ -20,30 +21,6 @@ logger = structlog.get_logger(__name__)
 
 
 class ExternalDataSource(CreatedMetaFields, UpdatedMetaFields, UUIDModel, DeletedMetaFields):
-    class Type(models.TextChoices):
-        STRIPE = "Stripe", "Stripe"
-        HUBSPOT = "Hubspot", "Hubspot"
-        POSTGRES = "Postgres", "Postgres"
-        ZENDESK = "Zendesk", "Zendesk"
-        SNOWFLAKE = "Snowflake", "Snowflake"
-        SALESFORCE = "Salesforce", "Salesforce"
-        MYSQL = "MySQL", "MySQL"
-        MONGODB = "MongoDB", "MongoDB"
-        MSSQL = "MSSQL", "MSSQL"
-        VITALLY = "Vitally", "Vitally"
-        BIGQUERY = "BigQuery", "BigQuery"
-        CHARGEBEE = "Chargebee", "Chargebee"
-        GOOGLEADS = "GoogleAds", "GoogleAds"
-        TEMPORALIO = "TemporalIO", "TemporalIO"
-        DOIT = "DoIt", "DoIt"
-        GOOGLESHEETS = "GoogleSheets", "GoogleSheets"
-        METAADS = "MetaAds", "MetaAds"
-        KLAVIYO = "Klaviyo", "Klaviyo"
-        MAILCHIMP = "Mailchimp", "Mailchimp"
-        BRAZE = "Braze", "Braze"
-        MAILJET = "Mailjet", "Mailjet"
-        REDSHIFT = "Redshift", "Redshift"
-
     class Status(models.TextChoices):
         RUNNING = "Running", "Running"
         PAUSED = "Paused", "Paused"
@@ -70,7 +47,7 @@ class ExternalDataSource(CreatedMetaFields, UpdatedMetaFields, UUIDModel, Delete
 
     # `status` is deprecated in favour of external_data_schema.status
     status = models.CharField(max_length=400)
-    source_type = models.CharField(max_length=128, choices=Type.choices)
+    source_type = models.CharField(max_length=128, choices=ExternalDataSourceType.choices)
     job_inputs = EncryptedJSONField(null=True, blank=True)
     are_tables_created = models.BooleanField(default=False)
     prefix = models.CharField(max_length=100, null=True, blank=True)

--- a/posthog/warehouse/test/utils.py
+++ b/posthog/warehouse/test/utils.py
@@ -3,10 +3,11 @@ import pandas as pd
 from pathlib import Path
 from typing import Optional
 
-from posthog.warehouse.models.external_data_source import ExternalDataSource
-from posthog.warehouse.models.credential import DataWarehouseCredential
-from posthog.warehouse.models.table import DataWarehouseTable
 from posthog.models.team import Team
+from posthog.warehouse.models.table import DataWarehouseTable
+from posthog.warehouse.models.credential import DataWarehouseCredential
+from posthog.warehouse.models.external_data_source import ExternalDataSource
+from posthog.warehouse.types import ExternalDataSourceType
 
 from posthog.settings import (
     OBJECT_STORAGE_BUCKET,
@@ -67,7 +68,7 @@ def create_data_warehouse_table_from_csv(
             source_id="source_id",
             connection_id="connection_id",
             status=ExternalDataSource.Status.COMPLETED,
-            source_type=ExternalDataSource.Type.STRIPE,
+            source_type=ExternalDataSourceType.STRIPE,
             prefix=source_prefix,
         )
 

--- a/posthog/warehouse/types.py
+++ b/posthog/warehouse/types.py
@@ -1,5 +1,6 @@
 import typing
 from enum import StrEnum
+from django.db import models
 
 
 class IncrementalFieldType(StrEnum):
@@ -29,3 +30,28 @@ class PartitionSettings(typing.NamedTuple):
 
     partition_count: int
     partition_size: int
+
+
+class ExternalDataSourceType(models.TextChoices):
+    STRIPE = "Stripe", "Stripe"
+    HUBSPOT = "Hubspot", "Hubspot"
+    POSTGRES = "Postgres", "Postgres"
+    ZENDESK = "Zendesk", "Zendesk"
+    SNOWFLAKE = "Snowflake", "Snowflake"
+    SALESFORCE = "Salesforce", "Salesforce"
+    MYSQL = "MySQL", "MySQL"
+    MONGODB = "MongoDB", "MongoDB"
+    MSSQL = "MSSQL", "MSSQL"
+    VITALLY = "Vitally", "Vitally"
+    BIGQUERY = "BigQuery", "BigQuery"
+    CHARGEBEE = "Chargebee", "Chargebee"
+    GOOGLEADS = "GoogleAds", "GoogleAds"
+    TEMPORALIO = "TemporalIO", "TemporalIO"
+    DOIT = "DoIt", "DoIt"
+    GOOGLESHEETS = "GoogleSheets", "GoogleSheets"
+    METAADS = "MetaAds", "MetaAds"
+    KLAVIYO = "Klaviyo", "Klaviyo"
+    MAILCHIMP = "Mailchimp", "Mailchimp"
+    BRAZE = "Braze", "Braze"
+    MAILJET = "Mailjet", "Mailjet"
+    REDSHIFT = "Redshift", "Redshift"

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_query_runner.py
@@ -7,7 +7,8 @@ from posthog.hogql.property import property_to_expr
 from posthog.hogql_queries.query_runner import QueryRunnerWithHogQLContext
 from posthog.hogql import ast
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
-from posthog.warehouse.models import ExternalDataSource, ExternalDataSchema
+from posthog.warehouse.models import ExternalDataSchema
+from posthog.warehouse.types import ExternalDataSourceType
 from posthog.models.filters.mixins.utils import cached_property
 from posthog.schema import (
     RevenueAnalyticsGrowthRateQuery,
@@ -500,7 +501,7 @@ class RevenueAnalyticsQueryRunner(QueryRunnerWithHogQLContext):
             team=self.team,
             should_sync=True,
             source__revenue_analytics_enabled=True,
-            source__source_type=ExternalDataSource.Type.STRIPE,
+            source__source_type=ExternalDataSourceType.STRIPE,
         )
 
         # If we can detect we're syncing Revenue data for the first time, cache for just 1 minute

--- a/products/revenue_analytics/backend/hogql_queries/test/test_revenue_analytics_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/test/test_revenue_analytics_query_runner.py
@@ -6,6 +6,7 @@ from products.revenue_analytics.backend.hogql_queries.revenue_analytics_revenue_
 from posthog.schema import RevenueAnalyticsRevenueQuery, IntervalType
 from posthog.test.base import APIBaseTest
 from posthog.warehouse.models import ExternalDataSource, ExternalDataSchema
+from posthog.warehouse.types import ExternalDataSourceType
 
 
 # This is required because we can't instantiate the base class directly
@@ -43,7 +44,7 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
             team=self.team,
             source_id="src_test",
             connection_id="conn_test",
-            source_type=ExternalDataSource.Type.STRIPE,
+            source_type=ExternalDataSourceType.STRIPE,
             revenue_analytics_enabled=True,
         )
 
@@ -67,7 +68,7 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
             team=self.team,
             source_id="src_test",
             connection_id="conn_test",
-            source_type=ExternalDataSource.Type.STRIPE,
+            source_type=ExternalDataSourceType.STRIPE,
             revenue_analytics_enabled=True,
         )
 
@@ -103,7 +104,7 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
             team=self.team,
             source_id="src_test",
             connection_id="conn_test",
-            source_type=ExternalDataSource.Type.STRIPE,
+            source_type=ExternalDataSourceType.STRIPE,
             revenue_analytics_enabled=True,
         )
 
@@ -138,7 +139,7 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
             team=self.team,
             source_id="src_test",
             connection_id="conn_test",
-            source_type=ExternalDataSource.Type.STRIPE,
+            source_type=ExternalDataSourceType.STRIPE,
             revenue_analytics_enabled=True,
         )
 
@@ -184,7 +185,7 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
             team=self.team,
             source_id="src_test",
             connection_id="conn_test",
-            source_type=ExternalDataSource.Type.POSTGRES,  # Not Stripe
+            source_type=ExternalDataSourceType.POSTGRES,  # Not Stripe
             revenue_analytics_enabled=True,
         )
 
@@ -210,7 +211,7 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
             team=self.team,
             source_id="src_test",
             connection_id="conn_test",
-            source_type=ExternalDataSource.Type.STRIPE,
+            source_type=ExternalDataSourceType.STRIPE,
             revenue_analytics_enabled=False,  # Disabled
         )
 
@@ -236,7 +237,7 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
             team=self.team,
             source_id="src_test",
             connection_id="conn_test",
-            source_type=ExternalDataSource.Type.STRIPE,
+            source_type=ExternalDataSourceType.STRIPE,
             revenue_analytics_enabled=True,
         )
 
@@ -262,7 +263,7 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
             team=self.team,
             source_id="src_test",
             connection_id="conn_test",
-            source_type=ExternalDataSource.Type.STRIPE,
+            source_type=ExternalDataSourceType.STRIPE,
             revenue_analytics_enabled=True,
         )
 
@@ -298,7 +299,7 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
             team=self.team,
             source_id="src_test",
             connection_id="conn_test",
-            source_type=ExternalDataSource.Type.STRIPE,
+            source_type=ExternalDataSourceType.STRIPE,
             revenue_analytics_enabled=True,
         )
 

--- a/products/revenue_analytics/backend/hogql_queries/test/test_views.py
+++ b/products/revenue_analytics/backend/hogql_queries/test/test_views.py
@@ -1,5 +1,6 @@
 from posthog.schema import CurrencyCode
 from posthog.warehouse.models import ExternalDataSource, ExternalDataSchema, DataWarehouseTable, DataWarehouseCredential
+from posthog.warehouse.types import ExternalDataSourceType
 from posthog.test.base import BaseTest
 
 from products.revenue_analytics.backend.views.revenue_analytics_base_view import RevenueAnalyticsBaseView
@@ -28,7 +29,7 @@ class TestRevenueAnalyticsViews(BaseTest):
             source_id="source_id",
             connection_id="connection_id",
             status=ExternalDataSource.Status.COMPLETED,
-            source_type=ExternalDataSource.Type.STRIPE,
+            source_type=ExternalDataSourceType.STRIPE,
         )
         self.credentials = DataWarehouseCredential.objects.create(
             access_key="blah", access_secret="blah", team=self.team

--- a/products/revenue_analytics/backend/views/revenue_analytics_base_view.py
+++ b/products/revenue_analytics/backend/views/revenue_analytics_base_view.py
@@ -3,13 +3,14 @@ from django.db.models import Prefetch
 from posthog.models.team.team import Team
 from posthog.warehouse.models.external_data_source import ExternalDataSource
 from posthog.warehouse.models.external_data_schema import ExternalDataSchema
+from posthog.warehouse.types import ExternalDataSourceType
 from posthog.hogql import ast
 from posthog.hogql.timings import HogQLTimings
 from posthog.hogql.database.models import SavedQuery
 from posthog.schema import DatabaseSchemaManagedViewTableKind
 import re
 
-SUPPORTED_SOURCES: list[ExternalDataSource.Type] = [ExternalDataSource.Type.STRIPE]
+SUPPORTED_SOURCES: list[ExternalDataSourceType] = [ExternalDataSourceType.STRIPE]
 
 
 class RevenueAnalyticsBaseView(SavedQuery):

--- a/products/revenue_analytics/backend/views/revenue_analytics_charge_view.py
+++ b/products/revenue_analytics/backend/views/revenue_analytics_charge_view.py
@@ -6,6 +6,7 @@ from posthog.schema import DatabaseSchemaManagedViewTableKind
 from posthog.warehouse.models.external_data_source import ExternalDataSource
 from posthog.warehouse.models.table import DataWarehouseTable
 from posthog.warehouse.models.external_data_schema import ExternalDataSchema
+from posthog.warehouse.types import ExternalDataSourceType
 from posthog.models.exchange_rate.sql import EXCHANGE_RATE_DECIMAL_PRECISION
 from posthog.hogql.database.models import (
     DateTimeDatabaseField,
@@ -133,7 +134,7 @@ class RevenueAnalyticsChargeView(RevenueAnalyticsBaseView):
     @classmethod
     def for_schema_source(cls, source: ExternalDataSource) -> list["RevenueAnalyticsBaseView"]:
         # Currently only works for stripe sources
-        if not source.source_type == ExternalDataSource.Type.STRIPE:
+        if not source.source_type == ExternalDataSourceType.STRIPE:
             return []
 
         # Get all schemas for the source, avoid calling `filter` and do the filtering on Python-land

--- a/products/revenue_analytics/backend/views/revenue_analytics_customer_view.py
+++ b/products/revenue_analytics/backend/views/revenue_analytics_customer_view.py
@@ -7,6 +7,7 @@ from posthog.schema import DatabaseSchemaManagedViewTableKind
 from posthog.warehouse.models.external_data_source import ExternalDataSource
 from posthog.warehouse.models.table import DataWarehouseTable
 from posthog.warehouse.models.external_data_schema import ExternalDataSchema
+from posthog.warehouse.types import ExternalDataSourceType
 from posthog.temporal.data_imports.sources.stripe.constants import (
     CUSTOMER_RESOURCE_NAME as STRIPE_CUSTOMER_RESOURCE_NAME,
     INVOICE_RESOURCE_NAME as STRIPE_INVOICE_RESOURCE_NAME,
@@ -117,7 +118,7 @@ class RevenueAnalyticsCustomerView(RevenueAnalyticsBaseView):
     @classmethod
     def for_schema_source(cls, source: ExternalDataSource) -> list["RevenueAnalyticsBaseView"]:
         # Currently only works for stripe sources
-        if not source.source_type == ExternalDataSource.Type.STRIPE:
+        if not source.source_type == ExternalDataSourceType.STRIPE:
             return []
 
         # Get all schemas for the source, avoid calling `filter` and do the filtering on Python-land

--- a/products/revenue_analytics/backend/views/revenue_analytics_product_view.py
+++ b/products/revenue_analytics/backend/views/revenue_analytics_product_view.py
@@ -6,6 +6,7 @@ from posthog.schema import DatabaseSchemaManagedViewTableKind
 from posthog.warehouse.models.external_data_source import ExternalDataSource
 from posthog.warehouse.models.table import DataWarehouseTable
 from posthog.warehouse.models.external_data_schema import ExternalDataSchema
+from posthog.warehouse.types import ExternalDataSourceType
 from posthog.hogql.database.models import (
     StringDatabaseField,
     FieldOrTable,
@@ -79,7 +80,7 @@ class RevenueAnalyticsProductView(RevenueAnalyticsBaseView):
     @classmethod
     def for_schema_source(cls, source: ExternalDataSource) -> list["RevenueAnalyticsBaseView"]:
         # Currently only works for stripe sources
-        if not source.source_type == ExternalDataSource.Type.STRIPE:
+        if not source.source_type == ExternalDataSourceType.STRIPE:
             return []
 
         # Get all schemas for the source, avoid calling `filter` and do the filtering on Python-land

--- a/products/revenue_analytics/backend/views/revenue_analytics_revenue_item_view.py
+++ b/products/revenue_analytics/backend/views/revenue_analytics_revenue_item_view.py
@@ -5,6 +5,7 @@ from posthog.models.team.team import Team
 from posthog.schema import DatabaseSchemaManagedViewTableKind
 from posthog.warehouse.models.external_data_source import ExternalDataSource
 from posthog.warehouse.models.table import DataWarehouseTable
+from posthog.warehouse.types import ExternalDataSourceType
 from posthog.models.exchange_rate.sql import EXCHANGE_RATE_DECIMAL_PRECISION
 from posthog.hogql.database.models import (
     BooleanDatabaseField,
@@ -271,7 +272,7 @@ class RevenueAnalyticsRevenueItemView(RevenueAnalyticsBaseView):
     @classmethod
     def for_schema_source(cls, source: ExternalDataSource) -> list["RevenueAnalyticsBaseView"]:
         # Currently only works for stripe sources
-        if not source.source_type == ExternalDataSource.Type.STRIPE:
+        if not source.source_type == ExternalDataSourceType.STRIPE:
             return []
 
         # Get all schemas for the source, avoid calling `filter` and do the filtering on Python-land

--- a/products/revenue_analytics/backend/views/revenue_analytics_subscription_view.py
+++ b/products/revenue_analytics/backend/views/revenue_analytics_subscription_view.py
@@ -6,6 +6,7 @@ from posthog.schema import DatabaseSchemaManagedViewTableKind
 from posthog.warehouse.models.external_data_source import ExternalDataSource
 from posthog.warehouse.models.table import DataWarehouseTable
 from posthog.warehouse.models.external_data_schema import ExternalDataSchema
+from posthog.warehouse.types import ExternalDataSourceType
 from posthog.temporal.data_imports.sources.stripe.constants import (
     SUBSCRIPTION_RESOURCE_NAME as STRIPE_SUBSCRIPTION_RESOURCE_NAME,
 )
@@ -115,7 +116,7 @@ class RevenueAnalyticsSubscriptionView(RevenueAnalyticsBaseView):
     @classmethod
     def for_schema_source(cls, source: ExternalDataSource) -> list["RevenueAnalyticsBaseView"]:
         # Currently only works for stripe sources
-        if not source.source_type == ExternalDataSource.Type.STRIPE:
+        if not source.source_type == ExternalDataSourceType.STRIPE:
             return []
 
         # Get all schemas for the source, avoid calling `filter` and do the filtering on Python-land


### PR DESCRIPTION
We've had a lot of problems since we started using `generated_configs.py` because it's very prone to generating import loops since it depends on `posthog.warehouse.models.ExternalDataSource`. Moving `ExternalDataSource.Type` to `posthog.warehouse.types.ExternalDataSourceType` makes that problem much less apparent, so here it is! This is also a better practice; less nesting makes importing in Python much easier overall.

I've also gone ahead and updated the `schema` file to fix that weird `Type4` we had in the generated config, so consider that a bonus :)