### PR TITLE
fix(hogql): Handle nth join for global join fix

### DIFF
--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -373,7 +373,6 @@ class Resolver(CloningVisitor):
             node.next_join = self.visit(node.next_join)
 
             # Look ahead if current is events table and next is s3 table, global join must be used for distributed query on external data to work
-            is_global = False
             global_table: ast.TableType | None = None
 
             if isinstance(node.type, ast.TableAliasType) and isinstance(node.type.table_type, ast.TableType):
@@ -382,16 +381,22 @@ class Resolver(CloningVisitor):
                 global_table = node.type
 
             if global_table and isinstance(global_table.table, EventsTable):
-                if self._is_next_s3(node.next_join):
-                    is_global = True
-                # Use GLOBAL joins for nested subqueries for S3 tables until https://github.com/ClickHouse/ClickHouse/pull/85839 is in
-                elif node.next_join and isinstance(node.next_join.type, ast.SelectQueryAliasType):
-                    select_query_type = node.next_join.type.select_query_type
-                    tables = self._extract_tables_from_query_type(select_query_type)
-                    is_global = any(self._is_s3_table(table) for table in tables)
+                next_join = node.next_join
+                while next_join:
+                    is_global = False
 
-            if is_global and node.next_join is not None:
-                node.next_join.join_type = f"GLOBAL {node.next_join.join_type}"
+                    if self._is_next_s3(next_join):
+                        is_global = True
+                    # Use GLOBAL joins for nested subqueries for S3 tables until https://github.com/ClickHouse/ClickHouse/pull/85839 is in
+                    elif isinstance(next_join.type, ast.SelectQueryAliasType):
+                        select_query_type = next_join.type.select_query_type
+                        tables = self._extract_tables_from_query_type(select_query_type)
+                        is_global = any(self._is_s3_table(table) for table in tables)
+
+                    if is_global:
+                        next_join.join_type = f"GLOBAL {next_join.join_type}"
+
+                    next_join = next_join.next_join
 
             if node.constraint and node.constraint.constraint_type == "ON":
                 node.constraint = self.visit_join_constraint(node.constraint)

--- a/posthog/hogql/test/__snapshots__/test_printer.ambr
+++ b/posthog/hogql/test/__snapshots__/test_printer.ambr
@@ -77,5 +77,5 @@
   "SELECT some_remote_table.event AS event FROM events GLOBAL JOIN (SELECT e.event AS event, t.id AS id FROM events AS e GLOBAL JOIN (SELECT * FROM s3(%(hogql_val_0_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_3_sensitive)s, 'Parquet', %(hogql_val_1)s)) AS t ON equals(toString(t.id), e.event) WHERE equals(e.team_id, 99999)) AS some_remote_table ON equals(events.event, toString(some_remote_table.id)) WHERE equals(events.team_id, 99999) LIMIT 50000"
 # ---
 # name: TestPrinter.test_s3_tables_global_join_with_multiple_joins
-  "SELECT e.event, s.event AS event, t.id AS id FROM events AS e JOIN (SELECT events.event AS event FROM events WHERE equals(events.team_id, 99999)) AS s ON equals(e.event, s.event) GLOBAL LEFT JOIN (SELECT * FROM s3(%(hogql_val_0_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_3_sensitive)s, 'Parquet', %(hogql_val_1)s)) AS t ON equals(e.event, toString(t.id)) WHERE equals(e.team_id, 99999) LIMIT 50000"
+  "SELECT e.event, s.event AS event, t.id AS id FROM events AS e GLOBAL JOIN (SELECT events.event AS event FROM events WHERE equals(events.team_id, 99999)) AS s ON equals(e.event, s.event) GLOBAL LEFT JOIN (SELECT * FROM s3(%(hogql_val_0_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_3_sensitive)s, 'Parquet', %(hogql_val_1)s)) AS t ON equals(e.event, toString(t.id)) WHERE equals(e.team_id, 99999) LIMIT 50000"
 # ---

--- a/posthog/hogql/test/__snapshots__/test_printer.ambr
+++ b/posthog/hogql/test/__snapshots__/test_printer.ambr
@@ -76,3 +76,6 @@
 # name: TestPrinter.test_s3_tables_global_join_with_cte_nested
   "SELECT some_remote_table.event AS event FROM events GLOBAL JOIN (SELECT e.event AS event, t.id AS id FROM events AS e GLOBAL JOIN (SELECT * FROM s3(%(hogql_val_0_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_3_sensitive)s, 'Parquet', %(hogql_val_1)s)) AS t ON equals(toString(t.id), e.event) WHERE equals(e.team_id, 99999)) AS some_remote_table ON equals(events.event, toString(some_remote_table.id)) WHERE equals(events.team_id, 99999) LIMIT 50000"
 # ---
+# name: TestPrinter.test_s3_tables_global_join_with_multiple_joins
+  "SELECT e.event, s.event AS event, t.id AS id FROM events AS e JOIN (SELECT events.event AS event FROM events WHERE equals(events.team_id, 99999)) AS s ON equals(e.event, s.event) GLOBAL LEFT JOIN (SELECT * FROM s3(%(hogql_val_0_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_3_sensitive)s, 'Parquet', %(hogql_val_1)s)) AS t ON equals(e.event, toString(t.id)) WHERE equals(e.team_id, 99999) LIMIT 50000"
+# ---

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -2556,7 +2556,8 @@ class TestPrinter(BaseTest):
             JOIN (SELECT event from events) as s ON e.event = s.event
             LEFT JOIN test_table t on e.event = toString(t.id)""")
 
-        assert "GLOBAL LEFT JOIN" in printed
+        assert "GLOBAL JOIN" in printed  # Join #1
+        assert "GLOBAL LEFT JOIN" in printed  # Join #2
 
         assert clean_varying_query_parts(printed, replace_all_numbers=False) == self.snapshot  # type: ignore
 

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -2539,6 +2539,27 @@ class TestPrinter(BaseTest):
 
         assert clean_varying_query_parts(printed, replace_all_numbers=False) == self.snapshot  # type: ignore
 
+    @pytest.mark.usefixtures("unittest_snapshot")
+    def test_s3_tables_global_join_with_multiple_joins(self):
+        credential = DataWarehouseCredential.objects.create(team=self.team, access_key="key", access_secret="secret")
+        DataWarehouseTable.objects.create(
+            team=self.team,
+            name="test_table",
+            format=DataWarehouseTable.TableFormat.DeltaS3Wrapper,
+            url_pattern="http://s3/folder/",
+            credential=credential,
+            columns={"id": {"hogql": "StringDatabaseField", "clickhouse": "String", "schema_valid": True}},
+        )
+        printed = self._select("""
+            SELECT e.event, s.event, t.id
+            FROM events e
+            JOIN (SELECT event from events) as s ON e.event = s.event
+            LEFT JOIN test_table t on e.event = toString(t.id)""")
+
+        assert "GLOBAL LEFT JOIN" in printed
+
+        assert clean_varying_query_parts(printed, replace_all_numbers=False) == self.snapshot  # type: ignore
+
 
 class TestPrinted(APIBaseTest):
     def test_can_call_parametric_function(self):


### PR DESCRIPTION
## Problem
- Follow up 2 for https://github.com/PostHog/posthog/pull/36977
- Solves multiple joins onto `events` when the S3 table is not the first join

## Changes
- Iteratively check all the `next_join`'s

## How did you test this code?
- unit test + snapshot
