### PR TITLE
refactor(demo): Rewrite legacy filters-based insights to query

### DIFF
--- a/posthog/demo/matrix/manager.py
+++ b/posthog/demo/matrix/manager.py
@@ -56,7 +56,7 @@ class MatrixManager:
     ) -> tuple[Organization, Team, User]:
         """If there's an email collision in signup in the demo environment, we treat it as a login."""
         existing_user: Optional[User] = User.objects.filter(email=email).first()
-        if existing_user is None or email_collision_handling == "log_in":
+        if existing_user is None or email_collision_handling == "disambiguate":
             if existing_user is not None:
                 print(f"User {email} already exists, trying to find a unique email...")
                 original_user, domain = email.split("@")

--- a/posthog/demo/matrix/manager.py
+++ b/posthog/demo/matrix/manager.py
@@ -56,7 +56,21 @@ class MatrixManager:
     ) -> tuple[Organization, Team, User]:
         """If there's an email collision in signup in the demo environment, we treat it as a login."""
         existing_user: Optional[User] = User.objects.filter(email=email).first()
-        if existing_user is None:
+        if existing_user is None or disallow_collision:
+            if existing_user is not None:
+                print(f"User {email} already exists, trying to find a unique email...")
+                original_user, domain = email.split("@")
+                for i in range(1, 1000):
+                    email = f"{original_user}+{i}@{domain}"
+                    if User.objects.filter(email=email).exists():
+                        continue
+                    break
+                else:
+                    raise exceptions.ValidationError(
+                        f"Cannot find a unique email for {original_user}@{domain} - unbelievable!"
+                    )
+                print(f"Collision resolved, using {email} for our demo user!")
+
             if self.print_steps:
                 print(f"Creating demo organization, project, and user...")
             organization_kwargs: dict[str, Any] = {"name": organization_name}
@@ -77,10 +91,6 @@ class MatrixManager:
             return (organization, team, new_user)
         elif existing_user.is_staff:
             raise exceptions.PermissionDenied("Cannot log in as staff user without password.")
-        elif disallow_collision:
-            raise exceptions.ValidationError(
-                f"Cannot save simulated data - email collision disallowed but there already is an account for {email}."
-            )
         else:
             assert existing_user.organization is not None
             assert existing_user.team is not None

--- a/posthog/demo/matrix/manager.py
+++ b/posthog/demo/matrix/manager.py
@@ -52,11 +52,11 @@ class MatrixManager:
         *,
         password: Optional[str] = None,
         is_staff: bool = False,
-        disallow_collision: bool = False,
+        email_collision_handling: Literal["log_in", "disambiguate"] = "log_in",
     ) -> tuple[Organization, Team, User]:
         """If there's an email collision in signup in the demo environment, we treat it as a login."""
         existing_user: Optional[User] = User.objects.filter(email=email).first()
-        if existing_user is None or disallow_collision:
+        if existing_user is None or email_collision_handling == "log_in":
             if existing_user is not None:
                 print(f"User {email} already exists, trying to find a unique email...")
                 original_user, domain = email.split("@")

--- a/posthog/demo/products/hedgebox/matrix.py
+++ b/posthog/demo/products/hedgebox/matrix.py
@@ -261,7 +261,7 @@ class HedgeboxMatrix(Matrix):
                     display=ChartDisplayType.WORLD_MAP,
                 ),
                 breakdownFilter=BreakdownFilter(
-                    breakdown_type="event",
+                    breakdown_type=BreakdownType.EVENT,
                     breakdown="$geoip_country_code",
                 ),
                 dateRange=DateRange(
@@ -494,7 +494,7 @@ class HedgeboxMatrix(Matrix):
                     EventsNode(
                         event=EVENT_PAID_BILL,
                         name=EVENT_PAID_BILL,
-                        math=BaseMathType.SUM,
+                        math=PropertyMathType.SUM,
                         math_property="amount_usd",
                     )
                 ],
