### PR TITLE
fix(revenue-analytics): negate contraction and churn calculations in revenue query runner

### DIFF
--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_revenue_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_revenue_query_runner.py
@@ -187,7 +187,7 @@ class RevenueAnalyticsRevenueQueryRunner(RevenueAnalyticsQueryRunner[RevenueAnal
                 ast.Alias(
                     alias="contraction_amount",
                     expr=parse_expr(
-                        "if(isNotNull(previous_amount) AND total_amount < previous_amount AND total_amount > 0, previous_amount - total_amount, {zero})",
+                        "negate(if(isNotNull(previous_amount) AND total_amount < previous_amount AND total_amount > 0, previous_amount - total_amount, {zero}))",
                         placeholders=ZERO_PLACEHOLDERS,
                     ),
                 ),
@@ -197,7 +197,7 @@ class RevenueAnalyticsRevenueQueryRunner(RevenueAnalyticsQueryRunner[RevenueAnal
                     # Else, if the amount went to zero, then assume the previous amount is the churned amount
                     # Else, just use 0, it's an ongoing subscription
                     expr=parse_expr(
-                        "multiIf(isNull(subscription_id), total_amount, total_amount = 0, coalesce(previous_amount, {zero}), {zero})",
+                        "negate(multiIf(isNull(subscription_id), total_amount, total_amount = 0, coalesce(previous_amount, {zero}), {zero}))",
                         placeholders=ZERO_PLACEHOLDERS,
                     ),
                 ),

--- a/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_revenue_query_runner.ambr
+++ b/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_revenue_query_runner.ambr
@@ -24,8 +24,8 @@
                                      ORDER BY day_start ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS previous_amount,
                                     if(isNull(previous_amount), total_amount, accurateCastOrNull(0, 'Decimal64(10)')) AS new_amount,
                                     if(and(isNotNull(previous_amount), ifNull(greater(total_amount, previous_amount), 0)), minus(total_amount, previous_amount), accurateCastOrNull(0, 'Decimal64(10)')) AS expansion_amount,
-                                    if(and(isNotNull(previous_amount), ifNull(less(total_amount, previous_amount), 0), ifNull(greater(total_amount, 0), 0)), minus(previous_amount, total_amount), accurateCastOrNull(0, 'Decimal64(10)')) AS contraction_amount,
-                                    multiIf(isNull(subscription_id), total_amount, ifNull(equals(total_amount, 0), 0), coalesce(previous_amount, accurateCastOrNull(0, 'Decimal64(10)')), accurateCastOrNull(0, 'Decimal64(10)')) AS churn_amount
+                                    negate(if(and(isNotNull(previous_amount), ifNull(less(total_amount, previous_amount), 0), ifNull(greater(total_amount, 0), 0)), minus(previous_amount, total_amount), accurateCastOrNull(0, 'Decimal64(10)'))) AS contraction_amount,
+                                    negate(multiIf(isNull(subscription_id), total_amount, ifNull(equals(total_amount, 0), 0), coalesce(previous_amount, accurateCastOrNull(0, 'Decimal64(10)')), accurateCastOrNull(0, 'Decimal64(10)'))) AS churn_amount
      FROM
        (
           (SELECT `revenue_analytics.events.purchase.revenue_item_events_revenue_view`.id AS id,
@@ -200,8 +200,8 @@
                                      ORDER BY day_start ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS previous_amount,
                                     if(isNull(previous_amount), total_amount, accurateCastOrNull(0, 'Decimal64(10)')) AS new_amount,
                                     if(and(isNotNull(previous_amount), ifNull(greater(total_amount, previous_amount), 0)), minus(total_amount, previous_amount), accurateCastOrNull(0, 'Decimal64(10)')) AS expansion_amount,
-                                    if(and(isNotNull(previous_amount), ifNull(less(total_amount, previous_amount), 0), ifNull(greater(total_amount, 0), 0)), minus(previous_amount, total_amount), accurateCastOrNull(0, 'Decimal64(10)')) AS contraction_amount,
-                                    multiIf(isNull(subscription_id), total_amount, ifNull(equals(total_amount, 0), 0), coalesce(previous_amount, accurateCastOrNull(0, 'Decimal64(10)')), accurateCastOrNull(0, 'Decimal64(10)')) AS churn_amount
+                                    negate(if(and(isNotNull(previous_amount), ifNull(less(total_amount, previous_amount), 0), ifNull(greater(total_amount, 0), 0)), minus(previous_amount, total_amount), accurateCastOrNull(0, 'Decimal64(10)'))) AS contraction_amount,
+                                    negate(multiIf(isNull(subscription_id), total_amount, ifNull(equals(total_amount, 0), 0), coalesce(previous_amount, accurateCastOrNull(0, 'Decimal64(10)')), accurateCastOrNull(0, 'Decimal64(10)'))) AS churn_amount
      FROM
        (
           (SELECT `revenue_analytics.events.purchase.revenue_item_events_revenue_view`.id AS id,
@@ -578,8 +578,8 @@
                                      ORDER BY day_start ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS previous_amount,
                                     if(isNull(previous_amount), total_amount, accurateCastOrNull(0, 'Decimal64(10)')) AS new_amount,
                                     if(and(isNotNull(previous_amount), ifNull(greater(total_amount, previous_amount), 0)), minus(total_amount, previous_amount), accurateCastOrNull(0, 'Decimal64(10)')) AS expansion_amount,
-                                    if(and(isNotNull(previous_amount), ifNull(less(total_amount, previous_amount), 0), ifNull(greater(total_amount, 0), 0)), minus(previous_amount, total_amount), accurateCastOrNull(0, 'Decimal64(10)')) AS contraction_amount,
-                                    multiIf(isNull(subscription_id), total_amount, ifNull(equals(total_amount, 0), 0), coalesce(previous_amount, accurateCastOrNull(0, 'Decimal64(10)')), accurateCastOrNull(0, 'Decimal64(10)')) AS churn_amount
+                                    negate(if(and(isNotNull(previous_amount), ifNull(less(total_amount, previous_amount), 0), ifNull(greater(total_amount, 0), 0)), minus(previous_amount, total_amount), accurateCastOrNull(0, 'Decimal64(10)'))) AS contraction_amount,
+                                    negate(multiIf(isNull(subscription_id), total_amount, ifNull(equals(total_amount, 0), 0), coalesce(previous_amount, accurateCastOrNull(0, 'Decimal64(10)')), accurateCastOrNull(0, 'Decimal64(10)'))) AS churn_amount
      FROM
        (
           (SELECT `revenue_analytics.events.purchase.revenue_item_events_revenue_view`.id AS id,
@@ -956,8 +956,8 @@
                                      ORDER BY day_start ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS previous_amount,
                                     if(isNull(previous_amount), total_amount, accurateCastOrNull(0, 'Decimal64(10)')) AS new_amount,
                                     if(and(isNotNull(previous_amount), ifNull(greater(total_amount, previous_amount), 0)), minus(total_amount, previous_amount), accurateCastOrNull(0, 'Decimal64(10)')) AS expansion_amount,
-                                    if(and(isNotNull(previous_amount), ifNull(less(total_amount, previous_amount), 0), ifNull(greater(total_amount, 0), 0)), minus(previous_amount, total_amount), accurateCastOrNull(0, 'Decimal64(10)')) AS contraction_amount,
-                                    multiIf(isNull(subscription_id), total_amount, ifNull(equals(total_amount, 0), 0), coalesce(previous_amount, accurateCastOrNull(0, 'Decimal64(10)')), accurateCastOrNull(0, 'Decimal64(10)')) AS churn_amount
+                                    negate(if(and(isNotNull(previous_amount), ifNull(less(total_amount, previous_amount), 0), ifNull(greater(total_amount, 0), 0)), minus(previous_amount, total_amount), accurateCastOrNull(0, 'Decimal64(10)'))) AS contraction_amount,
+                                    negate(multiIf(isNull(subscription_id), total_amount, ifNull(equals(total_amount, 0), 0), coalesce(previous_amount, accurateCastOrNull(0, 'Decimal64(10)')), accurateCastOrNull(0, 'Decimal64(10)'))) AS churn_amount
      FROM
        (
           (SELECT `revenue_analytics.events.purchase.revenue_item_events_revenue_view`.id AS id,
@@ -1238,8 +1238,8 @@
                                      ORDER BY day_start ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS previous_amount,
                                     if(isNull(previous_amount), total_amount, accurateCastOrNull(0, 'Decimal64(10)')) AS new_amount,
                                     if(and(isNotNull(previous_amount), ifNull(greater(total_amount, previous_amount), 0)), minus(total_amount, previous_amount), accurateCastOrNull(0, 'Decimal64(10)')) AS expansion_amount,
-                                    if(and(isNotNull(previous_amount), ifNull(less(total_amount, previous_amount), 0), ifNull(greater(total_amount, 0), 0)), minus(previous_amount, total_amount), accurateCastOrNull(0, 'Decimal64(10)')) AS contraction_amount,
-                                    multiIf(isNull(subscription_id), total_amount, ifNull(equals(total_amount, 0), 0), coalesce(previous_amount, accurateCastOrNull(0, 'Decimal64(10)')), accurateCastOrNull(0, 'Decimal64(10)')) AS churn_amount
+                                    negate(if(and(isNotNull(previous_amount), ifNull(less(total_amount, previous_amount), 0), ifNull(greater(total_amount, 0), 0)), minus(previous_amount, total_amount), accurateCastOrNull(0, 'Decimal64(10)'))) AS contraction_amount,
+                                    negate(multiIf(isNull(subscription_id), total_amount, ifNull(equals(total_amount, 0), 0), coalesce(previous_amount, accurateCastOrNull(0, 'Decimal64(10)')), accurateCastOrNull(0, 'Decimal64(10)'))) AS churn_amount
      FROM
        (
           (SELECT `revenue_analytics.events.purchase.revenue_item_events_revenue_view`.id AS id,
@@ -1520,8 +1520,8 @@
                                      ORDER BY day_start ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS previous_amount,
                                     if(isNull(previous_amount), total_amount, accurateCastOrNull(0, 'Decimal64(10)')) AS new_amount,
                                     if(and(isNotNull(previous_amount), ifNull(greater(total_amount, previous_amount), 0)), minus(total_amount, previous_amount), accurateCastOrNull(0, 'Decimal64(10)')) AS expansion_amount,
-                                    if(and(isNotNull(previous_amount), ifNull(less(total_amount, previous_amount), 0), ifNull(greater(total_amount, 0), 0)), minus(previous_amount, total_amount), accurateCastOrNull(0, 'Decimal64(10)')) AS contraction_amount,
-                                    multiIf(isNull(subscription_id), total_amount, ifNull(equals(total_amount, 0), 0), coalesce(previous_amount, accurateCastOrNull(0, 'Decimal64(10)')), accurateCastOrNull(0, 'Decimal64(10)')) AS churn_amount
+                                    negate(if(and(isNotNull(previous_amount), ifNull(less(total_amount, previous_amount), 0), ifNull(greater(total_amount, 0), 0)), minus(previous_amount, total_amount), accurateCastOrNull(0, 'Decimal64(10)'))) AS contraction_amount,
+                                    negate(multiIf(isNull(subscription_id), total_amount, ifNull(equals(total_amount, 0), 0), coalesce(previous_amount, accurateCastOrNull(0, 'Decimal64(10)')), accurateCastOrNull(0, 'Decimal64(10)'))) AS churn_amount
      FROM
        (
           (SELECT `revenue_analytics.events.purchase.revenue_item_events_revenue_view`.id AS id,
@@ -1919,8 +1919,8 @@
                                      ORDER BY day_start ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS previous_amount,
                                     if(isNull(previous_amount), total_amount, accurateCastOrNull(0, 'Decimal64(10)')) AS new_amount,
                                     if(and(isNotNull(previous_amount), ifNull(greater(total_amount, previous_amount), 0)), minus(total_amount, previous_amount), accurateCastOrNull(0, 'Decimal64(10)')) AS expansion_amount,
-                                    if(and(isNotNull(previous_amount), ifNull(less(total_amount, previous_amount), 0), ifNull(greater(total_amount, 0), 0)), minus(previous_amount, total_amount), accurateCastOrNull(0, 'Decimal64(10)')) AS contraction_amount,
-                                    multiIf(isNull(subscription_id), total_amount, ifNull(equals(total_amount, 0), 0), coalesce(previous_amount, accurateCastOrNull(0, 'Decimal64(10)')), accurateCastOrNull(0, 'Decimal64(10)')) AS churn_amount
+                                    negate(if(and(isNotNull(previous_amount), ifNull(less(total_amount, previous_amount), 0), ifNull(greater(total_amount, 0), 0)), minus(previous_amount, total_amount), accurateCastOrNull(0, 'Decimal64(10)'))) AS contraction_amount,
+                                    negate(multiIf(isNull(subscription_id), total_amount, ifNull(equals(total_amount, 0), 0), coalesce(previous_amount, accurateCastOrNull(0, 'Decimal64(10)')), accurateCastOrNull(0, 'Decimal64(10)'))) AS churn_amount
      FROM
        (
           (SELECT `revenue_analytics.events.purchase.revenue_item_events_revenue_view`.id AS id,
@@ -2222,8 +2222,8 @@
                                      ORDER BY day_start ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS previous_amount,
                                     if(isNull(previous_amount), total_amount, accurateCastOrNull(0, 'Decimal64(10)')) AS new_amount,
                                     if(and(isNotNull(previous_amount), ifNull(greater(total_amount, previous_amount), 0)), minus(total_amount, previous_amount), accurateCastOrNull(0, 'Decimal64(10)')) AS expansion_amount,
-                                    if(and(isNotNull(previous_amount), ifNull(less(total_amount, previous_amount), 0), ifNull(greater(total_amount, 0), 0)), minus(previous_amount, total_amount), accurateCastOrNull(0, 'Decimal64(10)')) AS contraction_amount,
-                                    multiIf(isNull(subscription_id), total_amount, ifNull(equals(total_amount, 0), 0), coalesce(previous_amount, accurateCastOrNull(0, 'Decimal64(10)')), accurateCastOrNull(0, 'Decimal64(10)')) AS churn_amount
+                                    negate(if(and(isNotNull(previous_amount), ifNull(less(total_amount, previous_amount), 0), ifNull(greater(total_amount, 0), 0)), minus(previous_amount, total_amount), accurateCastOrNull(0, 'Decimal64(10)'))) AS contraction_amount,
+                                    negate(multiIf(isNull(subscription_id), total_amount, ifNull(equals(total_amount, 0), 0), coalesce(previous_amount, accurateCastOrNull(0, 'Decimal64(10)')), accurateCastOrNull(0, 'Decimal64(10)'))) AS churn_amount
      FROM
        (
           (SELECT `revenue_analytics.events.purchase.revenue_item_events_revenue_view`.id AS id,
@@ -2504,8 +2504,8 @@
                                      ORDER BY day_start ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS previous_amount,
                                     if(isNull(previous_amount), total_amount, accurateCastOrNull(0, 'Decimal64(10)')) AS new_amount,
                                     if(and(isNotNull(previous_amount), ifNull(greater(total_amount, previous_amount), 0)), minus(total_amount, previous_amount), accurateCastOrNull(0, 'Decimal64(10)')) AS expansion_amount,
-                                    if(and(isNotNull(previous_amount), ifNull(less(total_amount, previous_amount), 0), ifNull(greater(total_amount, 0), 0)), minus(previous_amount, total_amount), accurateCastOrNull(0, 'Decimal64(10)')) AS contraction_amount,
-                                    multiIf(isNull(subscription_id), total_amount, ifNull(equals(total_amount, 0), 0), coalesce(previous_amount, accurateCastOrNull(0, 'Decimal64(10)')), accurateCastOrNull(0, 'Decimal64(10)')) AS churn_amount
+                                    negate(if(and(isNotNull(previous_amount), ifNull(less(total_amount, previous_amount), 0), ifNull(greater(total_amount, 0), 0)), minus(previous_amount, total_amount), accurateCastOrNull(0, 'Decimal64(10)'))) AS contraction_amount,
+                                    negate(multiIf(isNull(subscription_id), total_amount, ifNull(equals(total_amount, 0), 0), coalesce(previous_amount, accurateCastOrNull(0, 'Decimal64(10)')), accurateCastOrNull(0, 'Decimal64(10)'))) AS churn_amount
      FROM
        (
           (SELECT `revenue_analytics.events.purchase.revenue_item_events_revenue_view`.id AS id,
@@ -2882,8 +2882,8 @@
                                      ORDER BY day_start ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS previous_amount,
                                     if(isNull(previous_amount), total_amount, accurateCastOrNull(0, 'Decimal64(10)')) AS new_amount,
                                     if(and(isNotNull(previous_amount), ifNull(greater(total_amount, previous_amount), 0)), minus(total_amount, previous_amount), accurateCastOrNull(0, 'Decimal64(10)')) AS expansion_amount,
-                                    if(and(isNotNull(previous_amount), ifNull(less(total_amount, previous_amount), 0), ifNull(greater(total_amount, 0), 0)), minus(previous_amount, total_amount), accurateCastOrNull(0, 'Decimal64(10)')) AS contraction_amount,
-                                    multiIf(isNull(subscription_id), total_amount, ifNull(equals(total_amount, 0), 0), coalesce(previous_amount, accurateCastOrNull(0, 'Decimal64(10)')), accurateCastOrNull(0, 'Decimal64(10)')) AS churn_amount
+                                    negate(if(and(isNotNull(previous_amount), ifNull(less(total_amount, previous_amount), 0), ifNull(greater(total_amount, 0), 0)), minus(previous_amount, total_amount), accurateCastOrNull(0, 'Decimal64(10)'))) AS contraction_amount,
+                                    negate(multiIf(isNull(subscription_id), total_amount, ifNull(equals(total_amount, 0), 0), coalesce(previous_amount, accurateCastOrNull(0, 'Decimal64(10)')), accurateCastOrNull(0, 'Decimal64(10)'))) AS churn_amount
      FROM
        (
           (SELECT `revenue_analytics.events.purchase.revenue_item_events_revenue_view`.id AS id,
@@ -3261,8 +3261,8 @@
                                      ORDER BY day_start ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS previous_amount,
                                     if(isNull(previous_amount), total_amount, accurateCastOrNull(0, 'Decimal64(10)')) AS new_amount,
                                     if(and(isNotNull(previous_amount), ifNull(greater(total_amount, previous_amount), 0)), minus(total_amount, previous_amount), accurateCastOrNull(0, 'Decimal64(10)')) AS expansion_amount,
-                                    if(and(isNotNull(previous_amount), ifNull(less(total_amount, previous_amount), 0), ifNull(greater(total_amount, 0), 0)), minus(previous_amount, total_amount), accurateCastOrNull(0, 'Decimal64(10)')) AS contraction_amount,
-                                    multiIf(isNull(subscription_id), total_amount, ifNull(equals(total_amount, 0), 0), coalesce(previous_amount, accurateCastOrNull(0, 'Decimal64(10)')), accurateCastOrNull(0, 'Decimal64(10)')) AS churn_amount
+                                    negate(if(and(isNotNull(previous_amount), ifNull(less(total_amount, previous_amount), 0), ifNull(greater(total_amount, 0), 0)), minus(previous_amount, total_amount), accurateCastOrNull(0, 'Decimal64(10)'))) AS contraction_amount,
+                                    negate(multiIf(isNull(subscription_id), total_amount, ifNull(equals(total_amount, 0), 0), coalesce(previous_amount, accurateCastOrNull(0, 'Decimal64(10)')), accurateCastOrNull(0, 'Decimal64(10)'))) AS churn_amount
      FROM
        (
           (SELECT `revenue_analytics.events.purchase.revenue_item_events_revenue_view`.id AS id,
@@ -3660,8 +3660,8 @@
                                      ORDER BY day_start ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS previous_amount,
                                     if(isNull(previous_amount), total_amount, accurateCastOrNull(0, 'Decimal64(10)')) AS new_amount,
                                     if(and(isNotNull(previous_amount), ifNull(greater(total_amount, previous_amount), 0)), minus(total_amount, previous_amount), accurateCastOrNull(0, 'Decimal64(10)')) AS expansion_amount,
-                                    if(and(isNotNull(previous_amount), ifNull(less(total_amount, previous_amount), 0), ifNull(greater(total_amount, 0), 0)), minus(previous_amount, total_amount), accurateCastOrNull(0, 'Decimal64(10)')) AS contraction_amount,
-                                    multiIf(isNull(subscription_id), total_amount, ifNull(equals(total_amount, 0), 0), coalesce(previous_amount, accurateCastOrNull(0, 'Decimal64(10)')), accurateCastOrNull(0, 'Decimal64(10)')) AS churn_amount
+                                    negate(if(and(isNotNull(previous_amount), ifNull(less(total_amount, previous_amount), 0), ifNull(greater(total_amount, 0), 0)), minus(previous_amount, total_amount), accurateCastOrNull(0, 'Decimal64(10)'))) AS contraction_amount,
+                                    negate(multiIf(isNull(subscription_id), total_amount, ifNull(equals(total_amount, 0), 0), coalesce(previous_amount, accurateCastOrNull(0, 'Decimal64(10)')), accurateCastOrNull(0, 'Decimal64(10)'))) AS churn_amount
      FROM
        (
           (SELECT `revenue_analytics.events.purchase.revenue_item_events_revenue_view`.id AS id,
@@ -3963,8 +3963,8 @@
                                      ORDER BY day_start ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS previous_amount,
                                     if(isNull(previous_amount), total_amount, accurateCastOrNull(0, 'Decimal64(10)')) AS new_amount,
                                     if(and(isNotNull(previous_amount), ifNull(greater(total_amount, previous_amount), 0)), minus(total_amount, previous_amount), accurateCastOrNull(0, 'Decimal64(10)')) AS expansion_amount,
-                                    if(and(isNotNull(previous_amount), ifNull(less(total_amount, previous_amount), 0), ifNull(greater(total_amount, 0), 0)), minus(previous_amount, total_amount), accurateCastOrNull(0, 'Decimal64(10)')) AS contraction_amount,
-                                    multiIf(isNull(subscription_id), total_amount, ifNull(equals(total_amount, 0), 0), coalesce(previous_amount, accurateCastOrNull(0, 'Decimal64(10)')), accurateCastOrNull(0, 'Decimal64(10)')) AS churn_amount
+                                    negate(if(and(isNotNull(previous_amount), ifNull(less(total_amount, previous_amount), 0), ifNull(greater(total_amount, 0), 0)), minus(previous_amount, total_amount), accurateCastOrNull(0, 'Decimal64(10)'))) AS contraction_amount,
+                                    negate(multiIf(isNull(subscription_id), total_amount, ifNull(equals(total_amount, 0), 0), coalesce(previous_amount, accurateCastOrNull(0, 'Decimal64(10)')), accurateCastOrNull(0, 'Decimal64(10)'))) AS churn_amount
      FROM
        (
           (SELECT `revenue_analytics.events.purchase.revenue_item_events_revenue_view`.id AS id,

--- a/products/revenue_analytics/backend/hogql_queries/test/test_revenue_analytics_revenue_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/test/test_revenue_analytics_revenue_query_runner.py
@@ -493,10 +493,10 @@ class TestRevenueAnalyticsRevenueQueryRunner(ClickhouseTestMixin, APIBaseTest):
                     0,
                     0,
                     0,
-                    Decimal("4.39147"),
-                    Decimal("483.82682"),
+                    Decimal("-4.39147"),
+                    Decimal("-483.82682"),
                     0,
-                    Decimal("135.49000"),
+                    Decimal("-135.49000"),
                     0,
                     0,
                     0,
@@ -530,15 +530,15 @@ class TestRevenueAnalyticsRevenueQueryRunner(ClickhouseTestMixin, APIBaseTest):
                     0,
                     0,
                     0,
-                    Decimal("8882.54906"),
-                    Decimal("8729.34175"),
+                    Decimal("-8882.54906"),
+                    Decimal("-8729.34175"),
                     0,
                     0,
                     0,
                     0,
                     0,
                     0,
-                    Decimal("24.5077499999"),
+                    Decimal("-24.5077499999"),
                     0,
                     0,
                     0,
@@ -553,10 +553,12 @@ class TestRevenueAnalyticsRevenueQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         # Iterate over the values and check that the new/expansion/contraction/churn values
         # properly add up to the change between the previous period and the current period
+        #
+        # NOTE: We're summing contraction and churn because they're negative values
         previous = Decimal(0)
         for i in range(len(mrr.total["data"])):
             change_to_previous = mrr.total["data"][i] - previous
-            change = mrr.new["data"][i] + mrr.expansion["data"][i] - mrr.contraction["data"][i] - mrr.churn["data"][i]
+            change = mrr.new["data"][i] + mrr.expansion["data"][i] + mrr.contraction["data"][i] + mrr.churn["data"][i]
             self.assertEqual(change_to_previous, change, f"MRR change at index {i} is incorrect")
             previous = mrr.total["data"][i]
 
@@ -1088,7 +1090,7 @@ class TestRevenueAnalyticsRevenueQueryRunner(ClickhouseTestMixin, APIBaseTest):
                     0,
                     0,
                     0,
-                    Decimal("13.549"),
+                    Decimal("-13.549"),
                     0,
                     0,
                 ],
@@ -1112,8 +1114,8 @@ class TestRevenueAnalyticsRevenueQueryRunner(ClickhouseTestMixin, APIBaseTest):
                     0,
                     0,
                     0,
-                    Decimal("19.925"),
-                    Decimal("36.9999675355"),
+                    Decimal("-19.925"),
+                    Decimal("-36.9999675355"),
                 ],
                 "action": {
                     "days": LAST_6_MONTHS_FAKEDATETIMES,


### PR DESCRIPTION
Updated the revenue analytics query runner to negate the contraction and churn calculations. Adjusted test cases to reflect these changes, ensuring that negative values are correctly represented in the output. Updated snapshots accordingly.

This will make the UI much simpler because our `LineChart` already displays negative values in a nice way when stacked - see Lifecycle charts, for example
