### PR TITLE
feat: Improve plugin-server kafka consumer health checks

### DIFF
--- a/plugin-server/src/api/router.ts
+++ b/plugin-server/src/api/router.ts
@@ -92,7 +92,7 @@ const buildGetHealth =
                     return {
                         service: service.id,
                         status: 'error',
-                        message: error.message,
+                        message: error.message || 'Unknown error',
                     }
                 }
             })

--- a/plugin-server/src/api/router.ts
+++ b/plugin-server/src/api/router.ts
@@ -72,21 +72,53 @@ const buildGetHealth =
             // a 500 status code.
             services.map(async (service) => {
                 try {
-                    return { service: service.id, status: (await service.healthcheck()) ? 'ok' : 'error' }
+                    const result = await service.healthcheck()
+
+                    // Handle both boolean and HealthCheckResult returns
+                    if (typeof result === 'boolean') {
+                        return {
+                            service: service.id,
+                            status: result ? 'ok' : 'error',
+                        }
+                    } else {
+                        return {
+                            service: service.id,
+                            status: result.healthy ? 'ok' : 'error',
+                            message: result.message,
+                            details: result.details,
+                        }
+                    }
                 } catch (error) {
-                    return { service: service.id, status: 'error', error: error.message }
+                    return {
+                        service: service.id,
+                        status: 'error',
+                        message: error.message,
+                    }
                 }
             })
         )
 
         const statusCode = checkResults.every((result) => result.status === 'ok') ? 200 : 503
 
-        const checkResultsMapping = Object.fromEntries(checkResults.map((result) => [result.service, result.status]))
+        const checkResultsMapping = Object.fromEntries(
+            checkResults.map((result) => [
+                result.service,
+                result.message ? { status: result.status, message: result.message } : result.status,
+            ])
+        )
 
         if (statusCode === 200) {
             logger.info('💚', 'Server liveness check succeeded')
         } else {
-            logger.error('💔', 'Server liveness check failed', { checkResults: checkResultsMapping })
+            // Log detailed information for failures
+            const failedServices = checkResults.filter((r) => r.status === 'error')
+            logger.error('💔', 'Server liveness check failed', {
+                failedServices: failedServices.map((s) => ({
+                    service: s.service,
+                    message: s.message,
+                    details: s.details,
+                })),
+            })
         }
 
         return res.status(statusCode).json({ status: statusCode === 200 ? 'ok' : 'error', checks: checkResultsMapping })

--- a/plugin-server/src/cdp/consumers/cdp-base.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-base.consumer.ts
@@ -1,5 +1,5 @@
 import { KafkaProducerWrapper } from '../../kafka/producer'
-import { Hub, PluginServerService, TeamId } from '../../types'
+import { HealthCheckResult, Hub, PluginServerService, TeamId } from '../../types'
 import { logger } from '../../utils/logger'
 import { CdpRedis, createCdpRedisPool } from '../redis'
 import { HogExecutorService } from '../services/hog-executor.service'
@@ -80,7 +80,7 @@ export abstract class CdpConsumerBase {
         return {
             id: this.name,
             onShutdown: async () => await this.stop(),
-            healthcheck: () => this.isHealthy() ?? false,
+            healthcheck: () => this.isHealthy(),
         }
     }
 
@@ -112,5 +112,5 @@ export abstract class CdpConsumerBase {
         logger.info('👍', `${this.name} - stopped!`)
     }
 
-    public abstract isHealthy(): boolean
+    public abstract isHealthy(): boolean | HealthCheckResult
 }

--- a/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
@@ -1,4 +1,5 @@
 import { instrumented } from '~/common/tracing/tracing-utils'
+
 import { HealthCheckResult, Hub } from '../../types'
 import { logger } from '../../utils/logger'
 import { captureException } from '../../utils/posthog'

--- a/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
@@ -1,6 +1,5 @@
 import { instrumented } from '~/common/tracing/tracing-utils'
