### PR TITLE
chore(experiments): route dagster experiments alerts to it's channel

### DIFF
--- a/dags/slack_alerts.py
+++ b/dags/slack_alerts.py
@@ -12,6 +12,7 @@ notification_channel_per_team = {
     JobOwners.TEAM_REVENUE_ANALYTICS.value: "#alerts-revenue-analytics",
     JobOwners.TEAM_ERROR_TRACKING.value: "#alerts-error-tracking",
     JobOwners.TEAM_GROWTH.value: "#alerts-growth",
+    JobOwners.TEAM_EXPERIMENTS.value: "#alerts-experiments",
 }
 
 


### PR DESCRIPTION
## Problem/Changes

We have the JobOwners enum, but it routes the alerts to #alerts-clickhouse by default ([example](https://posthog.slack.com/archives/C07P4KHFFDF/p1755655671159999)) if there is no specific channel. I think this makes more sense, but feel free to disable the slack alerts if you want by using the tag `disable_slack_notifications` on the jobs/assets.

## How did you test this code?

Manually

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
