### PR TITLE
chore: Add kafka_tls config

### DIFF
--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -38,6 +38,9 @@ pub struct Config {
     #[envconfig(default = "snappy")]
     pub kafka_compression_codec: String,
 
+    #[envconfig(default = "false")]
+    pub kafka_tls: bool,
+
     // Output topic for deduplicated events (optional - if not set, events are only consumed for metrics)
     pub output_topic: Option<String>,
 
@@ -244,6 +247,13 @@ impl Config {
                 self.kafka_producer_linger_ms.to_string(),
             )
             .set("compression.type", &self.kafka_compression_codec);
+        
+        if self.kafka_tls {
+            config
+                .set("security.protocol", "ssl")
+                .set("enable.ssl.certificate.verification", "false");
+        }
+        
         config
     }
 }

--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -247,13 +247,13 @@ impl Config {
                 self.kafka_producer_linger_ms.to_string(),
             )
             .set("compression.type", &self.kafka_compression_codec);
-        
+
         if self.kafka_tls {
             config
                 .set("security.protocol", "ssl")
                 .set("enable.ssl.certificate.verification", "false");
         }
-        
+
         config
     }
 }

--- a/rust/kafka-deduplicator/src/kafka/config.rs
+++ b/rust/kafka-deduplicator/src/kafka/config.rs
@@ -41,6 +41,16 @@ impl ConsumerConfigBuilder {
         self
     }
 
+    /// Enable TLS/SSL for Kafka connection
+    pub fn with_tls(mut self, enabled: bool) -> Self {
+        if enabled {
+            self.config
+                .set("security.protocol", "ssl")
+                .set("enable.ssl.certificate.verification", "false");
+        }
+        self
+    }
+
     /// Build the final configuration
     pub fn build(self) -> ClientConfig {
         self.config

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -82,6 +82,7 @@ impl KafkaDeduplicatorService {
         // Create consumer config using the kafka module's builder
         let consumer_config =
             ConsumerConfigBuilder::new(&self.config.kafka_hosts, &self.config.kafka_consumer_group)
+                .with_tls(self.config.kafka_tls)
                 .offset_reset(&self.config.kafka_consumer_offset_reset)
                 .build();
 


### PR DESCRIPTION
## Problem

Kafka TLS settings are not enable for consumer in Kafka Deduplicator

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
