### PR TITLE
feat(crm): Rank groups by similarity with search term

### DIFF
--- a/posthog/hogql_queries/groups/groups_query_runner.py
+++ b/posthog/hogql_queries/groups/groups_query_runner.py
@@ -43,6 +43,8 @@ class GroupsQueryRunner(AnalyticsQueryRunner):
         if self.query.properties:
             where_exprs.append(property_to_expr(self.query.properties, self.team, scope="group"))
 
+        order_by: list[ast.OrderExpr] = []
+        similarity_order = None
         if self.query.search is not None and self.query.search != "":
             where_exprs.append(
                 ast.Or(
@@ -60,11 +62,14 @@ class GroupsQueryRunner(AnalyticsQueryRunner):
                     ]
                 )
             )
+            similarity_order = self._get_similarity_order_for_search()
 
         where = ast.And(exprs=list(where_exprs)) if where_exprs else None
 
-        order_by: list[ast.OrderExpr] = []
         order_by_exprs = self.query.orderBy if self.query.orderBy else ["created_at DESC"]
+        has_user_ordering = self.query.orderBy is not None and len(self.query.orderBy) > 0
+
+        # Add user-specified ordering first
         for col in order_by_exprs:
             # group_name isn't actually a field
             if col.startswith("group_name"):
@@ -78,6 +83,10 @@ class GroupsQueryRunner(AnalyticsQueryRunner):
                 )
             else:
                 order_by.append(parse_order_expr(col, timings=self.timings))
+
+        if similarity_order is not None:
+            # Add similarity ordering after user ordering (but not after default created_at DESC)
+            order_by.append(similarity_order) if has_user_ordering else order_by.insert(0, similarity_order)
 
         return ast.SelectQuery(
             select=[
@@ -107,4 +116,37 @@ class GroupsQueryRunner(AnalyticsQueryRunner):
             results=results,
             hogql=response.hogql,
             **self.paginator.response_params(),
+        )
+
+    def _get_similarity_order_for_search(self) -> ast.OrderExpr:
+        """
+        When a search term exists, we want to rank the results by how close they are to it.
+        """
+        display_name_expr = ast.Call(
+            name="coalesce", args=[ast.Field(chain=["properties", "name"]), ast.Field(chain=["key"])]
+        )
+
+        return ast.OrderExpr(
+            expr=ast.Call(
+                name="multiIf",
+                args=[
+                    # Exact match = 0 (highest priority)
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.ILike,
+                        left=display_name_expr,
+                        right=ast.Constant(value=self.query.search),
+                    ),
+                    ast.Constant(value=0),
+                    # Starts with search term = 1
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.ILike,
+                        left=display_name_expr,
+                        right=ast.Constant(value=f"{self.query.search}%"),
+                    ),
+                    ast.Constant(value=1),
+                    # Contains search term = 2 (lowest priority)
+                    ast.Constant(value=2),
+                ],
+            ),
+            order="ASC",
         )

--- a/posthog/hogql_queries/groups/test/__snapshots__/test_groups_query_runner.ambr
+++ b/posthog/hogql_queries/groups/test/__snapshots__/test_groups_query_runner.ambr
@@ -57,6 +57,34 @@
                     allow_experimental_join_condition=1
   '''
 # ---
+# name: TestGroupsQueryRunner.test_groups_query_runner_search_ranking
+  '''
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
+         groups.key AS key
+  FROM
+    (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
+            argMax(toTimeZone(groups.created_at, 'UTC'), toTimeZone(groups._timestamp, 'UTC')) AS created_at,
+            groups.group_type_index AS index,
+            groups.group_key AS key
+     FROM groups
+     WHERE equals(groups.team_id, 99999)
+     GROUP BY groups.group_type_index,
+              groups.group_key) AS groups
+  WHERE and(ifNull(equals(groups.index, 0), 0), or(ifNull(ilike(groups.properties___name, '%test%'), 0), ilike(toString(groups.key), '%test%')))
+  ORDER BY multiIf(ifNull(ilike(coalesce(groups.properties___name, groups.key), 'test'), 0), 0, ifNull(ilike(coalesce(groups.properties___name, groups.key), 'test%'), 0), 1, 2) ASC, groups.created_at DESC
+  LIMIT 11
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1
+  '''
+# ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_numeric_property
   '''
   SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