@@ -536,7 +536,7 @@ class HedgeboxMatrix(Matrix):
                     EventsNode(
                         event=EVENT_PAID_BILL,
                         name="paid_bill",
-                        math=BaseMathType.UNIQUE_GROUP,
+                        math="unique_group",
                         math_group_type_index=0,
                     )
                 ],

--- a/posthog/demo/products/hedgebox/matrix.py
+++ b/posthog/demo/products/hedgebox/matrix.py
@@ -13,6 +13,7 @@ from posthog.constants import (
 )
 from posthog.demo.matrix.matrix import Cluster, Matrix
 from posthog.demo.matrix.randomization import Industry
+from posthog.hogql_queries.legacy_compatibility.filter_to_query import filter_to_query
 from posthog.models import (
     Action,
     Cohort,
@@ -181,14 +182,16 @@ class HedgeboxMatrix(Matrix):
             dashboard=key_metrics_dashboard,
             saved=True,
             name="Weekly signups",
-            filters={
-                "events": [{"id": EVENT_SIGNED_UP, "type": "events", "order": 0}],
-                "actions": [],
-                "display": TRENDS_LINEAR,
-                "insight": INSIGHT_TRENDS,
-                "interval": "week",
-                "date_from": "-8w",
-            },
+            query=filter_to_query(
+                {
+                    "events": [{"id": EVENT_SIGNED_UP, "type": "events", "order": 0}],
+                    "actions": [],
+                    "display": TRENDS_LINEAR,
+                    "insight": INSIGHT_TRENDS,
+                    "interval": "week",
+                    "date_from": "-8w",
+                }
+            ),
             last_modified_at=self.now - dt.timedelta(days=23),
             last_modified_by=user,
         )
@@ -215,15 +218,17 @@ class HedgeboxMatrix(Matrix):
             dashboard=key_metrics_dashboard,
             saved=True,
             name="Last month's signups by country",
-            filters={
-                "events": [{"id": EVENT_SIGNED_UP, "type": "events", "order": 0}],
-                "actions": [],
-                "display": TRENDS_WORLD_MAP,
-                "insight": INSIGHT_TRENDS,
-                "breakdown_type": "event",
-                "breakdown": "$geoip_country_code",
-                "date_from": "-1m",
-            },
+            query=filter_to_query(
+                {
+                    "events": [{"id": EVENT_SIGNED_UP, "type": "events", "order": 0}],
+                    "actions": [],
+                    "display": TRENDS_WORLD_MAP,
+                    "insight": INSIGHT_TRENDS,
+                    "breakdown_type": "event",
+                    "breakdown": "$geoip_country_code",
+                    "date_from": "-1m",
+                }
+            ),
             last_modified_at=self.now - dt.timedelta(days=6),
             last_modified_by=user,
         )
@@ -249,38 +254,40 @@ class HedgeboxMatrix(Matrix):
             dashboard=key_metrics_dashboard,
             saved=True,
             name="Activation",
-            filters={
-                "events": [
-                    {
-                        "custom_name": "Signed up",
-                        "id": EVENT_SIGNED_UP,
-                        "name": EVENT_SIGNED_UP,
-                        "type": "events",
-                        "order": 2,
-                    },
-                    {
-                        "custom_name": "Upgraded plan",
-                        "id": EVENT_UPGRADED_PLAN,
-                        "name": EVENT_UPGRADED_PLAN,
-                        "type": "events",
-                        "order": 4,
-                    },
-                ],
-                "actions": [
-                    {
-                        "id": interacted_with_file_action.pk,
-                        "name": interacted_with_file_action.name,
-                        "type": "actions",
-                        "order": 3,
-                    }
-                ],
-                "display": "FunnelViz",
-                "insight": "FUNNELS",
-                "interval": "day",
-                "funnel_viz_type": "steps",
-                "filter_test_accounts": True,
-                "date_from": "-1m",
-            },
+            query=filter_to_query(
+                {
+                    "events": [
+                        {
+                            "custom_name": "Signed up",
+                            "id": EVENT_SIGNED_UP,
+                            "name": EVENT_SIGNED_UP,
+                            "type": "events",
+                            "order": 2,
+                        },
+                        {
+                            "custom_name": "Upgraded plan",
+                            "id": EVENT_UPGRADED_PLAN,
+                            "name": EVENT_UPGRADED_PLAN,
+                            "type": "events",
+                            "order": 4,
+                        },
+                    ],
+                    "actions": [
+                        {
+                            "id": interacted_with_file_action.pk,
+                            "name": interacted_with_file_action.name,
+                            "type": "actions",
+                            "order": 3,
+                        }
+                    ],
+                    "display": "FunnelViz",
+                    "insight": "FUNNELS",
+                    "interval": "day",
+                    "funnel_viz_type": "steps",
+                    "filter_test_accounts": True,
+                    "date_from": "-1m",
+                }
+            ),
             last_modified_at=self.now - dt.timedelta(days=19),
             last_modified_by=user,
         )
