### PR TITLE
fix(docker): bump patch version on ES base Docker Compose image for dev

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -329,7 +329,7 @@ services:
             - discovery.type=single-node
             - ES_JAVA_OPTS=-Xms256m -Xmx256m
             - xpack.security.enabled=false
-        image: elasticsearch:7.17.27
+        image: elasticsearch:7.17.28
         expose:
             - 9200
         volumes:


### PR DESCRIPTION
## Problem
Current `elasticsearch:7.17.27` has an image layer that won't download, appears stuck. Bumping to version `7.17.28` resolved this in my local env and CI.

## Changes
Update patch version of ES image in Docker Compose dev base spec.

## How did you test this code?
Locally and in CI 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
