### PR TITLE
fix: swap partition is considering more partitions than it should

### DIFF
--- a/dags/tests/test_web_preaggregated_partitions.py
+++ b/dags/tests/test_web_preaggregated_partitions.py
@@ -6,6 +6,7 @@ import dagster
 from dagster import TimeWindow
 
 from dags.web_preaggregated_daily import pre_aggregate_web_analytics_data
+from dags.web_preaggregated_utils import get_partitions, swap_partitions_from_staging
 from posthog.models.web_preaggregated.sql import DROP_PARTITION_SQL
 
 
@@ -157,3 +158,201 @@ class TestPartitionHandling:
         # Should still drop the partition for the single day
         expected_sql = DROP_PARTITION_SQL("web_stats_daily", "2024-01-01", granularity="daily")
         assert call(expected_sql) in mock_sync_execute.call_args_list
+
+
+class TestPartitionFiltering:
+    def setup_method(self):
+        self.mock_context = Mock()
+        self.mock_context.log.info = Mock()
+        self.mock_context.log.warning = Mock()
+        self.mock_cluster = Mock()
+
+    def test_get_partitions_without_filtering_returns_all_partitions(self):
+        mock_partition_data: list[tuple[str]] = [
+            ("19700101",),
+            ("20130816",),
+            ("20160730",),
+            ("20200818",),
+            ("20210817",),
+            ("20220819",),
+            ("20230419",),
+            ("20230714",),
+            ("20230729",),
+            ("20230815",),
+            ("20230816",),
+            ("20230817",),
+            ("20230818",),
+            ("20230819",),
+            ("20230820",),
+            ("20250815",),
+            ("20250816",),
+            ("20250817",),
+            ("20250818",),
+        ]
+
+        mock_client = Mock()
+        mock_client.execute.return_value = mock_partition_data
+        self.mock_cluster.any_host.return_value.result.return_value = mock_partition_data
+
+        partitions = get_partitions(
+            context=self.mock_context,
+            cluster=self.mock_cluster,
+            table_name="web_pre_aggregated_stats_staging",
+            filter_by_partition_window=False,
+        )
+
+        # Should return all partitions
+        assert len(partitions) == len(mock_partition_data)
+        assert "19700101" in partitions
+        assert "20250818" in partitions
+
+        # Verify the function was called
+        self.mock_cluster.any_host.assert_called()
+
+    def test_get_partitions_with_filtering_returns_only_current_partition_window(self):
+        # Set up partition time window for a single day: 2025-08-17
+        start_datetime = datetime(2025, 8, 17, tzinfo=UTC)
+        end_datetime = datetime(2025, 8, 18, tzinfo=UTC)  # Dagster end is exclusive
+        self.mock_context.partition_time_window = TimeWindow(start_datetime, end_datetime)
+
+        # Mock partition data with many partitions but only one should match
+        mock_partition_data = [("20250817",)]  # Only the target date
+
+        self.mock_cluster.any_host.return_value.result.return_value = mock_partition_data
+
+        partitions = get_partitions(
+            context=self.mock_context,
+            cluster=self.mock_cluster,
+            table_name="web_pre_aggregated_stats_staging",
+            filter_by_partition_window=True,
+        )
+
+        # Should return only the partition for the current day
+        assert len(partitions) == 1
+        assert partitions[0] == "20250817"
+
+        # Verify the SQL query includes date filtering
+        call_args = self.mock_cluster.any_host.call_args[0][0]
+        # The lambda function should be called with the client
+        mock_client = Mock()
+        call_args(mock_client)
+        executed_query = mock_client.execute.call_args[0][0]
+
+        assert "web_pre_aggregated_stats_staging" in executed_query
+        assert "partition >= '20250817'" in executed_query
+        assert "partition < '20250818'" in executed_query
+
+    def test_get_partitions_with_filtering_multi_day_window(self):
+        # Set up partition time window for three days: 2025-08-15 to 2025-08-18
+        start_datetime = datetime(2025, 8, 15, tzinfo=UTC)
+        end_datetime = datetime(2025, 8, 18, tzinfo=UTC)
+        self.mock_context.partition_time_window = TimeWindow(start_datetime, end_datetime)
+
+        # Mock partition data with partitions in and out of range
+        mock_partition_data = [("20250815",), ("20250816",), ("20250817",)]
+
+        self.mock_cluster.any_host.return_value.result.return_value = mock_partition_data
+
+        partitions = get_partitions(
+            context=self.mock_context,
+            cluster=self.mock_cluster,
+            table_name="web_pre_aggregated_stats_staging",
+            filter_by_partition_window=True,
+        )
+
+        # Should return all three partitions in the range
+        assert len(partitions) == 3
+        assert "20250815" in partitions
+        assert "20250816" in partitions
+        assert "20250817" in partitions
+
+    def test_swap_partitions_from_staging_uses_partition_filtering(self):
+        # Set up partition time window for a single day
+        start_datetime = datetime(2025, 8, 17, tzinfo=UTC)
+        end_datetime = datetime(2025, 8, 18, tzinfo=UTC)
+        self.mock_context.partition_time_window = TimeWindow(start_datetime, end_datetime)
+
+        # Mock only one partition in the time window
+        mock_partition_data = [("20250817",)]
+        self.mock_cluster.any_host.return_value.result.return_value = mock_partition_data
+
+        swap_partitions_from_staging(
+            context=self.mock_context,
+            cluster=self.mock_cluster,
+            target_table="web_pre_aggregated_stats",
+            staging_table="web_pre_aggregated_stats_staging",
+        )
+
+        # Verify get_partitions was called with filtering enabled
+        call_args = self.mock_cluster.any_host.call_args_list[0][0][0]
+        mock_client = Mock()
+        call_args(mock_client)
+        executed_query = mock_client.execute.call_args[0][0]
+
+        # Should include date filtering in the query
+        assert "partition >= '20250817'" in executed_query
+        assert "partition < '20250818'" in executed_query
+
+        # Verify only one partition replacement was attempted
+        replace_calls = [call for call in self.mock_cluster.any_host.call_args_list if len(call[0]) > 0]
+        # First call is for getting partitions, second call is for replacing partition
+        assert len(replace_calls) == 2
+
+    def test_get_partitions_without_partition_time_window_and_filtering_enabled(self):
+        self.mock_context.partition_time_window = None
+
+        mock_partition_data = [("20250817",), ("20250818",)]
+        self.mock_cluster.any_host.return_value.result.return_value = mock_partition_data
+
+        partitions = get_partitions(
+            context=self.mock_context,
+            cluster=self.mock_cluster,
+            table_name="web_pre_aggregated_stats_staging",
+            filter_by_partition_window=True,  # Should be ignored due to None partition_time_window
+        )
+
+        # Should return all partitions since filtering can't be applied
+        assert len(partitions) == 2
+
+        # Verify no date filtering was applied
+        call_args = self.mock_cluster.any_host.call_args[0][0]
+        mock_client = Mock()
+        call_args(mock_client)
+        executed_query = mock_client.execute.call_args[0][0]
+
+        assert "partition >=" not in executed_query
+        assert "partition <" not in executed_query
+
+    @pytest.mark.parametrize(
+        "start_date_str,end_date_str,expected_start_partition,expected_end_partition",
+        [
+            ("2025-01-01", "2025-01-02", "20250101", "20250102"),
+            ("2024-12-31", "2025-01-01", "20241231", "20250101"),
+            ("2025-08-15", "2025-08-18", "20250815", "20250818"),
+        ],
+    )
+    def test_partition_date_formatting(
+        self, start_date_str, end_date_str, expected_start_partition, expected_end_partition
+    ):
+        start_datetime = datetime.fromisoformat(start_date_str).replace(tzinfo=UTC)
+        end_datetime = datetime.fromisoformat(end_date_str).replace(tzinfo=UTC)
+        self.mock_context.partition_time_window = TimeWindow(start_datetime, end_datetime)
+
+        mock_partition_data: list[tuple[str, ...]] = []
+        self.mock_cluster.any_host.return_value.result.return_value = mock_partition_data
+
+        get_partitions(
+            context=self.mock_context,
+            cluster=self.mock_cluster,
+            table_name="test_table",
+            filter_by_partition_window=True,
+        )
+
+        # Verify the date formatting in the SQL query
+        call_args = self.mock_cluster.any_host.call_args[0][0]
+        mock_client = Mock()
+        call_args(mock_client)
+        executed_query = mock_client.execute.call_args[0][0]
+
+        assert f"partition >= '{expected_start_partition}'" in executed_query
+        assert f"partition < '{expected_end_partition}'" in executed_query