@@ -306,41 +313,43 @@ class HedgeboxMatrix(Matrix):
             dashboard=key_metrics_dashboard,
             saved=True,
             name="New user retention",
-            filters={
-                "period": "Week",
-                "display": "ActionsTable",
-                "insight": "RETENTION",
-                "properties": {
-                    "type": "AND",
-                    "values": [
-                        {
-                            "type": "AND",
-                            "values": [
-                                {
-                                    "key": "email",
-                                    "type": "person",
-                                    "value": "is_set",
-                                    "operator": "is_set",
-                                }
-                            ],
-                        }
-                    ],
-                },
-                "target_entity": {
-                    "id": EVENT_SIGNED_UP,
-                    "name": EVENT_SIGNED_UP,
-                    "type": "events",
-                    "order": 0,
-                },
-                "retention_type": RETENTION_FIRST_TIME,
-                "total_intervals": 9,
-                "returning_entity": {
-                    "id": interacted_with_file_action.pk,
-                    "name": interacted_with_file_action.name,
-                    "type": "actions",
-                    "order": 0,
-                },
-            },
+            query=filter_to_query(
+                {
+                    "period": "Week",
+                    "display": "ActionsTable",
+                    "insight": "RETENTION",
+                    "properties": {
+                        "type": "AND",
+                        "values": [
+                            {
+                                "type": "AND",
+                                "values": [
+                                    {
+                                        "key": "email",
+                                        "type": "person",
+                                        "value": "is_set",
+                                        "operator": "is_set",
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    "target_entity": {
+                        "id": EVENT_SIGNED_UP,
+                        "name": EVENT_SIGNED_UP,
+                        "type": "events",
+                        "order": 0,
+                    },
+                    "retention_type": RETENTION_FIRST_TIME,
+                    "total_intervals": 9,
+                    "returning_entity": {
+                        "id": interacted_with_file_action.pk,
+                        "name": interacted_with_file_action.name,
+                        "type": "actions",
+                        "order": 0,
+                    },
+                }
+            ),
             last_modified_at=self.now - dt.timedelta(days=34),
             last_modified_by=user,
         )
@@ -367,27 +376,29 @@ class HedgeboxMatrix(Matrix):
             saved=True,
             name="Active user lifecycle",
             description="An active user being defined by interaction with files.",
-            filters={
-                "events": [],
-                "actions": [
-                    {
-                        "id": interacted_with_file_action.pk,
-                        "math": "total",
-                        "name": interacted_with_file_action.name,
-                        "type": "actions",
-                        "order": 0,
-                    }
-                ],
-                "compare": False,
-                "display": "ActionsLineGraph",
-                "insight": "LIFECYCLE",
-                "interval": "day",
-                "shown_as": "Lifecycle",
-                "date_from": "-8w",
-                "new_entity": [],
-                "properties": [],
-                "filter_test_accounts": True,
-            },
+            query=filter_to_query(
+                {
+                    "events": [],
+                    "actions": [
+                        {
+                            "id": interacted_with_file_action.pk,
+                            "math": "total",
+                            "name": interacted_with_file_action.name,
+                            "type": "actions",
+                            "order": 0,
+                        }
+                    ],
+                    "compare": False,
+                    "display": "ActionsLineGraph",
+                    "insight": "LIFECYCLE",
+                    "interval": "day",
+                    "shown_as": "Lifecycle",
+                    "date_from": "-8w",
+                    "new_entity": [],
+                    "properties": [],
+                    "filter_test_accounts": True,
+                }
+            ),
             last_modified_at=self.now - dt.timedelta(days=34),
             last_modified_by=user,
         )
@@ -413,36 +424,38 @@ class HedgeboxMatrix(Matrix):
             dashboard=key_metrics_dashboard,
             saved=True,
             name="Weekly file volume",
-            filters={
-                "events": [
-                    {
-                        "custom_name": "Uploaded bytes",
-                        "id": EVENT_UPLOADED_FILE,
-                        "math": "sum",
-                        "name": EVENT_UPLOADED_FILE,
-                        "type": "events",
-                        "order": 0,
-                        "math_property": "file_size_b",
-                    },
-                    {
-                        "custom_name": "Deleted bytes",
-                        "id": EVENT_DELETED_FILE,
-                        "math": "sum",
-                        "name": EVENT_DELETED_FILE,
-                        "type": "events",
-                        "order": 1,
-                        "math_property": "file_size_b",
-                    },
-                ],
-                "actions": [],
-                "display": "ActionsLineGraph",
-                "insight": "TRENDS",
-                "interval": "week",
-                "date_from": "-8w",
-                "new_entity": [],
-                "properties": [],
-                "filter_test_accounts": True,
-            },
+            query=filter_to_query(
+                {
+                    "events": [
+                        {
+                            "custom_name": "Uploaded bytes",
+                            "id": EVENT_UPLOADED_FILE,
+                            "math": "sum",
+                            "name": EVENT_UPLOADED_FILE,
+                            "type": "events",
+                            "order": 0,
+                            "math_property": "file_size_b",
+                        },
+                        {
+                            "custom_name": "Deleted bytes",
+                            "id": EVENT_DELETED_FILE,
+                            "math": "sum",
+                            "name": EVENT_DELETED_FILE,
+                            "type": "events",
+                            "order": 1,
+                            "math_property": "file_size_b",
+                        },
+                    ],
+                    "actions": [],
+                    "display": "ActionsLineGraph",
+                    "insight": "TRENDS",
+                    "interval": "week",
+                    "date_from": "-8w",
+                    "new_entity": [],
+                    "properties": [],
+                    "filter_test_accounts": True,
+                }
+            ),
             last_modified_at=self.now - dt.timedelta(days=18),
             last_modified_by=user,
         )
@@ -471,22 +484,24 @@ class HedgeboxMatrix(Matrix):
             dashboard=revenue_dashboard,
             saved=True,
             name="Monthly app revenue",
-            filters={
-                "events": [
-                    {
-                        "id": EVENT_PAID_BILL,
-                        "type": "events",
-                        "order": 0,
-                        "math": "sum",
-                        "math_property": "amount_usd",
-                    }
-                ],
-                "actions": [],
-                "display": TRENDS_LINEAR,
-                "insight": INSIGHT_TRENDS,
-                "interval": "month",
-                "date_from": "-6m",
-            },
+            query=filter_to_query(
+                {
+                    "events": [
+                        {
+                            "id": EVENT_PAID_BILL,
+                            "type": "events",
+                            "order": 0,
+                            "math": "sum",
+                            "math_property": "amount_usd",
+                        }
+                    ],
+                    "actions": [],
+                    "display": TRENDS_LINEAR,
+                    "insight": INSIGHT_TRENDS,
+                    "interval": "month",
+                    "date_from": "-6m",
+                }
+            ),
             last_modified_at=self.now - dt.timedelta(days=29),
             last_modified_by=user,
         )
@@ -512,27 +527,29 @@ class HedgeboxMatrix(Matrix):
             dashboard=revenue_dashboard,
             saved=True,
             name="Bills paid",
-            filters={
-                "events": [
-                    {
-                        "id": EVENT_PAID_BILL,
-                        "math": "unique_group",
-                        "name": "paid_bill",
-                        "type": "events",
-                        "order": 0,
-                        "math_group_type_index": 0,
-                    }
-                ],
-                "actions": [],
-                "compare": True,
-                "date_to": None,
-                "display": "BoldNumber",
-                "insight": "TRENDS",
-                "interval": "day",
-                "date_from": "-30d",
-                "properties": [],
-                "filter_test_accounts": True,
-            },
+            query=filter_to_query(
+                {
+                    "events": [
+                        {
+                            "id": EVENT_PAID_BILL,
+                            "math": "unique_group",
+                            "name": "paid_bill",
+                            "type": "events",
+                            "order": 0,
+                            "math_group_type_index": 0,
+                        }
+                    ],
+                    "actions": [],
+                    "compare": True,
+                    "date_to": None,
+                    "display": "BoldNumber",
+                    "insight": "TRENDS",
+                    "interval": "day",
+                    "date_from": "-30d",
+                    "properties": [],
+                    "filter_test_accounts": True,
+                }
+            ),
             last_modified_at=self.now - dt.timedelta(days=29),
             last_modified_by=user,
         )
