### PR TITLE
fix(hogql): Check lambdas parent scope when resolving fields

### DIFF
--- a/posthog/hogql/ast.py
+++ b/posthog/hogql/ast.py
@@ -250,6 +250,8 @@ class SelectQueryType(Type):
     anonymous_tables: list[Union["SelectQueryType", "SelectSetQueryType"]] = field(default_factory=list)
     # the parent select query, if this is a lambda
     parent: Optional[Union["SelectQueryType", "SelectSetQueryType"]] = None
+    # whether this type is related to a lambda scope
+    is_lambda_type: bool = False
 
     def get_alias_for_table_type(self, table_type: TableOrSelectType) -> Optional[str]:
         for key, value in self.tables.items():

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -662,28 +662,8 @@ class Resolver(CloningVisitor):
                 # One likely cause is that the database context isn't set up as you
                 # expect it to be.
 
-                if scope.is_lambda_type and len(self.scopes) > 1:
-                    try:
-                        popped_scope = self.scopes.pop()
-                        visited_node = self.visit_field(node)
-                        self.scopes.append(popped_scope)
-                        return visited_node
-                    except:
-                        # We want to raise the original QueryError if the parent scope didn't work out
-                        pass
-
                 raise QueryError(f"Unable to resolve field: {name}")
             else:
-                if scope.is_lambda_type and len(self.scopes) > 1:
-                    try:
-                        popped_scope = self.scopes.pop()
-                        visited_node = self.visit_field(node)
-                        self.scopes.append(popped_scope)
-                        return visited_node
-                    except:
-                        # We want to follow the original error path if the parent scope didn't work out
-                        pass
-
                 type = ast.UnresolvedFieldType(name=name)
                 self.context.add_error(
                     start=node.start,

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -36,6 +36,7 @@ from posthog.hogql.resolver_utils import (
     extract_select_queries,
     lookup_cte_by_name,
     lookup_field_by_name,
+    lookup_table_by_name,
 )
 from posthog.hogql.visitor import CloningVisitor, TraversingVisitor, clone_expr
 from posthog.models.utils import UUIDT
@@ -555,7 +556,7 @@ class Resolver(CloningVisitor):
 
         # Each Lambda is a new scope in field name resolution.
         # This type keeps track of all lambda arguments that are in scope.
-        node_type = ast.SelectQueryType(parent=self.scopes[-1] if len(self.scopes) > 0 else None)
+        node_type = ast.SelectQueryType(parent=self.scopes[-1] if len(self.scopes) > 0 else None, is_lambda_type=True)
 
         for arg in node.args:
             node_type.aliases[arg] = ast.FieldAliasType(alias=arg, type=ast.LambdaArgumentType(name=arg))
@@ -588,8 +589,7 @@ class Resolver(CloningVisitor):
         name = str(node.chain[0])
 
         # If the field contains at least two parts, the first might be a table.
-        if len(node.chain) > 1 and name in scope.tables:
-            type = scope.tables[name]
+        type = lookup_table_by_name(scope, node)
 
         # If it's a wildcard
         if name == "*" and len(node.chain) == 1:
@@ -606,6 +606,13 @@ class Resolver(CloningVisitor):
         # Field in scope
         if not type:
             type = lookup_field_by_name(scope, name, self.context)
+
+        # If scope is a lambda, check with the parent scope
+        if not type and scope.is_lambda_type and len(self.scopes) > 1:
+            type = lookup_table_by_name(self.scopes[-2], node)
+
+            if not type:
+                type = lookup_field_by_name(self.scopes[-2], name, self.context)
 
         if not type:
             cte = lookup_cte_by_name(self.scopes, name)
@@ -645,14 +652,6 @@ class Resolver(CloningVisitor):
                     )
                 return ast.Constant(value=value, type=global_type)
 
-            def in_lambda_scope() -> bool:
-                # KLUDGE: This is a bit of a hack to check whether current scope is a lambda function.
-                # We should fix this properly by allowing scopes other than just `SelectQueryType`
-                if len(scope.aliases) == 0:
-                    return False
-
-                return all(isinstance(value.type, ast.LambdaArgumentType) for value in scope.aliases.values())
-
             if self.dialect == "clickhouse":
                 # To debug, add a breakpoint() here and print self.context.database
                 #
@@ -663,7 +662,7 @@ class Resolver(CloningVisitor):
                 # One likely cause is that the database context isn't set up as you
                 # expect it to be.
 
-                if in_lambda_scope() and len(self.scopes) > 1:
+                if scope.is_lambda_type and len(self.scopes) > 1:
                     try:
                         popped_scope = self.scopes.pop()
                         visited_node = self.visit_field(node)
@@ -675,7 +674,7 @@ class Resolver(CloningVisitor):
 
                 raise QueryError(f"Unable to resolve field: {name}")
             else:
