### PR TITLE
fix: don't quota check when flags are disabled

### DIFF
--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -58,7 +58,7 @@ pub async fn process_request(context: RequestContext) -> Result<FlagsResponse, F
             team.project_id
         );
 
-        // Early exit if flags are disabled 
+        // Early exit if flags are disabled
         let flags_response = if request.is_flags_disabled() {
             FlagsResponse::new(false, HashMap::new(), None, context.request_id)
         } else if let Some(quota_limited_response) =

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -18,6 +18,7 @@ use crate::{
     flags::flag_service::FlagService,
     metrics::consts::FLAG_REQUESTS_COUNTER,
 };
+use std::collections::HashMap;
 use tracing::{info, instrument, warn};
 
 /// Primary entry point for feature flag requests.
@@ -57,8 +58,10 @@ pub async fn process_request(context: RequestContext) -> Result<FlagsResponse, F
             team.project_id
         );
 
-        // Check quota limits - don't return early, just use quota limited response if needed
-        let flags_response = if let Some(quota_limited_response) =
+        // Early exit if flags are disabled 
+        let flags_response = if request.is_flags_disabled() {
+            FlagsResponse::new(false, HashMap::new(), None, context.request_id)
+        } else if let Some(quota_limited_response) =
             billing::check_limits(&context, &verified_token).await?
         {
             warn!("Request quota limited");

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -1241,42 +1241,51 @@ async fn test_fetch_and_filter_flags() {
 #[test]
 fn test_disable_flags_request_parsing() {
     // Test that disable_flags=true is properly parsed and detected
-    
+
     // Test case 1: disable_flags=true should be detected
     let payload_with_disable = json!({
         "token": "test_token",
         "distinct_id": "test_user",
         "disable_flags": true
     });
-    
+
     let bytes = Bytes::from(payload_with_disable.to_string());
     let request = crate::flags::flag_request::FlagRequest::from_bytes(bytes)
         .expect("Failed to parse request with disable_flags=true");
-    
-    assert!(request.is_flags_disabled(), "disable_flags=true should be detected");
-    
+
+    assert!(
+        request.is_flags_disabled(),
+        "disable_flags=true should be detected"
+    );
+
     // Test case 2: disable_flags=false should NOT be detected as disabled
     let payload_with_enable = json!({
-        "token": "test_token", 
+        "token": "test_token",
         "distinct_id": "test_user",
         "disable_flags": false
     });
-    
+
     let bytes = Bytes::from(payload_with_enable.to_string());
     let request = crate::flags::flag_request::FlagRequest::from_bytes(bytes)
         .expect("Failed to parse request with disable_flags=false");
-    
-    assert!(!request.is_flags_disabled(), "disable_flags=false should not be detected as disabled");
-    
+
+    assert!(
+        !request.is_flags_disabled(),
+        "disable_flags=false should not be detected as disabled"
+    );
+
     // Test case 3: No disable_flags field should default to enabled
     let payload_default = json!({
         "token": "test_token",
         "distinct_id": "test_user"
     });
-    
+
     let bytes = Bytes::from(payload_default.to_string());
     let request = crate::flags::flag_request::FlagRequest::from_bytes(bytes)
         .expect("Failed to parse request without disable_flags");
-    
-    assert!(!request.is_flags_disabled(), "Default should be flags enabled");
+
+    assert!(
+        !request.is_flags_disabled(),
+        "Default should be flags enabled"
+    );
 }

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -1237,3 +1237,46 @@ async fn test_fetch_and_filter_flags() {
         .iter()
         .all(|f| f.key.starts_with(SURVEY_TARGETING_FLAG_PREFIX)));
 }
+
+#[test]
+fn test_disable_flags_request_parsing() {
+    // Test that disable_flags=true is properly parsed and detected
+    
+    // Test case 1: disable_flags=true should be detected
+    let payload_with_disable = json!({
+        "token": "test_token",
+        "distinct_id": "test_user",
+        "disable_flags": true
+    });
+    
+    let bytes = Bytes::from(payload_with_disable.to_string());
+    let request = crate::flags::flag_request::FlagRequest::from_bytes(bytes)
+        .expect("Failed to parse request with disable_flags=true");
+    
+    assert!(request.is_flags_disabled(), "disable_flags=true should be detected");
+    
+    // Test case 2: disable_flags=false should NOT be detected as disabled
+    let payload_with_enable = json!({
+        "token": "test_token", 
+        "distinct_id": "test_user",
+        "disable_flags": false
+    });
+    
+    let bytes = Bytes::from(payload_with_enable.to_string());
+    let request = crate::flags::flag_request::FlagRequest::from_bytes(bytes)
+        .expect("Failed to parse request with disable_flags=false");
+    
+    assert!(!request.is_flags_disabled(), "disable_flags=false should not be detected as disabled");
+    
+    // Test case 3: No disable_flags field should default to enabled
+    let payload_default = json!({
+        "token": "test_token",
+        "distinct_id": "test_user"
+    });
+    
+    let bytes = Bytes::from(payload_default.to_string());
+    let request = crate::flags::flag_request::FlagRequest::from_bytes(bytes)
+        .expect("Failed to parse request without disable_flags");
+    
+    assert!(!request.is_flags_disabled(), "Default should be flags enabled");
+}


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

When proxying decide to flags, there are increased 400s. Logs and graphs show that flags saw an increase in `Request quota limited` errors (~200 extra per minute). This is due to how we check flag quotas before checking if flags are disabled in the Rust flags service, whereas in decide, we check disable_flags first and skip quota checking entirely for those requests.

https://github.com/PostHog/posthog/blob/4f4d702af6bde811f9f5d19f7ddfc8036b211099/posthog/api/decide.py#L413-L427


<img width="1006" height="537" alt="Screenshot 2025-08-19 at 2 09 03 PM" src="https://github.com/user-attachments/assets/03e1ca23-70ab-42ca-a204-84564a6d4784" />

https://grafana.prod-us.posthog.dev/goto/zDplAMXHR?orgId=1

## Changes

Check if `disable_flags=true` before quota checking in the Rust flags handler to match Python's behavior.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
