### PR TITLE
fix(activity-logs): Fix UploadedMedia serialization on Org logs

### DIFF
--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -470,7 +470,7 @@ def safely_get_field_value(instance: models.Model | None, field: str):
             # Only fetch the actual object if we have a valid ID
             related_model = field_obj.related_model
             if isinstance(related_model, type) and issubclass(related_model, models.Model):
-                return related_model.objects.get(pk=field_id)  # type: ignore[union-attr]
+                return related_model.objects.get(pk=field_id)  # type: ignore[attr-defined]
             else:
                 return field_id
 

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -10,7 +10,7 @@ from django.dispatch.dispatcher import receiver
 from posthog.exceptions_capture import capture_exception
 import structlog
 from django.core.paginator import Paginator
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist, FieldDoesNotExist
 from django.db import transaction
 
 from django.db import models
@@ -148,6 +148,11 @@ class ActivityDetailEncoder(json.JSONEncoder):
                 "id": obj.id,
                 "name": obj.name,
                 "team_id": obj.team_id,
+            }
+        if hasattr(obj, "__class__") and obj.__class__.__name__ == "UploadedMedia":
+            return {
+                "id": obj.id,
+                "media_location": obj.media_location,
             }
 
         return json.JSONEncoder.default(self, obj)
@@ -449,16 +454,33 @@ def safely_get_field_value(instance: models.Model | None, field: str):
     """Helper function to get the value of a field, handling related objects and exceptions."""
     if instance is None:
         return None
+
     try:
+        field_obj = instance._meta.get_field(field)
+
+        # For ForeignKey/OneToOneField, always access the ID first to avoid lazy loading
+        # throwing malformed UUID validation errors
+        if isinstance(field_obj, models.ForeignKey | models.OneToOneField):
+            field_id = getattr(instance, f"{field}_id", None)
+            if field_id is None:
+                return None
+            # Ensure field_id is actually an ID, not the object itself
+            if hasattr(field_id, "pk"):
+                field_id = field_id.pk
+            # Only fetch the actual object if we have a valid ID
+            return field_obj.related_model.objects.get(pk=field_id)
+
+        # For other fields, use normal access
         value = getattr(instance, field, None)
         if isinstance(value, models.Manager):
             value = _read_through_relation(value)
+        return value
+
     # If the field is a related field and the related object has been deleted, this will raise an ObjectDoesNotExist
     # exception. We catch this exception and return None, since the related object has been deleted, and we
     # don't need any additional information about it other than the fact that it was deleted.
