### PR TITLE
chore: expand list of trusted GitHub Actions

### DIFF
--- a/.github/actions/build-n-cache-image/action.yml
+++ b/.github/actions/build-n-cache-image/action.yml
@@ -45,7 +45,7 @@ runs:
     using: 'composite'
     steps:
         - name: Checkout
-          uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+          uses: actions/checkout@v4
 
         - name: Set up Docker Buildx
           uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3

--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -71,7 +71,7 @@ runs:
           run: echo "127.0.0.1 kafka clickhouse" | sudo tee -a /etc/hosts
 
         - name: Set up Python
-          uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+          uses: actions/setup-python@v5
           with:
               python-version: ${{ inputs.python-version }}
               cache: pip
@@ -101,7 +101,7 @@ runs:
           uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
 
         - name: Set up Node.js
-          uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3
+          uses: actions/setup-node@v4
           with:
               node-version: 22.17.1
               cache: pnpm
@@ -234,7 +234,7 @@ runs:
           run: docker compose -f docker-compose.dev.yml logs
 
         - name: Upload updated timing data as artifacts
-          uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+          uses: actions/upload-artifact@v4
           if: ${{ inputs.person-on-events != 'true' && inputs.clickhouse-server-image == 'clickhouse/clickhouse-server:25.3.6.56' }}
           with:
               name: timing_data-${{ inputs.segment }}-${{ inputs.group }}

--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -16,12 +16,12 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+              uses: actions/checkout@v4
               with:
                   fetch-depth: 0
 
             - name: Setup Node.js
-              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+              uses: actions/setup-node@v4
               with:
                   node-version: '20'
 

--- a/.github/workflows/browserslist.yml
+++ b/.github/workflows/browserslist.yml
@@ -14,7 +14,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
-              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+              uses: actions/checkout@v4
               with:
                   fetch-depth: 0
 
@@ -27,7 +27,7 @@ jobs:
               uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
 
             - name: Set up Node.js
-              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+              uses: actions/setup-node@v4
               with:
                   node-version: 22.17.1
                   cache: 'pnpm'

--- a/.github/workflows/build-hogql-parser.yml
+++ b/.github/workflows/build-hogql-parser.yml
@@ -17,7 +17,7 @@ jobs:
         outputs:
             parser-release-needed: ${{ steps.version.outputs.parser-release-needed }}
         steps:
-            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+            - uses: actions/checkout@v4
               with:
                   fetch-depth: 0 # Fetching all for comparison since last push (not just last commit)
 
@@ -62,9 +62,9 @@ jobs:
                 os: [ubuntu-22.04, buildjet-2vcpu-ubuntu-2204-arm, macos-13]
 
         steps:
-            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+            - uses: actions/checkout@v4
 
-            - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
+            - uses: actions/setup-python@v5
               with:
                   python-version: '3.11'
 
@@ -81,7 +81,7 @@ jobs:
                   MACOSX_DEPLOYMENT_TARGET: '13' # A modern target allows us to use C++20
 
             - name: Upload wheels artifact
-              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+              uses: actions/upload-artifact@v4
               with:
                   name: wheels-${{ matrix.os }}
                   path: |
@@ -98,19 +98,19 @@ jobs:
         runs-on: ubuntu-22.04
         steps:
             - name: Download wheels from ubuntu-22.04
-              uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
+              uses: actions/download-artifact@v4
               with:
                   name: wheels-ubuntu-22.04
                   path: dist
 
             - name: Download wheels from buildjet-2vcpu-ubuntu-2204-arm
-              uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
+              uses: actions/download-artifact@v4
               with:
                   name: wheels-buildjet-2vcpu-ubuntu-2204-arm
                   path: dist
 
             - name: Download wheels from macos-13
-              uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
+              uses: actions/download-artifact@v4
               with:
                   name: wheels-macos-13
                   path: dist
@@ -118,7 +118,7 @@ jobs:
             - name: Publish package to PyPI
               uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # release/v1
 
-            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+            - uses: actions/checkout@v4
               with:
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
                   ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/ci-ai.yml
+++ b/.github/workflows/ci-ai.yml
@@ -25,7 +25,7 @@ jobs:
             )
 
         steps:
-            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+            - uses: actions/checkout@v4
               with:
                   # Check out the actual branch instead of merge commit with master,
                   # because we want the Braintrust experiment to have accurate git metadata (on master it's empty)
@@ -38,7 +38,7 @@ jobs:
                   docker compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
-              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+              uses: actions/setup-python@v5
               with:
                   python-version-file: 'pyproject.toml'
 
