### PR TITLE
fix(data-management): [object Object] in property value examples

### DIFF
--- a/frontend/src/scenes/data-management/events/EventDefinitionProperties.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionProperties.tsx
@@ -38,7 +38,7 @@ export function EventDefinitionProperties({ definition }: { definition: EventDef
             title: 'Type',
             key: 'type',
             render: function Render(_, _definition: PropertyDefinition) {
-                return <LemonTag type="muted">{_definition.property_type ?? '-'}</LemonTag>
+                return <LemonTag type="muted">{_definition.property_type ?? '—'}</LemonTag>
             },
         },
         ...(hasTagging
@@ -59,7 +59,7 @@ export function EventDefinitionProperties({ definition }: { definition: EventDef
             render: function Render(_, _definition: PropertyDefinition) {
                 return (
                     <LemonTag className="font-mono" type="muted">
-                        {_definition.example ?? '-'}
+                        {_definition.example !== undefined ? JSON.stringify(_definition.example) : '—'}
                     </LemonTag>
                 )
             },


### PR DESCRIPTION
## Problem

Fixes a small issue with rendering example property values, where objects ended up being the infamous "[object Object]", because of how `String()` works. This was reported [by a user to me](https://posthog.slack.com/archives/C011L071P8U/p1755189838442149).

## Changes

We just need `JSON.stringify()` instead of the implicit `String()`. GitHub says you're the recommended reviewer @benjackwhite… so it must be right.