### PR TITLE
fix: fall back to base64 decode when no compression specified

### DIFF
--- a/rust/feature-flags/src/handler/decoding.rs
+++ b/rust/feature-flags/src/handler/decoding.rs
@@ -29,7 +29,8 @@ pub fn decode_request(
     match base_content_type {
         "application/json" | "text/plain" => {
             let decoded_body = decode_body(body, query.compression, headers)?;
-            FlagRequest::from_bytes(decoded_body)
+            
+            try_parse_with_fallbacks(decoded_body)
         }
         "application/x-www-form-urlencoded" => decode_form_data(body, query.compression),
         _ => {
@@ -121,6 +122,41 @@ fn decode_base64(body: Bytes) -> Result<Bytes, FlagError> {
         FlagError::RequestDecodingError(format!("Base64 decoding error: {e}"))
     })?;
     Ok(Bytes::from(decoded))
+}
+
+pub fn try_parse_with_fallbacks(body: Bytes) -> Result<FlagRequest, FlagError> {
+    // Strategy 1: Try parsing as JSON directly
+    if let Ok(request) = FlagRequest::from_bytes(body.clone()) {
+        return Ok(request);
+    }
+    
+    // Strategy 2: Try base64 decode then JSON 
+    // Even if compression is not specified, we still try to decode it as base64
+    tracing::warn!("Direct JSON parsing failed, trying base64 decode fallback");
+    match decode_base64(body.clone()) {
+        Ok(decoded) => {
+            match FlagRequest::from_bytes(decoded) {
+                Ok(request) => {
+                    inc(
+                        FLAG_REQUEST_KLUDGE_COUNTER,
+                        &[("type".to_string(), "base64_fallback_success".to_string())],
+                        1,
+                    );
+                    return Ok(request);
+                }
+                Err(e) => {
+                    tracing::warn!("Base64 decode succeeded but JSON parsing failed: {}", e);
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!("Base64 decode failed: {}", e);
+        }
+    }
+    
+    Err(FlagError::RequestDecodingError(
+        "invalid JSON".to_string()
+    ))
 }
 
 pub fn decode_form_data(

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use assert_json_diff::assert_json_include;
+use base64::{engine::general_purpose, Engine as _};
 
 use feature_flags::api::types::{FlagsResponse, LegacyFlagsResponse};
 use limiters::redis::ServiceName;
@@ -433,6 +434,59 @@ async fn it_handles_malformed_json() -> Result<()> {
         response_text.contains("Failed to decode request: invalid JSON"),
         "Unexpected error message: {response_text:?}"
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn it_handles_base64_auto_detection_fallback() -> Result<()> {
+    let config = DEFAULT_TEST_CONFIG.clone();
+    
+    // Set up Redis and PostgreSQL clients
+    let client = setup_redis_client(Some(config.redis_url.clone())).await;
+    let pg_client = setup_pg_reader_client(None).await;
+    let team = insert_new_team_in_redis(client.clone()).await.unwrap();
+    let token = team.api_token;
+
+    insert_new_team_in_pg(pg_client.clone(), Some(team.id))
+        .await
+        .unwrap();
+    
+    let server = ServerHandle::for_config(config).await;
+
+    let json_payload = json!({
+        "token": token,
+        "distinct_id": "user123",
+        "disable_flags": false
+    });
+
+    // Test 1: Normal JSON
+    let res = server
+        .send_flags_request(json_payload.to_string(), Some("2"), None)
+        .await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    // Test 2: Base64 encoded JSON with compression not specified
+    let json_string = json_payload.to_string();
+    let base64_payload = general_purpose::STANDARD.encode(json_string.as_bytes());
+    
+    let res = server
+        .send_flags_request(base64_payload, Some("2"), None)
+        .await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    // Test 3: Invalid base64 should fail gracefully
+    let invalid_base64 = "this is not valid base64 at all!";
+    let res = server
+        .send_flags_request(invalid_base64.to_string(), Some("2"), None)
+        .await;
+    assert_eq!(StatusCode::BAD_REQUEST, res.status());
+    
+    let response_text = res.text().await?;
+    assert!(
+        response_text.contains("Failed to decode request: invalid JSON"),
+        "Should fail with invalid JSON error for invalid base64: {response_text:?}"
+    );
+
     Ok(())
 }
 

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -440,7 +440,7 @@ async fn it_handles_malformed_json() -> Result<()> {
 #[tokio::test]
 async fn it_handles_base64_auto_detection_fallback() -> Result<()> {
     let config = DEFAULT_TEST_CONFIG.clone();
-    
+
     // Set up Redis and PostgreSQL clients
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let pg_client = setup_pg_reader_client(None).await;
@@ -450,7 +450,7 @@ async fn it_handles_base64_auto_detection_fallback() -> Result<()> {
     insert_new_team_in_pg(pg_client.clone(), Some(team.id))
         .await
         .unwrap();
-    
+
     let server = ServerHandle::for_config(config).await;
 
     let json_payload = json!({
@@ -468,7 +468,7 @@ async fn it_handles_base64_auto_detection_fallback() -> Result<()> {
     // Test 2: Base64 encoded JSON with compression not specified
     let json_string = json_payload.to_string();
     let base64_payload = general_purpose::STANDARD.encode(json_string.as_bytes());
-    
+
     let res = server
         .send_flags_request(base64_payload, Some("2"), None)
         .await;
@@ -480,7 +480,7 @@ async fn it_handles_base64_auto_detection_fallback() -> Result<()> {
         .send_flags_request(invalid_base64.to_string(), Some("2"), None)
         .await;
     assert_eq!(StatusCode::BAD_REQUEST, res.status());
-    
+
     let response_text = res.text().await?;
     assert!(
         response_text.contains("Failed to decode request: invalid JSON"),


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

In decide, if no compression is specified we still try to decode as base64 but we don't do this in flags. 

For example, the following request will return 400 for flags but 200 for decide:

```
curl "https://us.i.posthog.com/flags/?v=2" \
    -X POST -H 'Content-Type: application/json' \
    -d 'eyJhcGlfa2V5IjogInNUTUZQc0ZoZFAxU3NnIiwgImRpc3RpbmN0X2lkIjogImFuZHl6emhhbyJ9%3D%3D' -v
```
## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Make flags like decide by falling back to base64 decoding even when compression query parameter is not specified. 

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