@@ -70,7 +70,7 @@ jobs:
 
             - name: Post eval summary to PR
               if: github.event_name == 'pull_request'
-              uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
+              uses: actions/github-script@v6
               with:
                   github-token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
                   script: |

--- a/.github/workflows/ci-backend-update-test-timing.yml
+++ b/.github/workflows/ci-backend-update-test-timing.yml
@@ -21,7 +21,7 @@ jobs:
         name: Run Django tests and save test durations
         runs-on: ubuntu-24.04
         steps:
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
 
             - uses: ./.github/actions/run-backend-tests
               with:
@@ -34,7 +34,7 @@ jobs:
                   person-on-events: false
 
             - name: Upload updated timing data as artifacts
-              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+              uses: actions/upload-artifact@v4
               if: ${{ inputs.person-on-events != 'true' && inputs.clickhouse-server-image == 'clickhouse/clickhouse-server:25.3.6.56' }}
               with:
                   name: timing_data-${{ inputs.segment }}-${{ inputs.group }}

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -52,7 +52,7 @@ jobs:
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
 
             - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
               id: filter
@@ -105,7 +105,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
 
             - name: Stop/Start stack with Docker Compose
               run: |
@@ -113,7 +113,7 @@ jobs:
                   docker compose -f docker-compose.dev.yml up -d &
 
             - name: Set up Python
-              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+              uses: actions/setup-python@v5
               with:
                   python-version: 3.11.9
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
@@ -131,7 +131,7 @@ jobs:
 
             # First running migrations from master, to simulate the real-world scenario
             - name: Checkout master
-              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+              uses: actions/checkout@v4
               with:
                   ref: master
 
@@ -150,7 +150,7 @@ jobs:
 
             # Now we can consider this PR's migrations
             - name: Checkout this PR
-              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+              uses: actions/checkout@v4
 
             - name: Install python dependencies for this PR
               run: |
@@ -431,7 +431,7 @@ jobs:
                   echo "Skipping backend tests - no backend changes detected"
                   exit 0
 
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
               if: ${{ needs.changes.outputs.backend == 'true' }}
               with:
                   fetch-depth: 1
@@ -488,7 +488,7 @@ jobs:
 
             - name: Set up Python
               if: ${{ needs.changes.outputs.backend == 'true' }}
-              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+              uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python-version }}
                   cache: pip
@@ -523,7 +523,7 @@ jobs:
 
             - name: Set up Node.js
               if: ${{ needs.changes.outputs.backend == 'true' }}
-              uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 22.17.1
                   cache: pnpm
@@ -686,7 +686,7 @@ jobs:
               run: docker compose -f docker-compose.dev.yml logs
 
             - name: Upload updated timing data as artifacts
-              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+              uses: actions/upload-artifact@v4
               if: ${{ needs.changes.outputs.backend == 'true' && !matrix.person-on-events && matrix.clickhouse-server-image == 'clickhouse/clickhouse-server:25.3.6.56' }}
               with:
                   name: timing_data-${{ matrix.segment }}-${{ matrix.group }}
@@ -723,7 +723,7 @@ jobs:
                   exit 1
 
             - name: Archive email renders
-              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+              uses: actions/upload-artifact@v4
               if: needs.changes.outputs.backend == 'true' && matrix.segment == 'Core' && !matrix.person-on-events
               with:
                   name: email_renders-${{ github.sha }}-${{ github.run_attempt }}-${{ matrix.segment }}-${{ matrix.person-on-events }}-${{ matrix.group }}
@@ -758,7 +758,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: 'Checkout repo'
-              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+              uses: actions/checkout@v4
               with:
                   fetch-depth: 1
 
@@ -769,7 +769,7 @@ jobs:
                   docker compose -f docker-compose.dev.yml up -d &
 
             - name: Set up Python
-              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+              uses: actions/setup-python@v5
               with:
                   python-version-file: 'pyproject.toml'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -12,7 +12,7 @@ jobs:
             run:
                 working-directory: cli
         steps:
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
 
             - name: Install rust
               uses: dtolnay/rust-toolchain@6691ebadcb18182cc1391d07c9f295f657c593cd # 1.88

--- a/.github/workflows/ci-codeql.yml
+++ b/.github/workflows/ci-codeql.yml
@@ -68,7 +68,7 @@ jobs:
                 # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
         steps:
             - name: Checkout repository
-              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+              uses: actions/checkout@v4
 
             # Initializes the CodeQL tools for scanning.
             - name: Initialize CodeQL

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -37,7 +37,7 @@ jobs:
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
 
             - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
               id: filter
