### PR TITLE
fix: make distinct_id validation like decide

### DIFF
--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -31,8 +31,6 @@ pub enum FlagError {
     RequestDecodingError(String),
     #[error("failed to parse request: {0}")]
     RequestParsingError(#[from] serde_json::Error),
-    #[error("Empty distinct_id in request")]
-    EmptyDistinctId,
     #[error("No distinct_id in request")]
     MissingDistinctId,
     #[error("No api_key in request")]
@@ -95,9 +93,6 @@ impl IntoResponse for FlagError {
             }
             FlagError::RequestParsingError(err) => {
                 (StatusCode::BAD_REQUEST, format!("Failed to parse request: {err}. Please ensure your request is properly formatted and all required fields are present."))
-            }
-            FlagError::EmptyDistinctId => {
-                (StatusCode::BAD_REQUEST, "The distinct_id field cannot be empty. Please provide a valid identifier.".to_string())
             }
             FlagError::MissingDistinctId => {
                 (StatusCode::BAD_REQUEST, "The distinct_id field is missing from the request. Please include a valid identifier.".to_string())

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -204,10 +204,7 @@ mod tests {
 
         match flag_payload.extract_distinct_id() {
             Ok(distinct_id) => assert_eq!(distinct_id, ""),
-            Err(e) => panic!(
-                "expected empty distinct_id to be accepted, got error: {}",
-                e
-            ),
+            Err(e) => panic!("expected empty distinct_id to be accepted, got error: {e}"),
         };
     }
 

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -156,11 +156,7 @@ impl FlagRequest {
         };
 
         match distinct_id.len() {
-            0 => {
-                tracing::warn!("Empty distinct_id provided in request");
-                Err(FlagError::EmptyDistinctId)
-            }
-            1..=200 => Ok(distinct_id.to_owned()),
+            0..=200 => Ok(distinct_id.to_owned()),
             _ => Ok(distinct_id.chars().take(200).collect()),
         }
     }
@@ -197,7 +193,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn empty_distinct_id_not_accepted() {
+    fn empty_distinct_id_is_accepted() {
         let json = json!({
             "distinct_id": "",
             "token": "my_token1",
@@ -207,8 +203,8 @@ mod tests {
         let flag_payload = FlagRequest::from_bytes(bytes).expect("failed to parse request");
 
         match flag_payload.extract_distinct_id() {
-            Err(FlagError::EmptyDistinctId) => (),
-            _ => panic!("expected empty distinct id error"),
+            Ok(distinct_id) => assert_eq!(distinct_id, ""),
+            Err(e) => panic!("expected empty distinct_id to be accepted, got error: {}", e),
         };
     }
 

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -204,7 +204,10 @@ mod tests {
 
         match flag_payload.extract_distinct_id() {
             Ok(distinct_id) => assert_eq!(distinct_id, ""),
-            Err(e) => panic!("expected empty distinct_id to be accepted, got error: {}", e),
+            Err(e) => panic!(
+                "expected empty distinct_id to be accepted, got error: {}",
+                e
+            ),
         };
     }
 

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -315,7 +315,7 @@ async fn it_rejects_invalid_headers_flag_request() -> Result<()> {
 }
 
 #[tokio::test]
-async fn it_rejects_empty_distinct_id() -> Result<()> {
+async fn it_accepts_empty_distinct_id() -> Result<()> {
     let config = DEFAULT_TEST_CONFIG.clone();
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let pg_client = setup_pg_reader_client(None).await;
@@ -338,10 +338,16 @@ async fn it_rejects_empty_distinct_id() -> Result<()> {
     let res = server
         .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
-    assert_eq!(StatusCode::BAD_REQUEST, res.status());
-    assert_eq!(
-        res.text().await?,
-        "The distinct_id field cannot be empty. Please provide a valid identifier."
+    assert_eq!(StatusCode::OK, res.status());
+    
+    // Should return a valid response even with empty distinct_id
+    let json_data = res.json::<Value>().await?;
+    assert_json_include!(
+        actual: json_data,
+        expected: json!({
+            "errorsWhileComputingFlags": false,
+            "featureFlags": {}
+        })
     );
     Ok(())
 }

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -339,7 +339,7 @@ async fn it_accepts_empty_distinct_id() -> Result<()> {
         .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::OK, res.status());
-    
+
     // Should return a valid response even with empty distinct_id
     let json_data = res.json::<Value>().await?;
     assert_json_include!(


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->


When proxying decide to flags, we noticed increased 400s. Some of these are due to decide allowing empty string distinct_ids whereas flags does not. 

Empty distinct_ids accounted for approximately 150/min 400s when I did the proxy last time. 
<img width="2137" height="553" alt="Screenshot 2025-08-18 at 5 22 41 PM" src="https://github.com/user-attachments/assets/5f08dd0e-2ab5-45f5-a670-8d07dbf8b5d1" />

https://grafana.prod-us.posthog.dev/goto/v0MZ1kuHR?orgId=1
## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

Unit tests