### PR TITLE
revert(perf): make persorted events table the default for activity log

### DIFF
--- a/frontend/src/scenes/activity/explore/defaults.ts
+++ b/frontend/src/scenes/activity/explore/defaults.ts
@@ -11,9 +11,6 @@ export const getDefaultEventsSceneQuery = (properties?: AnyPropertyFilter[]): Da
         orderBy: ['timestamp DESC'],
         after: '-1h',
         ...(properties ? { properties } : {}),
-        modifiers: {
-            usePresortedEventsTable: true,
-        },
     },
     propertiesViaUrl: true,
     showSavedQueries: true,


### PR DESCRIPTION
Reverts PostHog/posthog#31192 to fix https://github.com/PostHog/posthog/issues/36424. This should be ok, as we only display the last hour (whereas before we had displayed a whole day). A better solution would be to use [read order optimization](https://clickhouse.com/docs/sql-reference/statements/select/order-by#optimization-of-data-reading) for the query.