### PR TITLE
chore: add warn logs for 400s

### DIFF
--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -190,12 +190,18 @@ impl IntoResponse for FlagError {
             FlagError::CookielessError(err) => {
                 match err {
                     // 400 Bad Request errors - client-side issues
-                    CookielessManagerError::MissingProperty(prop) =>
-                        (StatusCode::BAD_REQUEST, format!("Missing required property: {prop}")),
-                    CookielessManagerError::UrlParseError(e) =>
-                        (StatusCode::BAD_REQUEST, format!("Invalid URL: {e}")),
-                    CookielessManagerError::InvalidTimestamp(msg) =>
-                        (StatusCode::BAD_REQUEST, format!("Invalid timestamp: {msg}")),
+                    CookielessManagerError::MissingProperty(prop) => {
+                        tracing::warn!("Cookieless missing property: {}", prop);
+                        (StatusCode::BAD_REQUEST, format!("Missing required property: {prop}"))
+                    },
+                    CookielessManagerError::UrlParseError(e) => {
+                        tracing::warn!("Cookieless URL parse error: {}", e);
+                        (StatusCode::BAD_REQUEST, format!("Invalid URL: {e}"))
+                    },
+                    CookielessManagerError::InvalidTimestamp(msg) => {
+                        tracing::warn!("Cookieless invalid timestamp: {}", msg);
+                        (StatusCode::BAD_REQUEST, format!("Invalid timestamp: {msg}"))
+                    },
 
                     // 500 Internal Server Error - server-side issues
                     err @ (CookielessManagerError::HashError(_) |


### PR DESCRIPTION
## Problem


I missed these when I was adding warn logs to find the source of increased 400s when proxying decide to flags. 
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Add warn logs. 
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
