### PR TITLE
fix(max): broken insights from the insight search

### DIFF
--- a/ee/hogai/eval/conftest.py
+++ b/ee/hogai/eval/conftest.py
@@ -16,7 +16,7 @@ from ee.hogai.django_checkpoint.checkpointer import DjangoCheckpointer
 from ee.hogai.eval.scorers import PlanAndQueryOutput
 from ee.hogai.graph.graph import AssistantGraph, InsightsAssistantGraph
 from ee.hogai.utils.types import AssistantNodeName, AssistantState
-from ee.hogai.utils.types.base import AssistantQueryType
+from ee.hogai.utils.types.base import AnyAssistantGeneratedQuery
 from ee.models.assistant import Conversation, CoreMemory
 
 # We want the PostHog django_db_setup fixture here
@@ -130,7 +130,7 @@ def call_root_for_insight_generation(demo_org_team_user):
         if (
             not final_state.messages
             or not isinstance(final_state.messages[-1], VisualizationMessage)
-            or not isinstance(final_state.messages[-1].answer, AssistantQueryType)
+            or not isinstance(final_state.messages[-1].answer, AnyAssistantGeneratedQuery)
         ):
             return {
                 "plan": None,

--- a/ee/hogai/eval/conftest.py
+++ b/ee/hogai/eval/conftest.py
@@ -16,6 +16,7 @@ from ee.hogai.django_checkpoint.checkpointer import DjangoCheckpointer
 from ee.hogai.eval.scorers import PlanAndQueryOutput
 from ee.hogai.graph.graph import AssistantGraph, InsightsAssistantGraph
 from ee.hogai.utils.types import AssistantNodeName, AssistantState
+from ee.hogai.utils.types.base import AssistantQueryType
 from ee.models.assistant import Conversation, CoreMemory
 
 # We want the PostHog django_db_setup fixture here
@@ -126,7 +127,11 @@ def call_root_for_insight_generation(demo_org_team_user):
             final_state_raw = await graph.ainvoke(final_state, {"configurable": {"thread_id": conversation.id}})
             final_state = AssistantState.model_validate(final_state_raw)
 
-        if not final_state.messages or not isinstance(final_state.messages[-1], VisualizationMessage):
+        if (
+            not final_state.messages
+            or not isinstance(final_state.messages[-1], VisualizationMessage)
+            or not isinstance(final_state.messages[-1].answer, AssistantQueryType)
+        ):
             return {
                 "plan": None,
                 "query": None,

--- a/ee/hogai/eval/scorers.py
+++ b/ee/hogai/eval/scorers.py
@@ -7,7 +7,7 @@ from autoevals.ragas import AnswerSimilarity
 from braintrust import Score
 from langchain_core.messages import AIMessage as LangchainAIMessage
 
-from ee.hogai.utils.types import AssistantQuery
+from ee.hogai.utils.types.base import AssistantQueryType
 from posthog.schema import (
     AssistantMessage,
     AssistantToolCall,
@@ -55,7 +55,7 @@ class ToolRelevance(ScorerWithPartial):
 
 class PlanAndQueryOutput(TypedDict, total=False):
     plan: str | None
-    query: AssistantQuery
+    query: AssistantQueryType
     query_generation_retry_count: int | None
 
 

--- a/ee/hogai/eval/scorers.py
+++ b/ee/hogai/eval/scorers.py
@@ -7,13 +7,10 @@ from autoevals.ragas import AnswerSimilarity
 from braintrust import Score
 from langchain_core.messages import AIMessage as LangchainAIMessage
 
+from ee.hogai.utils.types import AssistantQuery
 from posthog.schema import (
-    AssistantFunnelsQuery,
-    AssistantHogQLQuery,
     AssistantMessage,
-    AssistantRetentionQuery,
     AssistantToolCall,
-    AssistantTrendsQuery,
     NodeKind,
 )
 
@@ -58,7 +55,7 @@ class ToolRelevance(ScorerWithPartial):
 
 class PlanAndQueryOutput(TypedDict, total=False):
     plan: str | None
-    query: AssistantTrendsQuery | AssistantFunnelsQuery | AssistantRetentionQuery | AssistantHogQLQuery
+    query: AssistantQuery
     query_generation_retry_count: int | None
 
 

--- a/ee/hogai/eval/scorers.py
+++ b/ee/hogai/eval/scorers.py
@@ -7,7 +7,7 @@ from autoevals.ragas import AnswerSimilarity
 from braintrust import Score
 from langchain_core.messages import AIMessage as LangchainAIMessage
 
-from ee.hogai.utils.types.base import AssistantQueryType
+from ee.hogai.utils.types.base import AnyAssistantGeneratedQuery
 from posthog.schema import (
     AssistantMessage,
     AssistantToolCall,
@@ -55,7 +55,7 @@ class ToolRelevance(ScorerWithPartial):
 
 class PlanAndQueryOutput(TypedDict, total=False):
     plan: str | None
-    query: AssistantQueryType
+    query: AnyAssistantGeneratedQuery
     query_generation_retry_count: int | None
 
 

--- a/ee/hogai/graph/insights/nodes.py
+++ b/ee/hogai/graph/insights/nodes.py
@@ -587,10 +587,10 @@ class InsightSearchNode(AssistantNode):
 
             insight_name = insight.name or insight.derived_name or "Unnamed Insight"
 
-            visualization_message = VisualizationMessage.model_construct(
+            visualization_message = VisualizationMessage(
                 query=f"Existing insight: {insight_name}",
                 plan=f"Showing existing insight: {insight_name}",
-                answer=query_obj,  # type: ignore[arg-type]
+                answer=query_obj,
                 id=str(uuid4()),
             )
 

--- a/ee/hogai/graph/insights/test/test_nodes.py
+++ b/ee/hogai/graph/insights/test/test_nodes.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from unittest.mock import patch, MagicMock, AsyncMock
 from django.utils import timezone
 import asyncio
@@ -7,8 +8,20 @@ from ee.hogai.graph.insights.nodes import InsightSearchNode
 from ee.hogai.utils.types import AssistantState, PartialAssistantState
 from ee.models.assistant import Conversation
 from posthog.models import Insight, InsightViewed
-from posthog.schema import AssistantToolCallMessage, HumanMessage
+from posthog.schema import (
+    AssistantToolCallMessage,
+    DataTableNode,
+    EntityType,
+    HogQLQuery,
+    HumanMessage,
+    InsightVizNode,
+    RetentionEntity,
+    RetentionFilter,
+    RetentionQuery,
+    VisualizationMessage,
+)
 from posthog.test.base import BaseTest
+from posthog.schema import TrendsQuery, FunnelsQuery
 
 
 class TestInsightSearchNode(BaseTest):
@@ -750,3 +763,115 @@ class TestInsightSearchNode(BaseTest):
         self.assertIn(self.insight1.id, result["selected_insights"])
         self.assertIn(self.insight2.id, result["selected_insights"])
         self.assertIn("Found 2 relevant insights", result["explanation"])
+
+    def test_returns_visualization_messag_with_trends_query(self):
+        """Test that VisualizationMessage answer field contains TrendsQuery."""
+
+        # Load insights first
+        self.node._load_insights_page(0)
+
+        # Test the full query processing
+        query_obj1, _ = self.node._process_insight_query(self.insight1)
+        self.assertIsNotNone(query_obj1, f"Query object should not be None for insight1. Query: {self.insight1.query}")
+        self.assertIsInstance(query_obj1, TrendsQuery)
+
+        # Test insight1 visualization message creation
+        viz_message1 = self.node._create_visualization_message_for_insight(self.insight1)
+        assert isinstance(viz_message1, VisualizationMessage), "Should create visualization message for insight1"
+        assert hasattr(viz_message1, "answer"), "VisualizationMessage should have answer attribute"
+
+        # Verify the answer contains the correct query type
+        answer1 = viz_message1.answer
+        self.assertIsInstance(answer1, TrendsQuery, "Answer should be a dictionary")
+
+    def test_returns_visualization_message_with_funnels_query(self):
+        """Test that VisualizationMessage answer field contains FunnelsQuery."""
+
+        # Load insights first
+        self.node._load_insights_page(0)
+
+        query_obj2, _ = self.node._process_insight_query(self.insight2)
+        self.assertIsNotNone(query_obj2, f"Query object should not be None for insight2. Query: {self.insight2.query}")
+        self.assertIsInstance(query_obj2, FunnelsQuery)
+
+        # Test insight2 visualization message creation
+        viz_message2 = self.node._create_visualization_message_for_insight(self.insight2)
+        assert isinstance(viz_message2, VisualizationMessage), "Should create visualization message for insight2"
+        assert hasattr(viz_message2, "answer"), "VisualizationMessage should have answer attribute"
+
+        # Verify the answer contains the correct query type
+        answer2 = viz_message2.answer
+        self.assertIsInstance(answer2, FunnelsQuery, "Answer should be a dictionary")
+
+    def test_returns_visualization_message_with_retention_query(self):
+        """Test that VisualizationMessage answer field contains RetentionQuery."""
+        query = InsightVizNode(
+            source=RetentionQuery(
+                retentionFilter=RetentionFilter(
+                    targetEntity=RetentionEntity(id="$pageview", type=EntityType.EVENTS),
+                    returningEntity=RetentionEntity(id="$pageview", type=EntityType.EVENTS),
+                )
+            )
+        )
+        insight = Insight.objects.create(
+            team=self.team,
+            name="Retention Query",
+            description="Retention Query",
+            query=query.model_dump(),
+            filters={},
+            created_by=self.user,
+        )
+        InsightViewed.objects.create(
+            team=self.team,
+            user=self.user,
+            insight=insight,
+            last_viewed_at=timezone.now() - timedelta(days=1),
+        )
+
+        self.node._load_insights_page(0)
+
+        query_obj, _ = self.node._process_insight_query(insight)
+        self.assertIsNotNone(query_obj, f"Query object should not be None for insight. Query: {insight.query}")
+        self.assertIsInstance(query_obj, RetentionQuery)
+
+        # Test insight visualization message creation
+        viz_message = self.node._create_visualization_message_for_insight(insight)
+        assert isinstance(viz_message, VisualizationMessage), "Should create visualization message for insight"
+        assert hasattr(viz_message, "answer"), "VisualizationMessage should have answer attribute"
+
+        # Verify the answer contains the correct query type
+        answer = viz_message.answer
+        self.assertIsInstance(answer, RetentionQuery, "Answer should be a dictionary")
+
+    def test_returns_visualization_message_with_hogql_query(self):
+        """Test that VisualizationMessage answer field contains HogQLQuery."""
+        query = DataTableNode(source=HogQLQuery(query="SELECT 1"))
+        insight = Insight.objects.create(
+            team=self.team,
+            name="HogQL Query",
+            description="HogQL Query",
+            query=query.model_dump(),
+            filters={},
+            created_by=self.user,
+        )
+        InsightViewed.objects.create(
+            team=self.team,
+            user=self.user,
+            insight=insight,
+            last_viewed_at=timezone.now(),
+        )
+
+        self.node._load_insights_page(0)
+
+        query_obj, _ = self.node._process_insight_query(insight)
+        self.assertIsNotNone(query_obj, f"Query object should not be None for insight. Query: {insight.query}")
+        self.assertIsInstance(query_obj, HogQLQuery)
+
+        # Test insight visualization message creation
+        viz_message = self.node._create_visualization_message_for_insight(insight)
+        assert isinstance(viz_message, VisualizationMessage), "Should create visualization message for insight"
+        assert hasattr(viz_message, "answer"), "VisualizationMessage should have answer attribute"
+
+        # Verify the answer contains the correct query type
+        answer = viz_message.answer
+        self.assertIsInstance(answer, HogQLQuery, "Answer should be a dictionary")

--- a/ee/hogai/graph/insights/test/test_nodes.py
+++ b/ee/hogai/graph/insights/test/test_nodes.py
@@ -764,7 +764,7 @@ class TestInsightSearchNode(BaseTest):
         self.assertIn(self.insight2.id, result["selected_insights"])
         self.assertIn("Found 2 relevant insights", result["explanation"])
 
-    def test_returns_visualization_messag_with_trends_query(self):
+    def test_returns_visualization_message_with_trends_query(self):
         """Test that VisualizationMessage answer field contains TrendsQuery."""
 
         # Load insights first
@@ -782,7 +782,7 @@ class TestInsightSearchNode(BaseTest):
 
         # Verify the answer contains the correct query type
         answer1 = viz_message1.answer
-        self.assertIsInstance(answer1, TrendsQuery, "Answer should be a dictionary")
+        self.assertIsInstance(answer1, TrendsQuery)
 
     def test_returns_visualization_message_with_funnels_query(self):
         """Test that VisualizationMessage answer field contains FunnelsQuery."""
@@ -801,7 +801,7 @@ class TestInsightSearchNode(BaseTest):
 
         # Verify the answer contains the correct query type
         answer2 = viz_message2.answer
-        self.assertIsInstance(answer2, FunnelsQuery, "Answer should be a dictionary")
+        self.assertIsInstance(answer2, FunnelsQuery)
 
     def test_returns_visualization_message_with_retention_query(self):
         """Test that VisualizationMessage answer field contains RetentionQuery."""
@@ -841,7 +841,7 @@ class TestInsightSearchNode(BaseTest):
 
         # Verify the answer contains the correct query type
         answer = viz_message.answer
-        self.assertIsInstance(answer, RetentionQuery, "Answer should be a dictionary")
+        self.assertIsInstance(answer, RetentionQuery)
 
     def test_returns_visualization_message_with_hogql_query(self):
         """Test that VisualizationMessage answer field contains HogQLQuery."""
@@ -874,4 +874,4 @@ class TestInsightSearchNode(BaseTest):
 
         # Verify the answer contains the correct query type
         answer = viz_message.answer
-        self.assertIsInstance(answer, HogQLQuery, "Answer should be a dictionary")
+        self.assertIsInstance(answer, HogQLQuery)

--- a/ee/hogai/utils/types/base.py
+++ b/ee/hogai/utils/types/base.py
@@ -23,8 +23,12 @@ from posthog.schema import (
     FailureMessage,
     HumanMessage,
     ReasoningMessage,
+    TrendsQuery,
     VisualizationMessage,
     NotebookUpdateMessage,
+    RetentionQuery,
+    FunnelsQuery,
+    HogQLQuery,
 )
 
 AIMessageUnion = Union[
@@ -42,7 +46,8 @@ AssistantOutput = (
     | tuple[Literal[AssistantEventType.MESSAGE], AssistantMessageOrStatusUnion]
 )
 
-AssistantQuery = AssistantTrendsQuery | AssistantFunnelsQuery | AssistantRetentionQuery | AssistantHogQLQuery
+AssistantQueryType = AssistantTrendsQuery | AssistantFunnelsQuery | AssistantRetentionQuery | AssistantHogQLQuery
+SupportedAssistantQuery = TrendsQuery | FunnelsQuery | RetentionQuery | HogQLQuery
 
 
 def merge(_: Any | None, right: Any | None) -> Any | None:

--- a/ee/hogai/utils/types/base.py
+++ b/ee/hogai/utils/types/base.py
@@ -46,8 +46,10 @@ AssistantOutput = (
     | tuple[Literal[AssistantEventType.MESSAGE], AssistantMessageOrStatusUnion]
 )
 
-AssistantQueryType = AssistantTrendsQuery | AssistantFunnelsQuery | AssistantRetentionQuery | AssistantHogQLQuery
-SupportedAssistantQuery = TrendsQuery | FunnelsQuery | RetentionQuery | HogQLQuery
+AnyAssistantGeneratedQuery = (
+    AssistantTrendsQuery | AssistantFunnelsQuery | AssistantRetentionQuery | AssistantHogQLQuery
+)
+AnyAssistantSupportedQuery = TrendsQuery | FunnelsQuery | RetentionQuery | HogQLQuery
 
 
 def merge(_: Any | None, right: Any | None) -> Any | None:

--- a/ee/hogai/utils/types/base.py
+++ b/ee/hogai/utils/types/base.py
@@ -13,9 +13,13 @@ from pydantic import BaseModel, Field
 from ee.models import Conversation
 from posthog.schema import (
     AssistantEventType,
+    AssistantFunnelsQuery,
     AssistantGenerationStatusEvent,
+    AssistantHogQLQuery,
     AssistantMessage,
+    AssistantRetentionQuery,
     AssistantToolCallMessage,
+    AssistantTrendsQuery,
     FailureMessage,
     HumanMessage,
     ReasoningMessage,
@@ -37,6 +41,8 @@ AssistantOutput = (
     tuple[Literal[AssistantEventType.CONVERSATION], Conversation]
     | tuple[Literal[AssistantEventType.MESSAGE], AssistantMessageOrStatusUnion]
 )
+
+AssistantQuery = AssistantTrendsQuery | AssistantFunnelsQuery | AssistantRetentionQuery | AssistantHogQLQuery
 
 
 def merge(_: Any | None, right: Any | None) -> Any | None:

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1726,6 +1726,23 @@
                 }
             ]
         },
+        "AssistantQueryType": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/AssistantTrendsQuery"
+                },
+                {
+                    "$ref": "#/definitions/AssistantFunnelsQuery"
+                },
+                {
+                    "$ref": "#/definitions/AssistantRetentionQuery"
+                },
+                {
+                    "$ref": "#/definitions/AssistantHogQLQuery"
+                }
+            ],
+            "description": "The union type with all cleaned queries for the assistant. Only used for generating the schemas with an LLM."
+        },
         "AssistantRetentionActionsNode": {
             "additionalProperties": false,
             "properties": {
@@ -23426,6 +23443,23 @@
             "required": ["questions"],
             "type": "object"
         },
+        "SupportedAssistantQuery": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/TrendsQuery"
+                },
+                {
+                    "$ref": "#/definitions/FunnelsQuery"
+                },
+                {
+                    "$ref": "#/definitions/RetentionQuery"
+                },
+                {
+                    "$ref": "#/definitions/HogQLQuery"
+                }
+            ],
+            "description": "The union type with all supported base queries for the assistant."
+        },
         "SurveyAppearanceSchema": {
             "additionalProperties": false,
             "properties": {
@@ -24610,16 +24644,10 @@
                 "answer": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/AssistantTrendsQuery"
+                            "$ref": "#/definitions/AssistantQueryType"
                         },
                         {
-                            "$ref": "#/definitions/AssistantFunnelsQuery"
-                        },
-                        {
-                            "$ref": "#/definitions/AssistantRetentionQuery"
-                        },
-                        {
-                            "$ref": "#/definitions/AssistantHogQLQuery"
+                            "$ref": "#/definitions/SupportedAssistantQuery"
                         }
                     ]
                 },

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -406,6 +406,40 @@
             "required": ["results"],
             "type": "object"
         },
