### PR TITLE
fix: Make performance tracking logs write only

### DIFF
--- a/products/batch_exports/backend/temporal/metrics.py
+++ b/products/batch_exports/backend/temporal/metrics.py
@@ -4,7 +4,6 @@ import time
 import typing
 
 import structlog
-from structlog import get_logger
 from temporalio import activity, workflow
 from temporalio.common import MetricCounter, MetricMeter
 from temporalio.worker import (
@@ -16,7 +15,9 @@ from temporalio.worker import (
     WorkflowInterceptorClassInput,
 )
 
-LOGGER = get_logger(__name__)
+from posthog.temporal.common.logger import get_write_only_logger
+
+LOGGER = get_write_only_logger(__name__)
 
 
 def get_rows_exported_metric() -> MetricCounter:


### PR DESCRIPTION
## Problem

We are displaying some internal performance logs to users. No big deal, but they can be a bit noisy and more intended for us to diagnose performance issues than for displaying to users, as they aren't actionable by users.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Make performance logs write-only.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
