### PR TITLE
Refactored events pagination to offset based.

### DIFF
--- a/posthog/api/test/__snapshots__/test_event.ambr
+++ b/posthog/api/test/__snapshots__/test_event.ambr
@@ -131,21 +131,6 @@
                     allow_experimental_join_condition=1
   '''
 # ---
-# name: TestEvents.test_event_property_values.7
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
-  FROM events
-  WHERE team_id = 99999
-    AND JSONHas(properties, 'random_prop')
-    AND timestamp >= '2020-01-13 00:00:00'
-    AND timestamp <= '2020-01-20 23:59:59'
-    AND (event = '404_i_dont_exist')
-    AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%qw%'
-  order by length(replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', ''))
-  LIMIT 10
-  '''
-# ---
 # name: TestEvents.test_event_property_values_materialized
   '''
   /* user_id:0 request:_snapshot_ */
@@ -276,20 +261,5 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1
-  '''
-# ---
-# name: TestEvents.test_event_property_values_materialized.7
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT DISTINCT "mat_random_prop"
-  FROM events
-  WHERE team_id = 99999
-    AND notEmpty("mat_random_prop")
-    AND timestamp >= '2020-01-13 00:00:00'
-    AND timestamp <= '2020-01-20 23:59:59'
-    AND (event = '404_i_dont_exist')
-    AND "mat_random_prop" ILIKE '%qw%'
-  order by length("mat_random_prop")
-  LIMIT 10
   '''
 # ---

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -470,7 +470,7 @@ FROM
     events
 where team_id = %(team_id)s
 {conditions}
-ORDER BY timestamp {order} {limit}
+ORDER BY timestamp {order}, uuid {order} {limit}
 """
 
 SELECT_EVENT_BY_TEAM_AND_CONDITIONS_FILTERS_SQL = """
@@ -488,7 +488,7 @@ WHERE
 team_id = %(team_id)s
 {conditions}
 {filters}
-ORDER BY timestamp {order} {limit}
+ORDER BY timestamp {order}, uuid {order} {limit}
 """
 
 SELECT_ONE_EVENT_SQL = """


### PR DESCRIPTION
## Problem
Events API skips records when paginating through events with duplicate timestamps.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
Closes #34143

## Changes
 - Switched from timestamp-based (before/after) to offset-based pagination
  - Added UUID as secondary sort key for deterministic ordering
  - Replaced custom `_build_next_url` with `format_paginated_url` utility
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
- Added test test_pagination_with_duplicate_timestamps that verifies all 25 events
  (including 15 with identical timestamps) are returned without duplication
- Updated existing pagination tests to validate offset-based approach

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
