### PR TITLE
fix(ux): fixed add to notebook dropdown width

### DIFF
--- a/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneAddToNotebookDropdownMenu.tsx
+++ b/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneAddToNotebookDropdownMenu.tsx
@@ -37,7 +37,7 @@ export function SceneAddToNotebookDropdownMenu({
                     <DropdownMenuOpenIndicator />
                 </ButtonPrimitive>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" matchTriggerWidth>
+            <DropdownMenuContent align="end" matchTriggerWidth className="min-w-none max-w-none">
                 <SceneNotebookMenuItems
                     notebookSelectButtonProps={{
                         resource: {

--- a/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneNotebookMenuItems.tsx
+++ b/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneNotebookMenuItems.tsx
@@ -86,7 +86,7 @@ export function SceneNotebookMenuItems({
                 <Combobox insideMenu>
                     <Combobox.Search placeholder="Search notebooks..." autoFocus />
 
-                    <Combobox.Content className="max-w-[300px]">
+                    <Combobox.Content className="max-w-[700px]">
                         <Combobox.Empty>No notebooks found</Combobox.Empty>
 
                         <AccessControlAction

--- a/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneNotebookMenuItems.tsx
+++ b/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneNotebookMenuItems.tsx
@@ -86,7 +86,7 @@ export function SceneNotebookMenuItems({
                 <Combobox insideMenu>
                     <Combobox.Search placeholder="Search notebooks..." autoFocus />
 
-                    <Combobox.Content className="max-w-[700px]">
+                    <Combobox.Content className="max-w-none min-w-none">
                         <Combobox.Empty>No notebooks found</Combobox.Empty>
 
                         <AccessControlAction

--- a/frontend/src/lib/ui/DropdownMenu/DropdownMenu.tsx
+++ b/frontend/src/lib/ui/DropdownMenu/DropdownMenu.tsx
@@ -110,7 +110,7 @@ const DropdownMenuContent = React.forwardRef<
                     sideOffset={sideOffset}
                     collisionPadding={collisionPadding}
                     className={cn(
-                        'primitive-menu-content max-h-[var(--radix-dropdown-menu-content-available-height)] transition-[width] duration-100 will-change-contents',
+                        'primitive-menu-content max-h-[var(--radix-dropdown-menu-content-available-height)]',
                         matchTriggerWidth && 'min-w-[var(--radix-dropdown-menu-trigger-width)]',
                         className
                     )}

--- a/frontend/src/lib/ui/DropdownMenu/DropdownMenu.tsx
+++ b/frontend/src/lib/ui/DropdownMenu/DropdownMenu.tsx
@@ -97,7 +97,7 @@ const DropdownMenuContent = React.forwardRef<
             className,
             children,
             sideOffset = 4,
-            collisionPadding = { top: 50, bottom: 50 },
+            collisionPadding = { top: 50, bottom: 50, left: 10, right: 10 },
             matchTriggerWidth,
             ...props
         },
@@ -110,7 +110,7 @@ const DropdownMenuContent = React.forwardRef<
                     sideOffset={sideOffset}
                     collisionPadding={collisionPadding}
                     className={cn(
-                        'primitive-menu-content max-h-[var(--radix-dropdown-menu-content-available-height)]',
+                        'primitive-menu-content max-h-[var(--radix-dropdown-menu-content-available-height)] transition-[width] duration-100 will-change-contents',
                         matchTriggerWidth && 'min-w-[var(--radix-dropdown-menu-trigger-width)]',
                         className
                     )}


### PR DESCRIPTION
## Problem
Add to notebook dropdown menu wasn't stretching to fit content / truncating

![2025-08-20 14 21 41](https://github.com/user-attachments/assets/bd0c9db8-f67d-44bf-85df-e5064f1b6da0)
![2025-08-20 14 26 42](https://github.com/user-attachments/assets/1f10851c-28fe-4b60-8058-688d71d76f49)

## Changes
Opted to fit content, as people likely want to see the name (without tooltip)
Added a left and right window collision padding of `10px`, which is just nice. This affects all dropdown menus (and looks nicer in the nav bar too, which is hugging the left of screen)

## How did you test this code?
Clicking around
