### PR TITLE
fix: match flags nan and infinity parsing with decide

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2441,6 +2441,7 @@ dependencies = [
  "flate2",
  "futures",
  "health",
+ "json5",
  "limiters",
  "md5",
  "moka",
@@ -3712,6 +3713,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4771,6 +4783,50 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pest"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
+dependencies = [
+ "memchr",
+ "thiserror 2.0.12",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "petgraph"
@@ -7565,6 +7621,12 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicase"

--- a/rust/feature-flags/Cargo.toml
+++ b/rust/feature-flags/Cargo.toml
@@ -30,6 +30,7 @@ redis = { version = "0.23.3", features = [
 ] }
 serde = { workspace = true }
 serde_json = { workspace = true }
+json5 = "0.4"
 thiserror = { workspace = true }
 sha1 = "0.10.6"
 regex.workspace = true

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -260,17 +260,16 @@ mod tests {
         );
 
         // Test NaN as quoted string (should be preserved)
-        let json_with_nan_string =
-            r#"{"api_key": "test", "distinct_id": "user", "person_properties": {"nan": "NaN", "infinity": 'Infinity'}}"#;
-        let request =
-            FlagRequest::from_bytes(Bytes::from(json_with_nan_string)).expect("Should handle quoted NaN");
+        let json_with_nan_string = r#"{"api_key": "test", "distinct_id": "user", "person_properties": {"nan": "NaN", "infinity": 'Infinity'}}"#;
+        let request = FlagRequest::from_bytes(Bytes::from(json_with_nan_string))
+            .expect("Should handle quoted NaN");
         assert_eq!(
             request.person_properties.as_ref().unwrap()["nan"],
-            json!("NaN")  // Quoted strings are preserved
+            json!("NaN") // Quoted strings are preserved
         );
         assert_eq!(
             request.person_properties.as_ref().unwrap()["infinity"],
-            json!("Infinity")  // Quoted strings are preserved
+            json!("Infinity") // Quoted strings are preserved
         );
 
         // Test Infinity (gets replaced with null)

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -105,8 +105,10 @@ impl FlagRequest {
     /// Sanitizes JSON by replacing unquoted NaN/Infinity with null, preserving quoted strings
     /// This matches Python decide endpoint behavior: parse_constant=lambda x: None
     fn sanitize_unquoted_non_finite_values(json_str: &str) -> String {
-        static NEG_INF_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?i)-infinity(\s*[,}\]])").unwrap());
-        static INF_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?i)\binfinity(\s*[,}\]])").unwrap());
+        static NEG_INF_RE: Lazy<Regex> =
+            Lazy::new(|| Regex::new(r"(?i)-infinity(\s*[,}\]])").unwrap());
+        static INF_RE: Lazy<Regex> =
+            Lazy::new(|| Regex::new(r"(?i)\binfinity(\s*[,}\]])").unwrap());
         static NAN_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?i)\bnan(\s*[,}\]])").unwrap());
 
         let result = NEG_INF_RE.replace_all(json_str, "null$1");

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -87,8 +87,6 @@ impl FlagRequest {
             }
         };
 
-        // Smart replacement that only affects unquoted values (preserves quoted strings)
-        // This matches Python decide endpoint behavior: parse_constant=lambda x: None
         let sanitized_payload = Self::sanitize_unquoted_non_finite_values(&payload);
 
         match serde_json::from_str::<FlagRequest>(&sanitized_payload) {

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -91,7 +91,7 @@ impl FlagRequest {
             .replace("-Infinity", "null")
             .replace("Infinity", "null")
             .replace("NaN", "null");
-        
+
         match serde_json::from_str::<FlagRequest>(&sanitized_payload) {
             Ok(request) => Ok(request),
             Err(e) => {
@@ -235,19 +235,32 @@ mod tests {
     #[test]
     fn json_sanitization_handles_nan_infinity() {
         // Test NaN
-        let json_with_nan = r#"{"api_key": "test", "distinct_id": "user", "person_properties": {"nan": NaN}}"#;
-        let request = FlagRequest::from_bytes(Bytes::from(json_with_nan)).expect("Should handle NaN");
-        assert_eq!(request.person_properties.as_ref().unwrap()["nan"], json!(null));
+        let json_with_nan =
+            r#"{"api_key": "test", "distinct_id": "user", "person_properties": {"nan": NaN}}"#;
+        let request =
+            FlagRequest::from_bytes(Bytes::from(json_with_nan)).expect("Should handle NaN");
+        assert_eq!(
+            request.person_properties.as_ref().unwrap()["nan"],
+            json!(null)
+        );
 
         // Test Infinity
         let json_with_infinity = r#"{"api_key": "test", "distinct_id": "user", "person_properties": {"infinity": Infinity}}"#;
-        let request = FlagRequest::from_bytes(Bytes::from(json_with_infinity)).expect("Should handle Infinity");
-        assert_eq!(request.person_properties.as_ref().unwrap()["infinity"], json!(null));
+        let request = FlagRequest::from_bytes(Bytes::from(json_with_infinity))
+            .expect("Should handle Infinity");
+        assert_eq!(
+            request.person_properties.as_ref().unwrap()["infinity"],
+            json!(null)
+        );
 
         // Test negative Infinity
         let json_with_neg_infinity = r#"{"api_key": "test", "distinct_id": "user", "person_properties": {"neg_infinity": -Infinity}}"#;
-        let request = FlagRequest::from_bytes(Bytes::from(json_with_neg_infinity)).expect("Should handle -Infinity");
-        assert_eq!(request.person_properties.as_ref().unwrap()["neg_infinity"], json!(null));
+        let request = FlagRequest::from_bytes(Bytes::from(json_with_neg_infinity))
+            .expect("Should handle -Infinity");
+        assert_eq!(
+            request.person_properties.as_ref().unwrap()["neg_infinity"],
+            json!(null)
+        );
     }
 
     #[test]

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -234,12 +234,12 @@ mod tests {
 
     #[test]
     fn json_sanitization_handles_nan_infinity() {
-        // Test NaN variations - these should parse successfully with NaN converted to null
+        // Test NaN
         let json_with_nan = r#"{"api_key": "test", "distinct_id": "user", "person_properties": {"nan": NaN}}"#;
         let request = FlagRequest::from_bytes(Bytes::from(json_with_nan)).expect("Should handle NaN");
         assert_eq!(request.person_properties.as_ref().unwrap()["nan"], json!(null));
 
-        // Test Infinity variations
+        // Test Infinity
         let json_with_infinity = r#"{"api_key": "test", "distinct_id": "user", "person_properties": {"infinity": Infinity}}"#;
         let request = FlagRequest::from_bytes(Bytes::from(json_with_infinity)).expect("Should handle Infinity");
         assert_eq!(request.person_properties.as_ref().unwrap()["infinity"], json!(null));


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

`NaN`, `Infinity` and `-Infinity` are sanitized in decide but serde errors on them.

The following request body return 400 in /flags, but return 200 in /decide:
```
"person_properties": {"score": -Infinity}
"person_properties": {"score": Infinity}
"person_properties": {"score": NaN}
```
We do this parsing in python here: https://github.com/PostHog/posthog/blob/973c6de107b7d55ced58cebb0ccdeeabf61ff6fc/posthog/utils.py#L756-L758
## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Match /flags parsing to /decide

https://github.com/PostHog/posthog/issues/33636

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
Unit test
