### PR TITLE
fix(data-warehouse): Wrap getting schemas with try/catch

### DIFF
--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -12,6 +12,7 @@ from rest_framework.exceptions import ValidationError
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
+from posthog.exceptions_capture import capture_exception
 from posthog.hogql.database.database import create_hogql_database
 from posthog.models.user import User
 from posthog.temporal.data_imports.sources.common.config import Config
@@ -543,7 +544,14 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 data={"message": credentials_error or "Invalid credentials"},
             )
 
-        schemas = source.get_schemas(source_config, self.team_id)
+        try:
+            schemas = source.get_schemas(source_config, self.team_id)
+        except Exception as e:
+            capture_exception(e)
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"message": str(e)},
+            )
 
         data = [
             {

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -547,7 +547,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         try:
             schemas = source.get_schemas(source_config, self.team_id)
         except Exception as e:
-            capture_exception(e)
+            capture_exception(e, {"source_type": source_type, "team_id": self.team_id})
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
                 data={"message": str(e)},


### PR DESCRIPTION
## Problem
- Users can get a "Non-OK error" when trying to create warehouses sources if their credentials aren't fully valid for getting the tables schemas
- Prompted by https://posthog.slack.com/archives/C0450KBMQBS/p1755527977056309

## Changes
- Wrap the `.get_schemas()` call and return any errors to the frontend 
