### PR TITLE
fix(dashboards): add to dashboard modal bug

### DIFF
--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -32,7 +32,7 @@ import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { entityFilterLogic } from 'scenes/insights/filters/ActionFilter/entityFilterLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
-import { savedInsightsLogic } from 'scenes/saved-insights/savedInsightsLogic'
+import { SavedInsightFilters } from 'scenes/saved-insights/savedInsightsLogic'
 import { Scene } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -714,16 +714,16 @@ const SAVED_INSIGHTS_COPY = {
     },
 }
 
-export function SavedInsightsEmptyState(): JSX.Element {
-    const {
-        filters: { tab },
-        insights,
-        usingFilters,
-    } = useValues(savedInsightsLogic)
-
+export function SavedInsightsEmptyState({
+    filters,
+    usingFilters,
+}: {
+    filters: SavedInsightFilters
+    usingFilters?: boolean
+}): JSX.Element {
     // show the search string that was used to make the results, not what it currently is
-    const searchString = insights.filters?.search || null
-    const { title, description } = SAVED_INSIGHTS_COPY[tab as keyof typeof SAVED_INSIGHTS_COPY] ?? {}
+    const searchString = filters?.search || null
+    const { title, description } = SAVED_INSIGHTS_COPY[filters.tab as keyof typeof SAVED_INSIGHTS_COPY] ?? {}
 
     return (
         <div
@@ -747,7 +747,7 @@ export function SavedInsightsEmptyState(): JSX.Element {
             ) : (
                 <p className="empty-state__description">{description}</p>
             )}
-            {tab !== SavedInsightsTabs.Favorites && (
+            {filters.tab !== SavedInsightsTabs.Favorites && (
                 <div className="flex justify-center">
                     <Link to={urls.insightNew()}>
                         <AccessControlledLemonButton

--- a/frontend/src/scenes/saved-insights/AddSavedInsightsToDashboard.tsx
+++ b/frontend/src/scenes/saved-insights/AddSavedInsightsToDashboard.tsx
@@ -144,7 +144,7 @@ export function AddSavedInsightsToDashboard(): JSX.Element {
                 </span>
             </div>
             {!insightsLoading && insights.count < 1 ? (
-                <SavedInsightsEmptyState />
+                <SavedInsightsEmptyState filters={filters} usingFilters />
             ) : (
                 <>
                     <LemonTable

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -615,8 +615,9 @@ function SavedInsightsGrid(): JSX.Element {
 export function SavedInsights(): JSX.Element {
     const { loadInsights, updateFavoritedInsight, renameInsight, duplicateInsight, setSavedInsightsFilters } =
         useActions(savedInsightsLogic)
-    const { insights, count, insightsLoading, filters, sorting, pagination, alertModalId } =
+    const { insights, count, insightsLoading, filters, sorting, pagination, alertModalId, usingFilters } =
         useValues(savedInsightsLogic)
+
     const { hasTagging } = useValues(organizationLogic)
     const { currentProjectId } = useValues(projectLogic)
     const summarizeInsight = useSummarizeInsight()
@@ -829,7 +830,7 @@ export function SavedInsights(): JSX.Element {
                         </div>
                     </div>
                     {!insightsLoading && insights.count < 1 ? (
-                        <SavedInsightsEmptyState />
+                        <SavedInsightsEmptyState filters={filters} usingFilters={usingFilters} />
                     ) : (
                         <>
                             <ReloadInsight />


### PR DESCRIPTION
## Problem

Searching inside the "Dashboards" > "Add insights do dashboard" model caused the app to crash if the filter matched 0 results.

## Changes

Fixes https://github.com/PostHog/posthog/issues/36707

Fix the bug --> finding 0 insights no longer crashes the entire page.

## How did you test this code?

Clicked around locally.