### PR TITLE
fix: decide requests need config=true

### DIFF
--- a/rust/feature-flags/src/api/endpoint.rs
+++ b/rust/feature-flags/src/api/endpoint.rs
@@ -60,21 +60,28 @@ pub async fn flags(
 ) -> Result<Json<ServiceResponse>, FlagError> {
     let request_id = Uuid::new_v4();
 
-    let context = RequestContext {
-        request_id,
-        state,
-        ip,
-        headers: headers.clone(),
-        meta: query_params.clone(),
-        body,
-    };
-
     // Check if this request came through the decide proxy
     let is_from_decide = headers
         .get("X-Original-Endpoint")
         .and_then(|v| v.to_str().ok())
         .map(|v| v == "decide")
-        .unwrap_or(false);
+        .unwrap_or(false) 
+        || path.as_str().starts_with("/decide");
+
+    // Modify query params to enable config for decide requests
+    let mut modified_query_params = query_params.clone();
+    if is_from_decide && modified_query_params.config.is_none() {
+        modified_query_params.config = Some(true);
+    }
+
+    let context = RequestContext {
+        request_id,
+        state,
+        ip,
+        headers: headers.clone(),
+        meta: modified_query_params,
+        body,
+    };
 
     // Parse version from query params
     let query_version = context

--- a/rust/feature-flags/src/api/endpoint.rs
+++ b/rust/feature-flags/src/api/endpoint.rs
@@ -65,8 +65,7 @@ pub async fn flags(
         .get("X-Original-Endpoint")
         .and_then(|v| v.to_str().ok())
         .map(|v| v == "decide")
-        .unwrap_or(false) 
-        || path.as_str().starts_with("/decide");
+        .unwrap_or(false);
 
     // Modify query params to enable config for decide requests
     let mut modified_query_params = query_params.clone();


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

decide requests that go to flags need config=true

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

if a request is from decide make config=true 

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
