### PR TITLE
chore: disable events backup

### DIFF
--- a/dags/backups.py
+++ b/dags/backups.py
@@ -27,7 +27,6 @@ SHARDED_TABLES = [
     "sharded_session_replay_events",
     "sharded_session_replay_events_v2_test",
     "sharded_sessions",
-    "sharded_events",
 ]
 
 NON_SHARDED_TABLES = [


### PR DESCRIPTION
## Problem

Events backups are so big that they take almost 2 days to complete in US and lead to cluster instability (at least in EU, where some node usually hangs). They rarely complete.

## Changes

Disable them while we find a better strategy.

