### PR TITLE
perf: threads for dashboard loads

### DIFF
--- a/ee/api/test/test_insight.py
+++ b/ee/api/test/test_insight.py
@@ -39,6 +39,7 @@ class TestInsightEnterpriseAPI(APILicensedTest):
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    @override_settings(IN_UNIT_TESTING=True)
     @freeze_time("2012-01-14T03:21:34.000Z")
     def test_can_add_and_remove_tags(self) -> None:
         insight_id, response_data = self.dashboard_api.create_insight(

--- a/ee/api/test/test_insight.py
+++ b/ee/api/test/test_insight.py
@@ -65,13 +65,6 @@ class TestInsightEnterpriseAPI(APILicensedTest):
         self.assertEqual(sorted(add_tags_response.json()["tags"]), ["1", "2", "3"])
 
         with freeze_time("2012-01-14T03:21:36.000Z"):
-            add_tags_response = self.client.patch(
-                # tags are displayed in order of insertion
-                f"/api/projects/{self.team.id}/insights/{insight_id}",
-                {"tags": ["2", "1", "3"]},
-            )
-
-        with freeze_time("2012-01-14T03:21:37.000Z"):
             remove_tags_response = self.client.patch(
                 f"/api/projects/{self.team.id}/insights/{insight_id}", {"tags": ["3"]}
             )
@@ -83,7 +76,7 @@ class TestInsightEnterpriseAPI(APILicensedTest):
             expected=[
                 {
                     "activity": "updated",
-                    "created_at": "2012-01-14T03:21:37Z",
+                    "created_at": "2012-01-14T03:21:36Z",
                     "detail": {
                         "changes": [
                             {

--- a/ee/api/test/test_insight.py
+++ b/ee/api/test/test_insight.py
@@ -40,30 +40,41 @@ class TestInsightEnterpriseAPI(APILicensedTest):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @override_settings(IN_UNIT_TESTING=True)
-    @freeze_time("2012-01-14T03:21:34.000Z")
     def test_can_add_and_remove_tags(self) -> None:
-        insight_id, response_data = self.dashboard_api.create_insight(
-            {
-                "name": "a created dashboard",
-                "filters": {
-                    "events": [{"id": "$pageview"}],
-                    "properties": [{"key": "$browser", "value": "Mac OS X"}],
-                    "date_from": "-90d",
-                },
-            }
-        )
+        with freeze_time("2012-01-14T03:21:34.000Z"):
+            insight_id, response_data = self.dashboard_api.create_insight(
+                {
+                    "name": "a created dashboard",
+                    "filters": {
+                        "events": [{"id": "$pageview"}],
+                        "properties": [{"key": "$browser", "value": "Mac OS X"}],
+                        "date_from": "-90d",
+                    },
+                }
+            )
         insight_short_id = response_data["short_id"]
         self.assertEqual(response_data["tags"], [])
 
-        add_tags_response = self.client.patch(
-            # tags are displayed in order of insertion
-            f"/api/projects/{self.team.id}/insights/{insight_id}",
-            {"tags": ["2", "1", "3"]},
-        )
+        with freeze_time("2012-01-14T03:21:35.000Z"):
+            add_tags_response = self.client.patch(
+                # tags are displayed in order of insertion
+                f"/api/projects/{self.team.id}/insights/{insight_id}",
+                {"tags": ["2", "1", "3"]},
+            )
 
         self.assertEqual(sorted(add_tags_response.json()["tags"]), ["1", "2", "3"])
 
-        remove_tags_response = self.client.patch(f"/api/projects/{self.team.id}/insights/{insight_id}", {"tags": ["3"]})
+        with freeze_time("2012-01-14T03:21:36.000Z"):
+            add_tags_response = self.client.patch(
+                # tags are displayed in order of insertion
+                f"/api/projects/{self.team.id}/insights/{insight_id}",
+                {"tags": ["2", "1", "3"]},
+            )
+
+        with freeze_time("2012-01-14T03:21:37.000Z"):
+            remove_tags_response = self.client.patch(
+                f"/api/projects/{self.team.id}/insights/{insight_id}", {"tags": ["3"]}
+            )
 
         self.assertEqual(remove_tags_response.json()["tags"], ["3"])
 
@@ -71,62 +82,62 @@ class TestInsightEnterpriseAPI(APILicensedTest):
             insight_id=insight_id,
             expected=[
                 {
-                    "user": {"first_name": "", "email": "user1@posthog.com"},
-                    "activity": "created",
-                    "scope": "Insight",
+                    "activity": "updated",
+                    "created_at": "2012-01-14T03:21:37Z",
+                    "detail": {
+                        "changes": [
+                            {
+                                "action": "changed",
+                                "after": ["3"],
+                                "before": ["1", "2", "3"],
+                                "field": "tags",
+                                "type": "Insight",
+                            }
+                        ],
+                        "name": "a created dashboard",
+                        "short_id": insight_short_id,
+                        "trigger": None,
+                        "type": None,
+                    },
                     "item_id": str(insight_id),
+                    "scope": "Insight",
+                    "user": {"email": "user1@posthog.com", "first_name": ""},
+                },
+                {
+                    "activity": "updated",
+                    "created_at": "2012-01-14T03:21:35Z",
+                    "detail": {
+                        "changes": [
+                            {
+                                "action": "changed",
+                                "after": ["1", "2", "3"],
+                                "before": [],
+                                "field": "tags",
+                                "type": "Insight",
+                            }
+                        ],
+                        "name": "a created dashboard",
+                        "short_id": insight_short_id,
+                        "trigger": None,
+                        "type": None,
+                    },
+                    "item_id": str(insight_id),
+                    "scope": "Insight",
+                    "user": {"email": "user1@posthog.com", "first_name": ""},
+                },
+                {
+                    "activity": "created",
+                    "created_at": "2012-01-14T03:21:34Z",
                     "detail": {
                         "changes": None,
-                        "trigger": None,
-                        "type": None,
                         "name": "a created dashboard",
                         "short_id": insight_short_id,
+                        "trigger": None,
+                        "type": None,
                     },
-                    "created_at": "2012-01-14T03:21:34Z",
-                },
-                {
-                    "user": {"first_name": "", "email": "user1@posthog.com"},
-                    "activity": "updated",
-                    "scope": "Insight",
                     "item_id": str(insight_id),
-                    "detail": {
-                        "changes": [
-                            {
-                                "type": "Insight",
-                                "action": "changed",
-                                "field": "tags",
-                                "before": [],
-                                "after": ["1", "2", "3"],
-                            }
-                        ],
-                        "trigger": None,
-                        "type": None,
-                        "name": "a created dashboard",
-                        "short_id": insight_short_id,
-                    },
-                    "created_at": "2012-01-14T03:21:34Z",
-                },
-                {
-                    "user": {"first_name": "", "email": "user1@posthog.com"},
-                    "activity": "updated",
                     "scope": "Insight",
-                    "item_id": str(insight_id),
-                    "detail": {
-                        "changes": [
-                            {
-                                "type": "Insight",
-                                "action": "changed",
-                                "field": "tags",
-                                "before": ["1", "2", "3"],
-                                "after": ["3"],
-                            }
-                        ],
-                        "trigger": None,
-                        "type": None,
-                        "name": "a created dashboard",
-                        "short_id": insight_short_id,
-                    },
-                    "created_at": "2012-01-14T03:21:34Z",
+                    "user": {"email": "user1@posthog.com", "first_name": ""},
                 },
             ],
         )

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -191,6 +191,7 @@ export const FEATURE_FLAGS = {
     INSIGHT_FUNNELS_USE_UDF_TRENDS: 'insight-funnels-use-udf-trends', // owner: @aspicer #team-product-analytics
     INSIGHT_FUNNELS_USE_UDF_TIME_TO_CONVERT: 'insight-funnels-use-udf-time-to-convert', // owner: @aspicer #team-product-analytics
     QUERY_CACHE_USE_S3: 'query-cache-use-s3', // owner: @aspicer #team-product-analytics
+    DASHBOARD_THREADS: 'dashboard-threads', // owner: @aspicer #team-product-analytics
     BATCH_EXPORTS_POSTHOG_HTTP: 'posthog-http-batch-exports',
     HEDGEHOG_SKIN_SPIDERHOG: 'hedgehog-skin-spiderhog', // owner: @benjackwhite
     WEB_EXPERIMENTS: 'web-experiments', // owner: @team-feature-success

--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -509,14 +509,14 @@ class DashboardSerializer(DashboardBasicSerializer):
 
             with ThreadPoolExecutor(max_workers=max_workers) as executor:
                 # Submit all tile serialization tasks
-                future_to_order = {}
+                futures = []
                 for order, tile in enumerate(sorted_tiles):
                     future = executor.submit(serialize_tile_with_context, tile, order, self.context)
-                    future_to_order[future] = order
+                    futures.append(future)
 
                 # Collect results maintaining original order
                 tile_results = [None] * len(sorted_tiles)
-                for future in as_completed(future_to_order):
+                for future in as_completed(futures):
                     order, tile_data = future.result()
                     tile_results[order] = tile_data
 

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -58,6 +58,7 @@ valid_template: dict = {
 }
 
 
+@override_settings(IN_UNIT_TESTING=True)
 class TestDashboard(APIBaseTest, QueryMatchingTest):
     def setUp(self) -> None:
         super().setUp()
@@ -270,7 +271,7 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
                 "insight": "TRENDS",
             }
 
-            baseline = 8
+            baseline = 9
 
             with self.assertNumQueries(baseline + 12):
                 self.dashboard_api.get_dashboard(dashboard_id, query_params={"no_items_field": "true"})

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -271,7 +271,7 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
                 "insight": "TRENDS",
             }
 
-            baseline = 9
+            baseline = 8
 
             with self.assertNumQueries(baseline + 12):
                 self.dashboard_api.get_dashboard(dashboard_id, query_params={"no_items_field": "true"})

--- a/posthog/api/test/dashboards/test_dashboard_text_tiles.py
+++ b/posthog/api/test/dashboards/test_dashboard_text_tiles.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 from freezegun import freeze_time
 from rest_framework import status
+from tests import override_settings
 
 from posthog.api.test.dashboards import DashboardAPI
 from posthog.models import User
@@ -114,6 +115,7 @@ class TestDashboardTiles(APIBaseTest, QueryMatchingTest):
             body="hello world",
         )
 
+    @override_settings(IN_UNIT_TESTING=True)
     def test_can_update_a_single_text_tile(self) -> None:
         with freeze_time("2022-04-01 12:45") as frozen_time:
             dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})

--- a/posthog/api/test/dashboards/test_dashboard_text_tiles.py
+++ b/posthog/api/test/dashboards/test_dashboard_text_tiles.py
@@ -105,6 +105,7 @@ class TestDashboardTiles(APIBaseTest, QueryMatchingTest):
         }
 
     @freeze_time("2022-04-01 12:45")
