### PR TITLE
chore(ux): new scene content for: cohorts + actions

### DIFF
--- a/frontend/src/layout/navigation-3000/Navigation.tsx
+++ b/frontend/src/layout/navigation-3000/Navigation.tsx
@@ -100,7 +100,7 @@ export function Navigation({
                         {(!sceneConfig?.hideBillingNotice || !sceneConfig?.hideProjectNotice) && (
                             <div className={sceneConfig?.layout === 'app-raw-no-header' ? 'px-4' : ''}>
                                 {!sceneConfig?.hideBillingNotice && <BillingAlertsV2 className="my-0 mb-4" />}
-                                {!sceneConfig?.hideProjectNotice && <ProjectNotice className="my-0 mb-4" />}
+                                {/* {!sceneConfig?.hideProjectNotice && <ProjectNotice className="my-0 mb-4" />} */}
                             </div>
                         )}
 

--- a/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
@@ -26,6 +26,7 @@ import {
 } from '@posthog/icons'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { IconCohort } from 'lib/lemon-ui/icons'
+import { cn } from 'lib/utils/css-classes'
 import React, { CSSProperties } from 'react'
 import { urls } from 'scenes/urls'
 
@@ -136,27 +137,41 @@ const iconTypes: Record<FileSystemIconType, { icon: JSX.Element; iconColor?: Fil
     },
 }
 
-const getIconColor = (type?: string): FileSystemIconColor => {
+const getIconColor = (type?: string, colorOverride?: FileSystemIconColor): FileSystemIconColor => {
     const fileSystemColor = (fileSystemTypes as unknown as Record<string, { iconColor?: FileSystemIconColor }>)[
         type as keyof typeof fileSystemTypes
     ]?.iconColor
 
     const iconTypeColor = type && iconTypes[type as keyof typeof iconTypes]?.iconColor
 
-    const color = iconTypeColor ?? fileSystemColor ?? ['currentColor']
+    const color = iconTypeColor ?? fileSystemColor ?? colorOverride ?? ['currentColor', 'currentColor']
     return color.length === 1 ? [color[0], color[0]] : (color as FileSystemIconColor)
 }
 
-const ProductIconWrapper = ({ type, children }: { type?: string; children: React.ReactNode }): JSX.Element => {
-    const [lightColor, darkColor] = getIconColor(type)
+type ProductIconWrapperProps = {
+    type?: string
+    children: React.ReactNode
+    // Light and dark color overrides
+    colorOverride?: FileSystemIconColor
+}
+
+const ProductIconWrapper = ({ type, children, colorOverride }: ProductIconWrapperProps): JSX.Element => {
+    const [lightColor, darkColor] = getIconColor(type, colorOverride)
 
     // By default icons will not be colorful, to add color, wrap the icon with the class: "group/colorful-product-icons colorful-product-icons-true"
     return (
         <span
-            className="group-[.colorful-product-icons-true]/colorful-product-icons:text-[var(--product-icon-color-light)] dark:group-[.colorful-product-icons-true]/colorful-product-icons:text-[var(--product-icon-color-dark)]"
+            className={cn(
+                `flex items-center group-[.colorful-product-icons-true]/colorful-product-icons:text-[var(--product-icon-color-light)] dark:group-[.colorful-product-icons-true]/colorful-product-icons:text-[var(--product-icon-color-dark)]`
+            )}
             // eslint-disable-next-line react/forbid-dom-props
             style={
-                { '--product-icon-color-light': lightColor, '--product-icon-color-dark': darkColor } as CSSProperties
+                (colorOverride
+                    ? { '--product-icon-color-light': colorOverride[0], '--product-icon-color-dark': colorOverride[1] }
+                    : {
+                          '--product-icon-color-light': lightColor,
+                          '--product-icon-color-dark': darkColor,
+                      }) as CSSProperties
             }
         >
             {children}
@@ -164,10 +179,10 @@ const ProductIconWrapper = ({ type, children }: { type?: string; children: React
     )
 }
 
-export function iconForType(type?: string): JSX.Element {
+export function iconForType(type?: string, colorOverride?: FileSystemIconColor): JSX.Element {
     if (!type) {
         return (
-            <ProductIconWrapper type={type}>
+            <ProductIconWrapper type={type} colorOverride={colorOverride}>
                 <IconBook />
             </ProductIconWrapper>
         )
@@ -176,17 +191,25 @@ export function iconForType(type?: string): JSX.Element {
     // Then check fileSystemTypes
     if (type in fileSystemTypes && fileSystemTypes[type as keyof typeof fileSystemTypes]?.icon) {
         const IconElement = fileSystemTypes[type as keyof typeof fileSystemTypes].icon
-        return <ProductIconWrapper type={type}>{IconElement}</ProductIconWrapper>
+        return (
+            <ProductIconWrapper type={type} colorOverride={colorOverride}>
+                {IconElement}
+            </ProductIconWrapper>
+        )
     }
 
     if (type in iconTypes) {
-        return <ProductIconWrapper type={type}>{iconTypes[type as keyof typeof iconTypes].icon}</ProductIconWrapper>
+        return (
+            <ProductIconWrapper type={type} colorOverride={colorOverride}>
+                {iconTypes[type as keyof typeof iconTypes].icon}
+            </ProductIconWrapper>
+        )
     }
 
     // Handle hog_function types
     if (type.startsWith('hog_function/')) {
         return (
-            <ProductIconWrapper type="plug">
+            <ProductIconWrapper type="plug" colorOverride={colorOverride}>
                 <IconPlug />
             </ProductIconWrapper>
         )
@@ -194,7 +217,7 @@ export function iconForType(type?: string): JSX.Element {
 
     // Default
     return (
-        <ProductIconWrapper type={type}>
+        <ProductIconWrapper type={type} colorOverride={colorOverride}>
             <IconBook />
         </ProductIconWrapper>
     )

--- a/frontend/src/layout/scenes/SceneContent.tsx
+++ b/frontend/src/layout/scenes/SceneContent.tsx
@@ -1,0 +1,299 @@
+import { LemonDivider, Link } from '@posthog/lemon-ui'
+
+import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
+import { ButtonPrimitive, buttonPrimitiveVariants } from 'lib/ui/Button/ButtonPrimitives'
+import { TextareaPrimitive } from 'lib/ui/TextareaPrimitive/TextareaPrimitive'
+import { TextInputPrimitive } from 'lib/ui/TextInputPrimitive/TextInputPrimitive'
+import { WrappingLoadingSkeleton } from 'lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton'
+import { cn } from 'lib/utils/css-classes'
+import { useEffect, useState } from 'react'
+import { fileSystemTypes } from '~/products'
+import { iconForType } from '../panel-layout/ProjectTree/defaultTree'
+import { IconDocument } from '@posthog/icons'
+
+export function SceneContent({ children }: { children: React.ReactNode }): JSX.Element {
+    return <div className="flex flex-col gap-y-4">{children}</div>
+}
+
+export interface SceneBreadcrumb {
+    name: string
+    url?: string
+}
+
+interface SceneSectionProps {
+    title: React.ReactNode
+    description?: React.ReactNode
+    isLoading?: boolean
+    children: React.ReactNode
+    className?: string
+}
+
+export function SceneSection({ title, description, isLoading, children, className }: SceneSectionProps): JSX.Element {
+    if (isLoading) {
+        return (
+            <div className={cn('flex flex-col gap-4', className)}>
+                <div className="flex flex-col gap-0">
+                    <h2 className="text-xl font-bold my-0 mb-1 max-w-prose">{title}</h2>
+                    {description && <p className="text-sm text-secondary my-0 max-w-prose">{description}</p>}
+                </div>
+                <WrappingLoadingSkeleton>{children}</WrappingLoadingSkeleton>
+            </div>
+        )
+    }
+
+    return (
+        <div className={cn('flex flex-col gap-4', className)}>
+            <div className="flex flex-col gap-0">
+                <h2 className="text-xl font-bold my-0 mb-1 max-w-prose">{title}</h2>
+                {description && <p className="text-sm text-secondary my-0 max-w-prose">{description}</p>}
+            </div>
+            {children}
+        </div>
+    )
+}
+
+type ResourceType = {
+    to?: string
+    tooltip?: string
+    // example: 'action'
+    type: keyof typeof fileSystemTypes
+    // example: 'actions'
+    typePlural: string
+}
+type SceneMainTitleProps = {
+    name?: string | null
+    description?: string | null
+    resourceType: ResourceType
+    markdown?: boolean
+    isLoading?: boolean
+    onNameBlur?: (value: string) => void
+    onDescriptionBlur?: (value: string) => void
+    docsLink?: string
+}
+
+export function SceneTitleSection({
+    name,
+    description,
+    resourceType,
+    markdown = false,
+    isLoading = false,
+    onNameBlur,
+    onDescriptionBlur,
+    docsLink,
+}: SceneMainTitleProps): JSX.Element {
+    // const [isEditing, setIsEditing] = useState(false)
+    // const resourceCapitalized: string | null = resourceType.type ? capitalizeFirstLetter(resourceType.type) : null
+    // const resourceCapitalizedPlural: string | null = resourceType.typePlural
+    //     ? capitalizeFirstLetter(resourceType.typePlural)
+    //     : null
+    const icon = iconForType(resourceType.type)
+
+    return (
+        <div className="w-full flex gap-0 group/colorful-product-icons colorful-product-icons-true">
+            <div className="flex flex-col gap-1.5 flex-1">
+                <div className="flex gap-3 [&_svg]:size-10 [&_svg]:p-2 items-center">
+                    {resourceType.to ? (
+                        <Link
+                            to={resourceType.to}
+                            tooltip={resourceType.tooltip || `View all ${resourceType.typePlural}`}
+                            buttonProps={{
+                                size: 'lg',
+                                iconOnly: true,
+                                variant: 'panel',
+                                className: 'rounded-sm',
+                            }}
+                        >
+                            {icon}
+                        </Link>
+                    ) : (
+                        icon
+                    )}
+                    <SceneName name={name} isLoading={isLoading} onBlur={onNameBlur} />
+                </div>
+                <SceneDescription
+                    description={description}
+                    markdown={markdown}
+                    isLoading={isLoading}
+                    onBlur={onDescriptionBlur}
+                />
+            </div>
+            {docsLink && (
+                <Link
+                    to={docsLink}
+                    buttonProps={{ variant: 'panel', className: 'rounded-sm' }}
+                    tooltip={`View docs for ${resourceType.typePlural}`}
+                >
+                    <IconDocument /> <span className="hidden lg:block">Read the docs</span>
+                </Link>
+            )}
+        </div>
+    )
+}
+
+type SceneNameProps = {
+    name?: string | null
+    isLoading?: boolean
+    onBlur?: (value: string) => void
+}
+
+export function SceneName({ name: initialName, isLoading = false, onBlur }: SceneNameProps): JSX.Element {
+    const [isEditing, setIsEditing] = useState(false)
+    const [name, setName] = useState(initialName)
+
+    const textClasses =
+        'text-3xl font-bold my-0 pl-[var(--button-padding-x-sm)] h-[var(--button-height-lg)] leading-[1.4] select-auto'
+
+    useEffect(() => {
+        if (!isLoading) {
+            setName(initialName)
+        }
+    }, [initialName, isLoading])
+
+    // If onBlur is provided, we want to show a button that allows the user to edit the name
+    // Otherwise, we want to show the name as a text
+    const Element = onBlur ? (
+        <ButtonPrimitive
+            size="lg"
+            onClick={() => setIsEditing(true)}
+            className={textClasses}
+            menuItem
+            variant="panel"
+            tooltip={isEditing ? 'Save' : 'Edit name'}
+        >
+            {name || <span className="text-tertiary">Unnamed</span>}
+        </ButtonPrimitive>
+    ) : (
+        <h1 className={cn(buttonPrimitiveVariants({ size: 'lg', inert: true, className: textClasses }))}>
+            {name || <span className="text-tertiary">Unnamed</span>}
+        </h1>
+    )
+
+    if (isLoading) {
+        return (
+            <div className="max-w-prose">
+                <WrappingLoadingSkeleton fullWidth>{Element}</WrappingLoadingSkeleton>
+            </div>
+        )
+    }
+
+    return (
+        <div className="max-w-prose flex flex-col gap-0 -ml-[calc(var(--button-padding-x-sm)+2px)]">
+            {isEditing ? (
+                <>
+                    <TextInputPrimitive
+                        variant="default"
+                        value={name || ''}
+                        onChange={(e) => setName(e.target.value)}
+                        className={`${textClasses} bg-transparent field-sizing-content w-full`}
+                        autoFocus
+                        onBlur={() => {
+                            setIsEditing(false)
+                            if (initialName !== name) {
+                                onBlur?.(name || '')
+                            }
+                        }}
+                        size="lg"
+                    />
+                </>
+            ) : (
+                Element
+            )}
+        </div>
+    )
+}
+
+type SceneDescriptionProps = {
+    description?: string | null
+    markdown?: boolean
+    isLoading?: boolean
+    onBlur?: (value: string) => void
+}
+
+export function SceneDescription({
+    description: initialDescription,
+    markdown = false,
+    isLoading = false,
+    onBlur,
+}: SceneDescriptionProps): JSX.Element {
+    const [isEditing, setIsEditing] = useState(false)
+    const [description, setDescription] = useState(initialDescription)
+
+    const textClasses = 'text-sm my-0 select-auto'
+
+    useEffect(() => {
+        if (!isLoading) {
+            setDescription(initialDescription)
+        }
+    }, [initialDescription, isLoading])
+
+    const Element = onBlur ? (
+        <ButtonPrimitive
+            onClick={() => setIsEditing(true)}
+            className={`${textClasses}`}
+            autoHeight
+            menuItem
+            variant="panel"
+            tooltip={isEditing ? 'Save' : 'Edit description'}
+        >
+            {markdown && description ? (
+                <LemonMarkdown lowKeyHeadings className="[&_p]:my-0 [&_p]:leading-[20px]">
+                    {description}
+                </LemonMarkdown>
+            ) : (
+                description || <span className="text-tertiary">No description (optional)</span>
+            )}
+        </ButtonPrimitive>
+    ) : (
+        <>
+            {markdown && description ? (
+                <LemonMarkdown
+                    lowKeyHeadings
+                    className={buttonPrimitiveVariants({ inert: true, className: textClasses, autoHeight: true })}
+                >
+                    {description}
+                </LemonMarkdown>
+            ) : (
+                <p className={buttonPrimitiveVariants({ inert: true, className: textClasses, autoHeight: true })}>
+                    {description ? description : <span className="text-tertiary">No description (optional)</span>}
+                </p>
+            )}
+        </>
+    )
+
+    if (isLoading) {
+        return (
+            <div className="max-w-prose">
+                <WrappingLoadingSkeleton fullWidth>{Element}</WrappingLoadingSkeleton>
+            </div>
+        )
+    }
+
+    return (
+        <div className="max-w-prose flex flex-col gap-0">
+            {isEditing ? (
+                <>
+                    <TextareaPrimitive
+                        variant="default"
+                        value={description || ''}
+                        onChange={(e) => setDescription(e.target.value)}
+                        className={`${textClasses} bg-transparent field-sizing-content w-full`}
+                        autoFocus
+                        onBlur={() => {
+                            setIsEditing(false)
+                            if (initialDescription !== description) {
+                                onBlur?.(description || '')
+                            }
+                        }}
+                        markdown
+                    />
+                </>
+            ) : (
+                Element
+            )}
+        </div>
+    )
+}
+
+export function SceneDivider(): JSX.Element {
+    return <LemonDivider className="-mx-4 w-[calc(100%+var(--spacing)*8)]" />
+}

--- a/frontend/src/layout/scenes/SceneContent.tsx
+++ b/frontend/src/layout/scenes/SceneContent.tsx
@@ -10,8 +10,19 @@ import { useEffect, useState } from 'react'
 import { fileSystemTypes } from '~/products'
 import { iconForType } from '../panel-layout/ProjectTree/defaultTree'
 import { IconDocument } from '@posthog/icons'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { useValues } from 'kea'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 export function SceneContent({ children }: { children: React.ReactNode }): JSX.Element {
+    const { featureFlags } = useValues(featureFlagLogic)
+    const newSceneLayout = featureFlags[FEATURE_FLAGS.NEW_SCENE_LAYOUT]
+
+    // If not in new scene layout, we don't want to show anything new
+    if (!newSceneLayout) {
+        return <div>{children}</div>
+    }
+
     return <div className="flex flex-col gap-y-4">{children}</div>
 }
 
@@ -29,6 +40,14 @@ interface SceneSectionProps {
 }
 
 export function SceneSection({ title, description, isLoading, children, className }: SceneSectionProps): JSX.Element {
+    const { featureFlags } = useValues(featureFlagLogic)
+    const newSceneLayout = featureFlags[FEATURE_FLAGS.NEW_SCENE_LAYOUT]
+
+    // If not in new scene layout, we don't want to show anything new
+    if (!newSceneLayout) {
+        return <div className={cn('flex flex-col gap-4', className)}>{children}</div>
+    }
+
     if (isLoading) {
         return (
             <div className={cn('flex flex-col gap-4', className)}>
@@ -81,32 +100,36 @@ export function SceneTitleSection({
     onDescriptionBlur,
     docsLink,
 }: SceneMainTitleProps): JSX.Element {
-    // const [isEditing, setIsEditing] = useState(false)
-    // const resourceCapitalized: string | null = resourceType.type ? capitalizeFirstLetter(resourceType.type) : null
-    // const resourceCapitalizedPlural: string | null = resourceType.typePlural
-    //     ? capitalizeFirstLetter(resourceType.typePlural)
-    //     : null
     const icon = iconForType(resourceType.type)
 
     return (
         <div className="w-full flex gap-0 group/colorful-product-icons colorful-product-icons-true">
             <div className="flex flex-col gap-1.5 flex-1">
-                <div className="flex gap-3 [&_svg]:size-10 [&_svg]:p-2 items-center">
+                <div className="flex gap-3 [&_svg]:size-6 items-center">
                     {resourceType.to ? (
                         <Link
                             to={resourceType.to}
                             tooltip={resourceType.tooltip || `View all ${resourceType.typePlural}`}
                             buttonProps={{
-                                size: 'lg',
+                                size: 'base',
                                 iconOnly: true,
                                 variant: 'panel',
-                                className: 'rounded-sm',
+                                className: 'rounded-sm h-[var(--button-height-lg)]',
                             }}
                         >
                             {icon}
                         </Link>
                     ) : (
-                        icon
+                        <span
+                            className={buttonPrimitiveVariants({
+                                size: 'base',
+                                iconOnly: true,
+                                className: 'rounded-sm h-[var(--button-height-lg)]',
+                                inert: true,
+                            })}
+                        >
+                            {icon}
+                        </span>
                     )}
                     <SceneName name={name} isLoading={isLoading} onBlur={onNameBlur} />
                 </div>
@@ -248,12 +271,22 @@ export function SceneDescription({
             {markdown && description ? (
                 <LemonMarkdown
                     lowKeyHeadings
-                    className={buttonPrimitiveVariants({ inert: true, className: textClasses, autoHeight: true })}
+                    className={buttonPrimitiveVariants({
+                        inert: true,
+                        className: `${textClasses} -ml-[var(--button-padding-x-base)]`,
+                        autoHeight: true,
+                    })}
                 >
                     {description}
                 </LemonMarkdown>
             ) : (
-                <p className={buttonPrimitiveVariants({ inert: true, className: textClasses, autoHeight: true })}>
+                <p
+                    className={buttonPrimitiveVariants({
+                        inert: true,
+                        className: `${textClasses} -ml-[var(--button-padding-x-base)]`,
+                        autoHeight: true,
+                    })}
+                >
                     {description ? description : <span className="text-tertiary">No description (optional)</span>}
                 </p>
             )}
@@ -295,5 +328,13 @@ export function SceneDescription({
 }
 
 export function SceneDivider(): JSX.Element {
+    const { featureFlags } = useValues(featureFlagLogic)
+    const newSceneLayout = featureFlags[FEATURE_FLAGS.NEW_SCENE_LAYOUT]
+
+    // If not in new scene layout, we don't want to show anything new
+    if (!newSceneLayout) {
+        return <></>
+    }
+
     return <LemonDivider className="-mx-4 w-[calc(100%+var(--spacing)*8)]" />
 }

--- a/frontend/src/layout/scenes/SceneLayout.tsx
+++ b/frontend/src/layout/scenes/SceneLayout.tsx
@@ -48,9 +48,11 @@ export const ScenePanelCommonActions = ({ children }: { children: React.ReactNod
     return (
         <>
             <div
-                className={cn(
-                    'flex flex-col gap-2 min-h-[var(--scene-layout-header-height)] py-2 border-b border-primary -mx-2 px-2 mb-2'
-                )}
+                // This is a hack to make the meta info panel have a margin top of 0 when it's the first child of the panel
+                className={`
+                    [&+.scene-panel-meta-info]:mt-0 
+                    flex flex-col gap-2 min-h-[var(--scene-layout-header-height)] py-2 border-b border-primary -mx-2 px-2 mb-2
+                `}
             >
                 {children}
             </div>
@@ -60,7 +62,7 @@ export const ScenePanelCommonActions = ({ children }: { children: React.ReactNod
 
 // Should be second!
 export function ScenePanelMetaInfo({ children }: { children: React.ReactNode }): JSX.Element {
-    return <div className="pl-1 pb-1 flex flex-col gap-2">{children}</div>
+    return <div className="scene-panel-meta-info pl-1 pb-1 flex flex-col gap-2 mt-2">{children}</div>
 }
 
 // Should be third!

--- a/frontend/src/lib/ui/Button/ButtonPrimitives.scss
+++ b/frontend/src/lib/ui/Button/ButtonPrimitives.scss
@@ -22,6 +22,26 @@
     --button-height-lg: 40px;
 }
 
+.button-padding-x-xxs {
+    padding-right: var(--button-padding-x-xxs);
+    padding-left: var(--button-padding-x-xxs);
+}
+
+.button-padding-x-xs {
+    padding-right: var(--button-padding-x-xs);
+    padding-left: var(--button-padding-x-xs);
+}
+
+.button-padding-x-sm {
+    padding-right: var(--button-padding-x-sm);
+    padding-left: var(--button-padding-x-sm);
+}
+
+.button-padding-x-lg {
+    padding-right: var(--button-padding-x-lg);
+    padding-left: var(--button-padding-x-lg);
+}
+
 .button-primitive {
     position: relative;
     display: inline-flex;

--- a/frontend/src/lib/ui/TextInputPrimitive/TextInputPrimitive.scss
+++ b/frontend/src/lib/ui/TextInputPrimitive/TextInputPrimitive.scss
@@ -1,5 +1,0 @@
-:root {
-    --text-input-height-sm: 28px;
-    --text-input-height-base: 30px;
-    --text-input-height-lg: 40px;
-}

--- a/frontend/src/lib/ui/TextInputPrimitive/TextInputPrimitive.tsx
+++ b/frontend/src/lib/ui/TextInputPrimitive/TextInputPrimitive.tsx
@@ -1,4 +1,3 @@
-import './TextInputPrimitive.scss'
 import { cva, type VariantProps } from 'cva'
 import { cn } from 'lib/utils/css-classes'
 import { forwardRef, useCallback, useEffect, useRef } from 'react'
@@ -11,9 +10,9 @@ export const textInputVariants = cva({
             default: 'border-primary bg-surface-primary hover:border-secondary',
         },
         size: {
-            sm: 'h-[var(--text-input-height-sm)]',
-            default: 'h-[var(--text-input-height-base)]',
-            lg: 'h-[var(--text-input-height-lg)]',
+            sm: 'text-input-primitive--height-sm',
+            default: 'text-input-primitive--height-base',
+            lg: 'text-input-primitive--height-lg',
             auto: '',
         },
         error: {

--- a/frontend/src/lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton.tsx
+++ b/frontend/src/lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton.tsx
@@ -15,7 +15,7 @@ export function WrappingLoadingSkeleton({ children, fullWidth = false }: Wrappin
             aria-hidden
             data-attr="wrapping-loading-skeleton"
         >
-            {children}
+            <span aria-hidden>{children}</span>
         </div>
     )
 }

--- a/frontend/src/models/cohortsModel.ts
+++ b/frontend/src/models/cohortsModel.ts
@@ -179,6 +179,39 @@ export const cohortsModel = kea<cohortsModelType>([
                 }
             },
         },
+        // Update allCohorts state to keep breadcrumbs in sync when cohorts are modified
+        // The cohortsById selector depends on allCohorts, not cohorts
+        allCohorts: {
+            updateCohort: (state, { cohort }) => {
+                if (!cohort) {
+                    return state
+                }
+                return {
+                    ...state,
+                    results: state.results.map((existingCohort) =>
+                        existingCohort.id === cohort.id ? cohort : existingCohort
+                    ),
+                }
+            },
+            cohortCreated: (state, { cohort }) => {
+                if (!cohort) {
+                    return state
+                }
+                return {
+                    ...state,
+                    results: [cohort, ...state.results],
+                }
+            },
+            deleteCohort: (state, { cohort }) => {
+                if (!cohort.id) {
+                    return state
+                }
+                return {
+                    ...state,
+                    results: state.results.filter((c) => c.id !== cohort.id),
+                }
+            },
+        },
     }),
     selectors({
         cohortsById: [

--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -33,12 +33,15 @@ import { Query } from '~/queries/Query/Query'
 import { IconCopy, IconTrash } from '@posthog/icons'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { createCohortDataNodeLogicKey } from './cohortUtils'
+import { SceneContent, SceneDivider, SceneSection, SceneTitleSection } from '~/layout/scenes/SceneContent'
+import { cn } from 'lib/utils/css-classes'
+import { WrappingLoadingSkeleton } from 'lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton'
 const RESOURCE_TYPE = 'cohort'
 
 export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
     const logicProps = { id }
     const logic = cohortEditLogic(logicProps)
-    const { deleteCohort, setOuterGroupsType, setQuery, duplicateCohort } = useActions(logic)
+    const { deleteCohort, setOuterGroupsType, setQuery, duplicateCohort, setCohortValue } = useActions(logic)
     const { cohort, cohortLoading, cohortMissing, query, duplicatedCohortLoading } = useValues(logic)
     const isNewCohort = cohort.id === 'new' || cohort.id === undefined
     const { featureFlags } = useValues(featureFlagLogic)
@@ -201,193 +204,314 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
                     </ButtonPrimitive>
                 </ScenePanelActions>
             </ScenePanel>
+
             <Form id="cohort" logic={cohortEditLogic} props={logicProps} formKey="cohort" enableFormOnSubmit>
-                <div className="deprecated-space-y-2 max-w-200">
-                    <div className="flex gap-4 flex-wrap">
-                        <div className="flex-1">
-                            <LemonField name="name" label="Name">
-                                <LemonInput data-attr="cohort-name" />
-                            </LemonField>
-                        </div>
-                        <div className="flex-1">
-                            <LemonField name="is_static" label="Type">
-                                {({ value, onChange }) => (
-                                    <LemonSelect
-                                        disabledReason={
-                                            isNewCohort
-                                                ? null
-                                                : 'Create a new cohort to use a different type of cohort.'
-                                        }
-                                        options={COHORT_TYPE_OPTIONS}
-                                        value={value ? CohortTypeEnum.Static : CohortTypeEnum.Dynamic}
-                                        onChange={(cohortType) => {
-                                            onChange(cohortType === CohortTypeEnum.Static)
-                                        }}
-                                        fullWidth
-                                        data-attr="cohort-type"
-                                    />
-                                )}
-                            </LemonField>
-                        </div>
-                        {!isNewCohort && !cohort?.is_static && (
-                            <div className="max-w-70 w-fit">
-                                <div className="flex gap-1 flex-col">
-                                    <LemonLabel>Last calculated</LemonLabel>
-                                    {cohort.is_calculating ? (
-                                        <div className="text-s">In progress...</div>
-                                    ) : cohort.last_calculation ? (
-                                        <div className="flex flex-1 flex-row gap-1">
-                                            <TZLabel time={cohort.last_calculation} />
-                                            {cohort.errors_calculating ? (
-                                                <Tooltip
-                                                    title={
-                                                        "The last attempted calculation failed. This means your current cohort data can be stale. This doesn't affect feature flag evaluation."
-                                                    }
-                                                >
-                                                    <div className="text-danger">
-                                                        <IconErrorOutline className="text-danger text-xl shrink-0" />
-                                                    </div>
-                                                </Tooltip>
-                                            ) : null}
-                                        </div>
-                                    ) : (
-                                        <div className="text-s">Not yet calculated</div>
+                <SceneContent>
+                    {newSceneLayout && (
+                        <SceneTitleSection
+                            name={cohort.name}
+                            description={cohort.description}
+                            resourceType={{
+                                to: urls.cohorts(),
+                                type: RESOURCE_TYPE,
+                                typePlural: 'cohorts',
+                                tooltip: 'Go to all cohorts',
+                            }}
+                            isLoading={cohortLoading}
+                            onNameBlur={(value) => {
+                                setCohortValue('name', value)
+                            }}
+                            onDescriptionBlur={(value) => {
+                                setCohortValue('description', value)
+                            }}
+                        />
+                    )}
+
+                    <SceneDivider />
+
+                    <SceneSection
+                        title="Type"
+                        description="Static cohorts are created once and never updated, while dynamic cohorts are recalculated based on the latest data."
+                        className={cn('max-w-200', {
+                            'deprecated-space-y-2 ': !newSceneLayout,
+                            'flex flex-col gap-y-2': newSceneLayout,
+                        })}
+                    >
+                        <div className="flex gap-4 flex-wrap">
+                            {!newSceneLayout && (
+                                <div className="flex-1">
+                                    <LemonField name="name" label="Name">
+                                        <LemonInput data-attr="cohort-name" />
+                                    </LemonField>
+                                </div>
+                            )}
+                            <div className={cn('flex-1', newSceneLayout && 'flex flex-col gap-y-4')}>
+                                <LemonField name="is_static" label={newSceneLayout ? <></> : 'Type'}>
+                                    {({ value, onChange }) => (
+                                        <LemonSelect
+                                            disabledReason={
+                                                isNewCohort
+                                                    ? null
+                                                    : 'Create a new cohort to use a different type of cohort.'
+                                            }
+                                            options={COHORT_TYPE_OPTIONS}
+                                            value={value ? CohortTypeEnum.Static : CohortTypeEnum.Dynamic}
+                                            onChange={(cohortType) => {
+                                                onChange(cohortType === CohortTypeEnum.Static)
+                                            }}
+                                            fullWidth
+                                            data-attr="cohort-type"
+                                        />
                                     )}
-                                    <div className="text-secondary text-xs">
-                                        Cohorts are recalculated every 24 hours
+                                </LemonField>
+
+                                {newSceneLayout && !isNewCohort && !cohort?.is_static && (
+                                    <div className="max-w-70 w-fit">
+                                        <p className="flex items-center gap-x-1 my-0">
+                                            <strong>Last calculated:</strong>
+                                            {cohort.is_calculating ? (
+                                                <WrappingLoadingSkeleton>In progress...</WrappingLoadingSkeleton>
+                                            ) : cohort.last_calculation ? (
+                                                <TZLabel time={cohort.last_calculation} />
+                                            ) : (
+                                                <>Not yet calculated</>
+                                            )}
+                                        </p>
+
+                                        {cohort.errors_calculating ? (
+                                            <Tooltip
+                                                title={
+                                                    "The last attempted calculation failed. This means your current cohort data can be stale. This doesn't affect feature flag evaluation."
+                                                }
+                                            >
+                                                <div className="text-danger">
+                                                    <IconErrorOutline className="text-danger text-xl shrink-0" />
+                                                </div>
+                                            </Tooltip>
+                                        ) : null}
+                                    </div>
+                                )}
+                            </div>
+                            {!newSceneLayout && !isNewCohort && !cohort?.is_static && (
+                                <div className="max-w-70 w-fit">
+                                    <div className="flex gap-1 flex-col">
+                                        <LemonLabel>Last calculated</LemonLabel>
+                                        {cohort.is_calculating ? (
+                                            <div className="text-s">In progress...</div>
+                                        ) : cohort.last_calculation ? (
+                                            <div className="flex flex-1 flex-row gap-1">
+                                                <TZLabel time={cohort.last_calculation} />
+                                                {cohort.errors_calculating ? (
+                                                    <Tooltip
+                                                        title={
+                                                            "The last attempted calculation failed. This means your current cohort data can be stale. This doesn't affect feature flag evaluation."
+                                                        }
+                                                    >
+                                                        <div className="text-danger">
+                                                            <IconErrorOutline className="text-danger text-xl shrink-0" />
+                                                        </div>
+                                                    </Tooltip>
+                                                ) : null}
+                                            </div>
+                                        ) : (
+                                            <div className="text-s">Not yet calculated</div>
+                                        )}
+                                        <div className="text-secondary text-xs">
+                                            Cohorts are recalculated every 24 hours
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
-                        )}
-                    </div>
-                    <div className="ph-ignore-input">
-                        <LemonField name="description" label="Description" data-attr="cohort-description">
-                            <LemonTextArea />
-                        </LemonField>
-                    </div>
-                </div>
-                {cohort.is_static ? (
-                    <div className="mt-4 ph-ignore-input">
-                        <LemonField
-                            name="csv"
-                            label={isNewCohort ? 'Upload users' : 'Add users'}
-                            data-attr="cohort-csv"
-                        >
-                            {({ onChange }) => (
-                                <>
-                                    <span>
-                                        Upload a CSV file to add users to your cohort. The CSV file only requires a
-                                        single column with the user’s distinct ID. The very first row (the header) will
-                                        be skipped during import.
-                                    </span>
-                                    <LemonFileInput
-                                        accept=".csv"
-                                        multiple={false}
-                                        value={cohort.csv ? [cohort.csv] : []}
-                                        onChange={(files) => onChange(files[0])}
-                                        showUploadedFiles={false}
-                                        callToAction={
-                                            <div className="flex flex-col items-center justify-center flex-1 cohort-csv-dragger text-text-3000 deprecated-space-y-1">
-                                                {cohort.csv ? (
-                                                    <>
-                                                        <IconUploadFile
-                                                            style={{
-                                                                fontSize: '3rem',
-                                                                color: 'var(--color-text-secondary)',
-                                                            }}
-                                                        />
-                                                        <div>{cohort.csv?.name ?? 'File chosen'}</div>
-                                                    </>
-                                                ) : (
-                                                    <>
-                                                        <IconUploadFile
-                                                            style={{
-                                                                fontSize: '3rem',
-                                                                color: 'var(--color-text-secondary)',
-                                                            }}
-                                                        />
-                                                        <div>Drag a file here or click to browse for a file</div>
-                                                    </>
-                                                )}
-                                            </div>
-                                        }
-                                    />
-                                </>
                             )}
-                        </LemonField>
-                    </div>
-                ) : (
-                    <>
-                        <LemonDivider className="my-6" />
-                        {!isNewCohort && cohort.experiment_set && cohort.experiment_set.length > 0 && (
-                            <LemonBanner type="info">
-                                This cohort manages exposure for an experiment. Editing this cohort may change
-                                experiment metrics. If unsure,{' '}
-                                <Link to={urls.experiment(cohort.experiment_set[0])}>
-                                    check the experiment details.
-                                </Link>
-                            </LemonBanner>
-                        )}
-                        <div className="flex items-center justify-between my-4">
-                            <div className="flex flex-col">
-                                <LemonLabel htmlFor="groups">Matching criteria</LemonLabel>
-                                <span>
-                                    Actors who match the following criteria will be part of the cohort. Continuously
-                                    updated automatically.
-                                </span>
-                            </div>
-                            <AndOrFilterSelect
-                                value={cohort.filters.properties.type}
-                                onChange={(value) => {
-                                    setOuterGroupsType(value)
-                                }}
-                                topLevelFilter={true}
-                                suffix={['criterion', 'criteria']}
-                            />
                         </div>
-                        <CohortCriteriaGroups id={logicProps.id} />
-                    </>
-                )}
+                        {!newSceneLayout && (
+                            <div className="ph-ignore-input">
+                                <LemonField name="description" label="Description" data-attr="cohort-description">
+                                    <LemonTextArea />
+                                </LemonField>
+                            </div>
+                        )}
+                    </SceneSection>
+                    {cohort.is_static ? (
+                        <>
+                            <SceneDivider />
+                            <SceneSection
+                                title={isNewCohort ? 'Upload users' : 'Add users'}
+                                description="Upload a CSV file to add users to your cohort. The CSV file only requires a single column with the user's distinct ID. The very first row (the header) will be skipped during import."
+                                className={cn('ph-ignore-input', !newSceneLayout && 'mt-4')}
+                            >
+                                {/* TODO: @adamleithp Allow users to download a template CSV file */}
+                                {/* TODO: @adamleithp Tell users that adding ANOTHER file will NOT(?) replace the current one */}
+                                {/* TODO: @adamleithp Render the csv file and validate it */}
+                                {/* TODO: @adamleithp Adding a csv file doesn't show up with cohort.csv... */}
 
-                {/* The typeof here is needed to pass the cohort id to the query below. Using `isNewCohort` won't work */}
-                {typeof cohort.id === 'number' && (
-                    <>
-                        <LemonDivider className="my-6" />
-                        <div>
-                            <h3 className="l3 mb-4">
-                                Persons in this cohort
-                                <span className="text-secondary ml-2">
-                                    {!cohort.is_calculating &&
-                                        cohort.count !== undefined &&
-                                        `(${cohort.count} matching ${pluralize(
-                                            cohort.count,
-                                            'person',
-                                            'persons',
-                                            false
-                                        )})`}
-                                </span>
-                            </h3>
-                            {cohort.is_calculating ? (
-                                <div className="cohort-recalculating flex items-center">
-                                    <Spinner className="mr-4" />
-                                    {cohort.is_static
-                                        ? "We're creating this cohort. This could take up to a couple of minutes."
-                                        : "We're recalculating who belongs to this cohort. This could take up to a couple of minutes."}
-                                </div>
-                            ) : (
-                                <Query
-                                    query={query}
-                                    setQuery={setQuery}
-                                    context={{
-                                        refresh: 'force_blocking',
-                                        fileNameForExport: cohort.name,
-                                        dataNodeLogicKey: dataNodeLogicKey,
-                                    }}
-                                />
+                                <LemonField
+                                    name="csv"
+                                    label={newSceneLayout ? null : isNewCohort ? 'Upload users' : 'Add users'}
+                                    data-attr="cohort-csv"
+                                >
+                                    {({ onChange }) => (
+                                        <>
+                                            {!newSceneLayout && (
+                                                <span>
+                                                    Upload a CSV file to add users to your cohort. The CSV file only
+                                                    requires a single column with the user's distinct ID. The very first
+                                                    row (the header) will be skipped during import.
+                                                </span>
+                                            )}
+                                            <LemonFileInput
+                                                accept=".csv"
+                                                multiple={false}
+                                                value={cohort.csv ? [cohort.csv] : []}
+                                                onChange={(files) => onChange(files[0])}
+                                                showUploadedFiles={false}
+                                                callToAction={
+                                                    <div
+                                                        className={cn(
+                                                            'flex flex-col items-center justify-center flex-1 cohort-csv-dragger text-text-3000 deprecated-space-y-1',
+                                                            newSceneLayout &&
+                                                                'text-primary mt-0 bg-transparent border border-dashed border-primary hover:border-secondary p-8',
+                                                            newSceneLayout && cohort.csv?.name && 'border-success'
+                                                        )}
+                                                    >
+                                                        {cohort.csv ? (
+                                                            <>
+                                                                <IconUploadFile
+                                                                    style={{
+                                                                        fontSize: '3rem',
+                                                                        color: !newSceneLayout
+                                                                            ? 'var(--color-text-secondary)'
+                                                                            : 'var(--color-text-primary)',
+                                                                    }}
+                                                                />
+                                                                <div>{cohort.csv?.name ?? 'File chosen'}</div>
+                                                            </>
+                                                        ) : (
+                                                            <>
+                                                                <IconUploadFile
+                                                                    style={{
+                                                                        fontSize: '3rem',
+                                                                        color: !newSceneLayout
+                                                                            ? 'var(--color-text-secondary)'
+                                                                            : 'var(--color-text-primary)',
+                                                                    }}
+                                                                />
+                                                                <div>
+                                                                    Drag a file here or click to browse for a file
+                                                                </div>
+                                                                {newSceneLayout && (
+                                                                    <div className="text-secondary text-xs">
+                                                                        Accepts .csv files only
+                                                                    </div>
+                                                                )}
+                                                            </>
+                                                        )}
+                                                    </div>
+                                                }
+                                            />
+                                        </>
+                                    )}
+                                </LemonField>
+                            </SceneSection>
+                        </>
+                    ) : (
+                        <>
+                            {!newSceneLayout ? <LemonDivider className="my-6" /> : <SceneDivider />}
+                            {!isNewCohort && cohort.experiment_set && cohort.experiment_set.length > 0 && (
+                                <LemonBanner type="info">
+                                    This cohort manages exposure for an experiment. Editing this cohort may change
+                                    experiment metrics. If unsure,{' '}
+                                    <Link to={urls.experiment(cohort.experiment_set[0])}>
+                                        check the experiment details.
+                                    </Link>
+                                </LemonBanner>
                             )}
-                        </div>
-                    </>
-                )}
+                            <SceneSection
+                                // TODO: @adamleithp Add a number of matching persons to the title "Matching criteria (100)"
+                                title="Matching criteria"
+                                description="Actors who match the following criteria will be part of the cohort. Continuously updated automatically."
+                                className={cn('flex items-start justify-between')}
+                            >
+                                {!newSceneLayout && (
+                                    <div className="flex flex-col">
+                                        <LemonLabel htmlFor="groups">Matching criteria</LemonLabel>
+                                        <span>
+                                            Actors who match the following criteria will be part of the cohort.
+                                            Continuously updated automatically.
+                                        </span>
+                                    </div>
+                                )}
+                                <AndOrFilterSelect
+                                    value={cohort.filters.properties.type}
+                                    onChange={(value) => {
+                                        setOuterGroupsType(value)
+                                    }}
+                                    topLevelFilter={true}
+                                    suffix={['criterion', 'criteria']}
+                                />
+                                <div className={cn('w-full', newSceneLayout && '[&>div]:my-0 [&>div]:w-full')}>
+                                    <CohortCriteriaGroups id={logicProps.id} />
+                                </div>
+                            </SceneSection>
+                        </>
+                    )}
+
+                    {/* The typeof here is needed to pass the cohort id to the query below. Using `isNewCohort` won't work */}
+                    {typeof cohort.id === 'number' && (
+                        <>
+                            <SceneDivider />
+                            <SceneSection
+                                title={
+                                    <>
+                                        Persons in this cohort
+                                        <span className="text-secondary ml-2">
+                                            {!cohort.is_calculating &&
+                                                cohort.count !== undefined &&
+                                                `(${cohort.count})`}
+                                        </span>
+                                    </>
+                                }
+                                description="Persons who match the following criteria will be part of the cohort."
+                            >
+                                {!newSceneLayout && <LemonDivider className="my-6" />}
+                                <div>
+                                    {!newSceneLayout && (
+                                        <h3 className="l3 mb-4">
+                                            Persons in this cohort
+                                            <span className="text-secondary ml-2">
+                                                {!cohort.is_calculating &&
+                                                    cohort.count !== undefined &&
+                                                    `(${cohort.count} matching ${pluralize(
+                                                        cohort.count,
+                                                        'person',
+                                                        'persons',
+                                                        false
+                                                    )})`}
+                                            </span>
+                                        </h3>
+                                    )}
+                                    {cohort.is_calculating ? (
+                                        <div className="cohort-recalculating flex items-center">
+                                            <Spinner className="mr-4" />
+                                            {cohort.is_static
+                                                ? "We're creating this cohort. This could take up to a couple of minutes."
+                                                : "We're recalculating who belongs to this cohort. This could take up to a couple of minutes."}
+                                        </div>
+                                    ) : (
+                                        <Query
+                                            query={query}
+                                            setQuery={setQuery}
+                                            context={{
+                                                refresh: 'force_blocking',
+                                                fileNameForExport: cohort.name,
+                                                dataNodeLogicKey: dataNodeLogicKey,
+                                            }}
+                                        />
+                                    )}
+                                </div>
+                            </SceneSection>
+                        </>
+                    )}
+                </SceneContent>
             </Form>
         </div>
     )

--- a/frontend/src/scenes/persons-management/PersonsManagementSceneTabs.tsx
+++ b/frontend/src/scenes/persons-management/PersonsManagementSceneTabs.tsx
@@ -5,6 +5,10 @@ import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { groupsModel } from '~/models/groupsModel'
 
 import { personsManagementSceneLogic } from './personsManagementSceneLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { SceneTitleSection } from '~/layout/scenes/SceneContent'
+const RESOURCE_TYPE = 'cohort'
 
 export interface PersonsManagementSceneTabsProps {
     tabKey: string
@@ -13,17 +17,36 @@ export interface PersonsManagementSceneTabsProps {
 export function PersonsManagementSceneTabs({ tabKey, buttons }: PersonsManagementSceneTabsProps): JSX.Element {
     const { lemonTabs } = useValues(personsManagementSceneLogic)
     const { showGroupsOptions } = useValues(groupsModel)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const newSceneLayout = featureFlags[FEATURE_FLAGS.NEW_SCENE_LAYOUT]
 
     return (
         <>
             <PageHeader
                 caption={
-                    showGroupsOptions
-                        ? 'A catalog of identified persons, groups, and your created cohorts.'
-                        : 'A catalog of identified persons and your created cohorts.'
+                    !newSceneLayout
+                        ? showGroupsOptions
+                            ? 'A catalog of identified persons, groups, and your created cohorts.'
+                            : 'A catalog of identified persons and your created cohorts.'
+                        : null
                 }
                 buttons={buttons}
             />
+
+            {newSceneLayout && (
+                <SceneTitleSection
+                    name="Cohorts"
+                    description={
+                        showGroupsOptions
+                            ? 'A catalog of identified persons, groups, and your created cohorts.'
+                            : 'A catalog of identified persons and your created cohorts.'
+                    }
+                    resourceType={{
+                        type: RESOURCE_TYPE,
+                        typePlural: 'cohorts',
+                    }}
+                />
+            )}
 
             <LemonTabs activeKey={tabKey} tabs={lemonTabs} />
         </>

--- a/products/actions/frontend/components/ActionHogFunctions.tsx
+++ b/products/actions/frontend/components/ActionHogFunctions.tsx
@@ -3,6 +3,7 @@ import { useValues } from 'kea'
 import { actionEditLogic } from '../logics/actionEditLogic'
 import { actionLogic } from '../logics/actionLogic'
 import { LinkedHogFunctions } from 'scenes/hog-functions/list/LinkedHogFunctions'
+import { SceneSection } from '~/layout/scenes/SceneContent'
 
 export function ActionHogFunctions(): JSX.Element | null {
     const { action } = useValues(actionLogic)
@@ -14,10 +15,11 @@ export function ActionHogFunctions(): JSX.Element | null {
     }
 
     return (
-        <div className="my-4 deprecated-space-y-2">
-            <h2 className="flex-1 subtitle">Connected destinations</h2>
-            <p>Actions can be used a filters for destinations such as Slack or Webhook delivery</p>
-
+        <SceneSection
+            className="@container"
+            title="Connected destinations"
+            description="Actions can be used a filters for destinations such as Slack or Webhook delivery"
+        >
             {showCohortDisablesFunctionsWarning ? (
                 <LemonBanner type="error">Adding a cohort filter will disable all connected destinations!</LemonBanner>
             ) : null}
@@ -43,6 +45,6 @@ export function ActionHogFunctions(): JSX.Element | null {
                           : undefined
                 }
             />
-        </div>
+        </SceneSection>
     )
 }

--- a/products/actions/frontend/logics/actionEditLogic.tsx
+++ b/products/actions/frontend/logics/actionEditLogic.tsx
@@ -198,6 +198,9 @@ export const actionEditLogic = kea<actionEditLogicType>([
     afterMount(({ actions, props }) => {
         if (!props.id) {
             actions.setActionValue('steps', [{ ...DEFAULT_ACTION_STEP }])
+        } else if (props.action) {
+            // Sync the prop action with the internal state when mounting with an existing action
+            actions.setAction(props.action, { merge: false })
         }
     }),
 

--- a/products/actions/frontend/logics/actionLogic.ts
+++ b/products/actions/frontend/logics/actionLogic.ts
@@ -1,4 +1,4 @@
-import { actions, events, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, connect, events, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import { DataManagementTab } from 'scenes/data-management/DataManagementScene'
@@ -10,6 +10,8 @@ import { ActionStepType, ActionType, ActivityScope, Breadcrumb, HogFunctionType,
 
 import { actionEditLogic } from './actionEditLogic'
 import type { actionLogicType } from './actionLogicType'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 
 export interface ActionLogicProps {
     id?: ActionType['id']
@@ -18,6 +20,9 @@ export interface ActionLogicProps {
 export const actionLogic = kea<actionLogicType>([
     props({} as ActionLogicProps),
     key((props) => props.id || 'new'),
+    connect(() => ({
+        values: [featureFlagLogic, ['featureFlags']],
+    })),
     path((key) => ['scenes', 'actions', 'actionLogic', key]),
     actions(() => ({
         updateAction: (action: Partial<ActionType>) => ({ action }),
@@ -74,10 +79,11 @@ export const actionLogic = kea<actionLogicType>([
         breadcrumbs: [
             (s) => [
                 s.action,
+                s.featureFlags,
                 (state, props) =>
                     actionEditLogic.findMounted(String(props?.id || 'new'))?.selectors.action(state).name || null,
             ],
-            (action, inProgressName): Breadcrumb[] => [
+            (action, featureFlags, inProgressName): Breadcrumb[] => [
                 {
                     key: Scene.DataManagement,
                     name: `Data management`,
@@ -91,14 +97,17 @@ export const actionLogic = kea<actionLogicType>([
                 {
                     key: [Scene.Action, action?.id || 'new'],
                     name: inProgressName ?? (action?.name || ''),
-                    onRename: async (name: string) => {
-                        const id = action?.id
-                        const actionEditLogicActions = actionEditLogic.find(String(id || 'new'))
-                        actionEditLogicActions.actions.setActionValue('name', name)
-                        if (id) {
-                            await actionEditLogicActions.asyncActions.submitAction()
-                        }
-                    },
+                    // We don't want to enable renaming if the flag is enabled
+                    ...(!featureFlags[FEATURE_FLAGS.NEW_SCENE_LAYOUT] && {
+                        onRename: async (name: string) => {
+                            const id = action?.id
+                            const actionEditLogicActions = actionEditLogic.find(String(id || 'new'))
+                            actionEditLogicActions.actions.setActionValue('name', name)
+                            if (id) {
+                                await actionEditLogicActions.asyncActions.submitAction()
+                            }
+                        },
+                    }),
                     forceEditMode: !action?.id,
                 },
             ],

--- a/products/actions/frontend/pages/Action.tsx
+++ b/products/actions/frontend/pages/Action.tsx
@@ -1,15 +1,7 @@
-import { LemonSkeleton } from '@posthog/lemon-ui'
 import { useValues } from 'kea'
-import { NotFound } from 'lib/components/NotFound'
-import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 import { actionLogic, ActionLogicProps } from 'products/actions/frontend/logics/actionLogic'
 import { SceneExport } from 'scenes/sceneTypes'
-
-import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
-import { Query } from '~/queries/Query/Query'
-import { NodeKind } from '~/queries/schema/schema-general'
 import { ActionType } from '~/types'
-
 import { ActionEdit } from './ActionEdit'
 
 export const scene: SceneExport = {
@@ -19,66 +11,8 @@ export const scene: SceneExport = {
 }
 
 export function Action({ id }: { id?: ActionType['id'] } = {}): JSX.Element {
-    const { action, actionLoading, isComplete } = useValues(actionLogic)
+    const logic = actionLogic({ id })
+    const { action, actionLoading } = useValues(logic)
 
-    if (actionLoading) {
-        return (
-            <div className="deprecated-space-y-2">
-                <LemonSkeleton className="w-1/4 h-6" />
-
-                <LemonSkeleton className="w-1/3 h-10" />
-                <LemonSkeleton className="w-1/2 h-6" />
-
-                <div className="flex gap-2">
-                    <LemonSkeleton className="w-1/2 h-120" />
-                    <LemonSkeleton className="w-1/2 h-120" />
-                </div>
-            </div>
-        )
-    }
-
-    if (id && !action) {
-        return <NotFound object="action" />
-    }
-
-    return (
-        <>
-            <ActionEdit id={id} action={action} />
-            {id && (
-                <>
-                    {isComplete ? (
-                        <div className="mt-8">
-                            <h2 className="subtitle">Matching events</h2>
-                            <p>
-                                This is the list of <strong>recent</strong> events that match this action.
-                            </p>
-                            <div className="pt-4 border-t" />
-                            <Query
-                                query={{
-                                    kind: NodeKind.DataTableNode,
-                                    source: {
-                                        kind: NodeKind.EventsQuery,
-                                        select: defaultDataTableColumns(NodeKind.EventsQuery),
-                                        actionId: id,
-                                        after: '-24h',
-                                    },
-                                    full: true,
-                                    showEventFilter: false,
-                                    showPropertyFilter: false,
-                                }}
-                            />
-                        </div>
-                    ) : (
-                        <div>
-                            <h2 className="subtitle">Matching events</h2>
-                            <div className="flex items-center">
-                                <Spinner className="mr-4" />
-                                Calculating action, please hold on.
-                            </div>
-                        </div>
-                    )}
-                </>
-            )}
-        </>
-    )
+    return <ActionEdit id={id} action={action} actionLoading={actionLoading} />
 }

--- a/products/actions/frontend/pages/ActionEdit.tsx
+++ b/products/actions/frontend/pages/ActionEdit.tsx
@@ -2,7 +2,9 @@ import { IconInfo, IconPlus, IconRewindPlay, IconTrash } from '@posthog/icons'
 import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { router } from 'kea-router'
+import { useEffect } from 'react'
 import { EditableField } from 'lib/components/EditableField/EditableField'
+import { NotFound } from 'lib/components/NotFound'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { PageHeader } from 'lib/components/PageHeader'
 import { SceneFile } from 'lib/components/Scenes/SceneFile'
@@ -22,28 +24,49 @@ import { ScenePanel, ScenePanelActions, ScenePanelDivider, ScenePanelMetaInfo } 
 import { tagsModel } from '~/models/tagsModel'
 import { ActionStepType, FilterLogicalOperator, ProductKey, ReplayTabs } from '~/types'
 
-import { SceneTextarea } from 'lib/components/Scenes/SceneTextarea'
-import { SceneTextInput } from 'lib/components/Scenes/SceneTextInput'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { actionEditLogic, ActionEditLogicProps, DEFAULT_ACTION_STEP } from '../logics/actionEditLogic'
 import { ActionStep } from '../components/ActionStep'
-
+import { SceneTitleSection, SceneSection, SceneDivider, SceneContent } from '~/layout/scenes/SceneContent'
+import { actionLogic } from '../logics/actionLogic'
+import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
+import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
+import { Query } from '~/queries/Query/Query'
+import { NodeKind } from '~/queries/schema/schema-general'
+import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 const RESOURCE_TYPE = 'action'
 
-export function ActionEdit({ action: loadedAction, id }: ActionEditLogicProps): JSX.Element {
+export interface ActionEditProps extends ActionEditLogicProps {
+    actionLoading?: boolean
+}
+
+export function ActionEdit({ action: loadedAction, id, actionLoading }: ActionEditProps): JSX.Element {
     const logicProps: ActionEditLogicProps = {
         id: id,
         action: loadedAction,
     }
+    const { isComplete } = useValues(actionLogic)
     const logic = actionEditLogic(logicProps)
-    const { action, actionLoading, actionChanged } = useValues(logic)
-    const { submitAction, deleteAction, setActionValue } = useActions(logic)
+    const { action, actionChanged } = useValues(logic)
+    const { submitAction, deleteAction, setActionValue, setAction } = useActions(logic)
+
+    // Sync the loaded action prop with the logic's internal state
+    useEffect(() => {
+        if (loadedAction && (!action || action.id !== loadedAction.id)) {
+            setAction(loadedAction, { merge: false })
+        }
+    }, [loadedAction, action, setAction])
     const { tags } = useValues(tagsModel)
     const { addProductIntentForCrossSell } = useActions(teamLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const newSceneLayout = featureFlags[FEATURE_FLAGS.NEW_SCENE_LAYOUT]
+
+    // Handle 404 when loading is done and action is missing
+    if (id && !actionLoading && !loadedAction) {
+        return <NotFound object="action" />
+    }
 
     const deleteButton = (): JSX.Element => (
         <LemonButton
@@ -72,9 +95,15 @@ export function ActionEdit({ action: loadedAction, id }: ActionEditLogicProps): 
         </LemonButton>
     )
 
-    const actionEditJSX = (
-        <div className="action-edit-container">
-            <Form logic={actionEditLogic} props={logicProps} formKey="action" enableFormOnSubmit>
+    return (
+        <SceneContent>
+            <Form
+                logic={actionEditLogic}
+                props={logicProps}
+                formKey="action"
+                enableFormOnSubmit
+                className="flex flex-col gap-y-4"
+            >
                 <PageHeader
                     caption={
                         <>
@@ -216,26 +245,6 @@ export function ActionEdit({ action: loadedAction, id }: ActionEditLogicProps): 
 
                 <ScenePanel>
                     <ScenePanelMetaInfo>
-                        <SceneTextInput
-                            name="name"
-                            defaultValue={action.name || ''}
-                            dataAttrKey={RESOURCE_TYPE}
-                            onSave={(value) => {
-                                setActionValue('name', value)
-                            }}
-                            isLoading={actionLoading}
-                        />
-
-                        <SceneTextarea
-                            name="description"
-                            defaultValue={action.description || ''}
-                            onSave={(value) => setActionValue('description', value)}
-                            dataAttrKey={RESOURCE_TYPE}
-                            optional
-                            isLoading={actionLoading}
-                            markdown
-                        />
-
                         <SceneTags
                             onSave={(tags) => {
                                 setActionValue('tags', tags)
@@ -306,66 +315,133 @@ export function ActionEdit({ action: loadedAction, id }: ActionEditLogicProps): 
                     </ScenePanelActions>
                 </ScenePanel>
 
-                <div className="@container">
-                    <h2 className="subtitle">Match groups</h2>
-                    <p>
-                        Your action will be triggered whenever <b>any of your match groups</b> are received.
-                        <Link to="https://posthog.com/docs/data/actions" target="_blank">
-                            <IconInfo className="ml-1 text-secondary text-xl" />
-                        </Link>
-                    </p>
-                    <LemonField name="steps">
-                        {({ value: stepsValue, onChange }) => (
-                            <div className="grid @4xl:grid-cols-2 gap-3">
-                                {stepsValue.map((step: ActionStepType, index: number) => {
-                                    const identifier = String(JSON.stringify(step))
-                                    return (
-                                        <ActionStep
-                                            key={index}
-                                            identifier={identifier}
-                                            index={index}
-                                            step={step}
-                                            actionId={action.id || 0}
-                                            isOnlyStep={!!stepsValue && stepsValue.length === 1}
-                                            onDelete={() => {
-                                                const newSteps = [...stepsValue]
-                                                newSteps.splice(index, 1)
-                                                onChange(newSteps)
-                                            }}
-                                            onChange={(newStep) => {
-                                                const newSteps = [...stepsValue]
-                                                newSteps.splice(index, 1, newStep)
-                                                onChange(newSteps)
-                                            }}
-                                        />
-                                    )
-                                })}
+                {newSceneLayout && (
+                    <SceneTitleSection
+                        name={action.name}
+                        description={action.description}
+                        resourceType={{
+                            to: urls.actions(),
+                            type: RESOURCE_TYPE,
+                            tooltip: 'Go to all actions',
+                            typePlural: 'actions',
+                        }}
+                        markdown={true}
+                        isLoading={actionLoading}
+                        onNameBlur={(value) => {
+                            setActionValue('name', value)
+                        }}
+                        onDescriptionBlur={(value) => {
+                            setActionValue('description', value)
+                        }}
+                        docsLink="https://posthog.com/docs/data/actions"
+                    />
+                )}
 
-                                <div>
-                                    <LemonButton
-                                        icon={<IconPlus />}
-                                        type="secondary"
-                                        onClick={() => {
-                                            onChange([...(action.steps || []), DEFAULT_ACTION_STEP])
-                                        }}
-                                        center
-                                        className="w-full h-full"
-                                    >
-                                        Add match group
-                                    </LemonButton>
+                <SceneDivider />
+
+                <SceneSection
+                    className="@container"
+                    title="Match groups"
+                    description={
+                        <>
+                            Your action will be triggered whenever <b>any of your match groups</b> are received.
+                            <Link to="https://posthog.com/docs/data/actions" target="_blank">
+                                <IconInfo className="ml-1 text-secondary text-xl" />
+                            </Link>
+                        </>
+                    }
+                >
+                    {actionLoading ? (
+                        <div className="flex gap-2">
+                            <LemonSkeleton className="w-1/2 h-[261px]" />
+                            <LemonSkeleton className="w-1/2 h-[261px]" />
+                        </div>
+                    ) : (
+                        <LemonField name="steps">
+                            {({ value: stepsValue, onChange }) => (
+                                <div className="grid @4xl:grid-cols-2 gap-3">
+                                    {stepsValue.map((step: ActionStepType, index: number) => {
+                                        const identifier = String(JSON.stringify(step))
+                                        return (
+                                            <ActionStep
+                                                key={index}
+                                                identifier={identifier}
+                                                index={index}
+                                                step={step}
+                                                actionId={action.id || 0}
+                                                isOnlyStep={!!stepsValue && stepsValue.length === 1}
+                                                onDelete={() => {
+                                                    const newSteps = [...stepsValue]
+                                                    newSteps.splice(index, 1)
+                                                    onChange(newSteps)
+                                                }}
+                                                onChange={(newStep) => {
+                                                    const newSteps = [...stepsValue]
+                                                    newSteps.splice(index, 1, newStep)
+                                                    onChange(newSteps)
+                                                }}
+                                            />
+                                        )
+                                    })}
+
+                                    <div>
+                                        <LemonButton
+                                            icon={<IconPlus />}
+                                            type="secondary"
+                                            onClick={() => {
+                                                onChange([...(action.steps || []), DEFAULT_ACTION_STEP])
+                                            }}
+                                            center
+                                            className="w-full h-full"
+                                        >
+                                            Add match group
+                                        </LemonButton>
+                                    </div>
                                 </div>
+                            )}
+                        </LemonField>
+                    )}
+                </SceneSection>
+            </Form>
+
+            <SceneDivider />
+
+            {id && (
+                <>
+                    <SceneSection
+                        className="@container"
+                        title="Matching events"
+                        description={
+                            <>
+                                This is the list of <strong>recent</strong> events that match this action.
+                            </>
+                        }
+                    >
+                        {isComplete ? (
+                            <Query
+                                query={{
+                                    kind: NodeKind.DataTableNode,
+                                    source: {
+                                        kind: NodeKind.EventsQuery,
+                                        select: defaultDataTableColumns(NodeKind.EventsQuery),
+                                        actionId: id,
+                                        after: '-24h',
+                                    },
+                                    full: true,
+                                    showEventFilter: false,
+                                    showPropertyFilter: false,
+                                }}
+                            />
+                        ) : (
+                            <div className="flex items-center">
+                                <Spinner className="mr-4" />
+                                Calculating action, please hold on...
                             </div>
                         )}
-                    </LemonField>
-                </div>
-            </Form>
-        </div>
-    )
-
-    return (
-        <>
-            {actionEditJSX}
+                    </SceneSection>
+                </>
+            )}
             <ActionHogFunctions />
-        </>
+        </SceneContent>
     )
 }

--- a/products/actions/frontend/pages/Actions.tsx
+++ b/products/actions/frontend/pages/Actions.tsx
@@ -3,6 +3,7 @@ import { ActionsTable } from '../components/ActionsTable'
 import { actionsLogic } from '../logics/actionsLogic'
 import { PageHeader } from 'lib/components/PageHeader'
 import { NewActionButton } from '../components/NewActionButton'
+import { SceneContent, SceneDivider, SceneTitleSection } from '~/layout/scenes/SceneContent'
 
 export const scene: SceneExport = {
     component: Actions,
@@ -11,9 +12,20 @@ export const scene: SceneExport = {
 
 export function Actions(): JSX.Element {
     return (
-        <>
+        <SceneContent>
             <PageHeader buttons={<NewActionButton />} />
+
+            <SceneTitleSection
+                name="Actions"
+                description="Triggered by events and can be used to perform actions such as sending an email, creating a task, or updating a record."
+                resourceType={{
+                    type: 'action',
+                    typePlural: 'actions',
+                }}
+                docsLink="https://posthog.com/docs/data/actions"
+            />
+            <SceneDivider />
             <ActionsTable />
-        </>
+        </SceneContent>
     )
 }


### PR DESCRIPTION
## Problem
In my recent PRs i pushed the new scene info panel, in the process i moved lots of `name` `description` into the panel, this was a UX mistake.

## Changes
All behind existing flag: `new-scene-layout`.

Re-imagine what scenes look like with a unified "scene title section" along with "scene sections"
These changes are applied to: 
* Cohorts (list), cohort (detail)
* Actions (list), action (detail)

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
