### PR TITLE
fix(materialization): Batch record batches so we're not writing every small batch from CH

### DIFF
--- a/posthog/hogql/constants.py
+++ b/posthog/hogql/constants.py
@@ -131,3 +131,4 @@ class HogQLGlobalSettings(HogQLQuerySettings):
     optimize_min_equality_disjunction_chain_length: Optional[int] = 4294967295
     # experimental support for nonequal joins
     allow_experimental_join_condition: Optional[bool] = True
+    preferred_block_size_bytes: Optional[int] = None

--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -698,7 +698,6 @@ async def get_query_row_count(query: str, team: Team, logger: FilteringBoundLogg
 
 
 MB_50_IN_BYTES = 50 * 1000 * 1000
-MB_200_IN_BYTES = 200 * 1000 * 1000
 
 
 async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger):
@@ -822,7 +821,7 @@ async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger):
             batches_size = batches_size + batch.nbytes
             batches.append(batch)
 
-            if batches_size >= MB_200_IN_BYTES:
+            if batches_size >= MB_50_IN_BYTES:
                 await logger.adebug(f"Yielding {len(batches)} batches for total size of {batches_size / 1000 / 1000}MB")
 
                 yield (

--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -814,7 +814,7 @@ async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger):
 
     await logger.adebug(f"Running clickhouse query: {arrow_printed}")
 
-    async with get_client() as client:
+    async with get_client(max_block_size=MB_50_IN_BYTES) as client:
         batches = []
         batches_size = 0
         async for batch in client.astream_query_as_arrow(arrow_printed, query_parameters=context.values):

--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -814,7 +814,8 @@ async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger):
 
     await logger.adebug(f"Running clickhouse query: {arrow_printed}")
 
-    async with get_client(max_block_size=MB_50_IN_BYTES) as client:
+    # Set max block size to 50,000 rows
+    async with get_client(max_block_size=50_000) as client:
         batches = []
         batches_size = 0
         async for batch in client.astream_query_as_arrow(arrow_printed, query_parameters=context.values):


### PR DESCRIPTION
## Problem
- We're hitting a 30-min timeout _somewhere_ when streaming results back from Clickhouse (even if the query took < 1 second)
  - Finding this 30 mins timeout isn't straightforward
- This is because Clickhouse was returning really small batches of rows and we were writing each one to deltalake - this was taking a long time (far too long)
  - The default block size is 1 MB 
- https://posthog.slack.com/archives/C019RAX2XBN/p1755689826525459

## Changes
- Batch the `pa.RecordBatch` objects we get back from clickhouse until they add up to a reasonable size for us to return (200 MB)
  - Combine the batches together and then yield them to be written to deltalake
- Increase the (preferred) returned block size to 50 MB

## How did you test this code?
Tested locally + existing unit test
