### PR TITLE
chore(experiments): Fix empty parameter error in timeseries window functions

### DIFF
--- a/posthog/hogql_queries/experiments/experiment_timeseries.py
+++ b/posthog/hogql_queries/experiments/experiment_timeseries.py
@@ -353,7 +353,15 @@ class ExperimentTimeseries:
                     alias="num_users",
                     expr=ast.WindowFunction(
                         name="sum",
-                        args=[ast.Field(chain=["combined_daily", "daily_new_users"])],
+                        args=[
+                            ast.Call(
+                                name="coalesce",
+                                args=[
+                                    ast.Field(chain=["combined_daily", "daily_new_users"]),
+                                    ast.Constant(value=0),
+                                ],
+                            )
+                        ],
                         over_expr=ast.WindowExpr(
                             partition_by=[ast.Field(chain=["combined_daily", "variant"])],
                             order_by=[ast.OrderExpr(expr=ast.Field(chain=["combined_daily", "date"]))],
@@ -373,7 +381,15 @@ class ExperimentTimeseries:
                     alias="total_sum",
                     expr=ast.WindowFunction(
                         name="sum",
-                        args=[ast.Field(chain=["combined_daily", "daily_metric_sum"])],
+                        args=[
+                            ast.Call(
+                                name="coalesce",
+                                args=[
+                                    ast.Field(chain=["combined_daily", "daily_metric_sum"]),
+                                    ast.Constant(value=0),
+                                ],
+                            )
+                        ],
                         over_expr=ast.WindowExpr(
                             partition_by=[ast.Field(chain=["combined_daily", "variant"])],
                             order_by=[ast.OrderExpr(expr=ast.Field(chain=["combined_daily", "date"]))],
@@ -393,7 +409,15 @@ class ExperimentTimeseries:
                     alias="total_sum_of_squares",
                     expr=ast.WindowFunction(
                         name="sum",
-                        args=[ast.Field(chain=["combined_daily", "daily_sum_of_squares"])],
+                        args=[
+                            ast.Call(
+                                name="coalesce",
+                                args=[
+                                    ast.Field(chain=["combined_daily", "daily_sum_of_squares"]),
+                                    ast.Constant(value=0),
+                                ],
+                            )
+                        ],
                         over_expr=ast.WindowExpr(
                             partition_by=[ast.Field(chain=["combined_daily", "variant"])],
                             order_by=[ast.OrderExpr(expr=ast.Field(chain=["combined_daily", "date"]))],


### PR DESCRIPTION
## Problem
Experiments timeseries in production are failing with ClickHouse error "Parameters list to aggregate functions cannot be empty" in the timeseries calculation. Example: https://posthog.dagster.cloud/prod-us/runs/df7917cc-1163-4fe4-b313-dec1b83c2500

## Changes
Added defensive `coalesce()` calls around window function arguments in `_get_cumulative_timeseries_query` to ensure they never receive null values from FULL OUTER JOIN operations.

I suspect the error happens when FULL OUTER JOINs produce null values that get passed to window functions, but unfortunately I couldn't reproduce this exact scenario in tests. This should be safe as this is just a defensive fix which doesn't change the query logic and the existing tests are passing.