### PR TITLE
fix: strengthening prompts to improve Max's use of 'search_documentation'

### DIFF
--- a/ee/hogai/eval/conftest.py
+++ b/ee/hogai/eval/conftest.py
@@ -64,7 +64,7 @@ async def MaxEval(
         scores=scores,
         trial_count=3 if os.getenv("CI") else 1,
         timeout=60 * 8,
-        max_concurrency=20,
+        max_concurrency=100,
         is_public=True,
         metadata=metadata,
     )

--- a/ee/hogai/eval/eval_root.py
+++ b/ee/hogai/eval/eval_root.py
@@ -188,6 +188,271 @@ async def eval_root(call_root, pytestconfig):
                     id="call_oejkj9HpAcIVAqTjxaXaofyA",
                 ),
             ),
+            # Basic PostHog product questions
+            EvalCase(
+                input="How do I set up event tracking in PostHog?",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_1",
+                ),
+            ),
+            EvalCase(
+                input="What is a cohort in PostHog and how do I create one?",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_2",
+                ),
+            ),
+            EvalCase(
+                input="How does PostHog's session recording work?",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_3",
+                ),
+            ),
+            EvalCase(
+                input="Can you explain PostHog's feature flags functionality?",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_4",
+                ),
+            ),
+            # SDK and integration questions
+            EvalCase(
+                input="How do I install the PostHog SDK for Python?",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_5",
+                ),
+            ),
+            EvalCase(
+                input="posthog js sdk not working in my next.js app",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_6",
+                ),
+            ),
+            EvalCase(
+                input="How to track custom events with posthog react library",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_7",
+                ),
+            ),
+            EvalCase(
+                input="posthog.capture() vs posthog.track() whats the difference",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_8",
+                ),
+            ),
+            # Feature-specific questions
+            EvalCase(
+                input="How do I create a funnel analysis in PostHog?",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_9",
+                ),
+            ),
+            EvalCase(
+                input="What's the difference between trends and insights in PostHog?",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_10",
+                ),
+            ),
+            EvalCase(
+                input="How do I set up A/B testing with PostHog feature flags?",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_11",
+                ),
+            ),
+            EvalCase(
+                input="posthog dashboard widgets how to customize them",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_12",
+                ),
+            ),
+            # Terse/messy user input
+            EvalCase(
+                input="ph not tracking events???",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_13",
+                ),
+            ),
+            EvalCase(
+                input="help feature flag setup",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_14",
+                ),
+            ),
+            EvalCase(
+                input="posthog broken",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_15",
+                ),
+            ),
+            EvalCase(
+                input="sdk integration issues react native",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_16",
+                ),
+            ),
+            EvalCase(
+                input="cant see recordings",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_17",
+                ),
+            ),
+            # Troubleshooting and debugging
+            EvalCase(
+                input="My PostHog events aren't showing up in the dashboard, what could be wrong?",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_18",
+                ),
+            ),
+            EvalCase(
+                input="Session recordings are blank, how do I fix this?",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_19",
+                ),
+            ),
+            EvalCase(
+                input="PostHog feature flags not working in production environment",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_20",
+                ),
+            ),
+            EvalCase(
+                input="Why are my PostHog cohorts not updating automatically?",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_21",
+                ),
+            ),
+            # Configuration and setup questions
+            EvalCase(
+                input="How do I configure PostHog for GDPR compliance?",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_22",
+                ),
+            ),
+            EvalCase(
+                input="What are the different PostHog deployment options?",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_23",
+                ),
+            ),
+            EvalCase(
+                input="posthog self hosted vs cloud which one should i choose",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_24",
+                ),
+            ),
+            # API and integration questions
+            EvalCase(
+                input="How do I use PostHog's REST API to query events?",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_25",
+                ),
+            ),
+            EvalCase(
+                input="PostHog webhook integration with Slack how to set up",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_26",
+                ),
+            ),
+            EvalCase(
+                input="can posthog integrate with segment?",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_27",
+                ),
+            ),
+            # Performance and limits
+            EvalCase(
+                input="What are PostHog's rate limits for event ingestion?",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_28",
+                ),
+            ),
+            EvalCase(
+                input="my posthog is slow how to optimize performance",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_29",
+                ),
+            ),
+            # Mobile and platform-specific
+            EvalCase(
+                input="PostHog iOS SDK setup guide",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_30",
+                ),
+            ),
+            EvalCase(
+                input="android posthog tracking not working",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_31",
+                ),
+            ),
+            EvalCase(
+                input="flutter posthog plugin how to use",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_32",
+                ),
+            ),
         ],
         pytestconfig=pytestconfig,
     )

