### PR TITLE
feat(msg): replace oauth placeholders before fetch

### DIFF
--- a/plugin-server/src/cdp/_tests/examples.ts
+++ b/plugin-server/src/cdp/_tests/examples.ts
@@ -1,3 +1,5 @@
+import { ACCESS_TOKEN_PLACEHOLDER } from '~/config/constants'
+
 import { PropertyOperator } from '../../types'
 import { HogFunctionType } from '../types'
 
@@ -334,6 +336,82 @@ export const HOG_INPUTS_EXAMPLES: Record<string, Pick<HogFunctionType, 'inputs' 
                     nested: { foo: ['_h', 32, 'url', 32, 'event', 1, 2] },
                     person: ['_h', 32, 'person', 1, 1],
                     event_url: ['_h', 32, '-test', 32, 'url', 32, 'event', 1, 2, 2, 'concat', 2],
+                },
+            },
+        },
+    },
+    simple_fetch_with_oauth: {
+        inputs_schema: [
+            { key: 'oauth', type: 'integration', label: 'OAuth', secret: false, required: true, integration: 'oauth' },
+            { key: 'url', type: 'string', label: 'Webhook URL', secret: false, required: true },
+            { key: 'body', type: 'json', label: 'JSON body', secret: false, required: true },
+            {
+                key: 'method',
+                type: 'choice',
+                label: 'HTTP Method',
+                secret: false,
+                choices: [
+                    { label: 'POST', value: 'POST' },
+                    { label: 'PUT', value: 'PUT' },
+                    { label: 'PATCH', value: 'PATCH' },
+                    { label: 'GET', value: 'GET' },
+                ],
+                required: true,
+            },
+            { key: 'headers', type: 'dictionary', label: 'Headers', secret: false, required: false },
+        ],
+        inputs: {
+            oauth: {
+                value: {
+                    access_token: ACCESS_TOKEN_PLACEHOLDER + '123',
+                },
+                bytecode: ['_h', 32, ACCESS_TOKEN_PLACEHOLDER, 32, '123'],
+            },
+            url: {
+                value: 'https://example.com/posthog-webhook?access_token={inputs.oauth.access_token}',
+                bytecode: [
+                    '_h',
+                    32,
+                    'https://example.com/posthog-webhook',
+                    32,
+                    'access_token',
+                    32,
+                    'inputs',
+                    1,
+                    2,
+                    32,
+                    'oauth',
+                    1,
+                    2,
+                ],
+            },
+            method: { value: 'POST' },
+            headers: {
+                value: {
+                    version: 'v={event.properties.$lib_version}',
+                    access_token: '{inputs.oauth.access_token}',
+                },
+                bytecode: {
+                    version: ['_h', 32, '$lib_version', 32, 'properties', 32, 'event', 1, 3, 32, 'v=', 2, 'concat', 2],
+                    access_token: ['_h', 32, 'access_token', 32, 'inputs', 1, 2, 32, 'oauth', 1, 2],
+                },
+            },
+            body: {
+                value: {
+                    event: '{event}',
+                    groups: '{groups}',
+                    nested: { foo: '{event.url}' },
+                    person: '{person}',
+                    event_url: "{f'{event.url}-test'}",
+                    access_token: '{inputs.oauth.access_token}',
+                },
+                bytecode: {
+                    event: ['_h', 32, 'event', 1, 1],
+                    groups: ['_h', 32, 'groups', 1, 1],
+                    nested: { foo: ['_h', 32, 'url', 32, 'event', 1, 2] },
+                    person: ['_h', 32, 'person', 1, 1],
+                    event_url: ['_h', 32, '-test', 32, 'url', 32, 'event', 1, 2, 2, 'concat', 2],
+                    access_token: ['_h', 32, 'access_token', 32, 'inputs', 1, 2, 32, 'oauth', 1, 2],
                 },
             },
         },

--- a/plugin-server/src/cdp/services/hog-executor.service.test.ts
+++ b/plugin-server/src/cdp/services/hog-executor.service.test.ts
@@ -1104,7 +1104,6 @@ describe('Hog Executor', () => {
                       "X-Test": "actual_secret_token_12345",
                     },
                     "method": "POST",
-                    "timeoutMs": 3000,
                   },
                 ]
             `)

--- a/plugin-server/src/cdp/services/hog-executor.service.test.ts
+++ b/plugin-server/src/cdp/services/hog-executor.service.test.ts
@@ -1065,5 +1065,49 @@ describe('Hog Executor', () => {
                 }
             `)
         })
+
+        it('replaces access token placeholders in body, headers, and url', async () => {
+            const mockIntegrationInputs = {
+                oauth: {
+                    value: {
+                        access_token: '$$_access_token_placeholder_123$$',
+                        access_token_raw: 'actual_secret_token_12345',
+                    },
+                },
+            }
+
+            jest.spyOn(executor['hogInputsService'], 'loadIntegrationInputs').mockResolvedValue(mockIntegrationInputs)
+
+            const invocation = createExampleInvocation()
+            invocation.state.globals.inputs = mockIntegrationInputs
+            invocation.state.vmState = { stack: [] } as any
+            invocation.queueParameters = {
+                type: 'fetch',
+                url: 'https://example.com/test?q=$$_access_token_placeholder_123$$',
+                method: 'POST',
+                headers: {
+                    'X-Test': '$$_access_token_placeholder_123$$',
+                    Authorization: 'Bearer $$_access_token_placeholder_123$$',
+                },
+                body: '$$_access_token_placeholder_123$$',
+            } as any
+
+            await executor.executeFetch(invocation)
+
+            expect(jest.mocked(fetch).mock.calls[0] as any).toMatchInlineSnapshot(`
+                [
+                  "https://example.com/test?q=actual_secret_token_12345",
+                  {
+                    "body": "actual_secret_token_12345",
+                    "headers": {
+                      "Authorization": "Bearer actual_secret_token_12345",
+                      "X-Test": "actual_secret_token_12345",
+                    },
+                    "method": "POST",
+                    "timeoutMs": 3000,
+                  },
+                ]
+            `)
+        })
     })
 })

