### PR TITLE
fix: add libclang dependency to rust Dockerfile

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -15,7 +15,8 @@ WORKDIR /app
 ARG BIN
 
 # Ensure working C compile setup (not installed by default in arm64 images)
-RUN apt-get update && apt-get install build-essential libssl-dev cmake -y
+# libclang-dev is required for bindgen (used by librocksdb-sys)
+RUN apt-get update && apt-get install build-essential libssl-dev cmake libclang-dev -y
 
 COPY --from=planner /app/recipe.json recipe.json
 RUN --mount=type=cache,target=/usr/local/cargo/registry \


### PR DESCRIPTION
## Problem

Builds are [failing](https://posthog.slack.com/archives/C0113360FFV/p1755544672674689) due to missing libclang dependency when building the Dockerimage

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
