### PR TITLE
fix(ux): change popover positioning strategy to absolute

### DIFF
--- a/frontend/src/lib/lemon-ui/Popover/Popover.tsx
+++ b/frontend/src/lib/lemon-ui/Popover/Popover.tsx
@@ -134,7 +134,7 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(function P
     } = useFloating<HTMLElement>({
         open: visible,
         placement,
-        strategy: 'fixed',
+        strategy: 'absolute',
         middleware: [
             ...(fallbackPlacements
                 ? [


### PR DESCRIPTION
## Problem
With the new panel layout, popover elements (dropdowns etc) were not positioning correctly (in fullscreen replay)
With the new flag `new-scene-layout`, popover elements (dropdowns etc) were not positioning correctly

## Changes
Change `floating-ui useFloating` strategy to `absolute` from `fixed`

> HOLD UP, ABSOLUTE?!
Usually `absolute` means the floating element will be anchored to it's relative parent, but because we use `FloatingPortal` [on this line](https://github.com/PostHog/posthog/blob/master/frontend/src/lib/lemon-ui/Popover/Popover.tsx#L257) it's ok to be absolute as it's referencing the root.

Here's the docs on the subject https://floating-ui.com/docs/misc#clipping

## How did you test this code?
Clicked around.

New layout flag: popovers are position correctly
Old layout flag: popovers are position correctly
^ Both: in replay fullscreen: popovers are position correctly