### PR TITLE
Fix session recording date filter alias

### DIFF
--- a/posthog/hogql_queries/utils/query_date_range.py
+++ b/posthog/hogql_queries/utils/query_date_range.py
@@ -95,7 +95,15 @@ class QueryDateRange:
         elif self._exact_timerange:
             return date_to
 
-        if not self._date_range or not self._date_range.explicitDate:
+        # Check if date_to is an ISO date string (YYYY-MM-DD format without time)
+        # and extend it to end of day even when explicitDate=True
+        is_iso_date_only = False
+        if self._date_range and self._date_range.date_to and delta_mapping is None:
+            # Check if the original date_to string is in YYYY-MM-DD format (10 characters, no time component)
+            date_to_str = self._date_range.date_to.strip()
+            is_iso_date_only = len(date_to_str) == 10 and date_to_str.count('-') == 2 and 'T' not in date_to_str and ':' not in date_to_str
+
+        if not self._date_range or not self._date_range.explicitDate or is_iso_date_only:
             is_relative = not self._date_range or not self._date_range.date_to or delta_mapping is not None
 
             if self.interval_name not in ("hour", "minute"):

--- a/posthog/session_recordings/queries/test/listing_recordings/__snapshots__/test_session_recording_list_from_query.ambr
+++ b/posthog/session_recordings/queries/test/listing_recordings/__snapshots__/test_session_recording_list_from_query.ambr
@@ -1369,7 +1369,7 @@
          greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('today', 6, 'UTC')) AS ongoing,
          round(multiply(divide(plus(plus(plus(divide(sum(s.active_milliseconds), 1000), sum(s.click_count)), sum(s.keypress_count)), sum(s.console_error_count)), plus(plus(plus(plus(sum(s.mouse_activity_count), dateDiff('SECOND', start_time, end_time)), sum(s.console_error_count)), sum(s.console_log_count)), sum(s.console_warn_count))), 100), 2) AS activity_score
   FROM session_replay_events AS s
-  WHERE and(equals(s.team_id, 99999), greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-11 13:46:23.000000', 6, 'UTC')), greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-29 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-28 00:00:00.000000', 6, 'UTC')))
+  WHERE and(equals(s.team_id, 99999), greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-11 13:46:23.000000', 6, 'UTC')), greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-29 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-28 23:59:59.999999', 6, 'UTC')))
   GROUP BY s.session_id
   HAVING 1
   ORDER BY start_time DESC


### PR DESCRIPTION
## Problem

Session recording filters were not working as expected when `date_from` and `date_to` were set to the same ISO date (YYYY-MM-DD), e.g., "2025-08-20" to "2025-08-20". This was because `date_to` was being interpreted as the start of the day (00:00:00) instead of the end of the day (23:59:59.999999), resulting in no sessions being found for that specific day. This occurred because `explicitDate=True` bypassed the necessary end-of-day adjustment logic.

## Changes

Modified the `QueryDateRange.date_to()` method in `posthog/hogql_queries/utils/query_date_range.py`.
Added logic to detect if the `date_to` value is an ISO date string (YYYY-MM-DD format without a time component). If it is, `date_to` is now correctly extended to the end of its respective day (23:59:59.999999), ensuring the full day is included in the filter range, even when `explicitDate` is `True`.

## How did you test this code?

Added new unit tests in `posthog/hogql_queries/utils/test/test_query_date_range.py` within the `test_iso_date_only_handling` method. These tests cover:
- A single ISO date range (e.g., "2021-08-20" to "2021-08-20") correctly expanding `date_to` to the end of the day.
- ISO datetime strings (with time components) remaining unchanged.
- Multi-day ISO date ranges correctly expanding `date_to` to the end of the last day.

---
<a href="https://cursor.com/background-agent?bcId=bc-c877313a-2674-43e6-a26a-eb5b37b28812">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c877313a-2674-43e6-a26a-eb5b37b28812">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

