### PR TITLE
feat(flags): handle all http methods

### DIFF
--- a/rust/feature-flags/src/api/endpoint.rs
+++ b/rust/feature-flags/src/api/endpoint.rs
@@ -102,11 +102,12 @@ pub async fn flags(
             // POST requests continue with full processing logic below
         }
         Method::HEAD => {
-            // HEAD should return the same headers as GET but without body
-            let mut response =
-                (StatusCode::OK, [("content-type", "application/json")]).into_response();
-            // Clear the body for HEAD requests
-            *response.body_mut() = axum::body::Body::empty();
+            // HEAD returns the same headers as GET but without body
+            let response = (
+                StatusCode::OK,
+                [("content-type", "application/json")],
+                axum::body::Body::empty(),
+            ).into_response();
             return Ok(response);
         }
         Method::OPTIONS => {

--- a/rust/feature-flags/src/api/endpoint.rs
+++ b/rust/feature-flags/src/api/endpoint.rs
@@ -2,8 +2,7 @@ use crate::{
     api::{
         errors::FlagError,
         types::{
-            ConfigResponse, FlagsOptionsResponse, FlagsQueryParams, FlagsResponse,
-            FlagsResponseCode, LegacyFlagsResponse, ServiceResponse,
+            ConfigResponse, FlagsQueryParams, FlagsResponse, LegacyFlagsResponse, ServiceResponse,
         },
     },
     handler::{process_request, RequestContext},
@@ -11,7 +10,8 @@ use crate::{
 };
 // TODO: stream this instead
 use axum::extract::{MatchedPath, Query, State};
-use axum::http::{HeaderMap, Method};
+use axum::http::{HeaderMap, Method, StatusCode};
+use axum::response::{IntoResponse, Response};
 use axum::{debug_handler, Json};
 use axum_client_ip::InsecureClientIp;
 use bytes::Bytes;
@@ -89,11 +89,44 @@ pub async fn flags(
     method: Method,
     path: MatchedPath,
     body: Bytes,
-) -> Result<Json<ServiceResponse>, FlagError> {
+) -> Result<Response, FlagError> {
     let request_id = Uuid::new_v4();
 
-    if method != Method::POST {
-        return get_minimal_flags_response(query_params.version.as_deref());
+    // Handle different HTTP methods
+    match method {
+        Method::GET => {
+            // GET requests return minimal flags response
+            return Ok(get_minimal_flags_response(query_params.version.as_deref())?.into_response());
+        }
+        Method::POST => {
+            // POST requests continue with full processing logic below
+        }
+        Method::HEAD => {
+            // HEAD should return the same headers as GET but without body
+            let mut response =
+                (StatusCode::OK, [("content-type", "application/json")]).into_response();
+            // Clear the body for HEAD requests
+            *response.body_mut() = axum::body::Body::empty();
+            return Ok(response);
+        }
+        Method::OPTIONS => {
+            // OPTIONS should return allowed methods
+            let response = (
+                StatusCode::NO_CONTENT,
+                [("allow", "GET, POST, OPTIONS, HEAD")],
+            )
+                .into_response();
+            return Ok(response);
+        }
+        _ => {
+            // Return 405 Method Not Allowed for all other methods
+            let response = (
+                StatusCode::METHOD_NOT_ALLOWED,
+                [("allow", "GET, POST, OPTIONS, HEAD")],
+            )
+                .into_response();
+            return Ok(response);
+        }
     }
 
     // Check if this request came through the decide proxy
@@ -171,13 +204,7 @@ pub async fn flags(
         )),
     };
 
-    Ok(Json(versioned_response?))
-}
-
-pub async fn options() -> Result<Json<FlagsOptionsResponse>, FlagError> {
-    Ok(Json(FlagsOptionsResponse {
-        status: FlagsResponseCode::Ok,
-    }))
+    Ok(Json(versioned_response?).into_response())
 }
 
 fn log_request_info(ctx: LogContext) {

--- a/rust/feature-flags/src/api/endpoint.rs
+++ b/rust/feature-flags/src/api/endpoint.rs
@@ -107,7 +107,8 @@ pub async fn flags(
                 StatusCode::OK,
                 [("content-type", "application/json")],
                 axum::body::Body::empty(),
-            ).into_response();
+            )
+                .into_response();
             return Ok(response);
         }
         Method::OPTIONS => {

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -3,7 +3,7 @@ use std::{future::ready, sync::Arc};
 use crate::billing_limiters::{FeatureFlagsLimiter, SessionReplayLimiter};
 use axum::{
     http::Method,
-    routing::{get, post},
+    routing::{any, get},
     Router,
 };
 use common_cookieless::CookielessManager;
@@ -76,7 +76,7 @@ where
     // Very permissive CORS policy, as old SDK versions
     // and reverse proxies might send funky headers.
     let cors = CorsLayer::new()
-        .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+        .allow_methods([Method::GET, Method::POST, Method::OPTIONS, Method::HEAD])
         .allow_headers(AllowHeaders::mirror_request())
         .allow_credentials(true)
         .allow_origin(AllowOrigin::mirror_request());
@@ -87,12 +87,12 @@ where
         .route("/_readiness", get(index))
         .route("/_liveness", get(move || ready(liveness.get_status())));
 
-    // flags endpoint
+    // flags endpoint - handle all HTTP methods
     let flags_router = Router::new()
-        .route("/flags", post(endpoint::flags).get(endpoint::flags))
-        .route("/flags/", post(endpoint::flags).get(endpoint::flags))
-        .route("/decide", post(endpoint::flags).get(endpoint::flags))
-        .route("/decide/", post(endpoint::flags).get(endpoint::flags))
+        .route("/flags", any(endpoint::flags))
+        .route("/flags/", any(endpoint::flags))
+        .route("/decide", any(endpoint::flags))
+        .route("/decide/", any(endpoint::flags))
         .layer(ConcurrencyLimitLayer::new(config.max_concurrency));
 
     let router = Router::new()

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -87,7 +87,7 @@ where
         .route("/_readiness", get(index))
         .route("/_liveness", get(move || ready(liveness.get_status())));
 
-    // flags endpoint - handle all HTTP methods
+    // flags endpoint
     let flags_router = Router::new()
         .route("/flags", any(endpoint::flags))
         .route("/flags/", any(endpoint::flags))

--- a/rust/feature-flags/tests/test_http_methods.rs
+++ b/rust/feature-flags/tests/test_http_methods.rs
@@ -66,5 +66,3 @@ async fn it_handles_http_methods_correctly() -> Result<()> {
 
     Ok(())
 }
-
-

--- a/rust/feature-flags/tests/test_http_methods.rs
+++ b/rust/feature-flags/tests/test_http_methods.rs
@@ -67,32 +67,4 @@ async fn it_handles_http_methods_correctly() -> Result<()> {
     Ok(())
 }
 
-#[tokio::test]
-async fn it_handles_options_method_with_proper_headers() -> Result<()> {
-    let config = DEFAULT_TEST_CONFIG.clone();
-    let server = ServerHandle::for_config(config).await;
-    let client = reqwest::Client::new();
-    let base_url = format!("http://{}/flags", server.addr);
 
-    let response = client.request(Method::OPTIONS, &base_url).send().await?;
-
-    // CORS middleware handles OPTIONS requests and returns 200 OK
-    assert_eq!(response.status(), StatusCode::OK);
-
-    // CORS middleware uses access-control-allow-methods instead of allow header
-    let allow_header = response.headers().get("access-control-allow-methods");
-    assert!(allow_header.is_some());
-    let allow_value = allow_header.unwrap().to_str().unwrap();
-
-    // Verify all required methods are present
-    assert!(allow_value.contains("GET"));
-    assert!(allow_value.contains("POST"));
-    assert!(allow_value.contains("OPTIONS"));
-    assert!(allow_value.contains("HEAD"));
-
-    // Body should be empty for OPTIONS
-    let body = response.text().await?;
-    assert!(body.is_empty());
-
-    Ok(())
-}

--- a/rust/feature-flags/tests/test_http_methods.rs
+++ b/rust/feature-flags/tests/test_http_methods.rs
@@ -1,0 +1,98 @@
+use anyhow::Result;
+use reqwest::{Method, StatusCode};
+
+use crate::common::*;
+use feature_flags::config::DEFAULT_TEST_CONFIG;
+
+pub mod common;
+
+#[tokio::test]
+async fn it_handles_http_methods_correctly() -> Result<()> {
+    let config = DEFAULT_TEST_CONFIG.clone();
+    let server = ServerHandle::for_config(config).await;
+    let client = reqwest::Client::new();
+    let base_url = format!("http://{}/flags", server.addr);
+
+    // Test OPTIONS method - should return 204 with Allow header
+    let options_response = client.request(Method::OPTIONS, &base_url).send().await?;
+
+    // The CORS middleware handles OPTIONS requests and returns 200 OK
+    assert_eq!(options_response.status(), StatusCode::OK);
+
+    // CORS middleware uses access-control-allow-methods header
+    let allow_header = options_response
+        .headers()
+        .get("access-control-allow-methods");
+    assert!(allow_header.is_some());
+    let allow_value = allow_header.unwrap().to_str().unwrap();
+    assert!(allow_value.contains("GET"));
+    assert!(allow_value.contains("POST"));
+    assert!(allow_value.contains("OPTIONS"));
+    assert!(allow_value.contains("HEAD"));
+
+    // Test HEAD method - should return headers without body
+    let head_response = client.request(Method::HEAD, &base_url).send().await?;
+
+    assert_eq!(head_response.status(), StatusCode::OK);
+    let content_type = head_response.headers().get("content-type");
+    assert!(content_type.is_some());
+    assert_eq!(content_type.unwrap().to_str().unwrap(), "application/json");
+
+    // HEAD response should have empty body
+    let body = head_response.text().await?;
+    assert!(body.is_empty());
+
+    // Test unsupported method (PUT) - should return 405 Method Not Allowed
+    let put_response = client.request(Method::PUT, &base_url).send().await?;
+
+    assert_eq!(put_response.status(), StatusCode::METHOD_NOT_ALLOWED);
+    let allow_header = put_response.headers().get("allow");
+    assert!(allow_header.is_some());
+    let allow_value = allow_header.unwrap().to_str().unwrap();
+    assert!(allow_value.contains("GET"));
+    assert!(allow_value.contains("POST"));
+    assert!(allow_value.contains("OPTIONS"));
+    assert!(allow_value.contains("HEAD"));
+
+    // Test DELETE method - should also return 405 Method Not Allowed
+    let delete_response = client.request(Method::DELETE, &base_url).send().await?;
+
+    assert_eq!(delete_response.status(), StatusCode::METHOD_NOT_ALLOWED);
+
+    // Test PATCH method - should also return 405 Method Not Allowed
+    let patch_response = client.request(Method::PATCH, &base_url).send().await?;
+
+    assert_eq!(patch_response.status(), StatusCode::METHOD_NOT_ALLOWED);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn it_handles_options_method_with_proper_headers() -> Result<()> {
+    let config = DEFAULT_TEST_CONFIG.clone();
+    let server = ServerHandle::for_config(config).await;
+    let client = reqwest::Client::new();
+    let base_url = format!("http://{}/flags", server.addr);
+
+    let response = client.request(Method::OPTIONS, &base_url).send().await?;
+
+    // CORS middleware handles OPTIONS requests and returns 200 OK
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // CORS middleware uses access-control-allow-methods instead of allow header
+    let allow_header = response.headers().get("access-control-allow-methods");
+    assert!(allow_header.is_some());
+    let allow_value = allow_header.unwrap().to_str().unwrap();
+
+    // Verify all required methods are present
+    assert!(allow_value.contains("GET"));
+    assert!(allow_value.contains("POST"));
+    assert!(allow_value.contains("OPTIONS"));
+    assert!(allow_value.contains("HEAD"));
+
+    // Body should be empty for OPTIONS
+    let body = response.text().await?;
+    assert!(body.is_empty());
+
+    Ok(())
+}


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Follow up on this https://github.com/PostHog/posthog/pull/36959 to better handle different HTTP requests.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- HEAD returns just the headers and OPTIONS returns the methods we allow: `GET,POST,OPTIONS,HEAD`
- return `405 Method Not Allowed` for other requests that are not allowed methods 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- Integ test
- locally

HEAD
```
curl -I "http://localhost:8010/flags/?v=2"

HTTP/1.1 200 OK
Access-Control-Allow-Credentials: true
Content-Length: 0
Content-Type: application/json
Date: Thu, 21 Aug 2025 20:52:24 GMT
Vary: origin, access-control-request-method, access-control-request-headers
Via: 1.1 Caddy
```

OPTIONS
```
curl -X OPTIONS "http://localhost:8010/flags/?v=2" -v

0/flags/?v=2" -v
* Host localhost:8010 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8010...
* Connected to localhost (::1) port 8010
> OPTIONS /flags/?v=2 HTTP/1.1
> Host: localhost:8010
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< Access-Control-Allow-Credentials: true
< Access-Control-Allow-Methods: GET,POST,OPTIONS,HEAD
< Content-Length: 0
< Date: Thu, 21 Aug 2025 20:52:44 GMT
< Vary: origin, access-control-request-method, access-control-request-headers
< Via: 1.1 Caddy
< 
* Connection #0 to host localhost left intact
```

GET
```
curl "http://localhost:8010/flags/?v=2" -v

* Host localhost:8010 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8010...
* Connected to localhost (::1) port 8010
> GET /flags/?v=2 HTTP/1.1
> Host: localhost:8010
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< Access-Control-Allow-Credentials: true
< Content-Length: 139
< Content-Type: application/json
< Date: Thu, 21 Aug 2025 20:56:19 GMT
< Vary: origin, access-control-request-method, access-control-request-headers
< Via: 1.1 Caddy
< 
* Connection #0 to host localhost left intact
{"errorsWhileComputingFlags":false,"flags":{},"requestId":"8c1ffe52-3a47-497e-bfac-5ced8930b851","supportedCompression":["gzip","gzip-js"]}%    
```
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
