### PR TITLE
feat(dw): add actionable insights to dwh scene

### DIFF
--- a/frontend/src/scenes/data-warehouse/DataWarehouseScene.tsx
+++ b/frontend/src/scenes/data-warehouse/DataWarehouseScene.tsx
@@ -25,8 +25,14 @@ const LIST_SIZE = 5
 
 export function DataWarehouseScene(): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
-    const { materializedViews, activityPaginationState, computedAllSources, totalRowsStats, tablesLoading } =
-        useValues(dataWarehouseSceneLogic)
+    const {
+        materializedViews,
+        activityPaginationState,
+        computedAllSources,
+        totalRowsStats,
+        tablesLoading,
+        actionableIssues,
+    } = useValues(dataWarehouseSceneLogic)
     const { setActivityCurrentPage } = useActions(dataWarehouseSceneLogic)
 
     const sourcesPagination = usePagination(computedAllSources, { pageSize: LIST_SIZE }, 'sources')
@@ -235,6 +241,76 @@ export function DataWarehouseScene(): JSX.Element {
             </div>
 
             <DataWarehouseRowsSyncedGraph />
+
+            {actionableIssues && actionableIssues.length > 0 && (
+                <div className="bg-transparent">
+                    <div className="flex items-center gap-2 mb-1">
+                        <h3 className="font-semibold text-xl">Actionable Issues ({actionableIssues.length})</h3>
+                    </div>
+                    <div className="space-y-3">
+                        {actionableIssues.map((issue) => {
+                            const isCritical = issue.severity === 'critical'
+                            const bgClass = isCritical ? 'bg-red-50 border-red-200' : 'bg-yellow-50 border-yellow-200'
+
+                            return (
+                                <div key={issue.id} className={`border rounded-xl px-4 py-2 ${bgClass} shadow-sm`}>
+                                    <div className="flex items-start gap-3">
+                                        <div className="flex-shrink-0 pt-0.5">
+                                            {isCritical ? (
+                                                <IconCancel className="text-red-600 w-5 h-5" />
+                                            ) : (
+                                                <IconExclamation className="text-yellow-600 w-5 h-5" />
+                                            )}
+                                        </div>
+
+                                        <div className="flex-1 min-w-0">
+                                            <div className="flex items-center gap-2 mb-2">
+                                                <span className="font-semibold text-gray-900">{issue.title}</span>
+                                                <LemonTag
+                                                    type={isCritical ? 'danger' : 'warning'}
+                                                    size="small"
+                                                    className="px-2 py-0.5 font-medium uppercase"
+                                                >
+                                                    {issue.severity}
+                                                </LemonTag>
+                                                <span className="text-xs text-gray-500">
+                                                    <TZLabel
+                                                        time={issue.timestamp}
+                                                        formatDate="MMM DD"
+                                                        formatTime="HH:mm"
+                                                    />
+                                                </span>
+                                            </div>
+
+                                            <div className="text-sm text-gray-700">
+                                                {issue.description}
+                                                {issue.count && issue.count > 1 && (
+                                                    <span className="ml-1 text-gray-500 font-medium">
+                                                        ({issue.count} recent failures)
+                                                    </span>
+                                                )}
+                                            </div>
+                                        </div>
+
+                                        <div className="ml-4 flex-shrink-0">
+                                            <LemonButton
+                                                type={isCritical ? 'primary' : 'secondary'}
+                                                size="small"
+                                                to={issue.actionUrl}
+                                                className="font-medium"
+                                            >
+                                                {issue.actionType
+                                                    .replace(/_/g, ' ')
+                                                    .replace(/\b\w/g, (l) => l.toUpperCase())}
+                                            </LemonButton>
+                                        </div>
+                                    </div>
+                                </div>
+                            )
+                        })}
+                    </div>
+                </div>
+            )}
 
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-3">
                 <div className="lg:col-span-2 space-y-2">

--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -1693,6 +1693,14 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
 
             await waitUntilMonaco().then(async () => {
                 await createQueryTab()
+                if (searchParams.tab) {
+                    const tabValue = searchParams.tab.toLowerCase()
+                    const validTabs = Object.values(OutputTab)
+                    if (validTabs.includes(tabValue as (typeof validTabs)[0])) {
+                        const outputLogic = outputPaneLogic.findMounted() || outputPaneLogic()
+                        outputLogic.actions.setActiveTab(tabValue as OutputTab)
+                    }
+                }
             })
         },
     })),

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -80,24 +80,24 @@ export const urls = {
             nodeTab ? `/${nodeTab}` : ''
         }`,
     customCss: (): string => '/themes/custom-css',
-    sqlEditor: (query?: string, view_id?: string, insightShortId?: string, draftId?: string): string => {
+    sqlEditor: (query?: string, view_id?: string, insightShortId?: string, draftId?: string, tab?: string): string => {
+        let url = ''
         if (query) {
-            return `/sql?open_query=${encodeURIComponent(query)}`
+            url = `/sql?open_query=${encodeURIComponent(query)}`
+        } else if (view_id) {
+            url = `/sql?open_view=${view_id}`
+        } else if (insightShortId) {
+            url = `/sql?open_insight=${insightShortId}`
+        } else if (draftId) {
+            url = `/sql?open_draft=${draftId}`
+        } else {
+            url = '/sql'
+        }
+        if (tab) {
+            url += url.includes('?') ? `&tab=${tab}` : `?tab=${tab}`
         }
 
-        if (view_id) {
-            return `/sql?open_view=${view_id}`
-        }
-
-        if (insightShortId) {
-            return `/sql?open_insight=${insightShortId}`
-        }
-
-        if (draftId) {
-            return `/sql?open_draft=${draftId}`
-        }
-
-        return '/sql'
+        return url
     },
     annotations: (): string => '/data-management/annotations',
     annotation: (id: AnnotationType['id'] | ':id'): string => `/data-management/annotations/${id}`,

--- a/posthog/warehouse/api/data_warehouse.py
+++ b/posthog/warehouse/api/data_warehouse.py
@@ -206,7 +206,6 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         Returns daily breakdown of rows synced within the current billing period.
         Used by the frontend data warehouse scene to display sync activity trends.
         """
-        log = structlog.get_logger()
         billing_period_start = billing_period_end = None
         billing_available = False
         breakdown_of_rows_by_day = []
@@ -271,10 +270,10 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
                     for row in daily_totals
                 ]
             else:
-                log.info("no_billing_period_for_daily_breakdown")
+                logger.info("no_billing_period_for_daily_breakdown")
 
         except Exception as e:
-            log.exception("daily_breakdown_error", exc_info=e)
+            logger.exception("daily_breakdown_error", exc_info=e)
             return Response(
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 data={"error": "An error occurred retrieving daily breakdown"},


### PR DESCRIPTION
## Problem

For Data Warehouse, users have limited action driven visibility into data warehouse sync failures. This can make it unclear for them on if any action needs to be taken. The purpose of this component is to allow them to have a clear action step on warnings and failures. 

## Changes

Added a frontend component to showcase failures and warnings
used the recent activity to get this actionable data, may need a separate api endpoint for this though

## How did you test this code?

manual testing atm

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
