### PR TITLE
feat(messaging): Email tracking

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -220,7 +220,7 @@ jobs:
             - name: Wait for Clickhouse, Redis, Kafka
               if: needs.changes.outputs.nodejs == 'true'
               run: |
-                  docker compose -f docker-compose.dev.yml up kafka redis clickhouse -d --wait
+                  docker compose -f docker-compose.dev.yml up kafka redis clickhouse maildev -d --wait
                   bin/check_kafka_clickhouse_up
 
             - name: Set up databases

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -173,10 +173,10 @@ services:
         image: maildev/maildev:2.0.5
         restart: on-failure
         healthcheck:
-            test: curl -f http://localhost:1080/email || exit 1
+            test: wget -qO- http://127.0.0.1:1080/healthz || exit 1
             interval: 3s
-            timeout: 10s
-            retries: 10
+            timeout: 1s
+            retries: 3
 
     flower:
         image: mher/flower:2.0.0

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -49,6 +49,8 @@ services:
                         path /public/webhooks
                         path /public/webhooks/
                         path /public/webhooks/*
+                        path /public/m/
+                        path /public/m/*
                     }
 
                     handle @capture {

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -172,6 +172,11 @@ services:
     maildev:
         image: maildev/maildev:2.0.5
         restart: on-failure
+        healthcheck:
+            test: curl -f http://localhost:1080/email || exit 1
+            interval: 3s
+            timeout: 10s
+            retries: 10
 
     flower:
         image: mher/flower:2.0.0

--- a/docker-compose.dev-minimal.yml
+++ b/docker-compose.dev-minimal.yml
@@ -47,6 +47,8 @@ services:
                     @webhooks {
                         path /public/webhooks
                         path /public/webhooks/*
+                        path /public/m/
+                        path /public/m/*
                     }
 
                     handle @capture {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -46,6 +46,8 @@ services:
                     @webhooks {
                         path /public/webhooks
                         path /public/webhooks/*
+                        path /public/m
+                        path /public/m/*
                     }
 
                     handle @capture {

--- a/plugin-server/src/capabilities.ts
+++ b/plugin-server/src/capabilities.ts
@@ -34,7 +34,7 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
                 cdpInternalEvents: true,
                 cdpLegacyOnEvent: true,
                 cdpCyclotronWorker: true,
-                // cdpCyclotronWorkerHogFlow: true,
+                cdpCyclotronWorkerHogFlow: true,
                 cdpBehaviouralEvents: true,
                 cdpAggregationWriter: config.CDP_AGGREGATION_WRITER_ENABLED,
                 cdpApi: true,

--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -95,9 +95,10 @@ export class CdpApi {
         router.patch('/api/projects/:team_id/hog_functions/:id/status', asyncHandler(this.patchFunctionStatus()))
         router.get('/api/hog_functions/states', asyncHandler(this.getFunctionStates()))
         router.get('/api/hog_function_templates', this.getHogFunctionTemplates)
-        router.post('/public/messaging/mailjet_webhook', asyncHandler(this.postMailjetWebhook()))
         router.post('/public/webhooks/:webhook_id', asyncHandler(this.postWebhook()))
         router.get('/public/webhooks/:webhook_id', asyncHandler(this.getWebhook()))
+        router.get('/public/m/pixel', asyncHandler(this.getEmailTrackingPixel()))
+        router.post('/public/m/mailjet_webhook', asyncHandler(this.postMailjetWebhook()))
 
         return router
     }
@@ -536,5 +537,11 @@ export class CdpApi {
             } catch (error) {
                 return res.status(500).json({ error: 'Internal error' })
             }
+        }
+
+    private getEmailTrackingPixel =
+        () =>
+        async (req: ModifiedRequest, res: express.Response): Promise<any> => {
+            await this.emailTrackingService.handleEmailTrackingPixel(req, res)
         }
 }

--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -533,7 +533,7 @@ export class CdpApi {
         () =>
         async (req: ModifiedRequest, res: express.Response): Promise<any> => {
             try {
-                const { status, message } = await this.emailTrackingService.handleWebhook(req)
+                const { status, message } = await this.emailTrackingService.handleMailjetWebhook(req)
                 return res.status(status).json({ message })
             } catch (error) {
                 return res.status(500).json({ error: 'Internal error' })

--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -99,6 +99,7 @@ export class CdpApi {
         router.get('/public/webhooks/:webhook_id', asyncHandler(this.getWebhook()))
         router.get('/public/m/pixel', asyncHandler(this.getEmailTrackingPixel()))
         router.post('/public/m/mailjet_webhook', asyncHandler(this.postMailjetWebhook()))
+        router.get('/public/m/redirect', asyncHandler(this.getEmailTrackingRedirect()))
 
         return router
     }
@@ -543,5 +544,11 @@ export class CdpApi {
         () =>
         async (req: ModifiedRequest, res: express.Response): Promise<any> => {
             await this.emailTrackingService.handleEmailTrackingPixel(req, res)
+        }
+
+    private getEmailTrackingRedirect =
+        () =>
+        async (req: ModifiedRequest, res: express.Response): Promise<any> => {
+            await this.emailTrackingService.handleEmailTrackingRedirect(req, res)
         }
 }

--- a/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
@@ -328,13 +328,19 @@ export class CdpEventsConsumer extends CdpConsumerBase {
                             try {
                                 const clickHouseEvent = parseJSON(message.value!.toString()) as RawClickHouseEvent
 
-                                const [team] = await Promise.all([
+                                const [teamHogFunctions, teamHogFlows, team] = await Promise.all([
+                                    this.hogFunctionManager.getHogFunctionsForTeam(
+                                        clickHouseEvent.team_id,
+                                        this.hogTypes
+                                    ),
+                                    this.hogFlowManager.getHogFlowsForTeam(clickHouseEvent.team_id),
                                     this.hub.teamManager.getTeam(clickHouseEvent.team_id),
                                 ])
 
-                                if (!team) {
+                                if ((!teamHogFunctions.length && !teamHogFlows.length) || !team) {
                                     return
                                 }
+
                                 events.push(
                                     convertToHogFunctionInvocationGlobals(clickHouseEvent, team, this.hub.SITE_URL)
                                 )

--- a/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
@@ -328,14 +328,11 @@ export class CdpEventsConsumer extends CdpConsumerBase {
                             try {
                                 const clickHouseEvent = parseJSON(message.value!.toString()) as RawClickHouseEvent
 
-                                const [teamHogFunctions, team] = await Promise.all([
-                                    this.hogFunctionManager.getHogFunctionsForTeam(clickHouseEvent.team_id, [
-                                        'destination',
-                                    ]),
+                                const [team] = await Promise.all([
                                     this.hub.teamManager.getTeam(clickHouseEvent.team_id),
                                 ])
 
-                                if (!teamHogFunctions.length || !team) {
+                                if (!team) {
                                     return
                                 }
                                 events.push(

--- a/plugin-server/src/cdp/services/messaging/email-tracking.service.test.ts
+++ b/plugin-server/src/cdp/services/messaging/email-tracking.service.test.ts
@@ -87,7 +87,7 @@ describe('EmailTrackingService', () => {
                 .digest('hex')
 
             const res = await supertest(app)
-                .post(`/public/messaging/mailjet_webhook`)
+                .post(`/public/m/mailjet_webhook`)
                 .set({
                     'x-mailjet-signature': signature,
                     'x-mailjet-timestamp': timestamp,
@@ -100,7 +100,7 @@ describe('EmailTrackingService', () => {
 
         describe('validation', () => {
             it('should return 403 if required headers are missing', async () => {
-                const res = await supertest(app).post(`/public/messaging/mailjet_webhook`).send({})
+                const res = await supertest(app).post(`/public/m/mailjet_webhook`).send({})
 
                 expect(res.status).toBe(403)
                 expect(res.body).toMatchInlineSnapshot(`
@@ -113,7 +113,7 @@ describe('EmailTrackingService', () => {
             it('should return 403 if signature is invalid', async () => {
                 const timestamp = Date.now().toString()
                 const res = await supertest(app)
-                    .post(`/public/messaging/mailjet_webhook`)
+                    .post(`/public/m/mailjet_webhook`)
                     .set({
                         'x-mailjet-signature': 'invalid-signature',
                         'x-mailjet-timestamp': timestamp,

--- a/plugin-server/src/cdp/services/messaging/email-tracking.service.test.ts
+++ b/plugin-server/src/cdp/services/messaging/email-tracking.service.test.ts
@@ -164,7 +164,7 @@ describe('EmailTrackingService', () => {
 
             it.each([
                 ['open', 'email_opened'],
-                ['click', 'email_clicked'],
+                ['click', 'email_link_clicked'],
                 ['bounce', 'email_bounced'],
                 ['spam', 'email_spam'],
                 ['unsub', 'email_unsubscribed'],
@@ -207,7 +207,7 @@ describe('EmailTrackingService', () => {
                     app_source_id: hogFunction.id,
                     instance_id: invocationId,
                     metric_kind: 'email',
-                    metric_name: 'email_clicked',
+                    metric_name: 'email_link_clicked',
                     team_id: team.id,
                     count: 1,
                 })

--- a/plugin-server/src/cdp/services/messaging/email-tracking.service.test.ts
+++ b/plugin-server/src/cdp/services/messaging/email-tracking.service.test.ts
@@ -18,7 +18,7 @@ import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
 import { closeHub, createHub } from '~/utils/db/hub'
 
 import { Hub, Team } from '../../../types'
-import { generateMailjetCustomId } from './email-tracking.service'
+import { generateEmailTrackingCode } from './email-tracking.service'
 import { MailjetEventBase, MailjetWebhookEvent } from './types'
 
 describe('EmailTrackingService', () => {
@@ -69,7 +69,7 @@ describe('EmailTrackingService', () => {
                 MessageID: 1,
                 Message_GUID: 'test-message-guid',
                 customcampaign: 'test-custom-campaign',
-                CustomID: generateMailjetCustomId({ functionId: hogFunction.id, id: invocationId }),
+                CustomID: generateEmailTrackingCode({ functionId: hogFunction.id, id: invocationId }),
                 Payload: JSON.stringify({}),
             }
         })
@@ -145,7 +145,7 @@ describe('EmailTrackingService', () => {
         it('should track a hog flow if given', async () => {
             const mailjetEvent: MailjetEventBase = {
                 ...exampleEvent,
-                CustomID: generateMailjetCustomId({ functionId: hogFlow.id, id: invocationId }),
+                CustomID: generateEmailTrackingCode({ functionId: hogFlow.id, id: invocationId }),
             }
             const res = await sendValidEvent(mailjetEvent)
 

--- a/plugin-server/src/cdp/services/messaging/email-tracking.service.test.ts
+++ b/plugin-server/src/cdp/services/messaging/email-tracking.service.test.ts
@@ -105,11 +105,9 @@ describe('EmailTrackingService', () => {
                     const res = await supertest(app).post(`/public/m/mailjet_webhook`).send({})
 
                     expect(res.status).toBe(403)
-                    expect(res.body).toMatchInlineSnapshot(`
-                    {
-                    "message": "Missing required headers or body",
-                    }
-                `)
+                    expect(res.body).toEqual({
+                        message: 'Missing required headers or body',
+                    })
                 })
 
                 it('should return 403 if signature is invalid', async () => {
@@ -123,11 +121,9 @@ describe('EmailTrackingService', () => {
                         .send(exampleEvent)
 
                     expect(res.status).toBe(403)
-                    expect(res.body).toMatchInlineSnapshot(`
-                    {
-                    "message": "Invalid signature",
-                    }
-                `)
+                    expect(res.body).toEqual({
+                        message: 'Invalid signature',
+                    })
                 })
             })
 
@@ -249,6 +245,12 @@ describe('EmailTrackingService', () => {
                 expect(messages).toHaveLength(1)
                 expect(messages[0].value).toMatchObject({
                     app_source: 'hog_function',
+                    app_source_id: hogFunction.id,
+                    instance_id: invocationId,
+                    metric_kind: 'email',
+                    metric_name: 'email_opened',
+                    team_id: team.id,
+                    count: 1,
                 })
             })
 

--- a/plugin-server/src/cdp/services/messaging/email-tracking.service.test.ts
+++ b/plugin-server/src/cdp/services/messaging/email-tracking.service.test.ts
@@ -16,9 +16,10 @@ import { KAFKA_APP_METRICS_2 } from '~/config/kafka-topics'
 import { HogFlow } from '~/schema/hogflow'
 import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
 import { closeHub, createHub } from '~/utils/db/hub'
+import { UUIDT } from '~/utils/utils'
 
 import { Hub, Team } from '../../../types'
-import { generateEmailTrackingCode } from './email-tracking.service'
+import { PIXEL_GIF, generateEmailTrackingCode } from './email-tracking.service'
 import { MailjetEventBase, MailjetWebhookEvent } from './types'
 
 describe('EmailTrackingService', () => {
@@ -40,7 +41,7 @@ describe('EmailTrackingService', () => {
         await closeHub(hub)
     })
 
-    describe('handleWebhook', () => {
+    describe('api', () => {
         // NOTE: These tests are done via the CdpApi router so we can get full coverage of the code
         let api: CdpApi
         let app: express.Application
@@ -78,118 +79,187 @@ describe('EmailTrackingService', () => {
             server.close()
         })
 
-        const sendValidEvent = async (mailjetEvent: MailjetEventBase): Promise<supertest.Response> => {
-            const timestamp = Date.now().toString()
-            const payload = JSON.stringify(mailjetEvent)
-            const signature = crypto
-                .createHmac('sha256', hub.MAILJET_SECRET_KEY)
-                .update(`${timestamp}.${payload}`)
-                .digest('hex')
-
-            const res = await supertest(app)
-                .post(`/public/m/mailjet_webhook`)
-                .set({
-                    'x-mailjet-signature': signature,
-                    'x-mailjet-timestamp': timestamp,
-                    'content-type': 'application/json',
-                })
-                .send(payload)
-
-            return res
-        }
-
-        describe('validation', () => {
-            it('should return 403 if required headers are missing', async () => {
-                const res = await supertest(app).post(`/public/m/mailjet_webhook`).send({})
-
-                expect(res.status).toBe(403)
-                expect(res.body).toMatchInlineSnapshot(`
-                {
-                  "message": "Missing required headers or body",
-                }
-            `)
-            })
-
-            it('should return 403 if signature is invalid', async () => {
+        describe('mailjet webhook', () => {
+            const sendValidEvent = async (mailjetEvent: MailjetEventBase): Promise<supertest.Response> => {
                 const timestamp = Date.now().toString()
+                const payload = JSON.stringify(mailjetEvent)
+                const signature = crypto
+                    .createHmac('sha256', hub.MAILJET_SECRET_KEY)
+                    .update(`${timestamp}.${payload}`)
+                    .digest('hex')
+
                 const res = await supertest(app)
                     .post(`/public/m/mailjet_webhook`)
                     .set({
-                        'x-mailjet-signature': 'invalid-signature',
+                        'x-mailjet-signature': signature,
                         'x-mailjet-timestamp': timestamp,
+                        'content-type': 'application/json',
                     })
-                    .send(exampleEvent)
+                    .send(payload)
 
-                expect(res.status).toBe(403)
-                expect(res.body).toMatchInlineSnapshot(`
-                {
-                  "message": "Invalid signature",
+                return res
+            }
+
+            describe('validation', () => {
+                it('should return 403 if required headers are missing', async () => {
+                    const res = await supertest(app).post(`/public/m/mailjet_webhook`).send({})
+
+                    expect(res.status).toBe(403)
+                    expect(res.body).toMatchInlineSnapshot(`
+                    {
+                    "message": "Missing required headers or body",
+                    }
+                `)
+                })
+
+                it('should return 403 if signature is invalid', async () => {
+                    const timestamp = Date.now().toString()
+                    const res = await supertest(app)
+                        .post(`/public/m/mailjet_webhook`)
+                        .set({
+                            'x-mailjet-signature': 'invalid-signature',
+                            'x-mailjet-timestamp': timestamp,
+                        })
+                        .send(exampleEvent)
+
+                    expect(res.status).toBe(403)
+                    expect(res.body).toMatchInlineSnapshot(`
+                    {
+                    "message": "Invalid signature",
+                    }
+                `)
+                })
+            })
+
+            it('should not track a metric if the hog function or flow is not found', async () => {
+                const mailjetEvent: MailjetEventBase = {
+                    ...exampleEvent,
+                    CustomID: 'ph_fn_id=invalid-function-id&ph_inv_id=invalid-invocation-id',
                 }
-            `)
+                const res = await sendValidEvent(mailjetEvent)
+
+                expect(res.status).toBe(200)
+                expect(res.body).toEqual({ message: 'OK' })
+                const messages = mockProducerObserver.getProducedKafkaMessagesForTopic(KAFKA_APP_METRICS_2)
+                expect(messages).toHaveLength(0)
+            })
+
+            it('should track a hog flow if given', async () => {
+                const mailjetEvent: MailjetEventBase = {
+                    ...exampleEvent,
+                    CustomID: generateEmailTrackingCode({ functionId: hogFlow.id, id: invocationId }),
+                }
+                const res = await sendValidEvent(mailjetEvent)
+
+                expect(res.status).toBe(200)
+                expect(res.body).toEqual({ message: 'OK' })
+                const messages = mockProducerObserver.getProducedKafkaMessagesForTopic(KAFKA_APP_METRICS_2)
+                expect(messages).toHaveLength(1)
+                expect(messages[0].value).toMatchObject({
+                    app_source: 'hog_flow',
+                    app_source_id: hogFlow.id,
+                    count: 1,
+                    instance_id: invocationId,
+                    metric_kind: 'email',
+                    metric_name: 'email_sent',
+                    team_id: team.id,
+                })
+            })
+
+            it.each([
+                ['open', 'email_opened'],
+                ['click', 'email_clicked'],
+                ['bounce', 'email_bounced'],
+                ['spam', 'email_spam'],
+                ['unsub', 'email_unsubscribed'],
+            ] as const)('should handle valid %s event', async (event, metric) => {
+                const mailjetEvent: MailjetEventBase = {
+                    ...exampleEvent,
+                    event,
+                }
+                const res = await sendValidEvent(mailjetEvent)
+
+                expect(res.status).toBe(200)
+                expect(res.body).toEqual({ message: 'OK' })
+                const messages = mockProducerObserver.getProducedKafkaMessagesForTopic(KAFKA_APP_METRICS_2)
+                expect(messages).toHaveLength(1)
+
+                expect(messages[0].value).toMatchObject({
+                    app_source: 'hog_function',
+                    app_source_id: hogFunction.id,
+                    count: 1,
+                    instance_id: invocationId,
+                    metric_kind: 'email',
+                    metric_name: metric,
+                    team_id: team.id,
+                })
             })
         })
 
-        it('should not track a metric if the hog function or flow is not found', async () => {
-            const mailjetEvent: MailjetEventBase = {
-                ...exampleEvent,
-                CustomID: 'ph_fn_id=invalid-function-id&ph_inv_id=invalid-invocation-id',
-            }
-            const res = await sendValidEvent(mailjetEvent)
+        describe('handleEmailTrackingRedirect', () => {
+            it('should redirect to the target url and track the click metric', async () => {
+                const res = await supertest(app).get(
+                    `/public/m/redirect?ph_fn_id=${hogFunction.id}&ph_inv_id=${invocationId}&target=https://example.com`
+                )
+                expect(res.status).toBe(302)
+                expect(res.headers.location).toBe('https://example.com')
 
-            expect(res.status).toBe(200)
-            expect(res.body).toEqual({ message: 'OK' })
-            const messages = mockProducerObserver.getProducedKafkaMessagesForTopic(KAFKA_APP_METRICS_2)
-            expect(messages).toHaveLength(0)
-        })
+                const messages = mockProducerObserver.getProducedKafkaMessagesForTopic(KAFKA_APP_METRICS_2)
+                expect(messages).toHaveLength(1)
+                expect(messages[0].value).toMatchObject({
+                    app_source: 'hog_function',
+                    app_source_id: hogFunction.id,
+                    instance_id: invocationId,
+                    metric_kind: 'email',
+                    metric_name: 'email_clicked',
+                    team_id: team.id,
+                    count: 1,
+                })
+            })
 
-        it('should track a hog flow if given', async () => {
-            const mailjetEvent: MailjetEventBase = {
-                ...exampleEvent,
-                CustomID: generateEmailTrackingCode({ functionId: hogFlow.id, id: invocationId }),
-            }
-            const res = await sendValidEvent(mailjetEvent)
+            it('should return 404 if the target is not provided', async () => {
+                const res = await supertest(app).get(
+                    `/public/m/redirect?ph_fn_id=${hogFunction.id}&ph_inv_id=${invocationId}`
+                )
+                expect(res.status).toBe(404)
+            })
 
-            expect(res.status).toBe(200)
-            expect(res.body).toEqual({ message: 'OK' })
-            const messages = mockProducerObserver.getProducedKafkaMessagesForTopic(KAFKA_APP_METRICS_2)
-            expect(messages).toHaveLength(1)
-            expect(messages[0].value).toMatchObject({
-                app_source: 'hog_flow',
-                app_source_id: hogFlow.id,
-                count: 1,
-                instance_id: invocationId,
-                metric_kind: 'email',
-                metric_name: 'email_sent',
-                team_id: team.id,
+            it('should redirect even if the tracking code is invalid', async () => {
+                const res = await supertest(app).get(
+                    `/public/m/redirect?ph_fn_id=invalid-function-id&ph_inv_id=invalid-invocation-id&target=https://example.com`
+                )
+                expect(res.status).toBe(302)
+                expect(res.headers.location).toBe('https://example.com')
+
+                const messages = mockProducerObserver.getProducedKafkaMessagesForTopic(KAFKA_APP_METRICS_2)
+                expect(messages).toHaveLength(0)
             })
         })
 
-        it.each([
-            ['open', 'email_opened'],
-            ['click', 'email_clicked'],
-            ['bounce', 'email_bounced'],
-            ['spam', 'email_spam'],
-            ['unsub', 'email_unsubscribed'],
-        ] as const)('should handle valid %s event', async (event, metric) => {
-            const mailjetEvent: MailjetEventBase = {
-                ...exampleEvent,
-                event,
-            }
-            const res = await sendValidEvent(mailjetEvent)
+        describe('email tracking pixel', () => {
+            it('should return a 200 and a gif image, tracking the open metric', async () => {
+                const res = await supertest(app).get(
+                    `/public/m/pixel?ph_fn_id=${hogFunction.id}&ph_inv_id=${invocationId}`
+                )
+                expect(res.status).toBe(200)
+                expect(res.headers['content-type']).toBe('image/gif')
+                expect(res.body).toEqual(PIXEL_GIF)
 
-            expect(res.status).toBe(200)
-            expect(res.body).toEqual({ message: 'OK' })
-            const messages = mockProducerObserver.getProducedKafkaMessagesForTopic(KAFKA_APP_METRICS_2)
-            expect(messages).toHaveLength(1)
+                const messages = mockProducerObserver.getProducedKafkaMessagesForTopic(KAFKA_APP_METRICS_2)
+                expect(messages).toHaveLength(1)
+                expect(messages[0].value).toMatchObject({
+                    app_source: 'hog_function',
+                })
+            })
 
-            expect(messages[0].value).toMatchObject({
-                app_source: 'hog_function',
-                app_source_id: hogFunction.id,
-                count: 1,
-                instance_id: invocationId,
-                metric_kind: 'email',
-                metric_name: metric,
-                team_id: team.id,
+            it('should return a 200 even if the tracking code is invalid', async () => {
+                const res = await supertest(app).get(`/public/m/pixel?ph_fn_id=${new UUIDT()}&ph_inv_id=${new UUIDT()}`)
+                expect(res.status).toBe(200)
+                expect(res.headers['content-type']).toBe('image/gif')
+                expect(res.body).toEqual(PIXEL_GIF)
+
+                const messages = mockProducerObserver.getProducedKafkaMessagesForTopic(KAFKA_APP_METRICS_2)
+                expect(messages).toHaveLength(0)
             })
         })
     })

--- a/plugin-server/src/cdp/services/messaging/email-tracking.service.ts
+++ b/plugin-server/src/cdp/services/messaging/email-tracking.service.ts
@@ -21,7 +21,7 @@ const LINK_REGEX =
 const EVENT_TYPE_TO_CATEGORY: Record<MailjetEventType, MinimalAppMetric['metric_name'] | undefined> = {
     sent: 'email_sent',
     open: 'email_opened',
-    click: 'email_clicked',
+    click: 'email_link_clicked',
     bounce: 'email_bounced',
     blocked: 'email_blocked',
     spam: 'email_spam',
@@ -249,7 +249,7 @@ export class EmailTrackingService {
             await this.trackMetric({
                 functionId: ph_fn_id as string,
                 invocationId: ph_inv_id as string,
-                metricName: 'email_clicked',
+                metricName: 'email_link_clicked',
                 source: 'direct',
             })
         } catch (error) {

--- a/plugin-server/src/cdp/services/messaging/email-tracking.service.ts
+++ b/plugin-server/src/cdp/services/messaging/email-tracking.service.ts
@@ -77,7 +77,7 @@ export const generateTrackingRedirectUrl = (
 export const addTrackingToEmail = (html: string, invocation: CyclotronJobInvocationHogFunction): string => {
     const trackingUrl = generateEmailTrackingPixelUrl(invocation)
 
-    html = html.replace(LINK_REGEX, (m, d, s, u, inner) => {
+    html = html.replace(LINK_REGEX, (m, d, s, u) => {
         const href = d || s || u || ''
         const tracked = generateTrackingRedirectUrl(invocation, href)
 
@@ -89,8 +89,6 @@ export const addTrackingToEmail = (html: string, invocation: CyclotronJobInvocat
 
     return html
 }
-
-export const replaceLinkWithTrackingPixel = (html: string, invocation: CyclotronJobInvocationHogFunction): string => {}
 
 export class EmailTrackingService {
     constructor(

--- a/plugin-server/src/cdp/services/messaging/email-tracking.service.ts
+++ b/plugin-server/src/cdp/services/messaging/email-tracking.service.ts
@@ -65,6 +65,11 @@ export const generateEmailTrackingPixelUrl = (
     return `${defaultConfig.CDP_EMAIL_TRACKING_URL}/public/m/pixel?${generateEmailTrackingCode(invocation)}`
 }
 
+export const addTrackingToEmail = (html: string, invocation: CyclotronJobInvocationHogFunction): string => {
+    const trackingUrl = generateEmailTrackingPixelUrl(invocation)
+    return html.replace('</body>', `<img src="${trackingUrl}" style="display: none;" /></body>`)
+}
+
 export class EmailTrackingService {
     constructor(
         private hub: Hub,

--- a/plugin-server/src/cdp/services/messaging/email-tracking.service.ts
+++ b/plugin-server/src/cdp/services/messaging/email-tracking.service.ts
@@ -162,7 +162,7 @@ export class EmailTrackingService {
         })
     }
 
-    public async handleWebhook(
+    public async handleMailjetWebhook(
         req: ModifiedRequest
     ): Promise<{ status: number; message?: string; metrics?: AppMetricType[] }> {
         const signature = req.headers['x-mailjet-signature'] as string
@@ -203,7 +203,7 @@ export class EmailTrackingService {
                 return { status: 400, message: 'Unmapped event type' }
             }
 
-            this.trackMetric({
+            await this.trackMetric({
                 functionId,
                 invocationId,
                 metricName: category,

--- a/plugin-server/src/cdp/services/messaging/email-tracking.service.ts
+++ b/plugin-server/src/cdp/services/messaging/email-tracking.service.ts
@@ -14,7 +14,7 @@ import { HogFunctionManagerService } from '../managers/hog-function-manager.serv
 import { HogFunctionMonitoringService } from '../monitoring/hog-function-monitoring.service'
 import { MailjetEventType, MailjetWebhookEvent } from './types'
 
-const PIXEL_GIF = Buffer.from('R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==', 'base64')
+export const PIXEL_GIF = Buffer.from('R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==', 'base64')
 const LINK_REGEX =
     /<a\b[^>]*\bhref\s*=\s*(?:"(?!javascript:)([^"]*)"|'(?!javascript:)([^']*)'|(?!javascript:)([^'">\s]+))[^>]*>([\s\S]*?)<\/a>/gi
 

--- a/plugin-server/src/cdp/services/messaging/email-tracking.service.ts
+++ b/plugin-server/src/cdp/services/messaging/email-tracking.service.ts
@@ -229,7 +229,7 @@ export class EmailTrackingService {
                 source: 'direct',
             })
         } catch (error) {
-            logger.error('[EmailTrackingService] handleEmailTrackingPixel: Error tracking metric', { error })
+            logger.error('[EmailTrackingService] handleEmailTrackingPixel: Error tracking open metric', { error })
             captureException(error)
         }
 
@@ -253,7 +253,7 @@ export class EmailTrackingService {
                 source: 'direct',
             })
         } catch (error) {
-            logger.error('[EmailTrackingService] handleEmailTrackingPixel: Error tracking metric', { error })
+            logger.error('[EmailTrackingService] handleEmailTrackingRedirect: Error tracking metric', { error })
             captureException(error)
         }
 

--- a/plugin-server/src/cdp/services/messaging/email-tracking.service.ts
+++ b/plugin-server/src/cdp/services/messaging/email-tracking.service.ts
@@ -6,7 +6,6 @@ import { ModifiedRequest } from '~/api/router'
 import { AppMetricType, CyclotronJobInvocationHogFunction, MinimalAppMetric } from '~/cdp/types'
 import { defaultConfig } from '~/config/config'
 import { captureException } from '~/utils/posthog'
-import { PromiseScheduler } from '~/utils/promise-scheduler'
 
 import { Hub } from '../../../types'
 import { logger } from '../../../utils/logger'
@@ -49,7 +48,7 @@ export const parseEmailTrackingCode = (customId: string): { functionId: string; 
             return null
         }
         return { functionId, invocationId }
-    } catch (error) {
+    } catch {
         return null
     }
 }
@@ -67,8 +66,6 @@ export const generateEmailTrackingPixelUrl = (
 }
 
 export class EmailTrackingService {
-    private promises = new PromiseScheduler()
-
     constructor(
         private hub: Hub,
         private hogFunctionManager: HogFunctionManagerService,

--- a/plugin-server/src/cdp/services/messaging/email.service.test.ts
+++ b/plugin-server/src/cdp/services/messaging/email.service.test.ts
@@ -90,7 +90,7 @@ describe('EmailService', () => {
                 const result = await service.executeSendEmail(invocation)
                 expect(result.error).toMatchInlineSnapshot(`"Email integration not found"`)
             })
-            it('should ignore a given email and use the intgeration config', async () => {
+            it('should ignore a given email and use the integration config', async () => {
                 invocation.queueParameters = createEmailParams({
                     from: { integrationId: 1, email: 'test@other-domain.com', name: '' },
                 })

--- a/plugin-server/src/cdp/services/messaging/email.service.test.ts
+++ b/plugin-server/src/cdp/services/messaging/email.service.test.ts
@@ -1,11 +1,14 @@
 import { mockFetch } from '~/tests/helpers/mocks/request.mock'
+
 import { createExampleInvocation, insertIntegration } from '~/cdp/_tests/fixtures'
 import { CyclotronJobInvocationHogFunction } from '~/cdp/types'
 import { CyclotronInvocationQueueParametersEmailType } from '~/schema/cyclotron'
 import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
 import { closeHub, createHub } from '~/utils/db/hub'
+
 import { Hub, Team } from '../../../types'
 import { EmailService } from './email.service'
+
 const createEmailParams = (
     params: Partial<CyclotronInvocationQueueParametersEmailType> = {}
 ): CyclotronInvocationQueueParametersEmailType => {

--- a/plugin-server/src/cdp/services/messaging/email.service.ts
+++ b/plugin-server/src/cdp/services/messaging/email.service.ts
@@ -61,7 +61,7 @@ export class EmailService {
 
         // Finally we create the response object as the VM expects
         result.invocation.state.vmState!.stack.push({
-            success: !!success,
+            success,
         })
 
         result.metrics.push({

--- a/plugin-server/src/cdp/services/messaging/email.service.ts
+++ b/plugin-server/src/cdp/services/messaging/email.service.ts
@@ -80,7 +80,7 @@ export class EmailService {
         integration: IntegrationType,
         params: CyclotronInvocationQueueParametersEmailType
     ): void {
-        // Currently we enforce using the name and email set on the integratio
+        // Currently we enforce using the name and email set on the integration
 
         if (!integration.config.mailjet_verified) {
             throw new Error('The selected email integration domain is not verified')

--- a/plugin-server/src/cdp/services/messaging/email.service.ts
+++ b/plugin-server/src/cdp/services/messaging/email.service.ts
@@ -6,7 +6,7 @@ import { isDevEnv } from '~/utils/env-utils'
 import { fetch } from '~/utils/request'
 
 import { Hub } from '../../../types'
-import { generateEmailTrackingCode, generateEmailTrackingPixelUrl } from './email-tracking.service'
+import { addTrackingToEmail, generateEmailTrackingCode } from './email-tracking.service'
 import { mailDevTransport, mailDevWebUrl } from './helpers/maildev'
 
 export class EmailService {
@@ -158,7 +158,7 @@ export class EmailService {
             to: params.to.name ? `"${params.to.name}" <${params.to.email}>` : params.to.email,
             subject: params.subject,
             text: params.text,
-            html: this.addTrackingToEmail(params.html, result.invocation),
+            html: addTrackingToEmail(params.html, result.invocation),
         })
 
         if (!response.accepted) {
@@ -166,10 +166,5 @@ export class EmailService {
         }
 
         result.logs.push(logEntry('debug', `Email sent to your local maildev server: ${mailDevWebUrl}`))
-    }
-
-    private addTrackingToEmail(html: string, invocation: CyclotronJobInvocationHogFunction): string {
-        const trackingUrl = generateEmailTrackingPixelUrl(invocation)
-        return html.replace('</body>', `<img src="${trackingUrl}" style="display: none;" /></body>`)
     }
 }

--- a/plugin-server/src/cdp/services/messaging/email.service.ts
+++ b/plugin-server/src/cdp/services/messaging/email.service.ts
@@ -2,7 +2,6 @@ import { CyclotronJobInvocationHogFunction, CyclotronJobInvocationResult, Integr
 import { createAddLogFunction, logEntry } from '~/cdp/utils'
 import { createInvocationResult } from '~/cdp/utils/invocation-utils'
 import { CyclotronInvocationQueueParametersEmailType } from '~/schema/cyclotron'
-import { isDevEnv } from '~/utils/env-utils'
 import { fetch } from '~/utils/request'
 
 import { Hub } from '../../../types'
@@ -100,7 +99,7 @@ export class EmailService {
             return 'mailjet'
         }
 
-        if (isDevEnv() && mailDevTransport) {
+        if (mailDevTransport) {
             return 'maildev'
         }
         return 'unsupported'

--- a/plugin-server/src/cdp/services/messaging/helpers/maildev.ts
+++ b/plugin-server/src/cdp/services/messaging/helpers/maildev.ts
@@ -16,7 +16,7 @@ export const mailDevTransport =
           })
         : null
 
-export const mailDevWebUrl = `http://${process.env.MAILDEV_HOST || 'localhost'}:${process.env.MAILDEV_WEB_PORT || 1080}`
+export const mailDevWebUrl = `http://${process.env.MAILDEV_HOST || '127.0.0.1'}:${process.env.MAILDEV_WEB_PORT || 1080}`
 
 registerShutdownHandler(() => {
     return Promise.resolve(mailDevTransport?.close())

--- a/plugin-server/src/cdp/services/messaging/helpers/maildev.ts
+++ b/plugin-server/src/cdp/services/messaging/helpers/maildev.ts
@@ -2,6 +2,7 @@ import nodemailer from 'nodemailer'
 
 import { registerShutdownHandler } from '~/lifecycle'
 import { isDevEnv, isTestEnv } from '~/utils/env-utils'
+import { fetch } from '~/utils/request'
 
 export const mailDevTransport =
     isDevEnv() || isTestEnv()
@@ -20,3 +21,18 @@ export const mailDevWebUrl = `http://${process.env.MAILDEV_HOST || 'localhost'}:
 registerShutdownHandler(() => {
     return Promise.resolve(mailDevTransport?.close())
 })
+
+export class MailDevAPI {
+    constructor() {}
+
+    async getEmails(): Promise<any[]> {
+        const response = await fetch(`${mailDevWebUrl}/email`)
+        return response.json()
+    }
+
+    async clearEmails(): Promise<void> {
+        await fetch(`${mailDevWebUrl}/email/all`, {
+            method: 'DELETE',
+        })
+    }
+}

--- a/plugin-server/src/cdp/services/messaging/helpers/maildev.ts
+++ b/plugin-server/src/cdp/services/messaging/helpers/maildev.ts
@@ -1,21 +1,22 @@
 import nodemailer from 'nodemailer'
 
 import { registerShutdownHandler } from '~/lifecycle'
-import { isDevEnv } from '~/utils/env-utils'
+import { isDevEnv, isTestEnv } from '~/utils/env-utils'
 
-export const mailDevTransport = isDevEnv()
-    ? nodemailer.createTransport({
-          url: `http://${process.env.MAILDEV_HOST || '127.0.0.1'}:${process.env.MAILDEV_PORT || 1025}`,
-          ignoreTLS: true,
-          secure: false, // MailDev doesn't use TLS
-          connectionTimeout: 1000, // ms
-          greetingTimeout: 1000,
-          socketTimeout: 1000,
-      })
-    : null
+export const mailDevTransport =
+    isDevEnv() || isTestEnv()
+        ? nodemailer.createTransport({
+              url: `http://${process.env.MAILDEV_HOST || '127.0.0.1'}:${process.env.MAILDEV_PORT || 1025}`,
+              ignoreTLS: true,
+              secure: false, // MailDev doesn't use TLS
+              connectionTimeout: 1000, // ms
+              greetingTimeout: 1000,
+              socketTimeout: 1000,
+          })
+        : null
 
 export const mailDevWebUrl = `http://${process.env.MAILDEV_HOST || 'localhost'}:${process.env.MAILDEV_WEB_PORT || 1080}`
 
-registerShutdownHandler(async () => {
-    mailDevTransport?.close()
+registerShutdownHandler(() => {
+    return Promise.resolve(mailDevTransport?.close())
 })

--- a/plugin-server/src/cdp/services/messaging/helpers/maildev.ts
+++ b/plugin-server/src/cdp/services/messaging/helpers/maildev.ts
@@ -1,6 +1,6 @@
 import nodemailer from 'nodemailer'
-import { registerShutdownHandler } from '~/lifecycle'
 
+import { registerShutdownHandler } from '~/lifecycle'
 import { isDevEnv } from '~/utils/env-utils'
 
 export const mailDevTransport = isDevEnv()
@@ -11,7 +11,6 @@ export const mailDevTransport = isDevEnv()
           connectionTimeout: 1000, // ms
           greetingTimeout: 1000,
           socketTimeout: 1000,
-        
       })
     : null
 

--- a/plugin-server/src/cdp/services/messaging/helpers/maildev.ts
+++ b/plugin-server/src/cdp/services/messaging/helpers/maildev.ts
@@ -17,5 +17,5 @@ export const mailDevTransport = isDevEnv()
 export const mailDevWebUrl = `http://${process.env.MAILDEV_HOST || 'localhost'}:${process.env.MAILDEV_WEB_PORT || 1080}`
 
 registerShutdownHandler(async () => {
-    await mailDevTransport?.close()
+    mailDevTransport?.close()
 })

--- a/plugin-server/src/cdp/services/messaging/helpers/maildev.ts
+++ b/plugin-server/src/cdp/services/messaging/helpers/maildev.ts
@@ -1,12 +1,22 @@
 import nodemailer from 'nodemailer'
+import { registerShutdownHandler } from '~/lifecycle'
 
 import { isDevEnv } from '~/utils/env-utils'
 
 export const mailDevTransport = isDevEnv()
     ? nodemailer.createTransport({
-          url: `http://${process.env.MAILDEV_HOST || 'localhost'}:${process.env.MAILDEV_PORT || 1025}`,
+          url: `http://${process.env.MAILDEV_HOST || '127.0.0.1'}:${process.env.MAILDEV_PORT || 1025}`,
+          ignoreTLS: true,
           secure: false, // MailDev doesn't use TLS
+          connectionTimeout: 1000, // ms
+          greetingTimeout: 1000,
+          socketTimeout: 1000,
+        
       })
     : null
 
 export const mailDevWebUrl = `http://${process.env.MAILDEV_HOST || 'localhost'}:${process.env.MAILDEV_WEB_PORT || 1080}`
+
+registerShutdownHandler(async () => {
+    await mailDevTransport?.close()
+})

--- a/plugin-server/src/cdp/services/messaging/types.ts
+++ b/plugin-server/src/cdp/services/messaging/types.ts
@@ -112,7 +112,7 @@ export type MailjetWebhookEvent =
 export const EVENT_TYPE_TO_CATEGORY = {
     sent: 'email_sent',
     open: 'email_opened',
-    click: 'email_clicked',
+    click: 'email_link_clicked',
     bounce: 'email_bounced',
     blocked: 'email_blocked',
     spam: 'email_spam',

--- a/plugin-server/src/cdp/types.ts
+++ b/plugin-server/src/cdp/types.ts
@@ -198,7 +198,7 @@ export type MinimalAppMetric = {
         | 'email_sent'
         | 'email_failed'
         | 'email_opened'
-        | 'email_clicked'
+        | 'email_link_clicked'
         | 'email_bounced'
         | 'email_blocked'
         | 'email_spam'

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -196,6 +196,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         CDP_OVERFLOW_QUEUE_ENABLED: false,
         CDP_WATCHER_AUTOMATICALLY_DISABLE_FUNCTIONS: isProdEnv() ? false : true, // For prod we primarily use overflow and some more manual control
         CDP_AGGREGATION_WRITER_ENABLED: false,
+        CDP_EMAIL_TRACKING_URL: 'http://localhost:8010',
 
         CDP_LEGACY_EVENT_CONSUMER_GROUP_ID: 'clickhouse-plugin-server-async-onevent',
         CDP_LEGACY_EVENT_CONSUMER_TOPIC: KAFKA_EVENTS_JSON,

--- a/plugin-server/src/lifecycle.ts
+++ b/plugin-server/src/lifecycle.ts
@@ -1,0 +1,9 @@
+const shutdownHandlers: (() => Promise<void>)[] = []
+
+export const registerShutdownHandler = (handler: () => Promise<void>): void => {
+    shutdownHandlers.push(handler)
+}
+
+export const onShutdown = async (): Promise<void> => {
+    await Promise.allSettled(shutdownHandlers.map((handler) => handler()))
+}

--- a/plugin-server/src/server.ts
+++ b/plugin-server/src/server.ts
@@ -42,6 +42,7 @@ import { PubSub } from './utils/pubsub'
 import { delay } from './utils/utils'
 import { teardownPlugins } from './worker/plugins/teardown'
 import { initPlugins as _initPlugins } from './worker/tasks'
+import { onShutdown } from './lifecycle'
 
 CompressionCodecs[CompressionTypes.Snappy] = SnappyCodec
 CompressionCodecs[CompressionTypes.LZ4] = new LZ4().codec
@@ -349,7 +350,7 @@ export class PluginServer {
         })
 
         logger.info('💤', ' Shutting down services...')
-        await Promise.allSettled([this.pubsub?.stop(), ...this.services.map((s) => s.onShutdown()), posthogShutdown()])
+        await Promise.allSettled([this.pubsub?.stop(), ...this.services.map((s) => s.onShutdown()), posthogShutdown(), onShutdown()])
 
         if (this.hub) {
             logger.info('💤', ' Shutting down plugins...')

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -152,6 +152,8 @@ export type CdpConfig = {
     HOG_FUNCTION_MONITORING_APP_METRICS_TOPIC: string
     HOG_FUNCTION_MONITORING_LOG_ENTRIES_TOPIC: string
     HOG_FUNCTION_MONITORING_EVENTS_PRODUCED_TOPIC: string
+
+    CDP_EMAIL_TRACKING_URL: string
 }
 
 export type IngestionConsumerConfig = {

--- a/posthog/api/hog_flow.py
+++ b/posthog/api/hog_flow.py
@@ -51,7 +51,7 @@ class HogFlowActionSerializer(serializers.Serializer):
     )
     created_at = serializers.IntegerField(required=False)
     updated_at = serializers.IntegerField(required=False)
-    filters = HogFunctionFiltersSerializer(required=False, default=dict)
+    filters = HogFunctionFiltersSerializer(required=False, default=dict, allow_null=True)
     type = serializers.CharField(max_length=100)
     config = serializers.JSONField()
 


### PR DESCRIPTION
## Problem

Want to have proper email tracking. Also a bunch of smaller fixes

## Changes

* Runs the workflow processor locally
* Removes the check for hog functions at the handle batch level as it blocks the hogflow processing if you dont have a hog function (might separate the code a little more later)
* Enforces the email for the integration
* Fixes maildev (localhost apparently is less reliable) and adds a simpler global shutdown listener
* Adds email tracking to the maildev stuff to help with some simple local testing - might use this more generally later

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
