### PR TITLE
feat(activity-logs): ExternalDataSource and ExternalDataSchema

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelActivityLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelActivityLogic.tsx
@@ -19,6 +19,7 @@ const HIDDEN_ACTIVITY_SCOPES: ActivityScope[] = [
     ActivityScope.TAGGED_ITEM, // Handled under ActivityScope.TAG
     ActivityScope.ORGANIZATION_MEMBERSHIP, // Handled under ActivityScope.ORGANIZATION
     ActivityScope.ORGANIZATION_INVITE, // Handled under ActivityScope.ORGANIZATION
+    ActivityScope.EXTERNAL_DATA_SCHEMA, // Handled under ActivityScope.EXTERNAL_DATA_SOURCE
 ]
 
 const getVisibleActivityScopes = (): ActivityScope[] => {

--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
@@ -21,6 +21,7 @@ import { cohortActivityDescriber } from 'scenes/cohorts/activityDescriptions'
 import { dataManagementActivityDescriber } from 'scenes/data-management/dataManagementDescribers'
 import { batchExportActivityDescriber } from 'scenes/data-pipelines/batch-exports/activityDescriptions'
 import { batchImportActivityDescriber } from 'scenes/data-pipelines/batch-imports/activityDescriptions'
+import { externalDataSourceActivityDescriber } from 'scenes/data-warehouse/external-data-sources/activityDescriptions'
 import { dataWarehouseSavedQueryActivityDescriber } from 'scenes/data-warehouse/saved_queries/activityDescriptions'
 import { experimentActivityDescriber } from 'scenes/experiments/experimentActivityDescriber'
 import { flagActivityDescriber } from 'scenes/feature-flags/activityDescriptions'
@@ -48,6 +49,7 @@ const SCOPE_EXPANSIONS: Partial<Record<ActivityScope, ActivityScope[]>> = {
         ActivityScope.ORGANIZATION_MEMBERSHIP,
         ActivityScope.ORGANIZATION_INVITE,
     ],
+    [ActivityScope.EXTERNAL_DATA_SOURCE]: [ActivityScope.EXTERNAL_DATA_SOURCE, ActivityScope.EXTERNAL_DATA_SCHEMA],
 }
 
 export const activityLogTransforms = {
@@ -144,6 +146,9 @@ export const describerFor = (logItem?: ActivityLogItem): Describer | undefined =
         case ActivityScope.TAG:
         case ActivityScope.TAGGED_ITEM:
             return tagActivityDescriber
+        case ActivityScope.EXTERNAL_DATA_SOURCE:
+        case ActivityScope.EXTERNAL_DATA_SCHEMA:
+            return externalDataSourceActivityDescriber
         default:
             return (logActivity, asNotification) => defaultDescriber(logActivity, asNotification)
     }

