### PR TITLE
feat: take memory usage measure less often

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -50,7 +50,7 @@ export function loadPostHogJS(): void {
                             return
                         }
 
-                        const oneMinuteInMs = 60000
+                        const tenMinuteInMs = 60000 * 10
                         setInterval(() => {
                             // this is deprecated and not available in all browsers,
                             // but the supposed standard at https://developer.mozilla.org/en-US/docs/Web/API/Performance/measureUserAgentSpecificMemory
@@ -60,9 +60,11 @@ export function loadPostHogJS(): void {
                                 loadedInstance.capture('memory_usage', {
                                     totalJSHeapSize: memory.totalJSHeapSize,
                                     usedJSHeapSize: memory.usedJSHeapSize,
+                                    pageIsVisible: document.visibilityState === 'visible',
+                                    pageIsFocused: document.hasFocus(),
                                 })
                             }
-                        }, oneMinuteInMs)
+                        }, tenMinuteInMs)
                     }
                 }
 


### PR DESCRIPTION
sometimes i wish we charged ourselves for posthog

one event per minute per active session is a bit ridiculous, let's pare it back

let's also capture whether the document has focus / is visible, i want to see if high mem usage corresponds with being in the background