### PR TITLE
fix(flags): use latest config options for requests that are missing both the `v` and the `config` query parameters

### DIFF
--- a/rust/feature-flags/src/api/endpoint.rs
+++ b/rust/feature-flags/src/api/endpoint.rs
@@ -310,7 +310,6 @@ mod tests {
             only_evaluate_survey_feature_flags: None,
         };
 
-        // Simulate the logic from lines 78-81 in the flags endpoint
         if params_both_none.version.is_none() && params_both_none.config.is_none() {
             params_both_none.version = Some("2".to_string());
             params_both_none.config = Some(true);

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -151,7 +151,7 @@ async fn it_gets_v2_response_by_default_when_no_params() -> Result<()> {
     });
 
     let res = server
-        .send_flags_request(payload.to_string(), Some("1"), None)
+        .send_flags_request(payload.to_string(), None, None)
         .await;
     assert_eq!(StatusCode::OK, res.status());
 
@@ -1000,7 +1000,7 @@ async fn test_feature_flags_with_group_relationships() -> Result<()> {
         });
 
         let res = server
-            .send_flags_request(payload.to_string(), None, None)
+            .send_flags_request(payload.to_string(), Some("1"), None)
             .await;
         assert_eq!(res.status(), StatusCode::OK);
 
@@ -1029,7 +1029,7 @@ async fn test_feature_flags_with_group_relationships() -> Result<()> {
         });
 
         let res = server
-            .send_flags_request(payload.to_string(), None, None)
+            .send_flags_request(payload.to_string(), Some("1"), None)
             .await;
         assert_eq!(res.status(), StatusCode::OK);
 
@@ -1058,7 +1058,7 @@ async fn test_feature_flags_with_group_relationships() -> Result<()> {
         });
 
         let res = server
-            .send_flags_request(payload.to_string(), None, None)
+            .send_flags_request(payload.to_string(), Some("1"), None)
             .await;
         assert_eq!(res.status(), StatusCode::OK);
 
@@ -3653,7 +3653,7 @@ async fn test_numeric_group_ids_work_correctly() -> Result<()> {
         });
 
         let res = server
-            .send_flags_request(payload.to_string(), None, None)
+            .send_flags_request(payload.to_string(), Some("1"), None)
             .await;
         assert_eq!(res.status(), StatusCode::OK);
 
@@ -3680,7 +3680,7 @@ async fn test_numeric_group_ids_work_correctly() -> Result<()> {
         });
 
         let res = server
-            .send_flags_request(payload.to_string(), None, None)
+            .send_flags_request(payload.to_string(), Some("1"), None)
             .await;
         assert_eq!(res.status(), StatusCode::OK);
 
@@ -3707,7 +3707,7 @@ async fn test_numeric_group_ids_work_correctly() -> Result<()> {
         });
 
         let res = server
-            .send_flags_request(payload.to_string(), None, None)
+            .send_flags_request(payload.to_string(), Some("1"), None)
             .await;
         assert_eq!(res.status(), StatusCode::OK);
 
@@ -3734,7 +3734,7 @@ async fn test_numeric_group_ids_work_correctly() -> Result<()> {
         });
 
         let res = server
