### PR TITLE
fix: Improve MAX_STORAGE_CAPACITY parser

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1339,6 +1339,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytesize"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
+
+[[package]]
 name = "bzip2"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3790,6 +3796,7 @@ dependencies = [
  "aws-sdk-s3",
  "axum 0.7.5",
  "bincode",
+ "bytesize",
  "chrono",
  "common-types",
  "dashmap 6.1.0",

--- a/rust/kafka-deduplicator/Cargo.toml
+++ b/rust/kafka-deduplicator/Cargo.toml
@@ -10,6 +10,7 @@ aws-config = { workspace = true }
 aws-sdk-s3 = { workspace = true }
 axum = { workspace = true }
 bincode = { version = "2.0.1", features = ["serde"] }
+bytesize = "1.3"
 chrono = { workspace = true }
 common-types = { path = "../common/types" }
 dashmap = "6.1"

--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -1,6 +1,7 @@
 use std::{fs, path::PathBuf, time::Duration};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+use bytesize::ByteSize;
 use envconfig::Envconfig;
 
 #[derive(Envconfig, Clone, Debug)]
@@ -44,8 +45,9 @@ pub struct Config {
     #[envconfig(default = "/tmp/deduplication-store")]
     pub store_path: String,
 
-    #[envconfig(default = "1073741824")] // 1GB default
-    pub max_store_capacity: u64,
+    #[envconfig(default = "1073741824")]
+    // 1GB default, supports: raw bytes, scientific notation (9.663676416e+09), or units (9Gi, 1GB)
+    pub max_store_capacity: String,
 
     // Consumer processing configuration
     #[envconfig(default = "100")]
@@ -176,6 +178,44 @@ impl Config {
         Duration::from_millis(self.kafka_producer_send_timeout_ms as u64)
     }
 
+    /// Parse storage capacity from various formats:
+    /// - Raw bytes: "1073741824"
+    /// - Scientific notation: "9.663676416e+09"
+    /// - Kubernetes units: "9Gi", "500Mi", "1Ki"
+    /// - Decimal units: "1GB", "500MB", "1KB"
+    pub fn parse_storage_capacity(&self) -> Result<u64> {
+        let s = self.max_store_capacity.trim();
+
+        // First try to parse as ByteSize (handles Gi, Mi, KB, MB, etc.)
+        if let Ok(size) = s.parse::<ByteSize>() {
+            return Ok(size.as_u64());
+        }
+
+        // Handle scientific notation (e.g., "9.663676416e+09")
+        if s.contains('e') || s.contains('E') {
+            let float_val: f64 = s
+                .parse()
+                .with_context(|| format!("Failed to parse scientific notation: {}", s))?;
+            if float_val < 0.0 {
+                return Err(anyhow::anyhow!(
+                    "Storage capacity cannot be negative: {}",
+                    s
+                ));
+            }
+            if float_val > u64::MAX as f64 {
+                return Err(anyhow::anyhow!(
+                    "Storage capacity exceeds maximum value: {}",
+                    s
+                ));
+            }
+            return Ok(float_val as u64);
+        }
+
+        // Try as raw integer
+        s.parse::<u64>()
+            .with_context(|| format!("Failed to parse storage capacity: '{}'. Expected format: raw bytes, scientific notation, or units (1Gi, 1GB)", s))
+    }
+
     /// Get checkpoint interval as Duration
     pub fn checkpoint_interval(&self) -> Duration {
         Duration::from_secs(self.checkpoint_interval_secs)
@@ -205,5 +245,119 @@ impl Config {
             )
             .set("compression.type", &self.kafka_compression_codec);
         config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_storage_capacity_raw_bytes() {
+        let mut config = Config::init_with_defaults().unwrap();
+
+        // Test raw bytes
+        config.max_store_capacity = "1073741824".to_string();
+        assert_eq!(config.parse_storage_capacity().unwrap(), 1073741824);
+
+        config.max_store_capacity = "0".to_string();
+        assert_eq!(config.parse_storage_capacity().unwrap(), 0);
+
+        config.max_store_capacity = "1234567890".to_string();
+        assert_eq!(config.parse_storage_capacity().unwrap(), 1234567890);
+    }
+
+    #[test]
+    fn test_parse_storage_capacity_scientific_notation() {
+        let mut config = Config::init_with_defaults().unwrap();
+
+        // Test scientific notation
+        config.max_store_capacity = "9.663676416e+09".to_string();
+        assert_eq!(config.parse_storage_capacity().unwrap(), 9663676416);
+
+        config.max_store_capacity = "1e9".to_string();
+        assert_eq!(config.parse_storage_capacity().unwrap(), 1000000000);
+
+        config.max_store_capacity = "1.5e10".to_string();
+        assert_eq!(config.parse_storage_capacity().unwrap(), 15000000000);
+
+        config.max_store_capacity = "2.5E9".to_string(); // Capital E
+        assert_eq!(config.parse_storage_capacity().unwrap(), 2500000000);
+    }
+
+    #[test]
+    fn test_parse_storage_capacity_kubernetes_units() {
+        let mut config = Config::init_with_defaults().unwrap();
+
+        // Test Kubernetes binary units (base 1024)
+        config.max_store_capacity = "1Ki".to_string();
+        assert_eq!(config.parse_storage_capacity().unwrap(), 1024);
+
+        config.max_store_capacity = "1Mi".to_string();
+        assert_eq!(config.parse_storage_capacity().unwrap(), 1024 * 1024);
+
+        config.max_store_capacity = "1Gi".to_string();
+        assert_eq!(config.parse_storage_capacity().unwrap(), 1024 * 1024 * 1024);
+
+        config.max_store_capacity = "9Gi".to_string();
+        assert_eq!(
+            config.parse_storage_capacity().unwrap(),
+            9 * 1024 * 1024 * 1024
+        );
+
+        config.max_store_capacity = "500Mi".to_string();
+        assert_eq!(config.parse_storage_capacity().unwrap(), 500 * 1024 * 1024);
+
+        // With B suffix
+        config.max_store_capacity = "1GiB".to_string();
+        assert_eq!(config.parse_storage_capacity().unwrap(), 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_parse_storage_capacity_decimal_units() {
+        let mut config = Config::init_with_defaults().unwrap();
+
+        // Test decimal units (base 1000)
+        config.max_store_capacity = "1KB".to_string();
+        assert_eq!(config.parse_storage_capacity().unwrap(), 1000);
+
+        config.max_store_capacity = "1MB".to_string();
+        assert_eq!(config.parse_storage_capacity().unwrap(), 1000 * 1000);
+
+        config.max_store_capacity = "1GB".to_string();
+        assert_eq!(config.parse_storage_capacity().unwrap(), 1000 * 1000 * 1000);
+
+        config.max_store_capacity = "500MB".to_string();
+        assert_eq!(config.parse_storage_capacity().unwrap(), 500 * 1000 * 1000);
+    }
+
+    #[test]
+    fn test_parse_storage_capacity_whitespace() {
+        let mut config = Config::init_with_defaults().unwrap();
+
+        // Test with whitespace
+        config.max_store_capacity = "  1Gi  ".to_string();
+        assert_eq!(config.parse_storage_capacity().unwrap(), 1024 * 1024 * 1024);
+
+        config.max_store_capacity = " 9.663676416e+09 ".to_string();
+        assert_eq!(config.parse_storage_capacity().unwrap(), 9663676416);
+    }
+
+    #[test]
+    fn test_parse_storage_capacity_errors() {
+        let mut config = Config::init_with_defaults().unwrap();
+
+        // Test invalid formats
+        config.max_store_capacity = "invalid".to_string();
+        assert!(config.parse_storage_capacity().is_err());
+
+        config.max_store_capacity = "-1".to_string();
+        assert!(config.parse_storage_capacity().is_err());
+
+        config.max_store_capacity = "-1e9".to_string();
+        assert!(config.parse_storage_capacity().is_err());
+
+        config.max_store_capacity = "".to_string();
+        assert!(config.parse_storage_capacity().is_err());
     }
 }

--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -195,7 +195,7 @@ impl Config {
         if s.contains('e') || s.contains('E') {
             let float_val: f64 = s
                 .parse()
-                .with_context(|| format!("Failed to parse scientific notation: {}", s))?;
+                .with_context(|| format!("Failed to parse scientific notation: {s}"))?;
             if float_val < 0.0 {
                 return Err(anyhow::anyhow!(
                     "Storage capacity cannot be negative: {}",
@@ -213,7 +213,7 @@ impl Config {
 
         // Try as raw integer
         s.parse::<u64>()
-            .with_context(|| format!("Failed to parse storage capacity: '{}'. Expected format: raw bytes, scientific notation, or units (1Gi, 1GB)", s))
+            .with_context(|| format!("Failed to parse storage capacity: '{s}'. Expected format: raw bytes, scientific notation, or units (1Gi, 1GB)"))
     }
 
     /// Get checkpoint interval as Duration

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -30,7 +30,9 @@ impl KafkaDeduplicatorService {
         // Create deduplication store config
         let store_config = DeduplicationStoreConfig {
             path: config.store_path_buf(),
-            max_capacity: config.max_store_capacity,
+            max_capacity: config
+                .parse_storage_capacity()
+                .context("Failed to parse max_store_capacity")?,
         };
 
         // Create deduplication processor


### PR DESCRIPTION
## Problem

Argo transforms large numbers to scientific notation, added better parsing for storage capacity

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
