### PR TITLE
fix(max): missing billing node in evals chain

### DIFF
--- a/ee/hogai/eval/eval_root_style.py
+++ b/ee/hogai/eval/eval_root_style.py
@@ -70,6 +70,7 @@ def call_root(demo_org_team_user):
             }
         )
         .add_inkeep_docs()
+        .add_billing()
         .compile()
     )
 


### PR DESCRIPTION
## Problem
A recent change in the `eval_root_style` introduced a regression and the AI evals are failing

## Changes
I added `.add_billing()` to the graph building chain. This method adds the `BILLING` node to the graph, which is required since the router in `root_tools` is configured to route to the billing node when the `retrieve_billing_information` tool is called.

## How did you test this code?
 running evals

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
