### PR TITLE
fix(max): Don't crash SQL generation if we got SOME SQL

### DIFF
--- a/ee/hogai/graph/schema_generator/nodes.py
+++ b/ee/hogai/graph/schema_generator/nodes.py
@@ -1,5 +1,6 @@
 import xml.etree.ElementTree as ET
 from typing import Generic, Optional, cast
+from collections.abc import Sequence
 from uuid import uuid4
 
 from langchain_core.agents import AgentAction
@@ -14,7 +15,7 @@ from langchain_core.runnables import RunnableConfig
 
 from ee.hogai.llm import MaxChatOpenAI
 from ee.hogai.utils.helpers import find_start_message
-from ee.hogai.utils.types import AssistantState, PartialAssistantState
+from ee.hogai.utils.types import AssistantState, IntermediateStep, PartialAssistantState
 from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.schema import (
     FailureMessage,
@@ -81,7 +82,7 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
     ) -> PartialAssistantState:
         start_id = state.start_id
         generated_plan = state.plan or ""
-        intermediate_steps = state.intermediate_steps or []
+        intermediate_steps: Sequence[IntermediateStep] = state.intermediate_steps or []
         validation_error_message = intermediate_steps[-1][1] if intermediate_steps else None
 
         message_history = await self._construct_messages(state, validation_error_message=validation_error_message)

--- a/ee/hogai/graph/schema_generator/nodes.py
+++ b/ee/hogai/graph/schema_generator/nodes.py
@@ -124,7 +124,7 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
                 )
 
         if not result:
