### PR TITLE
perf(batch-exports): Use Parquet file format for Snowflake 

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -545,7 +545,7 @@ class SnowflakeClient:
             file_stream = file
 
         query = f"""
-        PUT file://{file.name} '@%"{table_name}"/{table_stage_prefix}' AUTO_COMPRESS = FALSE
+        PUT file://{file.name} '@%"{table_name}"/{table_stage_prefix}'
         """
 
         with self.connection.cursor() as cursor:

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -595,7 +595,7 @@ class SnowflakeClient:
                 f'PARSE_JSON($1:"{field}")' if field in known_json_columns else f'$1:"{field}"' for field in col_names
             )
             query = f"""
-            COPY INTO "{table_name} ({', '.join(col_names)})"
+            COPY INTO "{table_name}" ({', '.join(f'"{col_name}"' for col_name in col_names)})"
             FROM (
                 SELECT {select_fields} FROM '@%"{table_name}"/{table_stage_prefix}'
             )

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -595,7 +595,7 @@ class SnowflakeClient:
                 f'PARSE_JSON($1:"{field}")' if field in known_json_columns else f'$1:"{field}"' for field in col_names
             )
             query = f"""
-            COPY INTO "{table_name}" ({', '.join(f'"{col_name}"' for col_name in col_names)})"
+            COPY INTO "{table_name}" ({', '.join(f'"{col_name}"' for col_name in col_names)})
             FROM (
                 SELECT {select_fields} FROM '@%"{table_name}"/{table_stage_prefix}'
             )

--- a/products/batch_exports/backend/tests/temporal/destinations/bigquery/__init__.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/bigquery/__init__.py
@@ -2,4 +2,4 @@ import pytest
 
 # ensure asserts in the utils module are rewritten by pytest
 # see: https://docs.pytest.org/en/stable/how-to/writing_plugins.html#assertion-rewriting
-pytest.register_assert_rewrite("products.batch_exports.backend.tests.temporal.destinations.snowflake.utils")
+pytest.register_assert_rewrite("products.batch_exports.backend.tests.temporal.destinations.bigquery.utils")

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/utils.py
@@ -4,6 +4,7 @@ import gzip
 import json
 import typing as t
 import datetime as dt
+import operator
 from collections import deque
 from uuid import uuid4
 

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/utils.py
@@ -4,7 +4,6 @@ import gzip
 import json
 import typing as t
 import datetime as dt
-import operator
 from collections import deque
 from uuid import uuid4
 


### PR DESCRIPTION
## Problem

Performance of our Snowflake batch exports could be improved

## Changes

Use Parquet with zstd compression for our Snowflake batch exports, as opposed to JSONLines. In our (limited) testing, this has shown to be over 3x more performant.

I'm just enabling this for the new pipeline, so we can more closely monitor the roll out.

Other changes:
- fixed an issue with exceptions not being propagated (not sure why this was happening but Snowflake SQL syntax errors were not being raised as an exception during the `COPY INTO`)
- fixed typo in the `BINARY` data type
- reduced the `max_record_batch_size_bytes` from 60MB to 10MB to reduce memory consumption
- moved the `assert_clickhouse_records_in_snowflake` from our test `utils.py` to `conftest.py`
    - it seems that unless `assert` statements are in a place `pytest` is aware of, you don't get the nicely formatted diff output when an assertion fails


## How did you test this code?

Automated tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
