### PR TITLE
fix: added null check to hidden indexes

### DIFF
--- a/posthog/schema_migrations/0002_stickiness_hidden_legend_indexes.py
+++ b/posthog/schema_migrations/0002_stickiness_hidden_legend_indexes.py
@@ -25,7 +25,7 @@ class Migration(SchemaMigration):
         result_customizations = insight_filter.get("resultCustomizations") or {}
         result_customization_by = insight_filter.get("resultCustomizationBy")
 
-        #remove hiddenLegendIndexes if it's null/empty
+        # remove hiddenLegendIndexes if it's null/empty
         if not hidden_indexes:
             new_insight_filter = dict(insight_filter)
             new_insight_filter.pop("hiddenLegendIndexes", None)

--- a/posthog/schema_migrations/0002_stickiness_hidden_legend_indexes.py
+++ b/posthog/schema_migrations/0002_stickiness_hidden_legend_indexes.py
@@ -28,7 +28,7 @@ class Migration(SchemaMigration):
         #remove hiddenLegendIndexes if it's null/empty
         if not hidden_indexes:
             new_insight_filter = dict(insight_filter)
-            new_insight_filter.pop("hiddenLegnedIndexes", None)
+            new_insight_filter.pop("hiddenLegendIndexes", None)
             query = dict(query)
             query[filter_key] = new_insight_filter
             return query

--- a/posthog/schema_migrations/0002_stickiness_hidden_legend_indexes.py
+++ b/posthog/schema_migrations/0002_stickiness_hidden_legend_indexes.py
@@ -21,12 +21,16 @@ class Migration(SchemaMigration):
         if not isinstance(insight_filter, dict):
             return query
 
-        hidden_indexes = insight_filter.get("hiddenLegendIndexes")
+        hidden_indexes = insight_filter.get("hiddenLegendIndexes") or []
         result_customizations = insight_filter.get("resultCustomizations") or {}
         result_customization_by = insight_filter.get("resultCustomizationBy")
 
-        # Nothing to do, if there are no hiddenLegendIndexes
+        #remove hiddenLegendIndexes if it's null/empty
         if not hidden_indexes:
+            new_insight_filter = dict(insight_filter)
+            new_insight_filter.pop("hiddenLegnedIndexes", None)
+            query = dict(query)
+            query[filter_key] = new_insight_filter
             return query
 
         # Handle case where we have resultCustomizations by value


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Bug with Trend insights causing TypeError: Cannot read properties of undefined (reading 'toString')

## Changes
Added some null checking and explicitly cleared hidden_indexes if it's null

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
