### PR TITLE
feat(err): add remote url to release git infos

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,8 @@
 # posthog-cli
 
-## 0.3.8
+## 0.4.1
+- add remote url to release metadata
+
+## 0.4.0
 - extract sourcemap url from source code
 - add process command to inject and upload sourcemaps

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -265,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.44"
+version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c1f056bae57e3e54c3375c41ff79619ddd13460a17d7438712bd0d83fda4ff8"
+checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -287,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.41"
+version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2205,9 +2205,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "7bc3fcb250e53458e712715cf74285c1f889686520d79294a9ef3bd7aa1fc619"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1474,7 +1474,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "posthog-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posthog-cli"
-version = "0.4.0"
+version = "0.4.1"
 authors = [
     "David <david@posthog.com>",
     "Olly <oliver@posthog.com>",

--- a/cli/src/utils/git.rs
+++ b/cli/src/utils/git.rs
@@ -47,7 +47,7 @@ fn find_git_dir(dir: Option<PathBuf>) -> Option<PathBuf> {
 }
 
 fn get_remote_url(git_dir: &Path) -> Option<String> {
-    // Try grab it from the configured remote, otherwise just use the directory name
+    // Try grab it from the git config
     let config_path = git_dir.join("config");
     if config_path.exists() {
         let config_content = match fs::read_to_string(&config_path) {

--- a/cli/src/utils/git.rs
+++ b/cli/src/utils/git.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GitInfo {
+    pub remote_url: Option<String>,
     pub repo_name: Option<String>,
     pub branch: String,
     pub commit_id: String,
@@ -17,11 +18,13 @@ pub fn get_git_info(dir: Option<PathBuf>) -> Result<Option<GitInfo>> {
         None => return Ok(None),
     };
 
+    let remote_url = get_remote_url(&git_dir);
     let repo_name = get_repo_name(&git_dir);
     let branch = get_current_branch(&git_dir).context("Failed to determine current branch")?;
     let commit = get_head_commit(&git_dir, &branch).context("Failed to determine commit ID")?;
 
     Ok(Some(GitInfo {
+        remote_url,
         repo_name,
         branch,
         commit_id: commit,
@@ -41,6 +44,27 @@ fn find_git_dir(dir: Option<PathBuf>) -> Option<PathBuf> {
             return None;
         }
     }
+}
+
+fn get_remote_url(git_dir: &Path) -> Option<String> {
+    // Try grab it from the configured remote, otherwise just use the directory name
+    let config_path = git_dir.join("config");
+    if config_path.exists() {
+        let config_content = match fs::read_to_string(&config_path) {
+            Ok(content) => content,
+            Err(_) => return None,
+        };
+
+        for line in config_content.lines() {
+            let line = line.trim();
+            if line.starts_with("url = ") && line.ends_with(".git") {
+                let url = line.trim_start_matches("url = ");
+                return Some(url.to_string());
+            }
+        }
+    }
+
+    None
 }
 
 fn get_repo_name(git_dir: &Path) -> Option<String> {


### PR DESCRIPTION
## Problem

- We cannot link releases to codebase because we are not capturing the url

## Changes

- add remote url to git infos