### PR TITLE
chore: add warn logs for 400s

### DIFF
--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -186,6 +186,12 @@ impl IntoResponse for FlagError {
             FlagError::PersonNotFound => {
                 (StatusCode::BAD_REQUEST, "Person not found. Please check your distinct_id and try again.".to_string())
             }
+            FlagError::PropertiesNotInCache => {
+                (StatusCode::BAD_REQUEST, "Person properties not found. Please check your distinct_id and try again.".to_string())
+            }
+            FlagError::StaticCohortMatchesNotCached => {
+                (StatusCode::BAD_REQUEST, "Static cohort matches not cached. Please check your distinct_id and try again.".to_string())
+            }
             FlagError::CookielessError(err) => {
                 match err {
                     // 400 Bad Request errors - client-side issues

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -186,12 +186,6 @@ impl IntoResponse for FlagError {
             FlagError::PersonNotFound => {
                 (StatusCode::BAD_REQUEST, "Person not found. Please check your distinct_id and try again.".to_string())
             }
-            FlagError::PropertiesNotInCache => {
-                (StatusCode::BAD_REQUEST, "Person properties not found. Please check your distinct_id and try again.".to_string())
-            }
-            FlagError::StaticCohortMatchesNotCached => {
-                (StatusCode::BAD_REQUEST, "Static cohort matches not cached. Please check your distinct_id and try again.".to_string())
-            }
             FlagError::CookielessError(err) => {
                 match err {
                     // 400 Bad Request errors - client-side issues

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -1423,6 +1423,7 @@ impl FeatureFlagMatcher {
             // i just want to be able to differentiate between no properties because we fetched no properties,
             // and no properties because we failed to fetch
             // maybe I need a fetch indicator in the cache?
+            tracing::warn!("Person properties not found in evaluation state cache");
             Err(FlagError::PersonNotFound)
         }
     }

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -148,12 +148,18 @@ impl FlagRequest {
     /// If the distinct_id is missing or empty, an error is returned.
     pub fn extract_distinct_id(&self) -> Result<String, FlagError> {
         let distinct_id = match &self.distinct_id {
-            None => return Err(FlagError::MissingDistinctId),
+            None => {
+                tracing::warn!("Missing distinct_id in request");
+                return Err(FlagError::MissingDistinctId);
+            }
             Some(id) => id,
         };
 
         match distinct_id.len() {
-            0 => Err(FlagError::EmptyDistinctId),
+            0 => {
+                tracing::warn!("Empty distinct_id provided in request");
+                Err(FlagError::EmptyDistinctId)
+            }
             1..=200 => Ok(distinct_id.to_owned()),
             _ => Ok(distinct_id.chars().take(200).collect()),
         }

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -75,7 +75,7 @@ impl FlagRequest {
         let payload = match String::from_utf8(bytes.to_vec()) {
             Ok(s) => s,
             Err(e) => {
-                tracing::debug!(
+                tracing::warn!(
                     "Invalid UTF-8 in request body, using lossy conversion: {}",
                     e
                 );
@@ -89,7 +89,7 @@ impl FlagRequest {
         let mut value: Value = match json5::from_str(&payload) {
             Ok(v) => v,
             Err(e) => {
-                tracing::debug!("failed to parse JSON: {}", e);
+                tracing::warn!("failed to parse JSON: {}", e);
                 return Err(FlagError::RequestDecodingError(String::from(
                     "invalid JSON",
                 )));
@@ -102,7 +102,7 @@ impl FlagRequest {
         match serde_json::from_value::<FlagRequest>(value) {
             Ok(request) => Ok(request),
             Err(e) => {
-                tracing::debug!("failed to parse JSON: {}", e);
+                tracing::warn!("failed to parse JSON: {}", e);
                 Err(FlagError::RequestDecodingError(String::from(
                     "invalid JSON",
                 )))

--- a/rust/feature-flags/src/handler/decoding.rs
+++ b/rust/feature-flags/src/handler/decoding.rs
@@ -100,12 +100,10 @@ fn decompress_gzip(compressed: Bytes) -> Result<Bytes, FlagError> {
 }
 
 fn decode_base64(body: Bytes) -> Result<Bytes, FlagError> {
-    let decoded = general_purpose::STANDARD
-        .decode(body)
-        .map_err(|e| {
-            tracing::warn!("Base64 decoding error: {}", e);
-            FlagError::RequestDecodingError(format!("Base64 decoding error: {e}"))
-        })?;
+    let decoded = general_purpose::STANDARD.decode(body).map_err(|e| {
+        tracing::warn!("Base64 decoding error: {}", e);
+        FlagError::RequestDecodingError(format!("Base64 decoding error: {e}"))
+    })?;
     Ok(Bytes::from(decoded))
 }
 
@@ -160,14 +158,14 @@ pub fn decode_form_data(
             tracing::warn!("Gzip compression not supported for form-urlencoded data");
             return Err(FlagError::RequestDecodingError(
                 "Gzip compression not supported for form-urlencoded data".into(),
-            ))
+            ));
         }
         Some(Compression::Base64) | None => decode_base64(Bytes::from(cleaned_base64))?,
         Some(Compression::Unsupported) => {
             tracing::warn!("Unsupported compression type for form-urlencoded data");
             return Err(FlagError::RequestDecodingError(
                 "Unsupported compression type".into(),
-            ))
+            ));
         }
     };
 

--- a/rust/feature-flags/src/handler/decoding.rs
+++ b/rust/feature-flags/src/handler/decoding.rs
@@ -32,9 +32,12 @@ pub fn decode_request(
             FlagRequest::from_bytes(decoded_body)
         }
         "application/x-www-form-urlencoded" => decode_form_data(body, query.compression),
-        _ => Err(FlagError::RequestDecodingError(format!(
-            "unsupported content type: {content_type}"
-        ))),
+        _ => {
+            tracing::warn!("unsupported content type: {}", content_type);
+            Err(FlagError::RequestDecodingError(format!(
+                "unsupported content type: {content_type}"
+            )))
+        }
     }
 }
 
@@ -48,9 +51,12 @@ fn decode_body(
         return match compression {
             Compression::Gzip => decompress_gzip(body),
             Compression::Base64 => decode_base64(body),
-            Compression::Unsupported => Err(FlagError::RequestDecodingError(
-                "Unsupported compression type".to_string(),
-            )),
+            Compression::Unsupported => {
+                tracing::warn!("unsupported compression type");
+                Err(FlagError::RequestDecodingError(
+                    "Unsupported compression type".to_string(),
+                ))
+            }
         };
     }
 
@@ -87,7 +93,7 @@ fn decompress_gzip(compressed: Bytes) -> Result<Bytes, FlagError> {
     let mut decoder = GzDecoder::new(&compressed[..]);
     let mut decompressed = Vec::new();
     decoder.read_to_end(&mut decompressed).map_err(|e| {
-        tracing::debug!("gzip decompression failed: {}", e);
+        tracing::warn!("gzip decompression failed: {}", e);
         FlagError::RequestDecodingError(format!("gzip decompression failed: {e}"))
     })?;
     Ok(Bytes::from(decompressed))
@@ -96,7 +102,10 @@ fn decompress_gzip(compressed: Bytes) -> Result<Bytes, FlagError> {
 fn decode_base64(body: Bytes) -> Result<Bytes, FlagError> {
     let decoded = general_purpose::STANDARD
         .decode(body)
-        .map_err(|e| FlagError::RequestDecodingError(format!("Base64 decoding error: {e}")))?;
+        .map_err(|e| {
+            tracing::warn!("Base64 decoding error: {}", e);
+            FlagError::RequestDecodingError(format!("Base64 decoding error: {e}"))
+        })?;
     Ok(Bytes::from(decoded))
 }
 
@@ -106,7 +115,7 @@ pub fn decode_form_data(
 ) -> Result<FlagRequest, FlagError> {
     // Convert bytes to string first so we can manipulate it
     let form_data = String::from_utf8(body.to_vec()).map_err(|e| {
-        tracing::debug!("Invalid UTF-8 in form data: {}", e);
+        tracing::warn!("Invalid UTF-8 in form data: {}", e);
         FlagError::RequestDecodingError("Invalid UTF-8 in form data".into())
     })?;
 
@@ -114,7 +123,7 @@ pub fn decode_form_data(
     let decoded_form = percent_decode(form_data.as_bytes())
         .decode_utf8()
         .map_err(|e| {
-            tracing::debug!("Failed to URL decode form data: {}", e);
+            tracing::warn!("Failed to URL decode form data: {}", e);
             FlagError::RequestDecodingError("Failed to URL decode form data".into())
         })?;
 
@@ -148,12 +157,14 @@ pub fn decode_form_data(
     // Handle compression if specified (we don't support gzip for form-urlencoded data)
     let decoded = match compression {
         Some(Compression::Gzip) => {
+            tracing::warn!("Gzip compression not supported for form-urlencoded data");
             return Err(FlagError::RequestDecodingError(
                 "Gzip compression not supported for form-urlencoded data".into(),
             ))
         }
         Some(Compression::Base64) | None => decode_base64(Bytes::from(cleaned_base64))?,
         Some(Compression::Unsupported) => {
+            tracing::warn!("Unsupported compression type for form-urlencoded data");
             return Err(FlagError::RequestDecodingError(
                 "Unsupported compression type".into(),
             ))
@@ -179,7 +190,7 @@ pub fn decode_form_data(
 
     // Parse JSON into FlagRequest
     serde_json::from_str(&json_str).map_err(|e| {
-        tracing::debug!("failed to parse JSON: {}", e);
+        tracing::warn!("failed to parse JSON: {}", e);
         FlagError::RequestDecodingError("invalid JSON structure".into())
     })
 }

--- a/rust/feature-flags/src/properties/property_matching.rs
+++ b/rust/feature-flags/src/properties/property_matching.rs
@@ -40,6 +40,7 @@ pub fn match_property(
     // only looks for matches where key exists in override_property_values
     // doesn't support operator is_not_set with partial_props
     if partial_props && !matching_property_values.contains_key(&property.key) {
+        tracing::warn!("Missing property for matching: {}", property.key);
         return Err(FlagMatchingError::MissingProperty(format!(
             "can't match properties without a value. Missing property: {}",
             property.key


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Going to proxy decide to flags and need to keep track of why there are elevated 400s

https://github.com/PostHog/posthog/issues/33636

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Add warn logs to all 400s. 

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
