### PR TITLE
fix(cohort field): Loading logic should be pointed to `allCohortsLoading`

### DIFF
--- a/frontend/src/scenes/cohorts/CohortFilters/cohortFieldLogic.ts
+++ b/frontend/src/scenes/cohorts/CohortFilters/cohortFieldLogic.ts
@@ -104,7 +104,7 @@ export const cohortFieldLogic = kea<cohortFieldLogicType>([
                 s.value,
                 p.criteria,
                 p.fieldKey,
-                cohortsModel.selectors.cohortsLoading,
+                cohortsModel.selectors.allCohortsLoading,
                 actionsModel.selectors.actionsLoading,
             ],
             (value, criteria, fieldKey, cohortsModelLoading, actionsModelLoading) =>
@@ -125,7 +125,7 @@ export const cohortFieldLogic = kea<cohortFieldLogicType>([
                 s.value,
                 p.criteria,
                 p.fieldKey,
-                cohortsModel.selectors.cohortsLoading,
+                cohortsModel.selectors.allCohortsLoading,
                 actionsModel.selectors.actionsLoading,
             ],
             (value, criteria, fieldKey, cohortsModelLoading, actionsModelLoading) =>


### PR DESCRIPTION
## Problem

The logic is using `cohortsById` to determine the label name: 
https://github.com/PostHog/posthog/blob/0f980b5a37dbec7e160d291de0f7b164e33fe8e8/frontend/src/scenes/cohorts/CohortFilters/cohortFieldLogic.ts#L142

`cohortsById` is a selector derived from `allCohorts`:
https://github.com/PostHog/posthog/blob/0f980b5a37dbec7e160d291de0f7b164e33fe8e8/frontend/src/models/cohortsModel.ts#L184-L188

So the loading state should be pointing to `allCohortsLoading` instead of `cohortsLoading`.

## Changes

Update the loading state to `allCohortsLoading` instead of `cohortsLoading`.

## How did you test this code?

Locally, went to create a new trends and made sure that i could still see the cohorts in the taxonomicField.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
