### PR TITLE
fix(max): open trace in new tab for localhost

### DIFF
--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -628,14 +628,15 @@ function SuccessActions({ retriable }: { retriable: boolean }): JSX.Element {
                 )}
                 {(user?.is_staff || location.hostname === 'localhost') && traceId && (
                     <LemonButton
-                        to={`${
-                            location.hostname !== 'localhost' ? 'https://us.posthog.com/project/2' : ''
-                        }${urls.llmObservabilityTrace(traceId)}`}
+                        onClick={() => {
+                            const baseUrl = location.hostname !== 'localhost' ? 'https://us.posthog.com/project/2' : ''
+                            const traceUrl = `${baseUrl}${urls.llmObservabilityTrace(traceId)}`
+                            window.open(traceUrl, '_blank')
+                        }}
                         icon={<IconEye />}
                         type="tertiary"
                         size="xsmall"
                         tooltip="View trace in LLM observability"
-                        targetBlank
                     />
                 )}
             </div>

--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -628,15 +628,16 @@ function SuccessActions({ retriable }: { retriable: boolean }): JSX.Element {
                 )}
                 {(user?.is_staff || location.hostname === 'localhost') && traceId && (
                     <LemonButton
-                        onClick={() => {
-                            const baseUrl = location.hostname !== 'localhost' ? 'https://us.posthog.com/project/2' : ''
-                            const traceUrl = `${baseUrl}${urls.llmObservabilityTrace(traceId)}`
-                            window.open(traceUrl, '_blank')
-                        }}
+                        to={`${
+                            location.hostname !== 'localhost'
+                                ? 'https://us.posthog.com/project/2'
+                                : `${window.location.origin}/project/2`
+                        }${urls.llmObservabilityTrace(traceId)}`}
                         icon={<IconEye />}
                         type="tertiary"
                         size="xsmall"
                         tooltip="View trace in LLM observability"
+                        targetBlank
                     />
                 )}
             </div>


### PR DESCRIPTION
## Problem
Tiny dev experience improvement on localhost, we can use the absolute url in localhost to get a new page to open up when we click the trace icon under message. `targetBlank` will not work correctly with a relative url, only absolute ones.

## Changes
Generate the absolute url in localhost to get a new page to open up when we click the trace icon under message

## How did you test this code?
Manual testing

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
