### PR TITLE
chore(myke): align wirtes to pg with partition strategy

### DIFF
--- a/plugin-server/src/cdp/consumers/cdp-aggregation-writer.consumer.test.ts
+++ b/plugin-server/src/cdp/consumers/cdp-aggregation-writer.consumer.test.ts
@@ -128,8 +128,7 @@ describe('CdpAggregationWriterConsumer', () => {
             expect(parsedBatch.behaviouralFilterMatchedEvents).toHaveLength(4) // Before aggregation
 
             // Process the batch (this tests deduplication, aggregation, and database writes)
-            const { backgroundTask } = processor['processBatch'](parsedBatch)
-            await backgroundTask
+            await processor['processBatch'](parsedBatch)
 
             // Verify person performed events in database (should be deduplicated)
             const personResult = await hub.postgres.query(
@@ -186,8 +185,7 @@ describe('CdpAggregationWriterConsumer', () => {
             expect(parsedBatch.behaviouralFilterMatchedEvents).toHaveLength(0)
 
             // Should not throw when processing empty batch
-            const { backgroundTask } = processor['processBatch'](parsedBatch)
-            await backgroundTask
+            await processor['processBatch'](parsedBatch)
 
             // Verify no records were written
             const personResult = await hub.postgres.query(

--- a/plugin-server/src/cdp/consumers/cdp-aggregation-writer.consumer.test.ts
+++ b/plugin-server/src/cdp/consumers/cdp-aggregation-writer.consumer.test.ts
@@ -128,7 +128,8 @@ describe('CdpAggregationWriterConsumer', () => {
             expect(parsedBatch.behaviouralFilterMatchedEvents).toHaveLength(4) // Before aggregation
 
             // Process the batch (this tests deduplication, aggregation, and database writes)
-            await processor['processBatch'](parsedBatch)
+            const { backgroundTask } = processor['processBatch'](parsedBatch)
+            await backgroundTask
 
             // Verify person performed events in database (should be deduplicated)
             const personResult = await hub.postgres.query(
@@ -185,7 +186,8 @@ describe('CdpAggregationWriterConsumer', () => {
             expect(parsedBatch.behaviouralFilterMatchedEvents).toHaveLength(0)
 
             // Should not throw when processing empty batch
-            await processor['processBatch'](parsedBatch)
+            const { backgroundTask } = processor['processBatch'](parsedBatch)
+            await backgroundTask
 
             // Verify no records were written
             const personResult = await hub.postgres.query(


### PR DESCRIPTION
## Problem

Excessive IO:DataFileRead waits (58+ AAS) when writing to hash-partitioned PostgreSQL tables. Each batch insert was touching multiple partitions because it contained events from different teams, forcing PostgreSQL to check all 100 partitions for ON CONFLICT constraints.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Group events by team_id before writing to PostgreSQL. Each INSERT now targets only one partition (determined by hash(team_id)), eliminating cross-partition lookups and reducing IO waits.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- all tests still pass

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
