### PR TITLE
feat: add limit for the number of merged distinct IDs

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -280,6 +280,8 @@ export function getDefaultConfig(): PluginsServerConfig {
         PERSON_PROPERTIES_DB_CONSTRAINT_LIMIT_BYTES: 655360,
         // Trim target is the customer-facing limit (512kb)
         PERSON_PROPERTIES_TRIM_TARGET_BYTES: 512 * 1024,
+        // Limit per merge for moving distinct IDs. 0 disables limiting (move all)
+        PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: 0,
         GROUP_BATCH_WRITING_MAX_CONCURRENT_UPDATES: 10,
         GROUP_BATCH_WRITING_OPTIMISTIC_UPDATE_RETRY_INTERVAL_MS: 50,
         GROUP_BATCH_WRITING_MAX_OPTIMISTIC_UPDATE_RETRIES: 5,

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -193,6 +193,8 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
     PERSON_UPDATE_CALCULATE_PROPERTIES_SIZE: number
     PERSON_PROPERTIES_DB_CONSTRAINT_LIMIT_BYTES: number // maximum size in bytes for person properties JSON as stored, checked via pg_column_size(properties)
     PERSON_PROPERTIES_TRIM_TARGET_BYTES: number // target size in bytes we trim JSON to before writing (customer-facing 512kb)
+    // Limit per merge for moving distinct IDs. 0 disables limiting.
+    PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: number
     GROUP_BATCH_WRITING_MAX_CONCURRENT_UPDATES: number // maximum number of concurrent updates to groups table per batch
     GROUP_BATCH_WRITING_MAX_OPTIMISTIC_UPDATE_RETRIES: number // maximum number of retries for optimistic update
     GROUP_BATCH_WRITING_OPTIMISTIC_UPDATE_RETRY_INTERVAL_MS: number // starting interval for exponential backoff between retries for optimistic update

--- a/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
@@ -19,6 +19,11 @@ export async function processPersonsStep(
     processPerson: boolean,
     personStoreBatch: PersonsStoreForBatch
 ): Promise<[PluginEvent, Person, Promise<void>]> {
+    const moveLimit =
+        runner.hub.PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT === 0
+            ? undefined
+            : runner.hub.PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT
+
     const context = new PersonContext(
         event,
         team,
@@ -28,7 +33,7 @@ export async function processPersonsStep(
         runner.hub.db.kafkaProducer,
         personStoreBatch,
         runner.hub.PERSON_JSONB_SIZE_ESTIMATE_ENABLE,
-        runner.hub.PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT
+        moveLimit
     )
 
     const processor = new PersonEventProcessor(

--- a/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
@@ -27,7 +27,8 @@ export async function processPersonsStep(
         processPerson,
         runner.hub.db.kafkaProducer,
         personStoreBatch,
-        runner.hub.PERSON_JSONB_SIZE_ESTIMATE_ENABLE
+        runner.hub.PERSON_JSONB_SIZE_ESTIMATE_ENABLE,
+        runner.hub.PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT
     )
 
     const processor = new PersonEventProcessor(

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
@@ -1012,7 +1012,7 @@ describe('BatchWritingPersonStore', () => {
             await personStoreForBatch.moveDistinctIds(sourcePerson, targetPerson, 'target-distinct')
 
             // Verify the repository method was called
-            expect(mockRepo.moveDistinctIds).toHaveBeenCalledWith(sourcePerson, targetPerson)
+            expect(mockRepo.moveDistinctIds).toHaveBeenCalledWith(sourcePerson, targetPerson, undefined)
 
             // Step 4: Verify that cached merged properties are preserved
             const cacheAfterMove = personStoreForBatch.getCachedPersonForUpdateByDistinctId(teamId, 'target-distinct')
@@ -1066,7 +1066,7 @@ describe('BatchWritingPersonStore', () => {
             await personStoreForBatch.moveDistinctIds(sourcePerson, targetPerson, 'target-distinct')
 
             // Verify the repository method was called
-            expect(mockRepo.moveDistinctIds).toHaveBeenCalledWith(sourcePerson, targetPerson)
+            expect(mockRepo.moveDistinctIds).toHaveBeenCalledWith(sourcePerson, targetPerson, undefined)
 
             // Should create fresh cache from target person
             const cacheAfterMove = personStoreForBatch.getCachedPersonForUpdateByDistinctId(teamId, 'target-distinct')
@@ -1110,7 +1110,7 @@ describe('BatchWritingPersonStore', () => {
             await personStoreForBatch.moveDistinctIds(sourcePerson, targetPerson, 'target-distinct')
 
             // Verify the repository method was called
-            expect(mockRepo.moveDistinctIds).toHaveBeenCalledWith(sourcePerson, targetPerson)
+            expect(mockRepo.moveDistinctIds).toHaveBeenCalledWith(sourcePerson, targetPerson, undefined)
 
             // Verify source cache is cleared
             expect(personStoreForBatch.getCachedPersonForUpdateByPersonId(teamId, sourcePerson.id)).toBeUndefined()
@@ -1180,7 +1180,7 @@ describe('BatchWritingPersonStore', () => {
             await personStoreForBatch.moveDistinctIds(sourcePerson, targetPerson, 'target-distinct')
 
             // Verify the repository method was called
-            expect(mockRepo.moveDistinctIds).toHaveBeenCalledWith(sourcePerson, targetPerson)
+            expect(mockRepo.moveDistinctIds).toHaveBeenCalledWith(sourcePerson, targetPerson, undefined)
 
             // Step 4: Verify all merged properties are preserved
             const finalCache = personStoreForBatch.getCachedPersonForUpdateByDistinctId(teamId, 'target-distinct')

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
@@ -88,6 +88,7 @@ describe('BatchWritingPersonStore', () => {
     const createMockRepository = () => {
         const mockRepo = {
             fetchPerson: jest.fn().mockResolvedValue(person),
+            fetchPersonDistinctIds: jest.fn().mockResolvedValue([]),
             createPerson: jest.fn().mockResolvedValue([person, []]),
             updatePerson: jest.fn().mockResolvedValue([person, [], false]),
             updatePersonAssertVersion: jest.fn().mockResolvedValue([person.version + 1, []]),
@@ -107,6 +108,7 @@ describe('BatchWritingPersonStore', () => {
 
     const createMockTransaction = () => {
         const mockTransaction = {
+            fetchPersonDistinctIds: jest.fn().mockResolvedValue([]),
             createPerson: jest.fn().mockResolvedValue([person, []]),
             updatePerson: jest.fn().mockResolvedValue([person, [], false]),
             deletePerson: jest.fn().mockResolvedValue([]),

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
@@ -113,7 +113,7 @@ describe('BatchWritingPersonStore', () => {
             updatePerson: jest.fn().mockResolvedValue([person, [], false]),
             deletePerson: jest.fn().mockResolvedValue([]),
             addDistinctId: jest.fn().mockResolvedValue([]),
-            moveDistinctIds: jest.fn().mockResolvedValue({ success: true, messages: [] }),
+            moveDistinctIds: jest.fn().mockResolvedValue({ success: true, messages: [], distinctIdsMoved: [] }),
             addPersonlessDistinctIdForMerge: jest.fn().mockResolvedValue(true),
             updateCohortsAndFeatureFlagsForMerge: jest.fn().mockResolvedValue(undefined),
         }
@@ -1009,10 +1009,13 @@ describe('BatchWritingPersonStore', () => {
             expect(cacheAfterMerge?.is_identified).toBe(true)
 
             // Step 3: moveDistinctIds - this should preserve the merged cache
-            await personStoreForBatch.moveDistinctIds(sourcePerson, targetPerson, 'target-distinct')
+            const tx = createMockTransaction() as any
+            await personStoreForBatch.moveDistinctIds(sourcePerson, targetPerson, 'target-distinct', undefined, tx)
 
             // Verify the repository method was called
-            expect(mockRepo.moveDistinctIds).toHaveBeenCalledWith(sourcePerson, targetPerson, undefined)
+            // moveDistinctIds is executed via tx, not repo
+            expect(tx.moveDistinctIds).toHaveBeenCalledTimes(1)
+            expect(tx.moveDistinctIds).toHaveBeenCalledWith(sourcePerson, targetPerson, undefined)
 
             // Step 4: Verify that cached merged properties are preserved
             const cacheAfterMove = personStoreForBatch.getCachedPersonForUpdateByDistinctId(teamId, 'target-distinct')
@@ -1063,10 +1066,12 @@ describe('BatchWritingPersonStore', () => {
             expect(personStoreForBatch.getCachedPersonForUpdateByPersonId(teamId, targetPerson.id)).toBeUndefined()
 
             // Move distinct IDs
-            await personStoreForBatch.moveDistinctIds(sourcePerson, targetPerson, 'target-distinct')
+            const tx = createMockTransaction() as any
+            await personStoreForBatch.moveDistinctIds(sourcePerson, targetPerson, 'target-distinct', undefined, tx)
 
             // Verify the repository method was called
-            expect(mockRepo.moveDistinctIds).toHaveBeenCalledWith(sourcePerson, targetPerson, undefined)
+            expect(tx.moveDistinctIds).toHaveBeenCalledTimes(1)
+            expect(tx.moveDistinctIds).toHaveBeenCalledWith(sourcePerson, targetPerson, undefined)
 
             // Should create fresh cache from target person
             const cacheAfterMove = personStoreForBatch.getCachedPersonForUpdateByDistinctId(teamId, 'target-distinct')
@@ -1107,10 +1112,12 @@ describe('BatchWritingPersonStore', () => {
             expect(personStoreForBatch.getCachedPersonForUpdateByPersonId(teamId, sourcePerson.id)).toBeDefined()
 
             // Move distinct IDs
-            await personStoreForBatch.moveDistinctIds(sourcePerson, targetPerson, 'target-distinct')
+            const tx = createMockTransaction() as any
+            await personStoreForBatch.moveDistinctIds(sourcePerson, targetPerson, 'target-distinct', undefined, tx)
 
             // Verify the repository method was called
-            expect(mockRepo.moveDistinctIds).toHaveBeenCalledWith(sourcePerson, targetPerson, undefined)
+            expect(tx.moveDistinctIds).toHaveBeenCalledTimes(1)
+            expect(tx.moveDistinctIds).toHaveBeenCalledWith(sourcePerson, targetPerson, undefined)
 
             // Verify source cache is cleared
             expect(personStoreForBatch.getCachedPersonForUpdateByPersonId(teamId, sourcePerson.id)).toBeUndefined()
@@ -1177,10 +1184,12 @@ describe('BatchWritingPersonStore', () => {
             )
 
             // Step 3: moveDistinctIds
-            await personStoreForBatch.moveDistinctIds(sourcePerson, targetPerson, 'target-distinct')
+            const tx = createMockTransaction() as any
+            await personStoreForBatch.moveDistinctIds(sourcePerson, targetPerson, 'target-distinct', undefined, tx)
 
             // Verify the repository method was called
-            expect(mockRepo.moveDistinctIds).toHaveBeenCalledWith(sourcePerson, targetPerson, undefined)
+            expect(tx.moveDistinctIds).toHaveBeenCalledTimes(1)
+            expect(tx.moveDistinctIds).toHaveBeenCalledWith(sourcePerson, targetPerson, undefined)
 
             // Step 4: Verify all merged properties are preserved
             const finalCache = personStoreForBatch.getCachedPersonForUpdateByDistinctId(teamId, 'target-distinct')

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -498,13 +498,13 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         source: InternalPerson,
         target: InternalPerson,
         distinctId: string,
-        limit?: number,
-        tx?: PersonRepositoryTransaction
+        limit: number | undefined,
+        tx: PersonRepositoryTransaction
     ): Promise<MoveDistinctIdsResult> {
         this.incrementCount('moveDistinctIds', distinctId)
         this.incrementDatabaseOperation('moveDistinctIds', distinctId)
         const start = performance.now()
-        const response = await (tx || this.personRepository).moveDistinctIds(source, target, limit)
+        const response = await tx.moveDistinctIds(source, target, limit)
         observeLatencyByVersion(target, start, 'moveDistinctIds')
 
         // Clear the cache for the source person id to ensure deleted person isn't cached
@@ -534,13 +534,13 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
     async fetchPersonDistinctIds(
         person: InternalPerson,
         distinctId: string,
-        limit?: number,
-        tx?: PersonRepositoryTransaction
+        limit: number | undefined,
+        tx: PersonRepositoryTransaction
     ): Promise<string[]> {
         this.incrementCount('fetchPersonDistinctIds', distinctId)
         this.incrementDatabaseOperation('fetchPersonDistinctIds', distinctId)
         const start = performance.now()
-        const response = await (tx || this.personRepository).fetchPersonDistinctIds(person, limit)
+        const response = await tx.fetchPersonDistinctIds(person, limit)
         observeLatencyByVersion(person, start, 'fetchPersonDistinctIds')
 
         return response

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -52,6 +52,7 @@ type MethodName =
     | 'deletePerson'
     | 'addDistinctId'
     | 'moveDistinctIds'
+    | 'fetchPersonDistinctIds'
     | 'updateCohortsAndFeatureFlagsForMerge'
     | 'addPersonlessDistinctId'
     | 'addPersonlessDistinctIdForMerge'
@@ -525,6 +526,21 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
                 this.setDistinctIdToPersonId(target.team_id, distinctId, target.id)
             }
         }
+
+        return response
+    }
+
+    async fetchPersonDistinctIds(
+        person: InternalPerson,
+        distinctId: string,
+        limit?: number,
+        tx?: PersonRepositoryTransaction
+    ): Promise<string[]> {
+        this.incrementCount('fetchPersonDistinctIds', distinctId)
+        this.incrementDatabaseOperation('fetchPersonDistinctIds', distinctId)
+        const start = performance.now()
+        const response = await (tx || this.personRepository).fetchPersonDistinctIds(person, limit)
+        observeLatencyByVersion(person, start, 'fetchPersonDistinctIds')
 
         return response
     }

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -498,12 +498,13 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         source: InternalPerson,
         target: InternalPerson,
         distinctId: string,
+        limit?: number,
         tx?: PersonRepositoryTransaction
     ): Promise<MoveDistinctIdsResult> {
         this.incrementCount('moveDistinctIds', distinctId)
         this.incrementDatabaseOperation('moveDistinctIds', distinctId)
         const start = performance.now()
-        const response = await (tx || this.personRepository).moveDistinctIds(source, target)
+        const response = await (tx || this.personRepository).moveDistinctIds(source, target, limit)
         observeLatencyByVersion(target, start, 'moveDistinctIds')
 
         // Clear the cache for the source person id to ensure deleted person isn't cached

--- a/plugin-server/src/worker/ingestion/persons/metrics.ts
+++ b/plugin-server/src/worker/ingestion/persons/metrics.ts
@@ -65,9 +65,9 @@ export const personPropertyKeyUpdateCounter = new Counter({
     labelNames: ['key'],
 })
 
-export const personMergePartialCounter = new Counter({
-    name: 'person_merge_partial_total',
-    help: 'Number of merges that resulted in a partial move due to distinct ID move limit',
+export const personMergeFailureCounter = new Counter({
+    name: 'person_merge_failure_total',
+    help: 'Number of person merges that failed',
     labelNames: ['call'], // $identify, $create_alias, $merge_dangerously
 })
 

--- a/plugin-server/src/worker/ingestion/persons/metrics.ts
+++ b/plugin-server/src/worker/ingestion/persons/metrics.ts
@@ -65,6 +65,12 @@ export const personPropertyKeyUpdateCounter = new Counter({
     labelNames: ['key'],
 })
 
+export const personMergePartialCounter = new Counter({
+    name: 'person_merge_partial_total',
+    help: 'Number of merges that resulted in a partial move due to distinct ID move limit',
+    labelNames: ['call'], // $identify, $create_alias, $merge_dangerously
+})
+
 export const personCacheSizeHistogram = new Histogram({
     name: 'person_cache_size',
     help: 'Size of the person cache',

--- a/plugin-server/src/worker/ingestion/persons/person-context.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-context.ts
@@ -22,7 +22,8 @@ export class PersonContext {
         public readonly processPerson: boolean, // $process_person_profile flag from the event
         public readonly kafkaProducer: KafkaProducerWrapper,
         public readonly personStore: PersonsStoreForBatch,
-        public readonly measurePersonJsonbSize: number = 0
+        public readonly measurePersonJsonbSize: number = 0,
+        public readonly personMergeMoveDistinctIdLimit: number = 0
     ) {
         this.eventProperties = event.properties!
     }

--- a/plugin-server/src/worker/ingestion/persons/person-context.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-context.ts
@@ -23,7 +23,7 @@ export class PersonContext {
         public readonly kafkaProducer: KafkaProducerWrapper,
         public readonly personStore: PersonsStoreForBatch,
         public readonly measurePersonJsonbSize: number = 0,
-        public readonly personMergeMoveDistinctIdLimit: number = 0
+        public readonly personMergeMoveDistinctIdLimit: number | undefined = undefined
     ) {
         this.eventProperties = event.properties!
     }

--- a/plugin-server/src/worker/ingestion/persons/person-merge-service.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-merge-service.ts
@@ -9,6 +9,7 @@ import { logger } from '../../../utils/logger'
 import { captureException } from '../../../utils/posthog'
 import { promiseRetry } from '../../../utils/retries'
 import { captureIngestionWarning } from '../utils'
+import { personMergePartialCounter } from './metrics'
 import { PersonContext } from './person-context'
 import { PersonCreateService } from './person-create-service'
 import { applyEventPropertyUpdates, computeEventPropertyUpdates } from './person-update'
@@ -536,11 +537,11 @@ export class PersonMergeService {
                         call: this.context.event.event, // $identify, $create_alias or $merge_dangerously
                         oldPersonIdentified: String(currentSourcePerson.is_identified),
                         newPersonIdentified: String(currentTargetPerson.is_identified),
-                        // TODO: add partial move flag
                     })
                     .inc()
 
                 if (partialMove) {
+                    personMergePartialCounter.labels({ call: this.context.event.event }).inc()
                     await captureIngestionWarning(
                         this.context.kafkaProducer,
                         this.context.team.id,

--- a/plugin-server/src/worker/ingestion/persons/person-merge-service.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-merge-service.ts
@@ -491,10 +491,12 @@ export class PersonMergeService {
                             this.context.distinctId
                         )
 
+                        const perCallLimit = this.context.personMergeMoveDistinctIdLimit || undefined
                         const distinctIdResult = await tx.moveDistinctIds(
                             currentSourcePerson,
                             currentTargetPerson,
-                            this.context.distinctId
+                            this.context.distinctId,
+                            perCallLimit
                         )
 
                         if (!distinctIdResult.success) {

--- a/plugin-server/src/worker/ingestion/persons/persons-store-for-batch.ts
+++ b/plugin-server/src/worker/ingestion/persons/persons-store-for-batch.ts
@@ -96,8 +96,8 @@ export interface PersonsStoreForBatch extends BatchWritingStore {
         source: InternalPerson,
         target: InternalPerson,
         distinctId: string,
-        limit?: number,
-        tx?: PersonRepositoryTransaction
+        limit: number | undefined,
+        tx: PersonRepositoryTransaction
     ): Promise<MoveDistinctIdsResult>
 
     /**
@@ -136,8 +136,8 @@ export interface PersonsStoreForBatch extends BatchWritingStore {
     fetchPersonDistinctIds(
         person: InternalPerson,
         distinctId: string,
-        limit?: number,
-        tx?: PersonRepositoryTransaction
+        limit: number | undefined,
+        tx: PersonRepositoryTransaction
     ): Promise<string[]>
 
     /**

--- a/plugin-server/src/worker/ingestion/persons/persons-store-for-batch.ts
+++ b/plugin-server/src/worker/ingestion/persons/persons-store-for-batch.ts
@@ -131,6 +131,16 @@ export interface PersonsStoreForBatch extends BatchWritingStore {
     personPropertiesSize(personId: string): Promise<number>
 
     /**
+     * Fetch distinct ids for a person inside a transaction-aware wrapper
+     */
+    fetchPersonDistinctIds(
+        person: InternalPerson,
+        distinctId: string,
+        limit?: number,
+        tx?: PersonRepositoryTransaction
+    ): Promise<string[]>
+
+    /**
      * Reports metrics about person operations in batch
      */
     reportBatch(): void

--- a/plugin-server/src/worker/ingestion/persons/persons-store-for-batch.ts
+++ b/plugin-server/src/worker/ingestion/persons/persons-store-for-batch.ts
@@ -96,6 +96,7 @@ export interface PersonsStoreForBatch extends BatchWritingStore {
         source: InternalPerson,
         target: InternalPerson,
         distinctId: string,
+        limit?: number,
         tx?: PersonRepositoryTransaction
     ): Promise<MoveDistinctIdsResult>
 

--- a/plugin-server/src/worker/ingestion/persons/persons-store-transaction.ts
+++ b/plugin-server/src/worker/ingestion/persons/persons-store-transaction.ts
@@ -103,4 +103,8 @@ export class PersonsStoreTransaction {
     async addPersonlessDistinctIdForMerge(teamId: number, distinctId: string): Promise<boolean> {
         return await this.store.addPersonlessDistinctIdForMerge(teamId, distinctId, this.tx)
     }
+
+    async fetchPersonDistinctIds(person: InternalPerson, distinctId: string, limit?: number): Promise<string[]> {
+        return await this.store.fetchPersonDistinctIds(person, distinctId, limit, this.tx)
+    }
 }

--- a/plugin-server/src/worker/ingestion/persons/persons-store-transaction.ts
+++ b/plugin-server/src/worker/ingestion/persons/persons-store-transaction.ts
@@ -79,9 +79,10 @@ export class PersonsStoreTransaction {
     async moveDistinctIds(
         source: InternalPerson,
         target: InternalPerson,
-        distinctId: string
+        distinctId: string,
+        limit?: number
     ): Promise<MoveDistinctIdsResult> {
-        return await this.store.moveDistinctIds(source, target, distinctId, this.tx)
+        return await this.store.moveDistinctIds(source, target, distinctId, limit, this.tx)
     }
 
     async updateCohortsAndFeatureFlagsForMerge(

--- a/plugin-server/src/worker/ingestion/persons/repositories/person-repository-transaction.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/person-repository-transaction.ts
@@ -29,7 +29,7 @@ export interface PersonRepositoryTransaction {
 
     addDistinctId(person: InternalPerson, distinctId: string, version: number): Promise<TopicMessage[]>
 
-    moveDistinctIds(source: InternalPerson, target: InternalPerson): Promise<MoveDistinctIdsResult>
+    moveDistinctIds(source: InternalPerson, target: InternalPerson, limit?: number): Promise<MoveDistinctIdsResult>
 
     fetchPersonDistinctIds(person: InternalPerson, limit?: number): Promise<string[]>
 

--- a/plugin-server/src/worker/ingestion/persons/repositories/person-repository-transaction.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/person-repository-transaction.ts
@@ -31,6 +31,8 @@ export interface PersonRepositoryTransaction {
 
     moveDistinctIds(source: InternalPerson, target: InternalPerson): Promise<MoveDistinctIdsResult>
 
+    fetchPersonDistinctIds(person: InternalPerson, limit?: number): Promise<string[]>
+
     addPersonlessDistinctIdForMerge(teamId: Team['id'], distinctId: string): Promise<boolean>
 
     updateCohortsAndFeatureFlagsForMerge(

--- a/plugin-server/src/worker/ingestion/persons/repositories/person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/person-repository.ts
@@ -51,8 +51,6 @@ export interface PersonRepository {
 
     addDistinctId(person: InternalPerson, distinctId: string, version: number): Promise<TopicMessage[]>
 
-    fetchPersonDistinctIds(person: InternalPerson, limit?: number): Promise<string[]>
-
     addPersonlessDistinctId(teamId: Team['id'], distinctId: string): Promise<boolean>
     addPersonlessDistinctIdForMerge(teamId: Team['id'], distinctId: string): Promise<boolean>
 

--- a/plugin-server/src/worker/ingestion/persons/repositories/person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/person-repository.ts
@@ -53,6 +53,8 @@ export interface PersonRepository {
 
     moveDistinctIds(source: InternalPerson, target: InternalPerson): Promise<MoveDistinctIdsResult>
 
+    fetchPersonDistinctIds(person: InternalPerson, limit?: number): Promise<string[]>
+
     addPersonlessDistinctId(teamId: Team['id'], distinctId: string): Promise<boolean>
     addPersonlessDistinctIdForMerge(teamId: Team['id'], distinctId: string): Promise<boolean>
 

--- a/plugin-server/src/worker/ingestion/persons/repositories/person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/person-repository.ts
@@ -51,7 +51,7 @@ export interface PersonRepository {
 
     addDistinctId(person: InternalPerson, distinctId: string, version: number): Promise<TopicMessage[]>
 
-    moveDistinctIds(source: InternalPerson, target: InternalPerson): Promise<MoveDistinctIdsResult>
+    moveDistinctIds(source: InternalPerson, target: InternalPerson, limit?: number): Promise<MoveDistinctIdsResult>
 
     fetchPersonDistinctIds(person: InternalPerson, limit?: number): Promise<string[]>
 

--- a/plugin-server/src/worker/ingestion/persons/repositories/person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/person-repository.ts
@@ -4,7 +4,7 @@ import { Properties } from '@posthog/plugin-scaffold'
 
 import { TopicMessage } from '../../../../kafka/producer'
 import { InternalPerson, PropertiesLastOperation, PropertiesLastUpdatedAt, Team } from '../../../../types'
-import { CreatePersonResult, MoveDistinctIdsResult } from '../../../../utils/db/db'
+import { CreatePersonResult } from '../../../../utils/db/db'
 import { PersonUpdate } from '../person-update-batch'
 import { PersonRepositoryTransaction } from './person-repository-transaction'
 
@@ -50,8 +50,6 @@ export interface PersonRepository {
     deletePerson(person: InternalPerson): Promise<TopicMessage[]>
 
     addDistinctId(person: InternalPerson, distinctId: string, version: number): Promise<TopicMessage[]>
-
-    moveDistinctIds(source: InternalPerson, target: InternalPerson, limit?: number): Promise<MoveDistinctIdsResult>
 
     fetchPersonDistinctIds(person: InternalPerson, limit?: number): Promise<string[]>
 

--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository-transaction.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository-transaction.ts
@@ -60,6 +60,10 @@ export class PostgresPersonRepositoryTransaction implements PersonRepositoryTran
         return await this.repository.moveDistinctIds(source, target, this.transaction)
     }
 
+    async fetchPersonDistinctIds(person: InternalPerson, limit?: number): Promise<string[]> {
+        return await this.repository.fetchPersonDistinctIds(person, limit, this.transaction)
+    }
+
     async addPersonlessDistinctIdForMerge(teamId: Team['id'], distinctId: string): Promise<boolean> {
         return await this.repository.addPersonlessDistinctIdForMerge(teamId, distinctId, this.transaction)
     }

--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository-transaction.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository-transaction.ts
@@ -56,8 +56,12 @@ export class PostgresPersonRepositoryTransaction implements PersonRepositoryTran
         return await this.repository.addDistinctId(person, distinctId, version, this.transaction)
     }
 
-    async moveDistinctIds(source: InternalPerson, target: InternalPerson): Promise<MoveDistinctIdsResult> {
-        return await this.repository.moveDistinctIds(source, target, this.transaction)
+    async moveDistinctIds(
+        source: InternalPerson,
+        target: InternalPerson,
+        limit?: number
+    ): Promise<MoveDistinctIdsResult> {
+        return await this.repository.moveDistinctIds(source, target, limit, this.transaction)
     }
 
     async fetchPersonDistinctIds(person: InternalPerson, limit?: number): Promise<string[]> {

--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.test.ts
@@ -512,9 +512,9 @@ describe('PostgresPersonRepository', () => {
             }
         })
 
-        it('should respect moveDistinctIdsLimit when configured', async () => {
+        it('should respect per-call move limit when provided', async () => {
             const team = await getFirstTeam(hub)
-            const limitedRepository = new PostgresPersonRepository(postgres, { moveDistinctIdsLimit: 2 })
+            const limitedRepository = new PostgresPersonRepository(postgres, {})
 
             const sourcePerson = await createTestPerson(team.id, 'source-distinct-id', { name: 'Source Person' })
             const targetPerson = await createTestPerson(team.id, 'target-distinct-id', { name: 'Target Person' })
@@ -524,7 +524,7 @@ describe('PostgresPersonRepository', () => {
             await repository.addDistinctId(sourcePerson, 'source-distinct-id-3', 1)
             await repository.addDistinctId(sourcePerson, 'source-distinct-id-4', 1)
 
-            const result = await limitedRepository.moveDistinctIds(sourcePerson, targetPerson)
+            const result = await limitedRepository.moveDistinctIds(sourcePerson, targetPerson, 2)
 
             expect(result.success).toBe(true)
             if (result.success) {
@@ -589,9 +589,9 @@ describe('PostgresPersonRepository', () => {
             }
         })
 
-        it('should move distinct IDs in deterministic order when limit is set', async () => {
+        it('should move distinct IDs in deterministic order when per-call limit is set', async () => {
             const team = await getFirstTeam(hub)
-            const limitedRepository = new PostgresPersonRepository(postgres, { moveDistinctIdsLimit: 2 })
+            const limitedRepository = new PostgresPersonRepository(postgres, {})
 
             const sourcePerson = await createTestPerson(team.id, 'source-deterministic', { name: 'Source Person' })
             const targetPerson = await createTestPerson(team.id, 'target-deterministic', { name: 'Target Person' })
@@ -612,7 +612,7 @@ describe('PostgresPersonRepository', () => {
             // Should have 4 total distinct IDs (1 from createTestPerson + 3 added)
             expect(allDistinctIdsBeforeMove.rows).toHaveLength(4)
 
-            const result = await limitedRepository.moveDistinctIds(sourcePerson, targetPerson)
+            const result = await limitedRepository.moveDistinctIds(sourcePerson, targetPerson, 2)
             expect(result.success).toBe(true)
             if (result.success) {
                 expect(result.distinctIdsMoved).toHaveLength(2)
@@ -644,9 +644,9 @@ describe('PostgresPersonRepository', () => {
             }
         })
 
-        it('should move all distinct IDs when person has fewer than the limit', async () => {
+        it('should move all distinct IDs when person has fewer than the per-call limit', async () => {
             const team = await getFirstTeam(hub)
-            const limitedRepository = new PostgresPersonRepository(postgres, { moveDistinctIdsLimit: 5 }) // Limit is 5
+            const limitedRepository = new PostgresPersonRepository(postgres, {}) // Limit is 5
 
             const sourcePerson = await createTestPerson(team.id, 'source-below-limit', { name: 'Source Person' })
             const targetPerson = await createTestPerson(team.id, 'target-below-limit', { name: 'Target Person' })
@@ -655,7 +655,7 @@ describe('PostgresPersonRepository', () => {
             await repository.addDistinctId(sourcePerson, 'source-below-limit-2', 1)
             await repository.addDistinctId(sourcePerson, 'source-below-limit-3', 1)
 
-            const result = await limitedRepository.moveDistinctIds(sourcePerson, targetPerson)
+            const result = await limitedRepository.moveDistinctIds(sourcePerson, targetPerson, 5)
 
             expect(result.success).toBe(true)
             if (result.success) {

--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.test.ts
@@ -646,7 +646,7 @@ describe('PostgresPersonRepository', () => {
 
         it('should move all distinct IDs when person has fewer than the per-call limit', async () => {
             const team = await getFirstTeam(hub)
-            const limitedRepository = new PostgresPersonRepository(postgres, {}) // Limit is 5
+            const limitedRepository = new PostgresPersonRepository(postgres, {})
 
             const sourcePerson = await createTestPerson(team.id, 'source-below-limit', { name: 'Source Person' })
             const targetPerson = await createTestPerson(team.id, 'target-below-limit', { name: 'Target Person' })

--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.test.ts
@@ -441,7 +441,7 @@ describe('PostgresPersonRepository', () => {
             // Add another distinct ID to source person
             await repository.addDistinctId(sourcePerson, 'source-distinct-id-2', 1)
 
-            const result = await repository.moveDistinctIds(sourcePerson, targetPerson)
+            const result = await repository.moveDistinctIds(sourcePerson, targetPerson, undefined)
 
             expect(result.success).toBe(true)
             if (result.success) {
@@ -480,7 +480,7 @@ describe('PostgresPersonRepository', () => {
                 is_identified: false,
             }
 
-            const result = await repository.moveDistinctIds(sourcePerson, nonExistentTargetPerson)
+            const result = await repository.moveDistinctIds(sourcePerson, nonExistentTargetPerson, undefined)
 
             expect(result.success).toBe(false)
             if (!result.success) {
@@ -504,7 +504,7 @@ describe('PostgresPersonRepository', () => {
                 is_identified: false,
             }
 
-            const result = await repository.moveDistinctIds(nonExistentSourcePerson, targetPerson)
+            const result = await repository.moveDistinctIds(nonExistentSourcePerson, targetPerson, undefined)
 
             expect(result.success).toBe(false)
             if (!result.success) {
@@ -570,7 +570,7 @@ describe('PostgresPersonRepository', () => {
             await repository.addDistinctId(sourcePerson, 'source-unlimited-3', 1)
             await repository.addDistinctId(sourcePerson, 'source-unlimited-4', 1)
 
-            const result = await unlimitedRepository.moveDistinctIds(sourcePerson, targetPerson)
+            const result = await unlimitedRepository.moveDistinctIds(sourcePerson, targetPerson, undefined)
 
             expect(result.success).toBe(true)
             if (result.success) {

--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.test.ts
@@ -511,6 +511,183 @@ describe('PostgresPersonRepository', () => {
                 expect(result.error).toBe('SourceNotFound')
             }
         })
+
+        it('should respect moveDistinctIdsLimit when configured', async () => {
+            const team = await getFirstTeam(hub)
+            const limitedRepository = new PostgresPersonRepository(postgres, { moveDistinctIdsLimit: 2 })
+
+            const sourcePerson = await createTestPerson(team.id, 'source-distinct-id', { name: 'Source Person' })
+            const targetPerson = await createTestPerson(team.id, 'target-distinct-id', { name: 'Target Person' })
+
+            // Add 3 more distinct IDs to source person (total of 4 distinct IDs)
+            await repository.addDistinctId(sourcePerson, 'source-distinct-id-2', 1)
+            await repository.addDistinctId(sourcePerson, 'source-distinct-id-3', 1)
+            await repository.addDistinctId(sourcePerson, 'source-distinct-id-4', 1)
+
+            const result = await limitedRepository.moveDistinctIds(sourcePerson, targetPerson)
+
+            expect(result.success).toBe(true)
+            if (result.success) {
+                // Should only move 2 distinct IDs due to limit
+                expect(result.messages).toHaveLength(2)
+                expect(result.distinctIdsMoved).toHaveLength(2)
+
+                // Verify the messages have the correct structure
+                for (const message of result.messages) {
+                    expect(message.topic).toBe('clickhouse_person_distinct_id_test')
+                    expect(message.messages).toHaveLength(1)
+
+                    const messageValue = parseJSON(message.messages[0].value as string)
+                    expect(messageValue).toMatchObject({
+                        person_id: targetPerson.uuid,
+                        team_id: team.id,
+                        is_deleted: 0,
+                    })
+                    expect(messageValue).toHaveProperty('distinct_id')
+                    expect(messageValue).toHaveProperty('version')
+                }
+
+                // Verify that there are still distinct IDs left on the source person
+                const remainingResult = await postgres.query(
+                    PostgresUse.PERSONS_WRITE,
+                    'SELECT COUNT(*) as count FROM posthog_persondistinctid WHERE person_id = $1 AND team_id = $2',
+                    [sourcePerson.id, team.id],
+                    'countRemainingDistinctIds'
+                )
+                expect(parseInt(remainingResult.rows[0].count)).toBe(2) // 4 - 2 = 2 remaining
+            }
+        })
+
+        it('should move all distinct IDs when no limit is configured', async () => {
+            const team = await getFirstTeam(hub)
+            const unlimitedRepository = new PostgresPersonRepository(postgres, {}) // No limit
+
+            const sourcePerson = await createTestPerson(team.id, 'source-unlimited', { name: 'Source Person' })
+            const targetPerson = await createTestPerson(team.id, 'target-unlimited', { name: 'Target Person' })
+
+            // Add 3 more distinct IDs to source person (total of 4 distinct IDs)
+            await repository.addDistinctId(sourcePerson, 'source-unlimited-2', 1)
+            await repository.addDistinctId(sourcePerson, 'source-unlimited-3', 1)
+            await repository.addDistinctId(sourcePerson, 'source-unlimited-4', 1)
+
+            const result = await unlimitedRepository.moveDistinctIds(sourcePerson, targetPerson)
+
+            expect(result.success).toBe(true)
+            if (result.success) {
+                // Should move all 4 distinct IDs
+                expect(result.messages).toHaveLength(4)
+                expect(result.distinctIdsMoved).toHaveLength(4)
+
+                // Verify no distinct IDs remain on the source person
+                const remainingResult = await postgres.query(
+                    PostgresUse.PERSONS_WRITE,
+                    'SELECT COUNT(*) as count FROM posthog_persondistinctid WHERE person_id = $1 AND team_id = $2',
+                    [sourcePerson.id, team.id],
+                    'countRemainingDistinctIds'
+                )
+                expect(parseInt(remainingResult.rows[0].count)).toBe(0) // All moved
+            }
+        })
+
+        it('should move distinct IDs in deterministic order when limit is set', async () => {
+            const team = await getFirstTeam(hub)
+            const limitedRepository = new PostgresPersonRepository(postgres, { moveDistinctIdsLimit: 2 })
+
+            const sourcePerson = await createTestPerson(team.id, 'source-deterministic', { name: 'Source Person' })
+            const targetPerson = await createTestPerson(team.id, 'target-deterministic', { name: 'Target Person' })
+
+            // Add distinct IDs in a specific order (not alphabetical to test database ID ordering)
+            await repository.addDistinctId(sourcePerson, 'distinct-z', 1)
+            await repository.addDistinctId(sourcePerson, 'distinct-a', 1)
+            await repository.addDistinctId(sourcePerson, 'distinct-m', 1)
+
+            // Get all distinct IDs in database order (by id, not by distinct_id value)
+            const allDistinctIdsBeforeMove = await postgres.query(
+                PostgresUse.PERSONS_WRITE,
+                'SELECT id, distinct_id FROM posthog_persondistinctid WHERE person_id = $1 AND team_id = $2 ORDER BY id',
+                [sourcePerson.id, team.id],
+                'getAllDistinctIds'
+            )
+
+            // Should have 4 total distinct IDs (1 from createTestPerson + 3 added)
+            expect(allDistinctIdsBeforeMove.rows).toHaveLength(4)
+
+            const result = await limitedRepository.moveDistinctIds(sourcePerson, targetPerson)
+            expect(result.success).toBe(true)
+            if (result.success) {
+                expect(result.distinctIdsMoved).toHaveLength(2)
+
+                // The moved distinct IDs should be the first 2 in database order (smallest IDs)
+                const expectedMovedDistinctIds = [
+                    allDistinctIdsBeforeMove.rows[0].distinct_id,
+                    allDistinctIdsBeforeMove.rows[1].distinct_id,
+                ]
+
+                expect(result.distinctIdsMoved.sort()).toEqual(expectedMovedDistinctIds.sort())
+
+                // Verify the remaining distinct IDs are the ones with higher database IDs
+                const remainingIds = await postgres.query(
+                    PostgresUse.PERSONS_WRITE,
+                    'SELECT distinct_id FROM posthog_persondistinctid WHERE person_id = $1 AND team_id = $2 ORDER BY id',
+                    [sourcePerson.id, team.id],
+                    'getRemainingDistinctIds'
+                )
+
+                expect(remainingIds.rows).toHaveLength(2)
+                const expectedRemainingDistinctIds = [
+                    allDistinctIdsBeforeMove.rows[2].distinct_id,
+                    allDistinctIdsBeforeMove.rows[3].distinct_id,
+                ]
+
+                const actualRemainingDistinctIds = remainingIds.rows.map((row) => row.distinct_id)
+                expect(actualRemainingDistinctIds.sort()).toEqual(expectedRemainingDistinctIds.sort())
+            }
+        })
+
+        it('should move all distinct IDs when person has fewer than the limit', async () => {
+            const team = await getFirstTeam(hub)
+            const limitedRepository = new PostgresPersonRepository(postgres, { moveDistinctIdsLimit: 5 }) // Limit is 5
+
+            const sourcePerson = await createTestPerson(team.id, 'source-below-limit', { name: 'Source Person' })
+            const targetPerson = await createTestPerson(team.id, 'target-below-limit', { name: 'Target Person' })
+
+            // Add only 2 more distinct IDs (total of 3, which is below the limit of 5)
+            await repository.addDistinctId(sourcePerson, 'source-below-limit-2', 1)
+            await repository.addDistinctId(sourcePerson, 'source-below-limit-3', 1)
+
+            const result = await limitedRepository.moveDistinctIds(sourcePerson, targetPerson)
+
+            expect(result.success).toBe(true)
+            if (result.success) {
+                // Should move all 3 distinct IDs since it's below the limit
+                expect(result.messages).toHaveLength(3)
+                expect(result.distinctIdsMoved).toHaveLength(3)
+
+                // Verify the messages have the correct structure
+                for (const message of result.messages) {
+                    expect(message.topic).toBe('clickhouse_person_distinct_id_test')
+                    expect(message.messages).toHaveLength(1)
+
+                    const messageValue = parseJSON(message.messages[0].value as string)
+                    expect(messageValue).toMatchObject({
+                        person_id: targetPerson.uuid,
+                        team_id: team.id,
+                        is_deleted: 0,
+                    })
+                    expect(messageValue).toHaveProperty('distinct_id')
+                    expect(messageValue).toHaveProperty('version')
+                }
+
+                // Verify no distinct IDs remain on the source person
+                const remainingResult = await postgres.query(
+                    PostgresUse.PERSONS_WRITE,
+                    'SELECT COUNT(*) as count FROM posthog_persondistinctid WHERE person_id = $1 AND team_id = $2',
+                    [sourcePerson.id, team.id],
+                    'countRemainingDistinctIds'
+                )
+                expect(parseInt(remainingResult.rows[0].count)).toBe(0) // All moved, none remaining
+            }
+        })
     })
 
     describe('addPersonlessDistinctId', () => {

--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
@@ -560,7 +560,7 @@ export class PostgresPersonRepository
         `
 
         const { rows } = await this.postgres.query<{ distinct_id: string }>(
-            tx ?? PostgresUse.PERSONS_READ,
+            tx ?? PostgresUse.PERSONS_WRITE,
             queryString,
             [person.id, person.team_id],
             'fetchPersonDistinctIds'

--- a/plugin-server/src/worker/ingestion/persons/repositories/raw-postgres-person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/raw-postgres-person-repository.ts
@@ -49,6 +49,7 @@ export interface RawPostgresPersonRepository {
     moveDistinctIds(
         source: InternalPerson,
         target: InternalPerson,
+        limit?: number,
         tx?: TransactionClient
     ): Promise<MoveDistinctIdsResult>
 

--- a/plugin-server/src/worker/ingestion/persons/repositories/raw-postgres-person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/raw-postgres-person-repository.ts
@@ -52,6 +52,8 @@ export interface RawPostgresPersonRepository {
         tx?: TransactionClient
     ): Promise<MoveDistinctIdsResult>
 
+    fetchPersonDistinctIds(person: InternalPerson, limit?: number, tx?: TransactionClient): Promise<string[]>
+
     addPersonlessDistinctId(teamId: Team['id'], distinctId: string): Promise<boolean>
     addPersonlessDistinctIdForMerge(teamId: Team['id'], distinctId: string, tx?: TransactionClient): Promise<boolean>
 

--- a/plugin-server/tests/worker/ingestion/person-state-batch.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state-batch.test.ts
@@ -2815,7 +2815,7 @@ describe('PersonState.processEvent()', () => {
                         // Simulate the race condition: move firstUserDistinctId to person3
                         // This simulates another process moving the distinct ID during the merge
                         await personRepository.inRawTransaction('test', async (tx) => {
-                            await personRepository.moveDistinctIds(person1, person3, tx)
+                            await personRepository.moveDistinctIds(person1, person3, undefined, tx)
                             await personRepository.deletePerson(person1, tx)
                         })
 

--- a/plugin-server/tests/worker/ingestion/person-state-batch.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state-batch.test.ts
@@ -2903,7 +2903,7 @@ describe('PersonState.processEvent()', () => {
             // Mock the batch store method which is what gets called through the transaction wrapper
             const moveDistinctIdsSpy = jest
                 .spyOn(batchStore, 'moveDistinctIds')
-                .mockImplementation(async (source, target, distinctId, tx) => {
+                .mockImplementation(async (source, target, distinctId, limit, tx) => {
                     moveDistinctIdsCalls++
                     if (moveDistinctIdsCalls === 1) {
                         // Simulate the race condition: move firstUserDistinctId to person3
@@ -2921,7 +2921,7 @@ describe('PersonState.processEvent()', () => {
                         })
                     }
                     // Second call succeeds - call the original method
-                    return originalMoveDistinctIds(source, target, distinctId, tx)
+                    return originalMoveDistinctIds(source, target, distinctId, limit, tx)
                 })
 
             // Attempt to merge persons - this should trigger the retry logic

--- a/plugin-server/tests/worker/ingestion/postgres-parity.test.ts
+++ b/plugin-server/tests/worker/ingestion/postgres-parity.test.ts
@@ -394,7 +394,7 @@ describe('postgres parity', () => {
         await clickhouse.delayUntilEventIngested(() => clickhouse.fetchDistinctIdValues(postgresPerson), 1)
 
         // move distinct ids from person to to anotherPerson
-        const moveDistinctIdsResult = await personRepository.moveDistinctIds(person, anotherPerson)
+        const moveDistinctIdsResult = await personRepository.moveDistinctIds(person, anotherPerson, undefined)
         expect(moveDistinctIdsResult.success).toEqual(true)
 
         if (moveDistinctIdsResult.success) {


### PR DESCRIPTION
## Problem

Merging persons with a large number of distinct IDs can crash the ingestion processes and halt the ingestion pipeline.

## Changes

- Adds a configurable limit for the number of distinct IDs moved per merge event
- Drops the events that cross the limit and stores them in the DLQ

## How did you test this code?

- Added new tests for the limit behaviour
- Existing tests cover the regression

TODO:
- Update docs

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