@@ -244,7 +272,7 @@
      GROUP BY groups.group_type_index,
               groups.group_key) AS groups
   WHERE and(ifNull(equals(groups.index, 0), 0), or(ifNull(ilike(groups.properties___name, '%org2%'), 0), ilike(toString(groups.key), '%org2%')))
-  ORDER BY groups.created_at DESC
+  ORDER BY multiIf(ifNull(ilike(coalesce(groups.properties___name, groups.key), 'org2'), 0), 0, ifNull(ilike(coalesce(groups.properties___name, groups.key), 'org2%'), 0), 1, 2) ASC, groups.created_at DESC
   LIMIT 11
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -273,6 +301,178 @@
               groups.group_key) AS groups
   WHERE and(ifNull(equals(groups.index, 0), 0), ifNull(equals(groups.properties___name, 'org0.inc'), 0))
   ORDER BY groups.created_at DESC
+  LIMIT 11
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestGroupsQueryRunner.test_search
+  '''
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
+         groups.key AS key
+  FROM
+    (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
+            argMax(toTimeZone(groups.created_at, 'UTC'), toTimeZone(groups._timestamp, 'UTC')) AS created_at,
+            groups.group_type_index AS index,
+            groups.group_key AS key
+     FROM groups
+     WHERE equals(groups.team_id, 99999)
+     GROUP BY groups.group_type_index,
+              groups.group_key) AS groups
+  WHERE and(ifNull(equals(groups.index, 0), 0), or(ifNull(ilike(groups.properties___name, '%org2%'), 0), ilike(toString(groups.key), '%org2%')))
+  ORDER BY multiIf(ifNull(ilike(coalesce(groups.properties___name, groups.key), 'org2'), 0), 0, ifNull(ilike(coalesce(groups.properties___name, groups.key), 'org2%'), 0), 1, 2) ASC, groups.created_at DESC
+  LIMIT 11
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestGroupsQueryRunner.test_search
+  '''
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
+         groups.key AS key
+  FROM
+    (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
+            argMax(toTimeZone(groups.created_at, 'UTC'), toTimeZone(groups._timestamp, 'UTC')) AS created_at,
+            groups.group_type_index AS index,
+            groups.group_key AS key
+     FROM groups
+     WHERE equals(groups.team_id, 99999)
+     GROUP BY groups.group_type_index,
+              groups.group_key) AS groups
+  WHERE and(ifNull(equals(groups.index, 0), 0), or(ifNull(ilike(groups.properties___name, '%org2%'), 0), ilike(toString(groups.key), '%org2%')))
+  ORDER BY multiIf(ifNull(ilike(coalesce(groups.properties___name, groups.key), 'org2'), 0), 0, ifNull(ilike(coalesce(groups.properties___name, groups.key), 'org2%'), 0), 1, 2) ASC, groups.created_at DESC
+  LIMIT 11
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestGroupsQueryRunner.test_search_ordering_with_user_orderby
+  '''
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
+         groups.key AS key,
+         groups.properties___arr AS arr
+  FROM
+    (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
+            argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'arr'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___arr,
+            groups.group_type_index AS index,
+            groups.group_key AS key
+     FROM groups
+     WHERE equals(groups.team_id, 99999)
+     GROUP BY groups.group_type_index,
+              groups.group_key) AS groups
+  WHERE and(ifNull(equals(groups.index, 0), 0), or(ifNull(ilike(groups.properties___name, '%test%'), 0), ilike(toString(groups.key), '%test%')))
+  ORDER BY groups.properties___arr DESC,
+           multiIf(ifNull(ilike(coalesce(groups.properties___name, groups.key), 'test'), 0), 0, ifNull(ilike(coalesce(groups.properties___name, groups.key), 'test%'), 0), 1, 2) ASC
+  LIMIT 11
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestGroupsQueryRunner.test_search_ordering_with_user_orderby.1
+  '''
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
+         groups.key AS key,
+         groups.properties___arr AS arr
+  FROM
+    (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
+            argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'arr'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___arr,
+            argMax(toTimeZone(groups.created_at, 'UTC'), toTimeZone(groups._timestamp, 'UTC')) AS created_at,
+            groups.group_type_index AS index,
+            groups.group_key AS key
+     FROM groups
+     WHERE equals(groups.team_id, 99999)
+     GROUP BY groups.group_type_index,
+              groups.group_key) AS groups
+  WHERE and(ifNull(equals(groups.index, 0), 0), or(ifNull(ilike(groups.properties___name, '%test%'), 0), ilike(toString(groups.key), '%test%')))
+  ORDER BY multiIf(ifNull(ilike(coalesce(groups.properties___name, groups.key), 'test'), 0), 0, ifNull(ilike(coalesce(groups.properties___name, groups.key), 'test%'), 0), 1, 2) ASC, groups.created_at DESC
+  LIMIT 11
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestGroupsQueryRunner.test_search_ranking
+  '''
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
+         groups.key AS key
+  FROM
+    (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
+            argMax(toTimeZone(groups.created_at, 'UTC'), toTimeZone(groups._timestamp, 'UTC')) AS created_at,
+            groups.group_type_index AS index,
+            groups.group_key AS key
+     FROM groups
+     WHERE equals(groups.team_id, 99999)
+     GROUP BY groups.group_type_index,
+              groups.group_key) AS groups
+  WHERE and(ifNull(equals(groups.index, 0), 0), or(ifNull(ilike(groups.properties___name, '%test%'), 0), ilike(toString(groups.key), '%test%')))
+  ORDER BY multiIf(ifNull(ilike(coalesce(groups.properties___name, groups.key), 'test'), 0), 0, ifNull(ilike(coalesce(groups.properties___name, groups.key), 'test%'), 0), 1, 2) ASC, groups.created_at DESC
+  LIMIT 11
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestGroupsQueryRunner.test_search_ranking_with_key_fallback
+  '''
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
+         groups.key AS key
+  FROM
+    (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
+            argMax(toTimeZone(groups.created_at, 'UTC'), toTimeZone(groups._timestamp, 'UTC')) AS created_at,
+            groups.group_type_index AS index,
+            groups.group_key AS key
+     FROM groups
+     WHERE equals(groups.team_id, 99999)
+     GROUP BY groups.group_type_index,
+              groups.group_key) AS groups
+  WHERE and(ifNull(equals(groups.index, 0), 0), or(ifNull(ilike(groups.properties___name, '%api%'), 0), ilike(toString(groups.key), '%api%')))
+  ORDER BY multiIf(ifNull(ilike(coalesce(groups.properties___name, groups.key), 'api'), 0), 0, ifNull(ilike(coalesce(groups.properties___name, groups.key), 'api%'), 0), 1, 2) ASC, groups.created_at DESC
   LIMIT 11
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,

