### PR TITLE
feat(capture): finalize event processing consolidation + condition session replay processing

### DIFF
--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -155,7 +155,6 @@ pub fn router<
         )
         .layer(DefaultBodyLimit::max(BATCH_BODY_SIZE));
 
-    // borrow the is_mirror_deploy flag to condintionally opt OUT of new capture processing if needed
     let batch_router = Router::new()
         .route(
             "/batch",

--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -156,120 +156,83 @@ pub fn router<
         .layer(DefaultBodyLimit::max(BATCH_BODY_SIZE));
 
     // borrow the is_mirror_deploy flag to condintionally opt OUT of new capture processing if needed
-    let mut batch_router = Router::new();
-    batch_router = if is_mirror_deploy {
-        batch_router
-            .route(
-                "/batch",
-                post(v0_endpoint::event)
-                    .get(v0_endpoint::event)
-                    .options(v0_endpoint::options),
-            )
-            .route(
-                "/batch/",
-                post(v0_endpoint::event)
-                    .get(v0_endpoint::event)
-                    .options(v0_endpoint::options),
-            )
-    } else {
-        batch_router
-            .route(
-                "/batch",
-                post(v0_endpoint::event_next)
-                    .get(v0_endpoint::event_next)
-                    .options(v0_endpoint::options),
-            )
-            .route(
-                "/batch/",
-                post(v0_endpoint::event_next)
-                    .get(v0_endpoint::event_next)
-                    .options(v0_endpoint::options),
-            )
-    };
-    batch_router = batch_router.layer(DefaultBodyLimit::max(BATCH_BODY_SIZE)); // Have to use this, rather than RequestBodyLimitLayer, because we use `Bytes` in the handler (this limit applies specifically to Bytes body types)
+    let batch_router = Router::new()
+        .route(
+            "/batch",
+            post(v0_endpoint::event)
+                .get(v0_endpoint::event)
+                .options(v0_endpoint::options),
+        )
+        .route(
+            "/batch/",
+            post(v0_endpoint::event)
+                .get(v0_endpoint::event)
+                .options(v0_endpoint::options),
+        )
+        .layer(DefaultBodyLimit::max(BATCH_BODY_SIZE)); // Have to use this, rather than RequestBodyLimitLayer, because we use `Bytes` in the handler (this limit applies specifically to Bytes body types)
 
-    let mut event_router = Router::new()
-        // legacy endpoints registered here
+    let event_router = Router::new()
+        .route(
+            "/i/v0/e",
+            post(v0_endpoint::event)
+                .get(v0_endpoint::event)
+                .options(v0_endpoint::options),
+        )
+        .route(
+            "/i/v0/e/",
+            post(v0_endpoint::event)
+                .get(v0_endpoint::event)
+                .options(v0_endpoint::options),
+        )
         .route(
             "/e",
-            post(v0_endpoint::event_next)
-                .get(v0_endpoint::event_next)
+            post(v0_endpoint::event)
+                .get(v0_endpoint::event)
                 .options(v0_endpoint::options),
         )
         .route(
             "/e/",
-            post(v0_endpoint::event_next)
-                .get(v0_endpoint::event_next)
+            post(v0_endpoint::event)
+                .get(v0_endpoint::event)
                 .options(v0_endpoint::options),
         )
         .route(
             "/track",
-            post(v0_endpoint::event_next)
-                .get(v0_endpoint::event_next)
+            post(v0_endpoint::event)
+                .get(v0_endpoint::event)
                 .options(v0_endpoint::options),
         )
         .route(
             "/track/",
-            post(v0_endpoint::event_next)
-                .get(v0_endpoint::event_next)
+            post(v0_endpoint::event)
+                .get(v0_endpoint::event)
                 .options(v0_endpoint::options),
         )
         .route(
             "/engage",
-            post(v0_endpoint::event_next)
-                .get(v0_endpoint::event_next)
+            post(v0_endpoint::event)
+                .get(v0_endpoint::event)
                 .options(v0_endpoint::options),
         )
         .route(
             "/engage/",
-            post(v0_endpoint::event_next)
-                .get(v0_endpoint::event_next)
+            post(v0_endpoint::event)
+                .get(v0_endpoint::event)
                 .options(v0_endpoint::options),
         )
         .route(
             "/capture",
-            post(v0_endpoint::event_next)
-                .get(v0_endpoint::event_next)
+            post(v0_endpoint::event)
+                .get(v0_endpoint::event)
                 .options(v0_endpoint::options),
         )
         .route(
             "/capture/",
-            post(v0_endpoint::event_next)
-                .get(v0_endpoint::event_next)
+            post(v0_endpoint::event)
+                .get(v0_endpoint::event)
                 .options(v0_endpoint::options),
-        );
-
-    // borrow the is_mirror_deploy flag to condintionally opt OUT of new capture processing if needed
-    event_router = if is_mirror_deploy {
-        event_router
-            .route(
-                "/i/v0/e",
-                post(v0_endpoint::event_next)
-                    .get(v0_endpoint::event_next)
-                    .options(v0_endpoint::options),
-            )
-            .route(
-                "/i/v0/e/",
-                post(v0_endpoint::event_next)
-                    .get(v0_endpoint::event_next)
-                    .options(v0_endpoint::options),
-            )
-    } else {
-        event_router
-            .route(
-                "/i/v0/e",
-                post(v0_endpoint::event)
-                    .get(v0_endpoint::event)
-                    .options(v0_endpoint::options),
-            )
-            .route(
-                "/i/v0/e/",
-                post(v0_endpoint::event_next)
-                    .get(v0_endpoint::event_next)
-                    .options(v0_endpoint::options),
-            )
-    };
-    event_router = event_router.layer(DefaultBodyLimit::max(EVENT_BODY_SIZE));
+        )
+        .layer(DefaultBodyLimit::max(EVENT_BODY_SIZE));
 
     let status_router = Router::new()
         .route("/", get(index))

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -288,7 +288,7 @@ async fn handle_event_payload(
 
 /// handle_deprecated is the request payload processor we're attempting to eliminate via
 /// consolidation with the handle_event_payload function.
-async fn handle_common(
+async fn handle_deprecated(
     state: &State<router::State>,
     InsecureClientIp(ip): &InsecureClientIp,
     meta: &EventQuery,
@@ -341,9 +341,9 @@ async fn handle_common(
                     ))
                 })?;
 
