### PR TITLE
fix(flags): add minimal response for non POST like decide

### DIFF
--- a/rust/feature-flags/src/api/endpoint.rs
+++ b/rust/feature-flags/src/api/endpoint.rs
@@ -2,8 +2,8 @@ use crate::{
     api::{
         errors::FlagError,
         types::{
-            FlagsOptionsResponse, FlagsQueryParams, FlagsResponseCode, LegacyFlagsResponse,
-            ServiceResponse,
+            ConfigResponse, FlagsOptionsResponse, FlagsQueryParams, FlagsResponse,
+            FlagsResponseCode, LegacyFlagsResponse, ServiceResponse,
         },
     },
     handler::{process_request, RequestContext},
@@ -15,6 +15,7 @@ use axum::http::{HeaderMap, Method};
 use axum::{debug_handler, Json};
 use axum_client_ip::InsecureClientIp;
 use bytes::Bytes;
+use std::collections::HashMap;
 use tracing::Instrument;
 use uuid::Uuid;
 
@@ -46,6 +47,35 @@ fn map_decide_version(query_version: Option<i32>, is_from_decide: bool) -> Optio
     }
 }
 
+fn get_minimal_flags_response(version: Option<&str>) -> Result<Json<ServiceResponse>, FlagError> {
+    let request_id = Uuid::new_v4();
+
+    // Parse version string to determine response format
+    let version_num = version.map(|v| v.parse::<i32>().unwrap_or(1)).unwrap_or(1);
+
+    // Create minimal config response
+    let mut config = ConfigResponse::default();
+    config.supported_compression = vec!["gzip".to_string(), "gzip-js".to_string()];
+
+    // Create empty flags response with minimal config
+    let response = FlagsResponse {
+        errors_while_computing_flags: false,
+        flags: HashMap::new(),
+        quota_limited: None,
+        request_id,
+        config,
+    };
+
+    // Return versioned response
+    let service_response = if version_num >= 2 {
+        ServiceResponse::V2(response)
+    } else {
+        ServiceResponse::Default(LegacyFlagsResponse::from_response(response))
+    };
+
+    Ok(Json(service_response))
+}
+
 /// Feature flag evaluation endpoint.
 /// Only supports a specific shape of data, and rejects any malformed data.
 #[debug_handler]
@@ -59,6 +89,10 @@ pub async fn flags(
     body: Bytes,
 ) -> Result<Json<ServiceResponse>, FlagError> {
     let request_id = Uuid::new_v4();
+
+    if method != Method::POST {
+        return get_minimal_flags_response(query_params.version.as_deref());
+    }
 
     // Check if this request came through the decide proxy
     let is_from_decide = headers

--- a/rust/feature-flags/src/api/endpoint.rs
+++ b/rust/feature-flags/src/api/endpoint.rs
@@ -54,8 +54,10 @@ fn get_minimal_flags_response(version: Option<&str>) -> Result<Json<ServiceRespo
     let version_num = version.map(|v| v.parse::<i32>().unwrap_or(1)).unwrap_or(1);
 
     // Create minimal config response
-    let mut config = ConfigResponse::default();
-    config.supported_compression = vec!["gzip".to_string(), "gzip-js".to_string()];
+    let config = ConfigResponse {
+        supported_compression: vec!["gzip".to_string(), "gzip-js".to_string()],
+        ..Default::default()
+    };
 
     // Create empty flags response with minimal config
     let response = FlagsResponse {

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -20,6 +20,49 @@ use feature_flags::utils::test_utils::{
 
 pub mod common;
 
+#[tokio::test]
+async fn it_handles_get_requests_with_minimal_response() -> Result<()> {
+    let config = DEFAULT_TEST_CONFIG.clone();
+
+    let client = setup_redis_client(Some(config.redis_url.clone())).await;
+    let pg_client = setup_pg_reader_client(None).await;
+    let team = insert_new_team_in_redis(client.clone()).await.unwrap();
+    let token = team.api_token;
+
+    insert_new_team_in_pg(pg_client.clone(), Some(team.id))
+        .await
+        .unwrap();
+
+    let server = ServerHandle::for_config(config).await;
+
+    // Test GET request without any body - should return 200 with minimal response
+    let get_response = reqwest::get(format!("http://{}/flags?v=2", server.addr)).await?;
+    assert_eq!(get_response.status(), StatusCode::OK);
+
+    let json: FlagsResponse = get_response.json().await?;
+    assert_eq!(json.errors_while_computing_flags, false);
+    assert!(json.flags.is_empty());
+    assert!(json.quota_limited.is_none());
+    assert_eq!(json.config.supported_compression, vec!["gzip", "gzip-js"]);
+
+    // Test GET request with token in query params
+    let get_response = reqwest::get(format!(
+        "http://{}/flags?v=2&api_key={}",
+        server.addr, token
+    ))
+    .await?;
+    assert_eq!(get_response.status(), StatusCode::OK);
+
+    // Test legacy version format
+    let get_response = reqwest::get(format!("http://{}/flags?v=1", server.addr)).await?;
+    assert_eq!(get_response.status(), StatusCode::OK);
+    let legacy_json: LegacyFlagsResponse = get_response.json().await?;
+    assert_eq!(legacy_json.errors_while_computing_flags, false);
+    assert!(legacy_json.feature_flags.is_empty());
+
+    Ok(())
+}
+
 #[rstest]
 #[case(Some("1"))]
 #[case(Some("banana"))]

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -40,7 +40,7 @@ async fn it_handles_get_requests_with_minimal_response() -> Result<()> {
     assert_eq!(get_response.status(), StatusCode::OK);
 
     let json: FlagsResponse = get_response.json().await?;
-    assert_eq!(json.errors_while_computing_flags, false);
+    assert!(!json.errors_while_computing_flags);
     assert!(json.flags.is_empty());
     assert!(json.quota_limited.is_none());
     assert_eq!(json.config.supported_compression, vec!["gzip", "gzip-js"]);
@@ -57,7 +57,7 @@ async fn it_handles_get_requests_with_minimal_response() -> Result<()> {
     let get_response = reqwest::get(format!("http://{}/flags?v=1", server.addr)).await?;
     assert_eq!(get_response.status(), StatusCode::OK);
     let legacy_json: LegacyFlagsResponse = get_response.json().await?;
-    assert_eq!(legacy_json.errors_while_computing_flags, false);
+    assert!(!legacy_json.errors_while_computing_flags);
     assert!(legacy_json.feature_flags.is_empty());
 
     Ok(())


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

decide returns a minimal response for non POST requests, but flags does not.

https://github.com/PostHog/posthog/blob/716a79e5dd2b2ba5ab86db3ec1e864c3a9a069db/posthog/api/decide.py#L239-L255

This bug accounts for some 400s in when proxying: 
https://grafana.prod-us.posthog.dev/goto/6bIgWNuHR?orgId=1
<img width="1039" height="413" alt="Screenshot 2025-08-20 at 11 28 16 PM" src="https://github.com/user-attachments/assets/6af85196-9c5e-48b2-9801-64d4a86f31f3" />

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Make flags do the same 
## How did you test this code?
integ test
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