-    except ObjectDoesNotExist:
-        value = None
-    return value
+    except (ObjectDoesNotExist, FieldDoesNotExist):
+        return None
 
 
 def changes_between(

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -468,7 +468,11 @@ def safely_get_field_value(instance: models.Model | None, field: str):
             if hasattr(field_id, "pk"):
                 field_id = field_id.pk
             # Only fetch the actual object if we have a valid ID
-            return field_obj.related_model.objects.get(pk=field_id)
+            related_model = field_obj.related_model
+            if isinstance(related_model, type) and issubclass(related_model, models.Model):
+                return related_model.objects.get(pk=field_id)  # type: ignore[union-attr]
+            else:
+                return field_id
 
         # For other fields, use normal access
         value = getattr(instance, field, None)


### PR DESCRIPTION
## Problem

Dump from Grafana
```
{"request_id": "a711f713-411b-4ed5-8675-c22b858f0df3", "ip": "129.208.1.27", "event_id": "115b2296-d9af-4365-b293-64f410a54357", "event": "ValidationError(['\u201cUploadedMedia object (0198ad92-7e32-0000-346f-5ba71674fd76)\u201d is not a valid UUID.'])", "host": "us.posthog.com", "team_id": 195311, "container_hostname": "posthog-web-django-85fc9b9454-pxcww", "x_forwarded_for": "129.208.1.27,10.0.43.173", "timestamp": "2025-08-15T11:52:00.208502Z", "logger": "posthog.exceptions_capture", "level": "error", "pid": 309, "tid": 281462787731296, "exception": "Traceback (most recent call last):\n  File \"/python-runtime/lib/python3.11/site-packages/django/db/models/fields/related_descriptors.py\", line 218, in __get__\n    rel_obj = self.field.get_cached_value(instance)\n              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/python-runtime/lib/python3.11/site-packages/django/db/models/fields/mixins.py\", line 15, in get_cached_value\n    return instance._state.fields_cache[cache_name]\n           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^\nKeyError: 'logo_media'\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/python-runtime/lib/python3.11/site-packages/django/db/models/fields/__init__.py\", line 2688, in to_python\n    return uuid.UUID(**{input_form: value})\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.11/uuid.py\", line 175, in __init__\n    hex = hex.replace('urn:', '').replace('uuid:', '')\n          ^^^^^^^^^^^\nAttributeError: 'UploadedMedia' object has no attribute 'replace'\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/python-runtime/lib/python3.11/site-packages/rest_framework/views.py\", line 506, in dispatch\n    response = handler(request, *args, **kwargs)\n               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/python-runtime/lib/python3.11/site-packages/rest_framework/mixins.py\", line 82, in partial_update\n    return self.update(request, *args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/code/posthog/api/organization.py\", line 316, in update\n    return super().update(request, *args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/python-runtime/lib/python3.11/site-packages/rest_framework/mixins.py\", line 68, in update\n    self.perform_update(serializer)\n  File \"/python-runtime/lib/python3.11/site-packages/rest_framework/mixins.py\", line 78, in perform_update\n    serializer.save()\n  File \"/python-runtime/lib/python3.11/site-packages/rest_framework/serializers.py\", line 203, in save\n    self.instance = self.update(self.instance, validated_data)\n                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/python-runtime/lib/python3.11/site-packages/rest_framework/serializers.py\", line 1033, in update\n    instance.save()\n  File \"/code/posthog/models/activity_logging/model_activity.py\", line 47, in save\n    model_activity_signal.send(\n  File \"/python-runtime/lib/python3.11/site-packages/django/dispatch/dispatcher.py\", line 176, in send\n    return [\n           ^\n  File \"/python-runtime/lib/python3.11/site-packages/django/dispatch/dispatcher.py\", line 177, in <listcomp>\n    (receiver, receiver(signal=self, sender=sender, **named))\n               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/code/posthog/api/organization.py\", line 428, in handle_organization_change\n    changes=changes_between(scope, previous=before_update, current=after_update),\n            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/code/posthog/models/activity_logging/activity_log.py\", line 490, in changes_between\n    right = safely_get_field_value(current, field_name)\n            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/code/posthog/models/activity_logging/activity_log.py\", line 453, in safely_get_field_value\n    value = getattr(instance, field, None)\n            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/python-runtime/lib/python3.11/site-packages/django/db/models/fields/related_descriptors.py\", line 236, in __get__\n    rel_obj = self.get_object(instance)\n              ^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/python-runtime/lib/python3.11/site-packages/django/db/models/fields/related_descriptors.py\", line 199, in get_object\n    return qs.get(self.field.get_reverse_related_filter(instance))\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/python-runtime/lib/python3.11/site-packages/django/db/models/query.py\", line 623, in get\n    clone = self._chain() if self.query.combinator else self.filter(*args, **kwargs)\n                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/python-runtime/lib/python3.11/site-packages/django/db/models/query.py\", line 1436, in filter\n    return self._filter_or_exclude(False, args, kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/python-runtime/lib/python3.11/site-packages/django/db/models/query.py\", line 1454, in _filter_or_exclude\n    clone._filter_or_exclude_inplace(negate, args, kwargs)\n  File \"/python-runtime/lib/python3.11/site-packages/django/db/models/query.py\", line 1461, in _filter_or_exclude_inplace\n    self._query.add_q(Q(*args, **kwargs))\n  File \"/python-runtime/lib/python3.11/site-packages/django/db/models/sql/query.py\", line 1546, in add_q\n    clause, _ = self._add_q(q_object, self.used_aliases)\n                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/python-runtime/lib/python3.11/site-packages/django/db/models/sql/query.py\", line 1577, in _add_q\n    child_clause, needed_inner = self.build_filter(\n                                 ^^^^^^^^^^^^^^^^^^\n  File \"/python-runtime/lib/python3.11/site-packages/django/db/models/sql/query.py\", line 1405, in build_filter\n    return self._add_q(\n           ^^^^^^^^^^^^\n  File \"/python-runtime/lib/python3.11/site-packages/django/db/models/sql/query.py\", line 1577, in _add_q\n    child_clause, needed_inner = self.build_filter(\n                                 ^^^^^^^^^^^^^^^^^^\n  File \"/python-runtime/lib/python3.11/site-packages/django/db/models/sql/query.py\", line 1492, in build_filter\n    condition = self.build_lookup(lookups, col, value)\n                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/python-runtime/lib/python3.11/site-packages/django/db/models/sql/query.py\", line 1319, in build_lookup\n    lookup = lookup_class(lhs, rhs)\n             ^^^^^^^^^^^^^^^^^^^^^^\n  File \"/python-runtime/lib/python3.11/site-packages/django/db/models/lookups.py\", line 27, in __init__\n    self.rhs = self.get_prep_lookup()\n               ^^^^^^^^^^^^^^^^^^^^^^\n  File \"/python-runtime/lib/python3.11/site-packages/django/db/models/lookups.py\", line 341, in get_prep_lookup\n    return super().get_prep_lookup()\n           ^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/python-runtime/lib/python3.11/site-packages/django/db/models/lookups.py\", line 85, in get_prep_lookup\n    return self.lhs.output_field.get_prep_value(self.rhs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/python-runtime/lib/python3.11/site-packages/django/db/models/fields/__init__.py\", line 2672, in get_prep_value\n    return self.to_python(value)\n           ^^^^^^^^^^^^^^^^^^^^^\n  File \"/python-runtime/lib/python3.11/site-packages/django/db/models/fields/__init__.py\", line 2690, in to_python\n    raise exceptions.ValidationError(\ndjango.core.exceptions.ValidationError: ['\u201cUploadedMedia object (0198ad92-7e32-0000-346f-5ba71674fd76)\u201d is not a valid UUID.']"}
```

## Changes

- Fix a bug where a field which was expected to be a UUID type returns the whole object.

## How did you test this code?

- Integration test

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