@@ -68,7 +68,7 @@ jobs:
         runs-on: depot-ubuntu-latest
         steps:
             - name: 'Checkout repo'
-              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+              uses: actions/checkout@v4
               with:
                   fetch-depth: 1
 
@@ -79,7 +79,7 @@ jobs:
                   docker compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
-              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+              uses: actions/setup-python@v5
               with:
                   python-version-file: 'pyproject.toml'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -93,7 +93,7 @@ jobs:
         steps:
             - name: Checkout
               if: needs.changes.outputs.shouldRun == 'true'
-              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+              uses: actions/checkout@v4
             - name: Build the Docker image with Depot
               if: needs.changes.outputs.shouldRun == 'true'
               # Build the container image in preparation for the E2E tests
@@ -115,7 +115,7 @@ jobs:
         steps:
             - name: Checkout
               if: needs.changes.outputs.shouldRun == 'true'
-              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+              uses: actions/checkout@v4
 
             - name: Install pnpm
               if: needs.changes.outputs.shouldRun == 'true'
@@ -123,7 +123,7 @@ jobs:
 
             - name: Set up Node.js
               if: needs.changes.outputs.shouldRun == 'true'
-              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+              uses: actions/setup-node@v4
               with:
                   node-version: 22.17.1
                   cache: 'pnpm'
@@ -133,7 +133,7 @@ jobs:
               id: pnpm-cache-dir
               run: echo "PNPM_STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-            - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+            - uses: actions/cache@v4
               if: needs.changes.outputs.shouldRun == 'true'
               id: pnpm-cache
               with:
@@ -239,7 +239,7 @@ jobs:
                   GITHUB_ACTION_RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
             - name: Archive report
-              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+              uses: actions/upload-artifact@v4
               with:
                   name: playwright-container-report
                   path: playwright/playwright-report/
@@ -248,7 +248,7 @@ jobs:
 
             - name: Archive screenshots
               if: always()
-              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+              uses: actions/upload-artifact@v4
               with:
                   name: playwright-container-screenshots
                   path: playwright/test-results
@@ -266,7 +266,7 @@ jobs:
                   echo "Skipping E2E checks - no changes detected"
                   exit 0
 
-            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+            - uses: actions/checkout@v4
               if: needs.changes.outputs.shouldRun == 'true'
 
             - name: Stop/Start stack with Docker Compose
@@ -313,7 +313,7 @@ jobs:
 
             - name: Set up Python
               if: needs.changes.outputs.shouldRun == 'true'
-              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+              uses: actions/setup-python@v5
               with:
                   python-version: 3.11.9
                   cache: pip
@@ -348,7 +348,7 @@ jobs:
 
             - name: Set up Node.js
               if: needs.changes.outputs.shouldRun == 'true'
-              uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 22.17.1
                   cache: pnpm
@@ -413,7 +413,7 @@ jobs:
               id: pnpm-cache-dir
               run: echo "PNPM_STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-            - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+            - uses: actions/cache@v4
               if: needs.changes.outputs.shouldRun == 'true'
               id: pnpm-cache
               with:
@@ -510,7 +510,7 @@ jobs:
 
             - name: Archive Playwright report on failure
               if: failure()
-              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+              uses: actions/upload-artifact@v4
               with:
                   name: playwright-report
                   path: playwright/playwright-report/
@@ -518,7 +518,7 @@ jobs:
 
             - name: Archive screenshots
               if: needs.changes.outputs.shouldRun == 'true'
-              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+              uses: actions/upload-artifact@v4
               with:
                   name: playwright-screenshots
                   path: playwright/test-results

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -23,7 +23,7 @@ jobs:
         steps:
             # For pull requests it's not necessary to check out the code, but we
             # also want this to run on master, so we need to check out
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
 
             - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
               id: filter
@@ -65,7 +65,7 @@ jobs:
                   exit 0
 
             # we need at least one thing to run to make sure we include everything for required jobs
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
               if: needs.changes.outputs.frontend == 'true'
 
             - name: Install pnpm
@@ -74,7 +74,7 @@ jobs:
 
             - name: Set up Node.js
               if: needs.changes.outputs.frontend == 'true'
-              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+              uses: actions/setup-node@v4
               with:
                   node-version: 22.17.1
                   cache: 'pnpm'
@@ -84,7 +84,7 @@ jobs:
               id: pnpm-cache-dir
               run: echo "PNPM_STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-            - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+            - uses: actions/cache@v4
               if: needs.changes.outputs.frontend == 'true'
               id: pnpm-cache
               with:
