### PR TITLE
fix: replay add filter button visible state

### DIFF
--- a/frontend/src/lib/components/UniversalFilters/UniversalFilters.tsx
+++ b/frontend/src/lib/components/UniversalFilters/UniversalFilters.tsx
@@ -175,7 +175,13 @@ const AddFilterButton = (props: Omit<LemonButtonProps, 'onClick' | 'sideAction' 
     )
 }
 
-const PureTaxonomicFilter = ({ fullWidth = true }: { fullWidth?: boolean }): JSX.Element => {
+const PureTaxonomicFilter = ({
+    fullWidth = true,
+    onChange,
+}: {
+    fullWidth?: boolean
+    onChange: () => void
+}): JSX.Element => {
     const { taxonomicGroupTypes } = useValues(universalFiltersLogic)
     const { addGroupFilter } = useActions(universalFiltersLogic)
 
@@ -183,6 +189,7 @@ const PureTaxonomicFilter = ({ fullWidth = true }: { fullWidth?: boolean }): JSX
         <TaxonomicFilter
             {...(fullWidth ? { width: '100%' } : {})}
             onChange={(taxonomicGroup, value, item, originalQuery) => {
+                onChange()
                 addGroupFilter(taxonomicGroup, value, item, originalQuery)
             }}
             taxonomicGroupTypes={taxonomicGroupTypes}

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -540,7 +540,12 @@ const RecordingsUniversalFilterGroup = (): JSX.Element => {
                         <RecordingsUniversalFilterGroup />
 
                         <Popover
-                            overlay={<UniversalFilters.PureTaxonomicFilter fullWidth={false} />}
+                            overlay={
+                                <UniversalFilters.PureTaxonomicFilter
+                                    fullWidth={false}
+                                    onChange={() => setIsPopoverVisible(false)}
+                                />
+                            }
                             placement="bottom"
                             visible={isPopoverVisible}
                             onClickOutside={() => setIsPopoverVisible(false)}


### PR DESCRIPTION
we weren't closing the "Add filter" pop-over when someone chose something and it was annoying

well, not anymore!

| before | after | 
| - | - | 
|![2025-08-19 15 41 39](https://github.com/user-attachments/assets/f00d2204-2b3d-4d1f-9842-12983370ac98)| ![2025-08-19 15 41 15](https://github.com/user-attachments/assets/101fccbb-28b9-4670-bda9-1956e5beb5ce)|