### PR TITLE
fix(max): Handle missing core memory gracefully

### DIFF
--- a/ee/hogai/graph/memory/nodes.py
+++ b/ee/hogai/graph/memory/nodes.py
@@ -292,9 +292,7 @@ class MemoryOnboardingEnquiryNode(AssistantNode):
         )
 
     def router(self, state: AssistantState) -> Literal["continue", "interrupt"]:
-        core_memory = self.core_memory
-        if core_memory is None:
-            raise ValueError("No core memory found.")
+        core_memory, _ = CoreMemory.objects.get_or_create(team=self._team)
         if state.onboarding_question and core_memory.answers_left > 0:
             return "interrupt"
         return "continue"
@@ -323,9 +321,7 @@ class MemoryOnboardingEnquiryInterruptNode(AssistantNode):
 
 class MemoryOnboardingFinalizeNode(AssistantNode):
     def run(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState:
-        core_memory = self.core_memory
-        if core_memory is None:
-            raise ValueError("No core memory found.")
+        core_memory, _ = CoreMemory.objects.get_or_create(team=self._team)
         # Compress the question/answer memory before saving it
         prompt = ChatPromptTemplate.from_messages(
             [
@@ -353,9 +349,7 @@ class MemoryOnboardingFinalizeNode(AssistantNode):
         )
 
     def router(self, state: AssistantState) -> Literal["continue", "insights"]:
-        core_memory = self.core_memory
-        if core_memory is None:
-            raise ValueError("No core memory found.")
+        core_memory, _ = CoreMemory.objects.get_or_create(team=self._team)
         if state.root_tool_insight_plan:
             return "insights"
         return "continue"

--- a/ee/hogai/graph/memory/nodes.py
+++ b/ee/hogai/graph/memory/nodes.py
@@ -349,7 +349,6 @@ class MemoryOnboardingFinalizeNode(AssistantNode):
         )
 
     def router(self, state: AssistantState) -> Literal["continue", "insights"]:
-        # This router only checks state, no CoreMemory needed
         if state.root_tool_insight_plan:
             return "insights"
         return "continue"

--- a/ee/hogai/graph/memory/nodes.py
+++ b/ee/hogai/graph/memory/nodes.py
@@ -292,12 +292,7 @@ class MemoryOnboardingEnquiryNode(AssistantNode):
         )
 
     def router(self, state: AssistantState) -> Literal["continue", "interrupt"]:
-        try:
-            core_memory = CoreMemory.objects.get(team=self._team)
-        except CoreMemory.DoesNotExist:
-            # Edge case: create if missing, but this shouldn't happen in normal flow
-            core_memory = CoreMemory.objects.create(team=self._team)
-        
+        core_memory, _ = CoreMemory.objects.get_or_create(team=self._team)
         if state.onboarding_question and core_memory.answers_left > 0:
             return "interrupt"
         return "continue"

--- a/ee/hogai/graph/memory/nodes.py
+++ b/ee/hogai/graph/memory/nodes.py
@@ -292,7 +292,12 @@ class MemoryOnboardingEnquiryNode(AssistantNode):
         )
 
     def router(self, state: AssistantState) -> Literal["continue", "interrupt"]:
-        core_memory, _ = CoreMemory.objects.get_or_create(team=self._team)
+        try:
+            core_memory = CoreMemory.objects.get(team=self._team)
+        except CoreMemory.DoesNotExist:
+            # Edge case: create if missing, but this shouldn't happen in normal flow
+            core_memory = CoreMemory.objects.create(team=self._team)
+        
         if state.onboarding_question and core_memory.answers_left > 0:
             return "interrupt"
         return "continue"
@@ -349,7 +354,7 @@ class MemoryOnboardingFinalizeNode(AssistantNode):
         )
 
     def router(self, state: AssistantState) -> Literal["continue", "insights"]:
-        core_memory, _ = CoreMemory.objects.get_or_create(team=self._team)
+        # This router only checks state, no CoreMemory needed
         if state.root_tool_insight_plan:
             return "insights"
         return "continue"

--- a/ee/hogai/graph/memory/test/test_nodes.py
+++ b/ee/hogai/graph/memory/test/test_nodes.py
@@ -411,7 +411,7 @@ class TestMemoryOnboardingEnquiryNode(ClickhouseTestMixin, BaseTest):
         # Should not raise an error, but create a new core memory and return "continue"
         result = self.node.router(AssistantState(messages=[]))
         self.assertEqual(result, "continue")
-        # Verify that a new CoreMemory was created
+        # Verify that a new CoreMemory was created as fallback
         self.assertTrue(CoreMemory.objects.filter(team=self.team).exists())
 
     def test_router_with_no_onboarding_question(self):

--- a/ee/hogai/graph/memory/test/test_nodes.py
+++ b/ee/hogai/graph/memory/test/test_nodes.py
@@ -408,10 +408,8 @@ class TestMemoryOnboardingEnquiryNode(ClickhouseTestMixin, BaseTest):
 
     def test_router_with_no_core_memory(self):
         self.core_memory.delete()
-        # Should not raise an error, but create a new core memory and return "continue"
         result = self.node.router(AssistantState(messages=[]))
         self.assertEqual(result, "continue")
-        # Verify that a new CoreMemory was created as fallback
         self.assertTrue(CoreMemory.objects.filter(team=self.team).exists())
 
     def test_router_with_no_onboarding_question(self):

--- a/ee/hogai/graph/memory/test/test_nodes.py
+++ b/ee/hogai/graph/memory/test/test_nodes.py
@@ -408,9 +408,11 @@ class TestMemoryOnboardingEnquiryNode(ClickhouseTestMixin, BaseTest):
 
     def test_router_with_no_core_memory(self):
         self.core_memory.delete()
-        with self.assertRaises(ValueError) as e:
-            self.node.router(AssistantState(messages=[]))
-        self.assertEqual(str(e.exception), "No core memory found.")
+        # Should not raise an error, but create a new core memory and return "continue"
+        result = self.node.router(AssistantState(messages=[]))
+        self.assertEqual(result, "continue")
+        # Verify that a new CoreMemory was created
+        self.assertTrue(CoreMemory.objects.filter(team=self.team).exists())
 
     def test_router_with_no_onboarding_question(self):
         self.assertEqual(self.node.router(AssistantState(messages=[])), "continue")


### PR DESCRIPTION
### Problem

Currently if there's no core memory (for any reason), `MemoryCollectorTools` fails. See [this trace for an example](core m). In that case, the actual response succeeds, but the user gets a confusing error that isn't related to anything:
 
<img width="311" height="109" alt="Screenshot 2025-08-20 at 15 32 06 (1)" src="https://github.com/user-attachments/assets/404c3648-47d3-4de5-86ce-406bd4f77941" />

### Change

Replaces "No core memory found." errors with `get_or_create` for core memory. This prevents the orphaned error.

The bigger question is: why were we making the hard assumption that a CoreMemory MUST be present at the point of running those paths throwing the error previously? Maybe I'm missing something. @skoob13 

### How did you test this?

One test about the "no core memory" case updated.