### PR TITLE
chore(crm): Refactor group notebook tab

### DIFF
--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -30,6 +30,7 @@ import type { ActionFilter, Group } from '~/types'
 import {
     ActivityScope,
     FilterLogicalOperator,
+    GroupsTabType,
     Group as IGroup,
     PersonsTabType,
     PropertyDefinitionType,
@@ -110,15 +111,15 @@ export function Group(): JSX.Element {
                 onChange={(tab) => router.actions.push(urls.group(String(groupTypeIndex), groupKey, true, tab))}
                 tabs={[
                     {
-                        key: 'overview',
+                        key: GroupsTabType.OVERVIEW,
                         label: <span data-attr="groups-overview-tab">Overview</span>,
                         content: <GroupOverview groupData={groupData} />,
                     },
                     ...(featureFlags[FEATURE_FLAGS.CRM_ITERATION_ONE] && groupData.notebook
                         ? [
                               {
-                                  key: 'notebook',
-                                  label: <span data-attr="groups-notebook-tab">Notebook</span>,
+                                  key: GroupsTabType.NOTES,
+                                  label: <span data-attr="groups-notes-tab">Notes</span>,
                                   content: <GroupNotebookCard shortId={groupData.notebook} />,
                               },
                           ]

--- a/frontend/src/scenes/groups/cards/GroupNotebookCard.tsx
+++ b/frontend/src/scenes/groups/cards/GroupNotebookCard.tsx
@@ -1,6 +1,4 @@
-import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Notebook } from 'scenes/notebooks/Notebook/Notebook'
-import { urls } from 'scenes/urls'
 
 interface GroupNotebookCardProps {
     shortId: string
@@ -8,15 +6,8 @@ interface GroupNotebookCardProps {
 
 export function GroupNotebookCard({ shortId }: GroupNotebookCardProps): JSX.Element {
     return (
-        <div className="flex flex-col gap-2">
-            <div className="flex justify-end">
-                <LemonButton type="secondary" size="small" to={urls.notebook(shortId)}>
-                    Open notebook
-                </LemonButton>
-            </div>
-            <div className="flex-1">
-                <Notebook shortId={shortId} editable={true} initialAutofocus="end" />
-            </div>
+        <div className="flex-1 bg-white rounded-lg px-4">
+            <Notebook shortId={shortId} editable={true} initialAutofocus="end" />
         </div>
     )
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1529,6 +1529,11 @@ export enum PersonsTabType {
     FEATURE_FLAGS = 'featureFlags',
 }
 
+export enum GroupsTabType {
+    NOTES = 'notes',
+    OVERVIEW = 'overview',
+}
+
 export enum LayoutView {
     Card = 'card',
     List = 'list',


### PR DESCRIPTION
## Problem
It was not much intuitive that the embedded notebook was editable. Additionally, the "Open notebook" button wasn't really needed.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Related to https://github.com/PostHog/posthog/issues/36460
## Changes
- Remove `Open notebook` button
- Make noteboook bg color white
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
<img width="1624" height="970" alt="image" src="https://github.com/user-attachments/assets/d66ce190-f0ec-48d9-b47f-5a03fa3de52f" />

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
