### PR TITLE
fix(dashboard): dashboard insight colors modal should use `allCohorts` instead

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardInsightColorsModalLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardInsightColorsModalLogic.ts
@@ -85,7 +85,7 @@ export function extractBreakdownValues(
 export const dashboardInsightColorsModalLogic = kea<dashboardInsightColorsModalLogicType>([
     path(['scenes', 'dashboard', 'dashboardInsightColorsModalLogic']),
     connect(() => ({
-        values: [cohortsModel, ['cohorts']],
+        values: [cohortsModel, ['allCohorts']],
     })),
     actions({
         showInsightColorsModal: (id: number) => ({ id }),
@@ -112,7 +112,7 @@ export const dashboardInsightColorsModalLogic = kea<dashboardInsightColorsModalL
             { resultEqualityCheck: () => false, equalityCheck: () => false },
         ],
         breakdownValues: [
-            (s) => [s.insightTiles, s.cohorts],
+            (s) => [s.insightTiles, s.allCohorts],
             (insightTiles, cohorts) => extractBreakdownValues(insightTiles, cohorts?.results),
         ],
     }),

--- a/frontend/src/scenes/dashboard/dashboardInsightColorsModalLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardInsightColorsModalLogic.ts
@@ -113,7 +113,7 @@ export const dashboardInsightColorsModalLogic = kea<dashboardInsightColorsModalL
         ],
         breakdownValues: [
             (s) => [s.insightTiles, s.allCohorts],
-            (insightTiles, cohorts) => extractBreakdownValues(insightTiles, cohorts?.results),
+            (insightTiles, allCohorts) => extractBreakdownValues(insightTiles, allCohorts?.results),
         ],
     }),
 ])


### PR DESCRIPTION
## Problem

Similar to https://github.com/PostHog/posthog/pull/36425, this helps to move one step closer to remove `cohorts` in `cohortsModel`. 

## Changes

Update the logic to use `allCohorts` instead of `cohorts.

## How did you test this code?

Locally: 
1) Create a dashboard where there is an insight that contains cohort breakdown.
2) Open info panel (top right info button)
3) Click on customise colors 
4) You should see that the cohort name is there



https://github.com/user-attachments/assets/8ebf2893-40c4-42cb-b232-3c84b133197f



<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
