### PR TITLE
fix(flags): fix `user_blast_radius` for group key targeting

### DIFF
--- a/ee/clickhouse/queries/test/test_groups_join_query.py
+++ b/ee/clickhouse/queries/test/test_groups_join_query.py
@@ -46,3 +46,45 @@ def test_groups_join_query_filtering_with_custom_key_names(snapshot):
     )
 
     assert GroupsJoinQuery(filter, 2, join_key="call_me_industry").get_join_query() == snapshot
+
+
+def test_groups_filter_query_with_group_key():
+    """Test that $group_key property generates correct filter query"""
+    filter = Filter(
+        data={
+            "properties": [
+                {
+                    "key": "$group_key",
+                    "value": "workspace-123",
+                    "type": "group",
+                    "group_type_index": 0,
+                }
+            ]
+        }
+    )
+
+    query, params = GroupsJoinQuery(filter, 2).get_filter_query(group_type_index=0)
+
+    # Should contain direct comparison against group_key column
+    assert "group_key = %(test_group_key_0)s" in query or "group_key =" in query
+    # Should NOT contain JSON extraction
+    assert "JSONExtract" not in query
+
+    # Test with icontains operator
+    filter_icontains = Filter(
+        data={
+            "properties": [
+                {
+                    "key": "$group_key",
+                    "value": "workspace",
+                    "operator": "icontains",
+                    "type": "group",
+                    "group_type_index": 0,
+                }
+            ]
+        }
+    )
+
+    query, params = GroupsJoinQuery(filter_icontains, 2).get_filter_query(group_type_index=0)
+    assert "group_key ILIKE" in query
+    assert "%workspace%" in str(params.values())

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -29,6 +29,45 @@
      HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)
   '''
 # ---
+# name: TestBlastRadius.test_user_blast_radius_with_group_key_property
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT count(1)
+  FROM
+    (SELECT group_key,
+            argMax(group_properties, _timestamp) AS group_properties_0
+     FROM groups
+     WHERE team_id = 99999
+       AND group_type_index = 0
+     GROUP BY group_key
+     HAVING 1=1
+     AND (group_key = 'special-workspace'))
+  '''
+# ---
+# name: TestBlastRadius.test_user_blast_radius_with_group_key_property.1
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT count(DISTINCT group_key)
+  FROM groups
+  WHERE team_id = 99999
+    AND group_type_index = 0
+  '''
+# ---
+# name: TestBlastRadius.test_user_blast_radius_with_group_key_property.2
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT count(1)
+  FROM
+    (SELECT group_key,
+            argMax(group_properties, _timestamp) AS group_properties_0
+     FROM groups
+     WHERE team_id = 99999
+       AND group_type_index = 0
+     GROUP BY group_key
+     HAVING 1=1
+     AND (group_key ILIKE '%org:%'))
+  '''
+# ---
 # name: TestBlastRadius.test_user_blast_radius_with_groups
   '''
   /* user_id:0 request:_snapshot_ */

--- a/posthog/models/feature_flag/user_blast_radius.py
+++ b/posthog/models/feature_flag/user_blast_radius.py
@@ -45,7 +45,11 @@ def get_user_blast_radius(
             filter = cleaned_filter
 
             for property in filter.property_groups.flat:
-                if property.group_type_index is None or (property.group_type_index != group_type_index):
+                # Special case: $group_key doesn't need a group_type_index as it refers to the key itself
+                if property.key == "$group_key":
+                    # Set the group_type_index to match the aggregation group type
+                    property.group_type_index = group_type_index
+                elif property.group_type_index is None or (property.group_type_index != group_type_index):
                     raise ValidationError("Invalid group type index for feature flag condition.")
 
             groups_query, groups_query_params = GroupsJoinQuery(filter, team.id).get_filter_query(


### PR DESCRIPTION
## Problem

When creating feature flags with "Match by: Workspaces" and using "Group key" as a condition to target specific workspaces, the UI incorrectly displayed "0% (0 / X) of total workspaces" even when the specified workspace existed.

The root cause was that `$group_key` properties were being treated as JSON properties within the group_properties column, when they actually refer to the `group_key` column itself in the database.

Closes https://github.com/PostHog/posthog/issues/34188

## Changes

  1. `posthog/models/feature_flag/user_blast_radius.py`:
    - Auto-set the correct `group_type_index` for `$group_key` properties to prevent validation errors
  2. `posthog/models/property/util.py`:
    - Generate direct SQL column comparisons (`group_key = 'value'`) instead of JSON extraction queries
    - Support all standard operators (exact, is_not, icontains, regex, etc.) for group key matching

## How did you test this code?

  - Added `test_user_blast_radius_with_group_key_property` to verify blast radius calculations work correctly with $group_key
  - Added `test_groups_filter_query_with_group_key` to ensure proper SQL generation