-            .send_flags_request(payload.to_string(), None, None)
+            .send_flags_request(payload.to_string(), Some("1"), None)
             .await;
         assert_eq!(res.status(), StatusCode::OK);
 

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -20,11 +20,10 @@ use feature_flags::utils::test_utils::{
 pub mod common;
 
 #[rstest]
-#[case(None)]
 #[case(Some("1"))]
 #[case(Some("banana"))]
 #[tokio::test]
-async fn it_gets_legacy_response_by_default_or_invalid_version(
+async fn it_gets_legacy_response_for_v1_or_invalid_version(
     #[case] version: Option<&str>,
 ) -> Result<()> {
     let config = DEFAULT_TEST_CONFIG.clone();
@@ -91,6 +90,93 @@ async fn it_gets_legacy_response_by_default_or_invalid_version(
             "featureFlags": {
                 "test-flag": true
             }
+        })
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn it_gets_v2_response_by_default_when_no_params() -> Result<()> {
+    // When no version and no config params are provided, we default to v=2 and config=true
+    let config = DEFAULT_TEST_CONFIG.clone();
+
+    let distinct_id = "user_distinct_id".to_string();
+
+    let client = setup_redis_client(Some(config.redis_url.clone())).await;
+    let pg_client = setup_pg_reader_client(None).await;
+    let team = insert_new_team_in_redis(client.clone()).await.unwrap();
+    let token = team.api_token;
+
+    insert_new_team_in_pg(pg_client.clone(), Some(team.id))
+        .await
+        .unwrap();
+
+    insert_person_for_team_in_pg(pg_client.clone(), team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
+
+    // Insert a specific flag for the team
+    let flag_json = json!([{
+        "id": 1,
+        "key": "test-flag",
+        "name": "Test Flag",
+        "active": true,
+        "deleted": false,
+        "team_id": team.id,
+        "filters": {
+            "groups": [
+                {
+                    "properties": [],
+                    "rollout_percentage": 100
+                }
+            ],
+        },
+    }]);
+
+    insert_flags_for_team_in_redis(
+        client,
+        team.id,
+        team.project_id,
+        Some(flag_json.to_string()),
+    )
+    .await?;
+
+    let server = ServerHandle::for_config(config).await;
+
+    let payload = json!({
+        "token": token,
+        "distinct_id": distinct_id,
+        "groups": {"group1": "group1"}
+    });
+
+    let res = server
+        .send_flags_request(payload.to_string(), Some("1"), None)
+        .await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    let json_data = res.json::<Value>().await?;
+    // With v=2 default, we get the new response format with config fields
+    assert_json_include!(
+        actual: json_data,
+        expected: json!({
+            "errorsWhileComputingFlags": false,
+            "flags": {
+                "test-flag": {
+                    "key": "test-flag",
+                    "enabled": true,
+                    "reason": {
+                        "code": "condition_match",
+                        "condition_index": 0,
+                        "description": "Matched condition set 1"
+                    },
+                    "metadata": {
+                        "id": 1,
+                        "version": 0
+                    }
+                }
+            },
+            "config": {}
         })
     );
 
@@ -250,7 +336,7 @@ async fn it_rejects_empty_distinct_id() -> Result<()> {
         "groups": {"group1": "group1"}
     });
     let res = server
-        .send_flags_request(payload.to_string(), None, None)
+        .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::BAD_REQUEST, res.status());
     assert_eq!(
@@ -273,7 +359,7 @@ async fn it_rejects_missing_distinct_id() -> Result<()> {
         "groups": {"group1": "group1"}
     });
     let res = server
-        .send_flags_request(payload.to_string(), None, None)
+        .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::BAD_REQUEST, res.status());
     assert_eq!(
@@ -293,7 +379,7 @@ async fn it_rejects_missing_token() -> Result<()> {
         "groups": {"group1": "group1"}
     });
     let res = server
-        .send_flags_request(payload.to_string(), None, None)
+        .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::UNAUTHORIZED, res.status());
     assert_eq!(
@@ -314,7 +400,7 @@ async fn it_rejects_invalid_token() -> Result<()> {
         "groups": {"group1": "group1"}
     });
     let res = server
-        .send_flags_request(payload.to_string(), None, None)
+        .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::UNAUTHORIZED, res.status());
     assert_eq!(
@@ -331,7 +417,7 @@ async fn it_handles_malformed_json() -> Result<()> {
 
     let payload = "{invalid_json}";
     let res = server
-        .send_flags_request(payload.to_string(), None, None)
+        .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::BAD_REQUEST, res.status());
 
@@ -368,7 +454,7 @@ async fn it_handles_quota_limiting() -> Result<()> {
     });
 
     let res = server
-        .send_flags_request(payload.to_string(), None, None)
+        .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::OK, res.status());
     let response_body = res.json::<LegacyFlagsResponse>().await?;
@@ -491,7 +577,7 @@ async fn it_handles_multivariate_flags() -> Result<()> {
     });
 
     let res = server
-        .send_flags_request(payload.to_string(), None, None)
+        .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::OK, res.status());
 
@@ -573,7 +659,7 @@ async fn it_handles_flag_with_property_filter() -> Result<()> {
     });
 
     let res = server
-        .send_flags_request(payload.to_string(), None, None)
+        .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::OK, res.status());
 
@@ -598,7 +684,7 @@ async fn it_handles_flag_with_property_filter() -> Result<()> {
     });
 
     let res = server
-        .send_flags_request(payload.to_string(), None, None)
+        .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::OK, res.status());
 
