### PR TITLE
fix: incorrect loading status in playermeta / overview

### DIFF
--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -213,6 +213,7 @@ export const defaultMocks: Mocks = {
         'api/environments/:team_id/error_tracking/symbol_sets': EMPTY_PAGINATED_RESPONSE,
         'api/projects/@current/global_access_controls': EMPTY_PAGINATED_RESPONSE,
         'api/projects/@current/access_controls': EMPTY_PAGINATED_RESPONSE,
+        'api/projects/:team_id/notebooks/recording_comments': EMPTY_PAGINATED_RESPONSE,
     },
     post: {
         'https://us.i.posthog.com/e/': (req, res, ctx): MockSignature => posthogCORSResponse(req, res, ctx),

--- a/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.test.ts
@@ -7,6 +7,7 @@ import { sessionRecordingPlayerLogic } from 'scenes/session-recordings/player/se
 
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
+import { SessionRecordingType } from '~/types'
 
 import recordingEventsJson from '../../__mocks__/recording_events_query'
 import { recordingMetaJson } from '../../__mocks__/recording_meta'
@@ -43,18 +44,22 @@ describe('playerMetaLogic', () => {
         })
         it('starts with loading state', () => {
             expectLogic(logic).toMatchValues({
-                sessionPlayerMetaDataLoading: true,
+                loading: true,
             })
         })
     })
 
     describe('loading state', () => {
         it('stops loading after meta load is successful', async () => {
+            const session: SessionRecordingType = {
+                id: '1',
+            } as SessionRecordingType
             await expectLogic(logic, () => {
                 sessionRecordingDataLogic(playerProps).actions.loadRecordingMeta()
+                logic.actions.maybeLoadPropertiesForSessions([session])
             })
-                .toDispatchActions(['loadRecordingMetaSuccess'])
-                .toMatchValues({ sessionPlayerMetaDataLoading: false })
+                .toDispatchActions(['loadRecordingMetaSuccess', 'loadPropertiesForSessionsSuccess'])
+                .toMatchValues({ loading: false })
         })
     })
 })

--- a/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
@@ -97,7 +97,7 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
             sessionRecordingDataLogic(props),
             ['loadRecordingMetaSuccess', 'setTrackedWindow'],
             sessionRecordingsListPropertiesLogic,
-            ['maybeLoadPropertiesForSessions'],
+            ['maybeLoadPropertiesForSessions', 'loadPropertiesForSessionsSuccess'],
         ],
     })),
     actions({

--- a/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
@@ -87,20 +87,11 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
     connect((props: SessionRecordingPlayerLogicProps) => ({
         values: [
             sessionRecordingDataLogic(props),
-            [
-                'urls',
-                'sessionPlayerData',
-                'sessionEventsData',
-                'sessionPlayerMetaData',
-                'sessionPlayerMetaDataLoading',
-                'snapshotsLoading',
-                'windowIds',
-                'trackedWindow',
-            ],
+            ['urls', 'sessionPlayerData', 'sessionEventsData', 'sessionPlayerMetaData', 'windowIds', 'trackedWindow'],
             sessionRecordingPlayerLogic(props),
             ['scale', 'currentTimestamp', 'currentPlayerTime', 'currentSegment', 'currentURL', 'resolution'],
             sessionRecordingsListPropertiesLogic,
-            ['recordingPropertiesById', 'recordingPropertiesLoading'],
+            ['recordingPropertiesById'],
         ],
         actions: [
             sessionRecordingDataLogic(props),
@@ -139,28 +130,11 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
     })),
     selectors(() => ({
         loading: [
-            (s) => [
-                s.sessionPlayerMetaDataLoading,
-                s.snapshotsLoading,
-                s.recordingPropertiesLoading,
-                s.sessionPlayerMetaData,
-                s.recordingPropertiesById,
-            ],
-            (
-                sessionPlayerMetaDataLoading,
-                snapshotsLoading,
-                recordingPropertiesLoading,
-                sessionPlayerMetaData,
-                recordingPropertiesById
-            ) => {
+            (s) => [s.sessionPlayerMetaData, s.recordingPropertiesById],
+            (sessionPlayerMetaData, recordingPropertiesById) => {
                 const hasSessionPlayerMetadata = !!sessionPlayerMetaData && !isEmptyObject(sessionPlayerMetaData)
                 const hasRecordingProperties = !!recordingPropertiesById && !isEmptyObject(recordingPropertiesById)
-                if (hasSessionPlayerMetadata && hasRecordingProperties) {
-                    // If we have session player metadata and recording properties, we are done loading
-                    return false
-                }
-
-                return sessionPlayerMetaDataLoading || snapshotsLoading || recordingPropertiesLoading
+                return !hasSessionPlayerMetadata || !hasRecordingProperties
             },
         ],
         sessionPerson: [

--- a/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
@@ -11,7 +11,13 @@ import api from 'lib/api'
 import { PropertyFilterIcon } from 'lib/components/PropertyFilters/components/PropertyFilterIcon'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
-import { capitalizeFirstLetter, ceilMsToClosestSecond, humanFriendlyDuration, percentage } from 'lib/utils'
+import {
+    capitalizeFirstLetter,
+    ceilMsToClosestSecond,
+    humanFriendlyDuration,
+    isEmptyObject,
+    percentage,
+} from 'lib/utils'
 import { COUNTRY_CODE_TO_LONG_NAME } from 'lib/utils/geography/country'
 import { OverviewItem } from 'scenes/session-recordings/components/OverviewGrid'
 import { TimestampFormat } from 'scenes/session-recordings/player/playerSettingsLogic'
@@ -133,9 +139,29 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
     })),
     selectors(() => ({
         loading: [
-            (s) => [s.sessionPlayerMetaDataLoading, s.snapshotsLoading, s.recordingPropertiesLoading],
-            (sessionPlayerMetaDataLoading, snapshotsLoading, recordingPropertiesLoading) =>
-                sessionPlayerMetaDataLoading || snapshotsLoading || recordingPropertiesLoading,
+            (s) => [
+                s.sessionPlayerMetaDataLoading,
+                s.snapshotsLoading,
+                s.recordingPropertiesLoading,
+                s.sessionPlayerMetaData,
+                s.recordingPropertiesById,
+            ],
+            (
+                sessionPlayerMetaDataLoading,
+                snapshotsLoading,
+                recordingPropertiesLoading,
+                sessionPlayerMetaData,
+                recordingPropertiesById
+            ) => {
+                const hasSessionPlayerMetadata = !!sessionPlayerMetaData && !isEmptyObject(sessionPlayerMetaData)
+                const hasRecordingProperties = !!recordingPropertiesById && !isEmptyObject(recordingPropertiesById)
+                if (hasSessionPlayerMetadata && hasRecordingProperties) {
+                    // If we have session player metadata and recording properties, we are done loading
+                    return false
+                }
+
+                return sessionPlayerMetaDataLoading || snapshotsLoading || recordingPropertiesLoading
+            },
         ],
         sessionPerson: [
             (s) => [s.sessionPlayerData],


### PR DESCRIPTION
player meta and overview are constantly showing as loading... that's silly

this does the simplest thing to get prod to a sensible state

| before | after |
| - | - | 
| <img width="862" height="562" alt="Screenshot 2025-08-21 at 14 53 01" src="https://github.com/user-attachments/assets/c06f3335-1617-4ffe-a572-1f999edff9d0" />|<img width="874" height="526" alt="Screenshot 2025-08-21 at 14 52 07" src="https://github.com/user-attachments/assets/49432ad9-6205-4eb8-8c3c-953de3dd800c" />|
