### PR TITLE
feat(activity-logs): Batch import/export activity logging

### DIFF
--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
@@ -19,6 +19,8 @@ import { alertConfigurationActivityDescriber } from 'scenes/alerts/activityDescr
 import { annotationActivityDescriber } from 'scenes/annotations/activityDescriptions'
 import { cohortActivityDescriber } from 'scenes/cohorts/activityDescriptions'
 import { dataManagementActivityDescriber } from 'scenes/data-management/dataManagementDescribers'
+import { batchExportActivityDescriber } from 'scenes/data-pipelines/batch-exports/activityDescriptions'
+import { batchImportActivityDescriber } from 'scenes/data-pipelines/batch-imports/activityDescriptions'
 import { dataWarehouseSavedQueryActivityDescriber } from 'scenes/data-warehouse/saved_queries/activityDescriptions'
 import { experimentActivityDescriber } from 'scenes/experiments/experimentActivityDescriber'
 import { flagActivityDescriber } from 'scenes/feature-flags/activityDescriptions'
@@ -99,6 +101,10 @@ export const describerFor = (logItem?: ActivityLogItem): Describer | undefined =
             return alertConfigurationActivityDescriber
         case ActivityScope.ANNOTATION:
             return annotationActivityDescriber
+        case ActivityScope.BATCH_EXPORT:
+            return batchExportActivityDescriber
+        case ActivityScope.BATCH_IMPORT:
+            return batchImportActivityDescriber
         case ActivityScope.FEATURE_FLAG:
             return flagActivityDescriber
         case ActivityScope.PLUGIN:

