### PR TITLE
fix(max): collapsed visualizations

### DIFF
--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -147,10 +147,9 @@ interface MessageGroupProps {
 
 function MessageGroup({ messages, isFinal: isFinalGroup }: MessageGroupProps): JSX.Element {
     const { user } = useValues(userLogic)
-    const { tools } = useValues(maxGlobalLogic)
+    const { editInsightToolRegistered } = useValues(maxGlobalLogic)
 
     const groupType = messages[0].type === 'human' ? 'human' : 'ai'
-    const isEditingInsight = tools?.some((tool) => tool.identifier === 'create_and_query_insight')
 
     return (
         <MessageGroupContainer groupType={groupType}>
@@ -235,7 +234,7 @@ function MessageGroup({ messages, isFinal: isFinalGroup }: MessageGroupProps): J
                                 key={messageIndex}
                                 message={message}
                                 status={message.status}
-                                isEditingInsight={isEditingInsight}
+                                isEditingInsight={editInsightToolRegistered}
                             />
                         )
                     } else if (isReasoningMessage(message)) {

--- a/frontend/src/scenes/max/maxGlobalLogic.test.ts
+++ b/frontend/src/scenes/max/maxGlobalLogic.test.ts
@@ -1,5 +1,11 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
 import { TOOL_DEFINITIONS, ToolRegistration } from './max-constants'
-import { STATIC_TOOLS } from './maxGlobalLogic'
+import { STATIC_TOOLS, maxGlobalLogic } from './maxGlobalLogic'
+import { maxMocks } from './testUtils'
 
 describe('maxGlobalLogic tool definitions', () => {
     it('all tool descriptions start with their name when provided', () => {
@@ -11,5 +17,40 @@ describe('maxGlobalLogic tool definitions', () => {
                 expect(tool.description.startsWith(tool.name)).toBe(true)
             }
         }
+    })
+})
+
+describe('maxGlobalLogic', () => {
+    let logic: ReturnType<typeof maxGlobalLogic.build>
+
+    beforeEach(() => {
+        useMocks(maxMocks)
+        initKeaTests()
+        logic = maxGlobalLogic()
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+        jest.restoreAllMocks()
+    })
+
+    describe('editInsightToolRegistered selector', () => {
+        it('returns true when contextual create_and_query_insight tool is registered', async () => {
+            // Initially should be false (only static tool available)
+            await expectLogic(logic).toMatchValues({
+                editInsightToolRegistered: false,
+            })
+
+            logic.actions.registerTool({
+                ...TOOL_DEFINITIONS.create_and_query_insight,
+                identifier: 'create_and_query_insight',
+            })
+
+            // Now should be true (contextual tool is registered)
+            await expectLogic(logic).toMatchValues({
+                editInsightToolRegistered: true,
+            })
+        })
     })
 })

--- a/frontend/src/scenes/max/maxGlobalLogic.tsx
+++ b/frontend/src/scenes/max/maxGlobalLogic.tsx
@@ -203,5 +203,19 @@ export const maxGlobalLogic = kea<maxGlobalLogicType>([
             }),
         ],
         tools: [(s) => [s.toolMap], (toolMap): ToolRegistration[] => Object.values(toolMap)],
+        editInsightToolRegistered: [
+            (s) => [s.tools],
+            (tools) =>
+                tools?.some((tool) => {
+                    const editInsightTool = TOOL_DEFINITIONS.create_and_query_insight
+                    // TRICKY: there are two tools with the same name and description: default and contextual.
+                    // If the contextual tool is registered, this means we're editing an insight.
+                    return (
+                        tool.identifier === 'create_and_query_insight' &&
+                        editInsightTool.name === tool.name &&
+                        editInsightTool.description === tool.description
+                    )
+                }),
+        ],
     }),
 ])

--- a/frontend/src/scenes/max/maxGlobalLogic.tsx
+++ b/frontend/src/scenes/max/maxGlobalLogic.tsx
@@ -204,18 +204,8 @@ export const maxGlobalLogic = kea<maxGlobalLogicType>([
         ],
         tools: [(s) => [s.toolMap], (toolMap): ToolRegistration[] => Object.values(toolMap)],
         editInsightToolRegistered: [
-            (s) => [s.tools],
-            (tools) =>
-                tools?.some((tool) => {
-                    const editInsightTool = TOOL_DEFINITIONS.create_and_query_insight
-                    // TRICKY: there are two tools with the same name and description: default and contextual.
-                    // If the contextual tool is registered, this means we're editing an insight.
-                    return (
-                        tool.identifier === 'create_and_query_insight' &&
-                        editInsightTool.name === tool.name &&
-                        editInsightTool.description === tool.description
-                    )
-                }),
+            (s) => [s.registeredToolMap],
+            (registeredToolMap) => !!registeredToolMap.create_and_query_insight,
         ],
     }),
 ])


### PR DESCRIPTION
## Problem

Visualizations are now collapsed in Max conversations. The check for the collapsed state looked for `create_and_query_insight`, but we actually have two different `create_and_query_insight` tools: the built-in and injected.

## Changes

- Fixed the check of registered tools to find a correct `creaet_and_query_insight`.

## How did you test this code?

Added a regression test.