@@ -680,7 +766,7 @@ async fn it_matches_flags_to_a_request_with_group_property_overrides() -> Result
     });
 
     let res = server
-        .send_flags_request(payload.to_string(), None, None)
+        .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::OK, res.status());
 
@@ -710,7 +796,7 @@ async fn it_matches_flags_to_a_request_with_group_property_overrides() -> Result
     });
 
     let res = server
-        .send_flags_request(payload.to_string(), None, None)
+        .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::OK, res.status());
 
@@ -798,7 +884,7 @@ async fn test_feature_flags_with_json_payloads() -> Result<()> {
     });
 
     let res = server
-        .send_flags_request(payload.to_string(), None, None)
+        .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
 
     assert_eq!(StatusCode::OK, res.status());
@@ -1050,7 +1136,7 @@ async fn it_handles_not_contains_property_filter() -> Result<()> {
     });
 
     let res = server
-        .send_flags_request(payload.to_string(), None, None)
+        .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::OK, res.status());
 
@@ -1150,7 +1236,7 @@ async fn it_handles_not_equal_and_not_regex_property_filters() -> Result<()> {
     });
 
     let res = server
-        .send_flags_request(payload.to_string(), None, None)
+        .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::OK, res.status());
 
@@ -1176,7 +1262,7 @@ async fn it_handles_not_equal_and_not_regex_property_filters() -> Result<()> {
     });
 
     let res = server
-        .send_flags_request(payload.to_string(), None, None)
+        .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::OK, res.status());
 
@@ -1202,7 +1288,7 @@ async fn it_handles_not_equal_and_not_regex_property_filters() -> Result<()> {
     });
 
     let res = server
-        .send_flags_request(payload.to_string(), None, None)
+        .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::OK, res.status());
 
@@ -1312,7 +1398,7 @@ async fn test_complex_regex_and_name_match_flag() -> Result<()> {
     });
 
     let res = server
-        .send_flags_request(payload.to_string(), None, None)
+        .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::OK, res.status());
 
@@ -1349,7 +1435,7 @@ async fn test_complex_regex_and_name_match_flag() -> Result<()> {
     });
 
     let res = server
-        .send_flags_request(payload.to_string(), None, None)
+        .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::OK, res.status());
 
@@ -1455,7 +1541,7 @@ async fn test_super_condition_with_complex_request() -> Result<()> {
     });
 
     let res = server
-        .send_flags_request(payload.to_string(), None, None)
+        .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::OK, res.status());
 
@@ -1578,7 +1664,7 @@ async fn it_sets_quota_limited_in_legacy_and_v2() -> Result<()> {
 
     // Legacy response (no version param)
     let res = server
-        .send_flags_request(payload.to_string(), None, None)
+        .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::OK, res.status());
     let legacy: LegacyFlagsResponse = res.json().await?;
@@ -3083,7 +3169,7 @@ async fn test_disable_flags_returns_empty_response() -> Result<()> {
     });
 
     let res = server
-        .send_flags_request(payload.to_string(), None, None)
+        .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::OK, res.status());
 
@@ -3226,7 +3312,7 @@ async fn test_disable_flags_false_still_returns_flags() -> Result<()> {
     });
 
     let res = server
-        .send_flags_request(payload.to_string(), None, None)
+        .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::OK, res.status());
 
@@ -4277,7 +4363,7 @@ async fn test_returns_empty_flags_when_no_active_flags_configured() -> Result<()
     });
 
     let res = server
-        .send_flags_request(payload.to_string(), None, None)
+        .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::OK, res.status());
 
@@ -4391,7 +4477,7 @@ async fn test_group_key_property_matching() -> Result<()> {
     });
 
     let res = server
-        .send_flags_request(payload.to_string(), None, None)
+        .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::OK, res.status());
 
@@ -4417,7 +4503,7 @@ async fn test_group_key_property_matching() -> Result<()> {
     });
 
     let res = server
-        .send_flags_request(payload.to_string(), None, None)
+        .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::OK, res.status());
 
@@ -4440,7 +4526,7 @@ async fn test_group_key_property_matching() -> Result<()> {
     });
 
     let res = server
-        .send_flags_request(payload.to_string(), None, None)
+        .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::OK, res.status());
 


### PR DESCRIPTION
## Problem

Response to this: https://posthog.slack.com/archives/C09AY1AM3M4