### PR TITLE
fix: kafka dedup hanging test

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -86,7 +86,7 @@ jobs:
                     - others
         needs: changes
         runs-on: depot-ubuntu-24.04-4
-        timeout-minutes: 10
+        timeout-minutes: 20
 
         defaults:
             run:


### PR DESCRIPTION
## Problem

Seems like there's a hanging test in kafka_integration_tests.rs, this PR aims to fix it, by increasing the timeout parameter of the job

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