+        "AnyAssistantGeneratedQuery": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/AssistantTrendsQuery"
+                },
+                {
+                    "$ref": "#/definitions/AssistantFunnelsQuery"
+                },
+                {
+                    "$ref": "#/definitions/AssistantRetentionQuery"
+                },
+                {
+                    "$ref": "#/definitions/AssistantHogQLQuery"
+                }
+            ],
+            "description": "The union type with all cleaned queries for the assistant. Only used for generating the schemas with an LLM."
+        },
+        "AnyAssistantSupportedQuery": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/TrendsQuery"
+                },
+                {
+                    "$ref": "#/definitions/FunnelsQuery"
+                },
+                {
+                    "$ref": "#/definitions/RetentionQuery"
+                },
+                {
+                    "$ref": "#/definitions/HogQLQuery"
+                }
+            ],
+            "description": "The union type with all supported base queries for the assistant."
+        },
         "AnyDataNode": {
             "anyOf": [
                 {
@@ -1725,23 +1759,6 @@
                     "$ref": "#/definitions/AssistantGroupPropertyFilter"
                 }
             ]
-        },
-        "AssistantQueryType": {
-            "anyOf": [
-                {
-                    "$ref": "#/definitions/AssistantTrendsQuery"
-                },
-                {
-                    "$ref": "#/definitions/AssistantFunnelsQuery"
-                },
-                {
-                    "$ref": "#/definitions/AssistantRetentionQuery"
-                },
-                {
-                    "$ref": "#/definitions/AssistantHogQLQuery"
-                }
-            ],
-            "description": "The union type with all cleaned queries for the assistant. Only used for generating the schemas with an LLM."
         },
         "AssistantRetentionActionsNode": {
             "additionalProperties": false,
@@ -23443,23 +23460,6 @@
             "required": ["questions"],
             "type": "object"
         },
