### PR TITLE
fix: the blob key should not have a leading slash, dangnammit

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -1166,7 +1166,7 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
                             sources.append(
                                 {
                                     "source": "blob_v2",
-                                    "blob_key": urlparse(recording.full_recording_v2_path).path,
+                                    "blob_key": urlparse(recording.full_recording_v2_path).path.lstrip("/"),
                                 }
                             )
                         except Exception as e:

--- a/posthog/session_recordings/test/test_session_recording_snapshots_api_blob_v2.py
+++ b/posthog/session_recordings/test/test_session_recording_snapshots_api_blob_v2.py
@@ -348,7 +348,7 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
             "sources": [
                 {
                     "source": "blob_v2",
-                    "blob_key": "/the_lts_path/the_session_uuid",
+                    "blob_key": "the_lts_path/the_session_uuid",
                     # it's ok for these to be None, since we don't use the data anyway
                     # and this key is the whole session
                     "start_timestamp": None,


### PR DESCRIPTION
e.g. looking here

https://us.posthog.com/project/2/error_tracking/0198a53a-737a-7e41-8bdc-6daa9a35f73e?timestamp=2025-08-20%2013%3A46%3A39.216000-07%3A00

we see the blob key and bucket are valid
but the blob key has a leading slash
i _believe_ that the AWS key needs to only start with a slash if we're actively adding one when writing, and we're not