### PR TITLE
fix: gather more context on V2 LTS error playback

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -1063,7 +1063,7 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
                         max_blob_key=validated_data["max_blob_key"],
                     )
                 elif "blob_key" in validated_data:
-                    response = self._stream_lts_blob_v2_to_client(recording, timer, blob_key=validated_data["blob_key"])
+                    response = self._stream_lts_blob_v2_to_client(blob_key=validated_data["blob_key"])
                 else:
                     response = self._gather_session_recording_sources(
                         recording, timer, is_v2_enabled, is_v2_lts_enabled
@@ -1367,15 +1367,13 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
 
     async def _stream_lts_blob_v2_to_client_async(
         self,
-        recording: SessionRecording,
-        timer: ServerTimingsGathered,
         blob_key: str,
     ) -> HttpResponse:
         with STREAM_RESPONSE_TO_CLIENT_HISTOGRAM.labels(blob_version="v2").time():
             with (
-                timer("list_blocks__stream_lts_blob_v2_to_client_async"),
                 tracer.start_as_current_span("list_blocks__stream_lts_blob_v2_to_client_async"),
             ):
+                posthoganalytics.tag("lts_v2_blob_key", blob_key)
                 content = await asyncio.to_thread(session_recording_v2_object_storage.client().fetch_file, blob_key)
 
             twenty_four_hours_in_seconds = 60 * 60 * 24
@@ -1462,11 +1460,9 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
 
     def _stream_lts_blob_v2_to_client(
         self,
-        recording: SessionRecording,
-        timer: ServerTimingsGathered,
         blob_key: str,
     ) -> HttpResponse:
-        return asyncio.run(self._stream_lts_blob_v2_to_client_async(recording, timer, blob_key))
+        return asyncio.run(self._stream_lts_blob_v2_to_client_async(blob_key))
 
     def _send_realtime_snapshots_to_client(self, recording: SessionRecording) -> HttpResponse | Response:
         with GET_REALTIME_SNAPSHOTS_FROM_REDIS.time():

--- a/posthog/storage/session_recording_v2_object_storage.py
+++ b/posthog/storage/session_recording_v2_object_storage.py
@@ -1,4 +1,6 @@
 import abc
+
+import posthoganalytics
 import structlog
 from boto3 import client as boto3_client
 from botocore.client import Config
@@ -132,6 +134,7 @@ class SessionRecordingV2ObjectStorage(SessionRecordingV2ObjectStorageBase):
             return snappy.decompress(file_body).decode("utf-8")
 
         except Exception as e:
+            posthoganalytics.tag("bucket", self.bucket)
             logger.exception("Failed to read and decompress file", error=e)
             raise FileFetchError(f"Failed to read and decompress file: {str(e)}")
 


### PR DESCRIPTION
we were getting errors but the error didn't help us see _why_ we were getting errors since the file did exist but the error suggested it didn't

add more context to the error