-            // by setting compression "unsupported" here, we route handle_common
+            // by setting compression "unsupported" here, we route handle_deprecated
             // outputs into the old RawRequest hydration behavior, prior to adding
-            // handle_next shims. handle_common doesn't extract compression hints
+            // handle_next shims. handle_deprecated doesn't extract compression hints
             // as reliably as it should, and is probably losing some data due to
             // this. We'll circle back once the legacy shims ship
             RawRequest::from_bytes(
@@ -541,7 +541,7 @@ pub async fn recording(
     {
         handle_event_payload(&state, &ip, &mut params, &headers, &method, &path, body).await
     } else {
-        handle_common(&state, &ip, &params, &headers, &method, &path, body).await
+        handle_deprecated(&state, &ip, &params, &headers, &method, &path, body).await
     };
 
     match result {

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -312,7 +312,6 @@ async fn handle_common(
     Span::current().record("method", method.as_str());
     Span::current().record("path", path.as_str().trim_end_matches('/'));
 
-    // TODO(eli): add event_next compression and lib_version extraction into this flow if we don't unify entirely
     let resolved_cmp = format!("{}", meta.compression.unwrap_or_default());
     Span::current().record("version", meta.lib_version.clone());
     Span::current().record("compression", resolved_cmp);
@@ -480,7 +479,7 @@ pub async fn event(
 
         Err(err) => {
             report_internal_error_metrics(err.to_metric_tag(), "parsing");
-            error!("event_next: request payload processing error: {:?}", err);
+            error!("event: request payload processing error: {:?}", err);
             Err(err)
         }
 
@@ -496,7 +495,7 @@ pub async fn event(
             {
                 report_dropped_events(err.to_metric_tag(), events.len() as u64);
                 report_internal_error_metrics(err.to_metric_tag(), "processing");
-                error!("event_next: rejected payload: {}", err);
+                error!("event: rejected payload: {}", err);
                 return Err(err);
             }
 

--- a/rust/capture/tests/billing_limits.rs
+++ b/rust/capture/tests/billing_limits.rs
@@ -350,7 +350,7 @@ async fn test_no_billing_limit_retains_all_events() {
     assert!(event_names.contains(&"click".to_string()));
 }
 
-// Test with /i/v0/e endpoint (handle_common)
+// Test with /i/v0/e endpoint
 #[tokio::test]
 async fn test_billing_limit_retains_survey_events_on_i_endpoint() {
     let token = "test_token_i_endpoint";


### PR DESCRIPTION
## Problem
Two fold:

* With the migration to consolidate all `CaptureMode::Events` endpoints to a single processing pipeline, we can remove the last round of conditional processing
* With only `CaptureMode::Recordings` blocking the final removal of the old processing codepath, we must condition processing of the `/s/` route for smoke testing

## Changes

* Removes conditional logic from `CaptureMode::Events` endpoint handler routing
* Add conditional logic to `CaptureMode::Recordings` endpoint for smoke testing prior to migration

## How did you test this code?
Locally and in CI

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