@@ -121,7 +121,7 @@ jobs:
                   echo "Skipping frontend checks - no frontend changes detected"
                   exit 0
 
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
               if: needs.changes.outputs.frontend == 'true'
             - name: Install pnpm
               if: needs.changes.outputs.frontend == 'true'
@@ -129,7 +129,7 @@ jobs:
 
             - name: Set up Node.js
               if: needs.changes.outputs.frontend == 'true'
-              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+              uses: actions/setup-node@v4
               with:
                   node-version: 22.17.1
                   cache: 'pnpm'
@@ -139,7 +139,7 @@ jobs:
               id: pnpm-cache-dir
               run: echo "PNPM_STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-            - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+            - uses: actions/cache@v4
               if: needs.changes.outputs.frontend == 'true'
               id: pnpm-cache
               with:
@@ -183,7 +183,7 @@ jobs:
                   echo "Skipping frontend checks - no frontend changes detected"
                   exit 0
 
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
               if: needs.changes.outputs.frontend == 'true'
 
             - name: Install pnpm
@@ -192,7 +192,7 @@ jobs:
 
             - name: Set up Node.js
               if: needs.changes.outputs.frontend == 'true'
-              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+              uses: actions/setup-node@v4
               with:
                   node-version: 22.17.1
                   cache: 'pnpm'
@@ -202,7 +202,7 @@ jobs:
               id: pnpm-cache-dir
               run: echo "PNPM_STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-            - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+            - uses: actions/cache@v4
               if: needs.changes.outputs.frontend == 'true'
               id: pnpm-cache
               with:
@@ -218,7 +218,7 @@ jobs:
 
             - name: Cache .typegen
               if: needs.changes.outputs.frontend == 'true'
-              uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+              uses: actions/cache@v4
               with:
                   path: .typegen
                   key: ${{ runner.os }}-typegen-${{ hashFiles('pnpm-lock.yaml') }}
@@ -266,7 +266,7 @@ jobs:
                   echo "Skipping frontend checks - no frontend changes detected"
                   exit 0
 
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
               if: needs.changes.outputs.frontend == 'true'
 
             - name: Remove ee
@@ -279,7 +279,7 @@ jobs:
 
             - name: Set up Node.js
               if: needs.changes.outputs.frontend == 'true'
-              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+              uses: actions/setup-node@v4
               with:
                   node-version: 22.17.1
                   cache: pnpm

--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -26,8 +26,8 @@ jobs:
         timeout-minutes: 30
         name: Setup DO Hobby Instance and test
         steps:
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
-            - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
+            - uses: actions/checkout@v4
+            - uses: actions/setup-python@v5
               with:
                   python-version: '3.8'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/ci-hog.yml
+++ b/.github/workflows/ci-hog.yml
@@ -28,7 +28,7 @@ jobs:
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
 
             - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
               id: filter
@@ -59,12 +59,12 @@ jobs:
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
 
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
               with:
                   fetch-depth: 1
 
             - name: Set up Python
-              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+              uses: actions/setup-python@v5
               with:
                   python-version-file: 'pyproject.toml'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
@@ -88,7 +88,7 @@ jobs:
               uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
 
             - name: Set up Node.js
-              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+              uses: actions/setup-node@v4
               with:
                   node-version: 18
                   cache: 'pnpm'
@@ -148,7 +148,7 @@ jobs:
             is-new-version: ${{ steps.check-package-version.outputs.is-new-version }}
         steps:
             - name: Checkout the repository
-              uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+              uses: actions/checkout@v4
             - name: Check package version and detect an update
               id: check-package-version
               uses: PostHog/check-package-version@v2
@@ -165,12 +165,12 @@ jobs:
             PUBLISHED_VERSION: ${{ needs.check-package-version.outputs.published-version }}
         steps:
             - name: Checkout the repository
-              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+              uses: actions/checkout@v4
               with:
                   fetch-depth: 1
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
             - name: Set up Python
-              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+              uses: actions/setup-python@v5
               with:
                   python-version-file: 'pyproject.toml'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
@@ -189,7 +189,7 @@ jobs:
             - name: Install pnpm
               uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
             - name: Set up Node 18
-              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+              uses: actions/setup-node@v4
               with:
                   node-version: 18
                   cache: 'pnpm'

--- a/.github/workflows/ci-livestream.yml
+++ b/.github/workflows/ci-livestream.yml
@@ -14,7 +14,7 @@ jobs:
               uses: actions/checkout@v4
 
             - name: Set up Go
-              uses: actions/setup-go@v2
+              uses: actions/setup-go@v5
               with:
                   go-version: 1.24
 