--- a/frontend/src/lib/components/ActivityLog/humanizeActivity.tsx
+++ b/frontend/src/lib/components/ActivityLog/humanizeActivity.tsx
@@ -133,6 +133,7 @@ const NO_PLURAL_SCOPES: ActivityScope[] = [
 
 const SCOPE_DISPLAY_NAMES: Partial<Record<ActivityScope, { singular: string; plural: string }>> = {
     [ActivityScope.ALERT_CONFIGURATION]: { singular: 'Alert', plural: 'Alerts' },
+    [ActivityScope.BATCH_EXPORT]: { singular: 'Destination', plural: 'Destinations' },
 }
 
 export function humanizeScope(scope: ActivityScope | string, singular = false): string {

--- a/frontend/src/scenes/data-pipelines/batch-exports/activityDescriptions.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/activityDescriptions.tsx
@@ -1,7 +1,7 @@
 import {
     ActivityLogItem,
-    defaultDescriber,
     HumanizedChange,
+    defaultDescriber,
     userNameForLogItem,
 } from 'lib/components/ActivityLog/humanizeActivity'
 import { Link } from 'lib/lemon-ui/Link'

--- a/frontend/src/scenes/data-pipelines/batch-exports/activityDescriptions.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/activityDescriptions.tsx
@@ -1,0 +1,71 @@
+import {
+    ActivityLogItem,
+    defaultDescriber,
+    HumanizedChange,
+    userNameForLogItem,
+} from 'lib/components/ActivityLog/humanizeActivity'
+import { Link } from 'lib/lemon-ui/Link'
+import { urls } from 'scenes/urls'
+
+const nameOrLinkToBatchExport = (
+    id?: string | null,
+    name?: string | null,
+    destinationType?: string
+): string | JSX.Element => {
+    const displayName = name || '(unnamed export)'
+    const suffix = destinationType ? ` to ${destinationType}` : ''
+    return id ? (
+        <Link to={urls.batchExport(id)}>
+            {displayName}
+            {suffix}
+        </Link>
+    ) : (
+        `${displayName}${suffix}`
+    )
+}
+
+export function batchExportActivityDescriber(logItem: ActivityLogItem, asNotification?: boolean): HumanizedChange {
+    const context = logItem?.detail?.context as any
+    const destinationType = context?.destination_type
+
+    if (logItem.activity == 'created') {
+        return {
+            description: (
+                <>
+                    <strong>{userNameForLogItem(logItem)}</strong> created batch export{' '}
+                    {nameOrLinkToBatchExport(logItem?.item_id, logItem?.detail.name, destinationType)}
+                </>
+            ),
+        }
+    }
+
+    if (logItem.activity == 'deleted') {
+        const displayName = logItem.detail.name || '(unnamed export)'
+        const suffix = destinationType ? ` to ${destinationType}` : ''
+        return {
+            description: (
+                <>
+                    <strong>{userNameForLogItem(logItem)}</strong> deleted batch export "{displayName}
+                    {suffix}"
+                </>
+            ),
+        }
+    }
+
+    if (logItem.activity == 'updated') {
+        return {
+            description: (
+                <>
+                    <strong>{userNameForLogItem(logItem)}</strong> updated batch export{' '}
+                    {nameOrLinkToBatchExport(logItem?.item_id, logItem?.detail.name, destinationType)}
+                </>
+            ),
+        }
+    }
+
+    return defaultDescriber(
+        logItem,
+        asNotification,
+        nameOrLinkToBatchExport(logItem?.item_id, logItem?.detail.name, destinationType)
+    )
+}

--- a/frontend/src/scenes/data-pipelines/batch-exports/activityDescriptions.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/activityDescriptions.tsx
@@ -7,33 +7,18 @@ import {
 import { Link } from 'lib/lemon-ui/Link'
 import { urls } from 'scenes/urls'
 
-const nameOrLinkToBatchExport = (
-    id?: string | null,
-    name?: string | null,
-    destinationType?: string
-): string | JSX.Element => {
+const nameOrLinkToBatchExport = (id?: string | null, name?: string | null): string | JSX.Element => {
     const displayName = name || '(unnamed export)'
-    const suffix = destinationType ? ` to ${destinationType}` : ''
-    return id ? (
-        <Link to={urls.batchExport(id)}>
-            {displayName}
-            {suffix}
-        </Link>
-    ) : (
-        `${displayName}${suffix}`
-    )
+    return id ? <Link to={urls.batchExport(id)}>{displayName}</Link> : `${displayName}`
 }
 
 export function batchExportActivityDescriber(logItem: ActivityLogItem, asNotification?: boolean): HumanizedChange {
-    const context = logItem?.detail?.context as any
-    const destinationType = context?.destination_type
-
     if (logItem.activity == 'created') {
         return {
             description: (
                 <>
-                    <strong>{userNameForLogItem(logItem)}</strong> created batch export{' '}
-                    {nameOrLinkToBatchExport(logItem?.item_id, logItem?.detail.name, destinationType)}
+                    <strong>{userNameForLogItem(logItem)}</strong> created destination{' '}
+                    <strong>{nameOrLinkToBatchExport(logItem?.item_id, logItem?.detail.name)}</strong>
                 </>
             ),
         }
@@ -41,12 +26,10 @@ export function batchExportActivityDescriber(logItem: ActivityLogItem, asNotific
 
     if (logItem.activity == 'deleted') {
         const displayName = logItem.detail.name || '(unnamed export)'
-        const suffix = destinationType ? ` to ${destinationType}` : ''
         return {
             description: (
                 <>
-                    <strong>{userNameForLogItem(logItem)}</strong> deleted batch export "{displayName}
-                    {suffix}"
+                    <strong>{userNameForLogItem(logItem)}</strong> deleted destination <strong>{displayName}</strong>
                 </>
             ),
         }
@@ -56,16 +39,12 @@ export function batchExportActivityDescriber(logItem: ActivityLogItem, asNotific
         return {
             description: (
                 <>
-                    <strong>{userNameForLogItem(logItem)}</strong> updated batch export{' '}
-                    {nameOrLinkToBatchExport(logItem?.item_id, logItem?.detail.name, destinationType)}
+                    <strong>{userNameForLogItem(logItem)}</strong> updated destination{' '}
+                    <strong>{nameOrLinkToBatchExport(logItem?.item_id, logItem?.detail.name)}</strong>
                 </>
             ),
         }
     }
 
-    return defaultDescriber(
-        logItem,
-        asNotification,
-        nameOrLinkToBatchExport(logItem?.item_id, logItem?.detail.name, destinationType)
-    )
+    return defaultDescriber(logItem, asNotification, nameOrLinkToBatchExport(logItem?.item_id, logItem?.detail.name))
 }

--- a/frontend/src/scenes/data-pipelines/batch-exports/activityDescriptions.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/activityDescriptions.tsx
@@ -24,7 +24,7 @@ export function batchExportActivityDescriber(logItem: ActivityLogItem, asNotific
         }
     }
 
-    if (logItem.activity == 'deleted') {
+    if (logItem.detail?.changes?.some((change) => change.field === 'deleted')) {
         const displayName = logItem.detail.name || '(unnamed export)'
         return {
             description: (

--- a/frontend/src/scenes/data-pipelines/batch-imports/activityDescriptions.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-imports/activityDescriptions.tsx
@@ -1,7 +1,7 @@
 import {
     ActivityLogItem,
-    defaultDescriber,
     HumanizedChange,
+    defaultDescriber,
     userNameForLogItem,
 } from 'lib/components/ActivityLog/humanizeActivity'
 

--- a/frontend/src/scenes/data-pipelines/batch-imports/activityDescriptions.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-imports/activityDescriptions.tsx
@@ -1,0 +1,62 @@
+import {
+    ActivityLogItem,
+    defaultDescriber,
+    HumanizedChange,
+    userNameForLogItem,
+} from 'lib/components/ActivityLog/humanizeActivity'
+
+const getDisplayName = (logItem: ActivityLogItem): string => {
+    const name = logItem?.detail?.name
+    if (name) {
+        return name
+    }
+
+    // Try to get info from the new context first
+    const context = logItem?.detail?.context as any
+    if (context?.source_type && context?.content_type) {
+        return `${context.source_type} import (${context.content_type})`
+    }
+
+    // Fall back to the old method for backward compatibility
+    const detail = logItem?.detail as any
+    const config = detail?.import_config
+    if (config?.source?.type) {
+        return `${config.source.type} import`
+    }
+
+    return 'batch import'
+}
+
+export function batchImportActivityDescriber(logItem: ActivityLogItem, asNotification?: boolean): HumanizedChange {
+    if (logItem.activity == 'created') {
+        return {
+            description: (
+                <>
+                    <strong>{userNameForLogItem(logItem)}</strong> created {getDisplayName(logItem)}
+                </>
+            ),
+        }
+    }
+
+    if (logItem.activity == 'deleted') {
+        return {
+            description: (
+                <>
+                    <strong>{userNameForLogItem(logItem)}</strong> deleted {getDisplayName(logItem)}
+                </>
+            ),
+        }
+    }
+
+    if (logItem.activity == 'updated') {
+        return {
+            description: (
+                <>
+                    <strong>{userNameForLogItem(logItem)}</strong> updated {getDisplayName(logItem)}
+                </>
+            ),
+        }
+    }
+
+    return defaultDescriber(logItem, asNotification, getDisplayName(logItem))
+}

--- a/frontend/src/scenes/data-pipelines/batch-imports/activityDescriptions.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-imports/activityDescriptions.tsx
@@ -11,20 +11,18 @@ const getDisplayName = (logItem: ActivityLogItem): string => {
         return name
     }
 
-    // Try to get info from the new context first
     const context = logItem?.detail?.context as any
     if (context?.source_type && context?.content_type) {
-        return `${context.source_type} import (${context.content_type})`
+        return `source ${context.source_type} (${context.content_type})`
     }
 
-    // Fall back to the old method for backward compatibility
     const detail = logItem?.detail as any
     const config = detail?.import_config
     if (config?.source?.type) {
-        return `${config.source.type} import`
+        return `source ${config.source.type}`
     }
 
-    return 'batch import'
+    return 'unknown source'
 }
 
 export function batchImportActivityDescriber(logItem: ActivityLogItem, asNotification?: boolean): HumanizedChange {
@@ -32,7 +30,7 @@ export function batchImportActivityDescriber(logItem: ActivityLogItem, asNotific
         return {
             description: (
                 <>
-                    <strong>{userNameForLogItem(logItem)}</strong> created {getDisplayName(logItem)}
+                    <strong>{userNameForLogItem(logItem)}</strong> created <strong>{getDisplayName(logItem)}</strong>
                 </>
             ),
         }
@@ -42,7 +40,7 @@ export function batchImportActivityDescriber(logItem: ActivityLogItem, asNotific
         return {
             description: (
                 <>
-                    <strong>{userNameForLogItem(logItem)}</strong> deleted {getDisplayName(logItem)}
+                    <strong>{userNameForLogItem(logItem)}</strong> deleted <strong>{getDisplayName(logItem)}</strong>
                 </>
             ),
         }
@@ -52,7 +50,7 @@ export function batchImportActivityDescriber(logItem: ActivityLogItem, asNotific
         return {
             description: (
                 <>
-                    <strong>{userNameForLogItem(logItem)}</strong> updated {getDisplayName(logItem)}
+                    <strong>{userNameForLogItem(logItem)}</strong> updated <strong>{getDisplayName(logItem)}</strong>
                 </>
             ),
         }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4570,6 +4570,8 @@ export enum ActivityScope {
     ACTION = 'Action',
     ALERT_CONFIGURATION = 'AlertConfiguration',
     ANNOTATION = 'Annotation',
+    BATCH_EXPORT = 'BatchExport',
+    BATCH_IMPORT = 'BatchImport',
     FEATURE_FLAG = 'FeatureFlag',
     PERSON = 'Person',
     GROUP = 'Group',

--- a/posthog/batch_exports/models.py
+++ b/posthog/batch_exports/models.py
@@ -7,7 +7,9 @@ from django.db import models
 
 from posthog.clickhouse.client import sync_execute
 from posthog.helpers.encrypted_fields import EncryptedJSONField
+
 from posthog.models.utils import UUIDTModel
+from posthog.models.activity_logging.model_activity import ModelActivityMixin
 
 
 class BatchExportDestination(UUIDTModel):
@@ -175,7 +177,7 @@ BATCH_EXPORT_INTERVALS = [
 ]
 
 
-class BatchExport(UUIDTModel):
+class BatchExport(ModelActivityMixin, UUIDTModel):
     """
     Defines the configuration of PostHog to export data to a destination,
     either on a schedule (via the interval parameter), or manually by a

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -379,12 +379,17 @@ field_exclusions: dict[ActivityScope, list[str]] = {
     ],
     "BatchExport": [
         "latest_runs",
+        "batchexportrun_set",
+        "batchexportbackfill_set",
     ],
     "BatchImport": [
         "leased_until",
         "status_message",
         "state",
         "secrets",
+        "lease_id",
+        "backoff_attempt",
+        "backoff_until",
     ],
     "Integration": [
         "sensitive_config",

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -389,6 +389,7 @@ field_exclusions: dict[ActivityScope, list[str]] = {
         "deleted",
     ],
     "BatchImport": [
+        "lease_id",
         "leased_until",
         "status_message",
         "state",

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -386,7 +386,6 @@ field_exclusions: dict[ActivityScope, list[str]] = {
         "last_paused_at",
         "batchexportrun_set",
         "batchexportbackfill_set",
-        "deleted",
     ],
     "BatchImport": [
         "lease_id",

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -234,6 +234,9 @@ field_name_overrides: dict[ActivityScope, dict[str, str]] = {
         "session_cookie_age": "session cookie age",
         "default_experiment_stats_method": "default experiment stats method",
     },
+    "BatchExport": {
+        "paused": "enabled",
+    },
 }
 
 # Fields that prevent activity signal triggering entirely when only these fields change
@@ -379,8 +382,11 @@ field_exclusions: dict[ActivityScope, list[str]] = {
     ],
     "BatchExport": [
         "latest_runs",
+        "last_updated_at",
+        "last_paused_at",
         "batchexportrun_set",
         "batchexportbackfill_set",
+        "deleted",
     ],
     "BatchImport": [
         "leased_until",

--- a/posthog/models/activity_logging/batch_export_utils.py
+++ b/posthog/models/activity_logging/batch_export_utils.py
@@ -1,0 +1,32 @@
+from typing import Optional
+
+
+def get_batch_export_destination_type(batch_export) -> str:
+    """Get destination type from BatchExport"""
+    destination_type = ""
+    try:
+        if batch_export.destination:
+            destination_type = batch_export.destination.type
+    except Exception:
+        destination_type = "unknown"
+    return destination_type
+
+
+def get_batch_export_created_by_info(batch_export) -> tuple[Optional[str], Optional[str], Optional[str]]:
+    """Get created by user information from BatchExport"""
+    created_by_user_id = None
+    created_by_user_email = None
+    created_by_user_name = None
+
+    if hasattr(batch_export, "created_by") and batch_export.created_by:
+        created_by_user_id = str(batch_export.created_by.id)
+        created_by_user_email = batch_export.created_by.email
+        created_by_user_name = f"{batch_export.created_by.first_name} {batch_export.created_by.last_name}".strip()
+
+    return created_by_user_id, created_by_user_email, created_by_user_name
+
+
+def get_batch_export_detail_name(batch_export, destination_type: str) -> str:
+    """Generate detail name for BatchExport activity"""
+    name = batch_export.name or "Unnamed Export"
+    return f"Batch export '{name}' to {destination_type}"

--- a/posthog/models/activity_logging/batch_export_utils.py
+++ b/posthog/models/activity_logging/batch_export_utils.py
@@ -29,4 +29,4 @@ def get_batch_export_created_by_info(batch_export) -> tuple[Optional[str], Optio
 def get_batch_export_detail_name(batch_export, destination_type: str) -> str:
     """Generate detail name for BatchExport activity"""
     name = batch_export.name or "Unnamed Export"
-    return f"Batch export '{name}' to {destination_type}"
+    return f"'{name}' ({destination_type})"

--- a/posthog/models/activity_logging/batch_import_utils.py
+++ b/posthog/models/activity_logging/batch_import_utils.py
@@ -1,0 +1,46 @@
+from typing import Optional
+
+from posthog.models.user import User
+
+
+def extract_batch_import_info(batch_import) -> tuple[str, str, Optional[str], Optional[str]]:
+    """Extract source type, content type, start date, and end date from BatchImport"""
+    source_type = "unknown"
+    content_type = "unknown"
+    start_date = None
+    end_date = None
+
+    if batch_import.import_config:
+        source = batch_import.import_config.get("source", {})
+        source_type = source.get("type", "unknown")
+        start_date = source.get("start")
+        end_date = source.get("end")
+
+        data_format = batch_import.import_config.get("data_format", {})
+        content = data_format.get("content", {})
+        content_type = content.get("type", "unknown")
+
+    return source_type, content_type, start_date, end_date
+
+
+def get_batch_import_created_by_info(batch_import) -> tuple[Optional[str], Optional[str], Optional[str]]:
+    """Get created by user information from BatchImport"""
+    created_by_user_id = None
+    created_by_user_email = None
+    created_by_user_name = None
+
+    if batch_import.created_by_id:
+        try:
+            user_obj = User.objects.get(id=batch_import.created_by_id)
+            created_by_user_id = str(user_obj.id)
+            created_by_user_email = user_obj.email
+            created_by_user_name = f"{user_obj.first_name} {user_obj.last_name}".strip()
+        except User.DoesNotExist:
+            pass
+
+    return created_by_user_id, created_by_user_email, created_by_user_name
+
+
+def get_batch_import_detail_name(source_type: str, content_type: str) -> str:
+    """Generate detail name for BatchImport activity"""
+    return f"Batch import from {source_type} ({content_type})"

--- a/posthog/models/activity_logging/batch_import_utils.py
+++ b/posthog/models/activity_logging/batch_import_utils.py
@@ -43,4 +43,4 @@ def get_batch_import_created_by_info(batch_import) -> tuple[Optional[str], Optio
 
 def get_batch_import_detail_name(source_type: str, content_type: str) -> str:
     """Generate detail name for BatchImport activity"""
-    return f"Batch import from {source_type} ({content_type})"
+    return f"{source_type} ({content_type})"

--- a/posthog/models/batch_imports.py
+++ b/posthog/models/batch_imports.py
@@ -2,6 +2,7 @@ from django.db import models
 
 from posthog.models.utils import UUIDTModel
 from posthog.models.team import Team
+from posthog.models.activity_logging.model_activity import ModelActivityMixin
 
 from posthog.helpers.encrypted_fields import EncryptedJSONStringField
 
@@ -23,7 +24,7 @@ class ContentType(str, Enum):
         return {"type": self.value}
 
 
-class BatchImport(UUIDTModel):
+class BatchImport(ModelActivityMixin, UUIDTModel):
     class Status(models.TextChoices):
         COMPLETED = "completed", "Completed"
         FAILED = "failed", "Failed"

--- a/posthog/test/activity_log_utils.py
+++ b/posthog/test/activity_log_utils.py
@@ -492,31 +492,45 @@ class ActivityLogTestHelper(APILicensedTest):
 
     # BatchExport
     def create_batch_export(self, name: str = "Test Export", **kwargs) -> dict[str, Any]:
-        """Create a batch export via API."""
-        data = {
-            "name": name,
-            "destination": {
-                "type": "S3",
-                "config": {
-                    "bucket_name": "test-bucket",
-                    "region": "us-east-1",
-                    "prefix": "posthog-events/",
-                    "aws_access_key_id": "test-key",
-                    "aws_secret_access_key": "test-secret",
-                },
-            },
-            "interval": "hour",
+        """Create a batch export via direct model creation (like the original tests)."""
+        from posthog.batch_exports.models import BatchExport, BatchExportDestination
+
+        # Create destination first (like the original tests do)
+        destination = BatchExportDestination.objects.create(
+            type=BatchExportDestination.Destination.HTTP, config={"url": "https://example.com"}
+        )
+
+        batch_export = BatchExport.objects.create(
+            team=self.team,
+            name=name,
+            destination=destination,
+            interval="hour",
             **kwargs,
+        )
+
+        # Return in the same format as API would
+        return {
+            "id": str(batch_export.id),
+            "name": batch_export.name,
+            "interval": batch_export.interval,
+            "paused": batch_export.paused,
         }
-        response = self.client.post(f"/api/projects/{self.team.id}/batch_exports/", data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        return response.json()
 
     def update_batch_export(self, export_id: str, updates: dict[str, Any]) -> dict[str, Any]:
-        """Update a batch export via API."""
-        response = self.client.patch(f"/api/projects/{self.team.id}/batch_exports/{export_id}/", updates, format="json")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        return response.json()
+        """Update a batch export via direct model access (like the original tests)."""
+        from posthog.batch_exports.models import BatchExport
+
+        batch_export = BatchExport.objects.get(id=export_id)
+        for field, value in updates.items():
+            setattr(batch_export, field, value)
+        batch_export.save()
+
+        return {
+            "id": str(batch_export.id),
+            "name": batch_export.name,
+            "interval": batch_export.interval,
+            "paused": batch_export.paused,
+        }
 
     # Integration
     def create_integration(self, kind: str = "twilio", **kwargs) -> dict[str, Any]:
@@ -547,7 +561,7 @@ class ActivityLogTestHelper(APILicensedTest):
         return response.json()
 
     # Tag
-    def create_tag(self, name: str = "test-tag", **kwargs) -> dict[str, Any]:
+    def create_tag(self, name: str = "test-tag", **_kwargs) -> dict[str, Any]:
         """Create a tag via API."""
         # Tags are typically created implicitly when tagging items
         # Create an insight and tag it
@@ -758,18 +772,37 @@ class ActivityLogTestHelper(APILicensedTest):
         return response.json()
 
     # BatchImport
-    def create_batch_import(self, name: str = "Test Import", **kwargs) -> dict[str, Any]:
+    def create_batch_import(self, _name: str = "Test Import", **kwargs) -> dict[str, Any]:
         """Create a batch import via API."""
-        data = {
-            "source_type": "s3",
-            "content_type": "captured",
-            "s3_bucket": "test-bucket",
-            "s3_region": "us-east-1",
-            "s3_prefix": "data/",
-            "access_key": "test-key",
-            "secret_key": "test-secret",
-            **kwargs,
-        }
+        # Allow import_config to be passed as parameter for testing specific configurations
+        if "import_config" in kwargs:
+            import_config = kwargs.pop("import_config")
+            source = import_config.get("source", {})
+            data_format = import_config.get("data_format", {})
+            content = data_format.get("content", {})
+
+            data = {
+                "source_type": source.get("type", "s3"),
+                "content_type": content.get("type", "captured"),
+                "s3_bucket": "test-bucket",
+                "s3_region": "us-east-1",
+                "s3_prefix": "data/",
+                "access_key": "test-key",
+                "secret_key": "test-secret",
+                **kwargs,
+            }
+        else:
+            data = {
+                "source_type": "s3",
+                "content_type": "captured",
+                "s3_bucket": "test-bucket",
+                "s3_region": "us-east-1",
+                "s3_prefix": "data/",
+                "access_key": "test-key",
+                "secret_key": "test-secret",
+                **kwargs,
+            }
+
         response = self.client.post(f"/api/projects/{self.team.id}/managed_migrations", data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         return response.json()
@@ -781,6 +814,18 @@ class ActivityLogTestHelper(APILicensedTest):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         return response.json()
+
+    def delete_batch_import(self, import_id: str) -> None:
+        """Delete a batch import."""
+        response = self.client.delete(f"/api/projects/{self.team.id}/managed_migrations/{import_id}/")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def delete_batch_export(self, export_id: str) -> None:
+        """Delete a batch export."""
+        from posthog.batch_exports.models import BatchExport
+
+        batch_export = BatchExport.objects.get(id=export_id)
+        batch_export.delete()
 
     # TaggedItem
     def create_tagged_item(self, tag_name: str, item_type: str, item_id: str) -> dict[str, Any]:

--- a/posthog/test/activity_log_utils.py
+++ b/posthog/test/activity_log_utils.py
@@ -822,10 +822,8 @@ class ActivityLogTestHelper(APILicensedTest):
 
     def delete_batch_export(self, export_id: str) -> None:
         """Delete a batch export."""
-        from posthog.batch_exports.models import BatchExport
-
-        batch_export = BatchExport.objects.get(id=export_id)
-        batch_export.delete()
+        response = self.client.delete(f"/api/projects/{self.team.id}/batch_exports/{export_id}/")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     # TaggedItem
     def create_tagged_item(self, tag_name: str, item_type: str, item_id: str) -> dict[str, Any]:

--- a/posthog/test/activity_logging/test_batch_export_activity_logging.py
+++ b/posthog/test/activity_logging/test_batch_export_activity_logging.py
@@ -40,10 +40,11 @@ class TestBatchExportActivityLogging(ActivityLogTestHelper):
     def test_batch_export_scope_in_activity_log_types(self):
         """Test that BatchExport scope is defined in ActivityScope"""
         from posthog.models.activity_logging.activity_log import ActivityScope
+        from typing import get_args
 
         # Check that BatchExport is in the literal type
         # We can't directly test literal types, but we can test that the string value works
-        self.assertIn("BatchExport", str(ActivityScope.__args__))
+        self.assertIn("BatchExport", get_args(ActivityScope))
 
     def test_batch_export_integration_test(self):
         """Integration test to verify the basic setup works"""
@@ -138,12 +139,14 @@ class TestBatchExportActivityLogging(ActivityLogTestHelper):
             ).first()
 
             self.assertIsNotNone(activity_log)
+            assert activity_log is not None  # For mypy
             self.assertEqual(activity_log.user, self.user)
             self.assertEqual(activity_log.team_id, self.team.id)
             self.assertEqual(activity_log.organization_id, self.team.organization_id)
 
             # Check that context is populated
             self.assertIsNotNone(activity_log.detail)
+            assert activity_log.detail is not None  # For mypy
             context = activity_log.detail.get("context")
             self.assertIsNotNone(context)
             self.assertEqual(context["name"], "Signal Test Export")
@@ -184,9 +187,11 @@ class TestBatchExportActivityLogging(ActivityLogTestHelper):
             ).first()
 
             self.assertIsNotNone(activity_log)
+            assert activity_log is not None  # For mypy
             self.assertEqual(activity_log.user, self.user)
 
             # Check that changes are recorded
+            assert activity_log.detail is not None  # For mypy
             changes = activity_log.detail.get("changes", [])
             self.assertTrue(len(changes) > 0)
 
@@ -224,6 +229,7 @@ class TestBatchExportActivityLogging(ActivityLogTestHelper):
             ).first()
 
             self.assertIsNotNone(activity_log)
+            assert activity_log is not None  # For mypy
             self.assertEqual(activity_log.user, self.user)
 
         finally:

--- a/posthog/test/activity_logging/test_batch_export_activity_logging.py
+++ b/posthog/test/activity_logging/test_batch_export_activity_logging.py
@@ -1,0 +1,230 @@
+from posthog.batch_exports.models import BatchExport, BatchExportDestination
+from posthog.test.activity_log_utils import ActivityLogTestHelper
+
+
+class TestBatchExportActivityLogging(ActivityLogTestHelper):
+    def create_test_destination(self):
+        """Helper to create a test destination for batch exports."""
+        return BatchExportDestination.objects.create(
+            type=BatchExportDestination.Destination.HTTP, config={"url": "https://example.com"}
+        )
+
+    def test_batch_export_model_has_activity_mixin(self):
+        """Test that BatchExport has ModelActivityMixin and proper scope"""
+        # Verify that BatchExport inherits from ModelActivityMixin
+        from posthog.models.activity_logging.model_activity import ModelActivityMixin
+
+        self.assertTrue(issubclass(BatchExport, ModelActivityMixin))
+
+        # Test that the model can be created
+        destination = self.create_test_destination()
+        batch_export = BatchExport.objects.create(
+            team=self.team, name="Test Export", destination=destination, interval="hour"
+        )
+
+        self.assertIsNotNone(batch_export)
+        self.assertEqual(batch_export.team, self.team)
+        self.assertEqual(batch_export.name, "Test Export")
+
+    def test_batch_export_field_exclusions_configured(self):
+        """Test that field exclusions are properly configured"""
+        from posthog.models.activity_logging.activity_log import field_exclusions
+
+        batch_export_exclusions = field_exclusions.get("BatchExport", [])
+
+        # Verify reverse relation fields are excluded
+        self.assertIn("latest_runs", batch_export_exclusions)
+        self.assertIn("batchexportrun_set", batch_export_exclusions)
+        self.assertIn("batchexportbackfill_set", batch_export_exclusions)
+
+    def test_batch_export_scope_in_activity_log_types(self):
+        """Test that BatchExport scope is defined in ActivityScope"""
+        from posthog.models.activity_logging.activity_log import ActivityScope
+
+        # Check that BatchExport is in the literal type
+        # We can't directly test literal types, but we can test that the string value works
+        self.assertIn("BatchExport", str(ActivityScope.__args__))
+
+    def test_batch_export_integration_test(self):
+        """Integration test to verify the basic setup works"""
+        # This is a minimal test to ensure no errors in the setup
+        from posthog.models.activity_logging.utils import activity_storage
+
+        # Set user context
+        activity_storage.set_user(self.user)
+
+        try:
+            # Create a batch export
+            destination = self.create_test_destination()
+            batch_export = BatchExport.objects.create(
+                team=self.team, name="Integration Test Export", destination=destination, interval="hour", paused=False
+            )
+
+            # Test basic model functionality
+            self.assertIsNotNone(batch_export.id)
+            self.assertEqual(batch_export.team, self.team)
+            self.assertEqual(batch_export.name, "Integration Test Export")
+
+            # Update the batch export to test update signals
+            batch_export.paused = True
+            batch_export.name = "Updated Integration Test Export"
+            batch_export.save()
+
+            # Test that we can update the interval
+            batch_export.interval = "day"
+            batch_export.save()
+
+            # The test passes if no exceptions are raised during save operations
+
+        finally:
+            activity_storage.clear_user()
+
+    def test_batch_export_status_changes(self):
+        """Test various status changes on batch exports"""
+        from posthog.models.activity_logging.utils import activity_storage
+
+        activity_storage.set_user(self.user)
+
+        try:
+            destination = self.create_test_destination()
+            batch_export = BatchExport.objects.create(
+                team=self.team, name="Status Test Export", destination=destination, interval="hour", paused=False
+            )
+
+            # Test pause
+            batch_export.paused = True
+            batch_export.save()
+
+            # Test resume
+            batch_export.paused = False
+            batch_export.save()
+
+            # Test model change
+            batch_export.model = "persons"
+            batch_export.save()
+
+            # Test schema change
+            batch_export.schema = [{"alias": "test", "table": "events", "fields": ["event"]}]
+            batch_export.save()
+
+            # All operations should complete without errors
+
+        finally:
+            activity_storage.clear_user()
+
+    def test_batch_export_signal_handler_create(self):
+        """Test that the signal handler works for batch export creation"""
+        from posthog.models.activity_logging.activity_log import ActivityLog
+        from posthog.models.activity_logging.utils import activity_storage
+
+        activity_storage.set_user(self.user)
+
+        try:
+            initial_count = ActivityLog.objects.count()
+
+            # Create a batch export
+            destination = self.create_test_destination()
+            batch_export = BatchExport.objects.create(
+                team=self.team, name="Signal Test Export", destination=destination, interval="hour"
+            )
+
+            # Check that activity log was created
+            new_count = ActivityLog.objects.count()
+            self.assertEqual(new_count, initial_count + 1)
+
+            # Get the activity log entry
+            activity_log = ActivityLog.objects.filter(
+                scope="BatchExport", activity="created", item_id=str(batch_export.id)
+            ).first()
+
+            self.assertIsNotNone(activity_log)
+            self.assertEqual(activity_log.user, self.user)
+            self.assertEqual(activity_log.team_id, self.team.id)
+            self.assertEqual(activity_log.organization_id, self.team.organization_id)
+
+            # Check that context is populated
+            self.assertIsNotNone(activity_log.detail)
+            context = activity_log.detail.get("context")
+            self.assertIsNotNone(context)
+            self.assertEqual(context["name"], "Signal Test Export")
+            self.assertEqual(context["destination_type"], "HTTP")
+            self.assertEqual(context["interval"], "hour")
+
+        finally:
+            activity_storage.clear_user()
+
+    def test_batch_export_signal_handler_update(self):
+        """Test that the signal handler works for batch export updates"""
+        from posthog.models.activity_logging.activity_log import ActivityLog
+        from posthog.models.activity_logging.utils import activity_storage
+
+        activity_storage.set_user(self.user)
+
+        try:
+            # Create a batch export first
+            destination = self.create_test_destination()
+            batch_export = BatchExport.objects.create(
+                team=self.team, name="Update Test Export", destination=destination, interval="hour"
+            )
+
+            initial_count = ActivityLog.objects.count()
+
+            # Update the batch export
+            batch_export.name = "Updated Test Export"
+            batch_export.interval = "day"
+            batch_export.save()
+
+            # Check that activity log was created for the update
+            new_count = ActivityLog.objects.count()
+            self.assertEqual(new_count, initial_count + 1)
+
+            # Get the update activity log entry
+            activity_log = ActivityLog.objects.filter(
+                scope="BatchExport", activity="updated", item_id=str(batch_export.id)
+            ).first()
+
+            self.assertIsNotNone(activity_log)
+            self.assertEqual(activity_log.user, self.user)
+
+            # Check that changes are recorded
+            changes = activity_log.detail.get("changes", [])
+            self.assertTrue(len(changes) > 0)
+
+        finally:
+            activity_storage.clear_user()
+
+    def test_batch_export_signal_handler_delete(self):
+        """Test that the signal handler works for batch export deletion"""
+        from posthog.models.activity_logging.activity_log import ActivityLog
+        from posthog.models.activity_logging.utils import activity_storage
+
+        activity_storage.set_user(self.user)
+
+        try:
+            # Create a batch export first
+            destination = self.create_test_destination()
+            batch_export = BatchExport.objects.create(
+                team=self.team, name="Delete Test Export", destination=destination, interval="hour"
+            )
+            batch_export_id = batch_export.id
+
+            # Get initial count AFTER creation (since creation also generates an activity log)
+            initial_count = ActivityLog.objects.count()
+
+            # Delete the batch export
+            batch_export.delete()
+
+            # Check that activity log was created for the deletion
+            new_count = ActivityLog.objects.count()
+            self.assertEqual(new_count, initial_count + 1)
+
+            # Get the delete activity log entry
+            activity_log = ActivityLog.objects.filter(
+                scope="BatchExport", activity="deleted", item_id=str(batch_export_id)
+            ).first()
+
+            self.assertIsNotNone(activity_log)
+            self.assertEqual(activity_log.user, self.user)
+
+        finally:
+            activity_storage.clear_user()

--- a/posthog/test/activity_logging/test_batch_export_activity_logging.py
+++ b/posthog/test/activity_logging/test_batch_export_activity_logging.py
@@ -32,10 +32,12 @@ class TestBatchExportActivityLogging(ActivityLogTestHelper):
 
         batch_export_exclusions = field_exclusions.get("BatchExport", [])
 
-        # Verify reverse relation fields are excluded
         self.assertIn("latest_runs", batch_export_exclusions)
+        self.assertIn("last_updated_at", batch_export_exclusions)
+        self.assertIn("last_paused_at", batch_export_exclusions)
         self.assertIn("batchexportrun_set", batch_export_exclusions)
         self.assertIn("batchexportbackfill_set", batch_export_exclusions)
+        self.assertIn("deleted", batch_export_exclusions)
 
     def test_batch_export_scope_in_activity_log_types(self):
         """Test that BatchExport scope is defined in ActivityScope"""
@@ -66,6 +68,7 @@ class TestBatchExportActivityLogging(ActivityLogTestHelper):
         try:
             batch_export = self.create_batch_export(name="Status Test Export", paused=False)
 
+            # Test pausing/unpausing which should appear as "enabled" field in activity log
             self.update_batch_export(batch_export["id"], {"paused": True})
             self.update_batch_export(batch_export["id"], {"paused": False})
             self.update_batch_export(batch_export["id"], {"model": "persons"})

--- a/posthog/test/activity_logging/test_batch_import_activity_logging.py
+++ b/posthog/test/activity_logging/test_batch_import_activity_logging.py
@@ -1,0 +1,193 @@
+from posthog.models.batch_imports import BatchImport
+from posthog.test.activity_log_utils import ActivityLogTestHelper
+
+
+class TestBatchImportActivityLogging(ActivityLogTestHelper):
+    def test_batch_import_model_has_activity_mixin(self):
+        """Test that BatchImport has ModelActivityMixin and proper scope"""
+        # Verify that BatchImport inherits from ModelActivityMixin
+        from posthog.models.activity_logging.model_activity import ModelActivityMixin
+
+        self.assertTrue(issubclass(BatchImport, ModelActivityMixin))
+
+        # Test that the model can be created
+        batch_import = BatchImport.objects.create(
+            team=self.team, created_by_id=self.user.id, import_config={"source": {"type": "test"}}, secrets="{}"
+        )
+
+        self.assertIsNotNone(batch_import)
+        self.assertEqual(batch_import.team, self.team)
+
+    def test_batch_import_field_exclusions_configured(self):
+        """Test that field exclusions are properly configured"""
+        from posthog.models.activity_logging.activity_log import field_exclusions
+
+        batch_import_exclusions = field_exclusions.get("BatchImport", [])
+
+        # Verify sensitive fields are excluded
+        self.assertIn("secrets", batch_import_exclusions)
+        self.assertIn("lease_id", batch_import_exclusions)
+        self.assertIn("state", batch_import_exclusions)
+        self.assertIn("status_message", batch_import_exclusions)
+        self.assertIn("backoff_attempt", batch_import_exclusions)
+        self.assertIn("backoff_until", batch_import_exclusions)
+
+    def test_batch_import_scope_in_activity_log_types(self):
+        """Test that BatchImport scope is defined in ActivityScope"""
+        from posthog.models.activity_logging.activity_log import ActivityScope
+
+        # Check that BatchImport is in the literal type
+        # We can't directly test literal types, but we can test that the string value works
+        self.assertIn("BatchImport", str(ActivityScope.__args__))
+
+    def test_batch_import_masked_fields_configured(self):
+        """Test that masked fields are properly configured"""
+        from posthog.models.activity_logging.activity_log import field_with_masked_contents
+
+        batch_import_masked = field_with_masked_contents.get("BatchImport", [])
+
+        # Verify import_config is masked
+        self.assertIn("import_config", batch_import_masked)
+
+    def test_batch_import_integration_test(self):
+        """Integration test to verify the basic setup works"""
+        # This is a minimal test to ensure no errors in the setup
+        from posthog.models.activity_logging.utils import activity_storage
+
+        # Set user context
+        activity_storage.set_user(self.user)
+
+        try:
+            # Create a batch import
+            batch_import = BatchImport.objects.create(
+                team=self.team, created_by_id=self.user.id, import_config={"source": {"type": "test"}}, secrets="{}"
+            )
+
+            # Test basic model functionality
+            self.assertIsNotNone(batch_import.id)
+            self.assertEqual(batch_import.team, self.team)
+
+            # Update the batch import to test update signals
+            batch_import.status = BatchImport.Status.COMPLETED
+            batch_import.save()
+
+            # The test passes if no exceptions are raised during save operations
+
+        finally:
+            activity_storage.clear_user()
+
+    def test_batch_import_signal_handler_create(self):
+        """Test that the signal handler works for batch import creation"""
+        from posthog.models.activity_logging.activity_log import ActivityLog
+        from posthog.models.activity_logging.utils import activity_storage
+
+        activity_storage.set_user(self.user)
+
+        try:
+            initial_count = ActivityLog.objects.count()
+
+            # Create a batch import
+            batch_import = BatchImport.objects.create(
+                team=self.team,
+                created_by_id=self.user.id,
+                import_config={"source": {"type": "s3"}, "data_format": {"content": {"type": "mixpanel"}}},
+                secrets="{}",
+            )
+
+            # Check that activity log was created
+            new_count = ActivityLog.objects.count()
+            self.assertEqual(new_count, initial_count + 1)
+
+            # Get the activity log entry
+            activity_log = ActivityLog.objects.filter(
+                scope="BatchImport", activity="created", item_id=str(batch_import.id)
+            ).first()
+
+            self.assertIsNotNone(activity_log)
+            self.assertEqual(activity_log.user, self.user)
+            self.assertEqual(activity_log.team_id, self.team.id)
+            self.assertEqual(activity_log.organization_id, self.team.organization_id)
+
+            # Check that context is populated
+            self.assertIsNotNone(activity_log.detail)
+            context = activity_log.detail.get("context")
+            self.assertIsNotNone(context)
+            self.assertEqual(context["source_type"], "s3")
+            self.assertEqual(context["content_type"], "mixpanel")
+            self.assertEqual(context["created_by_user_id"], str(self.user.id))
+
+        finally:
+            activity_storage.clear_user()
+
+    def test_batch_import_signal_handler_update(self):
+        """Test that the signal handler works for batch import updates"""
+        from posthog.models.activity_logging.activity_log import ActivityLog
+        from posthog.models.activity_logging.utils import activity_storage
+
+        activity_storage.set_user(self.user)
+
+        try:
+            # Create a batch import first
+            batch_import = BatchImport.objects.create(
+                team=self.team, created_by_id=self.user.id, import_config={"source": {"type": "test"}}, secrets="{}"
+            )
+
+            initial_count = ActivityLog.objects.count()
+
+            # Update the batch import
+            batch_import.status = BatchImport.Status.COMPLETED
+            batch_import.save()
+
+            # Check that activity log was created for the update
+            new_count = ActivityLog.objects.count()
+            self.assertEqual(new_count, initial_count + 1)
+
+            # Get the update activity log entry
+            activity_log = ActivityLog.objects.filter(
+                scope="BatchImport", activity="updated", item_id=str(batch_import.id)
+            ).first()
+
+            self.assertIsNotNone(activity_log)
+            self.assertEqual(activity_log.user, self.user)
+
+            # Check that changes are recorded
+            changes = activity_log.detail.get("changes", [])
+            self.assertTrue(len(changes) > 0)
+
+        finally:
+            activity_storage.clear_user()
+
+    def test_batch_import_signal_handler_delete(self):
+        """Test that the signal handler works for batch import deletion"""
+        from posthog.models.activity_logging.activity_log import ActivityLog
+        from posthog.models.activity_logging.utils import activity_storage
+
+        activity_storage.set_user(self.user)
+
+        try:
+            # Create a batch import first
+            batch_import = BatchImport.objects.create(
+                team=self.team, created_by_id=self.user.id, import_config={"source": {"type": "test"}}, secrets="{}"
+            )
+            batch_import_id = batch_import.id
+
+            # Get initial count AFTER creation (since creation also generates an activity log)
+            initial_count = ActivityLog.objects.count()
+
+            # Delete the batch import
+            batch_import.delete()
+
+            # Check that activity log was created for the deletion
+            new_count = ActivityLog.objects.count()
+            self.assertEqual(new_count, initial_count + 1)
+
+            # Get the delete activity log entry
+            activity_log = ActivityLog.objects.filter(
+                scope="BatchImport", activity="deleted", item_id=str(batch_import_id)
+            ).first()
+
+            self.assertIsNotNone(activity_log)
+            self.assertEqual(activity_log.user, self.user)
+
+        finally:
+            activity_storage.clear_user()

--- a/posthog/test/activity_logging/test_batch_import_activity_logging.py
+++ b/posthog/test/activity_logging/test_batch_import_activity_logging.py
@@ -35,10 +35,11 @@ class TestBatchImportActivityLogging(ActivityLogTestHelper):
     def test_batch_import_scope_in_activity_log_types(self):
         """Test that BatchImport scope is defined in ActivityScope"""
         from posthog.models.activity_logging.activity_log import ActivityScope
+        from typing import get_args
 
         # Check that BatchImport is in the literal type
         # We can't directly test literal types, but we can test that the string value works
-        self.assertIn("BatchImport", str(ActivityScope.__args__))
+        self.assertIn("BatchImport", get_args(ActivityScope))
 
     def test_batch_import_masked_fields_configured(self):
         """Test that masked fields are properly configured"""
@@ -104,12 +105,14 @@ class TestBatchImportActivityLogging(ActivityLogTestHelper):
             ).first()
 
             self.assertIsNotNone(activity_log)
+            assert activity_log is not None  # For mypy
             self.assertEqual(activity_log.user, self.user)
             self.assertEqual(activity_log.team_id, self.team.id)
             self.assertEqual(activity_log.organization_id, self.team.organization_id)
 
             # Check that context is populated
             self.assertIsNotNone(activity_log.detail)
+            assert activity_log.detail is not None  # For mypy
             context = activity_log.detail.get("context")
             self.assertIsNotNone(context)
             self.assertEqual(context["source_type"], "s3")
@@ -148,9 +151,11 @@ class TestBatchImportActivityLogging(ActivityLogTestHelper):
             ).first()
 
             self.assertIsNotNone(activity_log)
+            assert activity_log is not None  # For mypy
             self.assertEqual(activity_log.user, self.user)
 
             # Check that changes are recorded
+            assert activity_log.detail is not None  # For mypy
             changes = activity_log.detail.get("changes", [])
             self.assertTrue(len(changes) > 0)
 
@@ -187,6 +192,7 @@ class TestBatchImportActivityLogging(ActivityLogTestHelper):
             ).first()
 
             self.assertIsNotNone(activity_log)
+            assert activity_log is not None  # For mypy
             self.assertEqual(activity_log.user, self.user)
 
         finally:


### PR DESCRIPTION
## Changes

- Adds BatchExport (Destinations) and BatchImport (Sources) activity tracking
- Currently BatchImport only covers the model which is used for older integrations, such as Mixpanel. The more recent model ExternalDataSource will be tracked in another PR

<img width="583" height="758" alt="image" src="https://github.com/user-attachments/assets/a9d7a5e5-160c-47bd-ac04-bcc2234c8509" />


## How did you test this code?

- Integration tests