### PR TITLE
feat(flags): Transform flag dependencies for easier local evaluation

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -72,6 +72,7 @@ from posthog.models.feature_flag import (
 from posthog.models.feature_flag.flag_analytics import increment_request_count
 from posthog.models.feature_flag.flag_matching import check_flag_evaluation_query_is_ok
 from posthog.models.feature_flag.local_evaluation import _get_flag_properties_from_filters
+from posthog.models.feature_flag.types import PropertyFilterType
 from posthog.models.surveys.survey import Survey
 from posthog.models.property import Property
 from posthog.schema import PropertyOperator
@@ -445,7 +446,7 @@ class FeatureFlagSerializer(
         except FeatureFlag.DoesNotExist:
             raise serializers.ValidationError(f"Flag dependency references non-existent flag with ID {flag_id}")
 
-    def _get_properties_from_filters(self, filters: dict, property_type: str | None = None):
+    def _get_properties_from_filters(self, filters: dict, property_type: PropertyFilterType | None = None):
         """
         Extract properties from filters by iterating through groups.
 
@@ -463,7 +464,7 @@ class FeatureFlagSerializer(
 
     def _get_cohort_properties_from_filters(self, filters: dict):
         """Extract cohort properties from filters."""
-        return list(self._get_properties_from_filters(filters, "cohort"))
+        return list(self._get_properties_from_filters(filters, PropertyFilterType.COHORT))
 
     def _extract_flag_dependencies(self, filters):
         """Extract flag dependencies from filters."""

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import re
 import time
@@ -69,6 +71,7 @@ from posthog.models.feature_flag import (
 )
 from posthog.models.feature_flag.flag_analytics import increment_request_count
 from posthog.models.feature_flag.flag_matching import check_flag_evaluation_query_is_ok
+from posthog.models.feature_flag.local_evaluation import _get_flag_properties_from_filters
 from posthog.models.surveys.survey import Survey
 from posthog.models.property import Property
 from posthog.schema import PropertyOperator
@@ -442,16 +445,34 @@ class FeatureFlagSerializer(
         except FeatureFlag.DoesNotExist:
             raise serializers.ValidationError(f"Flag dependency references non-existent flag with ID {flag_id}")
 
+    def _get_properties_from_filters(self, filters: dict, property_type: str | None = None):
+        """
+        Extract properties from filters by iterating through groups.
+
+        Args:
+            filters: The filters dictionary containing groups
+            property_type: Optional filter by property type (e.g., 'flag', 'cohort')
+
+        Yields:
+            Property dictionaries matching the criteria
+        """
+        for group in filters.get("groups", []):
+            for prop in group.get("properties", []):
+                if property_type is None or prop.get("type") == property_type:
+                    yield prop
+
+    def _get_cohort_properties_from_filters(self, filters: dict):
+        """Extract cohort properties from filters."""
+        return list(self._get_properties_from_filters(filters, "cohort"))
+
     def _extract_flag_dependencies(self, filters):
         """Extract flag dependencies from filters."""
         dependencies = set()
-        for group in filters.get("groups", []):
-            for property_filter in group.get("properties", []):
-                if property_filter.get("type") == "flag":
-                    flag_reference = property_filter.get("key")
-                    if flag_reference:
-                        flag_key = self._validate_flag_reference(flag_reference)
-                        dependencies.add(flag_key)
+        for flag_prop in _get_flag_properties_from_filters(filters):
+            flag_reference = flag_prop.get("key")
+            if flag_reference:
+                flag_key = self._validate_flag_reference(flag_reference)
+                dependencies.add(flag_key)
         return dependencies
 
     def _check_flag_circular_dependencies(self, filters):
@@ -741,14 +762,11 @@ class FeatureFlagSerializer(
     def to_representation(self, instance):
         representation = super().to_representation(instance)
         filters = representation.get("filters", {})
-        groups = filters.get("groups", [])
 
         # Get all cohort IDs used in the feature flag
         cohort_ids = set()
-        for group in groups:
-            for property in group.get("properties", []):
-                if property.get("type") == "cohort":
-                    cohort_ids.add(property.get("value"))
+        for cohort_prop in self._get_cohort_properties_from_filters(filters):
+            cohort_ids.add(cohort_prop.get("value"))
 
         # Use prefetched cohorts if available
         if hasattr(instance.team, "available_cohorts"):
@@ -765,10 +783,8 @@ class FeatureFlagSerializer(
             }
 
         # Add cohort names to the response
-        for group in groups:
-            for property in group.get("properties", []):
-                if property.get("type") == "cohort":
-                    property["cohort_name"] = cohorts.get(str(property.get("value")))
+        for cohort_prop in self._get_cohort_properties_from_filters(filters):
+            cohort_prop["cohort_name"] = cohorts.get(str(cohort_prop.get("value")))
 
         representation["filters"] = filters
         return representation

--- a/posthog/api/test/test_local_evaluation.py
+++ b/posthog/api/test/test_local_evaluation.py
@@ -1,0 +1,440 @@
+from rest_framework import status
+
+from posthog.models import FeatureFlag
+from posthog.test.base import APIBaseTest
+
+
+class TestFeatureFlagDependencyTransformation(APIBaseTest):
+    """Test flag dependency transformation in local_evaluation endpoint."""
+
+    def setUp(self):
+        super().setUp()
+        # Clean up existing flags to avoid interference
+        FeatureFlag.objects.all().delete()
+
+    def _find_flag(self, flags: list[dict], key: str) -> dict:
+        """Helper method to find a flag by key in the flags list."""
+        return next(flag for flag in flags if flag["key"] == key)
+
+    def test_flag_dependency_transformation_complex_chain(self):
+        """Test dependency transformation with complex dependency chains."""
+        # Create a flag dependency chain: C -> B -> A
+        # Create flag A
+        flag_a = FeatureFlag.objects.create(
+            team=self.team,
+            key="flag-a",
+            name="Flag A",
+            filters={
+                "groups": [
+                    {
+                        "properties": [
+                            {"key": "email", "type": "person", "value": "test@example.com", "operator": "exact"}
+                        ],
+                        "rollout_percentage": 100,
+                    }
+                ]
+            },
+        )
+
+        # Create flag B that depends on flag A
+        flag_b = FeatureFlag.objects.create(
+            team=self.team,
+            key="flag-b",
+            name="Flag B",
+            filters={
+                "groups": [
+                    {
+                        "properties": [
+                            {"key": str(flag_a.id), "type": "flag", "value": True, "operator": "flag_evaluates_to"}
+                        ],
+                        "rollout_percentage": 100,
+                    }
+                ]
+            },
+        )
+
+        # Create flag C that depends on flag B
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="flag-c",
+            name="Flag C",
+            filters={
+                "groups": [
+                    {
+                        "properties": [
+                            {"key": str(flag_b.id), "type": "flag", "value": True, "operator": "flag_evaluates_to"}
+                        ],
+                        "rollout_percentage": 100,
+                    }
+                ]
+            },
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/local_evaluation")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        flags = data["flags"]
+
+        flag_c_data = self._find_flag(flags, "flag-c")
+
+        properties = flag_c_data["filters"]["groups"][0]["properties"]
+        flag_property = next(prop for prop in properties if prop["type"] == "flag")
+
+        # ID should be converted to key
+        self.assertEqual(flag_property["key"], "flag-b")
+
+        # Full dependency chain should be included (topologically sorted)
+        self.assertIn("dependency_chain", flag_property)
+        self.assertEqual(flag_property["dependency_chain"], ["flag-a", "flag-b"])
+
+        flag_b_data = self._find_flag(flags, "flag-b")
+        properties_b = flag_b_data["filters"]["groups"][0]["properties"]
+        flag_property_b = next(prop for prop in properties_b if prop["type"] == "flag")
+        self.assertEqual(flag_property_b["dependency_chain"], ["flag-a"])
+
+    def test_flag_dependency_transformation_circular_dependency(self):
+        """Test handling of circular dependencies."""
+        # Create flag A
+        flag_a = FeatureFlag.objects.create(
+            team=self.team,
+            key="flag-a",
+            name="Flag A",
+            filters={
+                "groups": [
+                    {
+                        "properties": [
+                            {"key": "email", "type": "person", "value": "test@example.com", "operator": "exact"}
+                        ],
+                        "rollout_percentage": 100,
+                    }
+                ]
+            },
+        )
+
+        # Create flag B that depends on flag A
+        flag_b = FeatureFlag.objects.create(
+            team=self.team,
+            key="flag-b",
+            name="Flag B",
+            filters={
+                "groups": [
+                    {
+                        "properties": [
+                            {"key": str(flag_a.id), "type": "flag", "value": True, "operator": "flag_evaluates_to"}
+                        ],
+                        "rollout_percentage": 100,
+                    }
+                ]
+            },
+        )
+
+        # Update flag A to depend on flag B (creating a cycle)
+        flag_a.filters = {
+            "groups": [
+                {
+                    "properties": [
+                        {"key": str(flag_b.id), "type": "flag", "value": True, "operator": "flag_evaluates_to"}
+                    ],
+                    "rollout_percentage": 100,
+                }
+            ]
+        }
+        flag_a.save()
+
+        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/local_evaluation")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        self.assertIn("flags", data)
+        self.assertEqual(len(data["flags"]), 2)
+
+        flag_a_data = self._find_flag(data["flags"], "flag-a")
+        flag_b_data = self._find_flag(data["flags"], "flag-b")
+
+        # Check flag A's dependency chain is empty
+        properties_a = flag_a_data["filters"]["groups"][0]["properties"]
+        flag_properties_a = [prop for prop in properties_a if prop["type"] == "flag"]
+        self.assertEqual(len(flag_properties_a), 1)
+        self.assertEqual(flag_properties_a[0]["dependency_chain"], [])
+
+        # Check flag B's dependency chain is empty
+        properties_b = flag_b_data["filters"]["groups"][0]["properties"]
+        flag_properties_b = [prop for prop in properties_b if prop["type"] == "flag"]
+        self.assertEqual(len(flag_properties_b), 1)
+        self.assertEqual(flag_properties_b[0]["dependency_chain"], [])
+
+    def test_flag_dependency_transformation_multiple_dependencies(self):
+        """Test transformation with multiple flag dependencies and transitive dependencies."""
+        # Create base flags
+        flag_a = FeatureFlag.objects.create(
+            team=self.team,
+            key="flag-a",
+            name="Flag A",
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        flag_b = FeatureFlag.objects.create(
+            team=self.team,
+            key="flag-b",
+            name="Flag B",
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        # Create flag C that depends on both A and B
+        flag_c = FeatureFlag.objects.create(
+            team=self.team,
+            key="flag-c",
+            name="Flag C",
+            filters={
+                "groups": [
+                    {
+                        "properties": [
+                            {"key": str(flag_a.id), "type": "flag", "value": True, "operator": "flag_evaluates_to"},
+                            {"key": str(flag_b.id), "type": "flag", "value": True, "operator": "flag_evaluates_to"},
+                            {"key": "email", "type": "person", "value": "test@example.com", "operator": "exact"},
+                        ],
+                        "rollout_percentage": 100,
+                    }
+                ]
+            },
+        )
+
+        # Create flag D that depends on flag C (testing transitive dependencies)
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="flag-d",
+            name="Flag D",
+            filters={
+                "groups": [
+                    {
+                        "properties": [
+                            {"key": str(flag_c.id), "type": "flag", "value": True, "operator": "flag_evaluates_to"},
+                            {"key": "country", "type": "person", "value": "US", "operator": "exact"},
+                        ],
+                        "rollout_percentage": 100,
+                    }
+                ]
+            },
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/local_evaluation")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        flags = data["flags"]
+
+        flag_c_data = self._find_flag(flags, "flag-c")
+
+        properties = flag_c_data["filters"]["groups"][0]["properties"]
+        flag_properties = [prop for prop in properties if prop["type"] == "flag"]
+        self.assertEqual(len(flag_properties), 2)
+
+        flag_keys = {prop["key"] for prop in flag_properties}
+        self.assertEqual(flag_keys, {"flag-a", "flag-b"})
+
+        for prop in flag_properties:
+            self.assertIn("dependency_chain", prop)
+            if prop["key"] == "flag-a":
+                self.assertEqual(prop["dependency_chain"], ["flag-a"])
+            elif prop["key"] == "flag-b":
+                self.assertEqual(prop["dependency_chain"], ["flag-b"])
+
+        flag_d_data = self._find_flag(flags, "flag-d")
+
+        properties_d = flag_d_data["filters"]["groups"][0]["properties"]
+        flag_properties_d = [prop for prop in properties_d if prop["type"] == "flag"]
+        self.assertEqual(len(flag_properties_d), 1)
+        self.assertEqual(flag_properties_d[0]["key"], "flag-c")
+
+        self.assertEqual(flag_properties_d[0]["dependency_chain"], ["flag-a", "flag-b", "flag-c"])
+
+    def test_flag_dependency_transformation_self_dependency(self):
+        """Test transformation handles self-dependency gracefully."""
+        # Create a flag that depends on itself
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="self-flag",
+            name="Self Flag",
+            filters={
+                "groups": [
+                    {
+                        "properties": [
+                            # This flag references itself - should be detected as self-dependency
+                            {"key": "self-flag", "type": "flag", "value": True, "operator": "flag_evaluates_to"},
+                            {"key": "email", "type": "person", "value": "test@example.com", "operator": "exact"},
+                        ],
+                        "rollout_percentage": 100,
+                    }
+                ]
+            },
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/local_evaluation")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        flags = data["flags"]
+
+        self_flag_data = self._find_flag(flags, "self-flag")
+
+        properties = self_flag_data["filters"]["groups"][0]["properties"]
+        flag_properties = [prop for prop in properties if prop["type"] == "flag"]
+        self.assertEqual(len(flag_properties), 1)
+        self.assertEqual(flag_properties[0]["key"], "self-flag")
+
+        self.assertEqual(flag_properties[0]["dependency_chain"], [])
+
+    def test_flag_dependency_transformation_self_referencing_circular_dependency(self):
+        """Test flagA -> flagB -> flagB scenario where flagB references itself."""
+        # Create flag B that references itself
+        flag_b = FeatureFlag.objects.create(
+            team=self.team,
+            key="flag-b",
+            name="Flag B",
+            filters={
+                "groups": [
+                    {
+                        "properties": [
+                            {"key": "flag-b", "type": "flag", "value": True, "operator": "flag_evaluates_to"}
+                        ],
+                        "rollout_percentage": 100,
+                    }
+                ]
+            },
+        )
+
+        # Create flag A that depends on flag B (which has self-dependency)
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="flag-a",
+            name="Flag A",
+            filters={
+                "groups": [
+                    {
+                        "properties": [
+                            {"key": str(flag_b.id), "type": "flag", "value": True, "operator": "flag_evaluates_to"}
+                        ],
+                        "rollout_percentage": 100,
+                    }
+                ]
+            },
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/local_evaluation")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        flags = data["flags"]
+
+        flag_a_data = self._find_flag(flags, "flag-a")
+        flag_b_data = self._find_flag(flags, "flag-b")
+
+        # Flag B should have empty dependency chain due to self-reference
+        properties_b = flag_b_data["filters"]["groups"][0]["properties"]
+        flag_properties_b = [prop for prop in properties_b if prop["type"] == "flag"]
+        self.assertEqual(len(flag_properties_b), 1)
+        self.assertEqual(flag_properties_b[0]["key"], "flag-b")
+        self.assertEqual(flag_properties_b[0]["dependency_chain"], [])
+
+        # Flag A should have empty dependency chain because it depends on flag B which can't be evaluated
+        properties_a = flag_a_data["filters"]["groups"][0]["properties"]
+        flag_properties_a = [prop for prop in properties_a if prop["type"] == "flag"]
+        self.assertEqual(len(flag_properties_a), 1)
+        self.assertEqual(flag_properties_a[0]["key"], "flag-b")
+        self.assertEqual(flag_properties_a[0]["dependency_chain"], [])
+
+    def test_flag_dependency_transformation_missing_dependency(self):
+        """Test that missing flag dependencies result in empty dependency chain."""
+        # Create flag A that references a non-existent flag by ID
+        non_existent_flag_id = "999999"  # ID that doesn't exist
+
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="flag-a",
+            name="Flag A",
+            filters={
+                "groups": [
+                    {
+                        "properties": [
+                            {
+                                "key": non_existent_flag_id,
+                                "type": "flag",
+                                "value": True,
+                                "operator": "flag_evaluates_to",
+                            },
+                            {"key": "email", "type": "person", "value": "test@example.com", "operator": "exact"},
+                        ],
+                        "rollout_percentage": 100,
+                    }
+                ]
+            },
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/local_evaluation")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        flags = data["flags"]
+
+        flag_a_data = self._find_flag(flags, "flag-a")
+
+        properties = flag_a_data["filters"]["groups"][0]["properties"]
+        flag_properties = [prop for prop in properties if prop["type"] == "flag"]
+        self.assertEqual(len(flag_properties), 1)
+
+        # The key should remain as the original ID since it can't be resolved
+        self.assertEqual(flag_properties[0]["key"], non_existent_flag_id)
+
+        # Dependency chain should be empty because the referenced flag doesn't exist
+        self.assertEqual(flag_properties[0]["dependency_chain"], [])
+
+    def test_flag_dependency_transformation_shared_dependencies(self):
+        """Test that shared dependencies are handled correctly and efficiently."""
+        # Create a base flag that will be shared by multiple other flags
+        shared_flag = FeatureFlag.objects.create(
+            team=self.team,
+            key="shared-dependency",
+            name="Shared Dependency",
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        # Create multiple flags that all depend on the same shared flag
+        dependent_flags = []
+        for i in range(5):  # Create 5 flags that depend on the shared flag
+            flag = FeatureFlag.objects.create(
+                team=self.team,
+                key=f"dependent-flag-{i}",
+                name=f"Dependent Flag {i}",
+                filters={
+                    "groups": [
+                        {
+                            "properties": [
+                                {
+                                    "key": str(shared_flag.id),
+                                    "type": "flag",
+                                    "value": True,
+                                    "operator": "flag_evaluates_to",
+                                }
+                            ],
+                            "rollout_percentage": 100,
+                        }
+                    ]
+                },
+            )
+            dependent_flags.append(flag)
+
+        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/local_evaluation")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        flags = data["flags"]
+
+        # Verify that all dependent flags have the correct dependency chain
+        for i, _flag in enumerate(dependent_flags):
+            flag_data = self._find_flag(flags, f"dependent-flag-{i}")
+            properties = flag_data["filters"]["groups"][0]["properties"]
+            flag_properties = [prop for prop in properties if prop["type"] == "flag"]
+
+            self.assertEqual(len(flag_properties), 1)
+            self.assertEqual(flag_properties[0]["key"], "shared-dependency")
+            self.assertEqual(flag_properties[0]["dependency_chain"], ["shared-dependency"])
+
+        # This test demonstrates that:
+        # 1. The shared dependency chain is built once and reused
+        # 2. All flags referencing the same dependency get the same chain
+        # 3. The optimization correctly handles multiple flags with shared dependencies

--- a/posthog/models/feature_flag/local_evaluation.py
+++ b/posthog/models/feature_flag/local_evaluation.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 import structlog
-import logging
 from typing import Any, cast, Union
 from collections.abc import Generator
 
@@ -270,9 +269,7 @@ def _transform_flag_property_dependencies(flags_data: list[dict[str, Any]], pars
     return flags_data
 
 
-def _apply_flag_dependency_transformation(
-    response_data: dict[str, Any], parsed_flags: list, logger: logging.Logger
-) -> None:
+def _apply_flag_dependency_transformation(response_data: dict[str, Any], parsed_flags: list) -> None:
     """
     Apply flag dependency transformation to response data.
 
@@ -282,7 +279,6 @@ def _apply_flag_dependency_transformation(
     Args:
         response_data: The response data containing flags to transform
         parsed_flags: The original parsed feature flags for ID-to-key mapping
-        logger: Logger instance for recording transformation results
     """
     try:
         flags_list = cast(list[dict[str, Any]], response_data["flags"])
@@ -450,7 +446,7 @@ def _get_flags_response_for_local_evaluation(team: Team, include_cohorts: bool) 
     }
 
     # Transform flag dependencies for simplified client-side evaluation
-    _apply_flag_dependency_transformation(response_data, flags, logger)
+    _apply_flag_dependency_transformation(response_data, flags)
 
     return response_data
 

--- a/posthog/models/feature_flag/local_evaluation.py
+++ b/posthog/models/feature_flag/local_evaluation.py
@@ -2,6 +2,11 @@ from django.conf import settings
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 import structlog
+import logging
+from typing import Any, cast, Union
+from collections.abc import Generator
+
+from posthog.models.feature_flag.types import FlagProperty, FlagFilters
 
 from django.db.models import Q
 from django.db import transaction
@@ -13,6 +18,283 @@ from posthog.models.team import Team
 from posthog.storage.hypercache import HyperCache
 
 logger = structlog.get_logger(__name__)
+
+
+def _get_properties_from_filters(
+    filters: Union[dict, FlagFilters], property_type: str | None = None
+) -> Generator[FlagProperty, None, None]:
+    """
+    Extract properties from filters by iterating through groups.
+
+    Args:
+        filters: The filters dictionary containing groups
+        property_type: Optional filter by property type (e.g., 'flag', 'cohort')
+
+    Yields:
+        Property dictionaries matching the criteria
+    """
+    for group in filters.get("groups", []):
+        for prop in group.get("properties", []):
+            if property_type is None or prop.get("type") == property_type:
+                yield prop
+
+
+def _get_flag_properties_from_filters(filters: Union[dict, FlagFilters]) -> Generator[FlagProperty, None, None]:
+    """Extract flag properties from filters."""
+    return _get_properties_from_filters(filters, "flag")
+
+
+def _resolve_flag_dependency_key(flag_prop: FlagProperty, flag_id_to_key: dict[str, str]) -> str:
+    """
+    Convert flag property reference to flag key.
+    Handles both flag IDs and flag keys as references.
+    """
+    flag_reference = flag_prop.get("key", "")
+    return flag_id_to_key.get(flag_reference, flag_reference)
+
+
+def _build_flag_id_to_key_mapping(flags) -> dict[str, str]:
+    """Build mapping from flag ID to flag key for dependency transformation."""
+    return {str(flag.id): flag.key for flag in flags}
+
+
+class _DependencyChainBuilder:
+    """
+    Internal class for building flag dependency chains using topological sorting.
+
+    Encapsulates the complex DFS logic and state management needed for dependency chain
+    computation while providing memoization for performance.
+    """
+
+    def __init__(self, all_flags: dict[str, Any]):
+        self.all_flags = all_flags
+        self.memo: dict[str, list[str]] = {}
+
+    def build_chain(self, flag_key: str) -> list[str]:
+        """
+        Build the dependency chain for a single flag using topological sorting.
+        Returns a list of flag keys in the order they should be evaluated.
+
+        Handles circular dependencies by detecting cycles and logging warnings.
+        When a cycle is detected, returns an empty array since the flag cannot be safely evaluated.
+        """
+        if flag_key in self.memo:
+            return self.memo[flag_key]
+
+        if self._has_self_dependency(flag_key):
+            logger.warning(
+                "Self-dependency detected in feature flag",
+                extra={"flag_key": flag_key},
+            )
+            self.memo[flag_key] = []
+            return []
+
+        # Build the chain using DFS
+        visited: set[str] = set()
+        temp_visited: set[str] = set()
+        chain: list[str] = []
+
+        if not self._dfs(flag_key, visited, temp_visited, chain):
+            logger.warning(
+                "Flag cannot be evaluated due to circular dependencies or missing dependencies",
+                extra={"flag_key": flag_key},
+            )
+            self.memo[flag_key] = []
+            return []
+
+        self.memo[flag_key] = chain
+        return chain
+
+    def _has_self_dependency(self, flag_key: str) -> bool:
+        """Check if a flag has a direct self-dependency."""
+        flag_data = self.all_flags.get(flag_key)
+        if not flag_data:
+            return False
+
+        filters = flag_data.get("filters", {})
+        for flag_prop in _get_flag_properties_from_filters(filters):
+            dep_flag_key = flag_prop["key"]  # Already normalized to key
+            if dep_flag_key == flag_key:
+                return True
+        return False
+
+    def _dfs(self, current_key: str, visited: set[str], temp_visited: set[str], chain: list[str]) -> bool:
+        """
+        Depth-first search to build dependency chain with cycle detection.
+
+        Returns False if a cycle or missing dependency is detected, True otherwise.
+        """
+        if current_key in temp_visited:
+            logger.warning(
+                "Circular dependency detected in feature flags",
+                extra={"circular_at": current_key},
+            )
+            return False
+
+        if current_key in visited:
+            return True
+
+        temp_visited.add(current_key)
+
+        if not self._validate_flag_exists(current_key):
+            return False
+
+        if not self._validate_all_dependencies_for_flag(current_key, visited, temp_visited, chain):
+            return False
+
+        temp_visited.remove(current_key)
+        visited.add(current_key)
+        chain.append(current_key)
+        return True
+
+    def _validate_flag_exists(self, flag_key: str) -> bool:
+        """Validate that a flag exists in the flags collection."""
+        if flag_key not in self.all_flags:
+            logger.warning(
+                "Attempting to build dependency chain for non-existent flag",
+                extra={"flag_key": flag_key},
+            )
+            return False
+        return True
+
+    def _validate_all_dependencies_for_flag(
+        self, current_key: str, visited: set[str], temp_visited: set[str], chain: list[str]
+    ) -> bool:
+        """Validates all dependencies of the current flag."""
+        current_flag = self.all_flags.get(current_key)
+        if not current_flag:
+            return False
+
+        filters = current_flag.get("filters", {})
+        for flag_prop in _get_flag_properties_from_filters(filters):
+            dep_flag_key = flag_prop["key"]  # Already normalized to key
+            if dep_flag_key != current_key:  # Avoid self-dependency
+                if not self._validate_dependency(dep_flag_key, current_key, visited, temp_visited, chain):
+                    return False
+        return True
+
+    def _validate_dependency(
+        self, dep_flag_key: str, current_key: str, visited: set[str], temp_visited: set[str], chain: list[str]
+    ) -> bool:
+        """Validates the dependency exists and recursively checks for cycles"""
+        # Validate the dependency exists
+        if dep_flag_key not in self.all_flags:
+            logger.warning(
+                "Flag dependency references non-existent flag",
+                extra={"flag": current_key, "missing_dependency": dep_flag_key},
+            )
+            return False
+
+        # Recursively process the dependency
+        if not self._dfs(dep_flag_key, visited, temp_visited, chain):
+            return False
+
+        return True
+
+
+def _normalize_and_collect_dependency_target_keys(
+    flags_data: list[dict[str, Any]], flag_id_to_key: dict[str, str]
+) -> tuple[list[dict[str, Any]], set[str]]:
+    """
+    Normalize flag properties and collect dependency target keys.
+
+    Args:
+        flags_data: List of flag data dictionaries to process
+        flag_id_to_key: Mapping from flag IDs to flag keys
+
+    Returns:
+        tuple: (normalized_flags_data, unique_dependency_target_keys)
+    """
+    unique_dependencies = set()
+
+    for flag_data in flags_data:
+        filters = flag_data.get("filters", {})
+        for flag_prop in _get_flag_properties_from_filters(filters):
+            # Transform flag ID to flag key
+            flag_key = _resolve_flag_dependency_key(flag_prop, flag_id_to_key)
+            flag_prop["key"] = flag_key
+            # Collect unique dependency at the same time
+            unique_dependencies.add(flag_key)
+
+    return flags_data, unique_dependencies
+
+
+def _build_all_dependency_chains(
+    flags_data: list[dict[str, Any]], unique_dependencies: set[str]
+) -> list[dict[str, Any]]:
+    """
+    Final pass: Build dependency chains for all flag properties using pre-collected dependencies.
+    Assumes flag IDs have already been normalized to keys and dependencies collected.
+    Uses optimized batch processing with memoization to avoid rebuilding chains for shared dependencies.
+    """
+    if not unique_dependencies:
+        return flags_data
+
+    all_flags_by_key = {flag["key"]: flag for flag in flags_data}
+
+    builder = _DependencyChainBuilder(all_flags_by_key)
+
+    for dep_key in unique_dependencies:
+        # This will populate the builder's cache
+        builder.build_chain(dep_key)
+
+    for flag_data in flags_data:
+        filters = flag_data.get("filters", {})
+
+        for flag_prop in _get_flag_properties_from_filters(filters):
+            flag_key = flag_prop["key"]
+
+            dependency_chain = builder.build_chain(flag_key)
+
+            # The dependency chain represents the order in which flags should be evaluated
+            # It includes the target flag and its dependencies in topological order
+            # Always add the dependency_chain property, even if empty (for self-dependencies, missing dependencies, etc.)
+            flag_prop["dependency_chain"] = dependency_chain
+
+    return flags_data
+
+
+def _transform_flag_property_dependencies(flags_data: list[dict[str, Any]], parsed_flags: list) -> list[dict[str, Any]]:
+    """
+    Transform flag properties in filter conditions to include dependency chains.
+    Uses an optimized two-pass approach:
+    1. Normalize flag IDs to keys and collect unique dependency target keys in single pass
+    2. Build dependency chains for collected dependency targets using batch processing
+    """
+    flag_id_to_key = _build_flag_id_to_key_mapping(parsed_flags)
+
+    flags_data, unique_dependencies = _normalize_and_collect_dependency_target_keys(flags_data, flag_id_to_key)
+
+    flags_data = _build_all_dependency_chains(flags_data, unique_dependencies)
+
+    return flags_data
+
+
+def _apply_flag_dependency_transformation(
+    response_data: dict[str, Any], parsed_flags: list, logger: logging.Logger
+) -> None:
+    """
+    Apply flag dependency transformation to response data.
+
+    This method transforms flag properties in filter conditions to include dependency chains,
+    enabling simple client-side evaluation without complex graph construction.
+
+    Args:
+        response_data: The response data containing flags to transform
+        parsed_flags: The original parsed feature flags for ID-to-key mapping
+        logger: Logger instance for recording transformation results
+    """
+    try:
+        flags_list = cast(list[dict[str, Any]], response_data["flags"])
+        response_data["flags"] = _transform_flag_property_dependencies(flags_list, parsed_flags)
+
+        logger.info("Flag dependency transformation completed")
+    except Exception as e:
+        logger.warning(
+            "Flag dependency transformation failed, proceeding without transformation",
+            extra={"error": str(e)},
+        )
+
 
 DATABASE_FOR_LOCAL_EVALUATION = (
     "default"
@@ -151,7 +433,7 @@ def _get_flags_for_local_evaluation(team: Team, include_cohorts: bool = True) ->
     return feature_flags, cohorts
 
 
-def _get_flags_response_for_local_evaluation(team: Team, include_cohorts: bool) -> dict:
+def _get_flags_response_for_local_evaluation(team: Team, include_cohorts: bool) -> dict[str, Any]:
     from posthog.api.feature_flag import MinimalFeatureFlagSerializer
 
     flags, cohorts = _get_flags_for_local_evaluation(team, include_cohorts)
@@ -166,6 +448,10 @@ def _get_flags_response_for_local_evaluation(team: Team, include_cohorts: bool) 
         },
         "cohorts": cohorts,
     }
+
+    # Transform flag dependencies for simplified client-side evaluation
+    _apply_flag_dependency_transformation(response_data, flags, logger)
+
     return response_data
 
 

--- a/posthog/models/feature_flag/local_evaluation.py
+++ b/posthog/models/feature_flag/local_evaluation.py
@@ -5,7 +5,7 @@ import structlog
 from typing import Any, cast, Union
 from collections.abc import Generator
 
-from posthog.models.feature_flag.types import FlagProperty, FlagFilters
+from posthog.models.feature_flag.types import FlagProperty, FlagFilters, PropertyFilterType
 
 from django.db.models import Q
 from django.db import transaction
@@ -40,7 +40,7 @@ def _get_properties_from_filters(
 
 def _get_flag_properties_from_filters(filters: Union[dict, FlagFilters]) -> Generator[FlagProperty, None, None]:
     """Extract flag properties from filters."""
-    return _get_properties_from_filters(filters, "flag")
+    return _get_properties_from_filters(filters, PropertyFilterType.FLAG)
 
 
 def _resolve_flag_dependency_key(flag_prop: FlagProperty, flag_id_to_key: dict[str, str]) -> str:

--- a/posthog/models/feature_flag/types.py
+++ b/posthog/models/feature_flag/types.py
@@ -1,0 +1,41 @@
+"""Type definitions for feature flag data structures."""
+
+from typing import Any, TypedDict
+
+
+class FlagProperty(TypedDict, total=False):
+    """Property within a feature flag filter group."""
+
+    key: str
+    type: str
+    value: Any
+    operator: str
+    dependency_chain: list[str]  # Optional: only present for flag dependencies
+
+
+class FilterGroup(TypedDict):
+    """Filter group within a feature flag."""
+
+    properties: list[FlagProperty]
+    rollout_percentage: float
+
+
+class FlagFilters(TypedDict):
+    """Filter configuration for a feature flag."""
+
+    groups: list[FilterGroup]
+
+
+class FlagData(TypedDict):
+    """Complete feature flag data structure."""
+
+    key: str
+    filters: FlagFilters
+
+
+class FlagResponse(TypedDict):
+    """Response structure for local evaluation endpoint."""
+
+    flags: list[FlagData]
+    group_type_mapping: dict[str, str]
+    cohorts: dict[str, dict[str, Any]]

--- a/posthog/models/feature_flag/types.py
+++ b/posthog/models/feature_flag/types.py
@@ -1,6 +1,16 @@
 """Type definitions for feature flag data structures."""
 
+from enum import StrEnum
 from typing import Any, TypedDict
+
+
+class PropertyFilterType(StrEnum):
+    """Enum for property filter types used in feature flag filtering."""
+
+    FLAG = "flag"
+    COHORT = "cohort"
+    PERSON = "person"
+    GROUP = "group"
 
 
 class FlagProperty(TypedDict, total=False):


### PR DESCRIPTION
This implements server-side transformation of feature flag dependencies to simplify client-side evaluation. Instead of complex dependency graph logic on clients, the server now provides dependency chains for sequential evaluation.

## Problem

Now that flags can depend on other flags, evaluating flags requires complex dependency logic such as topological sorting so we can evaluate dependencies before we evaluate the flags that depend on them.

Rather than have every SDK implement this logic, we could transform the flags to make local evaluation simpler.

## Changes

### Before: Complex Client-Side Dependency Logic

Without transformation, clients receive raw flag dependency references and must implement complex graph traversal:

```json
{
  "key": "premium-feature",
  "filters": {
    "groups": [{
      "properties": [
        {
          "key": "123",  // Flag ID reference
          "type": "flag",
          "value": true,
          "operator": "flag_evaluates_to"
        }
      ]
    }]
  }
}
```

Clients would need to:
- Resolve flag ID "123" to the actual flag key
- Build dependency graphs using DFS/topological sorting  
- Handle circular dependencies
- Implement memoization for shared dependencies

### After: Simple Sequential Evaluation

With server-side transformation, clients receive pre-computed dependency chains:

```json
{
  "key": "premium-feature", 
  "filters": {
    "groups": [{
      "properties": [
        {
          "key": "basic-access",  // Normalized to flag key
          "type": "flag",
          "value": true,
          "operator": "flag_evaluates_to",
          "dependency_chain": ["user-verified", "basic-access"]  // Pre-computed order
        }
      ]
    }]
  }
}
```

Clients now simply:
1. Iterate through the `dependency_chain` array in order
2. Evaluate each flag sequentially: `user-verified` → `basic-access`
3. If any dependency is false, the whole chain fails
4. Empty `dependency_chain: []` indicates circular dependency (evaluate as false)

### Key Improvements

- **Eliminates complex graph algorithms** from client SDKs
- **Handles circular dependencies** safely (empty chain = false)
- **Normalizes flag references** from IDs to keys
- **Optimizes shared dependencies** with server-side memoization
- **Reduces client complexity** to simple array iteration

> [!NOTE]
> We should never be in a situation with missing or circular dependencies because we try our best to prevent them. But just in case, we want local evaluation to handle it.

### SDK Integration

SDKs should implement dependency evaluation like this:

```typescript
function evaluateFlagDependency(property: FlagProperty): boolean {
  const dependencyChain = property.dependency_chain || [];
  
  // Handle circular or missing dependency
  if (dependencyChain.length === 0) {
    return false;
  }
  
  // Evaluate dependencies in order
  for (const flagKey of dependencyChain) {
    if (!evaluateFlag(flagKey)) {
      return false; // Stop on first failure
    }
  }
  
  return true;
}
```

## How did you test this code?

Unit tests and manual testing

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._