--- a/.github/workflows/ci-livestream.yml
+++ b/.github/workflows/ci-livestream.yml
@@ -11,10 +11,10 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+              uses: actions/checkout@v4
 
             - name: Set up Go
-              uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
+              uses: actions/setup-go@v2
               with:
                   go-version: 1.24
 

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -31,7 +31,7 @@ jobs:
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
 
             - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
               id: filter
@@ -53,7 +53,7 @@ jobs:
         needs: changes
         runs-on: depot-ubuntu-24.04-4
         steps:
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
               if: needs.changes.outputs.nodejs == 'true'
 
             - name: Install pnpm
@@ -62,7 +62,7 @@ jobs:
 
             - name: Set up Node.js
               if: needs.changes.outputs.nodejs == 'true'
-              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+              uses: actions/setup-node@v4
               with:
                   node-version: 22.17.1
                   cache: pnpm
@@ -86,7 +86,7 @@ jobs:
         needs: changes
         runs-on: depot-ubuntu-24.04-4
         steps:
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
               if: needs.changes.outputs.nodejs == 'true'
 
             - name: Install pnpm
@@ -95,7 +95,7 @@ jobs:
 
             - name: Set up Node.js
               if: needs.changes.outputs.nodejs == 'true'
-              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+              uses: actions/setup-node@v4
               with:
                   node-version: 22.17.1
                   cache: pnpm
@@ -143,7 +143,7 @@ jobs:
             - name: Code check out
               # NOTE: We need this check on every step so that it still runs if skipped as we need it to suceed for the CI
               if: needs.changes.outputs.nodejs == 'true'
-              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+              uses: actions/checkout@v4
 
             - name: Stop/Start stack with Docker Compose
               if: needs.changes.outputs.nodejs == 'true'
@@ -157,7 +157,7 @@ jobs:
 
             - name: Set up Python
               if: needs.changes.outputs.nodejs == 'true'
-              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+              uses: actions/setup-python@v5
               with:
                   python-version-file: 'pyproject.toml'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
@@ -172,7 +172,7 @@ jobs:
               if: needs.changes.outputs.nodejs == 'true'
               uses: dtolnay/rust-toolchain@6691ebadcb18182cc1391d07c9f295f657c593cd # 1.88
 
-            - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+            - uses: actions/cache@v4
               with:
                   path: |
                       ~/.cargo/registry
@@ -202,7 +202,7 @@ jobs:
 
             - name: Set up Node.js
               if: needs.changes.outputs.nodejs == 'true'
-              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+              uses: actions/setup-node@v4
               with:
                   node-version: 22.17.1
                   cache: pnpm

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -19,7 +19,7 @@ jobs:
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
 
             - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
               id: filter
@@ -56,13 +56,13 @@ jobs:
                   echo "Skipping python checks - no python changes detected"
                   exit 0
 
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
               if: needs.changes.outputs.python == 'true'
               with:
                   fetch-depth: 1
 
             - name: Set up Python
-              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+              uses: actions/setup-python@v5
               if: needs.changes.outputs.python == 'true'
               with:
                   python-version: 3.11.9
@@ -108,7 +108,7 @@ jobs:
 
             - name: Restore mypy cache
               if: needs.changes.outputs.python == 'true'
-              uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+              uses: actions/cache@v4
               with:
                   path: .mypy_cache
                   key: mypy-cache-${{ runner.os }}-${{ hashFiles('**/pyproject.toml', '**/mypy.ini') }}

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -22,7 +22,7 @@ jobs:
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
             - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
               id: filter
               with:
@@ -53,7 +53,7 @@ jobs:
             # Checkout project code
             # Use sparse checkout to only select files in rust directory
             # Turning off cone mode ensures that files in the project root are not included during checkout
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
               if: needs.changes.outputs.rust == 'true'
               with:
                   sparse-checkout: 'rust/'
@@ -93,7 +93,7 @@ jobs:
                 working-directory: rust
 
         steps:
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
               if: needs.changes.outputs.rust == 'true'
 
             - name: Setup main repo dependencies for flags
@@ -134,7 +134,7 @@ jobs:
 
             - name: Set up Python
               if: needs.changes.outputs.rust == 'true' && matrix.package == 'feature-flags'
-              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+              uses: actions/setup-python@v5
               with:
                   python-version-file: 'pyproject.toml'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
@@ -191,7 +191,7 @@ jobs:
             # Checkout project code
             # Use sparse checkout to only select files in rust directory
             # Turning off cone mode ensures that files in the project root are not included during checkout
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
               if: needs.changes.outputs.rust == 'true'
               with:
                   sparse-checkout: 'rust/'
