### PR TITLE
chore: bump temporal

### DIFF
--- a/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
+++ b/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
@@ -19,7 +19,7 @@ from posthog.temporal.common.heartbeat import Heartbeater
 
 LOGGER = get_logger(__name__)
 
-# Changed 8/12/25 11:20 AM
+# Changed 8/22/25 11:20 PM
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
## Problem
Want to switch over to s3 cache for users but don't want to overload clickhouse or make performance bad.

## Changes
Make the client start writing to both redis and s3 caches. Then can move people over after a day or so.