-        "SupportedAssistantQuery": {
-            "anyOf": [
-                {
-                    "$ref": "#/definitions/TrendsQuery"
-                },
-                {
-                    "$ref": "#/definitions/FunnelsQuery"
-                },
-                {
-                    "$ref": "#/definitions/RetentionQuery"
-                },
-                {
-                    "$ref": "#/definitions/HogQLQuery"
-                }
-            ],
-            "description": "The union type with all supported base queries for the assistant."
-        },
         "SurveyAppearanceSchema": {
             "additionalProperties": false,
             "properties": {
@@ -24644,10 +24644,10 @@
                 "answer": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/AssistantQueryType"
+                            "$ref": "#/definitions/AnyAssistantGeneratedQuery"
                         },
                         {
-                            "$ref": "#/definitions/SupportedAssistantQuery"
+                            "$ref": "#/definitions/AnyAssistantSupportedQuery"
                         }
                     ]
                 },

--- a/frontend/src/queries/schema/schema-assistant-messages.ts
+++ b/frontend/src/queries/schema/schema-assistant-messages.ts
@@ -7,6 +7,7 @@ import {
     AssistantRetentionQuery,
     AssistantTrendsQuery,
 } from './schema-assistant-queries'
+import { FunnelsQuery, HogQLQuery, RetentionQuery, TrendsQuery } from './schema-general'
 
 // re-export MaxBillingContext to make it available in the schema
 export type { MaxBillingContext }
