### PR TITLE
fix(charts): enable horizontal scrolling in chart tooltips

### DIFF
--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.scss
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.scss
@@ -3,6 +3,13 @@
     z-index: var(--z-graph-tooltip);
     pointer-events: none;
     transition: all 0.4s;
+
+    &:has(.ScrollableShadows--left),
+    &:has(.ScrollableShadows--right),
+    &:has(.ScrollableShadows--top),
+    &:has(.ScrollableShadows--bottom) {
+        pointer-events: auto;
+    }
 }
 
 .InsightTooltip {

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -52,6 +52,8 @@ import { isInsightVizNode } from '~/queries/utils'
 import { GraphDataset, GraphPoint, GraphPointPayload, GraphType } from '~/types'
 
 let tooltipRoot: Root
+let isMouseOverTooltip = false
+let hideTooltipTimeout: NodeJS.Timeout | null = null
 
 export function ensureTooltip(): [Root, HTMLElement] {
     let tooltipEl = document.getElementById('InsightTooltipWrapper')
@@ -62,6 +64,32 @@ export function ensureTooltip(): [Root, HTMLElement] {
             tooltipEl.id = 'InsightTooltipWrapper'
             tooltipEl.classList.add('InsightTooltipWrapper')
             document.body.appendChild(tooltipEl)
+
+            // Add mouse tracking
+            tooltipEl.addEventListener(
+                'mouseenter',
+                () => {
+                    isMouseOverTooltip = true
+                    if (hideTooltipTimeout) {
+                        clearTimeout(hideTooltipTimeout)
+                        hideTooltipTimeout = null
+                    }
+                },
+                { passive: true }
+            )
+            tooltipEl.addEventListener(
+                'mouseleave',
+                () => {
+                    isMouseOverTooltip = false
+                    hideTooltipTimeout = setTimeout(() => {
+                        const tooltipElement = document.getElementById('InsightTooltipWrapper')
+                        if (tooltipElement && !isMouseOverTooltip) {
+                            tooltipElement.classList.add('opacity-0', 'invisible')
+                        }
+                    }, 100)
+                },
+                { passive: true }
+            )
         }
 
         tooltipRoot = createRoot(tooltipEl)
@@ -70,10 +98,20 @@ export function ensureTooltip(): [Root, HTMLElement] {
 }
 
 export function hideTooltip(): void {
-    const tooltipEl = document.getElementById('InsightTooltipWrapper')
-    if (tooltipEl) {
-        tooltipEl.style.opacity = '0'
+    if (hideTooltipTimeout) {
+        clearTimeout(hideTooltipTimeout)
+        hideTooltipTimeout = null
     }
+    if (isMouseOverTooltip) {
+        return
+    }
+
+    hideTooltipTimeout = setTimeout(() => {
+        const tooltipEl = document.getElementById('InsightTooltipWrapper')
+        if (tooltipEl && !isMouseOverTooltip) {
+            tooltipEl.classList.add('opacity-0', 'invisible')
+        }
+    }, 100)
 }
 
 function truncateString(str: string, num: number): string {
@@ -710,15 +748,23 @@ export function LineGraph_({
 
                         const [tooltipRoot, tooltipEl] = ensureTooltip()
                         if (tooltip.opacity === 0) {
-                            tooltipEl.style.opacity = '0'
+                            // Don't hide if mouse is over tooltip
+                            if (!isMouseOverTooltip) {
+                                tooltipEl.classList.add('opacity-0', 'invisible')
+                            }
                             return
+                        }
+
+                        if (hideTooltipTimeout) {
+                            clearTimeout(hideTooltipTimeout)
+                            hideTooltipTimeout = null
                         }
 
                         // Set caret position
                         // Reference: https://www.chartjs.org/docs/master/configuration/tooltip.html
                         tooltipEl.classList.remove('above', 'below', 'no-transform')
                         tooltipEl.classList.add(tooltip.yAlign || 'no-transform')
-                        tooltipEl.style.opacity = '1'
+                        tooltipEl.classList.remove('opacity-0', 'invisible')
 
                         if (tooltip.body) {
                             const referenceDataPoint = tooltip.dataPoints[0] // Use this point as reference to get the date

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -82,9 +82,8 @@ export function ensureTooltip(): [Root, HTMLElement] {
                 () => {
                     isMouseOverTooltip = false
                     hideTooltipTimeout = setTimeout(() => {
-                        const tooltipElement = document.getElementById('InsightTooltipWrapper')
-                        if (tooltipElement && !isMouseOverTooltip) {
-                            tooltipElement.classList.add('opacity-0', 'invisible')
+                        if (tooltipEl && !isMouseOverTooltip) {
+                            tooltipEl.classList.add('opacity-0', 'invisible')
                         }
                     }, 100)
                 },


### PR DESCRIPTION
## Problem

Chart tooltips with long content (e.g. wide tables) couldn't be scrolled horizontally. When users tried to move their mouse onto the tooltip to scroll, it would immediately disappear, making the content inaccessible.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Closes https://github.com/PostHog/posthog/issues/19555

## Changes

This is another attempt at fixing this (previous PR [here](https://github.com/PostHog/posthog/pull/24165) by Anirudh). This uses mouse events to track when it enters and leaves the tooltip to avoid hiding it. Also uses the scrollableshadow classes that are automatically added to the tooltip to enable pointer events only on scrollable tooltips.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Create a line chart with multiple series and a break down to get the horizontal scroll showing. then confirm it works by hovering over it to scroll.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