+    @override_settings(IN_UNIT_TESTING=True)
     def test_can_create_a_single_text_tile(self) -> None:
         dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
 

--- a/posthog/api/test/dashboards/test_dashboard_text_tiles.py
+++ b/posthog/api/test/dashboards/test_dashboard_text_tiles.py
@@ -1,10 +1,10 @@
 import datetime
 from typing import Optional, Union
+from django.test import override_settings
 from unittest import mock
 
 from freezegun import freeze_time
 from rest_framework import status
-from tests import override_settings
 
 from posthog.api.test.dashboards import DashboardAPI
 from posthog.models import User

--- a/posthog/hogql_queries/legacy_compatibility/feature_flag.py
+++ b/posthog/hogql_queries/legacy_compatibility/feature_flag.py
@@ -172,7 +172,7 @@ def dashboard_threads_enabled(team: Team, user: Optional["User"] = None) -> bool
                 "id": str(team.id),
             },
         },
-        only_evaluate_locally=False,
+        only_evaluate_locally=True,
         send_feature_flag_events=False,
     )
 

--- a/posthog/hogql_queries/legacy_compatibility/feature_flag.py
+++ b/posthog/hogql_queries/legacy_compatibility/feature_flag.py
@@ -146,6 +146,37 @@ def query_cache_use_s3(team: Team, user: Optional["User"] = None) -> bool:
     )
 
 
