### PR TITLE
fix(data-warehouse): Set passphrase to None if its an empty string

### DIFF
--- a/posthog/temporal/data_imports/sources/snowflake/snowflake.py
+++ b/posthog/temporal/data_imports/sources/snowflake/snowflake.py
@@ -46,7 +46,9 @@ def get_schemas(config: SnowflakeSourceConfig) -> dict[str, list[tuple[str, str]
         auth_connect_args = {
             "user": config.auth_type.user,
             "private_key_file": file_name,
-            "private_key_file_pwd": config.auth_type.passphrase,
+            "private_key_file_pwd": config.auth_type.passphrase
+            if config.auth_type.passphrase and len(config.auth_type.passphrase) > 0
+            else None,
         }
     else:
         auth_connect_args = {


### PR DESCRIPTION
## Problem
- if a key pair has an empty passphrase (e.g. `""`), then it should be treated as None, otherwise snowflake attempts to decrypt the private key 

## Changes
- Use `None` as the passphrase when the passphrase is an empty key 