@@ -238,7 +238,7 @@ jobs:
             # Checkout project code
             # Use sparse checkout to only select files in rust directory
             # Turning off cone mode ensures that files in the project root are not included during checkout
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
               if: needs.changes.outputs.rust == 'true'
               with:
                   sparse-checkout: 'rust/'

--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -6,6 +6,9 @@ on:
 
 name: Security
 
+permissions:
+    contents: read
+
 jobs:
     ensure-pinned-actions:
         runs-on: ubuntu-latest
@@ -15,4 +18,11 @@ jobs:
             - name: Ensure SHA pinned actions
               uses: zgosalvez/github-actions-ensure-sha-pinned-actions@25ed13d0628a1601b4b44048e63cc4328ed03633 # v3
               with:
-                  allowlist: PostHog/ # It's a string, parsed by splitting on \r\n but we only have one entry
+                  allowlist: |
+                      actions/
+                      aws-actions/
+                      docker/
+                      github/
+                      hashicorp/
+                      PostHog/
+                      tailscale/

--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -14,7 +14,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+              uses: actions/checkout@v4
             - name: Ensure SHA pinned actions
               uses: zgosalvez/github-actions-ensure-sha-pinned-actions@25ed13d0628a1601b4b44048e63cc4328ed03633 # v3
               with:

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -47,7 +47,7 @@ jobs:
                   echo "Skipping storybook checks - no frontend changes detected"
                   exit 0
 
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
               if: needs.changes.outputs.frontend == 'true'
               with:
                   ref: ${{ github.event.pull_request.head.ref }}
@@ -61,7 +61,7 @@ jobs:
 
             - name: Set up Node.js
               if: needs.changes.outputs.frontend == 'true'
-              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+              uses: actions/setup-node@v4
               with:
                   node-version: 22.17.1
                   cache: pnpm
@@ -72,7 +72,7 @@ jobs:
 
             - name: Cache webpack build
               if: needs.changes.outputs.frontend == 'true'
-              uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+              uses: actions/cache@v4
               with:
                   path: common/storybook/node_modules/.cache/
                   key: ${{ runner.os }}-webpack-storybook-${{ hashFiles('pnpm-lock.yaml') }}
@@ -88,7 +88,7 @@ jobs:
 
             - name: Upload Storybook build artifact
               if: needs.changes.outputs.frontend == 'true'
-              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+              uses: actions/upload-artifact@v4
               with:
                   name: storybook-build
                   path: common/storybook/dist
@@ -109,7 +109,7 @@ jobs:
               run: |
                   echo "Skipping storybook checks - no frontend changes detected"
                   exit 0
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
               if: needs.changes.outputs.frontend == 'true'
               with:
                   ref: ${{ github.event.pull_request.head.ref }}
@@ -124,7 +124,7 @@ jobs:
 
             - name: Set up Node.js
               if: needs.changes.outputs.frontend == 'true'
-              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+              uses: actions/setup-node@v4
               with:
                   node-version: 22.17.1
                   cache: pnpm
@@ -344,7 +344,7 @@ jobs:
                   echo "Skipping storybook checks - no frontend changes detected"
                   exit 0
 
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
               if: needs.changes.outputs.frontend == 'true'
               with:
                   ref: ${{ github.event.pull_request.head.ref }}
@@ -358,7 +358,7 @@ jobs:
 
             - name: Set up Node.js
               if: needs.changes.outputs.frontend == 'true'
-              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+              uses: actions/setup-node@v4
               with:
                   node-version: 22.17.1
                   cache: pnpm
@@ -368,7 +368,7 @@ jobs:
               id: pnpm-cache-dir
               run: echo "PNPM_STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-            - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+            - uses: actions/cache@v4
               if: needs.changes.outputs.frontend == 'true'
               id: pnpm-cache
               with:
@@ -386,7 +386,7 @@ jobs:
 
             - name: Download Storybook build artifact
               if: needs.changes.outputs.frontend == 'true'
-              uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
+              uses: actions/download-artifact@v4
               with:
                   name: storybook-build
                   path: common/storybook/dist
@@ -453,7 +453,7 @@ jobs:
 
             - name: Archive failure screenshots
               if: needs.changes.outputs.frontend == 'true' && ${{ failure() }}
-              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+              uses: actions/upload-artifact@v4
               with:
                   name: failure-screenshots-${{ matrix.browser }}-${{ matrix.shard }}
                   path: frontend/__snapshots__/__failures__/
