### PR TITLE
chore(experiments): Fix window function empty parameters in timeseries

### DIFF
--- a/posthog/hogql_queries/experiments/experiment_timeseries.py
+++ b/posthog/hogql_queries/experiments/experiment_timeseries.py
@@ -353,7 +353,7 @@ class ExperimentTimeseries:
                     alias="num_users",
                     expr=ast.WindowFunction(
                         name="sum",
-                        args=[
+                        exprs=[
                             ast.Call(
                                 name="coalesce",
                                 args=[
@@ -381,7 +381,7 @@ class ExperimentTimeseries:
                     alias="total_sum",
                     expr=ast.WindowFunction(
                         name="sum",
-                        args=[
+                        exprs=[
                             ast.Call(
                                 name="coalesce",
                                 args=[
@@ -409,7 +409,7 @@ class ExperimentTimeseries:
                     alias="total_sum_of_squares",
                     expr=ast.WindowFunction(
                         name="sum",
-                        args=[
+                        exprs=[
                             ast.Call(
                                 name="coalesce",
                                 args=[


### PR DESCRIPTION
## Problem
After implementing the [last fix](https://github.com/PostHog/posthog/pull/36696), I was still getting ClickHouse errors `Parameters list to aggregate functions cannot be empty` in experiment timeseries calculations. The HogQL was generating invalid SQL like `sum()(coalesce(...))` instead of `sum(coalesce(...))` because WindowFunction AST nodes were using `args` instead of `exprs`.

## Changes  
I fixed the three WindowFunction definitions in `_get_cumulative_timeseries_query` to use `exprs=` instead of `args=`. I tested this by creating a management command that I copied to a production server, confirmed the fix generates correct SQL and verified the timeseries calculations now work without errors.