### PR TITLE
chore(dev): Add .session-summaries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ posthog/management/commands/clear_demo_data.py
 
 # Ignore local mprocs configs
 bin/mprocs*.local.yaml
+
+# Debug output of our session summaries product
+.session-summaries


### PR DESCRIPTION
## Problem

The `.session-summaries` dir is annoying when switching branches:

<img width="265" height="428" alt="Screenshot 2025-08-21 at 13 23 32" src="https://github.com/user-attachments/assets/ffc2c8ff-0b30-468f-9efc-f91d14cacb04" />

## Changes

Added it to .gitignore.