### PR TITLE
feat(err): add simple support for go frames

### DIFF
--- a/rust/cymbal/src/frames/mod.rs
+++ b/rust/cymbal/src/frames/mod.rs
@@ -76,7 +76,7 @@ impl RawFrame {
         match self {
             RawFrame::JavaScriptWeb(frame) | RawFrame::LegacyJS(frame) => frame.symbol_set_ref(),
             RawFrame::JavaScriptNode(_) => None, // Node.js frames don't have symbol sets
-            // TODO - python frames don't use symbol sets for frame resolution, but could still use "marker" symbol set
+            // TODO - Python and Go frames don't use symbol sets for frame resolution, but could still use "marker" symbol set
             // to associate a given frame with a given release (basically, a symbol set with no data, just some id,
             // which we'd then use to do a join on the releases table to get release information)
             RawFrame::Python(_) | RawFrame::Go(_) => None,

--- a/rust/cymbal/src/frames/mod.rs
+++ b/rust/cymbal/src/frames/mod.rs
@@ -7,7 +7,10 @@ use serde_json::Value;
 use crate::{
     error::UnhandledError,
     fingerprinting::{FingerprintBuilder, FingerprintComponent, FingerprintRecordPart},
-    langs::{custom::CustomFrame, js::RawJSFrame, node::RawNodeFrame, python::RawPythonFrame},
+    langs::{
+        custom::CustomFrame, go::RawGoFrame, js::RawJSFrame, node::RawNodeFrame,
+        python::RawPythonFrame,
+    },
     metric_consts::PER_FRAME_TIME,
     sanitize_string,
     symbol_store::Catalog,
@@ -28,6 +31,8 @@ pub enum RawFrame {
     JavaScriptWeb(RawJSFrame),
     #[serde(rename = "node:javascript")]
     JavaScriptNode(RawNodeFrame),
+    #[serde(rename = "go")]
+    Go(RawGoFrame),
     // TODO - remove once we're happy no clients are using this anymore
     #[serde(rename = "javascript")]
     LegacyJS(RawJSFrame),
@@ -47,6 +52,7 @@ impl RawFrame {
             }
             RawFrame::Python(frame) => (Ok(frame.into()), "python"),
             RawFrame::Custom(frame) => (Ok(frame.into()), "custom"),
+            RawFrame::Go(frame) => (Ok(frame.into()), "go"),
         };
 
         // The raw id of the frame is set after it's resolved
@@ -73,7 +79,7 @@ impl RawFrame {
             // TODO - python frames don't use symbol sets for frame resolution, but could still use "marker" symbol set
             // to associate a given frame with a given release (basically, a symbol set with no data, just some id,
             // which we'd then use to do a join on the releases table to get release information)
-            RawFrame::Python(_) => None,
+            RawFrame::Python(_) | RawFrame::Go(_) => None,
             RawFrame::Custom(_) => None,
         }
     }
@@ -83,6 +89,7 @@ impl RawFrame {
             RawFrame::JavaScriptWeb(raw) | RawFrame::LegacyJS(raw) => raw.frame_id(),
             RawFrame::JavaScriptNode(raw) => raw.frame_id(),
             RawFrame::Python(raw) => raw.frame_id(),
+            RawFrame::Go(raw) => raw.frame_id(),
             RawFrame::Custom(raw) => raw.frame_id(),
         }
     }

--- a/rust/cymbal/src/langs/go.rs
+++ b/rust/cymbal/src/langs/go.rs
@@ -1,0 +1,44 @@
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha512};
+
+use crate::{frames::Frame, langs::CommonFrameMetadata};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RawGoFrame {
+    filename: String,
+    function: String,
+    lineno: u32,
+    #[serde(flatten)]
+    meta: CommonFrameMetadata,
+}
+
+impl RawGoFrame {
+    pub fn frame_id(&self) -> String {
+        let mut hasher = Sha512::new();
+        hasher.update(self.filename.as_bytes());
+        hasher.update(self.function.as_bytes());
+        hasher.update(self.lineno.to_be_bytes());
+        format!("{:x}", hasher.finalize())
+    }
+}
+
+impl From<&RawGoFrame> for Frame {
+    fn from(frame: &RawGoFrame) -> Self {
+        Frame {
+            raw_id: frame.frame_id(),
+            mangled_name: frame.function.clone(),
+            line: Some(frame.lineno),
+            column: None,
+            source: Some(frame.filename.clone()),
+            in_app: frame.meta.in_app,
+            resolved_name: Some(frame.function.clone()),
+            lang: "go".to_string(),
+            resolved: true,
+            resolve_failure: None,
+            synthetic: frame.meta.synthetic,
+            junk_drawer: None,
+            context: None,
+            release: None,
+        }
+    }
+}

--- a/rust/cymbal/src/langs/mod.rs
+++ b/rust/cymbal/src/langs/mod.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 pub mod custom;
+pub mod go;
 pub mod js;
 pub mod node;
 pub mod python;


### PR DESCRIPTION
Pivoting from https://github.com/PostHog/posthog-go/pull/120/files, moving some of the frame ID generation and the final conversion over to cymbal to keep more logic out of the SDKs. Will coordinate with PR author to get go SDK sending raw frames in the right format, and then merge and release.