### PR TITLE
chore: db_sync_to_async execution time metric

### DIFF
--- a/posthog/sync.py
+++ b/posthog/sync.py
@@ -46,8 +46,9 @@ class DatabaseSyncToAsync(SyncToAsync):
             # Record the execution time metric
             if self._thread_sensitive:
                 execution_time = time() - start_time
-                DATABASE_SYNC_TO_ASYNC_TIME.labels(function_name=self.func.__name__).observe(execution_time)
-                logger.info(f"database_sync_to_async {self.func.__name__} took {execution_time} seconds")
+                fun_name = getattr(self.func, "__name__", "unknown")
+                DATABASE_SYNC_TO_ASYNC_TIME.labels(function_name=fun_name).observe(execution_time)
+                logger.info(f"database_sync_to_async {fun_name} took {execution_time} seconds")
 
     def thread_handler(self, loop, *args, **kwargs):
         close_old_connections()

--- a/posthog/sync.py
+++ b/posthog/sync.py
@@ -22,8 +22,8 @@ logger = get_logger(__name__)
 
 # Prometheus metric to track database_sync_to_async execution time
 DATABASE_SYNC_TO_ASYNC_TIME = Histogram(
-    "database_sync_to_async_main_thread_blocked_time_seconds",
-    "Time spent blocking the main thread while executing database_sync_to_async operations",
+    "database_sync_to_async_thread_sensitive_execution_time_seconds",
+    "Time spent while executing database_sync_to_async operations in thread-sensitive mode",
     labelnames=["function_name"],
     buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, float("inf")),
 )


### PR DESCRIPTION
## Problem

It's very easy to block the main thread of Django's async ORM implementation, i.e., `sync_to_async(thread_sensitive=True)`, for a long time. We don't have good observability around it, so let's change that.

## Changes

- Overload `__call__` of `database_sync_to_async` to capture the execution time.

Log:
```
2025-08-22 09:12:38.321164 [info     ] database_sync_to_async _put took 0.018240928649902344 seconds [posthog.sync] activity_id=1 activity_type=process_conversation_activity attempt=1 filename=sync.py func_name=__call__ lineno=44 task_queue=max-ai-task-queue workflow_id=conversation-f9392085-de0a-4050-8039-eca6de5540c8 workflow_namespace=default workflow_run_id=b1e6ece5-de5e-4d17-b73c-42452b832183 workflow_type=conversation-processing
2025-08-22 09:12:38.341221 [info     ] database_sync_to_async report_user_action took 0.007899045944213867 seconds [posthog.sync] activity_id=1 activity_type=process_conversation_activity attempt=1 filename=sync.py func_name=__call__ lineno=44 task_queue=max-ai-task-queue workflow_id=conversation-f9392085-de0a-4050-8039-eca6de5540c8 workflow_namespace=default workflow_run_id=b1e6ece5-de5e-4d17-b73c-42452b832183 workflow_type=conversation-processing
```

## How did you test this code?

Unit tests
