### PR TITLE
fix(experiments): human readable error messages

### DIFF
--- a/posthog/hogql_queries/experiments/base_query_utils.py
+++ b/posthog/hogql_queries/experiments/base_query_utils.py
@@ -35,8 +35,6 @@ from posthog.schema import (
     PropertyMathType,
 )
 
-from posthog.hogql_queries.experiments.error_handling import experiment_error_handler
-
 
 def get_data_warehouse_metric_source(
     metric: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric],
@@ -584,7 +582,6 @@ def get_source_aggregation_expr(
     return parse_expr(f"sum(coalesce(toFloat({table_alias}.value), 0))")
 
 
-@experiment_error_handler
 def get_metric_aggregation_expr(
     experiment: Experiment,
     metric: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric],

--- a/posthog/hogql_queries/experiments/base_query_utils.py
+++ b/posthog/hogql_queries/experiments/base_query_utils.py
@@ -1,11 +1,7 @@
 from typing import Literal, Union, cast
 from zoneinfo import ZoneInfo
 
-import structlog
-from rest_framework.exceptions import ValidationError
-
 from posthog.hogql import ast
-from posthog.hogql.errors import ExposedHogQLError, InternalHogQLError
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.property import action_to_expr, property_to_expr
 from posthog.hogql_queries.experiments.exposure_query_logic import (
@@ -39,7 +35,7 @@ from posthog.schema import (
     PropertyMathType,
 )
 
-logger = structlog.get_logger(__name__)
+from posthog.hogql_queries.experiments.error_handling import experiment_error_handler
 
 
 def get_data_warehouse_metric_source(
@@ -588,6 +584,7 @@ def get_source_aggregation_expr(
     return parse_expr(f"sum(coalesce(toFloat({table_alias}.value), 0))")
 
 
+@experiment_error_handler
 def get_metric_aggregation_expr(
     experiment: Experiment,
     metric: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric],
@@ -598,35 +595,21 @@ def get_metric_aggregation_expr(
     Returns the aggregation expression for the metric.
     For ratio metrics, source_type can be "numerator" or "denominator".
     """
-    try:
-        # For ratio metrics, get the appropriate source and delegate to source-based function
-        if isinstance(metric, ExperimentRatioMetric):
-            source = metric.numerator if source_type == "numerator" else metric.denominator
-            return get_source_aggregation_expr(source)
+    # For ratio metrics, get the appropriate source and delegate to source-based function
+    if isinstance(metric, ExperimentRatioMetric):
+        source = metric.numerator if source_type == "numerator" else metric.denominator
+        return get_source_aggregation_expr(source)
 
-        # For mean metrics, delegate to source-based function
-        elif isinstance(metric, ExperimentMeanMetric):
-            return get_source_aggregation_expr(metric.source)
+    # For mean metrics, delegate to source-based function
+    elif isinstance(metric, ExperimentMeanMetric):
+        return get_source_aggregation_expr(metric.source)
 
-        # For funnel metrics, use the existing funnel evaluation logic
-        elif isinstance(metric, ExperimentFunnelMetric):
-            return funnel_evaluation_expr(team, metric, events_alias="metric_events")
+    # For funnel metrics, use the existing funnel evaluation logic
+    elif isinstance(metric, ExperimentFunnelMetric):
+        return funnel_evaluation_expr(team, metric, events_alias="metric_events")
 
-        else:
-            raise ValueError(f"Unsupported metric type: {type(metric)}")
-
-    except InternalHogQLError as e:
-        logger.error(
-            "Internal HogQL error in metric aggregation expression",
-            experiment_id=experiment.id,
-            metric_type=metric.__class__.__name__,
-            metric_math=getattr(getattr(metric, "source", None), "math", None),
-            error_type=type(e).__name__,
-            exc_info=True,
-        )
-        raise ValidationError("Invalid metric configuration for experiment analysis.")
-    except ExposedHogQLError:
-        raise
+    else:
+        raise ValueError(f"Unsupported metric type: {type(metric)}")
 
 
 def get_winsorized_metric_values_query(

--- a/posthog/hogql_queries/experiments/error_handling.py
+++ b/posthog/hogql_queries/experiments/error_handling.py
@@ -1,0 +1,142 @@
+"""
+Centralized error handling for experiments to ensure users see friendly error messages
+while technical details are logged for engineers.
+"""
+
+import functools
+from typing import Any, Optional, TypeVar, Union
+from collections.abc import Callable
+import structlog
+from rest_framework.exceptions import ValidationError
+from posthog.exceptions_capture import capture_exception
+from posthog.hogql.errors import ExposedHogQLError, InternalHogQLError
+from posthog.errors import ExposedCHQueryError
+from products.experiments.stats.shared.statistics import StatisticError
+
+logger = structlog.get_logger(__name__)
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+# User-friendly error messages for technical errors
+ERROR_MESSAGES: dict[str, str] = {
+    # Statistical errors
+    "Sample size must be positive": "Not enough data to calculate results. Please wait for more participants to join the experiment.",
+    "sum_squares must be >= sum^2": "Invalid metric data detected. Please check your metric configuration and try again.",
+    "sum_squares incompatible with sum and n": "Unable to calculate statistics due to data inconsistency. Please refresh and try again.",
+    "No control variant found": "No control group data available. Please ensure your experiment has a control variant.",
+    "Multiple control variants found": "Multiple control groups detected. Please check your experiment configuration.",
+    # Validation errors
+    "NOT_ENOUGH_EXPOSURES": "Not enough participants yet. Experiments need at least 50 participants per variant.",
+    "NOT_ENOUGH_METRIC_DATA": "Not enough conversion data. Please wait for more events to be tracked.",
+    "BASELINE_MEAN_IS_ZERO": "The control group has no metric data. Please check your metric configuration.",
+    # HogQL errors
+    "Unable to execute experiment analysis": "Unable to calculate experiment results. Please check your metric configuration and try again.",
+    "Query timeout": "The analysis is taking too long. Try refreshing the page or simplifying your metrics.",
+    # Default fallback
+    "_DEFAULT": "Unable to calculate experiment results. Please try again or contact support if the issue persists.",
+}
+
+
+def get_user_friendly_message(error: Exception) -> str:
+    """Convert technical error messages to user-friendly ones."""
+    error_str = str(error)
+
+    # Check for exact matches first
+    if error_str in ERROR_MESSAGES:
+        return ERROR_MESSAGES[error_str]
+
+    # Check for partial matches
+    for key, message in ERROR_MESSAGES.items():
+        if key in error_str:
+            return message
+
+    # Special handling for specific error types
+    if isinstance(error, StatisticError):
+        return "Unable to calculate statistics. Please ensure your experiment has sufficient data."
+    elif isinstance(error, InternalHogQLError | ExposedHogQLError):
+        return "Unable to process your query. Please check your metric configuration."
+    elif isinstance(error, ExposedCHQueryError):
+        return "Unable to retrieve experiment data. Please try again."
+
+    # Default message
+    return ERROR_MESSAGES["_DEFAULT"]
+
+
+def experiment_error_handler(method: F) -> F:
+    """
+    Decorator that catches technical errors, logs them for engineers,
+    and raises user-friendly errors for the frontend.
+    """
+
+    @functools.wraps(method)
+    def wrapper(*args, **kwargs):
+        try:
+            return method(*args, **kwargs)
+        except (ValidationError, ExposedHogQLError):
+            # ValidationErrors and ExposedHogQLErrors are already user-facing, let them through
+            raise
+        except Exception as e:
+            # Get context for logging
+            self = args[0] if args else None
+            experiment_id = getattr(self, "experiment_id", None) or getattr(self, "experiment", {}).get("id", "unknown")
+            metric_type = None
+            if hasattr(self, "metric"):
+                metric_type = getattr(self.metric, "__class__", type(self.metric)).__name__
+
+            # Log the technical error for engineers
+            logger.error(
+                "Experiment calculation error",
+                experiment_id=experiment_id,
+                metric_type=metric_type,
+                error_type=type(e).__name__,
+                error_message=str(e),
+                error_detail=getattr(e, "detail", None),
+                exc_info=True,
+            )
+
+            # Capture exception for error tracking
+            capture_exception(
+                e,
+                additional_properties={
+                    "experiment_id": experiment_id,
+                    "metric_type": metric_type,
+                    "method": method.__name__,
+                },
+            )
+
+            # Raise user-friendly error
+            user_message = get_user_friendly_message(e)
+            raise ValidationError(user_message)
+
+    return wrapper
+
+
+def handle_experiment_error(
+    error: Exception,
+    experiment_id: Optional[Union[str, int]] = None,
+    metric_type: Optional[str] = None,
+    context: Optional[dict[str, Any]] = None,
+) -> None:
+    """
+    Utility function to handle experiment errors consistently.
+    Logs the error and raises a user-friendly ValidationError.
+    """
+    # Log the technical error
+    logger.error(
+        "Experiment error",
+        experiment_id=experiment_id,
+        metric_type=metric_type,
+        error_type=type(error).__name__,
+        error_message=str(error),
+        context=context,
+        exc_info=True,
+    )
+
+    # Capture for error tracking
+    capture_exception(
+        error, additional_properties={"experiment_id": experiment_id, "metric_type": metric_type, **(context or {})}
+    )
+
+    # Raise user-friendly error
+    user_message = get_user_friendly_message(error)
+    raise ValidationError(user_message)

--- a/posthog/hogql_queries/experiments/error_handling.py
+++ b/posthog/hogql_queries/experiments/error_handling.py
@@ -65,7 +65,12 @@ def experiment_error_handler(method: F) -> F:
         except Exception as e:
             # Get context for logging
             self = args[0] if args else None
-            experiment_id = getattr(self, "experiment_id", None) or getattr(self, "experiment", {}).get("id", "unknown")
+            experiment_id = "unknown"
+            if hasattr(self, "experiment_id"):
+                experiment_id = self.experiment_id
+            elif hasattr(self, "experiment") and hasattr(self.experiment, "id"):
+                experiment_id = self.experiment.id
+
             metric_type = None
             if hasattr(self, "metric"):
                 metric_type = getattr(self.metric, "__class__", type(self.metric)).__name__

--- a/posthog/hogql_queries/experiments/error_handling.py
+++ b/posthog/hogql_queries/experiments/error_handling.py
@@ -33,7 +33,8 @@ ERROR_TYPE_MESSAGES: dict[type, str] = {
 
 
 def get_user_friendly_message(error: Exception) -> str:
-    """Convert technical error messages to user-friendly ones based on error type."""
+    """Convert technical error messages to user-friendly ones based on error type and message content."""
+
     error_type = type(error)
 
     # Look for exact type match first

--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -3,10 +3,10 @@ from datetime import UTC, datetime, timedelta
 from typing import Optional
 
 from rest_framework.exceptions import ValidationError
+import structlog
 
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.constants import ExperimentNoResultsErrorKeys
-from posthog.exceptions_capture import capture_exception
 from posthog.hogql import ast
 from posthog.hogql.constants import HogQLGlobalSettings
 from posthog.hogql.modifiers import create_default_modifiers_for_team
@@ -414,7 +414,6 @@ class ExperimentQueryRunner(QueryRunner):
 
         return experiment_variant_results_query
 
-    @experiment_error_handler
     def _evaluate_experiment_query(
         self,
     ) -> list[tuple]:

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_base.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_base.py
@@ -763,7 +763,9 @@ class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
             query_runner.calculate()
 
         self.assertEqual(
-            context.exception.detail[0],
+            str(
+                context.exception.detail[0] if isinstance(context.exception.detail, list) else context.exception.detail
+            ),
             "No experiment exposures found. Please ensure users are being exposed to your experiment variants.",
         )
 
@@ -811,7 +813,9 @@ class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
             query_runner.calculate()
 
         self.assertEqual(
-            context.exception.detail[0],
+            str(
+                context.exception.detail[0] if isinstance(context.exception.detail, list) else context.exception.detail
+            ),
             "No experiment exposures found. Please ensure users are being exposed to your experiment variants.",
         )
 
@@ -867,7 +871,9 @@ class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
             query_runner.calculate()
 
         self.assertEqual(
-            context.exception.detail[0],
+            str(
+                context.exception.detail[0] if isinstance(context.exception.detail, list) else context.exception.detail
+            ),
             "No control variant found. Please ensure your experiment has a 'control' variant and that users are being exposed to it.",
         )
 
@@ -1099,7 +1105,11 @@ class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
                 query_runner.calculate()
 
             self.assertEqual(
-                context.exception.detail[0],
+                str(
+                    context.exception.detail[0]
+                    if isinstance(context.exception.detail, list)
+                    else context.exception.detail
+                ),
                 "No experiment exposures found. Please ensure users are being exposed to your experiment variants.",
             )
         else:

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_base.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_base.py
@@ -764,7 +764,7 @@ class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
 
         self.assertEqual(
             context.exception.detail[0],
-            "Invalid experiment configuration detected. Please check your experiment setup.",
+            "No experiment exposures found. Please ensure users are being exposed to your experiment variants.",
         )
 
     @freeze_time("2020-01-01T12:00:00Z")
@@ -812,7 +812,7 @@ class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
 
         self.assertEqual(
             context.exception.detail[0],
-            "Invalid experiment configuration detected. Please check your experiment setup.",
+            "No experiment exposures found. Please ensure users are being exposed to your experiment variants.",
         )
 
     @freeze_time("2020-01-01T12:00:00Z")
@@ -868,7 +868,7 @@ class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
 
         self.assertEqual(
             context.exception.detail[0],
-            "Invalid experiment configuration detected. Please check your experiment setup.",
+            "No control variant found. Please ensure your experiment has a 'control' variant and that users are being exposed to it.",
         )
 
     @parameterized.expand(
@@ -1100,7 +1100,7 @@ class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
 
             self.assertEqual(
                 context.exception.detail[0],
-                "Invalid experiment configuration detected. Please check your experiment setup.",
+                "No experiment exposures found. Please ensure users are being exposed to your experiment variants.",
             )
         else:
             result = query_runner.calculate()

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_base.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_base.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from django.test import override_settings
 from freezegun import freeze_time
 from parameterized import parameterized
+from rest_framework.exceptions import ValidationError
 
 from posthog.hogql_queries.experiments.experiment_query_runner import (
     ExperimentQueryRunner,
@@ -758,10 +759,13 @@ class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
         flush_persons_and_events()
 
         query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(ValidationError) as context:
             query_runner.calculate()
 
-        self.assertEqual(str(context.exception), "No control variant found")
+        self.assertEqual(
+            context.exception.detail[0],
+            "Invalid experiment configuration detected. Please check your experiment setup.",
+        )
 
     @freeze_time("2020-01-01T12:00:00Z")
     @snapshot_clickhouse_queries
@@ -803,10 +807,13 @@ class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
         flush_persons_and_events()
 
         query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(ValidationError) as context:
             query_runner.calculate()
 
-        self.assertEqual(str(context.exception), "No control variant found")
+        self.assertEqual(
+            context.exception.detail[0],
+            "Invalid experiment configuration detected. Please check your experiment setup.",
+        )
 
     @freeze_time("2020-01-01T12:00:00Z")
     @snapshot_clickhouse_queries
@@ -856,10 +863,13 @@ class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
         flush_persons_and_events()
 
         query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(ValidationError) as context:
             query_runner.calculate()
 
-        self.assertEqual(str(context.exception), "No control variant found")
+        self.assertEqual(
+            context.exception.detail[0],
+            "Invalid experiment configuration detected. Please check your experiment setup.",
+        )
 
     @parameterized.expand(
         [
@@ -1085,10 +1095,13 @@ class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
 
         # Handle cases where filters result in no exposures
         if expected_results["control_absolute_exposure"] == 0 and expected_results["test_absolute_exposure"] == 0:
-            with self.assertRaises(ValueError) as context:
+            with self.assertRaises(ValidationError) as context:
                 query_runner.calculate()
 
-            self.assertEqual(str(context.exception), "No control variant found")
+            self.assertEqual(
+                context.exception.detail[0],
+                "Invalid experiment configuration detected. Please check your experiment setup.",
+            )
         else:
             result = query_runner.calculate()
             assert result.variant_results is not None

--- a/posthog/hogql_queries/experiments/utils.py
+++ b/posthog/hogql_queries/experiments/utils.py
@@ -1,6 +1,5 @@
 from typing import TypeVar
 
-from posthog.errors import ExposedCHQueryError
 from posthog.hogql_queries.experiments import CONTROL_VARIANT_KEY
 from posthog.schema import (
     ExperimentFunnelMetric,
@@ -26,11 +25,7 @@ from products.experiments.stats.shared.statistics import (
     ProportionStatistic,
     RatioStatistic,
     SampleMeanStatistic,
-    StatisticError,
 )
-from products.experiments.stats.bayesian.method import BayesianMethod, BayesianConfig
-from posthog.hogql_queries.experiments import CONTROL_VARIANT_KEY
-from posthog.hogql_queries.experiments.error_handling import handle_experiment_error, experiment_error_handler
 
 V = TypeVar("V", ExperimentVariantTrendsBaseStats, ExperimentVariantFunnelsBaseStats, ExperimentStatsBase)
 
@@ -45,7 +40,6 @@ def get_experiment_stats_method(experiment) -> str:
         return stats_method
 
 
-@experiment_error_handler
 def split_baseline_and_test_variants(
     variants: list[V],
 ) -> tuple[V, list[V]]:
@@ -172,18 +166,11 @@ def get_frequentist_experiment_result(
     control_variant_validated = validate_variant_result(control_variant, metric, is_baseline=True)
     test_variants_validated = [validate_variant_result(test_variant, metric) for test_variant in test_variants]
 
-    try:
-        control_stat = (
-            metric_variant_to_statistic(metric, control_variant_validated)
-            if not control_variant_validated.validation_failures
-            else None
-        )
-    except StatisticError as e:
-        handle_experiment_error(
-            e,
-            metric_type=metric.__class__.__name__,
-            context={"control_variant_key": control_variant.key, "stats_method": "frequentist"},
-        )
+    control_stat = (
+        metric_variant_to_statistic(metric, control_variant_validated)
+        if not control_variant_validated.validation_failures
+        else None
+    )
 
     variants: list[ExperimentVariantResultFrequentist] = []
 
@@ -207,15 +194,8 @@ def get_frequentist_experiment_result(
 
         # Check if we can perform statistical analysis
         if control_stat and not test_variant_validated.validation_failures:
-            try:
-                test_stat = metric_variant_to_statistic(metric, test_variant_validated)
-                result = method.run_test(test_stat, control_stat)
-            except StatisticError as e:
-                handle_experiment_error(
-                    e,
-                    metric_type=metric.__class__.__name__,
-                    context={"test_variant_key": test_variant_validated.key, "stats_method": "frequentist"},
-                )
+            test_stat = metric_variant_to_statistic(metric, test_variant_validated)
+            result = method.run_test(test_stat, control_stat)
 
             confidence_interval = [result.confidence_interval[0], result.confidence_interval[1]]
 
@@ -253,18 +233,11 @@ def get_bayesian_experiment_result(
     control_variant_validated = validate_variant_result(control_variant, metric, is_baseline=True)
     test_variants_validated = [validate_variant_result(test_variant, metric) for test_variant in test_variants]
 
-    try:
-        control_stat = (
-            metric_variant_to_statistic(metric, control_variant_validated)
-            if not control_variant_validated.validation_failures
-            else None
-        )
-    except StatisticError as e:
-        handle_experiment_error(
-            e,
-            metric_type=metric.__class__.__name__,
-            context={"control_variant_key": control_variant.key, "stats_method": "bayesian"},
-        )
+    control_stat = (
+        metric_variant_to_statistic(metric, control_variant_validated)
+        if not control_variant_validated.validation_failures
+        else None
+    )
 
     variants: list[ExperimentVariantResultBayesian] = []
 
@@ -288,15 +261,8 @@ def get_bayesian_experiment_result(
 
         # Check if we can perform statistical analysis
         if control_stat and not test_variant_validated.validation_failures:
-            try:
-                test_stat = metric_variant_to_statistic(metric, test_variant_validated)
-                result = method.run_test(test_stat, control_stat)
-            except StatisticError as e:
-                handle_experiment_error(
-                    e,
-                    metric_type=metric.__class__.__name__,
-                    context={"test_variant_key": test_variant_validated.key, "stats_method": "bayesian"},
-                )
+            test_stat = metric_variant_to_statistic(metric, test_variant_validated)
+            result = method.run_test(test_stat, control_stat)
 
             # Convert credible interval to percentage
             credible_interval = [result.credible_interval[0], result.credible_interval[1]]


### PR DESCRIPTION
## Problem
We currently propagate raw error messages up to the user. They are too technical and not very helpful.

## Changes

Add a new decorator that handles experiment error messages and turns them into human readable error messages.

## How did you test this code?
- 👀 
