### PR TITLE
fix(hogql): Added support for partition by in postgres window conversion

### DIFF
--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -1876,7 +1876,13 @@ class _Printer(Visitor[str]):
         if node.exprs is not None and len(node.exprs) > 0:
             order_by = [ast.OrderExpr(expr=clone_expr(node.exprs[0]), order="ASC")]
 
+        # Preserve existing PARTITION BY if provided via an existing OVER () clause
+        partition_by: Optional[list[ast.Expr]] = None
+        if node.over_expr and node.over_expr.partition_by:
+            partition_by = [cast(ast.Expr, clone_expr(expr)) for expr in node.over_expr.partition_by]
+
         return ast.WindowExpr(
+            partition_by=partition_by,
             order_by=order_by,
             frame_method="ROWS",
             frame_start=ast.WindowFrameExpr(frame_type="PRECEDING", frame_value=None),

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -1483,6 +1483,13 @@ class TestPrinter(BaseTest):
             ),
             f"SELECT events.distinct_id AS distinct_id, lagInFrame(toNullable(toTimeZone(events.timestamp, %(hogql_val_0)s))) OVER (PARTITION BY events.distinct_id ORDER BY toTimeZone(events.timestamp, %(hogql_val_1)s) ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS prev_ts, min(toTimeZone(events.timestamp, %(hogql_val_2)s)) OVER win1 AS min_ts FROM events WHERE equals(events.team_id, {self.team.pk}) WINDOW win1 AS (PARTITION BY events.distinct_id ORDER BY toTimeZone(events.timestamp, %(hogql_val_3)s) ASC) LIMIT 50000",
         )
+        # Simple example with partiton by
+        self.assertEqual(
+            self._select(
+                "SELECT distinct_id, lag(timestamp) OVER (PARTITION BY distinct_id ORDER BY timestamp) FROM events"
+            ),
+            f"SELECT events.distinct_id AS distinct_id, lagInFrame(toNullable(toTimeZone(events.timestamp, %(hogql_val_0)s))) OVER (PARTITION BY events.distinct_id ORDER BY toTimeZone(events.timestamp, %(hogql_val_1)s) ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 50000",
+        )
 
     def test_window_functions_with_window(self):
         self.assertEqual(

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -1484,6 +1484,7 @@ class TestPrinter(BaseTest):
             f"SELECT events.distinct_id AS distinct_id, lagInFrame(toNullable(toTimeZone(events.timestamp, %(hogql_val_0)s))) OVER (PARTITION BY events.distinct_id ORDER BY toTimeZone(events.timestamp, %(hogql_val_1)s) ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS prev_ts, min(toTimeZone(events.timestamp, %(hogql_val_2)s)) OVER win1 AS min_ts FROM events WHERE equals(events.team_id, {self.team.pk}) WINDOW win1 AS (PARTITION BY events.distinct_id ORDER BY toTimeZone(events.timestamp, %(hogql_val_3)s) ASC) LIMIT 50000",
         )
         # Simple example with partiton by
+        # Simple example with partition by
         self.assertEqual(
             self._select(
                 "SELECT distinct_id, lag(timestamp) OVER (PARTITION BY distinct_id ORDER BY timestamp) FROM events"


### PR DESCRIPTION
## Problem
- When using postgres style syntax for window functions (`lead`, `lag`), we weren't converting over the `PARTITION BY` clause of the `OVER` window

## Changes
- Fix this by including the partition by clause

## How did you test this code?
- Extended our unit tests
