### PR TITLE
fix: do not retry merge limit errors

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/person-merge-service.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-merge-service.ts
@@ -211,7 +211,11 @@ export class PersonMergeService {
         }
         return promiseRetry(
             () => this.mergeDistinctIds(otherPersonDistinctId, mergeIntoDistinctId, teamId, timestamp),
-            'merge_distinct_ids'
+            'merge_distinct_ids',
+            undefined,
+            undefined,
+            undefined,
+            [PersonMergeLimitExceededError]
         )
     }
 


### PR DESCRIPTION
## Problem

We retry merge limit errors, which are non-retriable.

## Changes

Excludes the merge limit errors from retry logic in the person merge service.

## How did you test this code?

Regression tests.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
