### PR TITLE
fix: use fuzzy int when some queries can be cached

### DIFF
--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -3485,7 +3485,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
 
         self.client.logout()
 
-        with self.assertNumQueries(19):
+        with self.assertNumQueries(FuzzyInt(18, 19)):
             # 1. SAVEPOINT
             # 2. SELECT "posthog_personalapikey"."id",
             # 3. RELEASE SAVEPOINT


### PR DESCRIPTION
follow-up to https://github.com/PostHog/posthog/pull/36619 i still see this failing
it doesn't look like this test needs particularly 18 or 19 queries asserted and often the ORM caches differently in different test runs because computers are haunted