### PR TITLE
fix(trends): fix legend highlighting

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/tooltip-data.ts
+++ b/frontend/src/scenes/insights/views/LineGraph/tooltip-data.ts
@@ -17,6 +17,7 @@ export function createTooltipData(
                 id: idx,
                 dataIndex: dp.dataIndex,
                 datasetIndex: dp.datasetIndex,
+                seriesIndex: dp.dataIndex,
                 dotted: !!pointDataset?.dotted,
                 breakdown_value:
                     pointDataset?.breakdown_value ??


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C045L1VEG87/p1755591975501639

<img width="915" height="191" alt="Screenshot 2025-08-19 at 11 24 02" src="https://github.com/user-attachments/assets/af055324-f52c-453f-be5a-ea151e115d83" />


The item was missing a valid index.

## Changes

Derives one.

## How did you test this code?

Used storybook with the insight from the customer, where I needed to toggle on the legend.