### PR TITLE
fix: focus on wait period when clicked in the survey form

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -1043,6 +1043,7 @@ export default function SurveyEdit(): JSX.Element {
                                                                                   }
                                                                               }}
                                                                               className="w-12"
+                                                                              id="survey-wait-period-input"
                                                                           />{' '}
                                                                           {value?.seenSurveyWaitPeriodInDays === 1 ? (
                                                                               <span>day.</span>

--- a/frontend/src/scenes/surveys/SurveyRepeatSchedule.tsx
+++ b/frontend/src/scenes/surveys/SurveyRepeatSchedule.tsx
@@ -30,14 +30,18 @@ function AlwaysScheduleBanner({
     survey: Pick<Survey, 'type' | 'schedule' | 'conditions'>
 }): JSX.Element | null {
     const { setSelectedSection, setSurveyValue } = useActions(surveyLogic)
+    const { hasTargetingSet } = useValues(surveyLogic)
     const doesSurveyHaveWaitPeriod = (survey?.conditions?.seenSurveyWaitPeriodInDays ?? 0) > 0
 
     const handleWaitPeriodClick = (): void => {
         setSelectedSection(SurveyEditSection.DisplayConditions)
-        setSurveyValue('conditions', {
-            ...survey.conditions,
-            seenSurveyWaitPeriodInDays: 30,
-        })
+        // if the survey has no targeting set, set the url to an empty string so the full section is rendered
+        if (!hasTargetingSet) {
+            setSurveyValue('conditions', {
+                ...survey.conditions,
+                url: '',
+            })
+        }
         // timeout necessary so the section is rendered
         setTimeout(() => {
             document.getElementById('survey-wait-period-input')?.focus()

--- a/frontend/src/scenes/surveys/SurveyRepeatSchedule.tsx
+++ b/frontend/src/scenes/surveys/SurveyRepeatSchedule.tsx
@@ -9,6 +9,7 @@ import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { pluralize } from 'lib/utils'
 import { LinkToSurveyFormSection } from 'scenes/surveys/components/LinkToSurveyFormSection'
+import { SURVEY_FORM_INPUT_IDS } from 'scenes/surveys/constants'
 
 import { Survey, SurveySchedule, SurveyType } from '~/types'
 
@@ -44,7 +45,7 @@ function AlwaysScheduleBanner({
         }
         // timeout necessary so the section is rendered
         setTimeout(() => {
-            document.getElementById('survey-wait-period-input')?.focus()
+            document.getElementById(SURVEY_FORM_INPUT_IDS.WAIT_PERIOD_INPUT)?.focus()
         }, 200)
     }
 

--- a/frontend/src/scenes/surveys/SurveyRepeatSchedule.tsx
+++ b/frontend/src/scenes/surveys/SurveyRepeatSchedule.tsx
@@ -29,8 +29,20 @@ function AlwaysScheduleBanner({
 }: {
     survey: Pick<Survey, 'type' | 'schedule' | 'conditions'>
 }): JSX.Element | null {
-    const { setSelectedSection } = useActions(surveyLogic)
+    const { setSelectedSection, setSurveyValue } = useActions(surveyLogic)
     const doesSurveyHaveWaitPeriod = (survey?.conditions?.seenSurveyWaitPeriodInDays ?? 0) > 0
+
+    const handleWaitPeriodClick = (): void => {
+        setSelectedSection(SurveyEditSection.DisplayConditions)
+        setSurveyValue('conditions', {
+            ...survey.conditions,
+            seenSurveyWaitPeriodInDays: 30,
+        })
+        // timeout necessary so the section is rendered
+        setTimeout(() => {
+            document.getElementById('survey-wait-period-input')?.focus()
+        }, 200)
+    }
 
     if (doesSurveyHaveWaitPeriod) {
         return (
@@ -50,10 +62,7 @@ function AlwaysScheduleBanner({
                 </p>
                 <p className="font-normal">
                     If this isn't intended, consider&nbsp;
-                    <Link onClick={() => setSelectedSection(SurveyEditSection.DisplayConditions)}>
-                        adding a wait period
-                    </Link>
-                    .
+                    <Link onClick={handleWaitPeriodClick}>adding a wait period</Link>.
                 </p>
             </LemonBanner>
         )
@@ -67,10 +76,8 @@ function AlwaysScheduleBanner({
             </p>
             <p className="font-normal">
                 If not, consider&nbsp;
-                <Link onClick={() => setSelectedSection(SurveyEditSection.DisplayConditions)}>
-                    adding a wait period
-                </Link>
-                &nbsp; or changing its frequency.
+                <Link onClick={handleWaitPeriodClick}>adding a wait period</Link>
+                &nbsp;or changing its frequency.
             </p>
         </LemonBanner>
     )

--- a/frontend/src/scenes/surveys/constants.tsx
+++ b/frontend/src/scenes/surveys/constants.tsx
@@ -630,3 +630,7 @@ export enum SURVEY_EMPTY_STATE_EXPERIMENT_VARIANT {
     TEST = 'test', // new experience
     CONTROL = 'control', // current state
 }
+
+export enum SURVEY_FORM_INPUT_IDS {
+    WAIT_PERIOD_INPUT = 'survey-wait-period-input',
+}


### PR DESCRIPTION
## Problem

if the survey doesn't have any display conditions, clicking the `add a wait period` navigates to the correct section, but the form itself is empty.

## Changes

adds a default 30 days waiting period when button is clicked, and properly focuses on the right input when clicked.

## How did you test this code?

locally verified