### PR TITLE
fix(flags): deserialize empty non-boolean query params as none

### DIFF
--- a/rust/feature-flags/src/api/types.rs
+++ b/rust/feature-flags/src/api/types.rs
@@ -1,9 +1,9 @@
 use crate::flags::flag_matching::FeatureFlagMatch;
 use crate::flags::flag_models::FeatureFlag;
 use crate::{flags::flag_match_reason::FeatureFlagMatchReason, site_apps::WebJsUrl};
-use serde::{Deserialize, Serialize};
+use serde::{de, Deserialize, Deserializer, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt, str::FromStr};
 use uuid::Uuid;
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
@@ -42,6 +42,18 @@ pub enum Compression {
     Unsupported,
 }
 
+impl FromStr for Compression {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "gzip" | "gzip-js" => Ok(Compression::Gzip),
+            "base64" => Ok(Compression::Base64),
+            _ => Ok(Compression::Unsupported),
+        }
+    }
+}
+
 impl Compression {
     pub fn as_str(&self) -> &'static str {
         match self {
@@ -55,18 +67,23 @@ impl Compression {
 #[derive(Clone, Deserialize, Default)]
 pub struct FlagsQueryParams {
     /// Optional API version identifier, defaults to None (which returns a legacy response)
-    #[serde(alias = "v")]
+    #[serde(alias = "v", default, deserialize_with = "empty_string_as_none")]
     pub version: Option<String>,
 
     /// Compression type for the incoming request
+    #[serde(default, deserialize_with = "empty_string_as_none")]
     pub compression: Option<Compression>,
 
     /// Library version (alias: "ver")
-    #[serde(alias = "ver")]
+    #[serde(alias = "ver", default, deserialize_with = "empty_string_as_none")]
     pub lib_version: Option<String>,
 
     /// Optional timestamp indicating when the request was sent
-    #[serde(alias = "_")]
+    #[serde(
+        alias = "_",
+        default,
+        deserialize_with = "deserialize_optional_timestamp"
+    )]
     pub sent_at: Option<i64>,
 
     /// Optional boolean indicating whether to only evaluate survey feature flags
@@ -620,5 +637,40 @@ mod tests {
         // Config fields should be present when set
         assert!(obj.contains_key("analytics"));
         assert!(obj.contains_key("supportedCompression"));
+    }
+}
+
+/// Generic deserializer that treats empty strings as None for any type that implements FromStr
+fn empty_string_as_none<'de, D, T>(de: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: FromStr,
+    T::Err: fmt::Display,
+{
+    let opt = Option::<String>::deserialize(de)?;
+    match opt.as_deref() {
+        None | Some("") => Ok(None),
+        Some(s) => FromStr::from_str(s).map_err(de::Error::custom).map(Some),
+    }
+}
+
+/// Deserializer for timestamps that handles both strings and integers
+fn deserialize_optional_timestamp<'de, D>(de: D) -> Result<Option<i64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum IntOrString {
+        Int(i64),
+        String(String),
+    }
+
+    let opt = Option::<IntOrString>::deserialize(de)?;
+    match opt {
+        None => Ok(None),
+        Some(IntOrString::Int(i)) => Ok(Some(i)),
+        Some(IntOrString::String(s)) if s.is_empty() => Ok(None),
+        Some(IntOrString::String(s)) => s.parse().map(Some).map_err(de::Error::custom),
     }
 }

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -5241,7 +5241,7 @@ async fn it_handles_empty_query_parameters() -> Result<()> {
 
     let server = ServerHandle::for_config(config).await;
 
-    // Create a request with empty query parameters like the failing requests
+    // Create a request with empty query parameters
     let reqwest_client = reqwest::Client::new();
     let response = reqwest_client
         .post(format!(
@@ -5265,7 +5265,6 @@ async fn it_handles_empty_query_parameters() -> Result<()> {
     let response_text = response.text().await?;
     let response_json: serde_json::Value = serde_json::from_str(&response_text)?;
 
-    // Should have successfully processed the request despite empty query params
     assert!(
         response_json.get("flags").is_some(),
         "Response should contain flags field"

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -5250,8 +5250,7 @@ async fn it_handles_empty_query_parameters() -> Result<()> {
         ))
         .header("Content-Type", "application/json")
         .body(format!(
-            r#"{{"token": "{}", "distinct_id": "{}"}}"#,
-            token, distinct_id
+            r#"{{"token": "{token}", "distinct_id": "{distinct_id}"}}"#
         ))
         .send()
         .await?;

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -5271,3 +5271,85 @@ async fn it_handles_empty_query_parameters() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn it_handles_boolean_query_params_as_truthy() -> Result<()> {
+    let config = DEFAULT_TEST_CONFIG.clone();
+    let distinct_id = "user_distinct_id".to_string();
+
+    let client = setup_redis_client(Some(config.redis_url.clone())).await;
+    let pg_client = setup_pg_reader_client(None).await;
+    let team = insert_new_team_in_redis(client.clone()).await.unwrap();
+    let token = team.api_token;
+
+    insert_new_team_in_pg(pg_client.clone(), Some(team.id))
+        .await
+        .unwrap();
+
+    insert_person_for_team_in_pg(pg_client.clone(), team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
+
+    let server = ServerHandle::for_config(config).await;
+
+    // Test various boolean parameter formats
+    let test_cases = vec![
+        ("config=", "config with empty value should be truthy"),
+        ("config=true", "config=true should be truthy"),
+        ("config=1", "config=1 should be truthy"),
+    ];
+
+    for (query_param, description) in test_cases {
+        let reqwest_client = reqwest::Client::new();
+        let response = reqwest_client
+            .post(format!("http://{}/flags/?{query_param}", server.addr))
+            .header("Content-Type", "application/json")
+            .body(format!(
+                r#"{{"token": "{token}", "distinct_id": "{distinct_id}"}}"#
+            ))
+            .send()
+            .await?;
+
+        assert_eq!(
+            response.status(),
+            200,
+            "{description}: request should succeed"
+        );
+
+        let response_json: serde_json::Value = response.json().await?;
+
+        // When config=true or config=, we should get config fields in response
+        if query_param.starts_with("config") {
+            assert!(
+                response_json.get("config").is_some(),
+                "{description}: config field should be present"
+            );
+        }
+    }
+
+    // Test config=false should NOT include config fields
+    let reqwest_client = reqwest::Client::new();
+    let response = reqwest_client
+        .post(format!("http://{}/flags/?config=false", server.addr))
+        .header("Content-Type", "application/json")
+        .body(format!(
+            r#"{{"token": "{token}", "distinct_id": "{distinct_id}"}}"#
+        ))
+        .send()
+        .await?;
+
+    assert_eq!(
+        response.status(),
+        200,
+        "config=false request should succeed"
+    );
+    let response_json: serde_json::Value = response.json().await?;
+
+    // Config fields should not be present when config=false
+    assert!(
+        response_json.get("config").is_none(),
+        "config fields should not be present when config=false"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

flags doesn't allow empty query params. I.e. this fails when calling flags but not decide 

```
curl "https://us.i.posthog.com/flags/?v=2&ip=&ver=&compression="
```

I noticed this because some proxied decide requests that 400'ed has this in their uri log: 
```
/decide?v=3&ip=&_=&ver=&compression=
```

It appears that this issue accounted for approximately 140 request/min responding with a 400.
https://grafana.prod-us.posthog.dev/goto/-HUUMIXNR?orgId=1

<img width="1038" height="415" alt="Screenshot 2025-08-20 at 2 39 45 PM" src="https://github.com/user-attachments/assets/df8a372b-cefe-45e8-a8e2-29cfcbb25262" />

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Add methods to deserialize empty values for `v`, `compression`, `ver`, and `_` as none. 

Also add method for truthy boolean params `config` and `only_evaluate_survey_feature_flags`


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

integ test and locally. 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
