### PR TITLE
fix: don't require distinct_id if disable_flags=true

### DIFF
--- a/rust/feature-flags/src/handler/authentication.rs
+++ b/rust/feature-flags/src/handler/authentication.rs
@@ -8,10 +8,17 @@ use super::{decoding, types::RequestContext};
 pub async fn parse_and_authenticate(
     context: &RequestContext,
     flag_service: &FlagService,
-) -> Result<(String, String, FlagRequest), FlagError> {
+) -> Result<(Option<String>, String, FlagRequest), FlagError> {
     let request = decoding::decode_request(&context.headers, context.body.clone(), &context.meta)?;
     let token = request.extract_token()?;
-    let distinct_id = request.extract_distinct_id()?;
     let verified_token = flag_service.verify_token(&token).await?;
+    
+    // Only validate distinct_id if flags are NOT disabled
+    let distinct_id = if request.is_flags_disabled() {
+        None 
+    } else {
+        Some(request.extract_distinct_id()?)
+    };
+    
     Ok((distinct_id, verified_token, request))
 }

--- a/rust/feature-flags/src/handler/authentication.rs
+++ b/rust/feature-flags/src/handler/authentication.rs
@@ -12,13 +12,13 @@ pub async fn parse_and_authenticate(
     let request = decoding::decode_request(&context.headers, context.body.clone(), &context.meta)?;
     let token = request.extract_token()?;
     let verified_token = flag_service.verify_token(&token).await?;
-    
+
     // Only validate distinct_id if flags are NOT disabled
     let distinct_id = if request.is_flags_disabled() {
-        None 
+        None
     } else {
         Some(request.extract_distinct_id()?)
     };
-    
+
     Ok((distinct_id, verified_token, request))
 }

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -41,11 +41,11 @@ pub async fn process_request(context: RequestContext) -> Result<FlagsResponse, F
         let (original_distinct_id, verified_token, request) =
             authentication::parse_and_authenticate(&context, &flag_service).await?;
 
-        let distinct_id_for_logging = original_distinct_id.clone();
+        let distinct_id_for_logging = original_distinct_id.clone().unwrap_or_else(|| "disabled".to_string());
 
         tracing::debug!(
             "Authentication completed for distinct_id: {}",
-            original_distinct_id
+            distinct_id_for_logging
         );
 
         let team = flag_service
@@ -67,9 +67,13 @@ pub async fn process_request(context: RequestContext) -> Result<FlagsResponse, F
             warn!("Request quota limited");
             quota_limited_response
         } else {
-            let distinct_id =
-                cookieless::handle_distinct_id(&context, &request, &team, original_distinct_id)
-                    .await?;
+            let distinct_id = cookieless::handle_distinct_id(
+                &context,
+                &request,
+                &team,
+                original_distinct_id.expect("distinct_id should be present when flags are not disabled"),
+            )
+            .await?;
 
             tracing::debug!("Distinct ID resolved: {}", distinct_id);
 

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -41,7 +41,9 @@ pub async fn process_request(context: RequestContext) -> Result<FlagsResponse, F
         let (original_distinct_id, verified_token, request) =
             authentication::parse_and_authenticate(&context, &flag_service).await?;
 
-        let distinct_id_for_logging = original_distinct_id.clone().unwrap_or_else(|| "disabled".to_string());
+        let distinct_id_for_logging = original_distinct_id
+            .clone()
+            .unwrap_or_else(|| "disabled".to_string());
 
         tracing::debug!(
             "Authentication completed for distinct_id: {}",
@@ -71,7 +73,8 @@ pub async fn process_request(context: RequestContext) -> Result<FlagsResponse, F
                 &context,
                 &request,
                 &team,
-                original_distinct_id.expect("distinct_id should be present when flags are not disabled"),
+                original_distinct_id
+                    .expect("distinct_id should be present when flags are not disabled"),
             )
             .await?;
 

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -491,6 +491,49 @@ async fn it_handles_base64_auto_detection_fallback() -> Result<()> {
 }
 
 #[tokio::test]
+async fn it_handles_disable_flags_without_distinct_id() -> Result<()> {
+    let config = DEFAULT_TEST_CONFIG.clone();
+    
+    // Set up Redis and PostgreSQL clients
+    let client = setup_redis_client(Some(config.redis_url.clone())).await;
+    let pg_client = setup_pg_reader_client(None).await;
+    let team = insert_new_team_in_redis(client.clone()).await.unwrap();
+    let token = team.api_token;
+
+    insert_new_team_in_pg(pg_client.clone(), Some(team.id))
+        .await
+        .unwrap();
+
+    // Add some flags for the team to make this a meaningful test
+    insert_flags_for_team_in_redis(client.clone(), team.id, team.project_id, None)
+        .await
+        .unwrap();
+    
+    let server = ServerHandle::for_config(config).await;
+
+    // Test 1: Request with disable_flags=true but NO distinct_id should succeed
+    // This matches Python's decide behavior
+    let disabled_payload = json!({
+        "token": token,
+        "disable_flags": true
+        // Note: no distinct_id field
+    });
+
+    let res = server
+        .send_flags_request(disabled_payload.to_string(), Some("2"), None)
+        .await;
+    
+    // Should return 200 OK, not 400 BAD_REQUEST
+    assert_eq!(StatusCode::OK, res.status());
+    
+    let response_body = res.json::<FlagsResponse>().await?;
+    // Should return empty flags since they're disabled
+    assert!(response_body.flags.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn it_handles_quota_limiting() -> Result<()> {
     let config = DEFAULT_TEST_CONFIG.clone();
 

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -493,7 +493,7 @@ async fn it_handles_base64_auto_detection_fallback() -> Result<()> {
 #[tokio::test]
 async fn it_handles_disable_flags_without_distinct_id() -> Result<()> {
     let config = DEFAULT_TEST_CONFIG.clone();
-    
+
     // Set up Redis and PostgreSQL clients
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let pg_client = setup_pg_reader_client(None).await;
@@ -504,15 +504,13 @@ async fn it_handles_disable_flags_without_distinct_id() -> Result<()> {
         .await
         .unwrap();
 
-    // Add some flags for the team to make this a meaningful test
     insert_flags_for_team_in_redis(client.clone(), team.id, team.project_id, None)
         .await
         .unwrap();
-    
+
     let server = ServerHandle::for_config(config).await;
 
-    // Test 1: Request with disable_flags=true but NO distinct_id should succeed
-    // This matches Python's decide behavior
+    // Request with disable_flags=true but NO distinct_id should succeed
     let disabled_payload = json!({
         "token": token,
         "disable_flags": true
@@ -522,10 +520,9 @@ async fn it_handles_disable_flags_without_distinct_id() -> Result<()> {
     let res = server
         .send_flags_request(disabled_payload.to_string(), Some("2"), None)
         .await;
-    
-    // Should return 200 OK, not 400 BAD_REQUEST
+
     assert_eq!(StatusCode::OK, res.status());
-    
+
     let response_body = res.json::<FlagsResponse>().await?;
     // Should return empty flags since they're disabled
     assert!(response_body.flags.is_empty());


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

In decide, when `disable_flags=true` and a distinct_id is not included in the request, a 200 is returned. However, flags returns a 400. 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Don't require distinct_id if "disable_flags=true"

## How did you test this code?

Integration test, locally.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
