### PR TITLE
feat: add support for gemini model in insight search node

### DIFF
--- a/ee/hogai/graph/insights/nodes.py
+++ b/ee/hogai/graph/insights/nodes.py
@@ -782,11 +782,27 @@ class InsightSearchNode(AssistantNode):
 
     @property
     def _model(self):
-        return ChatOpenAI(
-            model="gpt-4.1-mini",
-            temperature=0.7,
-            max_completion_tokens=1000,
-            streaming=True,
-            stream_usage=True,
-            max_retries=3,
-        )
+        debug: bool = False
+
+        if debug:
+            logger.info("Using Gemini ✨")
+            from ee.hogai.llm import MaxGemini
+
+            return MaxGemini(
+                model="gemini-2.5-flash",
+                temperature=0.7,
+                max_retries=3,
+                max_output_tokens=700,
+                team=self._team,
+                user=self._user,
+            )
+
+        else:
+            return ChatOpenAI(
+                model="gpt-4.1-mini",
+                temperature=0.7,
+                max_completion_tokens=1000,
+                streaming=True,
+                stream_usage=True,
+                max_retries=3,
+            )

--- a/ee/hogai/graph/insights/prompts.py
+++ b/ee/hogai/graph/insights/prompts.py
@@ -1,22 +1,9 @@
 ITERATIVE_SEARCH_SYSTEM_PROMPT = """
-You are an expert at finding relevant insights from a large database. Your task is to find the 3 most relevant insights that match the user's search query.
+Find the 3 most relevant insights matching the user's query from this paginated database.
 
-You have access to a paginated database of insights. The first page has been loaded for you below. You can read additional pages using the read_insights_page tool if needed.
+Search through names, descriptions, and filters for keyword and semantic matches. Use read_insights_page(page_number) to access additional pages if needed.
 
-Each insight has:
-- ID: Unique numeric identifier
-- Name: The insight name
-- Description: Optional description of what the insight shows
-- Filters: Optional filters used to create the insight
-- Query: The query used to create the insight
-
-Guidelines:
-1. Focus on finding insights that directly relate to the user's search query
-2. Look for keyword matches in names and descriptions
-3. Consider semantic similarity and practical usefulness
-4. You can iterate through pages to find better matches
-5. If you are not satisfied with current found insight, you can replace them with ones found in next pages!
-6. Return ONLY 3 highly relevant insights IDs in your final response - no explanations or reasoning
+Return format: [ID1, ID2, ID3] (numbers only, no explanations)
 
 Available insights (Page 1):
 {first_page_insights}
@@ -25,36 +12,26 @@ Available insights (Page 1):
 """
 
 ITERATIVE_SEARCH_USER_PROMPT = """
-Find 3 insights matching this search query: {query}
+Search query: {query}
 
-IMPORTANT: Return ONLY the insight IDs as a list of numbers. Do not include any explanation or reasoning.
-
-Required output format (nothing else):
-[42, 17, 205]
+Return format: [ID1, ID2, ID3]
 """
 
 PAGINATION_INSTRUCTIONS_TEMPLATE = """You can read additional pages using the read_insights_page(page_number) tool. Read additional pages until you have found the most relevant insights. There are {total_pages} total pages available (0-indexed). Note: Page 0 data is already provided above in the initial context."""
 
 HYPERLINK_USAGE_INSTRUCTIONS = "\n\nINSTRUCTIONS: When mentioning insights in your response, always use the hyperlink format provided above. For example, write '[Weekly signups](/project/123/insights/abc123)' instead of just 'Weekly signups'."
 
-TOOL_BASED_EVALUATION_SYSTEM_PROMPT = """You are evaluating existing insights to determine which ones (if any) match the user's query.
-
-User Query: {user_query}
+TOOL_BASED_EVALUATION_SYSTEM_PROMPT = """Evaluate insights for relevance to the user's query: {user_query}
 
 Available Insights:
 {insights_summary}
 
 Instructions:
 1. {selection_instruction}