-                if in_lambda_scope() and len(self.scopes) > 1:
+                if scope.is_lambda_type and len(self.scopes) > 1:
                     try:
                         popped_scope = self.scopes.pop()
                         visited_node = self.visit_field(node)

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -670,6 +670,7 @@ class Resolver(CloningVisitor):
                         self.scopes.append(popped_scope)
                         return visited_node
                     except:
+                        # We want to raise the original QueryError if the parent scope didn't work out
                         pass
 
                 raise QueryError(f"Unable to resolve field: {name}")
@@ -681,6 +682,7 @@ class Resolver(CloningVisitor):
                         self.scopes.append(popped_scope)
                         return visited_node
                     except:
+                        # We want to follow the original error path if the parent scope didn't work out
                         pass
 
                 type = ast.UnresolvedFieldType(name=name)

--- a/posthog/hogql/resolver_utils.py
+++ b/posthog/hogql/resolver_utils.py
@@ -41,6 +41,13 @@ def lookup_field_by_name(
         return None
 
 
+def lookup_table_by_name(scope: ast.SelectQueryType, node: ast.Field) -> Optional[ast.TableOrSelectType]:
+    if len(node.chain) > 1 and str(node.chain[0]) in scope.tables:
+        return scope.tables[str(node.chain[0])]
+
+    return None
+
+
 def lookup_cte_by_name(scopes: list[ast.SelectQueryType], name: str) -> Optional[ast.CTE]:
     for scope in reversed(scopes):
         if scope and scope.ctes and name in scope.ctes:

--- a/posthog/hogql/test/__snapshots__/test_resolver.ambr
+++ b/posthog/hogql/test/__snapshots__/test_resolver.ambr
@@ -337,6 +337,7 @@
                 }
               }
               ctes: {}
+              is_lambda_type: False
               tables: {
                 events: <recursion ...>
               }
@@ -1336,6 +1337,7 @@
         uuid: <recursion ...>
       }
       ctes: {}
+      is_lambda_type: False
       tables: {}
     }
   }
@@ -2266,6 +2268,7 @@
         uuid: <recursion ...>
       }
       ctes: {}
+      is_lambda_type: False
       tables: {
         events: <recursion ...>
       }
@@ -2911,6 +2914,7 @@
         start_time: <recursion ...>
       }
       ctes: {}
+      is_lambda_type: False
       tables: {
         e: <recursion ...>,
         s: <recursion ...>
@@ -2957,6 +2961,7 @@
                   b: <recursion ...>
                 }
                 ctes: {}
+                is_lambda_type: False
                 tables: {}
               }
             }
@@ -3047,6 +3052,7 @@
                         b: <recursion ...>
                       }
                       ctes: {}
+                      is_lambda_type: False
                       tables: {}
                     }
                   }
@@ -3123,6 +3129,7 @@
         b: <recursion ...>
       }
       ctes: {}
+      is_lambda_type: False
       tables: {
         x: <recursion ...>,
         y: <recursion ...>
@@ -3469,6 +3476,7 @@
                 }
               }
               ctes: {}
+              is_lambda_type: False
               tables: {
                 events: <recursion ...>
               }
@@ -5359,6 +5367,7 @@
                   uuid: <recursion ...>
                 }
                 ctes: {}
+                is_lambda_type: False
                 tables: {
                   events: <recursion ...>
                 }
@@ -5406,6 +5415,7 @@
         uuid: <recursion ...>
       }
       ctes: {}
+      is_lambda_type: False
       tables: {}
     }
   }
@@ -5446,6 +5456,7 @@
                 b: <recursion ...>
               }
               ctes: {}
+              is_lambda_type: False
               tables: {}
             }
           }
@@ -5510,6 +5521,7 @@
         b: <recursion ...>
       }
       ctes: {}
+      is_lambda_type: False
       tables: {}
     }
   }
@@ -5553,6 +5565,7 @@
                   b: <recursion ...>
                 }
                 ctes: {}
+                is_lambda_type: False
                 tables: {}
               }
             }
@@ -5618,6 +5631,7 @@
         b: <recursion ...>
       }
       ctes: {}
+      is_lambda_type: False
       tables: {
         x: <recursion ...>
       }
@@ -6547,6 +6561,7 @@
         uuid: <recursion ...>
       }
       ctes: {}
+      is_lambda_type: False
       tables: {
         events: <recursion ...>
       }
@@ -7480,6 +7495,7 @@
         uuid: <recursion ...>
       }
       ctes: {}
+      is_lambda_type: False
       tables: {
         e: <recursion ...>
       }
@@ -7667,6 +7683,7 @@
         max(timestamp): <recursion ...>
       }
       ctes: {}
+      is_lambda_type: False
       tables: {
         events: <recursion ...>
       }
@@ -7978,6 +7995,7 @@
         some_expr: <recursion ...>
       }
       ctes: {}
