### PR TITLE
chore: upgrade minio

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -159,7 +159,7 @@ services:
             DYNAMIC_CONFIG_ENABLED: 'true'
 
     objectstorage:
-        image: minio/minio:RELEASE.2025-02-18T16-25-55Z
+        image: minio/minio:RELEASE.2025-04-22T22-12-26Z
         restart: on-failure
         environment:
             MINIO_ROOT_USER: object_storage_root_user


### PR DESCRIPTION
see https://posthog.slack.com/archives/C08MYQX74KH/p1755587195440489 and https://blog.min.io/from-open-source-to-free-and-open-source-minio-is-now-fully-licensed-under-gnu-agplv3/

minio have relicensed from apache 2.0 to agplv3

> With [RELEASE.2021-05-11T23-27-41Z](https://github.com/minio/minio/releases/tag/RELEASE.2021-05-11T23-27-41Z?ref=blog.min.io) MinIO has completed its transition to the GNU Affero General Public License v3.0 (GNU AGPL v3) license,

This updates us to the version just before that (although their docker hub tags are confusing) while we wait to see if we are happy upgrading to use the new license

tested by wiping my local stack and seeing that recordings can be captured with the new version