### PR TITLE
fix(hobby): avoid invalid empty string in Caddyfile global block, resulting in failure of self-hosted installation (P0)

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -15,7 +15,7 @@ services:
             CADDY_HOST: 'http://localhost:8000'
             CADDYFILE: |
                 {
-                ${CADDY_TLS_BLOCK:-''}
+                ${CADDY_TLS_BLOCK:-}
                 }
                 ${CADDY_HOST:-'http://localhost:8000'} {
                     @replay-capture {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
When running PostHog with `docker-compose.base.yml`, the default value for `CADDY_TLS_BLOCK` was set to ''.
This caused the generated `/etc/caddy/Caddyfile `to look like:

```
{
''
}

http://localhost:8000 {
    ...
}

```

➡️ Result: Caddy fails with below error, **resulting in failure of self-hosted installation**

`Error: adapting config using caddyfile: /etc/caddy/Caddyfile:2: unrecognized global option: ''
`

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

✅ Solution

Updated the `docker-compose.base.yml `so `${CADDY_TLS_BLOCK}` defaults to an empty string instead of `''`.

Now the generated Caddyfile will be valid:
```
{
}
http://localhost:8000 {
    ...
}

```

📸 **Screenshots**

<img width="2500" height="554" alt="error_message_during_container_start" src="https://github.com/user-attachments/assets/2a9aae09-5155-4d7e-9164-747ef629e65a" />

<img width="864" height="321" alt="wrong_file_with_bug" src="https://github.com/user-attachments/assets/aed1e6f5-e6ed-4ed8-a8cd-feca3d9f9264" />

<img width="933" height="338" alt="value_after_fix" src="https://github.com/user-attachments/assets/d53405f5-ff96-4476-93f7-36f2c6644679" />

## How did you test this code?
1. Tested by up the Posthog end to end.
2. Tested by up the failed container with this fix.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