+      is_lambda_type: False
       tables: {
         e: <recursion ...>,
         p: <recursion ...>
@@ -8053,6 +8071,7 @@
       anonymous_tables: []
       columns: {}
       ctes: {}
+      is_lambda_type: False
       tables: {}
     }
   }
@@ -8170,6 +8189,7 @@
       anonymous_tables: []
       columns: {}
       ctes: {}
+      is_lambda_type: False
       tables: {}
     }
   }
@@ -8355,6 +8375,7 @@
         timestamp: <recursion ...>
       }
       ctes: {}
+      is_lambda_type: False
       tables: {
         events: <recursion ...>
       }
@@ -8578,6 +8599,7 @@
         timestamp: <recursion ...>
       }
       ctes: {}
+      is_lambda_type: False
       tables: {
         e: <recursion ...>
       }
@@ -8833,6 +8855,7 @@
         timestamp: <recursion ...>
       }
       ctes: {}
+      is_lambda_type: False
       tables: {
         e: <recursion ...>
       }
@@ -9038,6 +9061,7 @@
                   c: <recursion ...>
                 }
                 ctes: {}
+                is_lambda_type: False
                 tables: {
                   events: <recursion ...>
                 }
@@ -9109,6 +9133,7 @@
         b: <recursion ...>
       }
       ctes: {}
+      is_lambda_type: False
       tables: {
         e: <recursion ...>
       }
@@ -9369,6 +9394,7 @@
         id: <recursion ...>
       }
       ctes: {}
+      is_lambda_type: False
       tables: {
         events: <recursion ...>
       }
@@ -9602,6 +9628,7 @@
         id: <recursion ...>
       }
       ctes: {}
+      is_lambda_type: False
       tables: {
         e: <recursion ...>
       }
@@ -9817,6 +9844,7 @@
         person_id: <recursion ...>
       }
       ctes: {}
+      is_lambda_type: False
       tables: {
         events: <recursion ...>
       }
@@ -10037,6 +10065,7 @@
         person_id: <recursion ...>
       }
       ctes: {}
+      is_lambda_type: False
       tables: {
         e: <recursion ...>
       }
@@ -10131,6 +10160,7 @@
         id: <recursion ...>
       }
       ctes: {}
+      is_lambda_type: False
       tables: {
         person_distinct_ids: <recursion ...>
       }
@@ -10318,6 +10348,7 @@
           timestamp: <recursion ...>
         }
         ctes: {}
+        is_lambda_type: False
         tables: {
           events: <recursion ...>
         }
@@ -10502,6 +10533,7 @@
               timestamp: <recursion ...>
             }
             ctes: {}
+            is_lambda_type: False
             tables: {
               events: <recursion ...>
             }
@@ -10728,6 +10760,7 @@
         id: <recursion ...>
       }
       ctes: {}
+      is_lambda_type: False
       tables: {
         events: <recursion ...>
       }

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -783,3 +783,8 @@ class TestResolver(BaseTest):
         query = "SELECT arrayMap(a -> e.timestamp, [1]) as a FROM events e"
         resolve_types(self._select(query), self.context, dialect="hogql")
         resolve_types(self._select(query), self.context, dialect="clickhouse")
+
+    def test_lambda_scope_mixed_scopes(self):
+        query = "SELECT arrayMap(a -> concat(a, e.event), ['str']) FROM events e"
+        resolve_types(self._select(query), self.context, dialect="hogql")
+        resolve_types(self._select(query), self.context, dialect="clickhouse")

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -778,3 +778,8 @@ class TestResolver(BaseTest):
         self.database.__setattr__("nested", table_group)
         query = "SELECT * FROM nested.events.some.other.table"
         resolve_types(self._select(query), self.context, dialect="hogql")
+
+    def test_lambda_scope(self):
+        query = "SELECT arrayMap(a -> e.timestamp, [1]) as a FROM events e"
+        resolve_types(self._select(query), self.context, dialect="hogql")
+        resolve_types(self._select(query), self.context, dialect="clickhouse")


### PR DESCRIPTION
## Problem
We have no access to table fields outside of a lambda function even though its valid clickhouse SQL - we just get unresolved field errors instead

**Example:**
```sql
SELECT arrayMap(a -> e.timestamp, [1]) as a FROM events e
```

We'd get `Unresolved field: e`

Prompted by this support thread: https://posthog.slack.com/archives/C07CUSVBJKB/p1755183605801349?thread_ts=1754840259.517379&cid=C07CUSVBJKB

## Changes
- This is a _bit_ of a hack to get this working, but if we get an unresolved field error and we're in a lambda scope, then try again with the parent scope to see if that can resolve
- Ideally this would be built in to how we do scopes, but the current scope functionality only allows `SelectQueryType`'s (we're forcing a lambda type into the scope as a pretend `SelectQueryType`, for example). 
  - The longer term solution is probably having a more flexible scope system, but that's quite the rewrite

## How did you test this code?
- Tested locally + added unit tests
