### PR TITLE
fix: dataAttr to data-attr in LemonCheckbox

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonCheckbox/LemonCheckbox.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCheckbox/LemonCheckbox.tsx
@@ -22,7 +22,7 @@ export interface LemonCheckboxProps {
     bordered?: boolean
     /** @deprecated See https://github.com/PostHog/posthog/pull/9357#pullrequestreview-933783868. */
     color?: string
-    dataAttr?: string
+    'data-attr'?: string
     /** Whether to stop propagation of events from the input */
     stopPropagation?: boolean
 }
@@ -52,7 +52,7 @@ export function LemonCheckbox({
     bordered,
     color,
     size,
-    dataAttr,
+    'data-attr': dataAttr,
     stopPropagation,
 }: LemonCheckboxProps): JSX.Element {
     const indeterminate = checked === 'indeterminate'

--- a/frontend/src/scenes/billing/UnsubscribeSurveyModal.tsx
+++ b/frontend/src/scenes/billing/UnsubscribeSurveyModal.tsx
@@ -215,7 +215,7 @@ export const UnsubscribeSurveyModal = ({
                                     bordered
                                     key={reason.reason}
                                     label={reason.reason}
-                                    dataAttr={`unsubscribe-reason-${reason.reason.toLowerCase().replace(' ', '-')}`}
+                                    data-attr={`unsubscribe-reason-${reason.reason.toLowerCase().replace(' ', '-')}`}
                                     checked={surveyResponse['$survey_response_2'].includes(reason.reason)}
                                     onChange={() => toggleSurveyReason(reason.reason)}
                                     className="w-full"

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -399,7 +399,7 @@ export function FeatureFlag({ id }: FeatureFlagLogicProps): JSX.Element {
                                                 label="Enable feature flag"
                                                 onChange={() => onChange(!value)}
                                                 checked={value}
-                                                dataAttr="feature-flag-enabled-checkbox"
+                                                data-attr="feature-flag-enabled-checkbox"
                                             />
                                         </div>
                                     )}
@@ -1266,7 +1266,7 @@ function FeatureFlagRollout({ readOnly }: { readOnly?: boolean }): JSX.Element {
                                                             label="Encrypt remote configuration payload"
                                                             onChange={() => onChange(!value)}
                                                             checked={value}
-                                                            dataAttr="feature-flag-payload-encrypted-checkbox"
+                                                            data-attr="feature-flag-payload-encrypted-checkbox"
                                                             disabledReason={
                                                                 hasEncryptedPayloadBeenSaved &&
                                                                 'An encrypted payload has already been saved for this flag. Reset the payload or create a new flag to create an unencrypted configuration payload.'
@@ -1568,7 +1568,7 @@ function FeatureFlagRollout({ readOnly }: { readOnly?: boolean }): JSX.Element {
                                                     label="Encrypt remote configuration payload"
                                                     onChange={() => onChange(!value)}
                                                     checked={value}
-                                                    dataAttr="feature-flag-payload-encrypted-checkbox"
+                                                    data-attr="feature-flag-payload-encrypted-checkbox"
                                                     disabledReason={
                                                         hasEncryptedPayloadBeenSaved &&
                                                         'An encrypted payload has already been saved for this flag. Reset the payload or create a new flag to create an unencrypted configuration payload.'

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingPreview.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingPreview.tsx
@@ -202,7 +202,7 @@ function ItemCheckbox({ recording }: { recording: SessionRecordingType }): JSX.E
     return (
         <LemonCheckbox
             checked={selectedRecordingsIds.some((s) => s === recording.id)}
-            dataAttr="select-recording"
+            data-attr="select-recording"
             aria-label="Select recording"
             disabledReason={
                 selectedRecordingsIds.length >= MAX_SELECTED_RECORDINGS

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
@@ -334,7 +334,7 @@ export function SessionRecordingsPlaylistTopSettings({
                     onChange={(checked) => handleSelectUnselectAll(checked, type)}
                     stopPropagation
                     className="ml-2"
-                    dataAttr="select-all-recordings"
+                    data-attr="select-all-recordings"
                     aria-label="Select all recordings"
                 />
                 {filters && setFilters ? (


### PR DESCRIPTION
In most Lemon UI components we use "data-attr" parameter.
However, in LemonCheckbox it called dataAttr.
A lot of folks were using data-attr not knowing that it wasn't applied.

Let's fix it