### PR TITLE
chore: Refactor HealthCheckResult

### DIFF
--- a/plugin-server/src/api/router.ts
+++ b/plugin-server/src/api/router.ts
@@ -2,7 +2,7 @@ import * as prometheus from 'prom-client'
 import express, { Request, Response } from 'ultimate-express'
 
 import { corsMiddleware } from '~/api/middleware/cors'
-import { PluginServerService } from '~/types'
+import { HealthCheckResultError, PluginServerService } from '~/types'
 import { logger } from '~/utils/logger'
 
 prometheus.collectDefaultMetrics()
@@ -65,40 +65,26 @@ const buildGetHealth =
         //     ...
         //   }
         // }
-        const checkResults = await Promise.all(
-            // Note that we do not use `Promise.allSettled` here so we can
-            // assume that all promises have resolved. If there was a
-            // rejected promise, the http server should catch it and return
-            // a 500 status code.
-            services.map(async (service) => {
-                try {
-                    const result = await service.healthcheck()
-
-                    // Handle both boolean and HealthCheckResult returns
-                    if (typeof result === 'boolean') {
-                        return {
-                            service: service.id,
-                            status: result ? 'ok' : 'error',
-                        }
-                    } else {
-                        return {
-                            service: service.id,
-                            status: result.healthy ? 'ok' : 'error',
-                            message: result.message,
-                            details: result.details,
-                        }
-                    }
-                } catch (error) {
-                    return {
-                        service: service.id,
-                        status: 'error',
-                        message: error.message || 'Unknown error',
-                    }
+        const healthCheckPromises = services.map(async (service) => {
+            try {
+                const result = await service.healthcheck()
+                return { service, result }
+            } catch (error) {
+                // If healthcheck throws, create an error result
+                return {
+                    service,
+                    result: new HealthCheckResultError(error.message, {}),
                 }
-            })
-        )
+            }
+        })
 
-        const statusCode = checkResults.every((result) => result.status === 'ok') ? 200 : 503
+        const healthChecks = await Promise.all(healthCheckPromises)
+
+        // Convert to response format for API
+        const checkResults = healthChecks.map(({ service, result }) => result.toResponse(service.id))
+
+        // Use isError() method to determine status code
+        const statusCode = healthChecks.every(({ result }) => !result.isError()) ? 200 : 503
 
         const checkResultsMapping = Object.fromEntries(
             checkResults.map((result) => [
@@ -116,7 +102,7 @@ const buildGetHealth =
                 failedServices: failedServices.map((s) => ({
                     service: s.service,
                     message: s.message,
-                    details: s.details,
+                    details: 'details' in s ? s.details : undefined,
                 })),
             })
         }

--- a/plugin-server/src/api/router.ts
+++ b/plugin-server/src/api/router.ts
@@ -73,7 +73,7 @@ const buildGetHealth =
                 // If healthcheck throws, create an error result
                 return {
                     service,
-                    result: new HealthCheckResultError(error.message, {}),
+                    result: new HealthCheckResultError(error instanceof Error ? error.message : 'Unknown error', {}),
                 }
             }
         })

--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -5,7 +5,7 @@ import { PluginEvent } from '@posthog/plugin-scaffold'
 
 import { ModifiedRequest } from '~/api/router'
 
-import { Hub, PluginServerService } from '../types'
+import { HealthCheckResult, HealthCheckResultError, HealthCheckResultOk, Hub, PluginServerService } from '../types'
 import { logger } from '../utils/logger'
 import { UUID, UUIDT, delay } from '../utils/utils'
 import { CdpSourceWebhooksConsumer, SourceWebhookError } from './consumers/cdp-source-webhooks.consumer'
@@ -78,7 +78,7 @@ export class CdpApi {
         return {
             id: 'cdp-api',
             onShutdown: async () => await this.stop(),
-            healthcheck: () => this.isHealthy() ?? false,
+            healthcheck: () => this.isHealthy() ?? new HealthCheckResultError('CDP API is not healthy', {}),
         }
     }
 
@@ -90,9 +90,9 @@ export class CdpApi {
         await Promise.all([this.cdpSourceWebhooksConsumer.stop()])
     }
 
