### PR TITLE
fix: always attempt base64 decode regardless of compression param

### DIFF
--- a/rust/feature-flags/src/handler/decoding.rs
+++ b/rust/feature-flags/src/handler/decoding.rs
@@ -47,18 +47,8 @@ fn decode_body(
     compression: Option<Compression>,
     headers: &HeaderMap,
 ) -> Result<Bytes, FlagError> {
-    // First try explicit compression parameter; Android doesn't send this but other clients do.
-    if let Some(compression) = compression {
-        return match compression {
-            Compression::Gzip => decompress_gzip(body),
-            Compression::Base64 => decode_base64(body),
-            Compression::Unsupported => {
-                tracing::warn!("unsupported compression type");
-                Err(FlagError::RequestDecodingError(
-                    "Unsupported compression type".to_string(),
-                ))
-            }
-        };
+    if let Some(Compression::Gzip) = compression {
+        return decompress_gzip(body);
     }
 
     // Check Content-Encoding header (Android uses this primarily)

--- a/rust/feature-flags/src/handler/decoding.rs
+++ b/rust/feature-flags/src/handler/decoding.rs
@@ -55,7 +55,7 @@ fn decode_body(
             }
             Compression::Unsupported => {
                 tracing::warn!("unsupported compression type");
-                return Err(FlagError::RequestDecodingError(
+                Err(FlagError::RequestDecodingError(
                     "Unsupported compression type".to_string(),
                 ));
             }

--- a/rust/feature-flags/src/handler/decoding.rs
+++ b/rust/feature-flags/src/handler/decoding.rs
@@ -55,7 +55,7 @@ fn decode_body(
             }
             Compression::Unsupported => {
                 tracing::warn!("unsupported compression type");
-                Err(FlagError::RequestDecodingError(
+                return Err(FlagError::RequestDecodingError(
                     "Unsupported compression type".to_string(),
                 ));
             }

--- a/rust/feature-flags/src/handler/decoding.rs
+++ b/rust/feature-flags/src/handler/decoding.rs
@@ -47,8 +47,19 @@ fn decode_body(
     compression: Option<Compression>,
     headers: &HeaderMap,
 ) -> Result<Bytes, FlagError> {
-    if let Some(Compression::Gzip) = compression {
-        return decompress_gzip(body);
+    if let Some(compression) = compression {
+        match compression {
+            Compression::Gzip => return decompress_gzip(body),
+            Compression::Base64 => {
+                // handle base64 detection separately in try_parse_with_fallbacks
+            }
+            Compression::Unsupported => {
+                tracing::warn!("unsupported compression type");
+                return Err(FlagError::RequestDecodingError(
+                    "Unsupported compression type".to_string(),
+                ));
+            }
+        }
     }
 
     // Check Content-Encoding header (Android uses this primarily)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Setting `?compression=base64` on decide requests doesn't actually do anything because we always attempt base64 decoding.

https://github.com/PostHog/posthog/blob/7a987356f39c2591484e2bb22005af91afa9dfec/posthog/utils.py#L765-L770


This contributed some 400s when proxying decide to flags: 
https://grafana.prod-us.posthog.dev/goto/zbaY5SXHR?orgId=1
<img width="1035" height="420" alt="Screenshot 2025-08-20 at 4 58 05 PM" src="https://github.com/user-attachments/assets/9959c2f5-7d4b-4d08-9308-c722cbe85b65" />

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Make flags do the same 

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

Locally

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