@@ -84,12 +85,26 @@ export interface ReasoningMessage extends BaseAssistantMessage {
     substeps?: string[]
 }
 
+/**
+ * The union type with all cleaned queries for the assistant. Only used for generating the schemas with an LLM.
+ */
+export type AssistantQueryType =
+    | AssistantTrendsQuery
+    | AssistantFunnelsQuery
+    | AssistantRetentionQuery
+    | AssistantHogQLQuery
+
+/**
+ * The union type with all supported base queries for the assistant.
+ */
+export type SupportedAssistantQuery = TrendsQuery | FunnelsQuery | RetentionQuery | HogQLQuery
+
 export interface VisualizationMessage extends BaseAssistantMessage {
     type: AssistantMessageType.Visualization
     /** @default '' */
     query: string
     plan?: string
-    answer: AssistantTrendsQuery | AssistantFunnelsQuery | AssistantRetentionQuery | AssistantHogQLQuery
+    answer: AssistantQueryType | SupportedAssistantQuery
     initiator?: string
 }
 

--- a/frontend/src/queries/schema/schema-assistant-messages.ts
+++ b/frontend/src/queries/schema/schema-assistant-messages.ts
@@ -88,7 +88,7 @@ export interface ReasoningMessage extends BaseAssistantMessage {
 /**
  * The union type with all cleaned queries for the assistant. Only used for generating the schemas with an LLM.
  */
-export type AssistantQueryType =
+export type AnyAssistantGeneratedQuery =
     | AssistantTrendsQuery
     | AssistantFunnelsQuery
     | AssistantRetentionQuery
@@ -97,14 +97,14 @@ export type AssistantQueryType =
 /**
  * The union type with all supported base queries for the assistant.
  */
-export type SupportedAssistantQuery = TrendsQuery | FunnelsQuery | RetentionQuery | HogQLQuery
+export type AnyAssistantSupportedQuery = TrendsQuery | FunnelsQuery | RetentionQuery | HogQLQuery
 
 export interface VisualizationMessage extends BaseAssistantMessage {
     type: AssistantMessageType.Visualization
     /** @default '' */
     query: string
     plan?: string
-    answer: AssistantQueryType | SupportedAssistantQuery
+    answer: AnyAssistantGeneratedQuery | AnyAssistantSupportedQuery
     initiator?: string
 }
 

--- a/frontend/src/scenes/max/utils.ts
+++ b/frontend/src/scenes/max/utils.ts
@@ -6,20 +6,16 @@ import { humanFriendlyDuration } from 'lib/utils'
 import {
     AssistantMessage,
     AssistantMessageType,
+    AssistantQueryType,
     AssistantToolCallMessage,
     FailureMessage,
     HumanMessage,
     NotebookUpdateMessage,
     ReasoningMessage,
     RootAssistantMessage,
+    SupportedAssistantQuery,
     VisualizationMessage,
 } from '~/queries/schema/schema-assistant-messages'
-import {
-    AssistantFunnelsQuery,
-    AssistantHogQLQuery,
-    AssistantRetentionQuery,
-    AssistantTrendsQuery,
-} from '~/queries/schema/schema-assistant-queries'
 import { FunnelsQuery, HogQLQuery, RetentionQuery, TrendsQuery } from '~/queries/schema/schema-general'
 import { isFunnelsQuery, isHogQLQuery, isRetentionQuery, isTrendsQuery } from '~/queries/utils'
 import { ActionType, DashboardType, EventDefinition, QueryBasedInsightModel, SidePanelTab } from '~/types'
@@ -61,7 +57,7 @@ export function isNotebookUpdateMessage(
 }
 
 export function castAssistantQuery(
-    query: AssistantTrendsQuery | AssistantFunnelsQuery | AssistantRetentionQuery | AssistantHogQLQuery
+    query: AssistantQueryType | SupportedAssistantQuery
 ): TrendsQuery | FunnelsQuery | RetentionQuery | HogQLQuery {
     if (isTrendsQuery(query)) {
         return query

--- a/frontend/src/scenes/max/utils.ts
+++ b/frontend/src/scenes/max/utils.ts
@@ -4,16 +4,16 @@ import { dayjs } from 'lib/dayjs'
 import { humanFriendlyDuration } from 'lib/utils'
 
 import {
+    AnyAssistantGeneratedQuery,
+    AnyAssistantSupportedQuery,
     AssistantMessage,
     AssistantMessageType,
-    AssistantQueryType,
     AssistantToolCallMessage,
     FailureMessage,
     HumanMessage,
     NotebookUpdateMessage,
     ReasoningMessage,
     RootAssistantMessage,
-    SupportedAssistantQuery,
     VisualizationMessage,
 } from '~/queries/schema/schema-assistant-messages'
 import { FunnelsQuery, HogQLQuery, RetentionQuery, TrendsQuery } from '~/queries/schema/schema-general'
@@ -57,7 +57,7 @@ export function isNotebookUpdateMessage(
 }
 
 export function castAssistantQuery(
-    query: AssistantQueryType | SupportedAssistantQuery
+    query: AnyAssistantGeneratedQuery | AnyAssistantSupportedQuery
 ): TrendsQuery | FunnelsQuery | RetentionQuery | HogQLQuery {
     if (isTrendsQuery(query)) {
         return query

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -12732,21 +12732,6 @@ class StickinessActorsQuery(BaseModel):
     version: Optional[float] = Field(default=None, description="version of the node, used for schema migrations")
 
 
-class VisualizationMessage(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    answer: Union[
-        Union[AssistantTrendsQuery, AssistantFunnelsQuery, AssistantRetentionQuery, AssistantHogQLQuery],
-        Union[TrendsQuery, FunnelsQuery, RetentionQuery, HogQLQuery],
-    ]
-    id: Optional[str] = None
-    initiator: Optional[str] = None
-    plan: Optional[str] = None
-    query: Optional[str] = ""
-    type: Literal["ai/viz"] = "ai/viz"
-
-
 class NamedArgs(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -13172,6 +13157,21 @@ class QueryResponseAlternative(
         QueryResponseAlternative69,
         QueryResponseAlternative70,
     ]
+
+
+class VisualizationMessage(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    answer: Union[
+        Union[AssistantTrendsQuery, AssistantFunnelsQuery, AssistantRetentionQuery, AssistantHogQLQuery],
+        Union[TrendsQuery, FunnelsQuery, RetentionQuery, HogQLQuery],
+    ]
+    id: Optional[str] = None
+    initiator: Optional[str] = None
+    plan: Optional[str] = None
+    query: Optional[str] = ""
+    type: Literal["ai/viz"] = "ai/viz"
 
 
 class DatabaseSchemaQueryResponse(BaseModel):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -10543,18 +10543,6 @@ class VectorSearchQueryResponse(BaseModel):
     )
 
 
-class VisualizationMessage(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    answer: Union[AssistantTrendsQuery, AssistantFunnelsQuery, AssistantRetentionQuery, AssistantHogQLQuery]
-    id: Optional[str] = None
-    initiator: Optional[str] = None
-    plan: Optional[str] = None
-    query: Optional[str] = ""
-    type: Literal["ai/viz"] = "ai/viz"
-
-
 class WebAnalyticsExternalSummaryQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -12742,6 +12730,21 @@ class StickinessActorsQuery(BaseModel):
     source: StickinessQuery
     tags: Optional[QueryLogTags] = None
     version: Optional[float] = Field(default=None, description="version of the node, used for schema migrations")
+
+
+class VisualizationMessage(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    answer: Union[
+        Union[AssistantTrendsQuery, AssistantFunnelsQuery, AssistantRetentionQuery, AssistantHogQLQuery],
+        Union[TrendsQuery, FunnelsQuery, RetentionQuery, HogQLQuery],
+    ]
+    id: Optional[str] = None
+    initiator: Optional[str] = None
+    plan: Optional[str] = None
+    query: Optional[str] = ""
+    type: Literal["ai/viz"] = "ai/viz"
 
 
 class NamedArgs(BaseModel):

--- a/products/product_analytics/backend/max_tools.py
+++ b/products/product_analytics/backend/max_tools.py
@@ -8,16 +8,10 @@ from ee.hogai.graph.root.prompts import ROOT_INSIGHT_DESCRIPTION_PROMPT
 from ee.hogai.tool import MaxTool
 from ee.hogai.utils.types import AssistantState
 from posthog.schema import (
-    AssistantFunnelsQuery,
-    AssistantHogQLQuery,
     AssistantMessage,
-    AssistantRetentionQuery,
     AssistantToolCallMessage,
-    AssistantTrendsQuery,
     VisualizationMessage,
 )
-
-QueryResult = AssistantTrendsQuery | AssistantFunnelsQuery | AssistantRetentionQuery | AssistantHogQLQuery
 
 
 class EditCurrentInsightArgs(BaseModel):


### PR DESCRIPTION
## Problem

Fixes [this issue](https://us.posthog.com/project/2/error_tracking/019877ee-06cb-7ea3-b363-f601b3d7c615?timestamp=2025-08-22%2001:54:17.020000-07:00&chat=efda2d7b-e2ce-494b-b5df-85ca2a0af8b3#panel=max). I've tried multiple ways to solve the issue, but having complete and assistant-specific schemas is the most straightforward way.

## Changes

- Added TrendsQuery/FunnelQuery/RetentionQuery/HogQLQuery to VisualizationMessage.

## How did you test this code?

Unit tests & manual testing