@@ -552,7 +552,7 @@ jobs:
         steps:
             - name: Post comment about updated snapshots
               if: needs.changes.outputs.frontend == 'true' && github.event.pull_request.head.repo.full_name == github.repository
-              uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
+              uses: actions/github-script@v6
               with:
                   github-token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN || github.token }}
                   script: |

--- a/.github/workflows/ci-turbo.yml
+++ b/.github/workflows/ci-turbo.yml
@@ -14,7 +14,7 @@ jobs:
 
         steps:
             - name: Check out code
-              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+              uses: actions/checkout@v4
               with:
                   # Just fetch the current commit/PR head
                   fetch-depth: 1
@@ -37,7 +37,7 @@ jobs:
                   fi
 
             - name: Set up Python
-              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+              uses: actions/setup-python@v5
               with:
                   python-version-file: 'pyproject.toml'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
@@ -52,13 +52,13 @@ jobs:
               uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
 
             - name: Set up Node.js
-              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+              uses: actions/setup-node@v4
               with:
                   node-version: 18
                   cache: 'pnpm'
 
             - name: Cache node-gyp artifacts
-              uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # v3
+              uses: actions/cache@v4
               with:
                   path: ~/.cache/node-gyp
                   key: ${{ runner.os }}-${{ env.ARCH }}-node-gyp-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/codespaces.yml
+++ b/.github/workflows/codespaces.yml
@@ -27,7 +27,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'codespaces-build')  }}
 
         steps:
-            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/checkout@v4
               with:
                   fetch-depth: 1
 

--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -30,7 +30,7 @@ jobs:
 
         steps:
             - name: Check out
-              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+              uses: actions/checkout@v4
               with:
                   fetch-depth: 2
 

--- a/.github/workflows/container-images-ci.yml
+++ b/.github/workflows/container-images-ci.yml
@@ -55,7 +55,7 @@ jobs:
                   workflow: .github/workflows/ci-backend.yml
 
             - name: Check out
-              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+              uses: actions/checkout@v4
               if: needs.changes.outputs.docker_files == 'true'
 
             - name: Build and cache Docker image in Depot
@@ -83,7 +83,7 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             - name: Check out
-              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+              uses: actions/checkout@v4
               with:
                   fetch-depth: 0
 

--- a/.github/workflows/foss-sync.yml
+++ b/.github/workflows/foss-sync.yml
@@ -31,7 +31,7 @@ jobs:
                   destination_repo: 'https://posthog-bot:${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}@github.com/posthog/posthog-foss.git'
                   destination_branch: 'refs/tags/*'
             - name: Checkout posthog-foss
-              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+              uses: actions/checkout@v4
               with:
                   repository: 'posthog/posthog-foss'
                   ref: master

--- a/.github/workflows/livestream-docker-image.yml
+++ b/.github/workflows/livestream-docker-image.yml
@@ -22,7 +22,7 @@ jobs:
 
         steps:
             - name: Check out livestream code
-              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+              uses: actions/checkout@v4
               with:
                   sparse-checkout: 'livestream/'
                   sparse-checkout-cone-mode: false

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -18,7 +18,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+              uses: actions/checkout@v4
 
             - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
               with:

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -19,7 +19,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+              uses: actions/checkout@v4
 
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         steps:
-            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+            - uses: actions/checkout@v4
               with:
                   submodules: recursive
             - name: Install dist
@@ -65,7 +65,7 @@ jobs:
               shell: bash
               run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.28.2/cargo-dist-installer.sh | sh"
             - name: Cache dist
-              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+              uses: actions/upload-artifact@v4
               with:
                   name: cargo-dist-cache
                   path: ~/.cargo/bin/dist
@@ -81,7 +81,7 @@ jobs:
                   cat plan-dist-manifest.json
                   echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
             - name: 'Upload dist-manifest.json'
-              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+              uses: actions/upload-artifact@v4
               with:
                   name: artifacts-plan-dist-manifest
                   path: plan-dist-manifest.json
@@ -116,7 +116,7 @@ jobs:
             - name: enable windows longpaths
               run: |
                   git config --global core.longpaths true
-            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+            - uses: actions/checkout@v4
               with:
                   submodules: recursive
             - name: Install Rust non-interactively if not already installed
@@ -130,7 +130,7 @@ jobs:
               run: ${{ matrix.install_dist.run }}
             # Get the dist-manifest
             - name: Fetch local artifacts
-              uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
+              uses: actions/download-artifact@v4
               with:
                   pattern: artifacts-*
                   path: target/distrib/