-
-import { Hub } from '../../types'
+import { HealthCheckResult, Hub } from '../../types'
 import { logger } from '../../utils/logger'
 import { captureException } from '../../utils/posthog'
 import { CyclotronJobQueue } from '../services/job-queue/job-queue'
@@ -146,7 +145,7 @@ export class CdpCyclotronWorker extends CdpConsumerBase {
         await super.stop()
     }
 
-    public isHealthy() {
+    public isHealthy(): boolean | HealthCheckResult {
         return this.cyclotronJobQueue.isHealthy()
     }
 }

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -58,6 +58,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         CONSUMER_BATCH_SIZE: 500,
         CONSUMER_MAX_HEARTBEAT_INTERVAL_MS: 30_000,
         CONSUMER_LOOP_STALL_THRESHOLD_MS: 60_000, // 1 minute - consider loop stalled after this
+        KAFKA_CONSUMER_LOOP_BASED_HEALTH_CHECK: false, // Use consumer loop monitoring for health checks instead of heartbeats
         CONSUMER_MAX_BACKGROUND_TASKS: 1,
         CONSUMER_WAIT_FOR_BACKGROUND_TASKS_ON_REBALANCE: false,
         CONSUMER_AUTO_CREATE_TOPICS: true,

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -57,6 +57,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: false,
         CONSUMER_BATCH_SIZE: 500,
         CONSUMER_MAX_HEARTBEAT_INTERVAL_MS: 30_000,
