### PR TITLE
fix: increase quota limiting timeout

### DIFF
--- a/posthog/temporal/quota_limiting/run_quota_limiting.py
+++ b/posthog/temporal/quota_limiting/run_quota_limiting.py
@@ -62,7 +62,7 @@ class RunQuotaLimitingWorkflow(PostHogWorkflow):
             await workflow.execute_activity(
                 run_quota_limiting_all_orgs,
                 RunQuotaLimitingAllOrgsInputs(),
-                start_to_close_timeout=timedelta(minutes=14),
+                start_to_close_timeout=timedelta(minutes=60),
                 retry_policy=common.RetryPolicy(
                     maximum_attempts=2,
                     initial_interval=timedelta(minutes=1),


### PR DESCRIPTION
Quota limiting has been failing in US due to timeouts - it seems that after some failed runs (which can happen for random reasons), it has to process more data and the initial timeout limit is not enough. Will look into a better schedule configuration but in the meantime just increasing the timeout from 15min to 60min.