### PR TITLE
chore(web-analytics): lower max partitions per run

### DIFF
--- a/dags/web_preaggregated.py
+++ b/dags/web_preaggregated.py
@@ -28,7 +28,7 @@ from posthog.models.web_preaggregated.sql import (
 )
 
 MAX_PARTITIONS_PER_RUN_ENV_VAR = "DAGSTER_WEB_PREAGGREGATED_MAX_PARTITIONS_PER_RUN"
-max_partitions_per_run = int(os.getenv(MAX_PARTITIONS_PER_RUN_ENV_VAR, 14))
+max_partitions_per_run = int(os.getenv(MAX_PARTITIONS_PER_RUN_ENV_VAR, 1))
 backfill_policy_def = BackfillPolicy.multi_run(max_partitions_per_run=max_partitions_per_run)
 partition_def = DailyPartitionsDefinition(start_date="2024-01-01", end_offset=1)
 


### PR DESCRIPTION
## Problem

Now that we're enabling more teams, we need to be more careful with the total volume of days we put together on a single run. 1 day seems in pair with the new hourly tables. 

## Changes

- Lower the default max_partitions_per_run to 1

## How did you test this code?

Just hoping for the best on this one

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
