### PR TITLE
fix: replay active screen/user queries

### DIFF
--- a/frontend/src/scenes/session-recordings/components/replayActiveScreensTableLogic.ts
+++ b/frontend/src/scenes/session-recordings/components/replayActiveScreensTableLogic.ts
@@ -22,13 +22,22 @@ export const replayActiveScreensTableLogic = kea<replayActiveScreensTableLogicTy
         countedScreens: {
             loadCountedScreens: async (_, breakpoint): Promise<{ screen: string; count: number }[]> => {
                 const q = hogql`
-                    select cutQueryString(cutFragment(url)) as u, count(distinct session_id) as c
-                    from (select session_id, arrayJoin(all_urls) as url
-                          from raw_session_replay_events
-                          where min_first_timestamp >= now() - toIntervalDay(7)
-                            and min_first_timestamp <= now())
-                    group by u
-                    order by c desc limit 10
+                    SELECT
+                cutQueryString(cutFragment(url)) as screen,
+                count(distinct session_id) as count
+            FROM (
+                SELECT
+                    session_id,
+                    arrayJoin(any(all_urls)) as url
+                FROM raw_session_replay_events
+                WHERE min_first_timestamp >= now() - interval 7 day
+                  AND min_first_timestamp <= now()
+                GROUP BY session_id
+                HAVING date_diff('second', min(min_first_timestamp), max(max_last_timestamp)) > 5
+            )
+            GROUP BY screen
+            ORDER BY count DESC
+            LIMIT 10
                 `
 
                 const qResponse = await api.queryHogQL(q)

--- a/frontend/src/scenes/session-recordings/components/replayActiveUsersTableLogic.ts
+++ b/frontend/src/scenes/session-recordings/components/replayActiveUsersTableLogic.ts
@@ -27,7 +27,6 @@ export const replayActiveUsersTableLogic = kea<replayActiveUsersTableLogicType>(
             counted_sessions AS (
                 SELECT
                     session_id,
-                    any(distinct_id) AS sess_di,
                     count() AS c
                 FROM raw_session_replay_events
                 WHERE min_first_timestamp >= now() - interval 7 day

--- a/frontend/src/scenes/session-recordings/components/replayActiveUsersTableLogic.ts
+++ b/frontend/src/scenes/session-recordings/components/replayActiveUsersTableLogic.ts
@@ -23,18 +23,40 @@ export const replayActiveUsersTableLogic = kea<replayActiveUsersTableLogicType>(
         countedUsers: {
             loadCountedUsers: async (_, breakpoint): Promise<{ person: PersonType; count: number }[]> => {
                 const q = hogql`
-                    select p, any (pp), count () as c
-                    from (
-                        select any (person_id) as p, any (person.properties) as pp
-                        from raw_session_replay_events
-                        where min_first_timestamp <= now()
-                        and min_first_timestamp >= now() - toIntervalDay(7)
-                        group by session_id
-                        having date_diff('second', min (min_first_timestamp), max (max_last_timestamp)) > 5000
-                        ) as q
-                    group by p
-                    order by c desc
-                        limit 10
+                    WITH
+            counted_sessions AS (
+                SELECT
+                    session_id,
+                    any(distinct_id) AS sess_di,
+                    count() AS c
+                FROM raw_session_replay_events
+                WHERE min_first_timestamp >= now() - interval 7 day
+                  AND min_first_timestamp <= now()
+                GROUP BY session_id
+                HAVING date_diff('second', min(min_first_timestamp), max(max_last_timestamp)) > 5
+            ),
+            session_persons AS (
+                SELECT
+                    $session_id as session_id,
+                    any(person_id) as person_id,
+                    any(person.properties) as pp
+                FROM events
+                WHERE timestamp >= now() - interval 7 day
+                  AND timestamp <= now()
+                  AND $session_id IN (SELECT session_id FROM counted_sessions)
+                  AND event IN ('$pageview', '$screen', '$autocapture', '$feature_flag_called', '$pageleave', '$identify', '$web_vitals', '$set', 'Application Opened', 'Application Backgrounded')
+                GROUP BY $session_id
+            )
+            SELECT
+                sp.person_id,
+                sp.pp,
+                sum(cs.c) as total_count
+            FROM counted_sessions cs
+            INNER JOIN session_persons sp ON cs.session_id = sp.session_id
+            WHERE sp.person_id IS NOT NULL
+            GROUP BY sp.person_id, sp.pp
+            ORDER BY total_count DESC
+            LIMIT 10
                 `
 
                 const qResponse = await api.queryHogQL(q)

--- a/frontend/src/scenes/session-recordings/components/replayActiveUsersTableLogic.ts
+++ b/frontend/src/scenes/session-recordings/components/replayActiveUsersTableLogic.ts
@@ -45,6 +45,11 @@ export const replayActiveUsersTableLogic = kea<replayActiveUsersTableLogicType>(
                 WHERE timestamp >= now() - interval 7 day
                   AND timestamp <= now()
                   AND $session_id IN (SELECT session_id FROM recorded_sessions)
+                  -- including events when querying the events table is always _much_ faster,
+                  -- but we don't know what events an account will have
+                  -- so we just include the most common ones
+                  -- this won't work for everyone but then that's try with the poorly performing query
+                  -- that this replaces, so it's at least no worse 🙈
                   AND event IN ('$pageview', '$screen', '$autocapture', '$feature_flag_called', '$pageleave', '$identify', '$web_vitals', '$set', 'Application Opened', 'Application Backgrounded')
                 GROUP BY $session_id
             )


### PR DESCRIPTION
(for posthog's posthog cloud account at least) the active users table in replay had stopped loading due to amount of memory consumed by the query

this much nicer query avoids joining with persons completely, and restricts the amount of data queried as much as possible

the active persons query moves from un-runnable on posthog cloud's account to 5 seconds

<img width="1415" height="721" alt="Screenshot 2025-08-21 at 21 11 23" src="https://github.com/user-attachments/assets/77ac8926-c66f-41a5-a718-77303494eeb7" />