-    isHealthy() {
+    isHealthy(): HealthCheckResult {
         // NOTE: There isn't really anything to check for here so we are just always healthy
-        return true
+        return new HealthCheckResultOk()
     }
 
     router(): express.Router {

--- a/plugin-server/src/cdp/consumers/cdp-base.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-base.consumer.ts
@@ -112,5 +112,5 @@ export abstract class CdpConsumerBase {
         logger.info('👍', `${this.name} - stopped!`)
     }
 
-    public abstract isHealthy(): boolean | HealthCheckResult
+    public abstract isHealthy(): HealthCheckResult
 }

--- a/plugin-server/src/cdp/consumers/cdp-behavioural-events.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-behavioural-events.consumer.ts
@@ -7,7 +7,7 @@ import { Action, ActionManagerCDP } from '~/utils/action-manager-cdp'
 
 import { KAFKA_CDP_CLICKHOUSE_BEHAVIORAL_COHORTS_MATCHES, KAFKA_EVENTS_JSON } from '../../config/kafka-topics'
 import { KafkaConsumer } from '../../kafka/consumer'
-import { Hub, RawClickHouseEvent } from '../../types'
+import { HealthCheckResult, Hub, RawClickHouseEvent } from '../../types'
 import { parseJSON } from '../../utils/json-parse'
 import { logger } from '../../utils/logger'
 import { HogFunctionFilterGlobals } from '../types'
@@ -231,7 +231,7 @@ export class CdpBehaviouralEventsConsumer extends CdpConsumerBase {
         logger.info('💤', 'Behavioural events consumer stopped!')
     }
 
-    public isHealthy() {
+    public isHealthy(): HealthCheckResult {
         return this.kafkaConsumer.isHealthy()
     }
 }

--- a/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
@@ -146,7 +146,7 @@ export class CdpCyclotronWorker extends CdpConsumerBase {
         await super.stop()
     }
 
-    public isHealthy(): boolean | HealthCheckResult {
+    public isHealthy(): HealthCheckResult {
         return this.cyclotronJobQueue.isHealthy()
     }
 }

--- a/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
@@ -6,7 +6,7 @@ import { instrumentFn, instrumented } from '~/common/tracing/tracing-utils'
 import { convertToHogFunctionInvocationGlobals } from '../../cdp/utils'
 import { KAFKA_EVENTS_JSON } from '../../config/kafka-topics'
 import { KafkaConsumer } from '../../kafka/consumer'
-import { Hub, RawClickHouseEvent } from '../../types'
+import { HealthCheckResult, Hub, RawClickHouseEvent } from '../../types'
 import { parseJSON } from '../../utils/json-parse'
 import { logger } from '../../utils/logger'
 import { captureException } from '../../utils/posthog'
@@ -407,7 +407,7 @@ export class CdpEventsConsumer extends CdpConsumerBase {
         logger.info('💤', 'Consumer stopped!')
     }
 
-    public isHealthy() {
+    public isHealthy(): HealthCheckResult {
         return this.kafkaConsumer.isHealthy()
     }
 

--- a/plugin-server/src/cdp/consumers/cdp-source-webhooks.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-source-webhooks.consumer.ts
@@ -3,7 +3,7 @@ import { DateTime } from 'luxon'
 import { ModifiedRequest } from '~/api/router'
 import { instrumented } from '~/common/tracing/tracing-utils'
 
-import { Hub } from '../../types'
+import { HealthCheckResult, HealthCheckResultOk, Hub } from '../../types'
 import { logger } from '../../utils/logger'
 import { PromiseScheduler } from '../../utils/promise-scheduler'
 import { UUID, UUIDT } from '../../utils/utils'
@@ -251,8 +251,8 @@ export class CdpSourceWebhooksConsumer extends CdpConsumerBase {
         await super.stop()
     }
 
-    public isHealthy() {
+    public isHealthy(): HealthCheckResult {
         // TODO: What should we consider healthy / unhealthy here? kafka?
-        return true
+        return new HealthCheckResultOk()
     }
 }

--- a/plugin-server/src/cdp/services/job-queue/job-queue-kafka.ts
+++ b/plugin-server/src/cdp/services/job-queue/job-queue-kafka.ts
@@ -8,7 +8,7 @@ import { compress, uncompress } from 'snappy'
 
 import { KafkaConsumer } from '../../../kafka/consumer'
 import { KafkaProducerWrapper } from '../../../kafka/producer'
-import { PluginsServerConfig } from '../../../types'
+import { HealthCheckResult, HealthCheckResultError, PluginsServerConfig } from '../../../types'
 import { parseJSON } from '../../../utils/json-parse'
 import { logger } from '../../../utils/logger'
 import { CyclotronJobInvocation, CyclotronJobInvocationResult, CyclotronJobQueueKind } from '../../types'
@@ -59,8 +59,11 @@ export class CyclotronJobQueueKafka {
         await this.kafkaProducer?.disconnect()
     }
 
-    public isHealthy() {
-        return this.kafkaConsumer?.isHealthy() ?? false
+    public isHealthy(): HealthCheckResult {
+        if (!this.kafkaConsumer) {
+            return new HealthCheckResultError('Kafka consumer not initialized', {})
+        }
+        return this.kafkaConsumer.isHealthy()
     }
 
     public async queueInvocations(invocations: CyclotronJobInvocation[]) {

--- a/plugin-server/src/cdp/services/job-queue/job-queue-postgres.ts
+++ b/plugin-server/src/cdp/services/job-queue/job-queue-postgres.ts
@@ -92,7 +92,9 @@ export class CyclotronJobQueuePostgres {
                 return new HealthCheckResultError('Cyclotron worker is not healthy', {})
             }
         } catch (error) {
-            return new HealthCheckResultError('Cyclotron worker not initialized', { error: error.message })
+            return new HealthCheckResultError('Cyclotron worker not initialized', {
+                error: error instanceof Error ? error.message : String(error),
+            })
         }
     }
 

--- a/plugin-server/src/cdp/services/job-queue/job-queue-postgres.ts
+++ b/plugin-server/src/cdp/services/job-queue/job-queue-postgres.ts
@@ -16,7 +16,7 @@ import {
 
 import { CyclotronInvocationQueueParametersType } from '~/schema/cyclotron'
 
-import { PluginsServerConfig } from '../../../types'
+import { HealthCheckResult, HealthCheckResultError, HealthCheckResultOk, PluginsServerConfig } from '../../../types'
 import { logger } from '../../../utils/logger'
 import { captureException } from '../../../utils/posthog'
 import { CyclotronJobInvocation, CyclotronJobInvocationResult, CyclotronJobQueueKind } from '../../types'
@@ -82,8 +82,18 @@ export class CyclotronJobQueuePostgres {
         return Promise.resolve()
     }
 
-    public isHealthy() {
-        return this.getCyclotronWorker().isHealthy()
+    public isHealthy(): HealthCheckResult {
+        try {
+            const worker = this.getCyclotronWorker()
+            const isHealthy = worker.isHealthy()
+            if (isHealthy) {
+                return new HealthCheckResultOk()
+            } else {
+                return new HealthCheckResultError('Cyclotron worker is not healthy', {})
+            }
+        } catch (error) {
+            return new HealthCheckResultError('Cyclotron worker not initialized', { error: error.message })
+        }
     }
 
     public async queueInvocations(invocations: CyclotronJobInvocation[]) {

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -58,7 +58,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         CONSUMER_BATCH_SIZE: 500,
         CONSUMER_MAX_HEARTBEAT_INTERVAL_MS: 30_000,
         CONSUMER_LOOP_STALL_THRESHOLD_MS: 60_000, // 1 minute - consider loop stalled after this
-        KAFKA_CONSUMER_LOOP_BASED_HEALTH_CHECK: false, // Use consumer loop monitoring for health checks instead of heartbeats
+        CONSUMER_LOOP_BASED_HEALTH_CHECK: false, // Use consumer loop monitoring for health checks instead of heartbeats
         CONSUMER_MAX_BACKGROUND_TASKS: 1,
         CONSUMER_WAIT_FOR_BACKGROUND_TASKS_ON_REBALANCE: false,
         CONSUMER_AUTO_CREATE_TOPICS: true,

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -12,6 +12,8 @@ import { KafkaProducerWrapper } from '../kafka/producer'
 import { ingestionOverflowingMessagesTotal } from '../main/ingestion-queues/batch-processing/metrics'
 import { latestOffsetTimestampGauge, setUsageInNonPersonEventsCounter } from '../main/ingestion-queues/metrics'
 import {
+    HealthCheckResult,
+    HealthCheckResultError,
     Hub,
     IncomingEventWithTeam,
     KafkaConsumerBreadcrumb,
@@ -220,9 +222,11 @@ export class IngestionConsumer {
         logger.info('👍', `${this.name} - stopped!`)
     }
 
-    public isHealthy(): boolean {
-        const result = this.kafkaConsumer?.isHealthy()
-        return result?.healthy ?? false
+    public isHealthy(): HealthCheckResult {
+        if (!this.kafkaConsumer) {
+            return new HealthCheckResultError('Kafka consumer not initialized', {})
+        }
+        return this.kafkaConsumer.isHealthy()
     }
 
     private runInstrumented<T>(name: string, func: () => Promise<T>): Promise<T> {

--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -195,7 +195,7 @@ export class KafkaConsumer {
             'metadata.max.age.ms': 30000, // Refresh metadata every 30s - Relevant for leader loss (MSK Security Patches)
             'socket.timeout.ms': 30000,
             // Only enable statistics when using loop-based health check
-            ...(defaultConfig.KAFKA_CONSUMER_LOOP_BASED_HEALTH_CHECK
+            ...(defaultConfig.CONSUMER_LOOP_BASED_HEALTH_CHECK
                 ? { 'statistics.interval.ms': STATISTICS_INTERVAL_MS }
                 : {}),
             // Custom settings and overrides - this is where most configuration overrides should be done
@@ -228,7 +228,7 @@ export class KafkaConsumer {
 
     public isHealthy(): HealthCheckResult {
         // Use legacy heartbeat-based health check if feature flag is disabled
-        if (!defaultConfig.KAFKA_CONSUMER_LOOP_BASED_HEALTH_CHECK) {
+        if (!defaultConfig.CONSUMER_LOOP_BASED_HEALTH_CHECK) {
             // this is called as a readiness and a liveness probe
             const isWithinInterval = Date.now() - this.lastHeartbeatTime < this.maxHealthHeartbeatIntervalMs
             const isConnected = this.rdKafkaConsumer.isConnected()

--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -232,9 +232,16 @@ export class KafkaConsumer {
             // this is called as a readiness and a liveness probe
             const isWithinInterval = Date.now() - this.lastHeartbeatTime < this.maxHealthHeartbeatIntervalMs
             const isConnected = this.rdKafkaConsumer.isConnected()
-            return {
-                healthy: isConnected && isWithinInterval,
-                message: isConnected && isWithinInterval ? 'Healthy' : 'Unhealthy',
+
+            if (isConnected && isWithinInterval) {
+                return new HealthCheckResultOk()
+            } else {
+                return new HealthCheckResultError('Consumer unhealthy', {
+                    isConnected,
+                    isWithinInterval,
+                    lastHeartbeatTime: this.lastHeartbeatTime,
+                    maxHealthHeartbeatIntervalMs: this.maxHealthHeartbeatIntervalMs,
+                })
             }
         }
 

--- a/plugin-server/src/main/ingestion-queues/on-event-handler-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/on-event-handler-consumer.ts
@@ -1,7 +1,14 @@
 import { Consumer } from 'kafkajs'
 
 import { KAFKA_EVENTS_JSON, prefix as KAFKA_PREFIX } from '../../config/kafka-topics'
-import { Hub, PluginServerService } from '../../types'
+import {
+    HealthCheckResult,
+    HealthCheckResultDegraded,
+    HealthCheckResultError,
+    HealthCheckResultOk,
+    Hub,
+    PluginServerService,
+} from '../../types'
 import { logger } from '../../utils/logger'
 import { HookCommander } from '../../worker/ingestion/hooks'
 import { eachBatchWebhooksHandlers } from './batch-processing/each-batch-webhooks'
@@ -77,7 +84,7 @@ export const startAsyncWebhooksHandlerConsumer = async (hub: Hub): Promise<Plugi
     }
 }
 
-export function makeHealthCheck(consumer: Consumer, sessionTimeout: number) {
+export function makeHealthCheck(consumer: Consumer, sessionTimeout: number): () => Promise<HealthCheckResult> {
     const { HEARTBEAT } = consumer.events
     let lastHeartbeat: number = Date.now()
     consumer.on(HEARTBEAT, ({ timestamp }) => (lastHeartbeat = timestamp))
@@ -87,7 +94,7 @@ export function makeHealthCheck(consumer: Consumer, sessionTimeout: number) {
         const milliSecondsToLastHeartbeat = Date.now() - lastHeartbeat
         if (milliSecondsToLastHeartbeat < sessionTimeout) {
             logger.info('👍', 'Consumer heartbeat is healthy', { milliSecondsToLastHeartbeat, sessionTimeout })
-            return true
+            return new HealthCheckResultOk()
         }
 
         // Consumer has not heartbeat, but maybe it's because the group is
@@ -97,10 +104,14 @@ export function makeHealthCheck(consumer: Consumer, sessionTimeout: number) {
 
             logger.info('ℹ️', 'Consumer group state', { state })
 
-            return ['CompletingRebalance', 'PreparingRebalance'].includes(state)
+            if (['CompletingRebalance', 'PreparingRebalance'].includes(state)) {
+                return new HealthCheckResultDegraded('Consumer group is rebalancing', { state })
+            }
+
+            return new HealthCheckResultOk()
         } catch (error) {
             logger.error('🚨', 'Error checking consumer group state', { error })
-            return false
+            return new HealthCheckResultError('Error checking consumer group state', { error })
         }
     }
     return isHealthy

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
@@ -8,6 +8,7 @@ import { KAFKA_CLICKHOUSE_SESSION_REPLAY_EVENTS_V2_TEST } from '../../../config/
 import { KafkaConsumer } from '../../../kafka/consumer'
 import { KafkaProducerWrapper } from '../../../kafka/producer'
 import {
+    HealthCheckResult,
     PluginServerService,
     PluginsServerConfig,
     RedisPool,
@@ -317,10 +318,9 @@ export class SessionRecordingIngester {
         return promiseResults
     }
 
-    public isHealthy(): boolean {
+    public isHealthy(): HealthCheckResult {
         // TODO: Maybe extend this to check if we are shutting down so we don't get killed early.
-        const result = this.kafkaConsumer.isHealthy()
-        return result.healthy
+        return this.kafkaConsumer.isHealthy()
     }
 
     private get assignedTopicPartitions(): TopicPartition[] {

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -14,6 +14,7 @@ import {
 import { KafkaConsumer } from '../../../kafka/consumer'
 import { KafkaProducerWrapper } from '../../../kafka/producer'
 import {
+    HealthCheckResult,
     PluginServerService,
     PluginsServerConfig,
     RedisPool,
@@ -479,7 +480,7 @@ export class SessionRecordingIngester {
             logger.info('🔁', 'blob_ingester_consumer - rebalancing', {
                 err,
                 topicPartitions,
-                connected: this.kafkaConsumer.isHealthy().healthy,
+                connected: !this.kafkaConsumer.isHealthy().isError(),
             })
             /**
              * see https://github.com/Blizzard/node-rdkafka#rebalancing
@@ -541,10 +542,9 @@ export class SessionRecordingIngester {
         return promiseResults
     }
 
-    public isHealthy() {
+    public isHealthy(): HealthCheckResult {
         // TODO: Maybe extend this to check if we are shutting down so we don't get killed early.
-        const result = this.kafkaConsumer.isHealthy()
-        return result.healthy
+        return this.kafkaConsumer.isHealthy()
     }
 
     private async reportPartitionMetrics() {

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -256,7 +256,7 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
     CONSUMER_BATCH_SIZE: number // Primarily for kafka consumers the batch size to use
     CONSUMER_MAX_HEARTBEAT_INTERVAL_MS: number // Primarily for kafka consumers the max heartbeat interval to use after which it will be considered unhealthy
     CONSUMER_LOOP_STALL_THRESHOLD_MS: number // Threshold in ms after which the consumer loop is considered stalled
-    KAFKA_CONSUMER_LOOP_BASED_HEALTH_CHECK: boolean // Use consumer loop monitoring for health checks instead of heartbeats
+    CONSUMER_LOOP_BASED_HEALTH_CHECK: boolean // Use consumer loop monitoring for health checks instead of heartbeats
     CONSUMER_MAX_BACKGROUND_TASKS: number
     CONSUMER_WAIT_FOR_BACKGROUND_TASKS_ON_REBALANCE: boolean
     CONSUMER_AUTO_CREATE_TOPICS: boolean

--- a/plugin-server/src/utils/commands.ts
+++ b/plugin-server/src/utils/commands.ts
@@ -1,6 +1,6 @@
 import express from 'ultimate-express'
 
-import { Hub, PluginServerService } from '../types'
+import { HealthCheckResultOk, Hub, PluginServerService } from '../types'
 import { reloadPlugins } from '../worker/tasks'
 import { populatePluginCapabilities } from '../worker/vm/lazy'
 import { logger } from './logger'
@@ -25,7 +25,7 @@ export class ServerCommands {
         return {
             id: 'server-commands',
             onShutdown: async () => {},
-            healthcheck: () => true,
+            healthcheck: () => new HealthCheckResultOk(),
         }
     }
 


### PR DESCRIPTION
## Problem

Currently the plugin server's health check has inconsistent return types across different services. Some returned boolean values, others returned a `HealthCheckResult`. 

## Changes

This PR makes all services follow the same contract and expands the response to add information for degraded services. Service healthcheck now can be:
- `HealthCheckResultOk` - Service is fully healthy
- `HealthCheckResultDegraded` - Service is operational but with warnings
- `HealthCheckResultError` - Service is unhealthy