-2. If you find suitable insights, use select_insight for each one with a clear explanation of why it matches
-3. If none of the insights are suitable, use reject_all_insights with a reason
-4. IMPORTANT: Focus primarily on conceptual relevance (name, description, purpose) rather than technical execution ability
-5. An insight that matches the user's intent conceptually should be selected even if it cannot be executed due to missing query data
-6. When multiple insights could work, prioritize:
-   - Exact matches over partial matches
-   - More specific insights over generic ones
-   - Insights with clear descriptions over vague ones
-7. Only reject insights if they are genuinely unrelated to the user's query, not because they lack executable query data
+2. Use select_insight for each relevant match with brief explanation
+3. Use reject_all_insights if none match
+4. Focus on conceptual relevance (name/description) over technical details
+5. Priority: exact matches > specific insights > generic ones
 """
 
 NO_INSIGHTS_FOUND_MESSAGE = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,7 @@ dependencies = [
     "django-admin-inline-paginator===0.4.0",
     "fastavro>=1.12.0",
     "pydantic-avro>=0.9.0",
+    "langchain-google-genai>=2.1.9",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.11.*"
 
 [[package]]
@@ -1848,6 +1848,15 @@ wheels = [
 ]
 
 [[package]]
+name = "filetype"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/29/745f7d30d47fe0f251d3ad3dc2978a23141917661998763bebb6da007eb1/filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb", size = 998020, upload-time = "2022-11-02T17:34:04.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/79/1b8fa1bb3568781e84c9200f951c735f3f157429f44be0495da55894d620/filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25", size = 19970, upload-time = "2022-11-02T17:34:01.425Z" },
+]
+
+[[package]]
 name = "flaky"
 version = "3.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2001,6 +2010,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/23/0e483d236f0f47cecd9b866614186a5845ad6fb03cfc265edcd962d500bf/google_ads-26.1.0.tar.gz", hash = "sha256:3ec4cc8ad07f71c923433bd2a783afc59acd5d428ed75bcc64f8ecaa5b3d8691", size = 7045268, upload-time = "2025-04-16T19:21:46.876Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/de/ecceaa4de5c344fabe6d9a739f92cda1de19889af1dd1aa372841d84b52c/google_ads-26.1.0-py3-none-any.whl", hash = "sha256:5fd2a7ac7216d45c6f7b8cadd765ea2670fda4a05aa280ea849ecc28f1aa7fd0", size = 13655250, upload-time = "2025-04-16T19:21:44.377Z" },
+]
+
+[[package]]
+name = "google-ai-generativelanguage"
+version = "0.6.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/77/3e89a4c4200135eac74eca2f6c9153127e3719a825681ad55f5a4a58b422/google_ai_generativelanguage-0.6.18.tar.gz", hash = "sha256:274ba9fcf69466ff64e971d565884434388e523300afd468fc8e3033cd8e606e", size = 1444757, upload-time = "2025-04-29T15:45:45.527Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/77/ca2889903a2d93b3072a49056d48b3f55410219743e338a1d7f94dc6455e/google_ai_generativelanguage-0.6.18-py3-none-any.whl", hash = "sha256:13d8174fea90b633f520789d32df7b422058fd5883b022989c349f1017db7fcf", size = 1372256, upload-time = "2025-04-29T15:45:43.601Z" },
 ]
 
 [[package]]
@@ -2783,6 +2807,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/82/26/c4770d3933237cde2918d502e3b0a8b6ce100b296840b632658f3e59b341/langchain_core-0.3.69.tar.gz", hash = "sha256:c132961117cc7f0227a4c58dd3e209674a6dd5b7e74abc61a0df93b0d736e283", size = 563824, upload-time = "2025-07-15T21:19:56.626Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/7b/bb7b088440ff9cc55e9e6eba94162cbdcd3b1693c194e1ad4764acba29b9/langchain_core-0.3.69-py3-none-any.whl", hash = "sha256:383e9cb4919f7ef4b24bf8552ef42e4323c064924fea88b28dd5d7ddb740d3b8", size = 441556, upload-time = "2025-07-15T21:19:55.342Z" },
+]
+
+[[package]]
+name = "langchain-google-genai"
+version = "2.1.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filetype" },
+    { name = "google-ai-generativelanguage" },
+    { name = "langchain-core" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/24/4ad44e9a8ad25682c22b56f0b665eb6d87090f2360355b48095e285a7810/langchain_google_genai-2.1.9.tar.gz", hash = "sha256:cd5d6f644b8dac3e312e30101bb97541aab240e82678e87a4df039ee1dc77531", size = 45866, upload-time = "2025-08-04T18:51:51.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d8/e1162835d5d6eefaae341c2d1cf750ab53222a421252346905187e53b8a2/langchain_google_genai-2.1.9-py3-none-any.whl", hash = "sha256:8d3aab59706b8f8920a22bcfd63c5000ce430fe61db6ecdec262977d1a0be5b8", size = 49381, upload-time = "2025-08-04T18:51:50.51Z" },
 ]
 
 [[package]]
@@ -3959,6 +3998,7 @@ dependencies = [
     { name = "kombu" },
     { name = "langchain" },
     { name = "langchain-community" },
+    { name = "langchain-google-genai" },
     { name = "langchain-openai" },
     { name = "langchain-perplexity" },
     { name = "langgraph" },
@@ -4182,6 +4222,7 @@ requires-dist = [
     { name = "kombu", specifier = "==5.3.2" },
     { name = "langchain", specifier = "==0.3.26" },
     { name = "langchain-community", specifier = "==0.3.27" },
+    { name = "langchain-google-genai", specifier = ">=2.1.9" },
     { name = "langchain-openai", specifier = "==0.3.27" },
     { name = "langchain-perplexity", specifier = ">=0.1.1" },
     { name = "langgraph", specifier = "==0.4.10" },


### PR DESCRIPTION
## Experiment

Testing `Gemini` models for the `search_insights` flow.

**Note**: `Gemini` models do NOT support [SystemMessage](https://python.langchain.com/api_reference/core/messages/langchain_core.messages.system.SystemMessage.html) (https://github.com/langchain-ai/langchain/issues/14700), thus requiring a filter operation to change them on the fly.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

* based off https://github.com/PostHog/posthog/pull/36846
* created `MaxGemini`

## Conclusions

* `gemini-2.5-flash` has notion of reasoning, haven't seen a dramatic speedup. Results seems much more reliable with `gpt-4.1-mini`
*  `gemini-2.5-flash-lite` is extremely fast but results are pretty much useless for this use case.

