### PR TITLE
feat(cdp): Move addon check to use DB lookups

### DIFF
--- a/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
@@ -127,72 +127,78 @@ export class CdpEventsConsumer extends CdpConsumerBase {
             const validInvocations: CyclotronJobInvocationHogFunction[] = []
 
             // Iterate over adding them to the list and updating their priority
-            for (const item of possibleInvocations) {
-                // Disable invocations for teams that don't have the addon (for now just metric them out..)
+            await Promise.all(
+                possibleInvocations.map(async (item) => {
+                    // Disable invocations for teams that don't have the addon (for now just metric them out..)
 
-                const isQuotaLimited = await this.hub.quotaLimiting.isTeamQuotaLimited(item.teamId, 'cdp_invocations')
-
-                // The legacy addon was not usage based so we skip dropping if they are on it
-                const isTeamOnLegacyAddon = !!teamsById[`${item.teamId}`]?.available_features.includes('data_pipelines')
-
-                if (isQuotaLimited && !isTeamOnLegacyAddon) {
-                    counterQuotaLimited.labels({ team_id: item.teamId }).inc()
-
-                    // TODO: Once happy - we add the below code to track a quota limited metric and skip the invocation
-
-                    // this.hogFunctionMonitoringService.queueAppMetric(
-                    //     {
-                    //         team_id: item.teamId,
-                    //         app_source_id: item.functionId,
-                    //         metric_kind: 'failure',
-                    //         metric_name: 'quota_limited',
-                    //         count: 1,
-                    //     },
-                    //     'hog_function'
-                    // )
-                    // continue
-                }
-
-                if (
-                    !teamsById[`${item.teamId}`]?.available_features.includes('data_pipelines') &&
-                    item.hogFunction.is_addon_required
-                ) {
-                    // NOTE: This will be removed in favour of the quota limited metric
-                    counterMissingAddon.labels({ team_id: item.teamId }).inc()
-                }
-
-                const state = states[item.hogFunction.id].state
-
-                counterHogFunctionStateOnEvent
-                    .labels({
-                        state: HogWatcherState[state],
-                        kind: item.hogFunction.type,
-                    })
-                    .inc()
-
-                if (state === HogWatcherState.disabled) {
-                    this.hogFunctionMonitoringService.queueAppMetric(
-                        {
-                            team_id: item.teamId,
-                            app_source_id: item.functionId,
-                            metric_kind: 'failure',
-                            metric_name: 'disabled_permanently',
-                            count: 1,
-                        },
-                        'hog_function'
+                    const isQuotaLimited = await this.hub.quotaLimiting.isTeamQuotaLimited(
+                        item.teamId,
+                        'cdp_invocations'
                     )
-                    continue
-                }
 
-                if (state === HogWatcherState.degraded) {
-                    item.queuePriority = 2
-                    if (this.hub.CDP_OVERFLOW_QUEUE_ENABLED) {
-                        item.queue = 'hog_overflow'
+                    // The legacy addon was not usage based so we skip dropping if they are on it
+                    const isTeamOnLegacyAddon =
+                        !!teamsById[`${item.teamId}`]?.available_features.includes('data_pipelines')
+
+                    if (isQuotaLimited && !isTeamOnLegacyAddon) {
+                        counterQuotaLimited.labels({ team_id: item.teamId }).inc()
+
+                        // TODO: Once happy - we add the below code to track a quota limited metric and skip the invocation
+
+                        // this.hogFunctionMonitoringService.queueAppMetric(
+                        //     {
+                        //         team_id: item.teamId,
+                        //         app_source_id: item.functionId,
+                        //         metric_kind: 'failure',
+                        //         metric_name: 'quota_limited',
+                        //         count: 1,
+                        //     },
+                        //     'hog_function'
+                        // )
+                        // return
                     }
-                }
 
-                validInvocations.push(item)
-            }
+                    if (
+                        !teamsById[`${item.teamId}`]?.available_features.includes('data_pipelines') &&
+                        (await this.isAddonRequired(item.hogFunction))
+                    ) {
+                        // NOTE: This will be removed in favour of the quota limited metric
+                        counterMissingAddon.labels({ team_id: item.teamId }).inc()
+                    }
+
+                    const state = states[item.hogFunction.id].state
+
+                    counterHogFunctionStateOnEvent
+                        .labels({
+                            state: HogWatcherState[state],
+                            kind: item.hogFunction.type,
+                        })
+                        .inc()
+
+                    if (state === HogWatcherState.disabled) {
+                        this.hogFunctionMonitoringService.queueAppMetric(
+                            {
+                                team_id: item.teamId,
+                                app_source_id: item.functionId,
+                                metric_kind: 'failure',
+                                metric_name: 'disabled_permanently',
+                                count: 1,
+                            },
+                            'hog_function'
+                        )
+                        return
+                    }
+
+                    if (state === HogWatcherState.degraded) {
+                        item.queuePriority = 2
+                        if (this.hub.CDP_OVERFLOW_QUEUE_ENABLED) {
+                            item.queue = 'hog_overflow'
+                        }
+                    }
+
+                    validInvocations.push(item)
+                })
+            )
 
             // Now we can filter by masking configs
             const { masked, notMasked: notMaskedInvocations } = await this.hogMasker.filterByMasking(validInvocations)
@@ -366,5 +372,25 @@ export class CdpEventsConsumer extends CdpConsumerBase {
 
     public isHealthy() {
         return this.kafkaConsumer.isHealthy()
+    }
+
+    private async isAddonRequired(hogFunction: HogFunctionType): Promise<boolean> {
+        // Load the template if possible
+        if (hogFunction.type !== 'destination') {
+            // Only destinations are part of the paid plan
+            return false
+        }
+
+        if (!hogFunction.template_id) {
+            return true // Assume templateless requires the addon
+        }
+
+        const template = await this.hogFunctionTemplateManager.getHogFunctionTemplate(hogFunction.template_id)
+
+        if (!template) {
+            return true // Assume templateless requires the addon
+        }
+
+        return !!template.free
     }
 }

--- a/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
@@ -391,6 +391,6 @@ export class CdpEventsConsumer extends CdpConsumerBase {
             return true // Assume templateless requires the addon
         }
 
-        return !!template.free
+        return !template.free
     }
 }

--- a/plugin-server/src/cdp/services/hogflows/actions/hog_function.ts
+++ b/plugin-server/src/cdp/services/hogflows/actions/hog_function.ts
@@ -80,7 +80,6 @@ export class HogFunctionHandler implements ActionHandler {
             bytecode: template.bytecode,
             inputs: action.config.inputs,
             inputs_schema: template.inputs_schema,
-            is_addon_required: false,
             created_at: '',
             updated_at: '',
         }

--- a/plugin-server/src/cdp/services/managers/hog-function-manager.service.test.ts
+++ b/plugin-server/src/cdp/services/managers/hog-function-manager.service.test.ts
@@ -131,7 +131,6 @@ describe('HogFunctionManager', () => {
                     "type": "string",
                   },
                 ],
-                "is_addon_required": true,
                 "mappings": null,
                 "masking": null,
                 "name": "Test Hog Function team 1",

--- a/plugin-server/src/cdp/services/managers/hog-function-manager.service.ts
+++ b/plugin-server/src/cdp/services/managers/hog-function-manager.service.ts
@@ -4,7 +4,6 @@ import { parseJSON } from '../../../utils/json-parse'
 import { LazyLoader } from '../../../utils/lazy-loader'
 import { logger } from '../../../utils/logger'
 import { captureException } from '../../../utils/posthog'
-import { HOG_FUNCTION_TEMPLATES } from '../../templates'
 import { HogFunctionType, HogFunctionTypeType } from '../../types'
 
 const HOG_FUNCTION_FIELDS = [
@@ -58,23 +57,6 @@ const sortHogFunctions = (functions: HogFunctionType[]): HogFunctionType[] => {
         // If execution orders are the same, sort by creation date
         return a.created_at.localeCompare(b.created_at)
     })
-}
-
-const isAddonRequired = (hogFunction: HogFunctionType): boolean => {
-    if (typeof hogFunction.is_addon_required === 'boolean') {
-        // Don't double check
-        return hogFunction.is_addon_required
-    }
-
-    if (hogFunction.type !== 'destination') {
-        // Only destinations are part of the paid plan
-        return false
-    }
-
-    // TODO: ensure all free-templates are moved to the templates here
-    // FUTURE: When we move templates fully to the DB we should be loading it from there
-    const template = HOG_FUNCTION_TEMPLATES.find((t) => t.id === hogFunction.template_id)
-    return template?.free !== true
 }
 
 export class HogFunctionManagerService {
@@ -238,8 +220,6 @@ export class HogFunctionManagerService {
 
     public sanitize(items: HogFunctionType[]): void {
         items.forEach((item) => {
-            item.is_addon_required = isAddonRequired(item)
-
             // Decrypt inputs
             const encryptedInputs = item.encrypted_inputs
 

--- a/plugin-server/src/cdp/templates/test/test-helpers.ts
+++ b/plugin-server/src/cdp/templates/test/test-helpers.ts
@@ -22,8 +22,7 @@ import {
     HogFunctionType,
     NativeTemplate,
 } from '../../types'
-import { cloneInvocation } from '../../utils/invocation-utils'
-import { createInvocation } from '../../utils/invocation-utils'
+import { cloneInvocation, createInvocation } from '../../utils/invocation-utils'
 import { compileHog } from '../compiler'
 
 export type DeepPartialHogFunctionInvocationGlobals = {
@@ -193,7 +192,6 @@ export class TemplateTester {
             mappings: this.template.mappings || null,
             created_at: '2024-01-01T00:00:00Z',
             updated_at: '2024-01-01T00:00:00Z',
-            is_addon_required: false,
             deleted: false,
         }
 
@@ -270,7 +268,6 @@ export class TemplateTester {
             deleted: false,
             inputs: compiledInputs,
             mappings: [compiledMappingInputs],
-            is_addon_required: false,
         }
 
         const globalsWithInputs = await this.executor.buildInputsWithGlobals(
@@ -380,7 +377,6 @@ export class DestinationTester {
             updated_at: '2024-01-01T00:00:00Z',
             deleted: false,
             inputs: compiledInputs,
-            is_addon_required: false,
         })
 
         const result = await this.executor.execute(invocation)

--- a/plugin-server/src/cdp/types.ts
+++ b/plugin-server/src/cdp/types.ts
@@ -339,7 +339,6 @@ export type HogFunctionType = {
     filters?: HogFunctionFilters | null
     mappings?: HogFunctionMappingType[] | null
     masking?: HogFunctionMasking | null
-    is_addon_required: boolean
     template_id?: string
     execution_order?: number
     created_at: string
@@ -382,6 +381,7 @@ export type DBHogFunctionTemplate = {
     inputs_schema: HogFunctionInputSchemaType[]
     bytecode: HogBytecode
     type: HogFunctionTypeType
+    free: boolean
 }
 
 export type IntegrationType = {


### PR DESCRIPTION
## Problem

We metric out the addon check. This is a bit redundant with new pricing coming up but I still want to feel confident about this metric so changed to looking up from the DB

## Changes

* Fix it to use a lookup

## How did you test this code?

* Didn't as it isnt especially important