### PR TITLE
fix(cohort): Upload csv file's description should revert to the one that mentions multi-column

### DIFF
--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -339,7 +339,10 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
                             <SceneDivider />
                             <SceneSection
                                 title={isNewCohort ? 'Upload users' : 'Add users'}
-                                description="Upload a CSV file to add users to your cohort. The CSV file only requires a single column with the user's distinct ID. The very first row (the header) will be skipped during import."
+                                description="Upload a CSV file to add users to your cohort. For single-column files, include
+                                        one distinct ID per row (all rows will be processed as data). For multi-column
+                                        files, include a header row with a 'distinct_id' column containing the user
+                                        identifiers."
                                 className={cn('ph-ignore-input', !newSceneLayout && 'mt-4')}
                             >
                                 {/* TODO: @adamleithp Allow users to download a template CSV file */}
@@ -356,9 +359,10 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
                                         <>
                                             {!newSceneLayout && (
                                                 <span>
-                                                    Upload a CSV file to add users to your cohort. The CSV file only
-                                                    requires a single column with the user's distinct ID. The very first
-                                                    row (the header) will be skipped during import.
+                                                    Upload a CSV file to add users to your cohort. For single-column
+                                                    files, include one distinct ID per row (all rows will be processed
+                                                    as data). For multi-column files, include a header row with a
+                                                    'distinct_id' column containing the user identifiers.
                                                 </span>
                                             )}
                                             <LemonFileInput


### PR DESCRIPTION
## Problem

In https://github.com/PostHog/posthog/pull/36533, the ability to upload multi-column csv file was unlocked. 

In https://github.com/PostHog/posthog/pull/36610, the description was reverted to the old one. 

## Changes

<img width="1251" height="597" alt="Screenshot 2025-08-19 at 10 42 55 AM" src="https://github.com/user-attachments/assets/e217b2ba-c1eb-4c96-a484-53b7b6b8b5f8" />



## How did you test this code?

Locally!

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
