### PR TITLE
fix(data-warehouse): Fixes for the source config form

### DIFF
--- a/frontend/src/scenes/data-warehouse/external/forms/SourceForm.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SourceForm.tsx
@@ -135,9 +135,8 @@ const sourceFieldToElement = (
                         <LemonSelect
                             options={field.options}
                             value={
-                                value === undefined || value === null
-                                    ? lastValue?.[field.name]
-                                    : value || field.defaultValue
+                                (value === undefined || value === null ? lastValue?.[field.name] : value) ||
+                                field.defaultValue
                             }
                             onChange={onChange}
                         />

--- a/frontend/src/scenes/data-warehouse/settings/source/Schemas.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/Schemas.tsx
@@ -46,11 +46,11 @@ interface SchemasProps {
 
 const REVENUE_ENABLED_SOURCES: ExternalDataSourceType[] = ['Stripe']
 export const Schemas = ({ id }: SchemasProps): JSX.Element => {
-    const { source, sourceLoading } = useValues(dataWarehouseSourceSettingsLogic({ id }))
+    const { source, sourceLoading } = useValues(dataWarehouseSourceSettingsLogic({ id, availableSources: {} }))
     const { addProductIntentForCrossSell } = useActions(teamLogic)
 
     return (
-        <BindLogic logic={dataWarehouseSourceSettingsLogic} props={{ id }}>
+        <BindLogic logic={dataWarehouseSourceSettingsLogic} props={{ id, availableSources: {} }}>
             <SchemaTable schemas={source?.schemas ?? []} isLoading={sourceLoading} />
             {source?.source_type && REVENUE_ENABLED_SOURCES.includes(source.source_type) && (
                 <div className="flex justify-end">

--- a/frontend/src/scenes/data-warehouse/settings/source/SourceConfiguration.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/SourceConfiguration.tsx
@@ -1,9 +1,12 @@
 import { BindLogic, useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
+import { useEffect, useState } from 'react'
 
 import { LemonButton, LemonSkeleton } from '@posthog/lemon-ui'
 
-import { SourceFormComponent, SourceFormProps } from 'scenes/data-warehouse/external/forms/SourceForm'
+import { SourceFormComponent } from 'scenes/data-warehouse/external/forms/SourceForm'
+import { availableSourcesDataLogic } from 'scenes/data-warehouse/new/availableSourcesDataLogic'
+import { buildKeaFormDefaultFromSourceDetails } from 'scenes/data-warehouse/new/sourceWizardLogic'
 
 import { dataWarehouseSourceSettingsLogic } from './dataWarehouseSourceSettingsLogic'
 
@@ -12,38 +15,62 @@ interface SourceConfigurationProps {
 }
 
 export const SourceConfiguration = ({ id }: SourceConfigurationProps): JSX.Element => {
-    const { sourceFieldConfig } = useValues(dataWarehouseSourceSettingsLogic({ id }))
+    const { availableSources, availableSourcesLoading } = useValues(availableSourcesDataLogic)
+
+    if (availableSourcesLoading || availableSources === null) {
+        return <LemonSkeleton />
+    }
+
     return (
-        <BindLogic logic={dataWarehouseSourceSettingsLogic} props={{ id }}>
-            {sourceFieldConfig ? (
-                <UpdateSourceConnectionFormContainer id={id} sourceConfig={sourceFieldConfig} showPrefix={false} />
-            ) : (
-                <LemonSkeleton />
-            )}
+        <BindLogic logic={dataWarehouseSourceSettingsLogic} props={{ id, availableSources }}>
+            <UpdateSourceConnectionFormContainer />
         </BindLogic>
     )
 }
 
-interface UpdateSourceConnectionFormContainerProps extends SourceFormProps {
-    id: string
-}
-
-function UpdateSourceConnectionFormContainer(props: UpdateSourceConnectionFormContainerProps): JSX.Element {
-    const { source, sourceLoading } = useValues(dataWarehouseSourceSettingsLogic({ id: props.id }))
+function UpdateSourceConnectionFormContainer(): JSX.Element {
+    const { sourceFieldConfig, source, sourceConfigLoading } = useValues(dataWarehouseSourceSettingsLogic)
     const { setSourceConfigValue } = useActions(dataWarehouseSourceSettingsLogic)
+
+    const [jobInputs, setJobInputs] = useState<Record<string, any>>({})
+
+    useEffect(() => {
+        if (!source || !sourceFieldConfig) {
+            return
+        }
+
+        setJobInputs({
+            ...buildKeaFormDefaultFromSourceDetails({ [source.source_type]: sourceFieldConfig })['payload'],
+            ...source.job_inputs,
+        })
+        // `source` is updating via a poll, and so we dont't want this updating when the object reference updates but not the actual data
+        // It's also the reason why it can't live in the kea logic - the selector will update on object reference changes
+    }, [
+        JSON.stringify(source?.job_inputs ?? {}),
+        JSON.stringify(sourceFieldConfig),
+        source.source_type,
+        source.job_inputs,
+        source,
+        sourceFieldConfig,
+    ])
+
+    if (!sourceFieldConfig || !source) {
+        return <LemonSkeleton />
+    }
 
     return (
         <>
             <span className="block mb-2">Overwrite your existing configuration here</span>
             <Form logic={dataWarehouseSourceSettingsLogic} formKey="sourceConfig" enableFormOnSubmit>
                 <SourceFormComponent
-                    {...props}
-                    jobInputs={source?.job_inputs}
+                    showPrefix={false}
+                    sourceConfig={sourceFieldConfig}
+                    jobInputs={jobInputs}
                     setSourceConfigValue={setSourceConfigValue}
                 />
                 <div className="mt-4 flex flex-row justify-end gap-2">
                     <LemonButton
-                        loading={sourceLoading && !source}
+                        loading={sourceConfigLoading}
                         type="primary"
                         center
                         htmlType="submit"

--- a/frontend/src/scenes/data-warehouse/settings/source/SourceConfiguration.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/SourceConfiguration.tsx
@@ -47,11 +47,7 @@ function UpdateSourceConnectionFormContainer(): JSX.Element {
         // It's also the reason why it can't live in the kea logic - the selector will update on object reference changes
     }, [
         JSON.stringify(source?.job_inputs ?? {}),
-        JSON.stringify(sourceFieldConfig),
-        source.source_type,
-        source.job_inputs,
-        source,
-        sourceFieldConfig,
+        JSON.stringify(sourceFieldConfig)
     ])
 
     if (!sourceFieldConfig || !source) {

--- a/frontend/src/scenes/data-warehouse/settings/source/SourceConfiguration.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/SourceConfiguration.tsx
@@ -46,8 +46,10 @@ function UpdateSourceConnectionFormContainer(): JSX.Element {
         // `source` is updating via a poll, and so we dont't want this updating when the object reference updates but not the actual data
         // It's also the reason why it can't live in the kea logic - the selector will update on object reference changes
     }, [
+        // oxlint-disable-next-line exhaustive-deps
         JSON.stringify(source?.job_inputs ?? {}),
-        JSON.stringify(sourceFieldConfig)
+        // oxlint-disable-next-line exhaustive-deps
+        JSON.stringify(sourceFieldConfig),
     ])
 
     if (!sourceFieldConfig || !source) {

--- a/frontend/src/scenes/data-warehouse/settings/source/Syncs.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/Syncs.tsx
@@ -22,8 +22,10 @@ interface SyncsProps {
 }
 
 export const Syncs = ({ id }: SyncsProps): JSX.Element => {
-    const { jobs, jobsLoading, canLoadMoreJobs } = useValues(dataWarehouseSourceSettingsLogic({ id }))
-    const { loadMoreJobs } = useActions(dataWarehouseSourceSettingsLogic({ id }))
+    const { jobs, jobsLoading, canLoadMoreJobs } = useValues(
+        dataWarehouseSourceSettingsLogic({ id, availableSources: {} })
+    )
+    const { loadMoreJobs } = useActions(dataWarehouseSourceSettingsLogic({ id, availableSources: {} }))
 
     return (
         <LemonTable

--- a/frontend/src/scenes/data-warehouse/settings/source/dataWarehouseSourceSettingsLogic.ts
+++ b/frontend/src/scenes/data-warehouse/settings/source/dataWarehouseSourceSettingsLogic.ts
@@ -137,7 +137,7 @@ export const dataWarehouseSourceSettingsLogic = kea<dataWarehouseSourceSettingsL
             },
         ],
     }),
-    forms(({ values, actions }) => ({
+    forms(({ values, actions, props }) => ({
         sourceConfig: {
             defaults: buildKeaFormDefaultFromSourceDetails(props.availableSources),
             errors: (sourceValues) => {

--- a/frontend/src/scenes/data-warehouse/settings/source/dataWarehouseSourceSettingsLogic.ts
+++ b/frontend/src/scenes/data-warehouse/settings/source/dataWarehouseSourceSettingsLogic.ts
@@ -7,8 +7,9 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { availableSourcesDataLogic } from 'scenes/data-warehouse/new/availableSourcesDataLogic'
-import { getErrorsForFields } from 'scenes/data-warehouse/new/sourceWizardLogic'
+import { buildKeaFormDefaultFromSourceDetails, getErrorsForFields } from 'scenes/data-warehouse/new/sourceWizardLogic'
 
+import { SourceConfig } from '~/queries/schema/schema-general'
 import { ExternalDataJob, ExternalDataSchemaStatus, ExternalDataSource, ExternalDataSourceSchema } from '~/types'
 
 import { externalDataSourcesLogic } from '../../externalDataSourcesLogic'
@@ -17,6 +18,7 @@ import type { dataWarehouseSourceSettingsLogicType } from './dataWarehouseSource
 
 export interface DataWarehouseSourceSettingsLogicProps {
     id: string
+    availableSources: Record<string, SourceConfig>
 }
 
 const REFRESH_INTERVAL = 5000
@@ -27,7 +29,7 @@ export const dataWarehouseSourceSettingsLogic = kea<dataWarehouseSourceSettingsL
     key(({ id }) => id),
     connect({
         values: [availableSourcesDataLogic, ['availableSources']],
-        actions: [externalDataSourcesLogic, ['updateSource as updateSourceCentralized']],
+        actions: [externalDataSourcesLogic, ['updateSource']],
     }),
     actions({
         setSourceId: (id: string) => ({ id }),
@@ -61,11 +63,6 @@ export const dataWarehouseSourceSettingsLogic = kea<dataWarehouseSourceSettingsL
                     }
 
                     return source
-                },
-                updateSource: async (source: ExternalDataSource) => {
-                    const updatedSource = await api.externalDataSources.update(values.sourceId, source)
-                    actions.loadSourceSuccess(updatedSource)
-                    return updatedSource
                 },
             },
         ],
@@ -119,6 +116,14 @@ export const dataWarehouseSourceSettingsLogic = kea<dataWarehouseSourceSettingsL
                 setIsProjectTime: (_, { isProjectTime }) => isProjectTime,
             },
         ],
+        sourceConfigLoading: [
+            false as boolean,
+            {
+                submitSourceConfigRequest: () => true,
+                submitSourceConfigSuccess: () => false,
+                submitSourceConfigFailure: () => false,
+            },
+        ],
     })),
     selectors({
         sourceFieldConfig: [
@@ -134,7 +139,7 @@ export const dataWarehouseSourceSettingsLogic = kea<dataWarehouseSourceSettingsL
     }),
     forms(({ values, actions }) => ({
         sourceConfig: {
-            defaults: {} as Record<string, any>,
+            defaults: buildKeaFormDefaultFromSourceDetails(props.availableSources),
             errors: (sourceValues) => {
                 return getErrorsForFields(values.sourceFieldConfig?.fields ?? [], sourceValues as any)
             },
@@ -167,7 +172,7 @@ export const dataWarehouseSourceSettingsLogic = kea<dataWarehouseSourceSettingsL
                 }
 
                 try {
-                    actions.updateSourceCentralized({
+                    await externalDataSourcesLogic.asyncActions.updateSource({
                         ...values.source!,
                         job_inputs: newJobInputs,
                     })


### PR DESCRIPTION
## Problem
- The source config form wasn't using the "formDefaults" function and so we weren't pre-populating all the expected fields when submitting the form, causing errors to be returned to the frontend
  - Raised by https://posthog.slack.com/archives/C08J7633WBY/p1755607719590289?thread_ts=1755602409.106819&cid=C08J7633WBY
- When submitting source updates, we weren't waiting for the response before showing the success toast
- We were now using the `defaultValue` when populating a select field on the source config page

## Changes
- Fixed all the above

## How did you test this code?
Tested it a bunch locally 