### PR TITLE
fix: Ensure `SESSION_REPLAY_RRWEB_SCRIPT_ALLOWED_TEAMS` is a list to

### DIFF
--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -619,7 +619,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
 
         with self.settings(
             SESSION_REPLAY_RRWEB_SCRIPT=rrweb_script_name,
-            SESSION_REPLAY_RRWEB_SCRIPT_ALLOWED_TEAMS=",".join(team_allow_list or []),
+            SESSION_REPLAY_RRWEB_SCRIPT_ALLOWED_TEAMS=team_allow_list or [],
         ):
             response = self._post_decide(api_version=3)
             assert response.status_code == 200


### PR DESCRIPTION
…avoid failed tests.

## Problem

- Test fails in CI (seems flaky: https://github.com/PostHog/posthog/actions/runs/17097864923/job/48486510802?pr=36572)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

As `SESSION_REPLAY_RRWEB_SCRIPT_ALLOWED_TEAMS` is created to be a list:

```python
SESSION_REPLAY_RRWEB_SCRIPT_ALLOWED_TEAMS = get_list(get_from_env("SESSION_REPLAY_RRWEB_SCRIPT_ALLOWED_TEAMS", ""))
```

it seems it should be the list in the test too (as before we checked not the "if in the list", but substring).

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