@@ -157,7 +157,7 @@ jobs:
 
                   cp dist-manifest.json "$BUILD_MANIFEST_NAME"
             - name: 'Upload artifacts'
-              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+              uses: actions/upload-artifact@v4
               with:
                   name: artifacts-build-local-${{ join(matrix.targets, '_') }}
                   path: |
@@ -175,18 +175,18 @@ jobs:
             BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
             POSTHOG_API_TOKEN: ${{ secrets.POSTHOG_API_TOKEN }}
         steps:
-            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+            - uses: actions/checkout@v4
               with:
                   submodules: recursive
             - name: Install cached dist
-              uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
+              uses: actions/download-artifact@v4
               with:
                   name: cargo-dist-cache
                   path: ~/.cargo/bin/
             - run: chmod +x ~/.cargo/bin/dist
             # Get all the local artifacts for the global tasks to use (for e.g. checksums)
             - name: Fetch local artifacts
-              uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
+              uses: actions/download-artifact@v4
               with:
                   pattern: artifacts-*
                   path: target/distrib/
@@ -204,7 +204,7 @@ jobs:
 
                   cp dist-manifest.json "$BUILD_MANIFEST_NAME"
             - name: 'Upload artifacts'
-              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+              uses: actions/upload-artifact@v4
               with:
                   name: artifacts-build-global
                   path: |
@@ -224,18 +224,18 @@ jobs:
         outputs:
             val: ${{ steps.host.outputs.manifest }}
         steps:
-            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+            - uses: actions/checkout@v4
               with:
                   submodules: recursive
             - name: Install cached dist
-              uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
+              uses: actions/download-artifact@v4
               with:
                   name: cargo-dist-cache
                   path: ~/.cargo/bin/
             - run: chmod +x ~/.cargo/bin/dist
             # Fetch artifacts from scratch-storage
             - name: Fetch artifacts
-              uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
+              uses: actions/download-artifact@v4
               with:
                   pattern: artifacts-*
                   path: target/distrib/
@@ -248,14 +248,14 @@ jobs:
                   cat dist-manifest.json
                   echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
             - name: 'Upload dist-manifest.json'
-              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+              uses: actions/upload-artifact@v4
               with:
                   # Overwrite the previous copy
                   name: artifacts-dist-manifest
                   path: dist-manifest.json
             # Create a GitHub Release while uploading all files to it
             - name: 'Download GitHub Artifacts'
-              uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
+              uses: actions/download-artifact@v4
               with:
                   pattern: artifacts-*
                   path: artifacts
@@ -287,12 +287,12 @@ jobs:
         if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
         steps:
             - name: Fetch npm packages
-              uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 #v4
+              uses: actions/download-artifact@v4
               with:
                   pattern: artifacts-*
                   path: npm/
                   merge-multiple: true
-            - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+            - uses: actions/setup-node@v4
               with:
                   node-version: '20.x'
                   registry-url: 'https://registry.npmjs.org'
@@ -317,6 +317,6 @@ jobs:
         env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         steps:
-            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+            - uses: actions/checkout@v4
               with:
                   submodules: recursive

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -75,7 +75,7 @@ jobs:
               # Checkout project code
               # Use sparse checkout to only select files in rust directory
               # Turning off cone mode ensures that files in the project root are not included during checkout
-              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+              uses: actions/checkout@v4
               with:
                   sparse-checkout: 'rust/'
                   sparse-checkout-cone-mode: false

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -9,7 +9,7 @@ jobs:
         if: ${{ github.repository == 'PostHog/posthog' }}
         runs-on: ubuntu-24.04
         steps:
-            - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
+            - uses: actions/stale@v9
               with:
                   days-before-issue-stale: 730
                   days-before-issue-close: 14

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -11,7 +11,7 @@ jobs:
         if: github.repository == 'PostHog/posthog'
         steps:
             - name: Check out PostHog/posthog repo
-              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+              uses: actions/checkout@v4
               with:
                   path: posthog
                   fetch-depth: 0
@@ -22,7 +22,7 @@ jobs:
                   package_json_file: posthog/package.json
 
             - name: Set up Node.js
-              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+              uses: actions/setup-node@v4
               with:
                   node-version: 22.17.1
                   cache: pnpm
@@ -35,7 +35,7 @@ jobs:
               run: cd posthog && bin/turbo --filter=@posthog/storybook build
 
             - name: Check out PostHog/storybook-build repo
-              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+              uses: actions/checkout@v4
               with:
                   path: storybook-build
                   repository: PostHog/storybook-build


### PR DESCRIPTION
We can use version numbers on GitHub's official actions and some other trusted actions.