### PR TITLE
fix(tabs): open new tab if closing last open tab

### DIFF
--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -206,6 +206,16 @@ export const sceneLogic = kea<sceneLogicType>([
                         const newActiveIndex = Math.max(index - 1, 0)
                         newState = newState.map((tab, i) => (i === newActiveIndex ? { ...tab, active: true } : tab))
                     }
+                    if (newState.length === 0) {
+                        newState.push({
+                            id: generateTabId(),
+                            active: true,
+                            pathname: '/new',
+                            search: '',
+                            hash: '',
+                            title: 'New tab',
+                        })
+                    }
                     return newState
                 },
                 activateTab: (state, { tab }) => {


### PR DESCRIPTION
## Problem

You couldn't close the last tab. It would reopen with the same content.

## Changes

You can now close it. The "new tab" view will pop up:

![2025-08-14 20 36 33](https://github.com/user-attachments/assets/e2f91cde-cf1f-4e54-8fc2-b2a09c2fbf04)


## How did you test this code?

See screencast above