### PR TITLE
fix: Make internal stage logs internal

### DIFF
--- a/products/batch_exports/backend/temporal/pipeline/entrypoint.py
+++ b/products/batch_exports/backend/temporal/pipeline/entrypoint.py
@@ -2,7 +2,6 @@ import collections.abc
 import datetime as dt
 
 from django.conf import settings
-from structlog import get_logger
 from temporalio import exceptions, workflow
 from temporalio.common import RetryPolicy
 
@@ -11,6 +10,7 @@ from posthog.batch_exports.service import (
     BatchExportInsertInputs,
 )
 from posthog.settings.base_variables import TEST
+from posthog.temporal.common.logger import get_write_only_logger
 from products.batch_exports.backend.temporal.batch_exports import (
     FinishBatchExportRunInputs,
     finish_batch_export_run,
@@ -25,7 +25,7 @@ from products.batch_exports.backend.temporal.pipeline.internal_stage import (
 )
 from products.batch_exports.backend.temporal.pipeline.types import BatchExportResult
 
-LOGGER = get_logger(__name__)
+LOGGER = get_write_only_logger(__name__)
 
 BatchExportInsertActivity = collections.abc.Callable[..., collections.abc.Awaitable[BatchExportResult]]
 

--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -30,7 +30,7 @@ from posthog.temporal.common.clickhouse import (
     get_client,
 )
 from posthog.temporal.common.heartbeat import Heartbeater
-from posthog.temporal.common.logger import get_logger
+from posthog.temporal.common.logger import get_write_only_logger
 from products.batch_exports.backend.temporal.batch_exports import default_fields
 from products.batch_exports.backend.temporal.record_batch_model import resolve_batch_exports_model
 from products.batch_exports.backend.temporal.spmc import (
@@ -52,7 +52,7 @@ from products.batch_exports.backend.temporal.sql import (
 )
 from products.batch_exports.backend.temporal.utils import set_status_to_running_task
 
-LOGGER = get_logger()
+LOGGER = get_write_only_logger()
 
 
 def _get_s3_endpoint_url() -> str:

--- a/products/batch_exports/backend/temporal/pipeline/producer.py
+++ b/products/batch_exports/backend/temporal/pipeline/producer.py
@@ -3,9 +3,9 @@ import typing
 
 from aiobotocore.response import StreamingBody
 from django.conf import settings
-from structlog import get_logger
 
 import posthog.temporal.common.asyncpa as asyncpa
+from posthog.temporal.common.logger import get_write_only_logger
 from products.batch_exports.backend.temporal.pipeline.internal_stage import (
     get_s3_client,
     get_s3_staging_folder,
@@ -18,7 +18,8 @@ from products.batch_exports.backend.temporal.spmc import (
 if typing.TYPE_CHECKING:
     from types_aiobotocore_s3.client import S3Client
 
-LOGGER = get_logger(__name__)
+
+LOGGER = get_write_only_logger(__name__)
 
 
 class Producer:


### PR DESCRIPTION
## Problem

A few more logs making their way to users when they shouldn't. Again, not critical, but they do give information to users that they cannot act upon, so it ends up polluting their logs view.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Make all internal stage logs, well, internal.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
