### PR TITLE
feat: Remove actions and events if mappings are in use

### DIFF
--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
@@ -134,7 +134,7 @@ export function sanitizeConfiguration(data: HogFunctionConfigurationType): HogFu
     const filters = data.filters ?? {}
     filters.source = filters.source ?? 'events'
 
-    if (filters.source === 'person-updates') {
+    if (filters.source === 'person-updates' || Array.isArray(data?.mappings)) {
         // Ensure we aren't passing in values that aren't supported
         delete filters.actions
         delete filters.events

--- a/posthog/api/hog_function.py
+++ b/posthog/api/hog_function.py
@@ -267,8 +267,8 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
         if attrs.get("mappings", None) is not None:
             # special case for items that migrate to mappings - we want to make sure event filters are not set
             if attrs.get("filters", None) is not None:
-                del attrs["filters"]["events"]
-                del attrs["filters"]["actions"]
+                attrs["filters"].pop("events", None)
+                attrs["filters"].pop("actions", None)
 
             if hog_type not in ["site_destination", "destination"]:
                 raise serializers.ValidationError({"mappings": "Mappings are only allowed for destinations."})

--- a/posthog/api/hog_function.py
+++ b/posthog/api/hog_function.py
@@ -265,6 +265,11 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
                     )
 
         if attrs.get("mappings", None) is not None:
+            # special case for items that migrate to mappings - we want to make sure event filters are not set
+            if attrs.get("filters", None) is not None:
+                del attrs["filters"]["events"]
+                del attrs["filters"]["actions"]
+
             if hog_type not in ["site_destination", "destination"]:
                 raise serializers.ValidationError({"mappings": "Mappings are only allowed for destinations."})
 


### PR DESCRIPTION
## Problem

We needlessly store filters if changed to mappings. We shouldn't do this

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
