### PR TITLE
feat(web-analytics): add web-pre-agg setting to team admin

### DIFF
--- a/posthog/admin/admins/team_admin.py
+++ b/posthog/admin/admins/team_admin.py
@@ -97,6 +97,7 @@ class TeamAdmin(admin.ModelAdmin):
                     "data_attributes",
                     "session_recording_version",
                     "inject_web_apps",
+                    "web_analytics_pre_aggregated_tables_enabled",
                     "extra_settings",
                     "modifiers",
                     "drop_events_older_than",


### PR DESCRIPTION
## Problem

This makes it slightly easier to enable the tables without needing to check the feature flags rollouts.

## Changes

- Add the field to the Django admin team settings.

## How did you test this code?

Checked the local admin

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
