### PR TITLE
fix: add RemoteConfigThrottle

### DIFF
--- a/posthog/settings/feature_flags.py
+++ b/posthog/settings/feature_flags.py
@@ -24,3 +24,9 @@ LOCAL_EVAL_RATE_LIMITS: dict[int, str] = {}
 with suppress(Exception):
     as_json = json.loads(os.getenv("LOCAL_EVAL_RATE_LIMITS", "{}"))
     LOCAL_EVAL_RATE_LIMITS = {int(k): str(v) for k, v in as_json.items()}
+
+# Per-team remote config rate limits, e.g. {"123": "1200/minute", "456": "2400/hour"}
+REMOTE_CONFIG_RATE_LIMITS: dict[int, str] = {}
+with suppress(Exception):
+    as_json = json.loads(os.getenv("REMOTE_CONFIG_RATE_LIMITS", "{}"))
+    REMOTE_CONFIG_RATE_LIMITS = {int(k): str(v) for k, v in as_json.items()}


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Remote config uses default rate limits which is 480/min burst and 4800/hour sustained.  
https://github.com/PostHog/posthog/blob/364b48764b31159cebc32f9f4dba96d3404c0fa9/posthog/rate_limit.py#L364-L375

A customer is hitting the limits https://posthog.slack.com/archives/C07Q2U4BH4L/p1755271886390839

## Changes

Add RemoteConfigThrottle which is an exact copy of LocalEvaluationThrottle which gives a baseline throttle of 600/min and allows us to increase per team with a config change to charts. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

Unit test