@@ -561,14 +578,16 @@ class HedgeboxMatrix(Matrix):
             dashboard=website_dashboard,
             saved=True,
             name="Daily unique visitors over time",
-            filters={
-                "events": [{"id": PAGEVIEW_EVENT, "type": "events", "order": 0, "math": "dau"}],
-                "actions": [],
-                "display": TRENDS_LINEAR,
-                "insight": INSIGHT_TRENDS,
-                "interval": "day",
-                "date_from": "-6m",
-            },
+            query=filter_to_query(
+                {
+                    "events": [{"id": PAGEVIEW_EVENT, "type": "events", "order": 0, "math": "dau"}],
+                    "actions": [],
+                    "display": TRENDS_LINEAR,
+                    "insight": INSIGHT_TRENDS,
+                    "interval": "day",
+                    "date_from": "-6m",
+                }
+            ),
             last_modified_at=self.now - dt.timedelta(days=29),
             last_modified_by=user,
         )
@@ -594,40 +613,42 @@ class HedgeboxMatrix(Matrix):
             dashboard=website_dashboard,
             saved=True,
             name="Most popular pages",
-            filters={
-                "events": [
-                    {
-                        "id": PAGEVIEW_EVENT,
-                        "math": "total",
-                        "type": "events",
-                        "order": 0,
-                    }
-                ],
-                "actions": [],
-                "display": "ActionsTable",
-                "insight": "TRENDS",
-                "interval": "day",
-                "breakdown": "$current_url",
-                "date_from": "-6m",
-                "new_entity": [],
-                "properties": {
-                    "type": "AND",
-                    "values": [
+            query=filter_to_query(
+                {
+                    "events": [
                         {
-                            "type": "AND",
-                            "values": [
-                                {
-                                    "key": "$current_url",
-                                    "type": "event",
-                                    "value": "/files/",
-                                    "operator": "not_icontains",
-                                }
-                            ],
+                            "id": PAGEVIEW_EVENT,
+                            "math": "total",
+                            "type": "events",
+                            "order": 0,
                         }
                     ],
-                },
-                "breakdown_type": "event",
-            },
+                    "actions": [],
+                    "display": "ActionsTable",
+                    "insight": "TRENDS",
+                    "interval": "day",
+                    "breakdown": "$current_url",
+                    "date_from": "-6m",
+                    "new_entity": [],
+                    "properties": {
+                        "type": "AND",
+                        "values": [
+                            {
+                                "type": "AND",
+                                "values": [
+                                    {
+                                        "key": "$current_url",
+                                        "type": "event",
+                                        "value": "/files/",
+                                        "operator": "not_icontains",
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    "breakdown_type": "event",
+                }
+            ),
             last_modified_at=self.now - dt.timedelta(days=26),
             last_modified_by=user,
         )
@@ -654,54 +675,56 @@ class HedgeboxMatrix(Matrix):
             team=team,
             saved=True,
             name="Homepage view to signup conversion",
-            filters={
-                "events": [
-                    {
-                        "custom_name": "Viewed homepage",
-                        "id": "$pageview",
-                        "name": "$pageview",
-                        "type": "events",
-                        "order": 0,
-                        "properties": [
-                            {
-                                "key": "$current_url",
-                                "type": "event",
-                                "value": URL_HOME,
-                                "operator": "exact",
-                            }
-                        ],
-                    },
-                    {
-                        "custom_name": "Viewed signup page",
-                        "id": "$pageview",
-                        "name": "$pageview",
-                        "type": "events",
-                        "order": 1,
-                        "properties": [
-                            {
-                                "key": "$current_url",
-                                "type": "event",
-                                "value": URL_SIGNUP,
-                                "operator": "regex",
-                            }
-                        ],
-                    },
-                    {
-                        "custom_name": "Signed up",
-                        "id": "signed_up",
-                        "name": "signed_up",
-                        "type": "events",
-                        "order": 2,
-                    },
-                ],
-                "actions": [],
-                "display": "FunnelViz",
-                "insight": "FUNNELS",
-                "interval": "day",
-                "funnel_viz_type": "steps",
-                "filter_test_accounts": True,
-                "date_from": "-1m",
-            },
+            query=filter_to_query(
+                {
+                    "events": [
+                        {
+                            "custom_name": "Viewed homepage",
+                            "id": "$pageview",
+                            "name": "$pageview",
+                            "type": "events",
+                            "order": 0,
+                            "properties": [
+                                {
+                                    "key": "$current_url",
+                                    "type": "event",
+                                    "value": URL_HOME,
+                                    "operator": "exact",
+                                }
+                            ],
+                        },
+                        {
+                            "custom_name": "Viewed signup page",
+                            "id": "$pageview",
+                            "name": "$pageview",
+                            "type": "events",
+                            "order": 1,
+                            "properties": [
+                                {
+                                    "key": "$current_url",
+                                    "type": "event",
+                                    "value": URL_SIGNUP,
+                                    "operator": "regex",
+                                }
+                            ],
+                        },
+                        {
+                            "custom_name": "Signed up",
+                            "id": "signed_up",
+                            "name": "signed_up",
+                            "type": "events",
+                            "order": 2,
+                        },
+                    ],
+                    "actions": [],
+                    "display": "FunnelViz",
+                    "insight": "FUNNELS",
+                    "interval": "day",
+                    "funnel_viz_type": "steps",
+                    "filter_test_accounts": True,
+                    "date_from": "-1m",
+                }
+            ),
             last_modified_at=self.now - dt.timedelta(days=19),
             last_modified_by=user,
         )
@@ -709,20 +732,22 @@ class HedgeboxMatrix(Matrix):
             team=team,
             saved=True,
             name="User paths starting at homepage",
-            filters={
-                "date_to": None,
-                "insight": "PATHS",
-                "date_from": "-30d",
-                "edge_limit": 50,
-                "properties": {"type": "AND", "values": []},
-                "step_limit": 5,
-                "start_point": URL_HOME,
-                "funnel_filter": {},
-                "exclude_events": [],
-                "path_groupings": ["/files/*"],
-                "include_event_types": ["$pageview"],
-                "local_path_cleaning_filters": [],
-            },
+            query=filter_to_query(
+                {
+                    "date_to": None,
+                    "insight": "PATHS",
+                    "date_from": "-30d",
+                    "edge_limit": 50,
+                    "properties": {"type": "AND", "values": []},
+                    "step_limit": 5,
+                    "start_point": URL_HOME,
+                    "funnel_filter": {},
+                    "exclude_events": [],
+                    "path_groupings": ["/files/*"],
+                    "include_event_types": ["$pageview"],
+                    "local_path_cleaning_filters": [],
+                }
+            ),
             last_modified_at=self.now - dt.timedelta(days=9),
             last_modified_by=user,
         )
@@ -730,18 +755,20 @@ class HedgeboxMatrix(Matrix):
             team=team,
             saved=True,
             name="File interactions",
-            filters={
-                "events": [
-                    {"id": EVENT_UPLOADED_FILE, "type": "events", "order": 0},
-                    {"id": EVENT_DELETED_FILE, "type": "events", "order": 2},
-                    {"id": EVENT_DOWNLOADED_FILE, "type": "events", "order": 1},
-                ],
-                "actions": [],
-                "display": TRENDS_LINEAR,
-                "insight": INSIGHT_TRENDS,
-                "interval": "day",
-                "date_from": "-30d",
-            },
+            query=filter_to_query(
+                {
+                    "events": [
+                        {"id": EVENT_UPLOADED_FILE, "type": "events", "order": 0},
+                        {"id": EVENT_DELETED_FILE, "type": "events", "order": 2},
+                        {"id": EVENT_DOWNLOADED_FILE, "type": "events", "order": 1},
+                    ],
+                    "actions": [],
+                    "display": TRENDS_LINEAR,
+                    "insight": INSIGHT_TRENDS,
+                    "interval": "day",
+                    "date_from": "-30d",
+                }
+            ),
             last_modified_at=self.now - dt.timedelta(days=13),
             last_modified_by=user,
         )

--- a/posthog/management/commands/generate_demo_data.py
+++ b/posthog/management/commands/generate_demo_data.py
@@ -135,7 +135,7 @@ class Command(BaseCommand):
                         "Hedgebox Inc.",
                         is_staff=bool(options.get("staff")),
                         password=password,
-                        disallow_collision=True,
+                        email_collision_handling="disambiguate",
                     )
             except exceptions.ValidationError as e:
                 print(f"Error: {e}")

--- a/posthog/management/commands/generate_demo_data.py
+++ b/posthog/management/commands/generate_demo_data.py
@@ -126,10 +126,10 @@ class Command(BaseCommand):
                         matrix_manager.reset_master()
                     else:
                         team = Team.objects.get(pk=existing_team_id)
-                        existing_user = team.organization.members.first()
-                        matrix_manager.run_on_team(team, existing_user)
+                        user = team.organization.members.first()
+                        matrix_manager.run_on_team(team, user)
                 else:
-                    matrix_manager.ensure_account_and_save(
+                    organization, team, user = matrix_manager.ensure_account_and_save(
                         email,
                         "Employee 427",
                         "Hedgebox Inc.",
@@ -146,12 +146,12 @@ class Command(BaseCommand):
                     else (
                         f"\nDemo data ready for project {team.name}!\n"
                         if existing_team_id is not None
-                        else f"\nDemo data ready for {email}!\n\n"
+                        else f"\nDemo data ready for {user.email}!\n\n"
                         "Pre-fill the login form with this link:\n"
-                        f"http://localhost:8000/login?email={email}\n"
+                        f"http://localhost:8000/login?email={user.email}\n"
                         f"The password is:\n{password}\n\n"
                         "If running demo mode (DEMO=1), log in instantly with this link:\n"
-                        f"http://localhost:8000/signup?email={email}\n"
+                        f"http://localhost:8000/signup?email={user.email}\n"
                     )
                 )
             print("Materializing common columns...")

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -525,8 +525,8 @@ async def initialize_self_capture_api_token():
         if user and getattr(user, "current_team", None):
             team = user.current_team
         else:
-            team = await Team.objects.only("api_token").aget()
-        local_api_key = team.api_token
+            team = await Team.objects.only("api_token").afirst()
+        local_api_key = team.api_token if team else None
     except (User.DoesNotExist, Team.DoesNotExist, ProgrammingError):
         local_api_key = None
 


### PR DESCRIPTION
## Problem

Our Hedgebox demo projects come with insights included, but they were all using the legacy `filters` format, which is unrealistic. Insights have long been using the `query` shape instead. The mismatch caused confusion in #35726.

## Changes

Refactored all the insights. Up-to-date format, same contents.

Bonus! `./manage.py generate_demo_data` now automatically handles `test@posthog.com` existing, by using `test+1@posthog.com` (or `+2`, `+3`, and so on) instead of crashing.