### PR TITLE
fix(data-warehouse): Add credential validation to getting incremental fields for a schema

### DIFF
--- a/posthog/warehouse/api/external_data_schema.py
+++ b/posthog/warehouse/api/external_data_schema.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 from posthog.api.log_entries import LogEntryMixin
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
+from posthog.exceptions_capture import capture_exception
 from posthog.hogql.database.database import create_hogql_database
 from posthog.temporal.data_imports.sources import SourceRegistry
 from posthog.temporal.data_imports.sources.common.schema import SourceSchema
@@ -310,7 +311,22 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, LogEntryMixin, viewsets.
 
         new_source = SourceRegistry.get_source(source_type_enum)
         config = new_source.parse_config(source.job_inputs)
-        schemas = new_source.get_schemas(config, self.team_id)
+
+        credentials_valid, credentials_error = new_source.validate_credentials(config, self.team_id)
+        if not credentials_valid:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"message": credentials_error or "Invalid credentials"},
+            )
+
+        try:
+            schemas = new_source.get_schemas(config, self.team_id)
+        except Exception as e:
+            capture_exception(e)
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"message": str(e)},
+            )
 
         schema: SourceSchema | None = None
 

--- a/posthog/warehouse/api/test/test_external_data_schema.py
+++ b/posthog/warehouse/api/test/test_external_data_schema.py
@@ -14,6 +14,7 @@ from posthog.api.test.test_organization import create_organization
 from posthog.api.test.test_team import create_team
 from posthog.api.test.test_user import create_user
 from posthog.temporal.common.schedule import describe_schedule
+from posthog.temporal.data_imports.sources.stripe.source import StripeSource
 from posthog.test.base import APIBaseTest
 from posthog.warehouse.api.test.utils import create_external_data_source_ok
 from posthog.warehouse.models import DataWarehouseTable
@@ -76,10 +77,10 @@ class TestExternalDataSchema(APIBaseTest):
             status=ExternalDataSchema.Status.COMPLETED,
             sync_type=ExternalDataSchema.SyncType.FULL_REFRESH,
         )
-
-        response = self.client.post(
-            f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}/incremental_fields",
-        )
+        with mock.patch.object(StripeSource, "validate_credentials", return_value=(True, None)):
+            response = self.client.post(
+                f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}/incremental_fields",
+            )
         payload = response.json()
 
         assert payload == {


### PR DESCRIPTION
## Problem
- Fixes https://posthog.slack.com/archives/C08J7633WBY/p1755605465180549?thread_ts=1755602409.106819&cid=C08J7633WBY
- Return credentials errors to the UI if a users database credentials no longer work when loading incremental fields for a schema

## Changes
- Validate credentials 