--- a/dags/web_preaggregated.py
+++ b/dags/web_preaggregated.py
@@ -16,6 +16,7 @@ from dags.web_preaggregated_utils import (
     swap_partitions_from_staging,
     web_analytics_retry_policy_def,
     check_for_concurrent_runs,
+    clear_all_staging_partitions,
 )
 from posthog.clickhouse import query_tagging
 from posthog.clickhouse.client import sync_execute
@@ -131,6 +132,31 @@ def web_pre_aggregated_stats(
         sql_generator=WEB_STATS_INSERT_SQL,
         cluster=cluster,
     )
+
+
+@dagster.asset(
+    name="clear_web_staging_partitions",
+    group_name="web_analytics_v2",
+    tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
+)
+def clear_web_staging_partitions(
+    context: dagster.AssetExecutionContext,
+    cluster: dagster.ResourceParam[ClickhouseCluster],
+) -> None:
+    """
+    Utility asset to clear all partitions from staging tables.
+    Use this to clean up accumulated historical data in staging tables.
+    Ideally, this should not be required, but can be useful for debugging the changes we're doing
+    """
+    query_tagging.get_query_tags().with_dagster(dagster_tags(context))
+
+    staging_tables = ["web_pre_aggregated_stats_staging", "web_pre_aggregated_bounces_staging"]
+
+    for staging_table in staging_tables:
+        context.log.info(f"Clearing all partitions from {staging_table}")
+        clear_all_staging_partitions(context, cluster, staging_table)
+
+    context.log.info("Finished clearing all staging partitions")
 
 
 web_pre_aggregate_job = dagster.define_asset_job(


### PR DESCRIPTION
### Problem

Web analytics v2 backfills (in test) were processing all historical partitions instead of just the target date's partition, causing performance issues and unnecessary work. 

e.g, When running single-day backfills, the system was swapping 111+ accumulated partitions, significantly impacting processing time and resource usage. The job itself fixes the number of partitions, but we should be more clinical about the swap operation and the partition count.

### Changes

- Updated swap logic: swap_partitions_from_staging now processes only current partition window by default
- Added cleanup utility: Created clear_web_staging_partitions asset for manual staging table maintenance

### How did you test this code?
- Mock data validation simulating the original many-partition scenario to confirm only target partitions are processed
- Edge case testing for missing partition windows, date formatting, and graceful fallbacks
- Tested locally