### PR TITLE
chore: allow /decide path to flags so we can do weighted load

### DIFF
--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -91,6 +91,8 @@ where
     let flags_router = Router::new()
         .route("/flags", post(endpoint::flags).get(endpoint::flags))
         .route("/flags/", post(endpoint::flags).get(endpoint::flags))
+        .route("/decide", post(endpoint::decide).get(endpoint::decide))
+        .route("/decide/", post(endpoint::decide).get(endpoint::decide))
         .layer(ConcurrencyLimitLayer::new(config.max_concurrency));
 
     let router = Router::new()

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -91,8 +91,8 @@ where
     let flags_router = Router::new()
         .route("/flags", post(endpoint::flags).get(endpoint::flags))
         .route("/flags/", post(endpoint::flags).get(endpoint::flags))
-        .route("/decide", post(endpoint::decide).get(endpoint::decide))
-        .route("/decide/", post(endpoint::decide).get(endpoint::decide))
+        .route("/decide", post(endpoint::flags).get(endpoint::flags))
+        .route("/decide/", post(endpoint::flags).get(endpoint::flags))
         .layer(ConcurrencyLimitLayer::new(config.max_concurrency));
 
     let router = Router::new()


### PR DESCRIPTION

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

In order to have a weighted contour proxy like this, we can't rewrite the path
```
 - name: decide
    routes:
      # Route for v=3 and v=4 requests, split 10/90
      - conditions:
        - prefix: /decide
        - queryParameter: # This can be simplified if your proxy supports 'or'
            name: v
            exact: "3"
        pathRewritePolicy: # Can't do this or else posthog-decide-django also gets requests with `/flags`
          replacePrefix:
          - prefix: /decide
            replacement: /flags
        services:
          # 10% to the new service (which now understands /decide)
          - name: posthog-feature-flags
            port: 3001
            weight: 10
          # 90% to the original service
          - name: posthog-decide-django
            port: 8000
            weight: 90
        includeDefaultSettingsPerRoute: true
        timeoutPolicy:
          response: 5s
```
## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

add /decide route to flags

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
