### PR TITLE
fix(data-modeling): Expose mat view errors to the frontend and logs

### DIFF
--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -553,8 +553,7 @@ async def materialize_model(
             await mark_job_as_failed(job, error_message, logger)
             raise Exception(f"Query exceeded memory limit for model {model_label}: {error_message}") from e
         else:
-            error_message = f"Query failed to materialize. If this query ran for a long time, try optimizing it."
-            saved_query.latest_error = error_message
+            saved_query.latest_error = f"Query failed to materialize: {error_message}"
             await logger.aerror("Failed to materialize model with unexpected error: %s", str(e))
             await database_sync_to_async(saved_query.save)()
             await mark_job_as_failed(job, error_message, logger)


### PR DESCRIPTION
## Problem
- We mask materialization errors with a generic catch-all error message

## Changes
- Actually expose the underlying error message on the job / frontend. If our ICP is engineers, they'll get a lot more value from something more actionable than "try optimizing it"
