### PR TITLE
feat(revenue-analytics): add team_id to `persons_revenue_analytics` table

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -45,7 +45,7 @@ from posthog.hogql.database.schema.channel_type import (
     create_initial_channel_type,
     create_initial_domain_type,
 )
-from posthog.hogql.database.schema.revenue_analytics import RawPersonsRevenueAnalyticsTable
+from posthog.hogql.database.schema.persons_revenue_analytics import PersonsRevenueAnalyticsTable
 from posthog.hogql.database.schema.cohort_people import CohortPeople, RawCohortPeople
 from posthog.hogql.database.schema.error_tracking_issue_fingerprint_overrides import (
     ErrorTrackingIssueFingerprintOverridesTable,
@@ -162,7 +162,7 @@ class Database(BaseModel):
     web_bounces_combined: WebBouncesCombinedTable = WebBouncesCombinedTable()
 
     # Revenue analytics tables
-    raw_persons_revenue_analytics: RawPersonsRevenueAnalyticsTable = RawPersonsRevenueAnalyticsTable()
+    persons_revenue_analytics: PersonsRevenueAnalyticsTable = PersonsRevenueAnalyticsTable()
 
     raw_session_replay_events: RawSessionReplayEventsTable = RawSessionReplayEventsTable()
     raw_person_distinct_ids: RawPersonDistinctIdsTable = RawPersonDistinctIdsTable()

--- a/posthog/hogql/database/schema/events.py
+++ b/posthog/hogql/database/schema/events.py
@@ -16,8 +16,8 @@ from posthog.hogql.database.schema.person_distinct_ids import (
     join_with_person_distinct_ids_table,
 )
 from posthog.hogql.database.schema.sessions_v1 import join_events_table_to_sessions_table, SessionsTableV1
-from posthog.hogql.database.schema.revenue_analytics import (
-    RawPersonsRevenueAnalyticsTable,
+from posthog.hogql.database.schema.persons_revenue_analytics import (
+    PersonsRevenueAnalyticsTable,
     join_with_persons_revenue_analytics_table,
 )
 
@@ -29,7 +29,7 @@ class EventsPersonSubTable(VirtualTable):
         "properties": StringJSONDatabaseField(name="person_properties", nullable=False),
         "revenue_analytics": LazyJoin(
             from_field=["person_id"],
-            join_table=RawPersonsRevenueAnalyticsTable(),
+            join_table=PersonsRevenueAnalyticsTable(),
             join_function=join_with_persons_revenue_analytics_table,
         ),
     }

--- a/posthog/hogql/database/schema/persons.py
+++ b/posthog/hogql/database/schema/persons.py
@@ -27,8 +27,8 @@ from posthog.hogql.errors import ResolutionError
 from posthog.hogql.visitor import clone_expr
 from posthog.models.organization import Organization
 from posthog.schema import PersonsArgMaxVersion
-from posthog.hogql.database.schema.revenue_analytics import (
-    RawPersonsRevenueAnalyticsTable,
+from posthog.hogql.database.schema.persons_revenue_analytics import (
+    PersonsRevenueAnalyticsTable,
     join_with_persons_revenue_analytics_table,
 )
 
@@ -47,7 +47,7 @@ PERSONS_FIELDS: dict[str, FieldOrTable] = {
     ),
     "revenue_analytics": LazyJoin(
         from_field=["id"],
-        join_table=RawPersonsRevenueAnalyticsTable(),
+        join_table=PersonsRevenueAnalyticsTable(),
         join_function=join_with_persons_revenue_analytics_table,
     ),
 }

--- a/posthog/hogql/database/schema/test/__snapshots__/test_persons_revenue_analytics.ambr
+++ b/posthog/hogql/database/schema/test/__snapshots__/test_persons_revenue_analytics.ambr
@@ -14,7 +14,8 @@
      GROUP BY person.id
      HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
   LEFT JOIN
-    (SELECT accurateCastOrNull(revenue_analytics_customer.id, 'UUID') AS person_id,
+    (SELECT 99999 AS team_id,
+            accurateCastOrNull(revenue_analytics_customer.id, 'UUID') AS person_id,
             sum(revenue_analytics_revenue_item.amount) AS revenue,
             sumIf(revenue_analytics_revenue_item.amount, ifNull(greaterOrEquals(revenue_analytics_revenue_item.timestamp, minus(today(), toIntervalDay(30))), 0)) AS revenue_last_30_days
      FROM
@@ -124,7 +125,8 @@
      GROUP BY person.id
      HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
   LEFT JOIN
-    (SELECT accurateCastOrNull(revenue_analytics_customer__persons.id, 'UUID') AS person_id,
+    (SELECT 99999 AS team_id,
+            accurateCastOrNull(revenue_analytics_customer__persons.id, 'UUID') AS person_id,
             sum(revenue_analytics_revenue_item.amount) AS revenue,
             sumIf(revenue_analytics_revenue_item.amount, ifNull(greaterOrEquals(revenue_analytics_revenue_item.timestamp, minus(today(), toIntervalDay(30))), 0)) AS revenue_last_30_days
      FROM
@@ -233,7 +235,8 @@
      GROUP BY person.id
      HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
   LEFT JOIN
-    (SELECT accurateCastOrNull(revenue_analytics_customer__persons.id, 'UUID') AS person_id,
+    (SELECT 99999 AS team_id,
+            accurateCastOrNull(revenue_analytics_customer__persons.id, 'UUID') AS person_id,
             sum(revenue_analytics_revenue_item.amount) AS revenue,
             sumIf(revenue_analytics_revenue_item.amount, ifNull(greaterOrEquals(revenue_analytics_revenue_item.timestamp, minus(today(), toIntervalDay(30))), 0)) AS revenue_last_30_days
      FROM
@@ -344,7 +347,8 @@
      GROUP BY person.id
      HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
   LEFT JOIN
-    (SELECT accurateCastOrNull(revenue_analytics_customer__persons.id, 'UUID') AS person_id,
+    (SELECT 99999 AS team_id,
+            accurateCastOrNull(revenue_analytics_customer__persons.id, 'UUID') AS person_id,
             sum(revenue_analytics_revenue_item.amount) AS revenue,
             sumIf(revenue_analytics_revenue_item.amount, ifNull(greaterOrEquals(revenue_analytics_revenue_item.timestamp, minus(today(), toIntervalDay(30))), 0)) AS revenue_last_30_days
      FROM
@@ -454,7 +458,8 @@
      GROUP BY person.id
      HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
   LEFT JOIN
-    (SELECT accurateCastOrNull(revenue_analytics_customer__persons.id, 'UUID') AS person_id,
+    (SELECT 99999 AS team_id,
+            accurateCastOrNull(revenue_analytics_customer__persons.id, 'UUID') AS person_id,
             sum(revenue_analytics_revenue_item.amount) AS revenue,
             sumIf(revenue_analytics_revenue_item.amount, ifNull(greaterOrEquals(revenue_analytics_revenue_item.timestamp, minus(today(), toIntervalDay(30))), 0)) AS revenue_last_30_days
      FROM
@@ -564,7 +569,8 @@
      GROUP BY person.id
      HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
   LEFT JOIN
-    (SELECT accurateCastOrNull(revenue_analytics_customer__persons.id, 'UUID') AS person_id,
+    (SELECT 99999 AS team_id,
+            accurateCastOrNull(revenue_analytics_customer__persons.id, 'UUID') AS person_id,
             sum(revenue_analytics_revenue_item.amount) AS revenue,
             sumIf(revenue_analytics_revenue_item.amount, ifNull(greaterOrEquals(revenue_analytics_revenue_item.timestamp, minus(today(), toIntervalDay(30))), 0)) AS revenue_last_30_days
      FROM
@@ -675,7 +681,8 @@
      GROUP BY person.id
      HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
   LEFT JOIN
-    (SELECT accurateCastOrNull(revenue_analytics_customer__persons.id, 'UUID') AS person_id,
+    (SELECT 99999 AS team_id,
+            accurateCastOrNull(revenue_analytics_customer__persons.id, 'UUID') AS person_id,
             sum(revenue_analytics_revenue_item.amount) AS revenue,
             sumIf(revenue_analytics_revenue_item.amount, ifNull(greaterOrEquals(revenue_analytics_revenue_item.timestamp, minus(today(), toIntervalDay(30))), 0)) AS revenue_last_30_days
      FROM
@@ -773,6 +780,111 @@
                      allow_experimental_join_condition=1
   '''
 # ---
+# name: TestRevenueAnalytics.test_query_revenue_analytics_table
+  '''
+  SELECT persons_revenue_analytics.person_id AS person_id,
+         persons_revenue_analytics.revenue AS revenue,
+         persons_revenue_analytics.revenue_last_30_days AS revenue_last_30_days
+  FROM
+    (SELECT 99999 AS team_id,
+            accurateCastOrNull(revenue_analytics_customer__persons.id, 'UUID') AS person_id,
+            sum(revenue_analytics_revenue_item.amount) AS revenue,
+            sumIf(revenue_analytics_revenue_item.amount, ifNull(greaterOrEquals(revenue_analytics_revenue_item.timestamp, minus(today(), toIntervalDay(30))), 0)) AS revenue_last_30_days
+     FROM
+       (SELECT outer.id AS id,
+               'stripe.posthog_test' AS source_label,
+               parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
+               outer.name AS name,
+               outer.email AS email,
+               outer.phone AS phone,
+               outer.address AS address,
+               outer.metadata AS metadata,
+               JSONExtractString(address, 'country') AS country,
+               cohort_inner.cohort AS cohort,
+               cohort_inner.initial_coupon AS initial_coupon,
+               cohort_inner.initial_coupon_id AS initial_coupon_id
+        FROM
+          (SELECT *
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
+        LEFT JOIN
+          (SELECT invoice.customer AS customer_id,
+                  formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
+                  argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
+                  argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
+           GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)) AS revenue_analytics_customer
+     LEFT JOIN
+       (SELECT persons.id AS id,
+               persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
+        FROM
+          (SELECT argMax(person.id, person.version) AS persons___id,
+                  person.id AS id
+           FROM person
+           WHERE equals(person.team_id, 99999)
+           GROUP BY person.id
+           HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
+        LEFT JOIN
+          (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id,
+                  person_distinct_id2.distinct_id AS distinct_id
+           FROM person_distinct_id2
+           WHERE equals(person_distinct_id2.team_id, 99999)
+           GROUP BY person_distinct_id2.distinct_id
+           HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.email, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
+     LEFT JOIN
+       (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+               invoice.invoice_item_id AS invoice_item_id,
+               'stripe.posthog_test' AS source_label,
+               addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+               invoice.created_at AS created_at,
+               ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+               invoice.product_id AS product_id,
+               invoice.customer_id AS customer_id,
+               invoice.id AS invoice_id,
+               invoice.subscription_id AS subscription_id,
+               NULL AS session_id,
+               NULL AS event_name,
+               JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+               JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+               upper(invoice.currency) AS original_currency,
+               accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+               in(original_currency,
+                  ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                 if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                 divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                 'GBP' AS currency,
+                 divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+        FROM
+          (SELECT posthog_test_stripe_invoice.id AS id,
+                  parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                  posthog_test_stripe_invoice.customer AS customer_id,
+                  posthog_test_stripe_invoice.subscription AS subscription_id,
+                  posthog_test_stripe_invoice.discount AS discount,
+                  arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                  JSONExtractString(data, 'id') AS invoice_item_id,
+                  JSONExtractString(data, 'amount') AS amount_captured,
+                  JSONExtractString(data, 'currency') AS currency,
+                  JSONExtractString(data, 'price', 'product') AS product_id,
+                  fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                  fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                  greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                  arrayJoin(range(0, period_months)) AS month_index,
+                  ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+           WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_analytics_revenue_item ON equals(revenue_analytics_customer.id, revenue_analytics_revenue_item.customer_id)
+     GROUP BY person_id) AS persons_revenue_analytics
+  ORDER BY persons_revenue_analytics.person_id ASC
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1
+  '''
+# ---
 # name: TestRevenueAnalytics.test_virtual_property_in_trend_0_disabled
   '''
   SELECT min(toTimeZone(events.timestamp, 'UTC')) AS `min(toTimeZone(timestamp, 'UTC'))`
@@ -826,7 +938,8 @@
               GROUP BY person.id
               HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__pdi__person ON equals(e__pdi.e__pdi___person_id, e__pdi__person.e__pdi__person___id)
            LEFT JOIN
-             (SELECT accurateCastOrNull(revenue_analytics_customer.id, 'UUID') AS person_id,
+             (SELECT 99999 AS team_id,
+                     accurateCastOrNull(revenue_analytics_customer.id, 'UUID') AS person_id,
                      sum(revenue_analytics_revenue_item.amount) AS revenue,
                      sumIf(revenue_analytics_revenue_item.amount, ifNull(greaterOrEquals(revenue_analytics_revenue_item.timestamp, minus(today(), toIntervalDay(30))), 0)) AS revenue_last_30_days
               FROM
@@ -973,7 +1086,8 @@
                   ifNull(nullIf(toString(e__poe__revenue_analytics.revenue), ''), '$$_posthog_breakdown_null_$$') AS breakdown_value_1
            FROM events AS e SAMPLE 1
            LEFT JOIN
-             (SELECT accurateCastOrNull(revenue_analytics_customer.id, 'UUID') AS person_id,
+             (SELECT 99999 AS team_id,
+                     accurateCastOrNull(revenue_analytics_customer.id, 'UUID') AS person_id,
                      sum(revenue_analytics_revenue_item.amount) AS revenue,
                      sumIf(revenue_analytics_revenue_item.amount, ifNull(greaterOrEquals(revenue_analytics_revenue_item.timestamp, minus(today(), toIntervalDay(30))), 0)) AS revenue_last_30_days
               FROM
@@ -1106,7 +1220,8 @@
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
            LEFT JOIN
-             (SELECT accurateCastOrNull(revenue_analytics_customer.id, 'UUID') AS person_id,
+             (SELECT 99999 AS team_id,
+                     accurateCastOrNull(revenue_analytics_customer.id, 'UUID') AS person_id,
                      sum(revenue_analytics_revenue_item.amount) AS revenue,
                      sumIf(revenue_analytics_revenue_item.amount, ifNull(greaterOrEquals(revenue_analytics_revenue_item.timestamp, minus(today(), toIntervalDay(30))), 0)) AS revenue_last_30_days
               FROM
@@ -1260,7 +1375,8 @@
               GROUP BY person.id
               HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.e__person___id)
            LEFT JOIN
-             (SELECT accurateCastOrNull(revenue_analytics_customer.id, 'UUID') AS person_id,
+             (SELECT 99999 AS team_id,
+                     accurateCastOrNull(revenue_analytics_customer.id, 'UUID') AS person_id,
                      sum(revenue_analytics_revenue_item.amount) AS revenue,
                      sumIf(revenue_analytics_revenue_item.amount, ifNull(greaterOrEquals(revenue_analytics_revenue_item.timestamp, minus(today(), toIntervalDay(30))), 0)) AS revenue_last_30_days
               FROM

--- a/posthog/hogql/database/schema/test/test_persons_revenue_analytics.py
+++ b/posthog/hogql/database/schema/test/test_persons_revenue_analytics.py
@@ -335,6 +335,18 @@ class TestRevenueAnalytics(ClickhouseTestMixin, APIBaseTest):
 
             self.assertEqual(response.results, [(Decimal("429.7423999996"),), (None,)])
 
+    def test_query_revenue_analytics_table(self):
+        self.setup_schema_sources()
+        self.join.source_table_key = "email"
+        self.join.save()
+
+        with freeze_time(self.QUERY_TIMESTAMP):
+            execute_hogql_query(
+                parse_select("SELECT * FROM persons_revenue_analytics ORDER BY person_id ASC"),
+                self.team,
+                modifiers=self.MODIFIERS,
+            )
+
     @parameterized.expand([e.value for e in PersonsOnEventsMode])
     def test_virtual_property_in_trend(self, mode):
         self.setup_events()

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -676,6 +676,7 @@
               "revenue_analytics": {
                   "chain": null,
                   "fields": [
+                      "team_id",
                       "person_id",
                       "revenue",
                       "revenue_last_30_days"
@@ -684,7 +685,7 @@
                   "id": "revenue_analytics",
                   "name": "revenue_analytics",
                   "schema_valid": true,
-                  "table": "raw_persons_revenue_analytics",
+                  "table": "persons_revenue_analytics",
                   "type": "lazy_table"
               },
               "$virt_initial_referring_domain_type": {
@@ -2040,6 +2041,7 @@
               "revenue_analytics": {
                   "chain": null,
                   "fields": [
+                      "team_id",
                       "person_id",
                       "revenue",
                       "revenue_last_30_days"
@@ -2048,7 +2050,7 @@
                   "id": "revenue_analytics",
                   "name": "revenue_analytics",
                   "schema_valid": true,
-                  "table": "raw_persons_revenue_analytics",
+                  "table": "persons_revenue_analytics",
                   "type": "lazy_table"
               },
               "$virt_initial_referring_domain_type": {

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -688,7 +688,7 @@ class TestDatabase(BaseTest, QueryMatchingTest):
                 },
             )
 
-            with self.assertNumQueries(FuzzyInt(5, 7)):
+            with self.assertNumQueries(FuzzyInt(6, 8)):
                 create_hogql_database(team=self.team)
 
     # We keep adding sources, credentials and tables, number of queries should be stable


### PR DESCRIPTION
Introduced `team_id` alias in the `select_from_persons_revenue_analytics_table` function to ensure compatibility with HogQL (always adds `team_id` clause to queries).

This is one of the only "tables" (it's lazy) in PostHog that don't include the `team_id` so it could be considered a security risk. It is NOT a security risk in practice because it is created from Revenue Analytics views, which are themselves created from DWH views and the events table, which are safe.

I've also renamed it to `persons_revenue_analytics` to better represent what it is. I'd like to eventually call it just `revenue_analytics` but that's not possible right now because a `TableGroup` cannot contain a leaf table in it, therefore it means we cannot have both `revenue_analytics` AND `revenue_analytics.events.purchase` at the same time - this should be fixed eventually.

Closes #36687