### PR TITLE
feat(capture-rs): facet event parse error by CaptureMode in metrics

### DIFF
--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -10,6 +10,15 @@ pub enum CaptureMode {
     Recordings,
 }
 
+impl CaptureMode {
+    pub fn as_tag(&self) -> &'static str {
+        match self {
+            CaptureMode::Events => "events",
+            CaptureMode::Recordings => "recordings",
+        }
+    }
+}
+
 impl std::str::FromStr for CaptureMode {
     type Err = String;
 

--- a/rust/capture/src/prometheus.rs
+++ b/rust/capture/src/prometheus.rs
@@ -15,8 +15,16 @@ pub fn report_overflow_partition(quantity: u64) {
     counter!("capture_partition_key_capacity_exceeded_total").increment(quantity);
 }
 
-pub fn report_internal_error_metrics(err_type: &'static str, stage_tag: &'static str) {
-    let tags = [("error", err_type), ("stage", stage_tag)];
+pub fn report_internal_error_metrics(
+    err_type: &'static str,
+    stage_tag: &'static str,
+    capture_mode: &'static str,
+) {
+    let tags = [
+        ("error", err_type),
+        ("stage", stage_tag),
+        ("mode", capture_mode),
+    ];
     counter!("capture_internal_error_by_stage_and_type", &tags).increment(1);
 }
 

--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -36,6 +36,7 @@ pub struct State {
     pub token_dropper: Arc<TokenDropper>,
     pub event_size_limit: usize,
     pub historical_cfg: HistoricalConfig,
+    pub capture_mode: CaptureMode,
     pub is_mirror_deploy: bool,
     pub verbose_sample_percent: f32,
 }
@@ -128,6 +129,7 @@ pub fn router<
             historical_rerouting_threshold_days,
             historical_tokens_keys,
         ),
+        capture_mode: capture_mode.clone(),
         is_mirror_deploy,
         verbose_sample_percent,
     };

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -478,7 +478,11 @@ pub async fn event(
         }
 
         Err(err) => {
-            report_internal_error_metrics(err.to_metric_tag(), "parsing");
+            report_internal_error_metrics(
+                err.to_metric_tag(),
+                "parsing",
+                state.capture_mode.as_tag(),
+            );
             error!("event: request payload processing error: {:?}", err);
             Err(err)
         }
@@ -494,7 +498,11 @@ pub async fn event(
             .await
             {
                 report_dropped_events(err.to_metric_tag(), events.len() as u64);
-                report_internal_error_metrics(err.to_metric_tag(), "processing");
+                report_internal_error_metrics(
+                    err.to_metric_tag(),
+                    "processing",
+                    state.capture_mode.as_tag(),
+                );
                 error!("event: rejected payload: {}", err);
                 return Err(err);
             }
@@ -554,8 +562,12 @@ pub async fn recording(
             let count = events.len() as u64;
             if let Err(err) = process_replay_events(state.sink.clone(), events, &context).await {
                 report_dropped_events(err.to_metric_tag(), count);
-                report_internal_error_metrics(err.to_metric_tag(), "process_replay_events");
-                warn!("rejected invalid payload: {:?}", err);
+                report_internal_error_metrics(
+                    err.to_metric_tag(),
+                    "process_replay_events",
+                    state.capture_mode.as_tag(),
+                );
+                warn!("rejected payload: {:?}", err);
                 return Err(err);
             }
             Ok(CaptureResponse {


### PR DESCRIPTION
## Problem
As I update the session replay & event capture dashboards, I'd like to facet event payload parse errors by `CaptureMode` to separate out useful signal for both boards

## Changes
Tag event processing error metrics with `CaptureMode`

## How did you test this code?
Locally and in CI; low (no) risk change 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