--- a/plugin-server/src/cdp/services/hog-executor.service.ts
+++ b/plugin-server/src/cdp/services/hog-executor.service.ts
@@ -554,10 +554,25 @@ export class HogExecutorService {
         const addLog = createAddLogFunction(result.logs)
 
         const method = params.method.toUpperCase()
-        const headers = params.headers ?? {}
+        let headers = params.headers ?? {}
 
         if (params.url.startsWith('https://googleads.googleapis.com/') && !headers['developer-token']) {
             headers['developer-token'] = this.hub.CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN
+        }
+
+        if (!!invocation.state.globals.inputs?.oauth) {
+            const integrationInputs = await this.hogInputsService.loadIntegrationInputs(invocation.hogFunction)
+            const accessToken: string = integrationInputs.oauth.value.access_token_raw
+            const placeholder: string = integrationInputs.oauth.value.access_token
+
+            params.body = params.body?.replaceAll(placeholder, accessToken)
+            headers = Object.fromEntries(
+                Object.entries(params.headers ?? {}).map(([key, value]) => [
+                    key,
+                    typeof value === 'string' ? value.replaceAll(placeholder, accessToken) : value,
+                ])
+            )
+            params.url = params.url?.replaceAll(placeholder, accessToken)
         }
 
         const fetchParams: FetchOptions = { method, headers }

--- a/plugin-server/src/cdp/services/hog-executor.service.ts
+++ b/plugin-server/src/cdp/services/hog-executor.service.ts
@@ -565,14 +565,16 @@ export class HogExecutorService {
             const accessToken: string = integrationInputs.oauth.value.access_token_raw
             const placeholder: string = integrationInputs.oauth.value.access_token
 
-            params.body = params.body?.replaceAll(placeholder, accessToken)
-            headers = Object.fromEntries(
-                Object.entries(params.headers ?? {}).map(([key, value]) => [
-                    key,
-                    typeof value === 'string' ? value.replaceAll(placeholder, accessToken) : value,
-                ])
-            )
-            params.url = params.url?.replaceAll(placeholder, accessToken)
+            if (placeholder && accessToken) {
+                params.body = params.body?.replaceAll(placeholder, accessToken)
+                headers = Object.fromEntries(
+                    Object.entries(params.headers ?? {}).map(([key, value]) => [
+                        key,
+                        typeof value === 'string' ? value.replaceAll(placeholder, accessToken) : value,
+                    ])
+                )
+                params.url = params.url?.replaceAll(placeholder, accessToken)
+            }
         }
 
         const fetchParams: FetchOptions = { method, headers }

--- a/plugin-server/src/cdp/services/hog-executor.service.ts
+++ b/plugin-server/src/cdp/services/hog-executor.service.ts
@@ -566,14 +566,16 @@ export class HogExecutorService {
             const placeholder: string = integrationInputs.oauth.value.access_token
 
             if (placeholder && accessToken) {
-                params.body = params.body?.replaceAll(placeholder, accessToken)
+                const replace = (val: string) => val.replaceAll(placeholder, accessToken)
+
+                params.body = params.body ? replace(params.body) : params.body
                 headers = Object.fromEntries(
                     Object.entries(params.headers ?? {}).map(([key, value]) => [
                         key,
-                        typeof value === 'string' ? value.replaceAll(placeholder, accessToken) : value,
+                        typeof value === 'string' ? replace(value) : value,
                     ])
                 )
-                params.url = params.url?.replaceAll(placeholder, accessToken)
+                params.url = replace(params.url)
             }
         }
 

--- a/plugin-server/src/cdp/services/hog-inputs.service.ts
+++ b/plugin-server/src/cdp/services/hog-inputs.service.ts
@@ -67,7 +67,7 @@ export class HogInputsService {
         }
     }
 
-    private async loadIntegrationInputs(hogFunction: HogFunctionType): Promise<Record<string, any>> {
+    public async loadIntegrationInputs(hogFunction: HogFunctionType): Promise<Record<string, any>> {
         const inputsToLoad: Record<string, number> = {}
 
         hogFunction.inputs_schema?.forEach((schema) => {

--- a/plugin-server/src/config/constants.ts
+++ b/plugin-server/src/config/constants.ts
@@ -9,3 +9,4 @@ export const KAFKAJS_LOG_LEVEL_MAPPING = {
     WARN: logLevel.WARN,
     ERROR: logLevel.ERROR,
 }
+export const ACCESS_TOKEN_PLACEHOLDER = '$$_access_token_placeholder_'


### PR DESCRIPTION
## Problem

During incidents when the lag of the hog-workers is higher than the expiration time of an oauth access token, all fetch requests will fail, and we do not have logic to requeue them.

## Changes

- Replace oauth placeholders before executing the fetch call
- [X] Keep a fallback value if you need to interpolate the access token through `inputs.oauth.access_token_raw`
- [x] test on dev

Followup
- [x] [Merge the other PR to default the `inputs.access_token` to the placeholder instead of the actual value](https://github.com/PostHog/posthog/pull/37025)
- [ ] [default all templates to use `oauth` as the key for oauth fields](https://github.com/PostHog/posthog/pull/37210)

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
