### PR TITLE
feat(capture-rs): quick touch-up to metric faceting + normalize error logging

### DIFF
--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -483,7 +483,7 @@ pub async fn event(
                 "parsing",
                 state.capture_mode.as_tag(),
             );
-            error!("event: request payload processing error: {:?}", err);
+            error!("event: request payload parsing error: {:?}", err);
             Err(err)
         }
 
@@ -557,17 +557,25 @@ pub async fn recording(
             status: CaptureResponseCode::Ok,
             quota_limited: Some(vec!["recordings".to_string()]),
         }),
-        Err(err) => Err(err),
+        Err(err) => {
+            report_internal_error_metrics(
+                err.to_metric_tag(),
+                "parsing",
+                state.capture_mode.as_tag(),
+            );
+            error!("recordings: request payload parsing error: {:?}", err);
+            Err(err)
+        }
         Ok((context, events)) => {
             let count = events.len() as u64;
             if let Err(err) = process_replay_events(state.sink.clone(), events, &context).await {
                 report_dropped_events(err.to_metric_tag(), count);
                 report_internal_error_metrics(
                     err.to_metric_tag(),
-                    "process_replay_events",
+                    "processing",
                     state.capture_mode.as_tag(),
                 );
-                warn!("rejected payload: {:?}", err);
+                error!("recordings:rejected payload: {:?}", err);
                 return Err(err);
             }
             Ok(CaptureResponse {


### PR DESCRIPTION
## Problem
Need one more missing metric submission now that we have mode-based faceting.

## Changes
* Add missing metric emit site
* Normalize error logs between `event` and `recording` processing paths

## How did you test this code?
Locally and in CI. Low (no) risk change
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
