### PR TITLE
fix: Use str as default serializer

### DIFF
--- a/posthog/hogql/test/__snapshots__/test_printer.ambr
+++ b/posthog/hogql/test/__snapshots__/test_printer.ambr
@@ -71,8 +71,8 @@
   '''
 # ---
 # name: TestPrinter.test_s3_tables_global_join_with_cte
-  "SELECT events.event AS event FROM events GLOBAL JOIN (SELECT test_table.id AS id FROM s3(%(hogql_val_0_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_3_sensitive)s, 'Parquet', %(hogql_val_1)s) AS test_table) AS some_remote_table ON equals(events.event, toString(some_remote_table.id)) WHERE equals(events.team_id, 93) LIMIT 50000"
+  "SELECT events.event AS event FROM events GLOBAL JOIN (SELECT test_table.id AS id FROM s3(%(hogql_val_0_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_3_sensitive)s, 'Parquet', %(hogql_val_1)s) AS test_table) AS some_remote_table ON equals(events.event, toString(some_remote_table.id)) WHERE equals(events.team_id, 92) LIMIT 50000"
 # ---
 # name: TestPrinter.test_s3_tables_global_join_with_cte_nested
-  "SELECT some_remote_table.event AS event FROM events GLOBAL JOIN (SELECT e.event AS event, t.id AS id FROM events AS e GLOBAL JOIN (SELECT * FROM s3(%(hogql_val_0_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_3_sensitive)s, 'Parquet', %(hogql_val_1)s)) AS t ON equals(toString(t.id), e.event) WHERE equals(e.team_id, 93)) AS some_remote_table ON equals(events.event, toString(some_remote_table.id)) WHERE equals(events.team_id, 93) LIMIT 50000"
+  "SELECT some_remote_table.event AS event FROM events GLOBAL JOIN (SELECT e.event AS event, t.id AS id FROM events AS e GLOBAL JOIN (SELECT * FROM s3(%(hogql_val_0_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_3_sensitive)s, 'Parquet', %(hogql_val_1)s)) AS t ON equals(toString(t.id), e.event) WHERE equals(e.team_id, 92)) AS some_remote_table ON equals(events.event, toString(some_remote_table.id)) WHERE equals(events.team_id, 92) LIMIT 50000"
 # ---

--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -27,6 +27,7 @@ automatically included.
 import asyncio
 import collections.abc
 import contextvars
+import functools
 import json
 import ssl
 import sys
@@ -113,6 +114,9 @@ class LogMessages(typing.TypedDict):
     produce_message: bytes | None
 
 
+DEFAULT_SERIALIZER = functools.partial(json.dumps, default=str)
+
+
 class LogMessagesRenderer:
     """Render messages for writing and producing.
 
@@ -120,7 +124,9 @@ class LogMessagesRenderer:
     """
 
     def __init__(
-        self, event_key: str = "event", json_serializer: typing.Callable[[structlog.types.EventDict], str] = json.dumps
+        self,
+        event_key: str = "event",
+        json_serializer: typing.Callable[[structlog.types.EventDict], str] = DEFAULT_SERIALIZER,
     ):
         """Initialize renderer.
 

--- a/posthog/temporal/tests/common/test_logger.py
+++ b/posthog/temporal/tests/common/test_logger.py
@@ -213,7 +213,8 @@ async def test_logger_context(log_capture, event_loop):
 
     We do **NOT** check for Temporal context in this test.
     """
-    structlog.contextvars.bind_contextvars(team_id=1, destination="Somewhere")
+    context_uuid = uuid.uuid4()
+    structlog.contextvars.bind_contextvars(team_id=1, destination="Somewhere", uuid=context_uuid)
     logger = structlog.get_logger("test_logger_context")
     bound = logger.bind(test=True)
 
@@ -239,6 +240,7 @@ async def test_logger_context(log_capture, event_loop):
         assert info_dict.pop("filename") == "test_logger.py"
         # Could change if test file changes, so we just check it's there.
         assert info_dict.pop("lineno") is not None
+        assert info_dict.pop("uuid") == str(context_uuid)
         assert not info_dict
 
 


### PR DESCRIPTION
## Problem

We have captured values in the context that are not JSON serializable. Use `str` to serialize them.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