--- a/posthog/hogql_queries/groups/test/test_groups_query_runner.py
+++ b/posthog/hogql_queries/groups/test/test_groups_query_runner.py
@@ -109,7 +109,7 @@ class TestGroupsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
     @freeze_time("2025-01-01")
     @snapshot_clickhouse_queries
-    def test_groups_query_runner_with_search(self):
+    def test_search(self):
         self.create_standard_test_groups()
         query = GroupsQuery(
             group_type_index=0,
@@ -117,13 +117,132 @@ class TestGroupsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             offset=0,
             search="org2",
         )
-
         query_runner = GroupsQueryRunner(query=query, team=self.team)
+
         result = query_runner.calculate()
 
         self.assertEqual(len(result.results), 1)
         self.assertEqual(result.columns, ["group_name", "key"])
         self.assertEqual(result.results[0][0], "org2.inc")
+
+    @freeze_time("2025-01-01")
+    @snapshot_clickhouse_queries
+    def test_search_ranking(self):
+        GroupTypeMapping.objects.create(
+            team=self.team, project_id=self.team.project_id, group_type="organization", group_type_index=0
+        )
+        test_groups = [
+            {"key": "prefix2", "name": "testable"},
+            {"key": "contains", "name": "my_test_group"},
+            {"key": "prefix", "name": "testing"},
+            {"key": "exact", "name": "test"},
+            {"key": "contains2", "name": "best_test_ever"},
+        ]
+        for group in test_groups:
+            create_group(
+                team_id=self.team.pk,
+                group_type_index=0,
+                group_key=group["key"],
+                properties={"name": group["name"]},
+            )
+
+        query = GroupsQuery(
+            group_type_index=0,
+            limit=10,
+            offset=0,
+            search="test",
+        )
+
+        query_runner = GroupsQueryRunner(query=query, team=self.team)
+        result = query_runner.calculate()
+
+        self.assertEqual(len(result.results), len(test_groups), "Should match all groups")
+        self.assertEqual(result.columns, ["group_name", "key"])
+        self.assertEqual(result.results[0][0], "test")
+        self.assertEqual(result.results[0][1], "exact")
+        self.assertEqual(result.results[1][0], "testable")
+        self.assertEqual(result.results[1][1], "prefix2")
+        self.assertEqual(result.results[2][0], "testing")
+        self.assertEqual(result.results[2][1], "prefix")
+        self.assertEqual(result.results[3][0], "best_test_ever")
+        self.assertEqual(result.results[3][1], "contains2")
+        self.assertEqual(result.results[4][0], "my_test_group")
+        self.assertEqual(result.results[4][1], "contains")
+
+    @freeze_time("2025-01-01")
+    @snapshot_clickhouse_queries
+    def test_search_ranking_with_key_fallback(self):
+        """Test search ranking when groups don't have name property and fall back to key"""
+        GroupTypeMapping.objects.create(
+            team=self.team, project_id=self.team.project_id, group_type="organization", group_type_index=0
+        )
+        test_groups = [
+            {"key": "api_v2", "name": None},
+            {"key": "api", "name": None},
+            {"key": "legacy_api", "name": None},
+        ]
+        for group in test_groups:
+            props = {"name": group["name"]} if group["name"] else {}
+            create_group(
+                team_id=self.team.pk,
+                group_type_index=0,
+                group_key=str(group["key"]),
+                properties=props,
+            )
+
+        query = GroupsQuery(
+            group_type_index=0,
+            limit=10,
+            offset=0,
+            search="api",
+        )
+
+        query_runner = GroupsQueryRunner(query=query, team=self.team)
+        result = query_runner.calculate()
+
+        self.assertEqual(len(result.results), len(test_groups), "Should match all groups")
+        self.assertEqual(result.results[0][1], "api", "Exact match ranked first")
+        self.assertEqual(result.results[1][1], "api_v2", "Prefix match ranked second")
+        self.assertEqual(result.results[2][1], "legacy_api", "Contains match ranked last")
+
+    @freeze_time("2025-01-01")
+    @snapshot_clickhouse_queries
+    def test_search_ordering_with_user_orderby(self):
+        """Test that similarity ordering comes after user-specified orderBy, not after default created_at DESC"""
+        GroupTypeMapping.objects.create(
+            team=self.team, project_id=self.team.project_id, group_type="organization", group_type_index=0
+        )
+        test_groups = [
+            {"key": "exact", "name": "test", "arr": 200},
+            {"key": "prefix", "name": "testing", "arr": 100},
+            {"key": "contains", "name": "my_test_group", "arr": 300},
+        ]
+        for group in test_groups:
+            create_group(
+                team_id=self.team.pk,
+                group_type_index=0,
+                group_key=str(group["key"]),
+                properties={"name": group["name"], "arr": group["arr"]},
+            )
+
+        query = GroupsQuery(
+            group_type_index=0,
+            limit=10,
+            offset=0,
+            search="test",
+            select=["properties.arr"],
+            orderBy=["properties.arr DESC"],  # User-specified ordering
+        )
+
+        query_runner = GroupsQueryRunner(query=query, team=self.team)
+        result = query_runner.calculate()
+        self.assertEqual(len(result.results), len(test_groups), "Should match all groups")
+        self.assertEqual(result.results[0][0], "my_test_group", "Contains match ranked first, highest arr")
+        self.assertEqual(result.results[0][2], "300")
+        self.assertEqual(result.results[1][0], "test", "Exact match ranked second, mid arr")
+        self.assertEqual(result.results[1][2], "200")
+        self.assertEqual(result.results[2][0], "testing", "Prefix match ranked last, lowest arr")
+        self.assertEqual(result.results[2][2], "100")
 
     @freeze_time("2025-01-01")
     @snapshot_clickhouse_queries


### PR DESCRIPTION
## Problem
When searching for a group, we don't rank results according to the search term. This is a bad UX, as an exact match can be at the bottom of the list.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Related to https://github.com/PostHog/posthog/issues/36460
## Changes
- Add simple ranking in `GroupsQueryRunner` to show exact matches first, then prefix matches and contains matches last
	- Hopefully this is not too taxing on CH, as orderBy happens after the where clause is executed
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Unit tests and in the UI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