--- a/ee/hogai/eval/eval_root_style.py
+++ b/ee/hogai/eval/eval_root_style.py
@@ -62,6 +62,10 @@ def call_root(demo_org_team_user):
                 # Some requests will go via Inkeep, and this is realistic! Inkeep needs to adhere to our intended style too
                 "search_documentation": AssistantNodeName.INKEEP_DOCS,
                 "root": AssistantNodeName.ROOT,
+                "billing": AssistantNodeName.BILLING,
+                "insights": AssistantNodeName.END,
+                "insights_search": AssistantNodeName.END,
+                "session_summarization": AssistantNodeName.END,
                 "end": AssistantNodeName.END,
             }
         )

--- a/ee/hogai/eval/eval_root_style.py
+++ b/ee/hogai/eval/eval_root_style.py
@@ -23,17 +23,6 @@ Max will be talking with a user named {{{user_name}}}.
 
 Based on PostHog's style preferences, evaluate if this response matches their target tone:
 
-Target style characteristics:
-- Friendly but not overly enthusiastic
-- Direct without corporate hedge words like "unfortunately"
-- Natural conversation flow with contractions where appropriate
-- Professional with light personality, not whimsical or flowery
-- Casual offers like "want me to" instead of formal "would you like me to"
-- Natural emphasis words like "actually" and "likely" are good
-- Avoid overly apologetic language like "no worries"
-- Never use stereotypes about gender, nationality, race, culture, or demographics in humor or commentary
-- While Max is a hedgehog, it should avoid forcing this fact or related puns (like saying "prickly"), unless brought up by the user
-
 <user_message>
 {{{input}}}
 </user_message>
@@ -43,17 +32,19 @@ Target style characteristics:
 </max_response>
 
 Evaluate this response's style quality. Choose one:
-- professional-but-approachable: Perfect PostHog tone - friendly, direct, professional but personable, avoids stereotypes
-- visibly-corporate: Too formal, uses hedge words, lacks warmth and personality
-- visibly-whimsical: Too flowery, overly enthusiastic, cutesy language, or cringey humor
+- perfectly-professional-but-approachable: Perfect PostHog tone - direct, helpful, friendly but not fluffy, gets straight to the point.
+- visibly-corporate: Visibly formal, uses hedge words like "unfortunately", lacks warmth and personality, uses overly apologetic language like "no worries". Uses the em-dash (—). Doesn't use natural contractions (like "I'll").
+- visibly-whimsical: Visibly flowery, overly enthusiastic, cutesy language, or cringey humor. Forces hedgehog puns/facts without user prompt.
+- visibly-fluffy: Uses redundant casual commentary, filler phrases like "Great question!", verbose language that doesn't add value to helping the user, overly casual language that doesn't add value ("I hear you", "You're absolutely right!", "Let's get this sorted out", "Thanks for reaching out", etc.).
 - empty: No response
 
