### PR TITLE
feat: Add HyperCache-based authentication

### DIFF
--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -56,6 +56,7 @@
                               e."$group_0" as aggregation_target,
                               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               person.person_props as person_props,
+                              person.pmat_email as pmat_email,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -79,6 +80,7 @@
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
                          (SELECT id,
+                                 argMax(pmat_email, version) as pmat_email,
                                  argMax(properties, version) as person_props
                           FROM person
                           WHERE team_id = 99999
@@ -95,7 +97,7 @@
                          AND event IN ['step one', 'step three', 'step two']
                          AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-10 23:59:59', 'UTC')
-                         AND ((replaceRegexpAll(JSONExtractRaw(person_props, 'email'), '^"|"$', '') ILIKE '%g0%'
+                         AND (("pmat_email" ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(e.properties, 'distinct_id'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(group_properties_0, 'name'), '^"|"$', '') ILIKE '%g0%'

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -30,6 +30,7 @@ from posthog.api.shared import UserBasicSerializer
 from posthog.api.tagged_item import TaggedItemSerializerMixin, TaggedItemViewSetMixin
 from posthog.api.utils import ClassicBehaviorBooleanFieldSerializer, action
 from posthog.auth import PersonalAPIKeyAuthentication, ProjectSecretAPIKeyAuthentication, TemporaryTokenAuthentication
+from posthog.authentication.cached_authentication import LocalEvaluationAuthentication
 from posthog.constants import SURVEY_TARGETING_FLAG_PREFIX, FlagRequestType
 from posthog.date_util import thirty_days_ago
 from posthog.event_usage import report_user_action
@@ -1214,7 +1215,12 @@ class FeatureFlagViewSet(
         detail=False,
         throttle_classes=[LocalEvaluationThrottle],
         required_scopes=["feature_flag:read"],
-        authentication_classes=[TemporaryTokenAuthentication, ProjectSecretAPIKeyAuthentication],
+        authentication_classes=[
+            LocalEvaluationAuthentication,
+            ProjectSecretAPIKeyAuthentication,
+            PersonalAPIKeyAuthentication,
+            TemporaryTokenAuthentication,
+        ],
         permission_classes=[ProjectSecretAPITokenPermission],
     )
     def local_evaluation(self, request: request.Request, **kwargs) -> Response:

--- a/posthog/api/test/test_authentication.py
+++ b/posthog/api/test/test_authentication.py
@@ -26,7 +26,7 @@ from social_django.models import UserSocialAuth
 from two_factor.utils import totp_digits
 
 from posthog.api.authentication import password_reset_token_generator, post_login, social_login_notification
-from posthog.auth import OAuthAccessTokenAuthentication, ProjectSecretAPIKeyAuthentication, ProjectSecretAPIKeyUser
+from posthog.auth import OAuthAccessTokenAuthentication, ProjectSecretAPIKeyAuthentication, SecuredSDKEndpointUser
 from posthog.models import User
 from posthog.models.instance_setting import set_instance_setting
 from posthog.models.oauth import OAuthAccessToken, OAuthApplication
@@ -986,7 +986,7 @@ class TestProjectSecretAPIKeyAuthentication(APIBaseTest):
         user, _ = result
 
         self.assertIsNotNone(user)
-        self.assertIsInstance(user, ProjectSecretAPIKeyUser)
+        self.assertIsInstance(user, SecuredSDKEndpointUser)
         self.assertEqual(user.team, self.team)
 
     def test_authenticate_with_valid_secret_api_key_in_body(self):
@@ -1005,7 +1005,7 @@ class TestProjectSecretAPIKeyAuthentication(APIBaseTest):
         user, _ = result
 
         self.assertIsNotNone(user)
-        self.assertIsInstance(user, ProjectSecretAPIKeyUser)
+        self.assertIsInstance(user, SecuredSDKEndpointUser)
         self.assertEqual(user.team, self.team)
 
     def test_authenticate_with_secret_api_key_in_query_string_not_supported(self):
@@ -1054,7 +1054,7 @@ class TestProjectSecretAPIKeyAuthentication(APIBaseTest):
 
         assert result is not None
         user, _ = result
-        self.assertIsInstance(user, ProjectSecretAPIKeyUser)
+        self.assertIsInstance(user, SecuredSDKEndpointUser)
         self.assertEqual(user.team, self.team)
 
     def test_authenticate_with_no_project_api_key_in_body_passes(self):
@@ -1073,7 +1073,7 @@ class TestProjectSecretAPIKeyAuthentication(APIBaseTest):
 
         assert result is not None
         user, _ = result
-        self.assertIsInstance(user, ProjectSecretAPIKeyUser)
+        self.assertIsInstance(user, SecuredSDKEndpointUser)
         self.assertEqual(user.team, self.team)
 
 

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -187,7 +187,7 @@ class ProjectSecretAPIKeyAuthentication(authentication.BaseAuthentication):
     Authenticates using a project secret API key. Unlike a personal API key, this is not associated with a
     user and should only be used for local_evaluation and flags remote_config (not to be confused with the
     other remote_config endpoint) requests. When authenticated, this returns a "synthetic"
-    ProjectSecretAPIKeyUser object that has the team set. This allows us to use the existing permissioning
+    SecuredSdkEndpointUser object that has the team set. This allows us to use the existing permissioning
     system for local_evaluation and flags remote_config requests.
 
     Only the first key candidate found in the request is tried, and the order is:
@@ -233,9 +233,9 @@ class ProjectSecretAPIKeyAuthentication(authentication.BaseAuthentication):
             if team is None:
                 return None
 
-            # Secret api keys are not associated with a user, so we create a ProjectSecretAPIKeyUser
+            # Secret api keys are not associated with a user, so we create a SecuredSdkEndpointUser
             # and attach the team. The team is the important part here.
-            return (ProjectSecretAPIKeyUser(team), None)
+            return (SecuredSDKEndpointUser(team), None)
         except Team.DoesNotExist:
             return None
 
@@ -244,9 +244,9 @@ class ProjectSecretAPIKeyAuthentication(authentication.BaseAuthentication):
         return cls.keyword
 
 
-class ProjectSecretAPIKeyUser:
+class SecuredSDKEndpointUser:
     """
-    A "synthetic" user object returned by the ProjectSecretAPIKeyAuthentication when authenticating with a project secret API key.
+    A "synthetic" user object returned by the ProjectSecretAPIKeyAuthentication or LocalEvaluationAuthentication when authenticating with a project secret API key.
     """
 
     def __init__(self, team):

--- a/posthog/authentication/cached_authentication.py
+++ b/posthog/authentication/cached_authentication.py
@@ -1,0 +1,324 @@
+"""
+Cached authentication backend for high-traffic API endpoints.
+
+This module provides a Django REST Framework authentication class that uses
+the team access token cache to authenticate requests without database calls.
+"""
+
+import logging
+from typing import Any, Optional, Union
+
+from django.http import HttpRequest
+
+from prometheus_client import Counter, Histogram
+from rest_framework import authentication
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.request import Request
+
+from posthog.auth import PersonalAPIKeyAuthentication, ProjectSecretAPIKeyAuthentication, SecuredSDKEndpointUser
+from posthog.clickhouse.query_tagging import tag_queries
+from posthog.storage.team_access_cache import team_access_cache, team_access_tokens_hypercache
+
+logger = logging.getLogger(__name__)
+
+# Prometheus metrics
+CACHED_AUTH_OPERATIONS = Counter(
+    "posthog_cached_auth_operations_total",
+    "Number of cached authentication operations",
+    labelnames=["result", "token_type"],
+)
+
+CACHED_AUTH_LATENCY = Histogram(
+    "posthog_cached_auth_latency_seconds", "Latency of cached authentication operations", labelnames=["result"]
+)
+
+
+class MinimalTeam:
+    """
+    Minimal team object synthesized from cached data.
+
+    This class provides the minimum team properties needed for authentication
+    without requiring a database query. It's compatible with the Team interface
+    used by SecuredSdkEndpointUser.
+    """
+
+    def __init__(self, api_token: str, team_id: int):
+        self.api_token = api_token
+        self.id = team_id
+        self.pk = team_id  # Django models use both .id and .pk
+
+    def __str__(self):
+        return f"MinimalTeam(id={self.id}, api_token='{self.api_token[:8]}...')"
+
+    def __repr__(self):
+        return self.__str__()
+
+
+class LocalEvaluationAuthentication(authentication.BaseAuthentication):
+    """
+    Cached authentication for local evaluation API endpoints.
+
+    This authentication class attempts to validate tokens using the team access
+    token cache. It's designed to achieve zero-database-call authentication for
+    local evaluation endpoints that receive high traffic volumes.
+
+    Only personal API keys with feature flag read access are allowed through
+    this authentication method.
+
+    Authentication flow:
+    1. Extract project API key and access token from request
+    2. Check if access token is cached as authorized for the team
+    3. If found in cache: return authenticated team without DB call
+    4. If not found: return None and let the next authentication handle it
+    """
+
+    keyword = "Bearer"
+
+    def authenticate(self, request: Union[HttpRequest, Request]) -> Optional[tuple[Any, Any]]:
+        """
+        Authenticate the request using cached token validation.
+
+        Args:
+            request: The incoming HTTP request
+
+        Returns:
+            Tuple of (user, auth) if authenticated, None if not applicable
+
+        Raises:
+            AuthenticationFailed: If authentication fails definitively
+        """
+        with CACHED_AUTH_LATENCY.labels(result="total").time():
+            try:
+                # Extract tokens from request
+                tokens = self._extract_tokens(request)
+                if not tokens:
+                    return None  # No applicable tokens found
+
+                project_api_key, access_token, token_type = tokens
+
+                # Attempt cached authentication
+                user = self._authenticate_with_cache(project_api_key, access_token, token_type)
+
+                if user is not None:
+                    # Cache hit - return the result
+                    # Tag queries for monitoring
+                    if hasattr(user, "team"):
+                        team_id = user.team.id
+                        # Use the token type to determine appropriate access method
+                        access_method = token_type if token_type in ["personal_api_key", "secret_api_key"] else "oauth"
+                        tag_queries(
+                            team_id=team_id,
+                            access_method=access_method,
+                        )
+
+                    CACHED_AUTH_OPERATIONS.labels(result="cache_hit", token_type=token_type).inc()
+
+                    logger.debug(
+                        f"Cached authentication successful for team {project_api_key}",
+                        extra={"project_api_key": project_api_key, "token_type": token_type},
+                    )
+                    return user, None
+
+                # Cache miss - fall through to standard authentication
+                return None
+
+            except AuthenticationFailed:
+                # Let authentication failures bubble up
+                raise
+            except Exception as e:
+                CACHED_AUTH_OPERATIONS.labels(result="error", token_type="unknown").inc()
+                logger.warning(f"Error in cached authentication: {e}")
+
+                # Fall through to standard authentication on unexpected errors
+                return None
+
+    def _extract_tokens(self, request: Union[HttpRequest, Request]) -> Optional[tuple[str, str, str]]:
+        """
+        Extract project API key and access token from request.
+
+        Args:
+            request: The HTTP request
+
+        Returns:
+            Tuple of (project_api_key, access_token, token_type) or None
+        """
+        try:
+            # Try to get access token first (personal API key or secret API key)
+            access_token_tuple = self._extract_access_token(request)
+            if access_token_tuple is None:
+                return None
+            access_token, access_token_type = access_token_tuple
+
+            # Try to get project API key from the request
+            # This could be in query params, headers, or body depending on endpoint
+            project_api_key = self._extract_project_api_key(request)
+
+            if not project_api_key:
+                return None
+
+            return project_api_key, access_token, access_token_type
+
+        except Exception as e:
+            logger.debug(f"Error extracting tokens: {e}")
+            return None
+
+    def _extract_project_api_key(self, request: Union[HttpRequest, Request]) -> Optional[str]:
+        """
+        Extract project API key from request.
+
+        This is typically in the request body or query params.
+        """
+        # Convert HttpRequest to DRF Request if needed
+        if not isinstance(request, Request):
+            request = Request(request)
+
+        # Check request body first
+        if hasattr(request, "data") and request.data:
+            project_key = request.data.get("project_api_key") or request.data.get("api_key")
+            if project_key:
+                return project_key
+
+        # Check query parameters
+        project_key = request.GET.get("project_api_key") or request.GET.get("api_key") or request.GET.get("token")
+        if project_key:
+            return project_key
+
+        return None
+
+    def _extract_access_token(self, request: Union[HttpRequest, Request]) -> Optional[tuple[str, str]]:
+        """
+        Extract access token from request using existing authentication methods.
+
+        This leverages the existing token extraction logic from PersonalAPIKeyAuthentication
+        and ProjectSecretAPIKeyAuthentication.
+        """
+        # Try secret API key extraction
+        secret_key = ProjectSecretAPIKeyAuthentication.find_secret_api_token(request)
+        if secret_key:
+            return secret_key, "secret_api_key"
+
+        # Try personal API key extraction
+        personal_key = PersonalAPIKeyAuthentication.find_key(request)
+        if personal_key:
+            return personal_key, "personal_api_key"
+
+        return None
+
+    def _authenticate_with_cache(
+        self, project_api_key: str, access_token: str, token_type: str
+    ) -> Optional[SecuredSDKEndpointUser]:
+        """
+        Attempt authentication using the team access token cache.
+
+        Args:
+            project_api_key: Team's project API key
+            access_token: Access token to validate
+            token_type: Type of access token
+
+        Returns:
+            User if cached auth successful, None if cache miss
+        """
+        try:
+            # Check access and get team data in a single cache lookup
+            has_access, team = team_access_cache.has_access_with_team(project_api_key, access_token)
+
+            if not has_access:
+                # Cache miss or token not authorized
+                return None
+
+            # Token is cached and authorized - get team object
+            if not team:
+                # This should never happen, but we'll log it just in case
+                logger.warning(f"Team not found for authentication", extra={"project_api_key": project_api_key})
+                return None
+
+            return SecuredSDKEndpointUser(team)
+        except Exception as e:
+            logger.warning(f"Error in cached authentication: {e}")
+            return None
+
+    def _get_team_from_cache_metadata(self, project_api_key: str) -> Optional[MinimalTeam]:
+        """
+        Extract team metadata from the access token cache to create a minimal team object.
+
+        This method reads the enhanced cache structure that includes team_id,
+        enabling zero-database-call authentication when the cache is warmed.
+
+        Args:
+            project_api_key: Team's project API key
+
+        Returns:
+            MinimalTeam object if cache contains team metadata, None otherwise
+        """
+        try:
+            if not project_api_key:
+                return None
+
+            # Get team access token data from HyperCache
+            token_data = team_access_tokens_hypercache.get_from_cache(project_api_key)
+            if not token_data:
+                return None
+
+            # Extract team metadata from cache
+            team_id = token_data.get("team_id")
+            if not team_id:
+                logger.debug(f"No team_id found in cache for {project_api_key}")
+                return None
+
+            # Create minimal team object from cached metadata
+            return MinimalTeam(api_token=project_api_key, team_id=team_id)
+
+        except Exception as e:
+            logger.debug(f"Error extracting team from cache metadata: {e}")
+            return None
+
+    def _get_personal_api_key_from_token(self, access_token: str):
+        """
+        Get personal API key object from the raw token value.
+
+        Args:
+            access_token: The raw personal API key token
+
+        Returns:
+            PersonalAPIKey object if found, None otherwise
+        """
+        try:
+            # Import moved to top of function to avoid repeated imports
+            from posthog.models.personal_api_key import find_personal_api_key
+
+            result = find_personal_api_key(access_token)
+            return result[0] if result else None
+        except Exception as e:
+            logger.warning(f"Error getting personal API key: {e}")
+            return None
+
+    def _has_feature_flag_access(self, personal_api_key) -> bool:
+        """
+        Check if a personal API key has feature flag read access.
+
+        Args:
+            personal_api_key: PersonalAPIKey object
+
+        Returns:
+            True if the key has feature flag read access, False otherwise
+        """
+        try:
+            # Legacy keys (no scopes) are allowed for backward compatibility
+            if not personal_api_key.scopes:
+                return True
+
+            # Check for wildcard access
+            if "*" in personal_api_key.scopes:
+                return True
+
+            # Check for specific feature flag read access
+            # Also check for write access (write implies read)
+            return "feature_flag:read" in personal_api_key.scopes or "feature_flag:write" in personal_api_key.scopes
+        except Exception as e:
+            logger.warning(f"Error checking feature flag access: {e}")
+            return False
+
+    @classmethod
+    def authenticate_header(cls, request) -> str:
+        """Return the authentication header keyword."""
+        return cls.keyword

--- a/posthog/authentication/test/test_cached_authentication.py
+++ b/posthog/authentication/test/test_cached_authentication.py
@@ -1,0 +1,276 @@
+"""
+Tests for cached token authentication backend.
+"""
+
+import json
+
+from posthog.test.base import APIBaseTest
+from unittest.mock import MagicMock, patch
+
+from django.test import RequestFactory
+
+from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
+from rest_framework.request import Request
+
+from posthog.auth import SecuredSDKEndpointUser
+from posthog.authentication.cached_authentication import LocalEvaluationAuthentication
+from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+from posthog.models.user import User
+from posthog.models.utils import generate_random_token_personal
+from posthog.storage.team_access_cache import team_access_cache
+
+
+class TestLocalEvaluationAuthentication(APIBaseTest):
+    """Test the LocalEvaluationAuthentication class."""
+
+    def setUp(self):
+        """Set up test data."""
+        super().setUp()
+        self.factory = RequestFactory()
+        self.auth = LocalEvaluationAuthentication()
+        self.access_token = "phs_SECRETAPITOKEN"
+        self.hashed_token = hash_key_value(self.access_token, mode="sha256")
+
+        # Set up the team with the secret API token
+        self.team.secret_api_token = self.access_token
+        self.team.save()
+        self.project_api_key = self.team.api_token
+
+    def test_authenticate_header(self):
+        """Test authenticate_header returns correct keyword."""
+        request = self.factory.get("/")
+        header = self.auth.authenticate_header(request)
+        assert header == "Bearer"
+
+    def test_authenticate_no_tokens(self):
+        """Test authentication with no tokens in request."""
+        request = self.factory.post("/", content_type="application/json")
+        drf_request = Request(request, parsers=[JSONParser(), FormParser(), MultiPartParser()])
+
+        result = self.auth.authenticate(drf_request)
+        assert result is None
+
+    def test_extract_project_api_key_from_body(self):
+        """Test extracting project API key from request body."""
+        data = json.dumps({"project_api_key": self.project_api_key, "other_field": "value"})
+        request = self.factory.post("/", data, content_type="application/json")
+        drf_request = Request(request, parsers=[JSONParser(), FormParser(), MultiPartParser()])
+
+        result = self.auth._extract_project_api_key(drf_request)
+        assert result == self.project_api_key
+
+    def test_extract_project_api_key_from_query(self):
+        """Test extracting project API key from query parameters."""
+        request = self.factory.get("/", {"project_api_key": self.project_api_key, "other_param": "value"})
+        drf_request = Request(request)
+
+        result = self.auth._extract_project_api_key(drf_request)
+        assert result == self.project_api_key
+
+    def test_extract_project_api_key_alternative_name(self):
+        """Test extracting project API key using alternative field name."""
+        data = json.dumps({"api_key": self.project_api_key})
+        request = self.factory.post("/", data, content_type="application/json")
+        drf_request = Request(request, parsers=[JSONParser(), FormParser(), MultiPartParser()])
+
+        result = self.auth._extract_project_api_key(drf_request)
+        assert result == self.project_api_key
+
+    def test_extract_access_token_personal_key(self):
+        """Test extracting personal API key as access token."""
+
+        request = self.factory.post(
+            "/", content_type="application/json", HTTP_AUTHORIZATION="Bearer phx_personalapitoken"
+        )
+        drf_request = Request(request, parsers=[JSONParser(), FormParser(), MultiPartParser()])
+
+        result = self.auth._extract_access_token(drf_request)
+        assert result == ("phx_personalapitoken", "personal_api_key")
+
+    def test_extract_access_token_secret_key(self):
+        """Test extracting secret API key as access token."""
+
+        request = self.factory.post(
+            "/", content_type="application/json", HTTP_AUTHORIZATION="Bearer phs_supersecrettoken"
+        )
+        drf_request = Request(request, parsers=[JSONParser(), FormParser(), MultiPartParser()])
+
+        result = self.auth._extract_access_token(drf_request)
+        assert result == ("phs_supersecrettoken", "secret_api_key")
+
+    @patch("posthog.auth.PersonalAPIKeyAuthentication.find_key")
+    @patch("posthog.auth.ProjectSecretAPIKeyAuthentication.find_secret_api_token")
+    def test_extract_tokens_complete(self, mock_secret, mock_personal):
+        """Test complete token extraction."""
+        mock_personal.return_value = None
+        mock_secret.return_value = self.access_token
+
+        data = json.dumps({"project_api_key": self.project_api_key})
+        request = self.factory.post("/", data, content_type="application/json")
+        drf_request = Request(request, parsers=[JSONParser(), FormParser(), MultiPartParser()])
+
+        result = self.auth._extract_tokens(drf_request)
+
+        assert result is not None
+        project_key, access_token, token_type = result
+        assert project_key == self.project_api_key
+        assert access_token == self.access_token
+        assert token_type == "secret_api_key"
+
+    def test_authenticate_with_cache_success(self):
+        """Test successful cached authentication."""
+        # Actually put the token in the cache
+        team_access_cache.update_team_tokens(self.project_api_key, self.team.id, [self.hashed_token])
+
+        result = self.auth._authenticate_with_cache(self.project_api_key, self.access_token, "secret_api_key")
+
+        assert isinstance(result, SecuredSDKEndpointUser)
+        assert result.team.id == self.team.id
+
+    def test_authenticate_with_cache_miss(self):
+        """Test cache miss in cached authentication."""
+        # Clear any existing cache and use a token that doesn't exist in database
+        team_access_cache.invalidate_team(self.project_api_key)
+        fake_secret_token = "phs_NONEXISTENT_SECRET_TOKEN"
+
+        result = self.auth._authenticate_with_cache(self.project_api_key, fake_secret_token, "secret_api_key")
+
+        assert result is None
+
+    def test_authenticate_with_cache_no_team(self):
+        """Test cached authentication when team is not found."""
+        # Use a fake secret API token that doesn't belong to any team
+        fake_secret_token = "phs_NONEXISTENT_SECRET_TOKEN"
+        fake_hashed_token = hash_key_value(fake_secret_token, mode="sha256")
+
+        # Put the fake token in cache
+        team_access_cache.update_team_tokens(self.project_api_key, self.team.id, [fake_hashed_token])
+
+        result = self.auth._authenticate_with_cache(self.project_api_key, fake_secret_token, "secret_api_key")
+
+        assert isinstance(result, SecuredSDKEndpointUser)
+        assert result.team.id == self.team.id
+
+    def test_authenticate_with_cache_personal_key_success(self):
+        """Test that personal API keys with valid scopes succeed in cached auth."""
+        # Create a real personal API key with proper token format and valid scopes
+        personal_token = generate_random_token_personal()  # Creates "phx_..." token
+        personal_hashed = hash_key_value(personal_token, mode="sha256")
+        # Put the personal API key token in cache
+        team_access_cache.update_team_tokens(self.project_api_key, self.team.id, [personal_hashed])
+
+        result = self.auth._authenticate_with_cache(self.project_api_key, personal_token, "personal_api_key")
+
+        assert isinstance(result, SecuredSDKEndpointUser)
+        assert result.team.id == self.team.id
+
+    @patch("posthog.storage.team_access_cache.team_access_cache.has_access_with_team")
+    def test_full_authenticate_cache_hit(self, mock_has_access):
+        """Test full authentication flow with cache hit."""
+        # Mock the cache to return True (token is authorized)
+        mock_has_access.return_value = True, self.team
+
+        data = json.dumps({"project_api_key": self.project_api_key})
+        request = self.factory.post(
+            "/", data, content_type="application/json", HTTP_AUTHORIZATION=f"Bearer {self.access_token}"
+        )
+        drf_request = Request(request, parsers=[JSONParser(), FormParser(), MultiPartParser()])
+
+        result = self.auth.authenticate(drf_request)
+
+        assert result is not None
+        user, auth = result
+        assert isinstance(user, SecuredSDKEndpointUser)
+        assert user.team.id == self.team.id
+
+    def test_full_authenticate_cache_miss_with_warming(self):
+        """Test full authentication flow with cache miss that warms successfully."""
+        # Clear any existing cache to ensure this is a real cache miss initially
+        team_access_cache.invalidate_team(self.project_api_key)
+
+        data = json.dumps({"project_api_key": self.project_api_key})
+        request = self.factory.post(
+            "/", data, content_type="application/json", HTTP_AUTHORIZATION=f"Bearer {self.access_token}"
+        )
+        drf_request = Request(request, parsers=[JSONParser(), FormParser(), MultiPartParser()])
+
+        result = self.auth.authenticate(drf_request)
+
+        # Should succeed because cache warming finds the valid token
+        assert result is not None
+        user, auth = result
+        assert isinstance(user, SecuredSDKEndpointUser)
+        assert user.team.id == self.team.id
+
+    def test_full_authenticate_handles_exceptions(self):
+        """Test that authentication handles unexpected exceptions gracefully."""
+        with patch.object(self.auth, "_extract_tokens", side_effect=Exception("Unexpected error")):
+            request = self.factory.post("/", content_type="application/json")
+            drf_request = Request(request, parsers=[JSONParser(), FormParser(), MultiPartParser()])
+
+            # Should return None instead of raising exception
+            result = self.auth.authenticate(drf_request)
+            assert result is None
+
+    def test_has_feature_flag_access_with_read_scope(self):
+        """Test that personal API keys with feature_flag:read scope have access."""
+        user = User.objects.create(email="scope1@example.com")
+        personal_key = PersonalAPIKey.objects.create(
+            label="Read Scope Key", user=user, scopes=["feature_flag:read", "insight:read"]
+        )
+
+        result = self.auth._has_feature_flag_access(personal_key)
+        assert result is True
+
+    def test_has_feature_flag_access_with_write_scope(self):
+        """Test that personal API keys with feature_flag:write scope have access."""
+        user = User.objects.create(email="scope2@example.com")
+        personal_key = PersonalAPIKey.objects.create(
+            label="Write Scope Key", user=user, scopes=["feature_flag:write", "insight:read"]
+        )
+
+        result = self.auth._has_feature_flag_access(personal_key)
+        assert result is True
+
+    def test_has_feature_flag_access_with_wildcard(self):
+        """Test that personal API keys with wildcard scope have access."""
+        user = User.objects.create(email="scope3@example.com")
+        personal_key = PersonalAPIKey.objects.create(label="Wildcard Key", user=user, scopes=["*"])
+
+        result = self.auth._has_feature_flag_access(personal_key)
+        assert result is True
+
+    def test_has_feature_flag_access_legacy_no_scopes(self):
+        """Test that legacy personal API keys (no scopes) have access."""
+        user = User.objects.create(email="scope4@example.com")
+        personal_key = PersonalAPIKey.objects.create(label="Legacy Key", user=user, scopes=None)
+
+        result = self.auth._has_feature_flag_access(personal_key)
+        assert result is True
+
+    def test_has_feature_flag_access_empty_scopes(self):
+        """Test that personal API keys with empty scopes have access (legacy)."""
+        user = User.objects.create(email="scope5@example.com")
+        personal_key = PersonalAPIKey.objects.create(label="Empty Scopes Key", user=user, scopes=[])
+
+        result = self.auth._has_feature_flag_access(personal_key)
+        assert result is True
+
+    def test_has_feature_flag_access_without_feature_flag_scope(self):
+        """Test that personal API keys without feature flag scope are denied."""
+        user = User.objects.create(email="scope6@example.com")
+        personal_key = PersonalAPIKey.objects.create(
+            label="No FF Scope Key", user=user, scopes=["insight:read", "cohort:write"]
+        )
+
+        result = self.auth._has_feature_flag_access(personal_key)
+        assert result is False
+
+    def test_has_feature_flag_access_handles_exceptions(self):
+        """Test that scope checking handles exceptions gracefully."""
+        # For this test, MagicMock is actually appropriate since we're testing exception handling
+        mock_personal_key = MagicMock()
+        mock_personal_key.scopes = MagicMock(side_effect=Exception("Scope error"))
+
+        result = self.auth._has_feature_flag_access(mock_personal_key)
+        assert result is False

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, ConfigDict
 
 class AccessMethod(StrEnum):
     PERSONAL_API_KEY = "personal_api_key"
+    SECRET_API_KEY = "secret_api_key"
     OAUTH = "oauth"
 
 

--- a/posthog/models/test/test_remote_config_signals.py
+++ b/posthog/models/test/test_remote_config_signals.py
@@ -1,0 +1,250 @@
+"""
+Tests for signal handlers in posthog/models/remote_config.py.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from posthog.models.organization import OrganizationMembership
+from posthog.models.remote_config import organization_membership_deleted, user_saved
+from posthog.models.user import User
+
+
+class TestUserSavedSignalHandler(TestCase):
+    """Test the user_saved signal handler in remote_config.py."""
+
+    @patch("django.db.transaction.on_commit")
+    def test_user_saved_calls_update_when_is_active_in_update_fields(self, mock_on_commit):
+        """Test that user_saved schedules update_user_authentication_cache when is_active is in update_fields."""
+
+        # Create mock user
+        mock_user = MagicMock()
+        mock_user.id = 42
+        mock_user.is_active = True
+
+        # Call user_saved with is_active in update_fields
+        user_saved(sender=User, instance=mock_user, created=False, update_fields=["is_active", "email"])
+
+        # Verify transaction.on_commit was called (update was scheduled)
+        mock_on_commit.assert_called_once()
+
+    @patch("django.db.transaction.on_commit")
+    def test_user_saved_calls_update_when_update_fields_is_none(self, mock_on_commit):
+        """Test that user_saved schedules update_user_authentication_cache when update_fields is None (bulk operations)."""
+
+        # Create mock user
+        mock_user = MagicMock()
+        mock_user.id = 42
+        mock_user.is_active = False
+
+        # Call user_saved without update_fields (None means bulk operation)
+        user_saved(sender=User, instance=mock_user, created=False, update_fields=None)
+
+        # Verify transaction.on_commit was called (update was scheduled)
+        mock_on_commit.assert_called_once()
+
+    @patch("django.db.transaction.on_commit")
+    def test_user_saved_does_not_call_update_when_is_active_not_in_update_fields(self, mock_on_commit):
+        """Test that user_saved does not schedule update when is_active is not in update_fields."""
+        from posthog.models.remote_config import user_saved
+
+        # Create mock user
+        mock_user = MagicMock()
+        mock_user.id = 42
+        mock_user.is_active = True
+
+        # Call user_saved with is_active NOT in update_fields
+        user_saved(sender=User, instance=mock_user, created=False, update_fields=["email", "name"])
+
+        # Verify transaction.on_commit was NOT called (update was not scheduled)
+        mock_on_commit.assert_not_called()
+
+    @patch("posthog.models.remote_config.logger")
+    @patch("django.db.transaction.on_commit")
+    def test_user_saved_logs_debug_when_skipping_update(self, mock_on_commit, mock_logger):
+        """Test that user_saved logs debug message when skipping cache update."""
+
+        # Create mock user
+        mock_user = MagicMock()
+        mock_user.id = 42
+        mock_user.is_active = True
+
+        # Call user_saved with is_active NOT in update_fields
+        user_saved(sender=User, instance=mock_user, created=False, update_fields=["email", "name"])
+
+        # Verify debug message was logged
+        mock_logger.debug.assert_called_once_with("User 42 updated but is_active unchanged, skipping cache update")
+
+        # Verify transaction.on_commit was not called
+        mock_on_commit.assert_not_called()
+
+    @patch("posthog.storage.team_access_cache_signal_handlers.update_user_authentication_cache")
+    @patch("django.db.transaction.on_commit")
+    def test_user_saved_uses_transaction_on_commit(self, mock_on_commit, mock_update_cache):
+        """Test that user_saved uses transaction.on_commit to defer cache updates."""
+
+        # Create mock user
+        mock_user = MagicMock()
+        mock_user.id = 42
+        mock_user.is_active = True
+
+        # Call user_saved with is_active in update_fields
+        user_saved(sender=User, instance=mock_user, created=False, update_fields=["is_active"])
+
+        # Verify transaction.on_commit was called
+        mock_on_commit.assert_called_once()
+
+        # Get the lambda function that was passed to on_commit and call it
+        on_commit_lambda = mock_on_commit.call_args[0][0]
+        on_commit_lambda()
+
+        # Verify that the update function would be called after transaction commits
+        # The lambda passes instance and **kwargs (which doesn't include created)
+        mock_update_cache.assert_called_once_with(mock_user, update_fields=["is_active"])
+
+    @patch("django.db.transaction.on_commit")
+    def test_user_saved_handles_empty_update_fields_list(self, mock_on_commit):
+        """Test that user_saved handles empty update_fields list correctly."""
+
+        # Create mock user
+        mock_user = MagicMock()
+        mock_user.id = 42
+        mock_user.is_active = True
+
+        # Call user_saved with empty update_fields list
+        user_saved(sender=User, instance=mock_user, created=False, update_fields=[])
+
+        # Verify transaction.on_commit was NOT called (is_active not in empty list)
+        mock_on_commit.assert_not_called()
+
+    @patch("django.db.transaction.on_commit")
+    def test_user_saved_handles_is_active_as_only_field(self, mock_on_commit):
+        """Test that user_saved works when is_active is the only field in update_fields."""
+
+        # Create mock user
+        mock_user = MagicMock()
+        mock_user.id = 42
+        mock_user.is_active = False
+
+        # Call user_saved with only is_active in update_fields
+        user_saved(sender=User, instance=mock_user, created=False, update_fields=["is_active"])
+
+        # Verify transaction.on_commit was called (update was scheduled)
+        mock_on_commit.assert_called_once()
+
+
+class TestOrganizationMembershipDeletedSignalHandler(TestCase):
+    """Test the organization_membership_deleted signal handler in remote_config.py."""
+
+    @patch("django.db.transaction.on_commit")
+    def test_organization_membership_deleted_calls_update_when_user_removed(self, mock_on_commit):
+        """Test that organization_membership_deleted schedules cache update when a user is removed from org."""
+
+        # Create mock user and organization
+        mock_user = MagicMock()
+        mock_user.id = 42
+
+        mock_org = MagicMock()
+        mock_org.id = "test-org-uuid"
+
+        # Create mock OrganizationMembership
+        mock_membership = MagicMock()
+        mock_membership.user = mock_user
+        mock_membership.organization = mock_org
+
+        # Call organization_membership_deleted
+        organization_membership_deleted(sender=OrganizationMembership, instance=mock_membership)
+
+        # Verify transaction.on_commit was called (update was scheduled)
+        mock_on_commit.assert_called_once()
+
+    @patch("posthog.storage.team_access_cache_signal_handlers.update_user_authentication_cache")
+    @patch("django.db.transaction.on_commit")
+    def test_organization_membership_deleted_uses_transaction_on_commit(self, mock_on_commit, mock_update_cache):
+        """Test that organization_membership_deleted uses transaction.on_commit to defer cache updates."""
+
+        # Create mock user and organization
+        mock_user = MagicMock()
+        mock_user.id = 42
+
+        mock_org = MagicMock()
+        mock_org.id = "test-org-uuid"
+
+        # Create mock OrganizationMembership
+        mock_membership = MagicMock()
+        mock_membership.user = mock_user
+        mock_membership.organization = mock_org
+
+        # Call organization_membership_deleted
+        organization_membership_deleted(sender=OrganizationMembership, instance=mock_membership)
+
+        # Verify transaction.on_commit was called
+        mock_on_commit.assert_called_once()
+
+        # Get the lambda function that was passed to on_commit and call it
+        on_commit_lambda = mock_on_commit.call_args[0][0]
+        on_commit_lambda()
+
+        # Verify that the update function would be called after transaction commits
+        # The lambda passes instance.user and **kwargs
+        mock_update_cache.assert_called_once_with(mock_user)
+
+    @patch("posthog.models.remote_config.logger")
+    @patch("django.db.transaction.on_commit")
+    def test_organization_membership_deleted_logs_when_scheduled(self, mock_on_commit, mock_logger):
+        """Test that organization_membership_deleted properly schedules cache updates."""
+
+        # Create mock user and organization
+        mock_user = MagicMock()
+        mock_user.id = 42
+
+        mock_org = MagicMock()
+        mock_org.id = "test-org-uuid"
+
+        # Create mock OrganizationMembership
+        mock_membership = MagicMock()
+        mock_membership.user = mock_user
+        mock_membership.organization = mock_org
+
+        # Call organization_membership_deleted
+        organization_membership_deleted(sender=OrganizationMembership, instance=mock_membership)
+
+        # Verify transaction.on_commit was called (update was scheduled)
+        mock_on_commit.assert_called_once()
+
+    def test_organization_membership_deleted_handles_none_user(self):
+        """Test that organization_membership_deleted handles membership with None user gracefully."""
+
+        # Create mock OrganizationMembership with None user
+        mock_membership = MagicMock()
+        mock_membership.user = None
+
+        # Should not raise an exception
+        try:
+            organization_membership_deleted(sender=OrganizationMembership, instance=mock_membership)
+        except Exception as e:
+            self.fail(f"organization_membership_deleted raised an exception with None user: {e}")
+
+    @patch("django.db.transaction.on_commit")
+    def test_organization_membership_deleted_with_different_kwargs(self, mock_on_commit):
+        """Test that organization_membership_deleted properly forwards kwargs to the cache update."""
+
+        # Create mock user and organization
+        mock_user = MagicMock()
+        mock_user.id = 42
+
+        mock_org = MagicMock()
+        mock_org.id = "test-org-uuid"
+
+        # Create mock OrganizationMembership
+        mock_membership = MagicMock()
+        mock_membership.user = mock_user
+        mock_membership.organization = mock_org
+
+        # Call organization_membership_deleted with additional kwargs
+        test_kwargs = {"raw": False, "using": "default"}
+        organization_membership_deleted(sender=OrganizationMembership, instance=mock_membership, **test_kwargs)
+
+        # Verify transaction.on_commit was called
+        mock_on_commit.assert_called_once()

--- a/posthog/storage/team_access_cache.py
+++ b/posthog/storage/team_access_cache.py
@@ -1,0 +1,436 @@
+"""
+Per-team access token cache layer for cache-based authentication.
+
+This module provides Redis-based caching of hashed access tokens per team,
+enabling zero-database-call authentication for the local_evaluation endpoint.
+"""
+
+import logging
+from datetime import UTC
+from typing import TYPE_CHECKING, Any, Optional
+
+from prometheus_client import Counter, Histogram
+
+from posthog.models.personal_api_key import hash_key_value
+from posthog.storage.hypercache import HyperCache, HyperCacheStoreMissing, KeyType
+
+if TYPE_CHECKING:
+    from posthog.authentication.cached_authentication import MinimalTeam
+
+logger = logging.getLogger(__name__)
+
+# Prometheus metrics
+TEAM_ACCESS_CACHE_OPERATIONS = Counter(
+    "posthog_team_access_cache_operations_total",
+    "Number of team access cache operations",
+    labelnames=["operation", "result", "token_status", "source"],
+)
+
+TEAM_ACCESS_CACHE_LATENCY = Histogram(
+    "posthog_team_access_cache_latency_seconds", "Latency of team access cache operations", labelnames=["operation"]
+)
+
+# Cache configuration
+DEFAULT_TTL = 300  # 5 minutes
+CACHE_KEY_PREFIX = "cache/teams"
+
+
+class TeamAccessTokenCache:
+    """
+    HyperCache-based cache for per-team access token lists.
+
+    This class manages hashed token lists per team to enable fast authentication
+    lookups without database queries. Each team has its own cache entry with
+    JSON data containing hashed authorized tokens and metadata. Uses HyperCache
+    for automatic Redis + S3 backup and improved reliability.
+    """
+
+    def __init__(self, ttl: int = DEFAULT_TTL):
+        """
+        Initialize the team access token cache.
+
+        Args:
+            ttl: Time-to-live for cache entries in seconds
+        """
+        self.ttl = ttl
+
+    def has_access_with_team(self, project_api_key: str, access_token: str) -> tuple[bool, Optional["MinimalTeam"]]:
+        """
+        Check if an access token is authorized for the given team and return team data.
+
+        This method combines token validation and team metadata extraction in a single
+        cache lookup, avoiding redundant cache calls in the authentication flow.
+
+        Args:
+            project_api_key: The team's project API key
+            access_token: The access token to validate
+
+        Returns:
+            Tuple of (has_access, minimal_team) where:
+            - has_access: True if the token is authorized, False otherwise
+            - minimal_team: MinimalTeam object if authorized and team_id available, None otherwise
+        """
+        with TEAM_ACCESS_CACHE_LATENCY.labels(operation="has_access_with_team").time():
+            try:
+                # Hash the access token for comparison
+                hashed_token = hash_key_value(access_token, mode="sha256")
+
+                # Get the team's token data from HyperCache
+                token_data, source = team_access_tokens_hypercache.get_from_cache_with_source(project_api_key)
+
+                if token_data is None:
+                    TEAM_ACCESS_CACHE_OPERATIONS.labels(
+                        operation="has_access_with_team", result="cache_miss", token_status="unknown", source="cache"
+                    ).inc()
+                    logger.debug(f"Cache miss for team {project_api_key}, attempting to warm cache")
+
+                    # Attempt to warm the cache and try again
+                    try:
+                        warm_result = warm_team_token_cache(project_api_key)
+                        if warm_result:
+                            # Try to get the data again after warming
+                            token_data, source = team_access_tokens_hypercache.get_from_cache_with_source(
+                                project_api_key
+                            )
+                    except Exception as e:
+                        logger.warning(f"Failed to warm cache for team {project_api_key}: {e}")
+
+                    # If we still don't have data after warming, return False, None
+                    if token_data is None:
+                        logger.debug(f"Cache still empty after warming for team {project_api_key}")
+                        return False, None
+
+                # Check if the hashed token exists in the list
+                # token_data is guaranteed to not be None at this point
+                hashed_tokens = token_data.get("hashed_tokens", [])
+                has_token = hashed_token in hashed_tokens
+
+                TEAM_ACCESS_CACHE_OPERATIONS.labels(
+                    operation="has_access_with_team",
+                    result="cache_hit",
+                    token_status="found" if has_token else "not_found",
+                    source=source,
+                ).inc()
+
+                if has_token:
+                    logger.debug(f"Token authorized for team {project_api_key}")
+
+                    # Extract team metadata for MinimalTeam creation
+                    team_id = token_data.get("team_id")
+                    if team_id:
+                        # Import here to avoid circular imports
+                        from posthog.authentication.cached_authentication import MinimalTeam
+
+                        minimal_team = MinimalTeam(api_token=project_api_key, team_id=team_id)
+                        return True, minimal_team
+                    else:
+                        logger.debug(f"No team_id found in cache for {project_api_key}")
+                        return True, None
+                else:
+                    logger.debug(f"Token not authorized for team {project_api_key}")
+                    return False, None
+
+            except Exception as e:
+                TEAM_ACCESS_CACHE_OPERATIONS.labels(
+                    operation="has_access_with_team", result="error", token_status="unknown", source="cache"
+                ).inc()
+                logger.warning(f"Error checking access with team for team {project_api_key}: {e}")
+                return False, None
+
+    def update_team_tokens(self, project_api_key: str, team_id: int, hashed_tokens: list[str]) -> None:
+        """
+        Update a team's complete token list in cache.
+
+        Args:
+            project_api_key: The team's project API key
+            team_id: The team's ID
+            hashed_tokens: List of hashed tokens (already in sha256$ format)
+        """
+        with TEAM_ACCESS_CACHE_LATENCY.labels(operation="update_team_tokens").time():
+            try:
+                from datetime import datetime
+
+                # Build structured data for HyperCache
+                token_data = {
+                    "hashed_tokens": hashed_tokens,
+                    "last_updated": datetime.now(UTC).isoformat(),
+                    "team_id": team_id,  # Always include team_id for zero-DB-call authentication
+                }
+
+                # Store via HyperCache (handles Redis + S3 automatically)
+                team_access_tokens_hypercache.set_cache_value(project_api_key, token_data)
+
+                TEAM_ACCESS_CACHE_OPERATIONS.labels(
+                    operation="update_team_tokens", result="success", token_status="updated", source="database"
+                ).inc()
+
+                logger.info(
+                    f"Updated token cache for team {project_api_key} with {len(hashed_tokens)} tokens",
+                    extra={"team_project_api_key": project_api_key, "token_count": len(hashed_tokens)},
+                )
+
+            except Exception as e:
+                TEAM_ACCESS_CACHE_OPERATIONS.labels(
+                    operation="update_team_tokens", result="error", token_status="failed", source="database"
+                ).inc()
+                logger.exception(f"Error updating tokens for team {project_api_key}: {e}")
+                raise
+
+    def invalidate_team(self, project_api_key: str) -> None:
+        """
+        Invalidate (delete) a team's token cache.
+
+        Args:
+            project_api_key: The team's project API key
+        """
+        with TEAM_ACCESS_CACHE_LATENCY.labels(operation="invalidate_team").time():
+            try:
+                # Clear from HyperCache (handles Redis + S3)
+                team_access_tokens_hypercache.clear_cache(project_api_key)
+
+                TEAM_ACCESS_CACHE_OPERATIONS.labels(
+                    operation="invalidate_team", result="success", token_status="invalidated", source="cache"
+                ).inc()
+
+                logger.info(f"Invalidated token cache for team {project_api_key}")
+
+            except Exception as e:
+                TEAM_ACCESS_CACHE_OPERATIONS.labels(
+                    operation="invalidate_team", result="error", token_status="failed", source="cache"
+                ).inc()
+                logger.exception(f"Error invalidating cache for team {project_api_key}: {e}")
+                raise
+
+    def get_cached_token_count(self, project_api_key: str) -> Optional[int]:
+        """
+        Get the number of tokens cached for a team (for monitoring).
+
+        Args:
+            project_api_key: The team's project API key
+
+        Returns:
+            Number of cached tokens or None if not cached
+        """
+        try:
+            token_data = team_access_tokens_hypercache.get_from_cache(project_api_key)
+
+            if token_data is None:
+                return None
+
+            # Compute token count from array length (no need to store redundant field)
+            return len(token_data.get("hashed_tokens", []))
+
+        except Exception as e:
+            logger.warning(f"Error getting token count for team {project_api_key}: {e}")
+            return None
+
+
+def _load_team_access_tokens(team_token: KeyType) -> dict[str, Any] | HyperCacheStoreMissing:
+    """
+    Load team access tokens from the database.
+
+    Args:
+        team_token: Team identifier (can be Team object, API token string, or team ID)
+
+    Returns:
+        Dictionary containing hashed tokens and metadata, or HyperCacheStoreMissing if team not found
+    """
+    from datetime import datetime
+
+    from posthog.models.personal_api_key import PersonalAPIKey
+    from posthog.models.team.team import Team
+
+    try:
+        # Convert KeyType to team object if needed
+        if isinstance(team_token, str):
+            team = Team.objects.get(api_token=team_token)
+        elif isinstance(team_token, int):
+            team = Team.objects.get(id=team_token)
+        else:
+            # team_token is already a Team object
+            team = team_token
+
+        # Collect all hashed tokens for this team
+        hashed_tokens = []
+
+        # 1. Personal API keys with access to this team and feature flag read access
+
+        # Get scoped keys that explicitly include this team and have feature flag read access
+        scoped_keys = PersonalAPIKey.objects.filter(
+            user__is_active=True, scoped_teams__contains=[team.id], scopes__contains=["feature_flag:read"]
+        ).values_list("secure_value", flat=True)
+
+        # Get unscoped keys (null/empty scoped_teams) from users in this team's organization
+        # Only include keys with feature flag read access or legacy keys (no scopes)
+        from django.db.models import Q
+
+        from posthog.models.organization import OrganizationMembership
+
+        unscoped_keys = (
+            PersonalAPIKey.objects.filter(
+                Q(scoped_teams__isnull=True) | Q(scoped_teams=[]),
+                user__is_active=True,
+                user__id__in=OrganizationMembership.objects.filter(organization_id=team.organization_id).values_list(
+                    "user_id", flat=True
+                ),
+            )
+            .filter(
+                # Include keys that have feature flag read access OR legacy keys with no scopes
+                Q(scopes__contains=["feature_flag:read"]) | Q(scopes__isnull=True) | Q(scopes=[])
+            )
+            .values_list("secure_value", flat=True)
+        )
+
+        # Combine both types of keys
+        all_personal_keys = list(scoped_keys) + list(unscoped_keys)
+
+        # Add personal API keys (already hashed in secure_value field)
+        for secure_value in all_personal_keys:
+            if secure_value:  # Ensure it's not None/empty
+                hashed_tokens.append(secure_value)
+
+        # 2. Team secret tokens (need to be hashed)
+        if team.secret_api_token:
+            hashed_secret = hash_key_value(team.secret_api_token, mode="sha256")
+            hashed_tokens.append(hashed_secret)
+
+        if team.secret_api_token_backup:
+            hashed_secret_backup = hash_key_value(team.secret_api_token_backup, mode="sha256")
+            hashed_tokens.append(hashed_secret_backup)
+
+        # Return structured data for caching
+        return {
+            "hashed_tokens": hashed_tokens,
+            "last_updated": datetime.now(UTC).isoformat(),
+            "team_id": team.id,  # Include team_id for zero-DB-call authentication
+        }
+
+    except Team.DoesNotExist:
+        logger.warning(f"Team not found for project API key: {team_token}")
+        return HyperCacheStoreMissing()
+
+    except Exception as e:
+        logger.exception(f"Error loading team access tokens for {team_token}: {e}")
+        return HyperCacheStoreMissing()
+
+
+# HyperCache instance for team access tokens
+team_access_tokens_hypercache = HyperCache(
+    namespace="team_access_tokens",
+    value="access_tokens.json",
+    token_based=True,  # Use team API token as key
+    load_fn=_load_team_access_tokens,
+)
+
+# Global instance for convenience
+team_access_cache = TeamAccessTokenCache()
+
+
+def warm_team_token_cache(project_api_key: str) -> bool:
+    """
+    Warm the token cache for a specific team by loading from database.
+
+    This function now uses the HyperCache to update the cache, which handles
+    both Redis and S3 storage automatically.
+
+    Args:
+        project_api_key: The team's project API key
+
+    Returns:
+        True if cache warming succeeded, False otherwise
+    """
+    # Use HyperCache to update the cache - this will call _load_team_access_tokens
+    # It does not raise an exception if the cache is not updated, so we don't need to try/except
+    success = team_access_tokens_hypercache.update_cache(project_api_key)
+
+    if success:
+        logger.info(
+            f"Warmed token cache for team {project_api_key} using HyperCache",
+            extra={"project_api_key": project_api_key},
+        )
+    else:
+        logger.warning(f"Failed to warm token cache for team {project_api_key}")
+
+    return success
+
+
+def get_teams_needing_cache_refresh() -> list[str]:
+    """
+    Get a list of project API keys for teams that need cache refresh.
+
+    This can be used by background tasks to identify teams whose
+    token caches are missing from HyperCache.
+
+    Returns:
+        List of project API keys
+
+    Raises:
+        Exception: Database connectivity or other systemic issues that should trigger retries
+    """
+    from posthog.models.team.team import Team
+
+    # Get all active teams - let database exceptions bubble up
+    teams = Team.objects.filter(
+        project__isnull=False  # Ensure team has a valid project
+    ).values_list("api_token", flat=True)
+
+    # Check which teams have missing caches in HyperCache
+    teams_needing_refresh = []
+
+    for project_api_key in teams:
+        try:
+            token_data = team_access_tokens_hypercache.get_from_cache(project_api_key)
+            if token_data is None:
+                teams_needing_refresh.append(project_api_key)
+        except Exception as e:
+            # Log individual team cache check failure but continue with others
+            logger.warning(
+                f"Failed to check cache for team {project_api_key}: {e}",
+                extra={"project_api_key": project_api_key, "error": str(e)},
+            )
+            # Assume this team needs refresh if we can't check its cache
+            teams_needing_refresh.append(project_api_key)
+
+    return teams_needing_refresh
+
+
+def get_teams_for_personal_api_key(personal_api_key_instance) -> list[str]:
+    """
+    Get project API keys for teams that a PersonalAPIKey has access to.
+
+    Personal API keys can have access to multiple teams via scoped_teams.
+    If scoped_teams is empty/null, the key has access to ALL teams within
+    the user's organizations (following the same access pattern as the user).
+
+    Args:
+        personal_api_key_instance: The PersonalAPIKey instance
+
+    Returns:
+        List of project API keys (strings) for teams the key has access to
+    """
+    from posthog.models.team.team import Team
+
+    scoped_teams = personal_api_key_instance.scoped_teams or []
+
+    if scoped_teams:
+        # Key is scoped to specific teams - return only those teams
+        team_tokens = Team.objects.filter(id__in=scoped_teams).values_list("api_token", flat=True)
+        return list(team_tokens)
+    else:
+        # Key is unscoped - has access to all teams within user's organizations
+        from posthog.models.organization import OrganizationMembership
+
+        # Get all organizations the user is a member of
+        user_organizations = OrganizationMembership.objects.filter(user=personal_api_key_instance.user).values_list(
+            "organization_id", flat=True
+        )
+
+        if user_organizations:
+            # Get all teams in those organizations
+            team_tokens = Team.objects.filter(organization_id__in=user_organizations).values_list(
+                "api_token", flat=True
+            )
+            return list(team_tokens)
+        else:
+            # User has no organization memberships
+            return []

--- a/posthog/storage/team_access_cache_signal_handlers.py
+++ b/posthog/storage/team_access_cache_signal_handlers.py
@@ -1,0 +1,180 @@
+"""
+Signal handler functions for team access token cache invalidation.
+
+This module provides handler functions that automatically update
+the team access token cache when PersonalAPIKey or Team models change,
+ensuring cache consistency with the database.
+
+Note: Signal subscriptions are registered in posthog/models/remote_config.py
+"""
+
+import logging
+
+from posthog.models.personal_api_key import PersonalAPIKey
+from posthog.models.team.team import Team
+from posthog.storage.team_access_cache import team_access_cache
+
+logger = logging.getLogger(__name__)
+
+
+def update_team_authentication_cache(instance: Team, created: bool, **kwargs):
+    """
+    Rebuild team access cache when Team model is saved.
+
+    This handler rebuilds the cache for any team save to ensure the cache
+    always reflects the latest authorized tokens. This is the most robust
+    approach as it avoids state tracking and works in all deployment scenarios.
+    """
+    try:
+        if not instance.api_token:
+            return
+
+        if created:
+            # New team - no cache to rebuild yet
+            logger.debug(f"New team created: {instance.pk}")
+            return
+
+        # Always rebuild cache on team save (most robust approach)
+        from posthog.storage.team_access_cache import warm_team_token_cache
+
+        try:
+            warm_team_token_cache(instance.api_token)
+            logger.info(
+                f"Rebuilt team access cache for team {instance.pk} after save",
+                extra={"team_id": instance.pk, "project_api_key": instance.api_token},
+            )
+        except Exception as e:
+            logger.warning(
+                f"Failed to rebuild cache for team {instance.pk}, falling back to invalidation: {e}",
+                extra={"team_id": instance.pk},
+            )
+            # Fall back to invalidation if rebuild fails
+            team_access_cache.invalidate_team(instance.api_token)
+
+    except Exception as e:
+        logger.exception(f"Error updating cache on team save for team {instance.pk}: {e}")
+
+
+def update_team_authentication_cache_on_delete(instance: Team, **kwargs):
+    """
+    Invalidate team access cache when Team is deleted.
+    """
+    try:
+        if instance.api_token:
+            team_access_cache.invalidate_team(instance.api_token)
+            logger.info(f"Invalidated cache for deleted team {instance.pk}")
+
+    except Exception as e:
+        logger.exception(f"Error invalidating cache on team delete for team {instance.pk}: {e}")
+
+
+def update_personal_api_key_authentication_cache(instance: PersonalAPIKey, created: bool, **kwargs):
+    """
+    Update team access cache when PersonalAPIKey is saved.
+
+    This handler warms the cache for all teams that the personal API key has
+    access to. For unscoped keys, this includes all teams within the user's
+    organizations. Since warming completely rebuilds the cache from the database,
+    no prior invalidation is needed.
+    """
+    from posthog.storage.team_access_cache import get_teams_for_personal_api_key, warm_team_token_cache
+
+    # Get the list of affected teams (no invalidation needed since warming rebuilds cache)
+    affected_teams = get_teams_for_personal_api_key(instance)
+
+    # Warm the cache for each affected team
+    for project_api_key in affected_teams:
+        try:
+            warm_team_token_cache(project_api_key)
+            logger.debug(f"Warmed cache for team {project_api_key} after PersonalAPIKey save")
+        except Exception as e:
+            logger.warning(
+                f"Failed to warm cache for team {project_api_key} after PersonalAPIKey save: {e}",
+                extra={"project_api_key": project_api_key, "personal_api_key_id": instance.id},
+            )
+
+
+def update_personal_api_key_authentication_cache_on_delete(instance: PersonalAPIKey, **kwargs):
+    """
+    Update team access cache when PersonalAPIKey is deleted.
+
+    This handler warms the cache for all teams that the deleted personal API key
+    had access to. For unscoped keys, this includes all teams within the user's
+    organizations. Since warming completely rebuilds the cache from the database,
+    no prior invalidation is needed.
+    """
+    from posthog.storage.team_access_cache import get_teams_for_personal_api_key, warm_team_token_cache
+
+    # Get the list of affected teams (no invalidation needed since warming rebuilds cache)
+    affected_teams = get_teams_for_personal_api_key(instance)
+
+    # Warm the cache for each affected team
+    for project_api_key in affected_teams:
+        try:
+            warm_team_token_cache(project_api_key)
+            logger.debug(f"Warmed cache for team {project_api_key} after PersonalAPIKey delete")
+        except Exception as e:
+            logger.warning(
+                f"Failed to warm cache for team {project_api_key} after PersonalAPIKey delete: {e}",
+                extra={"project_api_key": project_api_key, "personal_api_key_id": instance.id},
+            )
+
+
+def update_user_authentication_cache(instance, **kwargs):
+    """
+    Update team access caches when a User's status changes.
+
+    When a user is activated/deactivated, their Personal API Keys need to be
+    added/removed from the authentication caches of all teams they have access to.
+    This includes both scoped and unscoped keys.
+
+    Note: The update_fields filtering is now handled by the user_saved signal handler
+    in remote_config.py before calling this function.
+
+    Args:
+        sender: The model class (User)
+        instance: The User instance that changed
+        **kwargs: Additional signal arguments
+    """
+    from posthog.storage.team_access_cache import get_teams_for_personal_api_key, warm_team_token_cache
+
+    try:
+        # Get all personal API keys for this user
+        personal_keys = PersonalAPIKey.objects.filter(user_id=instance.id)
+
+        if not personal_keys.exists():
+            logger.debug(f"User {instance.id} has no personal API keys, no cache updates needed")
+            return
+
+        affected_teams = set()
+
+        # Collect all teams affected by this user's personal API keys
+        for key in personal_keys:
+            team_tokens = get_teams_for_personal_api_key(key)
+            affected_teams.update(team_tokens)
+
+        # Warm cache for all affected teams
+        if affected_teams:
+            for project_api_key in affected_teams:
+                try:
+                    warm_team_token_cache(project_api_key)
+                    logger.debug(f"Warmed cache for team {project_api_key} after user {instance.id} status change")
+                except Exception as e:
+                    logger.warning(
+                        f"Failed to warm cache for team {project_api_key} after user {instance.id} status change: {e}",
+                        extra={"project_api_key": project_api_key, "user_id": instance.id},
+                    )
+
+            logger.info(
+                f"Updated authentication cache for {len(affected_teams)} teams after user status change",
+                extra={
+                    "user_id": instance.id,
+                    "affected_teams_count": len(affected_teams),
+                    "user_is_active": instance.is_active,
+                },
+            )
+        else:
+            logger.debug(f"User {instance.id} has no accessible teams, no cache updates needed")
+
+    except Exception as e:
+        logger.exception(f"Error updating authentication cache for user {instance.id} status change: {e}")

--- a/posthog/storage/test/test_team_access_cache.py
+++ b/posthog/storage/test/test_team_access_cache.py
@@ -1,0 +1,995 @@
+"""
+Tests for team access token cache functionality.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.core.cache import cache
+from django.test import TestCase
+
+from posthog.models.personal_api_key import hash_key_value
+from posthog.storage.team_access_cache import (
+    TeamAccessTokenCache,
+    get_teams_for_personal_api_key,
+    get_teams_needing_cache_refresh,
+    team_access_cache,
+    team_access_tokens_hypercache,
+    warm_team_token_cache,
+)
+
+
+class TestTeamAccessTokenCache(TestCase):
+    """Test the TeamAccessTokenCache class."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.cache = TeamAccessTokenCache(ttl=300)
+        self.project_api_key = "phs_test_project_key_123"
+        self.team_id = 42
+        self.access_token = "phx_test_access_token_456"
+        self.hashed_token = hash_key_value(self.access_token, mode="sha256")
+
+        # Clear cache before each test
+        cache.clear()
+        # Also clear HyperCache
+        team_access_tokens_hypercache.clear_cache(self.project_api_key)
+
+    def tearDown(self):
+        """Clean up after tests."""
+        cache.clear()
+        # Also clear HyperCache
+        team_access_tokens_hypercache.clear_cache(self.project_api_key)
+
+    def test_cache_key_generation(self):
+        """Test cache key generation via HyperCache."""
+        expected_key = f"cache/team_tokens/{self.project_api_key}/team_access_tokens/access_tokens.json"
+        actual_key = team_access_tokens_hypercache.get_cache_key(self.project_api_key)
+        assert actual_key == expected_key
+
+    def test_update_team_tokens(self):
+        """Test updating team token list using HyperCache."""
+        tokens = [
+            hash_key_value("phx_token_one_123", mode="sha256"),
+            hash_key_value("phx_token_two_456", mode="sha256"),
+        ]
+
+        self.cache.update_team_tokens(self.project_api_key, self.team_id, tokens)
+
+        # Verify tokens are cached in JSON format
+        cached_data = team_access_tokens_hypercache.get_from_cache(self.project_api_key)
+
+        assert cached_data is not None
+        assert cached_data["hashed_tokens"] == tokens
+        assert cached_data["team_id"] == self.team_id
+        assert "last_updated" in cached_data
+
+    def test_invalidate_team(self):
+        """Test invalidating team cache."""
+        # Set up cache
+        self.cache.update_team_tokens(self.project_api_key, self.team_id, [self.hashed_token])
+
+        # Verify token is cached
+        has_access, _ = self.cache.has_access_with_team(self.project_api_key, self.access_token)
+        assert has_access is True
+
+        # Invalidate cache
+        self.cache.invalidate_team(self.project_api_key)
+
+        # Verify token is no longer cached
+        has_access, _ = self.cache.has_access_with_team(self.project_api_key, self.access_token)
+        assert has_access is False
+
+    def test_get_cached_token_count(self):
+        """Test getting token count from HyperCache."""
+        # Empty cache
+        count = self.cache.get_cached_token_count(self.project_api_key)
+        assert count is None
+
+        # Cache with tokens
+        tokens = [
+            hash_key_value("phx_token_one_123", mode="sha256"),
+            hash_key_value("phx_token_two_456", mode="sha256"),
+            hash_key_value("phx_token_three_789", mode="sha256"),
+        ]
+        self.cache.update_team_tokens(self.project_api_key, self.team_id, tokens)
+
+        count = self.cache.get_cached_token_count(self.project_api_key)
+        assert count == 3
+
+    @patch("posthog.storage.team_access_cache.logger")
+    def test_error_handling_in_has_access_with_team(self, mock_logger):
+        """Test error handling in has_access method."""
+        # First, add some tokens to cache so the method doesn't exit early
+        self.cache.update_team_tokens(self.project_api_key, self.team_id, [self.hashed_token])
+
+        # Then patch hash_key_value to raise an error (patch the imported name)
+        with patch("posthog.storage.team_access_cache.hash_key_value", side_effect=Exception("Hash error")):
+            result, _ = self.cache.has_access_with_team(self.project_api_key, "invalid_token")
+            assert result is False
+            mock_logger.warning.assert_called_once()
+
+    def test_ttl_configuration(self):
+        """Test that TTL can be configured (HyperCache manages TTL automatically)."""
+        custom_cache = TeamAccessTokenCache(ttl=600)
+        assert custom_cache.ttl == 600
+
+        # Test that cache respects configuration
+        custom_cache.update_team_tokens(self.project_api_key, self.team_id, [self.hashed_token])
+
+        # Verify cache was set via HyperCache
+        cached_data = team_access_tokens_hypercache.get_from_cache(self.project_api_key)
+        assert cached_data is not None
+        assert self.hashed_token in cached_data["hashed_tokens"]
+
+    def test_has_access_with_team_authorized(self):
+        """Test has_access_with_team returns True and MinimalTeam when token is authorized."""
+        # Set up cache with token and team_id
+        self.cache.update_team_tokens(self.project_api_key, self.team_id, [self.hashed_token])
+
+        # Test the combined method
+        has_access, team = self.cache.has_access_with_team(self.project_api_key, self.access_token)
+
+        assert has_access is True
+        assert team is not None
+        assert team.id == self.team_id
+        assert team.pk == self.team_id
+        assert team.api_token == self.project_api_key
+
+    def test_has_access_with_team_not_authorized(self):
+        """Test has_access_with_team returns False and None when token is not authorized."""
+        # Set up cache with different token
+        other_token = "phx_different_token_789"
+        other_hashed = hash_key_value(other_token, mode="sha256")
+        self.cache.update_team_tokens(self.project_api_key, self.team_id, [other_hashed])
+
+        # Test with our token (not in cache)
+        has_access, team = self.cache.has_access_with_team(self.project_api_key, self.access_token)
+
+        assert has_access is False
+        assert team is None
+
+    def test_has_access_with_team_cache_miss(self):
+        """Test has_access_with_team returns False and None on cache miss."""
+        # Don't put anything in cache
+        has_access, team = self.cache.has_access_with_team("unknown_project_key", self.access_token)
+
+        assert has_access is False
+        assert team is None
+
+    def test_has_access_with_team_missing_team_id(self):
+        """Test has_access_with_team returns True but None team when team_id is missing from cache."""
+        # Manually set cache data without team_id (simulate old cache format)
+        token_data = {
+            "hashed_tokens": [self.hashed_token],
+            "last_updated": "2024-01-01T00:00:00Z",
+            # team_id missing
+        }
+        team_access_tokens_hypercache.set_cache_value(self.project_api_key, token_data)
+
+        # Test the method
+        has_access, team = self.cache.has_access_with_team(self.project_api_key, self.access_token)
+
+        assert has_access is True  # Token is authorized
+        assert team is None  # But no team metadata available
+
+    def test_has_access_with_team_with_multiple_tokens(self):
+        """Test has_access works with multiple tokens in JSON list."""
+        token1 = "phx_token_one_123"
+        token2 = "phx_token_two_456"
+        token3 = "phx_token_three_789"
+
+        hashed1 = hash_key_value(token1, mode="sha256")
+        hashed2 = hash_key_value(token2, mode="sha256")
+        hashed3 = hash_key_value(token3, mode="sha256")
+
+        # Set up cache with multiple tokens using JSON format
+        token_data = {
+            "hashed_tokens": [hashed1, hashed2, hashed3],
+            "token_count": 3,
+            "last_updated": "2024-01-01T00:00:00Z",
+        }
+        team_access_tokens_hypercache.set_cache_value(self.project_api_key, token_data)
+
+        # Test each token can be found
+        has_access, _ = self.cache.has_access_with_team(self.project_api_key, token1)
+        assert has_access is True
+        has_access, _ = self.cache.has_access_with_team(self.project_api_key, token2)
+        assert has_access is True
+        has_access, _ = self.cache.has_access_with_team(self.project_api_key, token3)
+        assert has_access is True
+
+        # Test unknown token is not found
+        unknown_token = "phx_unknown_token_999"
+        has_access, _ = self.cache.has_access_with_team(self.project_api_key, unknown_token)
+        assert has_access is False
+
+
+class TestTeamAccessCacheIntegration(TestCase):
+    """Integration tests for team access cache with models."""
+
+    def setUp(self):
+        """Set up test data."""
+        cache.clear()
+
+    def tearDown(self):
+        """Clean up after tests."""
+        cache.clear()
+
+    @patch("posthog.models.team.team.Team.objects.get")
+    @patch("posthog.models.personal_api_key.PersonalAPIKey.objects.filter")
+    @patch("posthog.models.organization.OrganizationMembership.objects.filter")
+    def test_warm_team_token_cache(self, mock_org_membership, mock_personal_keys, mock_team_get):
+        """Test warming team token cache from database."""
+        # Mock team
+        mock_team = MagicMock()
+        mock_team.id = 123
+        mock_team.organization_id = "12345678-1234-5678-9012-123456789abc"  # UUID format
+        mock_team.secret_api_token = "phsk_secret_token_123"
+        mock_team.secret_api_token_backup = "phsk_backup_token_456"
+        mock_team_get.return_value = mock_team
+
+        # Mock organization membership query (for unscoped keys)
+        mock_org_membership.return_value.values_list.return_value = [1, 2]  # User IDs
+
+        # Mock personal API key queries
+        scoped_call_count = 0
+        unscoped_call_count = 0
+
+        def mock_filter_side_effect(*args, **kwargs):
+            nonlocal scoped_call_count, unscoped_call_count
+            mock_qs = MagicMock()
+
+            # Check if this is the scoped keys query
+            if "scoped_teams__contains" in kwargs:
+                scoped_call_count += 1
+                mock_qs.values_list.return_value = [
+                    "sha256$personal_key_hash_1",
+                    "sha256$personal_key_hash_2",
+                ]
+            else:
+                # This is the unscoped keys query
+                unscoped_call_count += 1
+                mock_qs.values_list.return_value = []  # No unscoped keys in this test
+
+            return mock_qs
+
+        mock_personal_keys.side_effect = mock_filter_side_effect
+
+        project_api_key = "phs_test_project_key"
+
+        # Warm the cache
+        warm_team_token_cache(project_api_key)
+
+        # Verify both scoped and unscoped queries were made
+        assert scoped_call_count == 1
+        assert unscoped_call_count == 1
+
+        # Verify organization membership query was called
+        mock_org_membership.assert_called_once_with(organization_id="12345678-1234-5678-9012-123456789abc")
+
+        # Verify cache was populated via HyperCache
+        cached_data = team_access_tokens_hypercache.get_from_cache(project_api_key)
+
+        assert cached_data is not None
+        hashed_tokens = cached_data["hashed_tokens"]
+
+        # Should contain personal API key hashes
+        assert "sha256$personal_key_hash_1" in hashed_tokens
+        assert "sha256$personal_key_hash_2" in hashed_tokens
+
+        # Should contain hashed secret tokens
+        expected_secret_hash = hash_key_value("phsk_secret_token_123", mode="sha256")
+        expected_backup_hash = hash_key_value("phsk_backup_token_456", mode="sha256")
+        assert expected_secret_hash in hashed_tokens
+        assert expected_backup_hash in hashed_tokens
+
+        # Verify metadata
+        assert cached_data["team_id"] == 123
+        assert "last_updated" in cached_data
+
+    @patch("posthog.models.team.team.Team.objects.get")
+    def test_warm_team_token_cache_team_not_found(self, mock_team_get):
+        """Test warming cache when team doesn't exist."""
+        from posthog.models.team.team import Team
+
+        mock_team_get.side_effect = Team.DoesNotExist()
+
+        # Should not raise exception
+        warm_team_token_cache("nonexistent_project_key")
+
+        # Cache should remain empty
+        cached_data = team_access_tokens_hypercache.get_from_cache("nonexistent_project_key")
+        assert cached_data is None
+
+    @patch("posthog.models.team.team.Team.objects.filter")
+    def test_get_teams_needing_cache_refresh(self, mock_teams_filter):
+        """Test getting teams that need cache refresh."""
+        mock_teams_filter.return_value.values_list.return_value = [
+            "phs_team_one_123",
+            "phs_team_two_456",
+            "phs_team_three_789",
+        ]
+
+        # Populate cache for team two only via HyperCache
+        token_data = {
+            "hashed_tokens": ["sha256$some_hash"],
+            "token_count": 1,
+            "last_updated": "2024-01-01T00:00:00Z",
+        }
+        team_access_tokens_hypercache.set_cache_value("phs_team_two_456", token_data)
+
+        teams_needing_refresh = get_teams_needing_cache_refresh()
+
+        # Should return teams one and three (missing cache)
+        expected = {"phs_team_one_123", "phs_team_three_789"}
+        assert set(teams_needing_refresh) == expected
+
+
+class TestGlobalCacheInstance(TestCase):
+    """Test the global team_access_cache instance."""
+
+    def setUp(self):
+        cache.clear()
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_global_instance_exists(self):
+        """Test that global instance exists and works."""
+        project_api_key = "phs_global_test_key"
+        access_token = "phx_global_test_token"
+
+        # Invalidate the cache
+        team_access_cache.invalidate_team(project_api_key)
+
+        # Should start with no access
+        has_access, _ = team_access_cache.has_access_with_team(project_api_key, access_token)
+        assert has_access is False
+
+        # Add token
+        hashed_token = hash_key_value(access_token, mode="sha256")
+        team_access_cache.update_team_tokens(project_api_key, 42, [hashed_token])
+
+        # Should now have access
+        has_access, _ = team_access_cache.has_access_with_team(project_api_key, access_token)
+        assert has_access is True
+
+
+class TestCacheWarmingWithUnscopedKeys(TestCase):
+    """Test cache warming functionality with unscoped PersonalAPIKeys."""
+
+    def setUp(self):
+        """Set up test data."""
+        cache.clear()
+
+    def tearDown(self):
+        """Clean up after tests."""
+        cache.clear()
+
+    @patch("posthog.models.team.team.Team.objects.get")
+    @patch("posthog.models.personal_api_key.PersonalAPIKey.objects.filter")
+    @patch("posthog.models.organization.OrganizationMembership.objects.filter")
+    def test_warm_team_cache_includes_unscoped_keys(self, mock_org_membership, mock_personal_keys, mock_team_get):
+        """Test that cache warming includes unscoped PersonalAPIKeys."""
+        # Mock team
+        mock_team = MagicMock()
+        mock_team.id = 123
+        mock_team.organization_id = "org1"
+        mock_team.secret_api_token = "phsk_secret_token_123"
+        mock_team.secret_api_token_backup = None
+        mock_team_get.return_value = mock_team
+
+        # Mock organization membership query (for unscoped keys)
+        mock_org_membership.return_value.values_list.return_value = [1, 2, 3]  # User IDs
+
+        # Mock personal API key queries
+        scoped_call_count = 0
+        unscoped_call_count = 0
+
+        def mock_filter_side_effect(*args, **kwargs):
+            nonlocal scoped_call_count, unscoped_call_count
+            mock_qs = MagicMock()
+
+            # Check if this is the scoped keys query
+            if "scoped_teams__contains" in kwargs:
+                scoped_call_count += 1
+                mock_qs.values_list.return_value = ["sha256$scoped_key_1", "sha256$scoped_key_2"]
+            else:
+                # This is the unscoped keys query
+                unscoped_call_count += 1
+                # Mock the chained filter call for scope filtering
+                mock_qs.filter.return_value.values_list.return_value = ["sha256$unscoped_key_1"]
+                mock_qs.values_list.return_value = ["sha256$unscoped_key_1"]
+
+            return mock_qs
+
+        mock_personal_keys.side_effect = mock_filter_side_effect
+
+        project_api_key = "phs_test_project_key"
+
+        # Warm the cache
+        warm_team_token_cache(project_api_key)
+
+        # Verify both scoped and unscoped queries were made
+        assert scoped_call_count == 1
+        assert unscoped_call_count == 1
+
+        # Verify organization membership query was called
+        mock_org_membership.assert_called_once_with(organization_id="org1")
+
+        # Verify cache was populated with all keys via HyperCache
+        cached_data = team_access_tokens_hypercache.get_from_cache(project_api_key)
+
+        assert cached_data is not None
+        hashed_tokens = cached_data["hashed_tokens"]
+
+        # Should contain scoped keys
+        assert "sha256$scoped_key_1" in hashed_tokens
+        assert "sha256$scoped_key_2" in hashed_tokens
+
+        # Should contain unscoped keys
+        assert "sha256$unscoped_key_1" in hashed_tokens
+
+        # Should contain team secret token
+        expected_secret_hash = hash_key_value("phsk_secret_token_123", mode="sha256")
+        assert expected_secret_hash in hashed_tokens
+
+    @patch("posthog.models.team.team.Team.objects.get")
+    @patch("posthog.models.personal_api_key.PersonalAPIKey.objects.filter")
+    @patch("posthog.models.organization.OrganizationMembership.objects.filter")
+    def test_warm_team_cache_no_unscoped_keys(self, mock_org_membership, mock_personal_keys, mock_team_get):
+        """Test cache warming when there are no unscoped PersonalAPIKeys."""
+        # Mock team
+        mock_team = MagicMock()
+        mock_team.id = 123
+        mock_team.organization_id = "org1"
+        mock_team.secret_api_token = None
+        mock_team.secret_api_token_backup = None
+        mock_team_get.return_value = mock_team
+
+        # Mock organization membership query (no users)
+        mock_org_membership.return_value.values_list.return_value = []
+
+        # Mock personal API key queries
+        def mock_filter_side_effect(*args, **kwargs):
+            mock_qs = MagicMock()
+            if "scoped_teams__contains" in kwargs:
+                mock_qs.values_list.return_value = ["sha256$scoped_key_1"]
+            else:
+                mock_qs.values_list.return_value = []  # No unscoped keys
+            return mock_qs
+
+        mock_personal_keys.side_effect = mock_filter_side_effect
+
+        project_api_key = "phs_test_project_key"
+
+        # Warm the cache
+        warm_team_token_cache(project_api_key)
+
+        # Verify cache was populated with only scoped keys
+        cached_data = team_access_tokens_hypercache.get_from_cache(project_api_key)
+
+        assert cached_data is not None
+        hashed_tokens = cached_data["hashed_tokens"]
+        assert "sha256$scoped_key_1" in hashed_tokens
+        # Should not contain any unscoped keys
+        assert "sha256$unscoped_key_1" not in hashed_tokens
+
+    @patch("posthog.models.team.team.Team.objects.get")
+    @patch("posthog.models.personal_api_key.PersonalAPIKey.objects.filter")
+    @patch("posthog.models.organization.OrganizationMembership.objects.filter")
+    def test_warm_team_cache_duplicate_key_handling(self, mock_org_membership, mock_personal_keys, mock_team_get):
+        """Test that duplicate keys between scoped and unscoped are handled correctly."""
+        # Mock team
+        mock_team = MagicMock()
+        mock_team.id = 123
+        mock_team.organization_id = "org1"
+        mock_team.secret_api_token = None
+        mock_team.secret_api_token_backup = None
+        mock_team_get.return_value = mock_team
+
+        # Mock organization membership query
+        mock_org_membership.return_value.values_list.return_value = [1]
+
+        # Mock personal API key queries to return the same key in both queries
+        # This could happen if a user has an unscoped key and it appears in both queries
+        def mock_filter_side_effect(*args, **kwargs):
+            mock_qs = MagicMock()
+            mock_qs.values_list.return_value = ["sha256$duplicate_key"]
+            # Mock the chained filter call for scope filtering (for unscoped queries)
+            mock_qs.filter.return_value.values_list.return_value = ["sha256$duplicate_key"]
+            return mock_qs
+
+        mock_personal_keys.side_effect = mock_filter_side_effect
+
+        project_api_key = "phs_test_project_key"
+
+        # Warm the cache
+        warm_team_token_cache(project_api_key)
+
+        # Verify cache was populated
+        cached_data = team_access_tokens_hypercache.get_from_cache(project_api_key)
+
+        assert cached_data is not None
+        hashed_tokens = cached_data["hashed_tokens"]
+
+        # The key should appear in the cache (duplicates don't matter for our use case)
+        assert "sha256$duplicate_key" in hashed_tokens
+
+        # Count occurrences - should work even with duplicates
+        duplicate_count = sum(1 for token in hashed_tokens if token == "sha256$duplicate_key")
+        # We expect 2 duplicates since it comes from both scoped and unscoped queries
+        assert duplicate_count == 2
+
+
+class TestGetTeamsForPersonalAPIKey(TestCase):
+    """Test the get_teams_for_personal_api_key function."""
+
+    @patch("posthog.models.team.team.Team.objects.filter")
+    def test_get_teams_for_scoped_personal_api_key(self, mock_team_filter):
+        """Test getting teams for a PersonalAPIKey with scoped teams."""
+        # Mock team query to return project API keys for scoped teams
+        mock_team_filter.return_value.values_list.return_value = ["phs_team1_123", "phs_team2_456"]
+
+        # Create mock PersonalAPIKey with scoped teams
+        mock_key = MagicMock()
+        mock_key.id = 1
+        mock_key.scoped_teams = [1, 2]
+        mock_key.user.id = 100
+
+        # Call the function
+        result = get_teams_for_personal_api_key(mock_key)
+
+        # Verify correct teams were returned
+        assert result == ["phs_team1_123", "phs_team2_456"]
+
+        # Verify correct query was made
+        mock_team_filter.assert_called_once_with(id__in=[1, 2])
+        mock_team_filter.return_value.values_list.assert_called_once_with("api_token", flat=True)
+
+    @patch("posthog.models.team.team.Team.objects.filter")
+    @patch("posthog.models.organization.OrganizationMembership.objects.filter")
+    def test_get_teams_for_unscoped_personal_api_key(self, mock_org_membership, mock_team_filter):
+        """Test getting teams for an unscoped PersonalAPIKey (all user's org teams)."""
+        # Mock organization membership query
+        mock_org_membership.return_value.values_list.return_value = ["org1", "org2"]
+
+        # Mock team query to return teams in those organizations
+        mock_team_filter.return_value.values_list.return_value = ["phs_team1_123", "phs_team2_456", "phs_team3_789"]
+
+        # Create mock PersonalAPIKey with no scoped teams (unscoped)
+        mock_key = MagicMock()
+        mock_key.id = 1
+        mock_key.scoped_teams = None  # Unscoped
+        mock_key.user.id = 100
+
+        # Call the function
+        result = get_teams_for_personal_api_key(mock_key)
+
+        # Verify correct teams were returned
+        assert result == ["phs_team1_123", "phs_team2_456", "phs_team3_789"]
+
+        # Verify organization membership query
+        mock_org_membership.assert_called_once_with(user=mock_key.user)
+        mock_org_membership.return_value.values_list.assert_called_once_with("organization_id", flat=True)
+
+        # Verify team query
+        mock_team_filter.assert_called_once_with(organization_id__in=["org1", "org2"])
+        mock_team_filter.return_value.values_list.assert_called_once_with("api_token", flat=True)
+
+    @patch("posthog.models.team.team.Team.objects.filter")
+    @patch("posthog.models.organization.OrganizationMembership.objects.filter")
+    def test_get_teams_for_unscoped_personal_api_key_empty_scoped_teams(self, mock_org_membership, mock_team_filter):
+        """Test getting teams for PersonalAPIKey with empty scoped_teams list."""
+        # Mock organization membership query
+        mock_org_membership.return_value.values_list.return_value = ["org1"]
+
+        # Mock team query
+        mock_team_filter.return_value.values_list.return_value = ["phs_team1_123"]
+
+        # Create mock PersonalAPIKey with empty scoped teams list
+        mock_key = MagicMock()
+        mock_key.id = 1
+        mock_key.scoped_teams = []  # Empty list = unscoped
+        mock_key.user.id = 100
+
+        # Call the function
+        result = get_teams_for_personal_api_key(mock_key)
+
+        # Verify correct team was returned
+        assert result == ["phs_team1_123"]
+
+        # Verify queries were made for unscoped key logic
+        mock_org_membership.assert_called_once_with(user=mock_key.user)
+        mock_team_filter.assert_called_once_with(organization_id__in=["org1"])
+
+    @patch("posthog.models.organization.OrganizationMembership.objects.filter")
+    def test_get_teams_for_unscoped_personal_api_key_no_organizations(self, mock_org_membership):
+        """Test getting teams when user has no organization memberships."""
+        # Mock organization membership query to return empty
+        mock_org_membership.return_value.values_list.return_value = []
+
+        # Create mock PersonalAPIKey with no scoped teams
+        mock_key = MagicMock()
+        mock_key.id = 1
+        mock_key.scoped_teams = None
+        mock_key.user.id = 100
+
+        # Call the function
+        result = get_teams_for_personal_api_key(mock_key)
+
+        # Verify empty list was returned
+        assert result == []
+
+        # Verify organization membership query was made
+        mock_org_membership.assert_called_once_with(user=mock_key.user)
+        mock_org_membership.return_value.values_list.assert_called_once_with("organization_id", flat=True)
+
+    @patch("posthog.models.team.team.Team.objects.filter")
+    def test_get_teams_for_scoped_personal_api_key_empty_team_ids(self, mock_team_filter):
+        """Test getting teams for PersonalAPIKey with empty scoped team IDs."""
+        # Mock team query to return empty
+        mock_team_filter.return_value.values_list.return_value = []
+
+        # Create mock PersonalAPIKey with scoped teams that don't exist
+        mock_key = MagicMock()
+        mock_key.id = 1
+        mock_key.scoped_teams = [999]  # Non-existent team ID
+        mock_key.user.id = 100
+
+        # Call the function
+        result = get_teams_for_personal_api_key(mock_key)
+
+        # Verify empty list was returned
+        assert result == []
+
+        # Verify correct query was made
+        mock_team_filter.assert_called_once_with(id__in=[999])
+        mock_team_filter.return_value.values_list.assert_called_once_with("api_token", flat=True)
+
+
+class TestUpdateUserAuthenticationCache(TestCase):
+    """Test the update_user_authentication_cache function."""
+
+    def setUp(self):
+        """Set up test data."""
+        cache.clear()
+
+    def tearDown(self):
+        """Clean up after tests."""
+        cache.clear()
+
+    @patch("posthog.storage.team_access_cache.warm_team_token_cache")
+    @patch("posthog.storage.team_access_cache.get_teams_for_personal_api_key")
+    @patch("posthog.models.personal_api_key.PersonalAPIKey.objects.filter")
+    def test_user_activated_warms_affected_team_caches(self, mock_personal_keys, mock_get_teams, mock_warm_cache):
+        """Test that when a user is activated, caches are warmed for all teams they have access to."""
+        from posthog.storage.team_access_cache_signal_handlers import update_user_authentication_cache
+
+        # Create mock user
+        mock_user = MagicMock()
+        mock_user.id = 42
+        mock_user.is_active = True
+
+        # Mock user has personal API keys with access to multiple teams
+        mock_key1 = MagicMock()
+        mock_key2 = MagicMock()
+        mock_queryset = MagicMock()
+        mock_queryset.exists.return_value = True
+        mock_queryset.__iter__ = lambda self: iter([mock_key1, mock_key2])
+        mock_personal_keys.return_value = mock_queryset
+
+        # Mock teams each key has access to
+        def mock_get_teams_side_effect(key):
+            if key == mock_key1:
+                return ["phs_team1_123", "phs_team2_456"]
+            elif key == mock_key2:
+                return ["phs_team2_456", "phs_team3_789"]
+            return []
+
+        mock_get_teams.side_effect = mock_get_teams_side_effect
+
+        # Call function for user activation
+        update_user_authentication_cache(instance=mock_user, update_fields=["is_active"])
+
+        # Verify cache warming was called for all unique teams
+        assert mock_warm_cache.call_count == 3
+        mock_warm_cache.assert_any_call("phs_team1_123")
+        mock_warm_cache.assert_any_call("phs_team2_456")
+        mock_warm_cache.assert_any_call("phs_team3_789")
+
+    @patch("posthog.storage.team_access_cache.warm_team_token_cache")
+    @patch("posthog.storage.team_access_cache.get_teams_for_personal_api_key")
+    @patch("posthog.models.personal_api_key.PersonalAPIKey.objects.filter")
+    def test_user_deactivated_warms_affected_team_caches(self, mock_personal_keys, mock_get_teams, mock_warm_cache):
+        """Test that when a user is deactivated, caches are warmed for all affected teams to remove their tokens."""
+        from posthog.storage.team_access_cache_signal_handlers import update_user_authentication_cache
+
+        # Create mock user
+        mock_user = MagicMock()
+        mock_user.id = 42
+        mock_user.is_active = False  # Deactivated
+
+        # Mock user has personal API keys
+        mock_key = MagicMock()
+        mock_queryset = MagicMock()
+        mock_queryset.exists.return_value = True
+        mock_queryset.__iter__ = lambda self: iter([mock_key])
+        mock_personal_keys.return_value = mock_queryset
+        mock_get_teams.return_value = ["phs_team1_123", "phs_team2_456"]
+
+        # Call function for user deactivation
+        update_user_authentication_cache(instance=mock_user, update_fields=["is_active"])
+
+        # Verify cache warming was called for affected teams (to remove deactivated user's tokens)
+        assert mock_warm_cache.call_count == 2
+        mock_warm_cache.assert_any_call("phs_team1_123")
+        mock_warm_cache.assert_any_call("phs_team2_456")
+
+    @patch("posthog.storage.team_access_cache.warm_team_token_cache")
+    @patch("posthog.storage.team_access_cache.get_teams_for_personal_api_key")
+    @patch("posthog.models.personal_api_key.PersonalAPIKey.objects.filter")
+    def test_update_user_authentication_cache_runs_regardless_of_update_fields(
+        self, mock_personal_keys, mock_get_teams, mock_warm_cache
+    ):
+        """Test that function now runs regardless of update_fields since filtering moved to user_saved."""
+        from posthog.storage.team_access_cache_signal_handlers import update_user_authentication_cache
+
+        # Create mock user
+        mock_user = MagicMock()
+        mock_user.id = 42
+        mock_user.is_active = True
+
+        # Mock user has personal API keys
+        mock_key = MagicMock()
+        mock_queryset = MagicMock()
+        mock_queryset.exists.return_value = True
+        mock_queryset.__iter__ = lambda self: iter([mock_key])
+        mock_personal_keys.return_value = mock_queryset
+        mock_get_teams.return_value = ["phs_team1_123"]
+
+        # Should run even when is_active is not in update_fields (filtering moved to user_saved)
+        update_user_authentication_cache(instance=mock_user, update_fields=["email", "name"])
+
+        # Verify cache operations occurred
+        mock_personal_keys.assert_called_once_with(user_id=42)
+        mock_get_teams.assert_called_once_with(mock_key)
+        mock_warm_cache.assert_called_once_with("phs_team1_123")
+
+    @patch("posthog.storage.team_access_cache.warm_team_token_cache")
+    @patch("posthog.storage.team_access_cache.get_teams_for_personal_api_key")
+    @patch("posthog.models.personal_api_key.PersonalAPIKey.objects.filter")
+    def test_update_user_authentication_cache_runs_without_update_fields(
+        self, mock_personal_keys, mock_get_teams, mock_warm_cache
+    ):
+        """Test that function runs when update_fields is None (bulk operations)."""
+        from posthog.storage.team_access_cache_signal_handlers import update_user_authentication_cache
+
+        # Create mock user
+        mock_user = MagicMock()
+        mock_user.id = 42
+        mock_user.is_active = True
+
+        # Mock user has personal API keys
+        mock_key = MagicMock()
+        mock_queryset = MagicMock()
+        mock_queryset.exists.return_value = True
+        mock_queryset.__iter__ = lambda self: iter([mock_key])
+        mock_personal_keys.return_value = mock_queryset
+        mock_get_teams.return_value = ["phs_team1_123", "phs_team2_456"]
+
+        # Call without update_fields (should run)
+        update_user_authentication_cache(instance=mock_user)
+
+        # Verify cache operations occurred
+        mock_personal_keys.assert_called_once_with(user_id=42)
+        mock_get_teams.assert_called_once_with(mock_key)
+        assert mock_warm_cache.call_count == 2
+        mock_warm_cache.assert_any_call("phs_team1_123")
+        mock_warm_cache.assert_any_call("phs_team2_456")
+
+    @patch("posthog.models.personal_api_key.PersonalAPIKey.objects.filter")
+    def test_update_user_authentication_cache_handles_no_api_keys(self, mock_personal_keys):
+        """Test function handles users with no personal API keys."""
+        from posthog.storage.team_access_cache_signal_handlers import update_user_authentication_cache
+
+        # Create mock user
+        mock_user = MagicMock()
+        mock_user.id = 42
+
+        # Mock user has no personal API keys
+        mock_personal_keys.return_value.exists.return_value = False
+
+        # Should not raise exception
+        update_user_authentication_cache(instance=mock_user, update_fields=["is_active"])
+
+        # Verify query was made but function returned early
+        mock_personal_keys.assert_called_once_with(user_id=42)
+
+    @patch("posthog.storage.team_access_cache_signal_handlers.logger")
+    @patch("posthog.storage.team_access_cache.warm_team_token_cache")
+    @patch("posthog.storage.team_access_cache.get_teams_for_personal_api_key")
+    @patch("posthog.models.personal_api_key.PersonalAPIKey.objects.filter")
+    def test_update_user_authentication_cache_handles_warm_cache_failures(
+        self, mock_personal_keys, mock_get_teams, mock_warm_cache, mock_logger
+    ):
+        """Test function handles individual cache warming failures gracefully."""
+        from posthog.storage.team_access_cache_signal_handlers import update_user_authentication_cache
+
+        # Create mock user
+        mock_user = MagicMock()
+        mock_user.id = 42
+        mock_user.is_active = True
+
+        # Mock user has personal API keys
+        mock_key = MagicMock()
+        mock_queryset = MagicMock()
+        mock_queryset.exists.return_value = True
+        mock_queryset.__iter__ = lambda self: iter([mock_key])
+        mock_personal_keys.return_value = mock_queryset
+        mock_get_teams.return_value = ["phs_team1_123", "phs_team2_456"]
+
+        # Make first cache warm fail, second succeed
+        def side_effect(project_api_key):
+            if project_api_key == "phs_team1_123":
+                raise Exception("Cache warming failed")
+
+        mock_warm_cache.side_effect = side_effect
+
+        # Should not raise exception
+        update_user_authentication_cache(instance=mock_user, update_fields=["is_active"])
+
+        # Verify both cache warming attempts were made
+        assert mock_warm_cache.call_count == 2
+        mock_warm_cache.assert_any_call("phs_team1_123")
+        mock_warm_cache.assert_any_call("phs_team2_456")
+
+        # Verify warning was logged for the failure
+        mock_logger.warning.assert_called_once()
+        assert "Failed to warm cache for team phs_team1_123" in str(mock_logger.warning.call_args)
+
+
+class TestSignalHandlerCacheWarming(TestCase):
+    """Test that signal handlers properly warm caches instead of just invalidating."""
+
+    def setUp(self):
+        """Set up test data."""
+        cache.clear()
+
+    def tearDown(self):
+        """Clean up after tests."""
+        cache.clear()
+
+    @patch("posthog.storage.team_access_cache.warm_team_token_cache")
+    @patch("posthog.storage.team_access_cache.get_teams_for_personal_api_key")
+    def test_personal_api_key_signal_handlers_warm_caches(self, mock_get_teams, mock_warm_cache):
+        """Test that personal API key signal handlers warm caches efficiently."""
+        from posthog.storage.team_access_cache_signal_handlers import (
+            update_personal_api_key_authentication_cache,
+            update_personal_api_key_authentication_cache_on_delete,
+        )
+
+        # Mock get_teams function returns affected teams
+        mock_get_teams.return_value = ["phs_team1_123", "phs_team2_456"]
+
+        # Create mock PersonalAPIKey
+        mock_key = MagicMock()
+        mock_key.id = "test_key"
+
+        # Test save handler
+        update_personal_api_key_authentication_cache(instance=mock_key, created=False)
+
+        # Verify get_teams was called
+        mock_get_teams.assert_called_once_with(mock_key)
+
+        # Verify cache warming was called for each affected team
+        assert mock_warm_cache.call_count == 2
+        mock_warm_cache.assert_any_call("phs_team1_123")
+        mock_warm_cache.assert_any_call("phs_team2_456")
+
+        # Reset mocks and test delete handler
+        mock_get_teams.reset_mock()
+        mock_warm_cache.reset_mock()
+        mock_get_teams.return_value = ["phs_team3_789"]
+
+        update_personal_api_key_authentication_cache_on_delete(instance=mock_key)
+
+        # Verify get_teams was called
+        mock_get_teams.assert_called_once_with(mock_key)
+
+        # Verify cache warming was called
+        mock_warm_cache.assert_called_once_with("phs_team3_789")
+
+    @patch("posthog.storage.team_access_cache.warm_team_token_cache")
+    def test_team_signal_handlers_warm_caches(self, mock_warm_cache):
+        """Test that team signal handlers warm caches instead of just invalidating."""
+        from posthog.storage.team_access_cache_signal_handlers import update_team_authentication_cache
+
+        # Create mock Team
+        mock_team = MagicMock()
+        mock_team.pk = 123
+        mock_team.api_token = "phs_team_token_123"
+
+        # Test save handler (not created)
+        update_team_authentication_cache(instance=mock_team, created=False)
+
+        # Verify cache warming was called (not just invalidation)
+        mock_warm_cache.assert_called_once_with("phs_team_token_123")
+
+        # Test that it doesn't warm cache for new teams (created=True)
+        mock_warm_cache.reset_mock()
+        update_team_authentication_cache(instance=mock_team, created=True)
+
+        # Should not warm cache for new teams
+        mock_warm_cache.assert_not_called()
+
+    @patch("posthog.storage.team_access_cache.team_access_cache.invalidate_team")
+    def test_team_delete_handler_invalidates_cache(self, mock_invalidate):
+        """Test that team delete handler invalidates cache (can't warm deleted team)."""
+        from posthog.storage.team_access_cache_signal_handlers import update_team_authentication_cache_on_delete
+
+        # Create mock Team
+        mock_team = MagicMock()
+        mock_team.pk = 123
+        mock_team.api_token = "phs_team_token_123"
+
+        # Test delete handler
+        update_team_authentication_cache_on_delete(instance=mock_team)
+
+        # Verify cache invalidation was called (can't warm a deleted team)
+        mock_invalidate.assert_called_once_with("phs_team_token_123")
+
+    @patch("posthog.storage.team_access_cache_signal_handlers.logger")
+    @patch("posthog.storage.team_access_cache.warm_team_token_cache")
+    @patch("posthog.storage.team_access_cache.get_teams_for_personal_api_key")
+    def test_signal_handlers_handle_cache_warming_failures(self, mock_get_teams, mock_warm_cache, mock_logger):
+        """Test that signal handlers handle cache warming failures gracefully."""
+        from posthog.storage.team_access_cache_signal_handlers import update_personal_api_key_authentication_cache
+
+        # Mock get_teams function returns affected teams
+        mock_get_teams.return_value = ["phs_team1_123", "phs_team2_456"]
+
+        # Make cache warming fail for one team
+        def side_effect(project_api_key):
+            if project_api_key == "phs_team1_123":
+                raise Exception("Cache warming failed")
+
+        mock_warm_cache.side_effect = side_effect
+
+        # Create mock PersonalAPIKey
+        mock_key = MagicMock()
+        mock_key.id = "test_key"
+
+        # Should not raise exception
+        update_personal_api_key_authentication_cache(instance=mock_key, created=False)
+
+        # Verify both cache warming attempts were made
+        assert mock_warm_cache.call_count == 2
+        mock_warm_cache.assert_any_call("phs_team1_123")
+        mock_warm_cache.assert_any_call("phs_team2_456")
+
+        # Verify warning was logged for the failure
+        mock_logger.warning.assert_called_once()
+        assert "Failed to warm cache for team phs_team1_123" in str(mock_logger.warning.call_args)
+
+    @patch("posthog.storage.team_access_cache.warm_team_token_cache")
+    @patch("posthog.storage.team_access_cache.get_teams_for_personal_api_key")
+    def test_signal_handlers_handle_empty_affected_teams(self, mock_get_teams, mock_warm_cache):
+        """Test signal handlers handle cases where no teams are affected."""
+        from posthog.storage.team_access_cache_signal_handlers import update_personal_api_key_authentication_cache
+
+        # Mock get_teams function returns no teams
+        mock_get_teams.return_value = []
+
+        # Create mock PersonalAPIKey
+        mock_key = MagicMock()
+        mock_key.id = "test_key"
+
+        # Should not raise exception
+        update_personal_api_key_authentication_cache(instance=mock_key, created=False)
+
+        # Verify get_teams was called
+        mock_get_teams.assert_called_once_with(mock_key)
+
+        # Verify no cache warming attempts (no teams affected)
+        mock_warm_cache.assert_not_called()

--- a/posthog/tasks/personal_api_key_tasks.py
+++ b/posthog/tasks/personal_api_key_tasks.py
@@ -1,0 +1,168 @@
+"""
+Background tasks for updating personal API key usage tracking.
+
+This module provides Celery tasks to update personal API key last_used_at
+timestamps in a resilient manner that doesn't block authentication flows.
+"""
+
+import logging
+from datetime import datetime, timedelta
+from typing import Optional
+
+from django.core.exceptions import ObjectDoesNotExist
+from django.db import OperationalError, transaction
+from django.utils import timezone
+
+from celery import shared_task
+from prometheus_client import Counter
+
+logger = logging.getLogger(__name__)
+
+# Prometheus metrics
+PERSONAL_API_KEY_USAGE_UPDATES = Counter(
+    "posthog_personal_api_key_usage_updates_total",
+    "Number of personal API key usage update operations",
+    labelnames=["result"],
+)
+
+
+@shared_task(ignore_result=True, max_retries=0)
+def update_personal_api_key_last_used(personal_api_key_id: str, timestamp_iso: str) -> None:
+    """
+    Update the last_used_at timestamp for a personal API key.
+
+    This task uses a fail-fast approach with no retries. If it fails due to
+    database connectivity or other issues, it logs the failure and relies on
+    the next authentication request to try again.
+
+    Args:
+        personal_api_key_id: The ID of the PersonalAPIKey to update
+        timestamp_iso: ISO format timestamp string for when the key was used
+
+    Note:
+        - No retries to avoid out-of-order updates from delayed tasks
+        - Only updates if more than 1 hour has passed since last update
+        - Fails fast on any error and logs for monitoring
+    """
+
+    try:
+        # Parse the timestamp
+        try:
+            usage_timestamp = datetime.fromisoformat(timestamp_iso.replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            logger.warning(f"Invalid timestamp format in update_personal_api_key_last_used: {timestamp_iso}")
+            PERSONAL_API_KEY_USAGE_UPDATES.labels(result="invalid_timestamp").inc()
+            return
+
+        # Import here to avoid circular imports
+        from posthog.models.personal_api_key import PersonalAPIKey
+
+        with transaction.atomic():
+            try:
+                # Get the personal API key with select_for_update to prevent race conditions
+                personal_api_key = PersonalAPIKey.objects.select_for_update().get(id=personal_api_key_id)
+            except ObjectDoesNotExist:
+                # Key was deleted - this is expected behavior, not an error
+                logger.debug(f"PersonalAPIKey {personal_api_key_id} no longer exists")
+                PERSONAL_API_KEY_USAGE_UPDATES.labels(result="key_not_found").inc()
+                return
+
+            # Check if we need to update (same logic as PersonalAPIKeyAuthentication)
+            # Only update if the hour has changed to avoid excessive UPDATE queries
+            key_last_used_at = personal_api_key.last_used_at
+            if key_last_used_at is None or (usage_timestamp - key_last_used_at > timedelta(hours=1)):
+                personal_api_key.last_used_at = usage_timestamp
+                personal_api_key.save(update_fields=["last_used_at"])
+
+                logger.debug(
+                    f"Updated last_used_at for PersonalAPIKey {personal_api_key_id}",
+                    extra={
+                        "personal_api_key_id": personal_api_key_id,
+                        "timestamp": usage_timestamp.isoformat(),
+                        "previous_last_used_at": key_last_used_at.isoformat() if key_last_used_at else None,
+                    },
+                )
+                PERSONAL_API_KEY_USAGE_UPDATES.labels(result="updated").inc()
+            else:
+                logger.debug(
+                    f"Skipped update for PersonalAPIKey {personal_api_key_id} - less than 1 hour since last update",
+                    extra={
+                        "personal_api_key_id": personal_api_key_id,
+                        "timestamp": usage_timestamp.isoformat(),
+                        "last_used_at": key_last_used_at.isoformat(),
+                    },
+                )
+                PERSONAL_API_KEY_USAGE_UPDATES.labels(result="skipped_recent").inc()
+
+    except OperationalError as e:
+        # Database connectivity issue - log and fail fast
+        logger.warning(
+            f"Database error updating PersonalAPIKey {personal_api_key_id} last_used_at: {e}",
+            extra={
+                "personal_api_key_id": personal_api_key_id,
+                "timestamp": timestamp_iso,
+                "error_type": "database_error",
+            },
+        )
+        PERSONAL_API_KEY_USAGE_UPDATES.labels(result="database_error").inc()
+
+    except Exception as e:
+        # Unexpected error - log and fail fast
+        logger.error(
+            f"Unexpected error updating PersonalAPIKey {personal_api_key_id} last_used_at: {e}",
+            extra={
+                "personal_api_key_id": personal_api_key_id,
+                "timestamp": timestamp_iso,
+                "error_type": e.__class__.__name__,
+            },
+            exc_info=True,
+        )
+        PERSONAL_API_KEY_USAGE_UPDATES.labels(result="unexpected_error").inc()
+
+
+def schedule_personal_api_key_usage_update(personal_api_key_id: str, timestamp: Optional[datetime] = None) -> bool:
+    """
+    Schedule a task to update personal API key usage timestamp.
+
+    This is a helper function that can be called from authentication flows
+    to schedule the background update task.
+
+    Args:
+        personal_api_key_id: The ID of the PersonalAPIKey to update
+        timestamp: When the key was used (defaults to now)
+
+    Returns:
+        True if task was scheduled successfully, False otherwise
+
+    Note:
+        This function never raises exceptions - it logs failures and returns False
+    """
+    try:
+        if timestamp is None:
+            timestamp = timezone.now()
+
+        # Convert to ISO format for task serialization
+        timestamp_iso = timestamp.isoformat()
+
+        # Schedule the task
+        update_personal_api_key_last_used.delay(personal_api_key_id, timestamp_iso)
+
+        logger.debug(
+            f"Scheduled usage update for PersonalAPIKey {personal_api_key_id}",
+            extra={
+                "personal_api_key_id": personal_api_key_id,
+                "timestamp": timestamp_iso,
+            },
+        )
+        return True
+
+    except Exception as e:
+        # Task scheduling failed - log but don't raise
+        logger.warning(
+            f"Failed to schedule usage update for PersonalAPIKey {personal_api_key_id}: {e}",
+            extra={
+                "personal_api_key_id": personal_api_key_id,
+                "error_type": e.__class__.__name__,
+            },
+        )
+        return False

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -55,6 +55,7 @@ from posthog.tasks.tasks import (
     update_survey_iteration,
     verify_persons_data_in_sync,
 )
+from posthog.tasks.team_access_cache_tasks import warm_all_teams_caches_task
 from posthog.utils import get_crontab
 
 TWENTY_FOUR_HOURS = 24 * 60 * 60
@@ -94,6 +95,14 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         crontab(hour="*", minute="0"),
         schedule_warming_for_teams_task.s(),
         name="schedule warming for largest teams",
+    )
+
+    # Team access cache warming - every 10 minutes
+    add_periodic_task_with_expiry(
+        sender,
+        600,  # Every 10 minutes (no TTL, just fill missing entries)
+        warm_all_teams_caches_task.s(),
+        name="warm team access caches",
     )
 
     # Update events table partitions twice a week

--- a/posthog/tasks/team_access_cache_tasks.py
+++ b/posthog/tasks/team_access_cache_tasks.py
@@ -1,0 +1,145 @@
+"""
+Background tasks for warming team access token caches.
+
+This module provides Celery tasks to periodically warm the team access token
+caches, ensuring that the cached authentication system has fresh data.
+"""
+
+import logging
+
+from django.conf import settings
+
+from celery import shared_task
+from celery.app.task import Task
+from prometheus_client import Counter, Histogram
+
+from posthog.storage.team_access_cache import get_teams_needing_cache_refresh, team_access_cache, warm_team_token_cache
+
+logger = logging.getLogger(__name__)
+
+# Prometheus metrics
+CACHE_WARMING_OPERATIONS = Counter(
+    "posthog_cache_warming_operations_total", "Number of cache warming operations", labelnames=["operation", "result"]
+)
+
+CACHE_WARMING_LATENCY = Histogram(
+    "posthog_cache_warming_latency_seconds", "Latency of cache warming operations", labelnames=["operation"]
+)
+
+# Configuration
+CACHE_WARMING_BATCH_SIZE = getattr(settings, "CACHE_WARMING_BATCH_SIZE", 50)
+CACHE_WARMING_ENABLED = getattr(settings, "CACHE_WARMING_ENABLED", True)
+
+
+@shared_task(bind=True, max_retries=3)
+def warm_team_cache_task(self: "Task", project_api_key: str) -> dict:
+    """
+    Warm the token cache for a specific team.
+
+    Args:
+        project_api_key: The team's project API key
+
+    Returns:
+        Dictionary with operation results
+    """
+    with CACHE_WARMING_LATENCY.labels(operation="single_team").time():
+        success = warm_team_token_cache(project_api_key)
+
+        if not success:
+            CACHE_WARMING_OPERATIONS.labels(operation="single_team", result="error").inc()
+            logger.warning(f"Failed to warm cache for team {project_api_key}")
+            # Retry with exponential backoff
+            raise self.retry(countdown=60 * (2**self.request.retries))
+
+        # Get token count for monitoring
+        token_count = team_access_cache.get_cached_token_count(project_api_key)
+
+        CACHE_WARMING_OPERATIONS.labels(operation="single_team", result="success").inc()
+
+        logger.info(
+            f"Successfully warmed cache for team {project_api_key}",
+            extra={"project_api_key": project_api_key, "token_count": token_count},
+        )
+
+        return {"status": "success", "project_api_key": project_api_key, "token_count": token_count}
+
+
+@shared_task(bind=True, max_retries=1)
+def warm_all_teams_caches_task(self: "Task") -> dict:
+    """
+    Warm caches for all teams that need refreshing.
+
+    This task identifies teams with expired or missing caches and
+    schedules individual warming tasks for each team.
+
+    Returns:
+        Dictionary with operation results
+    """
+    if not CACHE_WARMING_ENABLED:
+        logger.info("Cache warming is disabled")
+        return {"status": "disabled"}
+
+    with CACHE_WARMING_LATENCY.labels(operation="all_teams").time():
+        try:
+            # Get teams needing cache refresh - may raise exceptions for systemic issues
+            teams_needing_refresh = get_teams_needing_cache_refresh()
+
+            if not teams_needing_refresh:
+                logger.info("No teams need cache refresh")
+                CACHE_WARMING_OPERATIONS.labels(operation="all_teams", result="no_work").inc()
+                return {"status": "success", "teams_refreshed": 0, "message": "No teams needed refresh"}
+
+            logger.info(
+                f"Found {len(teams_needing_refresh)} teams needing cache refresh",
+                extra={"team_count": len(teams_needing_refresh)},
+            )
+
+            # Process teams in batches to avoid overwhelming the system
+            teams_scheduled = 0
+            failed_teams = 0
+
+            for i in range(0, len(teams_needing_refresh), CACHE_WARMING_BATCH_SIZE):
+                batch = teams_needing_refresh[i : i + CACHE_WARMING_BATCH_SIZE]
+
+                # Schedule warming tasks for this batch
+                for project_api_key in batch:
+                    try:
+                        warm_team_cache_task.delay(project_api_key)
+                        teams_scheduled += 1
+                    except Exception as e:
+                        # Log individual team scheduling failure but continue with others
+                        failed_teams += 1
+                        logger.warning(
+                            f"Failed to schedule cache warming for team {project_api_key}: {e}",
+                            extra={"project_api_key": project_api_key, "error": str(e)},
+                        )
+
+                logger.debug(f"Scheduled cache warming for batch of {len(batch)} teams")
+
+            # Log results
+            if failed_teams > 0:
+                logger.warning(
+                    f"Cache warming scheduled for {teams_scheduled} teams, {failed_teams} failed to schedule",
+                    extra={"teams_scheduled": teams_scheduled, "failed_teams": failed_teams},
+                )
+                CACHE_WARMING_OPERATIONS.labels(operation="all_teams", result="partial_success").inc()
+            else:
+                CACHE_WARMING_OPERATIONS.labels(operation="all_teams", result="success").inc()
+
+            logger.info(
+                f"Scheduled cache warming for {teams_scheduled} teams",
+                extra={"teams_scheduled": teams_scheduled, "failed_teams": failed_teams},
+            )
+
+            return {
+                "status": "success",
+                "teams_found": len(teams_needing_refresh),
+                "teams_scheduled": teams_scheduled,
+                "failed_teams": failed_teams,
+            }
+
+        except Exception as e:
+            # Retry for systemic failures (database connectivity, etc.)
+            CACHE_WARMING_OPERATIONS.labels(operation="all_teams", result="error").inc()
+            logger.exception(f"Systemic failure in cache warming batch task: {e}")
+            raise self.retry(exc=e, countdown=300)  # 5 minutes

--- a/posthog/tasks/test/test_personal_api_key_tasks.py
+++ b/posthog/tasks/test/test_personal_api_key_tasks.py
@@ -1,0 +1,207 @@
+"""
+Unit tests for personal API key usage tracking tasks.
+"""
+
+import uuid
+from datetime import UTC, timedelta
+from typing import Any
+
+from freezegun import freeze_time
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.utils import timezone
+
+from posthog.models import Organization, PersonalAPIKey, User
+from posthog.models.personal_api_key import hash_key_value
+from posthog.models.utils import generate_random_token_personal, mask_key_value
+from posthog.tasks.personal_api_key_tasks import (
+    schedule_personal_api_key_usage_update,
+    update_personal_api_key_last_used,
+)
+
+
+class TestUpdatePersonalAPIKeyLastUsed(TestCase):
+    def setUp(self) -> None:
+        self.organization = Organization.objects.create(name="Test Organization")
+        self.user = User.objects.create(
+            email="test@example.com",
+            is_active=True,
+        )
+        # Generate a token for the personal API key
+        self.token_value = generate_random_token_personal()
+        self.personal_api_key = PersonalAPIKey.objects.create(
+            id=str(uuid.uuid4()),
+            user=self.user,
+            label="Test Key",
+            secure_value=hash_key_value(self.token_value),
+            mask_value=mask_key_value(self.token_value),
+        )
+
+    def test_successful_update_when_no_previous_usage(self) -> None:
+        """Test updating last_used_at when key has never been used."""
+        # Ensure the key has no previous usage
+        self.personal_api_key.last_used_at = None
+        self.personal_api_key.save()
+
+        timestamp = timezone.now()
+        timestamp_iso = timestamp.isoformat()
+
+        # Execute the task
+        update_personal_api_key_last_used(self.personal_api_key.id, timestamp_iso)
+
+        # Verify the update
+        self.personal_api_key.refresh_from_db()
+        self.assertIsNotNone(self.personal_api_key.last_used_at)
+        self.assertEqual(self.personal_api_key.last_used_at, timestamp)
+
+    def test_successful_update_when_more_than_hour_passed(self) -> None:
+        """Test updating last_used_at when more than 1 hour has passed."""
+        # Set last usage to 2 hours ago
+        old_timestamp = timezone.now() - timedelta(hours=2)
+        self.personal_api_key.last_used_at = old_timestamp
+        self.personal_api_key.save()
+
+        new_timestamp = timezone.now()
+        timestamp_iso = new_timestamp.isoformat()
+
+        # Execute the task
+        update_personal_api_key_last_used(self.personal_api_key.id, timestamp_iso)
+
+        # Verify the update
+        self.personal_api_key.refresh_from_db()
+        self.assertEqual(self.personal_api_key.last_used_at, new_timestamp)
+
+    def test_no_update_when_less_than_hour_passed(self) -> None:
+        """Test no update when less than 1 hour has passed."""
+        # Set last usage to 30 minutes ago
+        old_timestamp = timezone.now() - timedelta(minutes=30)
+        self.personal_api_key.last_used_at = old_timestamp
+        self.personal_api_key.save()
+
+        new_timestamp = timezone.now()
+        timestamp_iso = new_timestamp.isoformat()
+
+        # Execute the task
+        update_personal_api_key_last_used(self.personal_api_key.id, timestamp_iso)
+
+        # Verify no update occurred
+        self.personal_api_key.refresh_from_db()
+        self.assertEqual(self.personal_api_key.last_used_at, old_timestamp)
+
+    def test_key_not_found_handles_gracefully(self) -> None:
+        """Test that missing keys are handled gracefully."""
+        nonexistent_key_id = str(uuid.uuid4())
+        timestamp_iso = timezone.now().isoformat()
+
+        # Execute the task - should not raise exception
+        update_personal_api_key_last_used(nonexistent_key_id, timestamp_iso)
+
+        # Verify original key is unchanged
+        self.personal_api_key.refresh_from_db()
+
+    def test_invalid_timestamp_handles_gracefully(self) -> None:
+        """Test that invalid timestamps are handled gracefully."""
+        invalid_timestamp = "not-a-timestamp"
+
+        # Execute the task - should not raise exception
+        update_personal_api_key_last_used(self.personal_api_key.id, invalid_timestamp)
+
+        # Verify original key is unchanged
+        self.personal_api_key.refresh_from_db()
+
+    @patch("posthog.tasks.personal_api_key_tasks.logger")
+    def test_database_error_logs_and_continues(self, mock_logger: Any) -> None:
+        """Test that database errors are logged but don't raise exceptions."""
+        # Mock a database error on the get() call
+        with patch("posthog.models.personal_api_key.PersonalAPIKey.objects.select_for_update") as mock_select:
+            from django.db import OperationalError
+
+            mock_select.return_value.get.side_effect = OperationalError("Database connection lost")
+
+            timestamp_iso = timezone.now().isoformat()
+
+            # Execute the task - should not raise exception
+            update_personal_api_key_last_used(self.personal_api_key.id, timestamp_iso)
+
+            # Verify error was logged
+            mock_logger.warning.assert_called()
+
+    def test_timezone_aware_timestamps(self) -> None:
+        """Test that timezone-aware timestamps are handled correctly."""
+        # Test with UTC timestamp
+        timestamp = timezone.now().replace(tzinfo=UTC)
+        timestamp_iso = timestamp.isoformat()
+
+        update_personal_api_key_last_used(self.personal_api_key.id, timestamp_iso)
+
+        self.personal_api_key.refresh_from_db()
+        self.assertEqual(self.personal_api_key.last_used_at, timestamp)
+
+
+class TestSchedulePersonalAPIKeyUsageUpdate(TestCase):
+    def setUp(self) -> None:
+        self.organization = Organization.objects.create(name="Test Organization")
+        self.user = User.objects.create(
+            email="test@example.com",
+            is_active=True,
+        )
+        self.token_value = generate_random_token_personal()
+        self.personal_api_key = PersonalAPIKey.objects.create(
+            id=str(uuid.uuid4()),
+            user=self.user,
+            label="Test Key",
+            secure_value=hash_key_value(self.token_value),
+            mask_value=mask_key_value(self.token_value),
+        )
+
+    @patch("posthog.tasks.personal_api_key_tasks.update_personal_api_key_last_used.delay")
+    def test_successful_scheduling(self, mock_delay: Any) -> None:
+        """Test successful task scheduling."""
+        timestamp = timezone.now()
+
+        result = schedule_personal_api_key_usage_update(self.personal_api_key.id, timestamp)
+
+        self.assertTrue(result)
+        mock_delay.assert_called_once()
+
+        # Verify the call arguments
+        call_args = mock_delay.call_args[0]
+        self.assertEqual(call_args[0], self.personal_api_key.id)
+        self.assertEqual(call_args[1], timestamp.isoformat())
+
+    @patch("posthog.tasks.personal_api_key_tasks.update_personal_api_key_last_used.delay")
+    def test_scheduling_with_default_timestamp(self, mock_delay: Any) -> None:
+        """Test scheduling with default timestamp (now)."""
+        with freeze_time("2023-01-01T12:00:00Z"):
+            result = schedule_personal_api_key_usage_update(self.personal_api_key.id)
+
+            self.assertTrue(result)
+            mock_delay.assert_called_once()
+
+            # Verify timestamp was set to current time (with timezone info)
+            call_args = mock_delay.call_args[0]
+            self.assertEqual(call_args[1], "2023-01-01T12:00:00+00:00")
+
+    @patch("posthog.tasks.personal_api_key_tasks.update_personal_api_key_last_used.delay")
+    @patch("posthog.tasks.personal_api_key_tasks.logger")
+    def test_scheduling_failure_logs_and_returns_false(self, mock_logger: Any, mock_delay: Any) -> None:
+        """Test that scheduling failures are logged and return False."""
+        # Mock task scheduling failure
+        mock_delay.side_effect = Exception("Celery broker unavailable")
+
+        result = schedule_personal_api_key_usage_update(self.personal_api_key.id)
+
+        self.assertFalse(result)
+        mock_logger.warning.assert_called()
+
+    @patch("posthog.tasks.personal_api_key_tasks.update_personal_api_key_last_used.delay")
+    def test_scheduling_with_custom_timestamp(self, mock_delay: Any) -> None:
+        """Test scheduling with a custom timestamp."""
+        custom_timestamp = timezone.now() - timedelta(minutes=5)
+
+        result = schedule_personal_api_key_usage_update(self.personal_api_key.id, custom_timestamp)
+
+        self.assertTrue(result)
+        call_args = mock_delay.call_args[0]
+        self.assertEqual(call_args[1], custom_timestamp.isoformat())

--- a/posthog/tasks/test/test_team_access_cache_tasks.py
+++ b/posthog/tasks/test/test_team_access_cache_tasks.py
@@ -1,0 +1,232 @@
+"""
+Tests for team access cache Celery tasks.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from posthog.tasks.team_access_cache_tasks import warm_all_teams_caches_task, warm_team_cache_task
+
+
+class TestWarmTeamCacheTask(TestCase):
+    """Test the individual team cache warming task."""
+
+    @patch("posthog.tasks.team_access_cache_tasks.warm_team_token_cache")
+    @patch("posthog.tasks.team_access_cache_tasks.team_access_cache.get_cached_token_count")
+    def test_warm_team_cache_task_success(self, mock_get_count: MagicMock, mock_warm: MagicMock) -> None:
+        """Test successful cache warming for a team."""
+        # Setup mocks
+        mock_warm.return_value = True
+        mock_get_count.return_value = 5
+
+        project_api_key = "phs_test_team_123"
+
+        # Execute task
+        result = warm_team_cache_task(project_api_key)
+
+        # Verify calls
+        mock_warm.assert_called_once_with(project_api_key)
+        mock_get_count.assert_called_once_with(project_api_key)
+
+        # Verify result
+        assert result["status"] == "success"
+        assert result["project_api_key"] == project_api_key
+        assert result["token_count"] == 5
+
+    @patch("posthog.tasks.team_access_cache_tasks.warm_team_token_cache")
+    def test_warm_team_cache_task_failure_triggers_retry(self, mock_warm: MagicMock) -> None:
+        """Test that cache warming failure triggers retry with exponential backoff."""
+        # Setup mock to return failure
+        mock_warm.return_value = False
+
+        project_api_key = "phs_test_team_123"
+
+        from celery.exceptions import Retry
+
+        with self.assertRaises(Retry):
+            warm_team_cache_task(project_api_key)
+
+        # Verify warm was called
+        mock_warm.assert_called_once_with(project_api_key)
+        # The Retry exception was raised, which is what we're testing
+
+    @patch("posthog.tasks.team_access_cache_tasks.warm_team_token_cache")
+    @patch("posthog.tasks.team_access_cache_tasks.team_access_cache.get_cached_token_count")
+    def test_warm_team_cache_task_none_token_count(self, mock_get_count: MagicMock, mock_warm: MagicMock) -> None:
+        """Test handling when token count is None."""
+        # Setup mocks
+        mock_warm.return_value = True
+        mock_get_count.return_value = None
+
+        project_api_key = "phs_test_team_123"
+
+        # Execute task
+        result = warm_team_cache_task(project_api_key)
+
+        # Verify result handles None token count
+        assert result["status"] == "success"
+        assert result["project_api_key"] == project_api_key
+        assert result["token_count"] is None
+
+
+class TestWarmAllTeamsCachesTask(TestCase):
+    """Test the batch cache warming task."""
+
+    @patch("posthog.tasks.team_access_cache_tasks.get_teams_needing_cache_refresh")
+    @patch("posthog.tasks.team_access_cache_tasks.warm_team_cache_task.delay")
+    def test_warm_all_teams_caches_task_success(self, mock_delay: MagicMock, mock_get_teams: MagicMock) -> None:
+        """Test successful batch cache warming."""
+        # Setup mock teams needing refresh
+        mock_teams = ["phs_team1_123", "phs_team2_456", "phs_team3_789"]
+        mock_get_teams.return_value = mock_teams
+
+        # Execute task
+        result = warm_all_teams_caches_task()
+
+        # Verify teams were identified
+        mock_get_teams.assert_called_once()
+
+        # Verify individual tasks were scheduled
+        assert mock_delay.call_count == 3
+        mock_delay.assert_any_call("phs_team1_123")
+        mock_delay.assert_any_call("phs_team2_456")
+        mock_delay.assert_any_call("phs_team3_789")
+
+        # Verify result
+        assert result["status"] == "success"
+        assert result["teams_found"] == 3
+        assert result["teams_scheduled"] == 3
+
+    @patch("posthog.tasks.team_access_cache_tasks.get_teams_needing_cache_refresh")
+    def test_warm_all_teams_caches_task_no_teams(self, mock_get_teams: MagicMock) -> None:
+        """Test batch warming when no teams need refresh."""
+        # Setup mock - no teams need refresh
+        mock_get_teams.return_value = []
+
+        # Execute task
+        result = warm_all_teams_caches_task()
+
+        # Verify result
+        assert result["status"] == "success"
+        assert result["teams_refreshed"] == 0
+        assert result["message"] == "No teams needed refresh"
+
+    @patch("posthog.tasks.team_access_cache_tasks.CACHE_WARMING_ENABLED", False)
+    def test_warm_all_teams_caches_task_disabled(self) -> None:
+        """Test batch warming when cache warming is disabled."""
+        # Execute task
+        result = warm_all_teams_caches_task()
+
+        # Verify result
+        assert result["status"] == "disabled"
+
+    @patch("posthog.tasks.team_access_cache_tasks.get_teams_needing_cache_refresh")
+    @patch("posthog.tasks.team_access_cache_tasks.warm_team_cache_task.delay")
+    @patch("posthog.tasks.team_access_cache_tasks.CACHE_WARMING_BATCH_SIZE", 2)
+    def test_warm_all_teams_caches_task_batching(self, mock_delay: MagicMock, mock_get_teams: MagicMock) -> None:
+        """Test that teams are processed in configured batches."""
+        # Setup mock teams - more than batch size
+        mock_teams = ["phs_team1_123", "phs_team2_456", "phs_team3_789", "phs_team4_012"]
+        mock_get_teams.return_value = mock_teams
+
+        # Execute task
+        result = warm_all_teams_caches_task()
+
+        # Verify all teams were scheduled despite batching
+        assert mock_delay.call_count == 4
+        for team in mock_teams:
+            mock_delay.assert_any_call(team)
+
+        # Verify result
+        assert result["status"] == "success"
+        assert result["teams_found"] == 4
+        assert result["teams_scheduled"] == 4
+
+    @patch("posthog.tasks.team_access_cache_tasks.get_teams_needing_cache_refresh")
+    @patch("posthog.tasks.team_access_cache_tasks.warm_team_cache_task.delay")
+    def test_warm_all_teams_caches_task_handles_individual_failures(
+        self, mock_delay: MagicMock, mock_get_teams: MagicMock
+    ) -> None:
+        """Test that batch warming handles individual team failures gracefully."""
+        # Setup mocks
+        mock_teams = ["phs_team1_123", "phs_team2_456", "phs_team3_789"]
+        mock_get_teams.return_value = mock_teams
+
+        # Make delay fail for the second team only
+        def delay_side_effect(project_api_key: str) -> None:
+            if project_api_key == "phs_team2_456":
+                raise Exception("Task scheduling failed for team 2")
+            return None
+
+        mock_delay.side_effect = delay_side_effect
+
+        # Execute task - should NOT raise exception, but should handle failure gracefully
+        result = warm_all_teams_caches_task()
+
+        # Verify get_teams was called
+        mock_get_teams.assert_called_once()
+
+        # Verify all teams were attempted
+        assert mock_delay.call_count == 3
+        mock_delay.assert_any_call("phs_team1_123")
+        mock_delay.assert_any_call("phs_team2_456")
+        mock_delay.assert_any_call("phs_team3_789")
+
+        # Verify result shows partial success
+        assert result["status"] == "success"
+        assert result["teams_found"] == 3
+        assert result["teams_scheduled"] == 2  # team2 failed to schedule
+        assert result["failed_teams"] == 1
+
+    @patch("posthog.tasks.team_access_cache_tasks.get_teams_needing_cache_refresh")
+    def test_warm_all_teams_caches_task_handles_systemic_failures(self, mock_get_teams: MagicMock) -> None:
+        """Test that batch warming retries on systemic failures like database connectivity issues."""
+        # Make get_teams_needing_cache_refresh fail (systemic issue)
+        mock_get_teams.side_effect = Exception("Database connection failed")
+
+        # Execute task - should raise some exception that triggers retry
+        # The retry mechanism may raise the original exception or a Retry exception
+        with self.assertRaises(Exception) as cm:
+            warm_all_teams_caches_task()
+
+        # Verify get_teams was called
+        mock_get_teams.assert_called_once()
+
+        # Verify the exception is related to our test failure
+        self.assertIn("Database connection failed", str(cm.exception))
+
+
+class TestTaskIntegration(TestCase):
+    """Integration tests for the complete task flow."""
+
+    @patch("posthog.tasks.team_access_cache_tasks.warm_team_token_cache")
+    @patch("posthog.tasks.team_access_cache_tasks.get_teams_needing_cache_refresh")
+    @patch("posthog.tasks.team_access_cache_tasks.team_access_cache.get_cached_token_count")
+    def test_complete_cache_refresh_flow(
+        self, mock_get_count: MagicMock, mock_get_teams: MagicMock, mock_warm: MagicMock
+    ) -> None:
+        """Test the complete flow from batch task to individual warming."""
+        # Setup mocks
+        mock_teams = ["phs_team1_123"]
+        mock_get_teams.return_value = mock_teams
+        mock_warm.return_value = True
+        mock_get_count.return_value = 3
+
+        # Execute batch task (without actually scheduling async tasks)
+        with patch("posthog.tasks.team_access_cache_tasks.warm_team_cache_task.delay") as mock_delay:
+            batch_result = warm_all_teams_caches_task()
+
+            # Verify batch task scheduled individual task
+            mock_delay.assert_called_once_with("phs_team1_123")
+
+        # Simulate individual task execution
+        individual_result = warm_team_cache_task("phs_team1_123")
+
+        # Verify both tasks succeeded
+        assert batch_result["status"] == "success"
+        assert batch_result["teams_scheduled"] == 1
+
+        assert individual_result["status"] == "success"
+        assert individual_result["project_api_key"] == "phs_team1_123"
+        assert individual_result["token_count"] == 3


### PR DESCRIPTION
Add a new authentication handler `CachedTokenAuthentication` that uses cached access tokens to authenticate requests.

This handler is applied to `local_evaluation` requests, but could be used for any endpoint that requires authentication with a personal access token or a secret api token.

## Problem

When the database is under load or having outages, the `local_evaluation` endpoint starts to throw errors. And this is an important endpoint for customers.

The `local_evaluation` endpoint [already serves up cached flag definitions](https://github.com/PostHog/posthog/pull/36616). But it still requires database calls for authentication. We'd like a solution that's resilient to database outages.

## Changes

- Added signal handlers to handle changes to personal access tokens, users (`is_active`), and teams. The signal handlers build a cache of hashed tokens: personal api keys that have access to the team, `team.secret_api_token` and `team.secret_api_token_backup`
- Added `CachedTokenAuthentication` to hash incoming tokens and look them up in the cache. If they exist, then the user is authenticated.
- If the token is not found in the cache, then authentication falls back to the next `Authentication` class in the list per the standard Django model.
- Schedule warming the cache to run every 10 minutes.

## How did you test this code?

- Bunch of unit tests
- Manual testing.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Notes

- @benjackwhite and I discussed a Rust service to serve up the cached `local_evaluation`. That's next on my list. But first, we want to make sure that we've made the authentication cache bulletproof. In this implementation, if we missed a cache scenario, authentication falls back to the normal system and everything continues to work.
- This PR is conservative in when to build the cache. For example, we listen to all team changes. We could filter team changes to only rebuild the cache when `api_token`, `secret_api_token`, or `secret_api_token_backup` change. I welcome feedback.
- For users, I worried listening to all changes would cause too much contention so we only listen for changes to `is_active`.

### Cache Format

Cache key format: `cache/team_tokens/{project_api_token}/array/access_tokens.json`
Example: `cache/team_tokens/phc_some-api-token/array/access_tokens.json`

Cache data has three fields:

* `hashed_tokens`: an array of sha256 hashed tokens.
* `team_id`: The team id.
* `last_updated`: when the cache was last updated (we'll use this for etags support later).

Example: 
```json
{
  "hashed_tokens": [
    "sha256$abc123",
    "sha256$def456",
    …
  ],
  "last_updated": "2025-01-15T10:30:00Z",
  "team_id": 42
}
```

## Test Plan

- [ ] Test access with personal access token that has `flags:read` scope for the org.
- [ ] Test access with personal access token that has `flags:write` scope for the org.
- [ ] Test access with personal access token that has `flags:read` scope for all orgs.
- [ ] Test access with personal access token that has `*` scope for the org.
- [ ] Test access with `secure_api_key`
- [ ] Test access with `secure_api_key_backup`
- [ ] Test no access with wrong `secure_api_key`
- [ ] Test no access with wrong `secure_api_key_backup`
- [ ] Test no access with personal access token for the org without `flag:read`
- [ ] Test no access with personal access token with `flags:read` but different org
- [ ] Clear cache and test access
- [ ] Clear cache and test no access
- [ ] Test Organization / project access for a key revoked
- [ ] Test api key rotated / revoked
- [ ] Remove user from organization membership and make sure cache rebuilt
- [ ] Ensure that personal access token last used is updated