### PR TITLE
fix: search/commands button accessibility in the navbar

### DIFF
--- a/frontend/src/layout/scenes/SceneTabs.tsx
+++ b/frontend/src/layout/scenes/SceneTabs.tsx
@@ -76,8 +76,10 @@ export function SceneTabs({ className }: SceneTabsProps): JSX.Element {
                                 onClick={toggleSearchBar}
                                 data-attr="tree-navbar-search-button"
                                 size="sm"
+                                aria-label="Search (Command + K) or Commands (Command + Shift + K)"
+                                aria-describedby="search-tooltip"
                                 tooltip={
-                                    <div className="flex flex-col gap-0.5">
+                                    <div className="flex flex-col gap-0.5" id="search-tooltip">
                                         <span>
                                             For search, press <KeyboardShortcut command k />
                                         </span>


### PR DESCRIPTION
## Overview

The screenshot below shows an accessibility issue with the search/commands button in the navbar. This PR addresses and fixes that problem.

<img width="1268" height="850" alt="Screenshot 2025-08-18 at 17 47 31" src="https://github.com/user-attachments/assets/5a6184db-063a-439b-817c-7b1a7edc68ae" />

## How did you test this code?

I ran Storybook, and after applying the code changes, the accessibility error shown in the screenshot no longer appears.