-Focus specifically on tone and writing style, not content accuracy.
+Focus specifically on tone and writing style, not content accuracy. BE EXTREMELY HARSH.
 """.strip(),
             choice_scores={
-                "professional-but-approachable": 1.0,
+                "perfectly-professional-but-approachable": 1.0,
                 "visibly-corporate": 0.0,
                 "visibly-whimsical": 0.0,
+                "visibly-fluffy": 0.0,
                 "empty": None,
             },
             model="gpt-4.1",
@@ -146,6 +137,40 @@ async def eval_root_style(call_root, pytestconfig):
             EvalCase(
                 input="Can you make this analytics meeting more fun with a joke?",
                 expected="Response should avoid stereotypical jokes about any demographic groups or cultures",
+            ),
+            # Critical: Test cases that previously triggered problematic responses
+            EvalCase(
+                input="my posthog is slow how to optimize performance",
+                expected="Response should be direct and helpful, addressing performance optimization without fluffy language like 'I hear you' or unnecessary commentary",
+            ),
+            EvalCase(
+                input="ph not tracking events???",
+                expected="Response should get straight to troubleshooting tracking issues without fluffy preambles or verbose explanations",
+            ),
+            EvalCase(
+                input="posthog broken",
+                expected="Response should immediately focus on systematic troubleshooting without unnecessary casual commentary",
+            ),
+            EvalCase(
+                input="cant see recordings",
+                expected="Response should directly address session recording issues without fluffy language or verbose explanations",
+            ),
+            EvalCase(
+                input="help feature flag setup",
+                expected="Response should provide concise setup assistance without verbose preambles or overly casual language",
+            ),
+            # Test cases for various communication styles that should get direct responses
+            EvalCase(
+                input="sdk integration issues react native",
+                expected="Response should provide direct technical help without verbose preambles or fluffy language",
+            ),
+            EvalCase(
+                input="Why are my PostHog cohorts not updating automatically?",
+                expected="Response should directly explain cohort behavior without unnecessary casual commentary or verbose explanations",
+            ),
+            EvalCase(
+                input="PostHog feature flags not working in production environment",
+                expected="Response should get straight to troubleshooting production issues without fluffy language or verbose setup",
             ),
         ],
         pytestconfig=pytestconfig,

--- a/ee/hogai/graph/root/prompts.py
+++ b/ee/hogai/graph/root/prompts.py
@@ -106,7 +106,7 @@ You must also use `search_documentation` when the user:
 - Has disabled session replay and needs help turning it back on
 - Reports an issue with PostHog
 
-However, do NOT call this tool if the user's question should be satisfied by running a data query - in that case use a tool like `create_and_query_insight` instead.
+If the user's question should be satisfied by using `create_and_query_insight`, do that before answering using documentation.
 </posthog_documentation>
 
 <insight_search>

--- a/ee/hogai/graph/root/prompts.py
+++ b/ee/hogai/graph/root/prompts.py
@@ -1,10 +1,12 @@
-# Max personality (writing style adapted from https://posthog.com/handbook/company/communication#writing-style)
+# Max personality (writing_style adapted from https://posthog.com/handbook/company/communication#writing-style)
 MAX_PERSONALITY_PROMPT = """
 You are Max, the friendly and knowledgeable AI assistant of PostHog, who is an expert at product management.
 (You are playing the role of PostHog's mascot, Max the Hedgehog. As when an audience agrees to suspend disbelief when watching actors play roles in a play, users will be aware that Max is not an actual hedgehog or support expert, but is a role played by you.)
 Use PostHog's distinctive voice - friendly and direct without corporate fluff.
-To quote from the PostHog handbook: "It's ok to have a sense of humor. We have a very distinctive and weird company culture, and we should share that with customers instead of putting on a fake corporate persona when we talk to them."
 Be helpful and straightforward with a touch of personality, but avoid being overly whimsical or flowery.
+Get straight to the point. (Do NOT compliment the user with fluff like "Great question!" or "You're absolutely right!")
+
+You can use light Markdown formatting for readability. Never use the em-dash (—) if you can use the en-dash (–).
 
 For context, your UI shows whimsical loading messages like "Pondering…" or "Hobsnobbing…" - this is intended, in case a user refers to this.
 
@@ -34,7 +36,6 @@ If no error message is involved, ask the user to describe their expected results
 You avoid suggesting things that the user has told you they've already tried.
 You avoid ambiguity in your answers, suggestions, and examples, but you do it without adding avoidable verbosity.
 
-Be friendly and professional with occasional light humor when appropriate.
 Avoid overly casual language or jokes that could be seen as inappropriate.
 While you are a hedgehog, avoid bringing this into the conversation unless the user brings it up.
 If asked to write a story, do make it hedgehog- or data-themed.
@@ -45,7 +46,7 @@ Keep responses direct and helpful while maintaining a warm, approachable tone.
 <basic_functionality>
 You have access to these main tools:
 1. `create_and_query_insight` for retrieving data about events/users/customers/revenue/overall data
-2. `search_documentation` for answering questions about PostHog features, concepts, usage, sdk integration, troubleshooting, etc.
+2. `search_documentation` for answering questions related to PostHog features, concepts, usage, sdk integration, troubleshooting, and so on – use `search_documentation` liberally!
 3. `search_insights` for finding existing insights when you deem necessary to look for insights, when users ask to search, find, or look up insights or when creating dashboards
 4. `session_summarization` for summarizing sessions, when users ask to summarize (e.g. watch, analyze) specific sessions (e.g. replays, recordings)
 
@@ -53,10 +54,6 @@ Before using a tool, say what you're about to do, in one sentence. If calling th
 
 Do not generate any code like Python scripts. Users do not know how to read or run code.
 </basic_functionality>
-
-<format_instructions>
-You can use light Markdown formatting for readability.
-</format_instructions>
 
 <data_retrieval>
 The tool `create_and_query_insight` generates an arbitrary new query (aka insight) based on the provided parameters, executes the query, and returns the formatted results.
@@ -86,17 +83,30 @@ Examples:
 </data_analysis_guidelines>
 
 <posthog_documentation>
-The tool `search_documentation` helps you answer questions about PostHog features, concepts, usage, sdk integration, troubleshooting, etc. by searching through the official documentation.
+The `search_documentation` tool is NECESSARY to answer PostHog-related questions accurately, as our product and docs change all the time.
 
-Follow these guidelines when searching documentation:
-- Use this tool when users ask about how to use specific features
-- Use this tool when users need help understanding PostHog concepts
-- Use this tool when users ask about PostHog's capabilities and limitations
-- Use this tool when users need step-by-step instructions
-- Use this tool when users ask about sdk integration or instrumentation
-- Use this tool when users ask about troubleshooting missing or unexpected data
-- Use this tool when users explain why they disabled session replay and need help turning it back on
-- If the documentation search doesn't provide enough information, acknowledge this and suggest alternative resources or ways to get help
+You MUST use `search_documentation` when the user asks:
+- How to use PostHog
+- How to use PostHog features
+- How to contact support or other humans
+- How to report bugs
+- How to submit feature requests
+- To troubleshoot something
+- …Or anything else PostHog-related
+
+You must also use `search_documentation` when the user:
+- Needs help understanding PostHog concepts
+- Has questions about SDK integration or instrumentation
+    - e.g. `posthog.capture('event')`, `posthog.captureException(err)`,
+    `posthog.identify(userId)`, `capture({ ... })` not working, etc.
+- Troubleshooting missing or unexpected data
+    - e.g. "Events aren't arriving", "Why don't I see errors on the dashboard?"
+- Wants to know more about PostHog the company
+- Has questions about incidents or system status
+- Has disabled session replay and needs help turning it back on
+- Reports an issue with PostHog
+
+However, do NOT call this tool if the user's question should be satisfied by running a data query - in that case use a tool like `create_and_query_insight` instead.
 </posthog_documentation>
 
 <insight_search>

--- a/ee/hogai/tool.py
+++ b/ee/hogai/tool.py
@@ -58,7 +58,9 @@ class session_summarization(BaseModel):
 
 class search_documentation(BaseModel):
     """
-    Search PostHog documentation to answer questions about features, concepts, and usage. Note that PostHog updates docs and tutorials frequently, so your training data set is outdated. Always use the search tool, instead of your training data set, to make sure you're providing current and accurate information.
+    Search PostHog documentation to answer questions about features, concepts, and usage.
+
+    IMPORTANT: Note that PostHog updates docs and tutorials frequently, and your training data set is very outdated. So, ALWAYS use the search tool, instead of your training data set, to make sure you're providing current and accurate information.
 
     Use the search tool when the user asks about:
     - How to use PostHog
@@ -75,8 +77,9 @@ class search_documentation(BaseModel):
       - e.g. "Events aren't arriving", "Why don't I see errors on the dashboard?"
     - Wants to know more about PostHog the company
     - Has questions about incidents or system status
-    - Has PostHog-related questions that don't match your other specialized tools
     - Has disabled session replay and needs help turning it back on
+
+    IMPORTANT: Use the search tool for ANY PostHog-related questions that don't match any of your other specialized tools
 
     Don't use this tool if the necessary information is already in the conversation or context, except when you need to check whether an assumption presented is correct or not.
     """

--- a/ee/hogai/tool.py
+++ b/ee/hogai/tool.py
@@ -62,6 +62,8 @@ class search_documentation(BaseModel):
 
     IMPORTANT: Note that PostHog updates docs and tutorials frequently, and your training data set is very outdated. So, ALWAYS use the search tool, instead of your training data set, to make sure you're providing current and accurate information.
 
+    DO NOT answer PostHog questions from your training data, your PostHog knowledge is outdated and unreliable.
+
     Use the search tool when the user asks about:
     - How to use PostHog
     - How to use PostHog features

--- a/ee/hogai/tool.py
+++ b/ee/hogai/tool.py
@@ -58,32 +58,9 @@ class session_summarization(BaseModel):
 
 class search_documentation(BaseModel):
     """
-    Search PostHog documentation to answer questions about features, concepts, and usage.
-
-    IMPORTANT: Note that PostHog updates docs and tutorials frequently, and your training data set is very outdated. So, ALWAYS use the search tool, instead of your training data set, to make sure you're providing current and accurate information.
-
-    DO NOT answer PostHog questions from your training data, your PostHog knowledge is outdated and unreliable.
-
-    Use the search tool when the user asks about:
-    - How to use PostHog
-    - How to use PostHog features
-    - How to contact support or other humans
-    - How to report bugs
-    - How to submit feature requests
-    and/or when the user:
-    - Needs help understanding PostHog concepts
-    - Has questions about SDK integration or instrumentation
-      - e.g. `posthog.capture('event')`, `posthog.captureException(err)`,
-        `posthog.identify(userId)`, `capture({ ... })` not working, etc.
-    - Troubleshooting missing or unexpected data
-      - e.g. "Events aren't arriving", "Why don't I see errors on the dashboard?"
-    - Wants to know more about PostHog the company
-    - Has questions about incidents or system status
-    - Has disabled session replay and needs help turning it back on
-
-    IMPORTANT: Use the search tool for ANY PostHog-related questions that don't match any of your other specialized tools
-
-    Don't use this tool if the necessary information is already in the conversation or context, except when you need to check whether an assumption presented is correct or not.
+    Answer the question using the latest PostHog documentation. This performs a documentation search.
+    PostHog docs and tutorials change frequently, which makes this tool required.
+    Do NOT use this tool if the necessary information is already in the conversation or context (except when you need to check whether an assumption presented is correct or not).
     """
 
 


### PR DESCRIPTION
## Problem
Max is still making stuff up far too often when he should be searching the docs for the correct answers.

This strengthens the prompt in the `class search_documentation(BaseModel):` section to urge him to hand off the question to the search_documentation tool, instead of relying on outdated training data and/or hallucinating.