+def dashboard_threads_enabled(team: Team, user: Optional["User"] = None) -> bool:
+    """
+    Use thread pool execution for dashboard tile serialization instead of IN_UNIT_TESTING logic.
+
+    Args:
+        team: The team to check the feature flag for
+        user: Optional user to check user-specific feature flags
+    """
+
+    distinct_id = str(user.distinct_id) if user else ""
+
+    return posthoganalytics.feature_enabled(
+        "dashboard-threads",
+        distinct_id,
+        groups={
+            "organization": str(team.organization_id),
+            "project": str(team.id),
+        },
+        group_properties={
+            "organization": {
+                "id": str(team.organization_id),
+            },
+            "project": {
+                "id": str(team.id),
+            },
+        },
+        only_evaluate_locally=False,
+        send_feature_flag_events=False,
+    )
+
+
 LegacyAPIQueryMethod = Literal["legacy", "hogql"]
 
 


### PR DESCRIPTION
## Problem
Some dashboards have 40+ insights which serially hit the DB and check cache etc. 

## Changes
Launch threads (up to 10) and build the insight responses. Not a cure all but should make this better for not. Flagged so we can test it on prod - it works locally but can't be sure with this sort of thing. 

Similar to what we do in trends_query_runner

## How did you test this code?
Tested it locally with a large dashboard. Have a feature flag