### PR TITLE
chore: max width on rules

### DIFF
--- a/products/error_tracking/frontend/configuration/rules/ErrorTrackingRules.tsx
+++ b/products/error_tracking/frontend/configuration/rules/ErrorTrackingRules.tsx
@@ -108,7 +108,7 @@ const SortableRule = ({
                     {...listeners}
                 />
             )}
-            <LemonCard hoverEffect={false} className="flex flex-col flex-1 p-0">
+            <LemonCard hoverEffect={false} className="flex flex-col flex-1 p-0 w-full">
                 {children}
             </LemonCard>
         </div>


### PR DESCRIPTION
## Problem

Reported in https://posthoghelp.zendesk.com/agent/tickets/36284 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/39327)

## Changes

|Before|After|
|----|----|
| <img width="847" height="429" alt="Screenshot 2025-08-19 at 14 11 06" src="https://github.com/user-attachments/assets/dc5b9ace-6e58-44fc-b8aa-562c157a5e44" /> | <img width="855" height="416" alt="Screenshot 2025-08-19 at 14 10 53" src="https://github.com/user-attachments/assets/26f6b929-ff86-4085-8d61-a271e7ce21a9" /> |