--- a/frontend/src/lib/components/ActivityLog/humanizeActivity.tsx
+++ b/frontend/src/lib/components/ActivityLog/humanizeActivity.tsx
@@ -134,6 +134,7 @@ const NO_PLURAL_SCOPES: ActivityScope[] = [
 const SCOPE_DISPLAY_NAMES: Partial<Record<ActivityScope, { singular: string; plural: string }>> = {
     [ActivityScope.ALERT_CONFIGURATION]: { singular: 'Alert', plural: 'Alerts' },
     [ActivityScope.BATCH_EXPORT]: { singular: 'Destination', plural: 'Destinations' },
+    [ActivityScope.EXTERNAL_DATA_SOURCE]: { singular: 'Source', plural: 'Sources' },
 }
 
 export function humanizeScope(scope: ActivityScope | string, singular = false): string {

--- a/frontend/src/scenes/data-pipelines/batch-exports/activityDescriptions.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/activityDescriptions.tsx
@@ -17,7 +17,7 @@ export function batchExportActivityDescriber(logItem: ActivityLogItem, asNotific
         return {
             description: (
                 <>
-                    < strong > {userNameForLogItem(logItem)}</strong > created destination{' '}
+                    <strong> {userNameForLogItem(logItem)}</strong> created destination{' '}
                     <strong>{nameOrLinkToBatchExport(logItem?.item_id, logItem?.detail.name)}</strong>
                 </>
             ),
@@ -39,14 +39,12 @@ export function batchExportActivityDescriber(logItem: ActivityLogItem, asNotific
         return {
             description: (
                 <>
-                    < strong > {userNameForLogItem(logItem)}</strong > updated destination{' '}
+                    <strong>{userNameForLogItem(logItem)}</strong> updated destination{' '}
                     <strong>{nameOrLinkToBatchExport(logItem?.item_id, logItem?.detail.name)}</strong>
-
                 </>
             ),
         }
     }
 
     return defaultDescriber(logItem, asNotification, nameOrLinkToBatchExport(logItem?.item_id, logItem?.detail.name))
-
 }

--- a/frontend/src/scenes/data-pipelines/batch-exports/activityDescriptions.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/activityDescriptions.tsx
@@ -17,7 +17,7 @@ export function batchExportActivityDescriber(logItem: ActivityLogItem, asNotific
         return {
             description: (
                 <>
-                    <strong>{userNameForLogItem(logItem)}</strong> created destination{' '}
+                    < strong > {userNameForLogItem(logItem)}</strong > created destination{' '}
                     <strong>{nameOrLinkToBatchExport(logItem?.item_id, logItem?.detail.name)}</strong>
                 </>
             ),
@@ -39,12 +39,14 @@ export function batchExportActivityDescriber(logItem: ActivityLogItem, asNotific
         return {
             description: (
                 <>
-                    <strong>{userNameForLogItem(logItem)}</strong> updated destination{' '}
+                    < strong > {userNameForLogItem(logItem)}</strong > updated destination{' '}
                     <strong>{nameOrLinkToBatchExport(logItem?.item_id, logItem?.detail.name)}</strong>
+
                 </>
             ),
         }
     }
 
     return defaultDescriber(logItem, asNotification, nameOrLinkToBatchExport(logItem?.item_id, logItem?.detail.name))
+
 }

--- a/frontend/src/scenes/data-pipelines/batch-imports/activityDescriptions.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-imports/activityDescriptions.tsx
@@ -30,7 +30,7 @@ export function batchImportActivityDescriber(logItem: ActivityLogItem, asNotific
         return {
             description: (
                 <>
-                    < strong > {userNameForLogItem(logItem)}</strong > created < strong > {getDisplayName(logItem)}</strong >
+                    <strong>{userNameForLogItem(logItem)}</strong> created <strong>{getDisplayName(logItem)}</strong>
                 </>
             ),
         }
@@ -40,7 +40,7 @@ export function batchImportActivityDescriber(logItem: ActivityLogItem, asNotific
         return {
             description: (
                 <>
-                    < strong > {userNameForLogItem(logItem)}</strong > deleted < strong > {getDisplayName(logItem)}</strong >
+                    <strong>{userNameForLogItem(logItem)}</strong> deleted <strong>{getDisplayName(logItem)}</strong>
                 </>
             ),
         }
@@ -50,7 +50,7 @@ export function batchImportActivityDescriber(logItem: ActivityLogItem, asNotific
         return {
             description: (
                 <>
-                    < strong > {userNameForLogItem(logItem)}</strong > updated < strong > {getDisplayName(logItem)}</strong >
+                    <strong>{userNameForLogItem(logItem)}</strong> updated <strong>{getDisplayName(logItem)}</strong>
                 </>
             ),
         }

--- a/frontend/src/scenes/data-pipelines/batch-imports/activityDescriptions.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-imports/activityDescriptions.tsx
@@ -30,7 +30,7 @@ export function batchImportActivityDescriber(logItem: ActivityLogItem, asNotific
         return {
             description: (
                 <>
-                    <strong>{userNameForLogItem(logItem)}</strong> created <strong>{getDisplayName(logItem)}</strong>
+                    < strong > {userNameForLogItem(logItem)}</strong > created < strong > {getDisplayName(logItem)}</strong >
                 </>
             ),
         }
@@ -40,7 +40,7 @@ export function batchImportActivityDescriber(logItem: ActivityLogItem, asNotific
         return {
             description: (
                 <>
-                    <strong>{userNameForLogItem(logItem)}</strong> deleted <strong>{getDisplayName(logItem)}</strong>
+                    < strong > {userNameForLogItem(logItem)}</strong > deleted < strong > {getDisplayName(logItem)}</strong >
                 </>
             ),
         }
@@ -50,7 +50,7 @@ export function batchImportActivityDescriber(logItem: ActivityLogItem, asNotific
         return {
             description: (
                 <>
-                    <strong>{userNameForLogItem(logItem)}</strong> updated <strong>{getDisplayName(logItem)}</strong>
+                    < strong > {userNameForLogItem(logItem)}</strong > updated < strong > {getDisplayName(logItem)}</strong >
                 </>
             ),
         }

--- a/frontend/src/scenes/data-warehouse/external-data-sources/activityDescriptions.tsx
+++ b/frontend/src/scenes/data-warehouse/external-data-sources/activityDescriptions.tsx
@@ -1,9 +1,10 @@
 import {
     ActivityLogItem,
-    defaultDescriber,
     HumanizedChange,
+    defaultDescriber,
     userNameForLogItem,
 } from 'lib/components/ActivityLog/humanizeActivity'
+
 import { ActivityScope } from '~/types'
 
 const getDisplayName = (logItem: ActivityLogItem): string => {
@@ -14,8 +15,8 @@ const getDisplayName = (logItem: ActivityLogItem): string => {
 
     // Handle ExternalDataSource display name
     if (logItem.scope === ActivityScope.EXTERNAL_DATA_SOURCE) {
-        const sourceType = logItem?.detail?.source_type
-        const prefix = logItem?.detail?.prefix
+        const sourceType = (logItem?.detail as any)?.source_type
+        const prefix = (logItem?.detail as any)?.prefix
 
         if (sourceType && prefix) {
             return `${sourceType} (${prefix})`
@@ -27,8 +28,8 @@ const getDisplayName = (logItem: ActivityLogItem): string => {
     // Handle ExternalDataSchema display name
     if (logItem.scope === ActivityScope.EXTERNAL_DATA_SCHEMA) {
         const schemaName = logItem?.detail?.name || 'Unnamed Schema'
-        const syncType = logItem?.detail?.sync_type
-        const syncFrequency = logItem?.detail?.sync_frequency
+        const syncType = (logItem?.detail as any)?.sync_type
+        const syncFrequency = (logItem?.detail as any)?.sync_frequency
 
         if (syncType && syncFrequency) {
             return `${schemaName} (${syncType}, ${syncFrequency})`

--- a/frontend/src/scenes/data-warehouse/external-data-sources/activityDescriptions.tsx
+++ b/frontend/src/scenes/data-warehouse/external-data-sources/activityDescriptions.tsx
@@ -1,0 +1,112 @@
+import {
+    ActivityLogItem,
+    defaultDescriber,
+    HumanizedChange,
+    userNameForLogItem,
+} from 'lib/components/ActivityLog/humanizeActivity'
+import { ActivityScope } from '~/types'
+
+const getDisplayName = (logItem: ActivityLogItem): string => {
+    const name = logItem?.detail?.name
+    if (name) {
+        return name
+    }
+
+    // Handle ExternalDataSource display name
+    if (logItem.scope === ActivityScope.EXTERNAL_DATA_SOURCE) {
+        const sourceType = logItem?.detail?.source_type
+        const prefix = logItem?.detail?.prefix
+
+        if (sourceType && prefix) {
+            return `${sourceType} (${prefix})`
+        } else if (sourceType) {
+            return sourceType
+        }
+    }
+
+    // Handle ExternalDataSchema display name
+    if (logItem.scope === ActivityScope.EXTERNAL_DATA_SCHEMA) {
+        const schemaName = logItem?.detail?.name || 'Unnamed Schema'
+        const syncType = logItem?.detail?.sync_type
+        const syncFrequency = logItem?.detail?.sync_frequency
+
+        if (syncType && syncFrequency) {
+            return `${schemaName} (${syncType}, ${syncFrequency})`
+        } else if (syncType) {
+            return `${schemaName} (${syncType})`
+        }
+        return schemaName
+    }
+
+    return 'External Data Source'
+}
+
+export function externalDataSourceActivityDescriber(
+    logItem: ActivityLogItem,
+    asNotification?: boolean
+): HumanizedChange {
+    const displayName = getDisplayName(logItem)
+
+    if (logItem.activity == 'created') {
+        if (logItem.scope === ActivityScope.EXTERNAL_DATA_SCHEMA) {
+            return {
+                description: (
+                    <>
+                        <strong>{userNameForLogItem(logItem)}</strong> created schema <strong>{displayName}</strong>
+                    </>
+                ),
+            }
+        }
+        return {
+            description: (
+                <>
+                    <strong>{userNameForLogItem(logItem)}</strong> created source <strong>{displayName}</strong>
+                </>
+            ),
+        }
+    }
+
+    if (
+        logItem.activity == 'deleted' ||
+        (logItem.activity == 'updated' &&
+            logItem.detail?.changes?.some((change: any) => change.field === 'deleted' && change.after === true))
+    ) {
+        if (logItem.scope === ActivityScope.EXTERNAL_DATA_SCHEMA) {
+            return {
+                description: (
+                    <>
+                        <strong>{userNameForLogItem(logItem)}</strong> deleted schema <strong>{displayName}</strong>
+                    </>
+                ),
+            }
+        }
+        return {
+            description: (
+                <>
+                    <strong>{userNameForLogItem(logItem)}</strong> deleted source <strong>{displayName}</strong>
+                </>
+            ),
+        }
+    }
+
+    if (logItem.activity == 'updated') {
+        if (logItem.scope === ActivityScope.EXTERNAL_DATA_SCHEMA) {
+            return {
+                description: (
+                    <>
+                        <strong>{userNameForLogItem(logItem)}</strong> updated schema <strong>{displayName}</strong>
+                    </>
+                ),
+            }
+        }
+        return {
+            description: (
+                <>
+                    <strong>{userNameForLogItem(logItem)}</strong> updated source <strong>{displayName}</strong>
+                </>
+            ),
+        }
+    }
+
+    return defaultDescriber(logItem, asNotification, displayName)
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4613,6 +4613,8 @@ export enum ActivityScope {
     USER_INTERVIEW = 'UserInterview',
     TAG = 'Tag',
     TAGGED_ITEM = 'TaggedItem',
+    EXTERNAL_DATA_SOURCE = 'ExternalDataSource',
+    EXTERNAL_DATA_SCHEMA = 'ExternalDataSchema',
 }
 
 export type CommentType = {

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -126,6 +126,8 @@ class ActivityDetailEncoder(json.JSONEncoder):
             return str(obj)
         if hasattr(obj, "__class__") and obj.__class__.__name__ == "User":
             return {"first_name": obj.first_name, "email": obj.email}
+        if hasattr(obj, "__class__") and obj.__class__.__name__ == "DataWarehouseTable":
+            return obj.name
         if isinstance(obj, float):
             # more precision than we'll need but avoids rounding too unnecessarily
             return format(obj, ".6f").rstrip("0").rstrip(".")

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -389,6 +389,7 @@ field_exclusions: dict[ActivityScope, list[str]] = {
         "last_paused_at",
         "batchexportrun_set",
         "batchexportbackfill_set",
+        "deleted",
     ],
     "BatchImport": [
         "lease_id",

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -1,6 +1,6 @@
 import json
 import dataclasses
-from datetime import datetime
+from datetime import datetime, time
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 from uuid import UUID
@@ -115,6 +115,8 @@ class ActivityDetailEncoder(json.JSONEncoder):
         if isinstance(obj, Detail | Change | Trigger | ActivityContextBase):
             return obj.__dict__
         if isinstance(obj, datetime):
+            return obj.isoformat()
+        if isinstance(obj, time):
             return obj.isoformat()
         if isinstance(obj, UUIDT):
             return str(obj)

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -227,6 +227,9 @@ field_with_masked_contents: dict[ActivityScope, list[str]] = {
     "Subscription": [
         "target_value",
     ],
+    "ExternalDataSource": [
+        "job_inputs",
+    ],
 }
 
 field_name_overrides: dict[ActivityScope, dict[str, str]] = {
@@ -245,6 +248,9 @@ field_name_overrides: dict[ActivityScope, dict[str, str]] = {
     },
     "BatchExport": {
         "paused": "enabled",
+    },
+    "ExternalDataSource": {
+        "job_inputs": "configuration",
     },
     "ExternalDataSchema": {
         "should_sync": "enabled",
@@ -443,7 +449,6 @@ field_exclusions: dict[ActivityScope, list[str]] = {
         "steps_json",
     ],
     "ExternalDataSource": [
-        "job_inputs",
         "connection_id",
         "destination_id",
         "are_tables_created",

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -67,6 +67,8 @@ ActivityScope = Literal[
     "AlertConfiguration",
     "Threshold",
     "AlertSubscription",
+    "ExternalDataSource",
+    "ExternalDataSchema",
 ]
 ChangeAction = Literal["changed", "created", "deleted", "merged", "split", "exported"]
 
@@ -389,7 +391,6 @@ field_exclusions: dict[ActivityScope, list[str]] = {
         "last_paused_at",
         "batchexportrun_set",
         "batchexportbackfill_set",
-        "deleted",
     ],
     "BatchImport": [
         "lease_id",
@@ -433,6 +434,19 @@ field_exclusions: dict[ActivityScope, list[str]] = {
         "bytecode",
         "bytecode_error",
         "steps_json",
+    ],
+    "ExternalDataSource": [
+        "job_inputs",
+        "connection_id",
+        "destination_id",
+        "are_tables_created",
+    ],
+    "ExternalDataSchema": [
+        "sync_type_config",
+        "latest_error",
+        "last_synced_at",
+        "table",
+        "sync_frequency_interval",
     ],
 }
 

--- a/posthog/models/activity_logging/external_data_utils.py
+++ b/posthog/models/activity_logging/external_data_utils.py
@@ -11,45 +11,6 @@ def get_external_data_source_detail_name(external_data_source) -> str:
     return source_type
 
 
-def get_external_data_schema_detail_name(external_data_schema) -> str:
-    """Generate detail name for ExternalDataSchema activity"""
-    name = external_data_schema.name or "Unnamed Schema"
-    sync_type = external_data_schema.sync_type or "unknown"
-
-    # Use the deprecated sync_frequency if available, otherwise use sync_frequency_interval
-    sync_frequency = None
-    if hasattr(external_data_schema, "sync_frequency") and external_data_schema.sync_frequency:
-        sync_frequency = external_data_schema.sync_frequency
-    elif external_data_schema.sync_frequency_interval:
-        # Convert timedelta to human-readable format
-        days = external_data_schema.sync_frequency_interval.days
-        hours = external_data_schema.sync_frequency_interval.seconds // 3600
-
-        if days > 0:
-            if days == 1:
-                sync_frequency = "daily"
-            elif days == 7:
-                sync_frequency = "weekly"
-            elif days >= 30:
-                sync_frequency = "monthly"
-            else:
-                sync_frequency = f"{days}d"
-        elif hours > 0:
-            if hours == 1:
-                sync_frequency = "hourly"
-            elif hours == 6:
-                sync_frequency = "6h"
-            elif hours == 12:
-                sync_frequency = "12h"
-            else:
-                sync_frequency = f"{hours}h"
-
-    if sync_frequency:
-        return f"{name} ({sync_type}, {sync_frequency})"
-
-    return f"{name} ({sync_type})"
-
-
 def get_external_data_source_created_by_info(
     external_data_source,
 ) -> tuple[Optional[str], Optional[str], Optional[str]]:

--- a/posthog/models/activity_logging/external_data_utils.py
+++ b/posthog/models/activity_logging/external_data_utils.py
@@ -1,7 +1,9 @@
 from typing import Optional
 
+from posthog.warehouse.models.external_data_source import ExternalDataSource
 
-def get_external_data_source_detail_name(external_data_source) -> str:
+
+def get_external_data_source_detail_name(external_data_source: ExternalDataSource) -> str:
     """Generate detail name for ExternalDataSource activity"""
     source_type = external_data_source.source_type or "unknown"
 
@@ -12,7 +14,7 @@ def get_external_data_source_detail_name(external_data_source) -> str:
 
 
 def get_external_data_source_created_by_info(
-    external_data_source,
+    external_data_source: ExternalDataSource,
 ) -> tuple[Optional[str], Optional[str], Optional[str]]:
     """Get created by user information from ExternalDataSource"""
     created_by_user_id = None

--- a/posthog/models/activity_logging/external_data_utils.py
+++ b/posthog/models/activity_logging/external_data_utils.py
@@ -1,0 +1,68 @@
+from typing import Optional
+
+
+def get_external_data_source_detail_name(external_data_source) -> str:
+    """Generate detail name for ExternalDataSource activity"""
+    source_type = external_data_source.source_type or "unknown"
+
+    if external_data_source.prefix:
+        return f"{source_type} ({external_data_source.prefix})"
+
+    return source_type
+
+
+def get_external_data_schema_detail_name(external_data_schema) -> str:
+    """Generate detail name for ExternalDataSchema activity"""
+    name = external_data_schema.name or "Unnamed Schema"
+    sync_type = external_data_schema.sync_type or "unknown"
+
+    # Use the deprecated sync_frequency if available, otherwise use sync_frequency_interval
+    sync_frequency = None
+    if hasattr(external_data_schema, "sync_frequency") and external_data_schema.sync_frequency:
+        sync_frequency = external_data_schema.sync_frequency
+    elif external_data_schema.sync_frequency_interval:
+        # Convert timedelta to human-readable format
+        days = external_data_schema.sync_frequency_interval.days
+        hours = external_data_schema.sync_frequency_interval.seconds // 3600
+
+        if days > 0:
+            if days == 1:
+                sync_frequency = "daily"
+            elif days == 7:
+                sync_frequency = "weekly"
+            elif days >= 30:
+                sync_frequency = "monthly"
+            else:
+                sync_frequency = f"{days}d"
+        elif hours > 0:
+            if hours == 1:
+                sync_frequency = "hourly"
+            elif hours == 6:
+                sync_frequency = "6h"
+            elif hours == 12:
+                sync_frequency = "12h"
+            else:
+                sync_frequency = f"{hours}h"
+
+    if sync_frequency:
+        return f"{name} ({sync_type}, {sync_frequency})"
+
+    return f"{name} ({sync_type})"
+
+
+def get_external_data_source_created_by_info(
+    external_data_source,
+) -> tuple[Optional[str], Optional[str], Optional[str]]:
+    """Get created by user information from ExternalDataSource"""
+    created_by_user_id = None
+    created_by_user_email = None
+    created_by_user_name = None
+
+    if hasattr(external_data_source, "created_by") and external_data_source.created_by:
+        created_by_user_id = str(external_data_source.created_by.id)
+        created_by_user_email = external_data_source.created_by.email
+        created_by_user_name = (
+            f"{external_data_source.created_by.first_name} {external_data_source.created_by.last_name}".strip()
+        )
+
+    return created_by_user_id, created_by_user_email, created_by_user_name

--- a/posthog/test/activity_log_utils.py
+++ b/posthog/test/activity_log_utils.py
@@ -848,38 +848,44 @@ class ActivityLogTestHelper(APILicensedTest):
 
     def create_external_data_source(self, source_type: str = "Stripe", **kwargs) -> dict[str, Any]:
         """Create an external data source via API."""
-        data = {
-            "source_type": source_type,
-            "payload": {
-                "stripe_account_id": "acct_test123",
-                **kwargs.get("payload", {}),
-            },
-            "schemas": [
-                {
-                    "name": "customers",
-                    "should_sync": kwargs.get("should_sync", True),
-                    "sync_type": kwargs.get("sync_type", "full_refresh"),
+        from unittest.mock import patch
+
+        # Mock the Stripe validation to avoid needing real credentials
+        with patch("posthog.temporal.data_imports.sources.stripe.stripe.validate_credentials", return_value=True):
+            with patch("posthog.warehouse.data_load.service.sync_external_data_job_workflow"):
+                data = {
+                    "source_type": source_type,
+                    "payload": {
+                        "stripe_account_id": "acct_test_placeholder",
+                        "stripe_secret_key": "test_key_placeholder_not_real",
+                        "schemas": [
+                            {
+                                "name": "Customer",
+                                "should_sync": kwargs.get("should_sync", True),
+                                "sync_type": kwargs.get("sync_type", "full_refresh"),
+                            }
+                        ],
+                        **kwargs.get("payload", {}),
+                    },
+                    **{k: v for k, v in kwargs.items() if k not in ["payload", "should_sync", "sync_type"]},
                 }
-            ],
-            **{k: v for k, v in kwargs.items() if k not in ["payload", "should_sync", "sync_type"]},
-        }
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse/external_data_sources/", data, format="json"
-        )
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        return response.json()
+                response = self.client.post(
+                    f"/api/environments/{self.team.id}/external_data_sources/", data, format="json"
+                )
+                self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+                return response.json()
 
     def update_external_data_source(self, source_id: str, updates: dict[str, Any]) -> dict[str, Any]:
         """Update an external data source via API."""
         response = self.client.patch(
-            f"/api/projects/{self.team.id}/warehouse/external_data_sources/{source_id}/", updates, format="json"
+            f"/api/environments/{self.team.id}/external_data_sources/{source_id}/", updates, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         return response.json()
 
     def delete_external_data_source(self, source_id: str) -> None:
         """Delete an external data source via API."""
-        response = self.client.delete(f"/api/projects/{self.team.id}/warehouse/external_data_sources/{source_id}/")
+        response = self.client.delete(f"/api/environments/{self.team.id}/external_data_sources/{source_id}/")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     def create_external_data_schema(self, source_id: str, name: str = "test_schema", **kwargs) -> dict[str, Any]:
@@ -889,12 +895,30 @@ class ActivityLogTestHelper(APILicensedTest):
     def update_external_data_schema(self, schema_id: str, updates: dict[str, Any]) -> dict[str, Any]:
         """Update an external data schema via API."""
         response = self.client.patch(
-            f"/api/projects/{self.team.id}/warehouse/external_data_schemas/{schema_id}/", updates, format="json"
+            f"/api/environments/{self.team.id}/external_data_schemas/{schema_id}/", updates, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         return response.json()
 
     def delete_external_data_schema(self, schema_id: str) -> None:
         """Delete an external data schema via API."""
-        response = self.client.delete(f"/api/projects/{self.team.id}/warehouse/external_data_schemas/{schema_id}/")
+        response = self.client.delete(f"/api/environments/{self.team.id}/external_data_schemas/{schema_id}/")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def get_activity_logs_for_item(self, scope: str, item_id: str) -> list[Any]:
+        """Get activity logs for a specific item."""
+        from posthog.models.activity_logging.activity_log import ActivityLog
+
+        return list(
+            ActivityLog.objects.filter(
+                team_id=self.team.id,
+                scope=scope,
+                item_id=str(item_id),
+            ).order_by("-created_at")
+        )
+
+    def clear_activity_logs(self) -> None:
+        """Clear all activity logs for the test team."""
+        from posthog.models.activity_logging.activity_log import ActivityLog
+
+        ActivityLog.objects.filter(team_id=self.team.id).delete()

--- a/posthog/test/activity_logging/test_batch_export_activity_logging.py
+++ b/posthog/test/activity_logging/test_batch_export_activity_logging.py
@@ -37,7 +37,6 @@ class TestBatchExportActivityLogging(ActivityLogTestHelper):
         self.assertIn("last_paused_at", batch_export_exclusions)
         self.assertIn("batchexportrun_set", batch_export_exclusions)
         self.assertIn("batchexportbackfill_set", batch_export_exclusions)
-        self.assertIn("deleted", batch_export_exclusions)
 
     def test_batch_export_scope_in_activity_log_types(self):
         """Test that BatchExport scope is defined in ActivityScope"""

--- a/posthog/test/activity_logging/test_batch_export_activity_logging.py
+++ b/posthog/test/activity_logging/test_batch_export_activity_logging.py
@@ -49,6 +49,7 @@ class TestBatchExportActivityLogging(ActivityLogTestHelper):
         self.assertIn("BatchExport", get_args(ActivityScope))
 
     def test_batch_export_integration_test(self):
+        """Integration test to verify the basic setup works"""
         from posthog.models.activity_logging.utils import activity_storage
 
         activity_storage.set_user(self.user)
@@ -58,10 +59,12 @@ class TestBatchExportActivityLogging(ActivityLogTestHelper):
 
             self.update_batch_export(batch_export["id"], {"paused": True, "name": "Updated Export"})
             self.update_batch_export(batch_export["id"], {"interval": "day"})
+
         finally:
             activity_storage.clear_user()
 
     def test_batch_export_status_changes(self):
+        """Test various status changes on batch exports"""
         from posthog.models.activity_logging.utils import activity_storage
 
         activity_storage.set_user(self.user)
@@ -75,10 +78,12 @@ class TestBatchExportActivityLogging(ActivityLogTestHelper):
             self.update_batch_export(
                 batch_export["id"], {"schema": [{"alias": "test", "table": "events", "fields": ["event"]}]}
             )
+
         finally:
             activity_storage.clear_user()
 
     def test_batch_export_signal_handler_create(self):
+        """Test that the signal handler works for batch export creation"""
         from posthog.models.activity_logging.activity_log import ActivityLog
         from posthog.models.activity_logging.utils import activity_storage
 
@@ -106,10 +111,12 @@ class TestBatchExportActivityLogging(ActivityLogTestHelper):
             self.assertEqual(context["name"], "Signal Test Export")
             self.assertEqual(context["destination_type"], "HTTP")
             self.assertEqual(context["interval"], "hour")
+
         finally:
             activity_storage.clear_user()
 
     def test_batch_export_signal_handler_update(self):
+        """Test that the signal handler works for batch export updates"""
         from posthog.models.activity_logging.activity_log import ActivityLog
         from posthog.models.activity_logging.utils import activity_storage
 
@@ -133,10 +140,12 @@ class TestBatchExportActivityLogging(ActivityLogTestHelper):
             assert activity_log.detail is not None
             changes = activity_log.detail.get("changes", [])
             self.assertTrue(len(changes) > 0)
+
         finally:
             activity_storage.clear_user()
 
     def test_batch_export_signal_handler_delete(self):
+        """Test that the signal handler works for batch export deletion"""
         from posthog.models.activity_logging.activity_log import ActivityLog
         from posthog.models.activity_logging.utils import activity_storage
 
@@ -162,5 +171,6 @@ class TestBatchExportActivityLogging(ActivityLogTestHelper):
             changes = activity_log.detail.get("changes", [])
             deleted_change = next((change for change in changes if change["field"] == "deleted"), None)
             self.assertIsNotNone(deleted_change)
+
         finally:
             activity_storage.clear_user()

--- a/posthog/test/activity_logging/test_batch_export_activity_logging.py
+++ b/posthog/test/activity_logging/test_batch_export_activity_logging.py
@@ -59,12 +59,10 @@ class TestBatchExportActivityLogging(ActivityLogTestHelper):
 
             self.update_batch_export(batch_export["id"], {"paused": True, "name": "Updated Export"})
             self.update_batch_export(batch_export["id"], {"interval": "day"})
-
         finally:
             activity_storage.clear_user()
 
     def test_batch_export_status_changes(self):
-        """Test various status changes on batch exports"""
         from posthog.models.activity_logging.utils import activity_storage
 
         activity_storage.set_user(self.user)
@@ -83,7 +81,6 @@ class TestBatchExportActivityLogging(ActivityLogTestHelper):
             activity_storage.clear_user()
 
     def test_batch_export_signal_handler_create(self):
-        """Test that the signal handler works for batch export creation"""
         from posthog.models.activity_logging.activity_log import ActivityLog
         from posthog.models.activity_logging.utils import activity_storage
 
@@ -111,12 +108,10 @@ class TestBatchExportActivityLogging(ActivityLogTestHelper):
             self.assertEqual(context["name"], "Signal Test Export")
             self.assertEqual(context["destination_type"], "HTTP")
             self.assertEqual(context["interval"], "hour")
-
         finally:
             activity_storage.clear_user()
 
     def test_batch_export_signal_handler_update(self):
-        """Test that the signal handler works for batch export updates"""
         from posthog.models.activity_logging.activity_log import ActivityLog
         from posthog.models.activity_logging.utils import activity_storage
 
@@ -140,12 +135,10 @@ class TestBatchExportActivityLogging(ActivityLogTestHelper):
             assert activity_log.detail is not None
             changes = activity_log.detail.get("changes", [])
             self.assertTrue(len(changes) > 0)
-
         finally:
             activity_storage.clear_user()
 
     def test_batch_export_signal_handler_delete(self):
-        """Test that the signal handler works for batch export deletion"""
         from posthog.models.activity_logging.activity_log import ActivityLog
         from posthog.models.activity_logging.utils import activity_storage
 

--- a/posthog/test/activity_logging/test_batch_export_activity_logging.py
+++ b/posthog/test/activity_logging/test_batch_export_activity_logging.py
@@ -37,6 +37,7 @@ class TestBatchExportActivityLogging(ActivityLogTestHelper):
         self.assertIn("last_paused_at", batch_export_exclusions)
         self.assertIn("batchexportrun_set", batch_export_exclusions)
         self.assertIn("batchexportbackfill_set", batch_export_exclusions)
+        self.assertIn("deleted", batch_export_exclusions)
 
     def test_batch_export_scope_in_activity_log_types(self):
         """Test that BatchExport scope is defined in ActivityScope"""

--- a/posthog/test/activity_logging/test_batch_import_activity_logging.py
+++ b/posthog/test/activity_logging/test_batch_import_activity_logging.py
@@ -52,6 +52,7 @@ class TestBatchImportActivityLogging(ActivityLogTestHelper):
         self.assertIn("import_config", batch_import_masked)
 
     def test_batch_import_integration_test(self):
+        """Integration test to verify the basic setup works"""
         from posthog.models.activity_logging.utils import activity_storage
 
         activity_storage.set_user(self.user)
@@ -60,10 +61,12 @@ class TestBatchImportActivityLogging(ActivityLogTestHelper):
             self.assertIsNotNone(batch_import["id"])
 
             self.update_batch_import(batch_import["id"], {"status": "completed"})
+
         finally:
             activity_storage.clear_user()
 
     def test_batch_import_signal_handler_create(self):
+        """Test that the signal handler works for batch import creation"""
         from posthog.models.activity_logging.activity_log import ActivityLog
         from posthog.models.activity_logging.utils import activity_storage
 
@@ -120,6 +123,7 @@ class TestBatchImportActivityLogging(ActivityLogTestHelper):
             assert activity_log.detail is not None
             changes = activity_log.detail.get("changes", [])
             self.assertTrue(len(changes) > 0)
+
         finally:
             activity_storage.clear_user()
 
@@ -144,5 +148,6 @@ class TestBatchImportActivityLogging(ActivityLogTestHelper):
             self.assertIsNotNone(activity_log)
             assert activity_log is not None
             self.assertEqual(activity_log.user, self.user)
+
         finally:
             activity_storage.clear_user()

--- a/posthog/test/activity_logging/test_batch_import_activity_logging.py
+++ b/posthog/test/activity_logging/test_batch_import_activity_logging.py
@@ -61,12 +61,10 @@ class TestBatchImportActivityLogging(ActivityLogTestHelper):
             self.assertIsNotNone(batch_import["id"])
 
             self.update_batch_import(batch_import["id"], {"status": "completed"})
-
         finally:
             activity_storage.clear_user()
 
     def test_batch_import_signal_handler_create(self):
-        """Test that the signal handler works for batch import creation"""
         from posthog.models.activity_logging.activity_log import ActivityLog
         from posthog.models.activity_logging.utils import activity_storage
 
@@ -123,7 +121,6 @@ class TestBatchImportActivityLogging(ActivityLogTestHelper):
             assert activity_log.detail is not None
             changes = activity_log.detail.get("changes", [])
             self.assertTrue(len(changes) > 0)
-
         finally:
             activity_storage.clear_user()
 
@@ -148,6 +145,5 @@ class TestBatchImportActivityLogging(ActivityLogTestHelper):
             self.assertIsNotNone(activity_log)
             assert activity_log is not None
             self.assertEqual(activity_log.user, self.user)
-
         finally:
             activity_storage.clear_user()

--- a/posthog/test/activity_logging/test_external_data_schema_activity_logging.py
+++ b/posthog/test/activity_logging/test_external_data_schema_activity_logging.py
@@ -1,5 +1,5 @@
-from posthog.warehouse.models.external_data_schema import ExternalDataSchema
 from posthog.test.activity_log_utils import ActivityLogTestHelper
+from posthog.warehouse.models.external_data_schema import ExternalDataSchema
 
 
 class TestExternalDataSchemaActivityLogging(ActivityLogTestHelper):
@@ -20,8 +20,9 @@ class TestExternalDataSchemaActivityLogging(ActivityLogTestHelper):
         self.assertIn("sync_frequency_interval", external_data_schema_exclusions)
 
     def test_external_data_schema_scope_in_activity_log_types(self):
-        from posthog.models.activity_logging.activity_log import ActivityScope
         from typing import get_args
+
+        from posthog.models.activity_logging.activity_log import ActivityScope
 
         self.assertIn("ExternalDataSchema", get_args(ActivityScope))
 

--- a/posthog/test/activity_logging/test_external_data_schema_activity_logging.py
+++ b/posthog/test/activity_logging/test_external_data_schema_activity_logging.py
@@ -1,0 +1,118 @@
+from posthog.warehouse.models.external_data_schema import ExternalDataSchema
+from posthog.test.activity_log_utils import ActivityLogTestHelper
+
+
+class TestExternalDataSchemaActivityLogging(ActivityLogTestHelper):
+    def test_external_data_schema_model_has_activity_mixin(self):
+        from posthog.models.activity_logging.model_activity import ModelActivityMixin
+
+        self.assertTrue(issubclass(ExternalDataSchema, ModelActivityMixin))
+
+    def test_external_data_schema_field_exclusions_configured(self):
+        from posthog.models.activity_logging.activity_log import field_exclusions
+
+        external_data_schema_exclusions = field_exclusions.get("ExternalDataSchema", [])
+
+        self.assertIn("sync_type_config", external_data_schema_exclusions)
+        self.assertIn("latest_error", external_data_schema_exclusions)
+        self.assertIn("last_synced_at", external_data_schema_exclusions)
+        self.assertIn("table", external_data_schema_exclusions)
+        self.assertIn("sync_frequency_interval", external_data_schema_exclusions)
+
+    def test_external_data_schema_scope_in_activity_log_types(self):
+        from posthog.models.activity_logging.activity_log import ActivityScope
+        from typing import get_args
+
+        self.assertIn("ExternalDataSchema", get_args(ActivityScope))
+
+    def test_external_data_schema_creation_activity_logging(self):
+        external_data_source = self.create_external_data_source()
+
+        # Get the created schema from the source
+        from posthog.warehouse.models import ExternalDataSource
+
+        source_obj = ExternalDataSource.objects.get(id=external_data_source["id"])
+        schema = source_obj.schemas.first()
+
+        activity_logs = self.get_activity_logs_for_item("ExternalDataSchema", str(schema.id))
+        self.assertEqual(len(activity_logs), 1)
+
+        log_entry = activity_logs[0]
+        self.assertEqual(log_entry.activity, "created")
+        self.assertEqual(log_entry.scope, "ExternalDataSchema")
+
+        detail_changes = log_entry.detail.get("changes", [])
+        field_names = [change.get("field") for change in detail_changes if change.get("field")]
+
+        self.assertNotIn("sync_type_config", field_names)
+        self.assertNotIn("latest_error", field_names)
+        self.assertNotIn("last_synced_at", field_names)
+        self.assertNotIn("table", field_names)
+        self.assertNotIn("sync_frequency_interval", field_names)
+
+    def test_external_data_schema_update_activity_logging(self):
+        external_data_source = self.create_external_data_source()
+
+        # Get the created schema from the source
+        from posthog.warehouse.models import ExternalDataSource
+
+        source_obj = ExternalDataSource.objects.get(id=external_data_source["id"])
+        schema = source_obj.schemas.first()
+
+        self.clear_activity_logs()
+
+        self.update_external_data_schema(str(schema.id), {"should_sync": False, "sync_type": "incremental"})
+
+        activity_logs = self.get_activity_logs_for_item("ExternalDataSchema", str(schema.id))
+        self.assertEqual(len(activity_logs), 1)
+
+        log_entry = activity_logs[0]
+        self.assertEqual(log_entry.activity, "updated")
+        self.assertEqual(log_entry.scope, "ExternalDataSchema")
+
+    def test_external_data_schema_deletion_activity_logging(self):
+        external_data_source = self.create_external_data_source()
+
+        # Get the created schema from the source
+        from posthog.warehouse.models import ExternalDataSource
+
+        source_obj = ExternalDataSource.objects.get(id=external_data_source["id"])
+        schema = source_obj.schemas.first()
+        schema_id = str(schema.id)
+
+        self.clear_activity_logs()
+
+        self.delete_external_data_schema(schema_id)
+
+        activity_logs = self.get_activity_logs_for_item("ExternalDataSchema", schema_id)
+        self.assertEqual(len(activity_logs), 1)
+
+        log_entry = activity_logs[0]
+        self.assertEqual(log_entry.activity, "updated")
+        self.assertEqual(log_entry.scope, "ExternalDataSchema")
+
+        # Check that deletion is tracked via deleted field change
+        detail_changes = log_entry.detail.get("changes", [])
+        deleted_change = next((change for change in detail_changes if change.get("field") == "deleted"), None)
+        self.assertIsNotNone(deleted_change)
+        self.assertEqual(deleted_change["after"], True)
+
+    def test_external_data_schema_relationship_logging(self):
+        external_data_source = self.create_external_data_source()
+
+        # Get the created schema from the source
+        from posthog.warehouse.models import ExternalDataSource
+
+        source_obj = ExternalDataSource.objects.get(id=external_data_source["id"])
+        schema = source_obj.schemas.first()
+
+        activity_logs = self.get_activity_logs_for_item("ExternalDataSchema", str(schema.id))
+        self.assertEqual(len(activity_logs), 1)
+
+        log_entry = activity_logs[0]
+        detail_changes = log_entry.detail.get("changes", [])
+        source_changes = [change for change in detail_changes if change.get("field") == "source"]
+
+        if source_changes:
+            source_change = source_changes[0]
+            self.assertEqual(source_change.get("after"), external_data_source["id"])

--- a/posthog/test/activity_logging/test_external_data_schema_activity_logging.py
+++ b/posthog/test/activity_logging/test_external_data_schema_activity_logging.py
@@ -34,6 +34,7 @@ class TestExternalDataSchemaActivityLogging(ActivityLogTestHelper):
 
         source_obj = ExternalDataSource.objects.get(id=external_data_source["id"])
         schema = source_obj.schemas.first()
+        assert schema is not None
 
         activity_logs = self.get_activity_logs_for_item("ExternalDataSchema", str(schema.id))
         self.assertEqual(len(activity_logs), 1)
@@ -59,6 +60,7 @@ class TestExternalDataSchemaActivityLogging(ActivityLogTestHelper):
 
         source_obj = ExternalDataSource.objects.get(id=external_data_source["id"])
         schema = source_obj.schemas.first()
+        assert schema is not None
 
         self.clear_activity_logs()
 
@@ -79,6 +81,7 @@ class TestExternalDataSchemaActivityLogging(ActivityLogTestHelper):
 
         source_obj = ExternalDataSource.objects.get(id=external_data_source["id"])
         schema = source_obj.schemas.first()
+        assert schema is not None
         schema_id = str(schema.id)
 
         self.clear_activity_logs()
@@ -96,6 +99,7 @@ class TestExternalDataSchemaActivityLogging(ActivityLogTestHelper):
         detail_changes = log_entry.detail.get("changes", [])
         deleted_change = next((change for change in detail_changes if change.get("field") == "deleted"), None)
         self.assertIsNotNone(deleted_change)
+        assert deleted_change is not None
         self.assertEqual(deleted_change["after"], True)
 
     def test_external_data_schema_relationship_logging(self):
@@ -106,6 +110,7 @@ class TestExternalDataSchemaActivityLogging(ActivityLogTestHelper):
 
         source_obj = ExternalDataSource.objects.get(id=external_data_source["id"])
         schema = source_obj.schemas.first()
+        assert schema is not None
 
         activity_logs = self.get_activity_logs_for_item("ExternalDataSchema", str(schema.id))
         self.assertEqual(len(activity_logs), 1)

--- a/posthog/test/activity_logging/test_external_data_schema_activity_logging.py
+++ b/posthog/test/activity_logging/test_external_data_schema_activity_logging.py
@@ -1,62 +1,40 @@
+from typing import get_args
+
+from posthog.models.activity_logging.activity_log import ActivityScope, field_exclusions
+from posthog.models.activity_logging.model_activity import ModelActivityMixin
 from posthog.test.activity_log_utils import ActivityLogTestHelper
+from posthog.warehouse.models import ExternalDataSource
 from posthog.warehouse.models.external_data_schema import ExternalDataSchema
 
 
 class TestExternalDataSchemaActivityLogging(ActivityLogTestHelper):
     def test_external_data_schema_model_has_activity_mixin(self):
-        from posthog.models.activity_logging.model_activity import ModelActivityMixin
-
         self.assertTrue(issubclass(ExternalDataSchema, ModelActivityMixin))
 
     def test_external_data_schema_field_exclusions_configured(self):
-        from posthog.models.activity_logging.activity_log import field_exclusions
-
         external_data_schema_exclusions = field_exclusions.get("ExternalDataSchema", [])
 
         self.assertIn("sync_type_config", external_data_schema_exclusions)
         self.assertIn("latest_error", external_data_schema_exclusions)
         self.assertIn("last_synced_at", external_data_schema_exclusions)
-        self.assertIn("table", external_data_schema_exclusions)
-        self.assertIn("sync_frequency_interval", external_data_schema_exclusions)
+        self.assertEqual(len(external_data_schema_exclusions), 3)
 
     def test_external_data_schema_scope_in_activity_log_types(self):
-        from typing import get_args
-
-        from posthog.models.activity_logging.activity_log import ActivityScope
-
         self.assertIn("ExternalDataSchema", get_args(ActivityScope))
 
     def test_external_data_schema_creation_activity_logging(self):
         external_data_source = self.create_external_data_source()
 
-        # Get the created schema from the source
-        from posthog.warehouse.models import ExternalDataSource
-
         source_obj = ExternalDataSource.objects.get(id=external_data_source["id"])
         schema = source_obj.schemas.first()
         assert schema is not None
 
+        # Verify that no creation logs are created
         activity_logs = self.get_activity_logs_for_item("ExternalDataSchema", str(schema.id))
-        self.assertEqual(len(activity_logs), 1)
-
-        log_entry = activity_logs[0]
-        self.assertEqual(log_entry.activity, "created")
-        self.assertEqual(log_entry.scope, "ExternalDataSchema")
-
-        detail_changes = log_entry.detail.get("changes", [])
-        field_names = [change.get("field") for change in detail_changes if change.get("field")]
-
-        self.assertNotIn("sync_type_config", field_names)
-        self.assertNotIn("latest_error", field_names)
-        self.assertNotIn("last_synced_at", field_names)
-        self.assertNotIn("table", field_names)
-        self.assertNotIn("sync_frequency_interval", field_names)
+        self.assertEqual(len(activity_logs), 0)
 
     def test_external_data_schema_update_activity_logging(self):
         external_data_source = self.create_external_data_source()
-
-        # Get the created schema from the source
-        from posthog.warehouse.models import ExternalDataSource
 
         source_obj = ExternalDataSource.objects.get(id=external_data_source["id"])
         schema = source_obj.schemas.first()
@@ -77,7 +55,6 @@ class TestExternalDataSchemaActivityLogging(ActivityLogTestHelper):
         external_data_source = self.create_external_data_source()
 
         # Get the created schema from the source
-        from posthog.warehouse.models import ExternalDataSource
 
         source_obj = ExternalDataSource.objects.get(id=external_data_source["id"])
         schema = source_obj.schemas.first()
@@ -105,20 +82,22 @@ class TestExternalDataSchemaActivityLogging(ActivityLogTestHelper):
     def test_external_data_schema_relationship_logging(self):
         external_data_source = self.create_external_data_source()
 
-        # Get the created schema from the source
-        from posthog.warehouse.models import ExternalDataSource
-
         source_obj = ExternalDataSource.objects.get(id=external_data_source["id"])
         schema = source_obj.schemas.first()
         assert schema is not None
 
         activity_logs = self.get_activity_logs_for_item("ExternalDataSchema", str(schema.id))
+        self.assertEqual(len(activity_logs), 0)
+
+        self.update_external_data_schema(str(schema.id), {"should_sync": False})
+
+        activity_logs = self.get_activity_logs_for_item("ExternalDataSchema", str(schema.id))
         self.assertEqual(len(activity_logs), 1)
 
         log_entry = activity_logs[0]
-        detail_changes = log_entry.detail.get("changes", [])
-        source_changes = [change for change in detail_changes if change.get("field") == "source"]
+        self.assertEqual(log_entry.activity, "updated")
 
-        if source_changes:
-            source_change = source_changes[0]
-            self.assertEqual(source_change.get("after"), external_data_source["id"])
+        context = log_entry.detail.get("context")
+        self.assertIsNotNone(context)
+        self.assertEqual(context.get("source_id"), str(source_obj.id))
+        self.assertEqual(context.get("source_type"), "Stripe")

--- a/posthog/test/activity_logging/test_external_data_source_activity_logging.py
+++ b/posthog/test/activity_logging/test_external_data_source_activity_logging.py
@@ -13,7 +13,6 @@ class TestExternalDataSourceActivityLogging(ActivityLogTestHelper):
 
         external_data_source_exclusions = field_exclusions.get("ExternalDataSource", [])
 
-        self.assertIn("job_inputs", external_data_source_exclusions)
         self.assertIn("connection_id", external_data_source_exclusions)
         self.assertIn("destination_id", external_data_source_exclusions)
         self.assertIn("are_tables_created", external_data_source_exclusions)

--- a/posthog/test/activity_logging/test_external_data_source_activity_logging.py
+++ b/posthog/test/activity_logging/test_external_data_source_activity_logging.py
@@ -46,12 +46,14 @@ class TestExternalDataSourceActivityLogging(ActivityLogTestHelper):
 
     def test_external_data_source_update_activity_logging(self):
         external_data_source = self.create_external_data_source()
+        db_obj = ExternalDataSource.objects.get(id=external_data_source["id"])
+
+        current_value = db_obj.revenue_analytics_enabled
+        new_value = not current_value
 
         self.clear_activity_logs()
 
-        self.update_external_data_source(
-            external_data_source["id"], {"job_inputs": {"stripe_account_id": "acct_updated123"}}
-        )
+        self.update_external_data_source(external_data_source["id"], {"revenue_analytics_enabled": new_value})
 
         activity_logs = self.get_activity_logs_for_item("ExternalDataSource", external_data_source["id"])
         self.assertEqual(len(activity_logs), 1)

--- a/posthog/test/activity_logging/test_external_data_source_activity_logging.py
+++ b/posthog/test/activity_logging/test_external_data_source_activity_logging.py
@@ -1,5 +1,5 @@
-from posthog.warehouse.models.external_data_source import ExternalDataSource
 from posthog.test.activity_log_utils import ActivityLogTestHelper
+from posthog.warehouse.models.external_data_source import ExternalDataSource
 
 
 class TestExternalDataSourceActivityLogging(ActivityLogTestHelper):
@@ -19,8 +19,9 @@ class TestExternalDataSourceActivityLogging(ActivityLogTestHelper):
         self.assertIn("are_tables_created", external_data_source_exclusions)
 
     def test_external_data_source_scope_in_activity_log_types(self):
-        from posthog.models.activity_logging.activity_log import ActivityScope
         from typing import get_args
+
+        from posthog.models.activity_logging.activity_log import ActivityScope
 
         self.assertIn("ExternalDataSource", get_args(ActivityScope))
 

--- a/posthog/test/activity_logging/test_external_data_source_activity_logging.py
+++ b/posthog/test/activity_logging/test_external_data_source_activity_logging.py
@@ -1,0 +1,81 @@
+from posthog.warehouse.models.external_data_source import ExternalDataSource
+from posthog.test.activity_log_utils import ActivityLogTestHelper
+
+
+class TestExternalDataSourceActivityLogging(ActivityLogTestHelper):
+    def test_external_data_source_model_has_activity_mixin(self):
+        from posthog.models.activity_logging.model_activity import ModelActivityMixin
+
+        self.assertTrue(issubclass(ExternalDataSource, ModelActivityMixin))
+
+    def test_external_data_source_field_exclusions_configured(self):
+        from posthog.models.activity_logging.activity_log import field_exclusions
+
+        external_data_source_exclusions = field_exclusions.get("ExternalDataSource", [])
+
+        self.assertIn("job_inputs", external_data_source_exclusions)
+        self.assertIn("connection_id", external_data_source_exclusions)
+        self.assertIn("destination_id", external_data_source_exclusions)
+        self.assertIn("are_tables_created", external_data_source_exclusions)
+
+    def test_external_data_source_scope_in_activity_log_types(self):
+        from posthog.models.activity_logging.activity_log import ActivityScope
+        from typing import get_args
+
+        self.assertIn("ExternalDataSource", get_args(ActivityScope))
+
+    def test_external_data_source_creation_activity_logging(self):
+        external_data_source = self.create_external_data_source()
+
+        activity_logs = self.get_activity_logs_for_item("ExternalDataSource", external_data_source["id"])
+        self.assertEqual(len(activity_logs), 1)
+
+        log_entry = activity_logs[0]
+        self.assertEqual(log_entry.activity, "created")
+        self.assertEqual(log_entry.scope, "ExternalDataSource")
+        self.assertEqual(log_entry.item_id, external_data_source["id"])
+
+        detail_changes = log_entry.detail.get("changes", [])
+        field_names = [change.get("field") for change in detail_changes if change.get("field")]
+
+        self.assertNotIn("job_inputs", field_names)
+        self.assertNotIn("connection_id", field_names)
+        self.assertNotIn("destination_id", field_names)
+        self.assertNotIn("are_tables_created", field_names)
+
+    def test_external_data_source_update_activity_logging(self):
+        external_data_source = self.create_external_data_source()
+
+        self.clear_activity_logs()
+
+        self.update_external_data_source(
+            external_data_source["id"], {"job_inputs": {"stripe_account_id": "acct_updated123"}}
+        )
+
+        activity_logs = self.get_activity_logs_for_item("ExternalDataSource", external_data_source["id"])
+        self.assertEqual(len(activity_logs), 1)
+
+        log_entry = activity_logs[0]
+        self.assertEqual(log_entry.activity, "updated")
+        self.assertEqual(log_entry.scope, "ExternalDataSource")
+
+    def test_external_data_source_deletion_activity_logging(self):
+        external_data_source = self.create_external_data_source()
+        external_data_source_id = external_data_source["id"]
+
+        self.clear_activity_logs()
+
+        self.delete_external_data_source(external_data_source_id)
+
+        activity_logs = self.get_activity_logs_for_item("ExternalDataSource", external_data_source_id)
+        self.assertEqual(len(activity_logs), 1)
+
+        log_entry = activity_logs[0]
+        self.assertEqual(log_entry.activity, "updated")
+        self.assertEqual(log_entry.scope, "ExternalDataSource")
+
+        # Check that deletion is tracked via deleted field change
+        detail_changes = log_entry.detail.get("changes", [])
+        deleted_change = next((change for change in detail_changes if change.get("field") == "deleted"), None)
+        self.assertIsNotNone(deleted_change)
+        self.assertEqual(deleted_change["after"], True)

--- a/posthog/test/activity_logging/test_external_data_source_activity_logging.py
+++ b/posthog/test/activity_logging/test_external_data_source_activity_logging.py
@@ -79,4 +79,5 @@ class TestExternalDataSourceActivityLogging(ActivityLogTestHelper):
         detail_changes = log_entry.detail.get("changes", [])
         deleted_change = next((change for change in detail_changes if change.get("field") == "deleted"), None)
         self.assertIsNotNone(deleted_change)
+        assert deleted_change is not None
         self.assertEqual(deleted_change["after"], True)

--- a/posthog/warehouse/api/external_data_schema.py
+++ b/posthog/warehouse/api/external_data_schema.py
@@ -1,5 +1,8 @@
 import datetime as dt
+import dataclasses
 from typing import Any, Optional
+
+from django.dispatch import receiver
 
 import structlog
 import temporalio
@@ -14,6 +17,8 @@ from posthog.api.log_entries import LogEntryMixin
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
 from posthog.exceptions_capture import capture_exception
+from posthog.models.activity_logging.activity_log import ActivityContextBase, Detail, changes_between, log_activity
+from posthog.models.signals import model_activity_signal
 from posthog.temporal.data_imports.sources import SourceRegistry
 from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.warehouse.data_load.service import (
@@ -32,10 +37,6 @@ from posthog.warehouse.models.external_data_schema import (
 )
 from posthog.warehouse.models.external_data_source import ExternalDataSource
 from posthog.warehouse.types import ExternalDataSourceType
-from django.dispatch import receiver
-from posthog.models.signals import model_activity_signal
-from posthog.models.activity_logging.activity_log import Detail, log_activity, changes_between, ActivityContextBase
-import dataclasses
 
 logger = structlog.get_logger(__name__)
 
@@ -368,9 +369,7 @@ class ExternalDataSchemaContext(ActivityContextBase):
 def handle_external_data_schema_change(
     sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
 ):
-    from posthog.models.activity_logging.external_data_utils import (
-        get_external_data_schema_detail_name,
-    )
+    from posthog.models.activity_logging.external_data_utils import get_external_data_schema_detail_name
 
     # Use after_update for create/update, before_update for delete
     external_data_schema = after_update or before_update

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -1,7 +1,9 @@
 import uuid
+import dataclasses
 from typing import Any
 
 from django.db.models import Prefetch, Q
+from django.dispatch import receiver
 
 import structlog
 import temporalio
@@ -16,6 +18,8 @@ from posthog.hogql.database.database import create_hogql_database
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
 from posthog.exceptions_capture import capture_exception
+from posthog.models.activity_logging.activity_log import ActivityContextBase, Detail, changes_between, log_activity
+from posthog.models.signals import model_activity_signal
 from posthog.models.user import User
 from posthog.temporal.data_imports.sources import SourceRegistry
 from posthog.temporal.data_imports.sources.common.config import Config
@@ -30,10 +34,6 @@ from posthog.warehouse.data_load.service import (
 )
 from posthog.warehouse.models import ExternalDataJob, ExternalDataSchema, ExternalDataSource
 from posthog.warehouse.types import ExternalDataSourceType
-from django.dispatch import receiver
-from posthog.models.signals import model_activity_signal
-from posthog.models.activity_logging.activity_log import Detail, log_activity, changes_between, ActivityContextBase
-import dataclasses
 
 logger = structlog.get_logger(__name__)
 
@@ -634,8 +634,8 @@ def handle_external_data_source_change(
     sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
 ):
     from posthog.models.activity_logging.external_data_utils import (
-        get_external_data_source_detail_name,
         get_external_data_source_created_by_info,
+        get_external_data_source_detail_name,
     )
 
     # Use after_update for create/update, before_update for delete

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -19,6 +19,10 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
 from posthog.exceptions_capture import capture_exception
 from posthog.models.activity_logging.activity_log import ActivityContextBase, Detail, changes_between, log_activity
+from posthog.models.activity_logging.external_data_utils import (
+    get_external_data_source_created_by_info,
+    get_external_data_source_detail_name,
+)
 from posthog.models.signals import model_activity_signal
 from posthog.models.user import User
 from posthog.temporal.data_imports.sources import SourceRegistry
@@ -633,11 +637,6 @@ class ExternalDataSourceContext(ActivityContextBase):
 def handle_external_data_source_change(
     sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
 ):
-    from posthog.models.activity_logging.external_data_utils import (
-        get_external_data_source_created_by_info,
-        get_external_data_source_detail_name,
-    )
-
     # Use after_update for create/update, before_update for delete
     external_data_source = after_update or before_update
 

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -30,6 +30,10 @@ from posthog.warehouse.data_load.service import (
 )
 from posthog.warehouse.models import ExternalDataJob, ExternalDataSchema, ExternalDataSource
 from posthog.warehouse.types import ExternalDataSourceType
+from django.dispatch import receiver
+from posthog.models.signals import model_activity_signal
+from posthog.models.activity_logging.activity_log import Detail, log_activity, changes_between, ActivityContextBase
+import dataclasses
 
 logger = structlog.get_logger(__name__)
 
@@ -614,3 +618,56 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             status=status.HTTP_200_OK,
             data={str(key): value.model_dump() for key, value in configs.items()},
         )
+
+
+@dataclasses.dataclass(frozen=True)
+class ExternalDataSourceContext(ActivityContextBase):
+    source_type: str
+    prefix: str | None
+    created_by_user_id: str | None
+    created_by_user_email: str | None
+    created_by_user_name: str | None
+
+
+@receiver(model_activity_signal, sender=ExternalDataSource)
+def handle_external_data_source_change(
+    sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
+):
+    from posthog.models.activity_logging.external_data_utils import (
+        get_external_data_source_detail_name,
+        get_external_data_source_created_by_info,
+    )
+
+    # Use after_update for create/update, before_update for delete
+    external_data_source = after_update or before_update
+
+    if not external_data_source:
+        return
+
+    created_by_user_id, created_by_user_email, created_by_user_name = get_external_data_source_created_by_info(
+        external_data_source
+    )
+    detail_name = get_external_data_source_detail_name(external_data_source)
+
+    context = ExternalDataSourceContext(
+        source_type=external_data_source.source_type or "",
+        prefix=external_data_source.prefix,
+        created_by_user_id=created_by_user_id,
+        created_by_user_email=created_by_user_email,
+        created_by_user_name=created_by_user_name,
+    )
+
+    log_activity(
+        organization_id=external_data_source.team.organization_id,
+        team_id=external_data_source.team_id,
+        user=user,
+        was_impersonated=was_impersonated,
+        item_id=external_data_source.id,
+        scope=scope,
+        activity=activity,
+        detail=Detail(
+            changes=changes_between(scope, previous=before_update, current=after_update),
+            name=detail_name,
+            context=context,
+        ),
+    )

--- a/posthog/warehouse/models/external_data_schema.py
+++ b/posthog/warehouse/models/external_data_schema.py
@@ -10,6 +10,7 @@ from dateutil import parser
 from django_deprecate_fields import deprecate_field
 from dlt.common.normalizers.naming.snake_case import NamingConvention
 
+from posthog.models.activity_logging.model_activity import ModelActivityMixin
 from posthog.models.team import Team
 from posthog.models.utils import CreatedMetaFields, DeletedMetaFields, UpdatedMetaFields, UUIDTModel, sane_repr
 from posthog.sync import database_sync_to_async
@@ -24,7 +25,7 @@ from posthog.warehouse.s3 import get_s3_client
 from posthog.warehouse.types import IncrementalFieldType
 
 
-class ExternalDataSchema(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, DeletedMetaFields):
+class ExternalDataSchema(ModelActivityMixin, CreatedMetaFields, UpdatedMetaFields, UUIDTModel, DeletedMetaFields):
     class Status(models.TextChoices):
         RUNNING = "Running", "Running"
         PAUSED = "Paused", "Paused"

--- a/posthog/warehouse/models/external_data_source.py
+++ b/posthog/warehouse/models/external_data_source.py
@@ -7,6 +7,7 @@ import structlog
 import temporalio
 
 from posthog.helpers.encrypted_fields import EncryptedJSONField
+from posthog.models.activity_logging.model_activity import ModelActivityMixin
 from posthog.models.team import Team
 from posthog.models.utils import CreatedMetaFields, DeletedMetaFields, UpdatedMetaFields, UUIDTModel, sane_repr
 from posthog.sync import database_sync_to_async
@@ -15,7 +16,7 @@ from posthog.warehouse.types import ExternalDataSourceType
 logger = structlog.get_logger(__name__)
 
 
-class ExternalDataSource(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, DeletedMetaFields):
+class ExternalDataSource(ModelActivityMixin, CreatedMetaFields, UpdatedMetaFields, UUIDTModel, DeletedMetaFields):
     class Status(models.TextChoices):
         RUNNING = "Running", "Running"
         PAUSED = "Paused", "Paused"

--- a/products/revenue_analytics/backend/hogql_queries/test/test_revenue_analytics_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/test/test_revenue_analytics_query_runner.py
@@ -83,7 +83,7 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
             should_sync=True,
             status=ExternalDataSchema.Status.COMPLETED,
             last_synced_at=datetime.now(),
-            sync_frequency_interval=timedelta(hours=4),  # 4 hours
+            sync_frequency_interval=timedelta(hours=6),  # 6 hours
         )
 
         ExternalDataSchema.objects.create(
@@ -93,11 +93,11 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
             should_sync=True,
             status=ExternalDataSchema.Status.COMPLETED,
             last_synced_at=datetime.now(),
-            sync_frequency_interval=timedelta(hours=8),  # 8 hours
+            sync_frequency_interval=timedelta(hours=12),  # 12 hours
         )
 
-        # Should cache for half of the minimum interval (4 hours / 2 = 2 hours)
-        self.assertDiff(timedelta(hours=2))
+        # Should cache for half of the minimum interval (6 hours / 2 = 3 hours)
+        self.assertDiff(timedelta(hours=3))
 
     def test_cache_target_age_without_sync_intervals(self):
         """Test that when schemas have no sync intervals, we use our default cache target age"""
@@ -174,11 +174,11 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
             should_sync=True,
             status=ExternalDataSchema.Status.COMPLETED,
             last_synced_at=datetime.now(),
-            sync_frequency_interval=timedelta(hours=2),  # 2 hours (minimum)
+            sync_frequency_interval=timedelta(hours=1),  # 1 hour (minimum)
         )
 
-        # Should cache for half of the minimum interval (2 hours / 2 = 1 hour)
-        self.assertDiff(timedelta(hours=1))
+        # Should cache for half of the minimum interval (1 hour / 2 = 0.5 hour)
+        self.assertDiff(timedelta(minutes=30))
 
     def test_cache_target_age_non_stripe_sources_ignored(self):
         """Test that non-Stripe sources are ignored"""
@@ -200,7 +200,7 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
             should_sync=True,
             status=ExternalDataSchema.Status.COMPLETED,
             last_synced_at=datetime.now(),
-            sync_frequency_interval=timedelta(hours=2),
+            sync_frequency_interval=timedelta(hours=1),
         )
 
         # Should use our default cache target age since no Stripe sources
@@ -226,7 +226,7 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
             should_sync=True,
             status=ExternalDataSchema.Status.COMPLETED,
             last_synced_at=datetime.now(),
-            sync_frequency_interval=timedelta(hours=2),
+            sync_frequency_interval=timedelta(hours=1),
         )
 
         # Should use our default cache target age since revenue analytics is disabled
@@ -252,7 +252,7 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
             should_sync=False,  # Should not sync
             status=ExternalDataSchema.Status.COMPLETED,
             last_synced_at=datetime.now(),
-            sync_frequency_interval=timedelta(hours=2),
+            sync_frequency_interval=timedelta(hours=1),
         )
 
         # Should use our default cache target age since schema shouldn't sync
@@ -288,7 +288,7 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
             should_sync=True,
             status=ExternalDataSchema.Status.COMPLETED,
             last_synced_at=datetime.now(),
-            sync_frequency_interval=timedelta(hours=4),
+            sync_frequency_interval=timedelta(hours=6),
         )
 
         # Should return our small cache target age since it's the first time syncing
@@ -314,7 +314,7 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
             should_sync=True,
             status=ExternalDataSchema.Status.RUNNING,
             last_synced_at=None,  # First-time sync (should take priority)
-            sync_frequency_interval=timedelta(hours=8),
+            sync_frequency_interval=timedelta(hours=12),
         )
 
         ExternalDataSchema.objects.create(
@@ -334,7 +334,7 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
             should_sync=False,  # Should be ignored
             status=ExternalDataSchema.Status.COMPLETED,
             last_synced_at=datetime.now(),
-            sync_frequency_interval=timedelta(hours=2),
+            sync_frequency_interval=timedelta(hours=1),
         )
 
         ExternalDataSchema.objects.create(


### PR DESCRIPTION
## Changes

- Add external data source and schema models to activity logging. This is different to the BatchImport model, as it's used only on portion of the available integrations, while the rest use this one.

## How did you test this code?

- Integration tests