### PR TITLE
fix: make decoding like python

### DIFF
--- a/rust/feature-flags/src/handler/decoding.rs
+++ b/rust/feature-flags/src/handler/decoding.rs
@@ -108,14 +108,14 @@ fn decode_base64(body: Bytes) -> Result<Bytes, FlagError> {
             tracing::warn!("Failed to URL decode base64 data: {}", e);
             FlagError::RequestDecodingError(format!("Failed to URL decode: {e}"))
         })?;
-    
+
     // Remove whitespace and add padding if necessary
     let mut cleaned = url_decoded.replace(" ", "");
     let padding_needed = cleaned.len() % 4;
     if padding_needed > 0 {
         cleaned.push_str(&"=".repeat(4 - padding_needed));
     }
-    
+
     let decoded = general_purpose::STANDARD.decode(cleaned).map_err(|e| {
         tracing::warn!("Base64 decoding error: {}", e);
         FlagError::RequestDecodingError(format!("Base64 decoding error: {e}"))

--- a/rust/feature-flags/src/handler/decoding.rs
+++ b/rust/feature-flags/src/handler/decoding.rs
@@ -100,7 +100,23 @@ fn decompress_gzip(compressed: Bytes) -> Result<Bytes, FlagError> {
 }
 
 fn decode_base64(body: Bytes) -> Result<Bytes, FlagError> {
-    let decoded = general_purpose::STANDARD.decode(body).map_err(|e| {
+    // Convert to string and apply URL decoding like base64_decode in Python decide
+    let body_str = String::from_utf8_lossy(&body);
+    let url_decoded = percent_decode(body_str.as_bytes())
+        .decode_utf8()
+        .map_err(|e| {
+            tracing::warn!("Failed to URL decode base64 data: {}", e);
+            FlagError::RequestDecodingError(format!("Failed to URL decode: {e}"))
+        })?;
+    
+    // Remove whitespace and add padding if necessary
+    let mut cleaned = url_decoded.replace(" ", "");
+    let padding_needed = cleaned.len() % 4;
+    if padding_needed > 0 {
+        cleaned.push_str(&"=".repeat(4 - padding_needed));
+    }
+    
+    let decoded = general_purpose::STANDARD.decode(cleaned).map_err(|e| {
         tracing::warn!("Base64 decoding error: {}", e);
         FlagError::RequestDecodingError(format!("Base64 decoding error: {e}"))
     })?;
@@ -280,5 +296,27 @@ mod tests {
         let request = result.unwrap();
         assert_eq!(request.distinct_id, Some("test".to_string()));
         assert_eq!(request.token, Some("test_token".to_string()));
+    }
+
+    #[test]
+    fn test_base64_with_url_encoding() {
+        // This test verifies the fix for URL-encoded base64 data
+        // Base64 with padding: eyJ0b2tlbiI6ICJ0ZXN0IiwgImRpc3RpbmN0X2lkIjogInVzZXIifQo=
+        // URL-encoded (= becomes %3D): eyJ0b2tlbiI6ICJ0ZXN0IiwgImRpc3RpbmN0X2lkIjogInVzZXIifQo%3D
+        let url_encoded_base64 = "eyJ0b2tlbiI6ICJ0ZXN0IiwgImRpc3RpbmN0X2lkIjogInVzZXIifQo%3D";
+        let body = Bytes::from(url_encoded_base64);
+
+        let headers = HeaderMap::new();
+        let query = FlagsQueryParams {
+            compression: Some(Compression::Base64),
+            ..Default::default()
+        };
+
+        let result = decode_request(&headers, body, &query);
+        assert!(result.is_ok());
+
+        let request = result.unwrap();
+        assert_eq!(request.distinct_id, Some("user".to_string()));
+        assert_eq!(request.token, Some("test".to_string()));
     }
 }


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

There is a difference in base64 decoding between flags and decide.



https://posthog.slack.com/archives/C07Q2U4BH4L/p1755294136857019?thread_ts=1755286346.832719&cid=C07Q2U4BH4L

## Changes

Match Python's decode 
https://github.com/PostHog/posthog/blob/9878cc1a030450a0bc546c481461d46de4668ee1/posthog/utils.py#L711-L733

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