-            # We've got no usable result after exhausting all attempts - it's failure message time
+            # We've got no usable result after exhausting all iteration attempts - it's failure message time
             return PartialAssistantState(
                 messages=[
                     FailureMessage(
@@ -136,6 +136,7 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
                 query_generation_retry_count=len(intermediate_steps) + 1,
             )
 
+        # We've got a result that either passed the quality check or we've exhausted all attempts at iterating - return
         return PartialAssistantState(
             messages=[
                 VisualizationMessage(

--- a/ee/hogai/graph/schema_generator/nodes.py
+++ b/ee/hogai/graph/schema_generator/nodes.py
@@ -1,5 +1,5 @@
 import xml.etree.ElementTree as ET
-from typing import Generic, Optional, TypeVar
+from typing import Generic, Optional, cast
 from uuid import uuid4
 
 from langchain_core.agents import AgentAction
@@ -11,7 +11,6 @@ from langchain_core.messages import (
 )
 from langchain_core.prompts import ChatPromptTemplate, HumanMessagePromptTemplate
 from langchain_core.runnables import RunnableConfig
-from pydantic import BaseModel
 
 from ee.hogai.llm import MaxChatOpenAI
 from ee.hogai.utils.helpers import find_start_message
@@ -35,9 +34,9 @@ from .prompts import (
     PLAN_PROMPT,
     QUESTION_PROMPT,
 )
-from .utils import SchemaGeneratorOutput
+from .utils import SchemaGeneratorOutput, Q
 
-Q = TypeVar("Q", bound=BaseModel)
+RETRIES_ALLOWED = 2
 
 
 class SchemaGeneratorNode(AssistantNode, Generic[Q]):
@@ -60,8 +59,19 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
             include_raw=False,
         )
 
-    async def _parse_output(self, output: dict) -> SchemaGeneratorOutput[Q]:
+    def _parse_output(self, output: dict) -> SchemaGeneratorOutput[Q]:
+        """This can raise a PydanticOutputParserException if the output is not parsable (therefore unusable)."""
         return parse_pydantic_structured_output(self.OUTPUT_MODEL)(output)
+
+    async def _quality_check_output(self, output: SchemaGeneratorOutput[Q]) -> None:
+        """
+        If implemented, this can raise a PydanticOutputParserException exception if something's off about the output
+        (e.g. a non-existent table field is used).
+
+        Raising here means that the LLM should iterate on the output, but also that it's still usable
+        if we aren't able to resolve the issue in a couple attempts.
+        """
+        pass
 
     async def _run_with_prompt(
         self,
@@ -80,8 +90,9 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
 
         chain = generation_prompt | merger | self._model | self._parse_output
 
+        result: SchemaGeneratorOutput[Q] | None = None
         try:
-            message: SchemaGeneratorOutput[Q] = await chain.ainvoke(
+            result = await chain.ainvoke(
                 {
                     "project_datetime": self.project_now,
                     "project_timezone": self.project_timezone,
@@ -89,21 +100,12 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
                 },
                 config,
             )
+            # If quality check raises, we will still iterate if we've got any attempts left,
+            # however if we don't have any more attempts, we're okay to use `result` (instead of throwing)
+            await self._quality_check_output(cast(SchemaGeneratorOutput[Q], result))
         except (PydanticOutputParserException, OutputParserException) as e:
-            # Generation step is expensive. After a second unsuccessful attempt, it's better to send a failure message.
-            if len(intermediate_steps) >= 2:
-                return PartialAssistantState(
-                    messages=[
-                        FailureMessage(
-                            content=f"Oops! It looks like I'm having trouble generating this {self.INSIGHT_NAME} insight. Could you please try again?"
-                        )
-                    ],
-                    intermediate_steps=None,
-                    plan=None,
-                    query_generation_retry_count=len(intermediate_steps) + 1,
-                )
-
-            if isinstance(e, OutputParserException):
+            # Try again with feedback a couple times
+            if len(intermediate_steps) < RETRIES_ALLOWED:
                 return PartialAssistantState(
                     intermediate_steps=[
                         *intermediate_steps,
@@ -111,7 +113,9 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
                             AgentAction(
                                 "handle_incorrect_response",
                                 e.llm_output or "No input was provided.",
-                                "The provided JSON was invalid.",
+                                e.validation_message
+                                if isinstance(e, PydanticOutputParserException)
+                                else "The provided JSON was invalid.",
                             ),
                             None,
                         ),
@@ -119,24 +123,29 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
                     query_generation_retry_count=len(intermediate_steps) + 1,
                 )
 
+        if not result:
+            # We've got no usable result after exhausting all attempts - it's failure message time
             return PartialAssistantState(
-                intermediate_steps=[
-                    *intermediate_steps,
-                    (AgentAction("handle_incorrect_response", e.llm_output, e.validation_message), None),
+                messages=[
+                    FailureMessage(
+                        content=f"It looks like I'm having trouble generating this {self.INSIGHT_NAME} insight."
+                    )
                 ],
+                intermediate_steps=None,
+                plan=None,
                 query_generation_retry_count=len(intermediate_steps) + 1,
             )
 
-        final_message = VisualizationMessage(
-            query=self._get_insight_plan(state),
-            plan=generated_plan,
-            answer=message.query,
-            initiator=start_id,
-            id=str(uuid4()),
-        )
-
         return PartialAssistantState(
-            messages=[final_message],
+            messages=[
+                VisualizationMessage(
+                    query=self._get_insight_plan(state),
+                    plan=generated_plan,
+                    answer=result.query,
+                    initiator=start_id,
+                    id=str(uuid4()),
+                )
+            ],
             intermediate_steps=None,
             plan=None,
             query_generation_retry_count=len(intermediate_steps),

--- a/ee/hogai/graph/schema_generator/parsers.py
+++ b/ee/hogai/graph/schema_generator/parsers.py
@@ -12,7 +12,7 @@ class PydanticOutputParserException(ValueError):
     """Pydantic validation error message."""
 
     def __init__(self, llm_output: str, validation_message: str):
-        super().__init__(f"{validation_message} at `{llm_output}`")
+        super().__init__(f"{validation_message}, occurred at:\n```\n{llm_output}\n```")
         self.llm_output = llm_output
         self.validation_message = validation_message
 

--- a/ee/hogai/graph/schema_generator/utils.py
+++ b/ee/hogai/graph/schema_generator/utils.py
@@ -1,9 +1,11 @@
-from typing import Generic, Optional, TypeVar
+from typing import Generic, TypeVar
 
 from pydantic import BaseModel
 
-T = TypeVar("T", bound=BaseModel)
+from posthog.schema import AssistantFunnelsQuery, AssistantHogQLQuery, AssistantRetentionQuery, AssistantTrendsQuery
+
+Q = TypeVar("T", AssistantHogQLQuery, AssistantTrendsQuery, AssistantFunnelsQuery, AssistantRetentionQuery)
 
 
-class SchemaGeneratorOutput(BaseModel, Generic[T]):
-    query: Optional[T] = None
+class SchemaGeneratorOutput(BaseModel, Generic[Q]):
+    query: Q

--- a/ee/hogai/graph/schema_generator/utils.py
+++ b/ee/hogai/graph/schema_generator/utils.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 
 from posthog.schema import AssistantFunnelsQuery, AssistantHogQLQuery, AssistantRetentionQuery, AssistantTrendsQuery
 
-Q = TypeVar("T", AssistantHogQLQuery, AssistantTrendsQuery, AssistantFunnelsQuery, AssistantRetentionQuery)
+Q = TypeVar("Q", AssistantHogQLQuery, AssistantTrendsQuery, AssistantFunnelsQuery, AssistantRetentionQuery)
 
 
 class SchemaGeneratorOutput(BaseModel, Generic[Q]):

--- a/ee/hogai/graph/sql/mixins.py
+++ b/ee/hogai/graph/sql/mixins.py
@@ -94,5 +94,3 @@ class HogQLGeneratorMixin(AssistantContextMixin):
                 # The "no viable alternative" ANTLR error is horribly unhelpful, both for humans and LLMs
                 err_msg = 'ANTLR parsing error: "no viable alternative at input". This means that the query isn\'t valid HogQL.'
             raise PydanticOutputParserException(llm_output=query, validation_message=err_msg)
-        except Exception as e:
-            raise PydanticOutputParserException(llm_output=query, validation_message=str(e))

--- a/ee/hogai/graph/sql/mixins.py
+++ b/ee/hogai/graph/sql/mixins.py
@@ -73,7 +73,7 @@ class HogQLGeneratorMixin(AssistantContextMixin):
         hogql_context = self._get_default_hogql_context(database)
         query = output.query.query if output.query else None
         if not query:
-            raise PydanticOutputParserException(llm_output="", validation_message=f"Output is empty ({output})")
+            raise PydanticOutputParserException(llm_output="", validation_message=f"Output is empty")
         try:
             parsed_query = parse_select(query, placeholders={})
 

--- a/ee/hogai/graph/sql/nodes.py
+++ b/ee/hogai/graph/sql/nodes.py
@@ -4,13 +4,9 @@ from ee.hogai.utils.types import AssistantState, PartialAssistantState
 from posthog.hogql.context import HogQLContext
 from posthog.schema import AssistantHogQLQuery
 
-from ..schema_generator.parsers import parse_pydantic_structured_output
 from ..schema_generator.nodes import SchemaGeneratorNode, SchemaGeneratorToolsNode
-from ..schema_generator.utils import SchemaGeneratorOutput
-from .mixins import HogQLGeneratorMixin
+from .mixins import HogQLGeneratorMixin, SQLSchemaGeneratorOutput
 from .toolkit import SQL_SCHEMA
-
-SQLSchemaGeneratorOutput = SchemaGeneratorOutput[AssistantHogQLQuery]
 
 
 class SQLGeneratorNode(HogQLGeneratorMixin, SchemaGeneratorNode[AssistantHogQLQuery]):
@@ -23,13 +19,6 @@ class SQLGeneratorNode(HogQLGeneratorMixin, SchemaGeneratorNode[AssistantHogQLQu
     async def arun(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState:
         prompt = await self._construct_system_prompt()
         return await super()._run_with_prompt(state, prompt, config=config)
-
-    async def _parse_output(self, output: dict) -> SchemaGeneratorOutput[AssistantHogQLQuery]:
-        result = parse_pydantic_structured_output(SchemaGeneratorOutput[str])(output)  # type: ignore
-        database = await self._get_database()
-        hogql_context = self._get_default_hogql_context(database)
-        query = await self._parse_generated_hogql(result.query, hogql_context)
-        return SQLSchemaGeneratorOutput(query=AssistantHogQLQuery(query=query))
 
 
 class SQLGeneratorToolsNode(SchemaGeneratorToolsNode):

--- a/ee/hogai/graph/sql/test/test_sql_mixins.py
+++ b/ee/hogai/graph/sql/test/test_sql_mixins.py
@@ -30,9 +30,9 @@ class TestSQLMixins(NonAtomicBaseTest):
         self.assertIn("Table", prompt)
         self.assertIn("<core_memory>", prompt)
 
-    async def test_assert_database_is_cached(self):
+    def test_assert_database_is_cached(self):
         mixin = self._node
-        database = await mixin._get_database()
+        database = mixin._get_database()
         self.assertEqual(mixin._database_instance, database)
 
     def test_parse_output_success_path(self):

--- a/ee/hogai/graph/sql/test/test_sql_mixins.py
+++ b/ee/hogai/graph/sql/test/test_sql_mixins.py
@@ -1,4 +1,6 @@
-from ee.hogai.graph.sql.mixins import HogQLGeneratorMixin
+from ee.hogai.graph.schema_generator.parsers import PydanticOutputParserException
+from ee.hogai.graph.sql.mixins import HogQLGeneratorMixin, SQLSchemaGeneratorOutput
+from posthog.schema import AssistantHogQLQuery
 from posthog.test.base import NonAtomicBaseTest
 
 
@@ -33,9 +35,125 @@ class TestSQLMixins(NonAtomicBaseTest):
         database = await mixin._get_database()
         self.assertEqual(mixin._database_instance, database)
 
-    async def test_parses_queries_with_placeholders(self):
+    def test_parse_output_success_path(self):
+        """Test successful parsing in HogQLGeneratorMixin."""
         mixin = self._node
-        query = "SELECT properties FROM events WHERE {filters} AND {custom_filter}"
-        database = await mixin._get_database()
-        result = await mixin._parse_generated_hogql(query, mixin._get_default_hogql_context(database))
-        self.assertEqual(result, query)
+
+        # Test direct _parse_output method
+        test_output = {"query": "SELECT count() FROM events"}
+        result = mixin._parse_output(test_output)
+
+        self.assertIsInstance(result, SQLSchemaGeneratorOutput)
+        self.assertEqual(
+            result, SQLSchemaGeneratorOutput(query=AssistantHogQLQuery(query="SELECT count() FROM events"))
+        )
+
+    def test_parse_output_with_empty_query(self):
+        """Test parsing with empty query string."""
+        mixin = self._node
+
+        test_output = {"query": ""}
+        result = mixin._parse_output(test_output)
+
+        self.assertIsInstance(result, SQLSchemaGeneratorOutput)
+        self.assertEqual(result.query.query, "")
+
+    async def test_quality_check_output_success_simple_query(self):
+        """Test successful quality check with simple valid query."""
+        mixin = self._node
+
+        valid_output = SQLSchemaGeneratorOutput(query=AssistantHogQLQuery(query="SELECT count() FROM events"))
+
+        # Should not raise any exception for valid SQL
+        await mixin._quality_check_output(valid_output)
+
+    async def test_quality_check_output_success_with_placeholders(self):
+        """Test successful quality check with placeholders."""
+        mixin = self._node
+
+        valid_output = SQLSchemaGeneratorOutput(
+            query=AssistantHogQLQuery(query="SELECT properties FROM events WHERE {filters}")
+        )
+
+        # Should not raise any exception for valid SQL with placeholders
+        await mixin._quality_check_output(valid_output)
+
+    async def test_quality_check_output_invalid_syntax_raises_exception(self):
+        """Test quality check failure with an invalid table in the SQL."""
+        mixin = self._node
+
+        invalid_output = SQLSchemaGeneratorOutput(query=AssistantHogQLQuery(query="SELECT * FROM nowhere"))
+
+        with self.assertRaises(PydanticOutputParserException) as context:
+            await mixin._quality_check_output(invalid_output)
+
+        self.assertEqual(context.exception.llm_output, "SELECT * FROM nowhere")
+        self.assertEqual(context.exception.validation_message, 'Unknown table "nowhere".')
+
+    async def test_quality_check_output_empty_query_raises_exception(self):
+        """Test quality check failure with empty query."""
+        mixin = self._node
+
+        # Create output with None query using model_construct to bypass validation
+        empty_output = SQLSchemaGeneratorOutput.model_construct(query=None)
+
+        with self.assertRaises(PydanticOutputParserException) as context:
+            await mixin._quality_check_output(empty_output)
+
+        self.assertEqual(context.exception.llm_output, "")
+        self.assertEqual(context.exception.validation_message, "Output is empty")
+
+    async def test_quality_check_output_blank_query_raises_exception(self):
+        """Test quality check failure with blank query string."""
+        mixin = self._node
+
+        blank_output = SQLSchemaGeneratorOutput(query=AssistantHogQLQuery(query=""))
+
+        with self.assertRaises(PydanticOutputParserException) as context:
+            await mixin._quality_check_output(blank_output)
+
+        self.assertEqual(context.exception.llm_output, "")
+        self.assertEqual(context.exception.validation_message, "Output is empty")
+
+    async def test_quality_check_output_no_viable_alternative_error_handling(self):
+        """Test that 'no viable alternative' errors get helpful messages."""
+        mixin = self._node
+
+        # Create a query that will trigger the "no viable alternative" ANTLR error
+        invalid_syntax_output = SQLSchemaGeneratorOutput(
+            query=AssistantHogQLQuery(query="SELECT FROM events")  # Missing column
+        )
+
+        with self.assertRaises(PydanticOutputParserException) as context:
+            await mixin._quality_check_output(invalid_syntax_output)
+
+        # Should replace unhelpful ANTLR error with better message
+        self.assertEqual(context.exception.llm_output, "SELECT FROM events")
+        self.assertIn("query isn't valid HogQL", context.exception.validation_message)
+
+    async def test_quality_check_output_nonexistent_table_raises_exception(self):
+        """Test quality check failure with nonexistent table."""
+        mixin = self._node
+
+        invalid_table_output = SQLSchemaGeneratorOutput(
+            query=AssistantHogQLQuery(query="SELECT count() FROM nonexistent_table")
+        )
+
+        with self.assertRaises(PydanticOutputParserException) as context:
+            await mixin._quality_check_output(invalid_table_output)
+
+        self.assertEqual(context.exception.llm_output, "SELECT count() FROM nonexistent_table")
+        self.assertEqual(context.exception.validation_message, 'Unknown table "nonexistent_table".')
+
+    async def test_quality_check_output_complex_query_with_joins(self):
+        """Test quality check success with complex query including joins."""
+        mixin = self._node
+
+        complex_output = SQLSchemaGeneratorOutput(
+            query=AssistantHogQLQuery(
+                query="SELECT e.event, p.id FROM events e LEFT JOIN persons p ON e.person_id = p.id LIMIT 10"
+            )
+        )
+
+        # Should not raise any exception for valid complex SQL
+        await mixin._quality_check_output(complex_output)

--- a/ee/hogai/utils/types.py
+++ b/ee/hogai/utils/types.py
@@ -127,7 +127,7 @@ class _SharedAssistantState(BaseState):
     Whether the graph was interrupted or resumed.
     """
 
-    intermediate_steps: Optional[list[IntermediateStep]] = Field(default=None)
+    intermediate_steps: Optional[Sequence[IntermediateStep]] = Field(default=None)
     """
     Actions taken by the query planner agent.
     """

--- a/products/data_warehouse/backend/hogql_fixer_ai.py
+++ b/products/data_warehouse/backend/hogql_fixer_ai.py
@@ -253,7 +253,5 @@ The newly updated query gave us this error:
                 # The "no viable alternative" ANTLR error is horribly unhelpful, both for humans and LLMs
                 err_msg = 'ANTLR parsing error: "no viable alternative at input". This means that the query isn\'t valid HogQL.'
             raise PydanticOutputParserException(llm_output=result.query, validation_message=err_msg)
-        except Exception as e:
-            raise PydanticOutputParserException(llm_output=result.query, validation_message=str(e))
 
         return result.query

--- a/products/data_warehouse/backend/max_tools.py
+++ b/products/data_warehouse/backend/max_tools.py
@@ -1,11 +1,14 @@
+from typing import Optional, cast
+
 from langchain_core.prompts import ChatPromptTemplate
 from pydantic import BaseModel, Field
-from typing import Optional
 from asgiref.sync import async_to_sync
-from ee.hogai.graph.schema_generator.parsers import parse_pydantic_structured_output
+
+from ee.hogai.graph.schema_generator.parsers import PydanticOutputParserException
 from ee.hogai.graph.schema_generator.utils import SchemaGeneratorOutput
-from ee.hogai.graph.sql.mixins import HogQLGeneratorMixin
+from ee.hogai.graph.sql.mixins import HogQLGeneratorMixin, SQLSchemaGeneratorOutput
 from ee.hogai.tool import MaxTool
+from posthog.schema import AssistantHogQLQuery
 from products.data_warehouse.backend.prompts import (
     HOGQL_GENERATOR_USER_PROMPT,
     SQL_ASSISTANT_ROOT_SYSTEM_PROMPT,
@@ -17,7 +20,7 @@ from ee.hogai.graph.taxonomy.agent import TaxonomyAgent
 from ee.hogai.graph.taxonomy.tools import base_final_answer
 from ee.hogai.graph.taxonomy.types import TaxonomyAgentState
 from posthog.models import Team, User
-from ee.hogai.graph.schema_generator.parsers import PydanticOutputParserException
+from posthoganalytics import capture_exception
 
 
 class HogQLGeneratorArgs(BaseModel):
@@ -46,6 +49,9 @@ class HogQLGeneratorToolkit(TaxonomyAgentToolkit):
         Override parent implementation to use YAML format instead of XML.
         """
         return self._format_properties_yaml(props)
+
+
+GENERATION_ATTEMPTS_ALLOWED = 3
 
 
 class HogQLGeneratorNode(
@@ -127,29 +133,35 @@ class HogQLGeneratorTool(MaxTool, HogQLGeneratorMixin):
             **self.context,
         }
 
-        final_error: Optional[Exception] = None
-        for _ in range(3):
+        final_result: SchemaGeneratorOutput[str] | None = None  # type: ignore
+        final_error: Optional[PydanticOutputParserException] = None
+        for _ in range(GENERATION_ATTEMPTS_ALLOWED):
             try:
-                result = await graph.ainvoke(graph_context)
-                if result.get("intermediate_steps"):
-                    if result["intermediate_steps"][-1]:
-                        return result["intermediate_steps"][-1][0].tool_input, ""
+                result_so_far = await graph.ainvoke(graph_context)
+                if result_so_far.get("intermediate_steps"):
+                    if result_so_far["intermediate_steps"][-1]:
+                        return result_so_far["intermediate_steps"][-1][0].tool_input, ""
                     else:
                         return "I need more information to generate the query.", ""
                 else:
-                    result = await self._parse_output(FinalAnswerArgs.model_validate(result["output"]))
-                    return "```sql\n" + result + "\n```", result
-
+                    final_result = result_so_far["output"]
+                    assert final_result is not None
+                    # If quality check raises, we will still iterate if we've got any attempts left,
+                    # however if we don't have any more attempts, we're okay to use `resulting_query` (instead of throwing)
+                    await self._quality_check_output(
+                        SQLSchemaGeneratorOutput(query=AssistantHogQLQuery(query=final_result.query))
+                    )
+                    final_error = None
             except PydanticOutputParserException as e:
                 graph_context["change"] += f"\n\nAvoid this error: {str(e)}"
                 final_error = e
-        else:
-            assert final_error is not None
-            raise final_error
 
-    async def _parse_output(self, output: dict) -> str:
-        result = parse_pydantic_structured_output(SchemaGeneratorOutput[str])(output)  # type: ignore
-        database = await self._get_database()
-        hogql_context = self._get_default_hogql_context(database)
-        query = await self._parse_generated_hogql(result.query, hogql_context)
-        return query
+        if not final_result:
+            raise cast(Exception, final_error)  # We haven't managed to create valid query JSON even once
+
+        if final_error is not None:
+            # We've got some result but the last time still had some syntactic issue (_validate_hogql() raised)
+            # Well, better that that nothing - let's just capture the error and send what we've got
+            capture_exception(final_error)
+
+        return "```sql\n" + final_result.query + "\n```", final_result.query

--- a/products/data_warehouse/backend/max_tools.py
+++ b/products/data_warehouse/backend/max_tools.py
@@ -110,7 +110,7 @@ class HogQLGeneratorGraph(TaxonomyAgent[TaxonomyAgentState, TaxonomyAgentState[F
         )
 
 
-class HogQLGeneratorTool(MaxTool, HogQLGeneratorMixin):
+class HogQLGeneratorTool(HogQLGeneratorMixin, MaxTool):
     name: str = "generate_hogql_query"
     description: str = (
         "Write or edit an SQL query to answer the user's question, and apply it to the current SQL editor"
@@ -153,7 +153,7 @@ class HogQLGeneratorTool(MaxTool, HogQLGeneratorMixin):
                     )
                     final_error = None
             except PydanticOutputParserException as e:
-                graph_context["change"] += f"\n\nAvoid this error: {str(e)}"
+                graph_context["change"] += f"\n\nAvoid this error that we had with our previous attempt:\n\n{str(e)}"
                 final_error = e
 
         if not final_result:

--- a/products/data_warehouse/backend/max_tools.py
+++ b/products/data_warehouse/backend/max_tools.py
@@ -152,6 +152,7 @@ class HogQLGeneratorTool(HogQLGeneratorMixin, MaxTool):
                         SQLSchemaGeneratorOutput(query=AssistantHogQLQuery(query=final_result.query))
                     )
                     final_error = None
+                    break  # All good, let's go
             except PydanticOutputParserException as e:
                 graph_context["change"] += f"\n\nAvoid this error that we had with our previous attempt:\n\n{str(e)}"
                 final_error = e

--- a/products/data_warehouse/backend/test/test_max_tools.py
+++ b/products/data_warehouse/backend/test/test_max_tools.py
@@ -1,9 +1,10 @@
 from unittest.mock import patch, AsyncMock
 
+from ee.hogai.graph.schema_generator.parsers import PydanticOutputParserException
 from ee.hogai.utils.types import AssistantState
 from posthog.schema import AssistantToolCall
 from posthog.test.base import NonAtomicBaseTest
-from products.data_warehouse.backend.max_tools import HogQLGeneratorTool
+from products.data_warehouse.backend.max_tools import HogQLGeneratorTool, FinalAnswerArgs
 
 
 class TestDataWarehouseMaxTools(NonAtomicBaseTest):
@@ -17,7 +18,7 @@ class TestDataWarehouseMaxTools(NonAtomicBaseTest):
         }
 
         mock_result = {
-            "output": {"query": "SELECT AVG(properties.$session_length) FROM events"},
+            "output": FinalAnswerArgs(query="SELECT AVG(properties.$session_length) FROM events"),
             "intermediate_steps": None,
         }
 
@@ -54,7 +55,7 @@ class TestDataWarehouseMaxTools(NonAtomicBaseTest):
         }
 
         mock_result = {
-            "output": {"query": "SELECT properties FROM events WHERE {filters} AND {custom_filter}"},
+            "output": FinalAnswerArgs(query="SELECT properties FROM events WHERE {filters} AND {custom_filter}"),
             "intermediate_steps": None,
         }
 
@@ -82,3 +83,135 @@ class TestDataWarehouseMaxTools(NonAtomicBaseTest):
             self.assertEqual(
                 result.content, "```sql\nSELECT properties FROM events WHERE {filters} AND {custom_filter}\n```"
             )
+
+    async def test_hogql_tool_quality_check_integration(self):
+        """Test that HogQLGeneratorTool properly calls quality check methods."""
+        config = {
+            "configurable": {
+                "team": self.team,
+                "user": self.user,
+                "contextual_tools": {"generate_hogql_query": {"current_query": ""}},
+            },
+        }
+
+        with (
+            patch("products.data_warehouse.backend.max_tools.HogQLGeneratorGraph.compile_full_graph") as mock_compile,
+            patch.object(HogQLGeneratorTool, "_quality_check_output") as mock_quality_check,
+        ):
+            mock_graph = AsyncMock()
+            mock_graph.ainvoke.return_value = {
+                "output": FinalAnswerArgs(query="SELECT count() FROM events"),
+                "intermediate_steps": None,
+            }
+
+            mock_compile.return_value = mock_graph
+
+            tool = HogQLGeneratorTool(team=self.team, user=self.user, state=AssistantState(messages=[]))
+            tool_call = AssistantToolCall(
+                id="1",
+                name="generate_hogql_query",
+                type="tool_call",
+                args={"instructions": "Count events"},
+            )
+
+            result = await tool.ainvoke(tool_call.model_dump(), config)
+
+            # Should succeed
+            self.assertEqual(result.content, "```sql\nSELECT count() FROM events\n```")
+            # Quality check should have been called at least once
+            mock_quality_check.assert_called()
+            # Verify it was called with the expected SQL query
+            call_args = mock_quality_check.call_args[0][0]
+            self.assertEqual(call_args.query.query, "SELECT count() FROM events")
+
+    async def test_hogql_tool_retry_exhausted_still_returns_result(self):
+        """Test HogQLGeneratorTool behavior when retries are exhausted but we have a valid parsed result."""
+        config = {
+            "configurable": {
+                "team": self.team,
+                "user": self.user,
+                "contextual_tools": {"generate_hogql_query": {"current_query": ""}},
+            },
+        }
+
+        # Mock the graph to return same result that fails quality check every time
+        mock_result = {
+            "output": FinalAnswerArgs(query="SELECT suspicious_query FROM events"),
+            "intermediate_steps": None,
+        }
+
+        with (
+            patch("products.data_warehouse.backend.max_tools.HogQLGeneratorGraph.compile_full_graph") as mock_compile,
+            patch.object(HogQLGeneratorTool, "_quality_check_output") as mock_quality_check,
+            patch("products.data_warehouse.backend.max_tools.capture_exception") as mock_capture,
+        ):
+            mock_graph = AsyncMock()
+            mock_graph.ainvoke.return_value = mock_result
+            mock_compile.return_value = mock_graph
+
+            # Quality check always fails
+            mock_quality_check.side_effect = PydanticOutputParserException(
+                "SELECT suspicious_query FROM events", "Suspicious query detected"
+            )
+
+            tool = HogQLGeneratorTool(team=self.team, user=self.user, state=AssistantState(messages=[]))
+            tool_call = AssistantToolCall(
+                id="1",
+                name="generate_hogql_query",
+                type="tool_call",
+                args={"instructions": "Count events"},
+            )
+
+            result = await tool.ainvoke(tool_call.model_dump(), config)
+
+            # Should still return the result despite quality check failure
+            self.assertEqual(result.content, "```sql\nSELECT suspicious_query FROM events\n```")
+            # Should have tried 3 times (GENERATION_ATTEMPTS_ALLOWED = 3)
+            self.assertEqual(mock_quality_check.call_count, 3)
+            # Should capture the exception
+            mock_capture.assert_called_once()
+
+            # Verify that error feedback was incorporated in retry attempts
+            # The graph should be called 3 times, with error messages appended after failures
+            self.assertEqual(mock_graph.ainvoke.call_count, 3)
+
+            # Check that the second call includes the error message from the first failure
+            second_call_context = mock_graph.ainvoke.call_args_list[1][0][0]
+            self.assertIn("Suspicious query detected", second_call_context["change"])
+
+            # Check that the third call includes error messages from previous failures
+            third_call_context = mock_graph.ainvoke.call_args_list[2][0][0]
+            self.assertIn("Suspicious query detected", third_call_context["change"])
+
+    async def test_hogql_tool_no_valid_result_raises_exception(self):
+        """Test HogQLGeneratorTool behavior when no valid result is ever produced."""
+        config = {
+            "configurable": {
+                "team": self.team,
+                "user": self.user,
+                "contextual_tools": {"generate_hogql_query": {"current_query": ""}},
+            },
+        }
+
+        # Mock the graph to return no output
+        mock_result = {
+            "output": None,
+            "intermediate_steps": None,
+        }
+
+        with patch("products.data_warehouse.backend.max_tools.HogQLGeneratorGraph.compile_full_graph") as mock_compile:
+            mock_graph = AsyncMock()
+            mock_graph.ainvoke.return_value = mock_result
+            mock_compile.return_value = mock_graph
+
+            tool = HogQLGeneratorTool(team=self.team, user=self.user, state=AssistantState(messages=[]))
+            tool_call = AssistantToolCall(
+                id="1",
+                name="generate_hogql_query",
+                type="tool_call",
+                args={"instructions": "Count events"},
+            )
+
+            # Should raise an exception when no valid result is produced
+            with self.assertRaises(Exception):
+                await tool.ainvoke(tool_call.model_dump(), config)

--- a/products/data_warehouse/backend/test/test_max_tools.py
+++ b/products/data_warehouse/backend/test/test_max_tools.py
@@ -118,8 +118,10 @@ class TestDataWarehouseMaxTools(NonAtomicBaseTest):
 
             # Should succeed
             self.assertEqual(result.content, "```sql\nSELECT count() FROM events\n```")
-            # Quality check should have been called at least once
-            mock_quality_check.assert_called()
+            # Quality check should have been called exactly once (happy path, loop breaks on success)
+            mock_quality_check.assert_called_once()
+            # Graph should have been called exactly once (happy path, loop breaks on success)
+            mock_graph.ainvoke.assert_called_once()
             # Verify it was called with the expected SQL query
             call_args = mock_quality_check.call_args[0][0]
             self.assertEqual(call_args.query.query, "SELECT count() FROM events")


### PR DESCRIPTION
## Problem

Users commonly hit Max SQL generation errors when after the third attempt there's still some incorrect field of function used (so we've got _some_ SQL, just its HogQL-level check fails). That's much too dramatic and destroys trust - most often it's much better to put out _something_ instead of crashing. Resolving because of ticket ZEN-35607 (see the related trace, a classic example, [here](https://us.posthog.com/project/2/llm-observability/traces/81a4bf7d-0058-421b-ba99-6377472c597d?timestamp=2025-08-05T21%3A30%3A09Z)).

## Changes

I've separated validation of the generated query into `_parse_output()` (whether it's usable at all) and a new `_quality_check_output()` method (whether there's something we _should_ iterate on, but not fatal).

Now _parsing_ errors still mean a complete failure, but _quality check_ errors means worst case we still return that result instead of crashing. In both cases we share the same limit of 3 iterations.

This means users may get SQL that uses non-existent fields and such.

The specific SQL validation is shared between `HogQLGeneratorTool` and `SchemaGeneratorNode` via `HogQLGeneratorMixin`, however these two call the LLM differently, so they each have their own implementation of actually handling potential errors from parsing / quality checking.

## How did you test this code?

Added lots of tests.