+        CONSUMER_LOOP_STALL_THRESHOLD_MS: 60_000, // 1 minute - consider loop stalled after this
         CONSUMER_MAX_BACKGROUND_TASKS: 1,
         CONSUMER_WAIT_FOR_BACKGROUND_TASKS_ON_REBALANCE: false,
         CONSUMER_AUTO_CREATE_TOPICS: true,

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -221,7 +221,8 @@ export class IngestionConsumer {
     }
 
     public isHealthy(): boolean {
-        return this.kafkaConsumer?.isHealthy()
+        const result = this.kafkaConsumer?.isHealthy()
+        return result?.healthy ?? false
     }
 
     private runInstrumented<T>(name: string, func: () => Promise<T>): Promise<T> {

--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -316,16 +316,7 @@ export class KafkaConsumer {
     }
 
     public assignments(): Assignment[] {
-        if (!this.rdKafkaConsumer.isConnected()) {
-            return []
-        }
-        try {
-            return this.rdKafkaConsumer.assignments()
-        } catch (error) {
-            // Consumer might be connected but in an erroneous state (e.g., during rebalancing)
-            logger.debug('Failed to get assignments', { error: error.message })
-            return []
-        }
+        return this.rdKafkaConsumer.isConnected() ? this.rdKafkaConsumer.assignments() : []
     }
 
     public offsetsStore(topicPartitionOffsets: TopicPartitionOffset[]): void {
@@ -570,9 +561,10 @@ export class KafkaConsumer {
             throw error
         }
 
-        // Initialize health monitoring state
+        this.heartbeat() // Setup the heartbeat so we are healthy since connection is established
+
+        // Initialize health monitoring state for new loop-based check
         this.lastConsumerLoopTime = Date.now()
-        this.lastHeartbeatTime = Date.now() // Also initialize heartbeat for backward compatibility
 
         if (defaultConfig.CONSUMER_AUTO_CREATE_TOPICS) {
             // For hobby deploys we want to auto-create, but on cloud we don't

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
@@ -165,8 +165,6 @@ export class SessionRecordingIngester {
     }
 
     public async handleEachBatch(messages: Message[]): Promise<void> {
-        this.kafkaConsumer.heartbeat()
-
         if (messages.length > 0) {
             logger.info('🔁', `blob_ingester_consumer_v2 - handling batch`, {
                 size: messages.length,
@@ -204,13 +202,9 @@ export class SessionRecordingIngester {
             return processedMessages
         })
 
-        this.kafkaConsumer.heartbeat()
-
         await instrumentFn(`recordingingesterv2.handleEachBatch.processMessages`, async () =>
             this.processMessages(processedMessages)
         )
-
-        this.kafkaConsumer.heartbeat()
 
         if (this.sessionBatchManager.shouldFlush()) {
             await instrumentFn(`recordingingesterv2.handleEachBatch.flush`, async () =>

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
@@ -165,6 +165,8 @@ export class SessionRecordingIngester {
     }
 
     public async handleEachBatch(messages: Message[]): Promise<void> {
+        this.kafkaConsumer.heartbeat()
+
         if (messages.length > 0) {
             logger.info('🔁', `blob_ingester_consumer_v2 - handling batch`, {
                 size: messages.length,
@@ -202,9 +204,13 @@ export class SessionRecordingIngester {
             return processedMessages
         })
 
+        this.kafkaConsumer.heartbeat()
+
         await instrumentFn(`recordingingesterv2.handleEachBatch.processMessages`, async () =>
             this.processMessages(processedMessages)
         )
+
+        this.kafkaConsumer.heartbeat()
 
         if (this.sessionBatchManager.shouldFlush()) {
             await instrumentFn(`recordingingesterv2.handleEachBatch.flush`, async () =>

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
@@ -313,7 +313,8 @@ export class SessionRecordingIngester {
 
     public isHealthy(): boolean {
         // TODO: Maybe extend this to check if we are shutting down so we don't get killed early.
-        return this.kafkaConsumer.isHealthy()
+        const result = this.kafkaConsumer.isHealthy()
+        return result.healthy
     }
 
     private get assignedTopicPartitions(): TopicPartition[] {

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -383,6 +383,7 @@ export class SessionRecordingIngester {
                     this.partitionMetrics[partitionStat.partition] = metrics
                 }
             })
+            this.kafkaConsumer.heartbeat()
 
             await this.reportPartitionMetrics()
 
@@ -395,7 +396,6 @@ export class SessionRecordingIngester {
                     }
                 }
             })
-            this.kafkaConsumer.heartbeat()
 
             await instrumentFn(
                 `recordingingester.handleEachBatch.flushAllReadySessions`,
@@ -411,13 +411,14 @@ export class SessionRecordingIngester {
                 await instrumentFn(`recordingingester.handleEachBatch.consumeReplayEvents`, async () => {
                     await this.replayEventsIngester!.consumeBatch(recordingMessages)
                 })
+                this.kafkaConsumer.heartbeat()
             }
-            this.kafkaConsumer.heartbeat()
 
             if (this.consoleLogsIngester) {
                 await instrumentFn(`recordingingester.handleEachBatch.consumeConsoleLogEvents`, async () => {
                     await this.consoleLogsIngester!.consumeBatch(recordingMessages)
                 })
+                this.kafkaConsumer.heartbeat()
             }
         })
     }

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -474,7 +474,7 @@ export class SessionRecordingIngester {
             logger.info('🔁', 'blob_ingester_consumer - rebalancing', {
                 err,
                 topicPartitions,
-                connected: this.kafkaConsumer.isHealthy(),
+                connected: this.kafkaConsumer.isHealthy().healthy,
             })
             /**
              * see https://github.com/Blizzard/node-rdkafka#rebalancing
@@ -538,7 +538,8 @@ export class SessionRecordingIngester {
 
     public isHealthy() {
         // TODO: Maybe extend this to check if we are shutting down so we don't get killed early.
-        return this.kafkaConsumer.isHealthy()
+        const result = this.kafkaConsumer.isHealthy()
+        return result.healthy
     }
 
     private async reportPartitionMetrics() {

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -346,8 +346,6 @@ export class SessionRecordingIngester {
     }
 
     public async handleEachBatch(messages: Message[]): Promise<void> {
-        this.kafkaConsumer.heartbeat()
-
         if (messages.length !== 0) {
             logger.info('🔁', `blob_ingester_consumer - handling batch`, {
                 size: messages.length,
@@ -383,7 +381,6 @@ export class SessionRecordingIngester {
                     this.partitionMetrics[partitionStat.partition] = metrics
                 }
             })
-            this.kafkaConsumer.heartbeat()
 
             await this.reportPartitionMetrics()
 
@@ -411,14 +408,12 @@ export class SessionRecordingIngester {
                 await instrumentFn(`recordingingester.handleEachBatch.consumeReplayEvents`, async () => {
                     await this.replayEventsIngester!.consumeBatch(recordingMessages)
                 })
-                this.kafkaConsumer.heartbeat()
             }
 
             if (this.consoleLogsIngester) {
                 await instrumentFn(`recordingingester.handleEachBatch.consumeConsoleLogEvents`, async () => {
                     await this.consoleLogsIngester!.consumeBatch(recordingMessages)
                 })
-                this.kafkaConsumer.heartbeat()
             }
         })
     }
@@ -666,8 +661,6 @@ export class SessionRecordingIngester {
             this.config.SESSION_RECORDING_MAX_PARALLEL_FLUSHES,
             sessions,
             async ([key, sessionManager], ctx) => {
-                this.kafkaConsumer.heartbeat()
-
                 if (this.isStopping) {
                     // We can end up with a large number of flushes. We want to stop early if we hit shutdown
                     return ctx.break()

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -411,14 +411,13 @@ export class SessionRecordingIngester {
                 await instrumentFn(`recordingingester.handleEachBatch.consumeReplayEvents`, async () => {
                     await this.replayEventsIngester!.consumeBatch(recordingMessages)
                 })
-                this.kafkaConsumer.heartbeat()
             }
+            this.kafkaConsumer.heartbeat()
 
             if (this.consoleLogsIngester) {
                 await instrumentFn(`recordingingester.handleEachBatch.consumeConsoleLogEvents`, async () => {
                     await this.consoleLogsIngester!.consumeBatch(recordingMessages)
                 })
-                this.kafkaConsumer.heartbeat()
             }
         })
     }

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -255,6 +255,7 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
 
     CONSUMER_BATCH_SIZE: number // Primarily for kafka consumers the batch size to use
     CONSUMER_MAX_HEARTBEAT_INTERVAL_MS: number // Primarily for kafka consumers the max heartbeat interval to use after which it will be considered unhealthy
+    CONSUMER_LOOP_STALL_THRESHOLD_MS: number // Threshold in ms after which the consumer loop is considered stalled
     CONSUMER_MAX_BACKGROUND_TASKS: number
     CONSUMER_WAIT_FOR_BACKGROUND_TASKS_ON_REBALANCE: boolean
     CONSUMER_AUTO_CREATE_TOPICS: boolean

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -96,10 +96,16 @@ export const stringToPluginServerMode = Object.fromEntries(
     ])
 ) as Record<string, PluginServerMode>
 
+export interface HealthCheckResult {
+    healthy: boolean
+    message?: string
+    details?: Record<string, any>
+}
+
 export type PluginServerService = {
     id: string
     onShutdown: () => Promise<any>
-    healthcheck: () => boolean | Promise<boolean>
+    healthcheck: () => boolean | HealthCheckResult | Promise<boolean | HealthCheckResult>
 }
 
 export type CdpConfig = {

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -256,6 +256,7 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
     CONSUMER_BATCH_SIZE: number // Primarily for kafka consumers the batch size to use
     CONSUMER_MAX_HEARTBEAT_INTERVAL_MS: number // Primarily for kafka consumers the max heartbeat interval to use after which it will be considered unhealthy
     CONSUMER_LOOP_STALL_THRESHOLD_MS: number // Threshold in ms after which the consumer loop is considered stalled
+    KAFKA_CONSUMER_LOOP_BASED_HEALTH_CHECK: boolean // Use consumer loop monitoring for health checks instead of heartbeats
     CONSUMER_MAX_BACKGROUND_TASKS: number
     CONSUMER_WAIT_FOR_BACKGROUND_TASKS_ON_REBALANCE: boolean
     CONSUMER_AUTO_CREATE_TOPICS: boolean

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
@@ -591,6 +591,17 @@ describe.each([[true], [false]])('ingester with consumeOverflow=%p', (consumeOve
                 })
             })
         })
+
+        describe('heartbeats', () => {
+            it('it should send them whilst processing', async () => {
+                // non-zero offset because the code can't commit offset 0
+                const partitionMsgs1 = [createMessage('session_id_1', 1), createMessage('session_id_2', 1)]
+                await ingester.handleEachBatch(partitionMsgs1)
+
+                // NOTE: the number here can change as we change the code. Important is that it is called a number of times
+                expect(mockConsumer.heartbeat).toHaveBeenCalledTimes(6)
+            })
+        })
     })
 
     describe('when ingester.stop is called in teardown', () => {

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
@@ -591,17 +591,6 @@ describe.each([[true], [false]])('ingester with consumeOverflow=%p', (consumeOve
                 })
             })
         })
-
-        describe('heartbeats', () => {
-            it('it should send them whilst processing', async () => {
-                // non-zero offset because the code can't commit offset 0
-                const partitionMsgs1 = [createMessage('session_id_1', 1), createMessage('session_id_2', 1)]
-                await ingester.handleEachBatch(partitionMsgs1)
-
-                // NOTE: the number here can change as we change the code. Important is that it is called a number of times
-                expect(mockConsumer.heartbeat).toHaveBeenCalledTimes(6)
-            })
-        })
     })
 
     describe('when ingester.stop is called in teardown', () => {


### PR DESCRIPTION
## Summary
This PR improves the Kafka consumer health check mechanism by replacing the manual heartbeat tracking with a health monitoring system that leverages librdkafka's built-in statistics and connection state. It also enriches error data for the consumer with details for the failures

## Motivation

The previous implementation had some limitations that could cause unexpected service restarts in production, the expectation for the application logic is that between each heartbeat interval a heartbeat method would have to be called. This method, by default, was called upon completion of every pool and processing of a batch. 

By the node-rdkafka docs, `heartbeat.interval.ms` represents `Group session keepalive heartbeat interval`, this heartbeat runs on a separate thread in `librdkafka` and sends a message to the broker within that interval. For actual service health, we can refer to the definition of `session.timeout.ms` -> `Client group session and failure detection timeout. The consumer sends periodic heartbeats (heartbeat.interval.ms) to indicate its liveness to the broker. If no hearts are received by the broker for a group member within the session timeout, the broker will remove the consumer from the group and trigger a rebalance`.

Since this configuration is doing both, it becomes very hard to process slow messages, as this setting works both as a maximum batch timer as well as the interval to which we send kafka information.

### Main challenges of previous approach:
- Mixed Responsibilities 
  - The health check tracked manual heartbeats alongside Kafka's protocol heartbeats (handled by librdkafka via session.timeout.ms), which served different purposes
- Health Check False Negatives:
    - Empty topics: Consumer marked unhealthy after 30s without messages, even when actively polling
    - Slow batch processing: Any batch taking >30s to process triggered unhealthy state (this couldn't be easily changed, i.e for overflow)
    - Rebalancing: Consumer could be marked unhealthy during normal rebalancing operations
    - Backpressure: Waiting for background tasks could trigger unhealthy state
- Manual Heartbeat Management
  -  Required explicit heartbeat() calls throughout the codebase, which session recording had several to avoid getting timed out

## Changes
- Enabled librdkafka statistics: Configured statistics.interval.ms to emit internal metrics every 5 seconds
- Consumer state tracking: Monitor librdkafka's internal state via statistics events
- Pool loop liveness: Track consumer loop iterations with stall threshold
- Connection monitoring: Check if we can connect to Kafka explicitly
- Improved Health Check Interface, by providing more data for service reports
