### PR TITLE
perf: don't build schema in to_dict

### DIFF
--- a/posthog/schema_helpers.py
+++ b/posthog/schema_helpers.py
@@ -32,10 +32,7 @@ def strip_version_recursive(d):
 
 
 def to_dict(query: BaseModel) -> dict:
-    # Start with the normal Pydantic serialization (this replaces next_serializer(self))
     dumped = query.model_dump(exclude_none=True, exclude_defaults=True)
-
-    # strip version
     dumped = strip_version_recursive(dumped)
 
     ###

--- a/posthog/schema_helpers.py
+++ b/posthog/schema_helpers.py
@@ -1,5 +1,5 @@
-from typing import Any, Literal, get_origin
-from pydantic import BaseModel, ValidationError, model_serializer
+from typing import Literal, get_origin
+from pydantic import BaseModel, ValidationError
 
 from posthog.hogql_queries.insights.utils.utils import series_should_be_set_to_dau
 from posthog.schema import (
@@ -32,110 +32,98 @@ def strip_version_recursive(d):
 
 
 def to_dict(query: BaseModel) -> dict:
-    klass: Any = type(query)
+    # Start with the normal Pydantic serialization (this replaces next_serializer(self))
+    dumped = query.model_dump(exclude_none=True, exclude_defaults=True)
 
-    class ExtendedQuery(klass):
-        @model_serializer(mode="wrap")
-        def serialize_query(self, next_serializer):
-            dumped = next_serializer(self)
+    # strip version
+    dumped = strip_version_recursive(dumped)
 
-            # strip version
-            dumped = strip_version_recursive(dumped)
+    ###
+    # Our schema is generated with `Literal` fields for type, kind, etc. These
+    # are stripped by the `exclude_defaults=True` option, so we add them back in
+    # here.
+    for name, field_info in query.model_fields.items():
+        if get_origin(field_info.annotation) == Literal:
+            dumped[name] = getattr(query, name)
+
+    if isinstance(
+        query,
+        (TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery),
+    ):
+        insightFilterKey = filter_key_for_query(query)
+
+        for name in query.model_fields.keys():
+            if name not in dumped:
+                continue
 
             ###
-            # Our schema is generated with `Literal` fields for type, kind, etc. These
-            # are stripped by the `exclude_defaults=True` option, so we add them back in
-            # here.
-            for name, field_info in self.model_fields.items():
-                if get_origin(field_info.annotation) == Literal:
-                    dumped[name] = getattr(self, name)
+            # Frontend only settings like which graph type is displayed, that don't affect
+            # the generated dataset should be removed.
+            #
+            # Keep this in sync with the frontend side "cleanInsightQuery" function.
+            if name == "series":
+                # remove frontend-only props from series
+                new_series_list = []
+                for dumped_series, series in zip(dumped[name], query.series):
+                    new_series = {key: value for key, value in dumped_series.items() if key != "custom_name"}
+                    if isinstance(query, TrendsQuery) and series_should_be_set_to_dau(query.interval, series):
+                        new_series["math"] = BaseMathType.DAU
+                    new_series_list.append(new_series)
+                dumped["series"] = new_series_list
+            elif name == insightFilterKey:
+                # Remove frontend-only props from insight filters
+                # Keep this in sync with frontend/src/scenes/insights/utils/queryUtils.ts `cleanInsightQuery` method
+                dumped[insightFilterKey] = {
+                    key: value
+                    for key, value in dumped[insightFilterKey].items()
+                    if key
+                    not in [
+                        "showLegend",
+                        "showPercentStackView",
+                        "showValuesOnSeries",
+                        "aggregationAxisFormat",
+                        "aggregationAxisPrefix",
+                        "aggregationAxisPostfix",
+                        "decimalPlaces",
+                        "layout",
+                        "toggledLifecycles",
+                        "showLabelsOnSeries",
+                        "showMean",
+                        "meanRetentionCalculation",
+                        "yAxisScaleType",
+                        "hiddenLegendIndexes",
+                        "hiddenLegendBreakdowns",
+                        "resultCustomizations",
+                        "resultCustomizationBy",
+                        "goalLines",
+                        "dashboardDisplay",
+                        "showConfidenceIntervals",
+                        "confidenceLevel",
+                        "showTrendLines",
+                        "showMovingAverage",
+                        "movingAverageIntervals",
+                    ]
+                }
 
-            if isinstance(
-                self,
-                (TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery),
-            ):
-                insightFilterKey = filter_key_for_query(self)
+                for key in ("targetEntity", "returningEntity"):
+                    if key in dumped[insightFilterKey] and "uuid" in dumped[insightFilterKey][key]:
+                        del dumped[insightFilterKey][key]["uuid"]
 
-                for name in self.model_fields.keys():
-                    if name not in dumped:
-                        continue
+                # use a canonical value for each display category
+                if "display" in dumped[insightFilterKey]:
+                    canonical_display = grouped_chart_display_types(dumped[insightFilterKey]["display"])
+                    if canonical_display == ChartDisplayType.ACTIONS_LINE_GRAPH:
+                        del dumped[insightFilterKey]["display"]  # default value, remove
+                    else:
+                        dumped[insightFilterKey]["display"] = canonical_display
 
-                    ###
-                    # Frontend only settings like which graph type is displayed, that don't affect
-                    # the generated dataset should be removed.
-                    #
-                    # Keep this in sync with the frontend side "cleanInsightQuery" function.
-                    if name == "series":
-                        # remove frontend-only props from series
-                        new_series_list = []
-                        for dumped_series, series in zip(dumped[name], self.series):
-                            new_series = {key: value for key, value in dumped_series.items() if key != "custom_name"}
-                            if isinstance(self, TrendsQuery) and series_should_be_set_to_dau(self.interval, series):
-                                new_series["math"] = BaseMathType.DAU
-                            new_series_list.append(new_series)
-                        dumped["series"] = new_series_list
-                    elif name == insightFilterKey:
-                        # Remove frontend-only props from insight filters
-                        # Keep this in sync with frontend/src/scenes/insights/utils/queryUtils.ts `cleanInsightQuery` method
-                        dumped[insightFilterKey] = {
-                            key: value
-                            for key, value in dumped[insightFilterKey].items()
-                            if key
-                            not in [
-                                "showLegend",
-                                "showPercentStackView",
-                                "showValuesOnSeries",
-                                "aggregationAxisFormat",
-                                "aggregationAxisPrefix",
-                                "aggregationAxisPostfix",
-                                "decimalPlaces",
-                                "layout",
-                                "toggledLifecycles",
-                                "showLabelsOnSeries",
-                                "showMean",
-                                "meanRetentionCalculation",
-                                "yAxisScaleType",
-                                "hiddenLegendIndexes",
-                                "hiddenLegendBreakdowns",
-                                "resultCustomizations",
-                                "resultCustomizationBy",
-                                "goalLines",
-                                "dashboardDisplay",
-                                "showConfidenceIntervals",
-                                "confidenceLevel",
-                                "showTrendLines",
-                                "showMovingAverage",
-                                "movingAverageIntervals",
-                            ]
-                        }
+            ###
+            # Remove empty nested models, so that empty and not existing models serialize to the same json.
+            filterKeys = [insightFilterKey, "breakdownFilter", "dateRange"]
+            if name in filterKeys and len(dumped[name]) == 0:
+                del dumped[name]
 
-                        for key in ("targetEntity", "returningEntity"):
-                            if key in dumped[insightFilterKey] and "uuid" in dumped[insightFilterKey][key]:
-                                del dumped[insightFilterKey][key]["uuid"]
-
-                        # use a canonical value for each display category
-                        if "display" in dumped[insightFilterKey]:
-                            canonical_display = grouped_chart_display_types(dumped[insightFilterKey]["display"])
-                            if canonical_display == ChartDisplayType.ACTIONS_LINE_GRAPH:
-                                del dumped[insightFilterKey]["display"]  # default value, remove
-                            else:
-                                dumped[insightFilterKey]["display"] = canonical_display
-
-                    ###
-                    # Remove empty nested models, so that empty and not existing models serialize to the same json.
-                    filterKeys = [insightFilterKey, "breakdownFilter", "dateRange"]
-                    if name in filterKeys and len(dumped[name]) == 0:
-                        del dumped[name]
-
-            return dumped
-
-    # our schema is generated, so extend the models here
-    query = ExtendedQuery(**query.model_dump())
-
-    # generate a dict from the pydantic model
-    instance_dict = query.model_dump(exclude_none=True, exclude_defaults=True)
-
-    return instance_dict
+    return dumped
 
 
 def filter_key_for_query(node: InsightQueryNode) -> str:

--- a/posthog/schema_helpers.py
+++ b/posthog/schema_helpers.py
@@ -63,13 +63,19 @@ def to_dict(query: BaseModel) -> dict:
             # Keep this in sync with the frontend side "cleanInsightQuery" function.
             if name == "series":
                 # remove frontend-only props from series
-                new_series_list = []
-                for dumped_series, series in zip(dumped[name], query.series):
-                    new_series = {key: value for key, value in dumped_series.items() if key != "custom_name"}
-                    if isinstance(query, TrendsQuery) and series_should_be_set_to_dau(query.interval, series):
-                        new_series["math"] = BaseMathType.DAU
-                    new_series_list.append(new_series)
-                dumped["series"] = new_series_list
+                # Only TrendsQuery, FunnelsQuery, StickinessQuery, and LifecycleQuery have series
+                if hasattr(query, "series"):
+                    new_series_list = []
+                    for dumped_series, series in zip(dumped[name], query.series):
+                        new_series = {key: value for key, value in dumped_series.items() if key != "custom_name"}
+                        if (
+                            isinstance(query, TrendsQuery)
+                            and query.interval is not None
+                            and series_should_be_set_to_dau(query.interval, series)
+                        ):
+                            new_series["math"] = BaseMathType.DAU
+                        new_series_list.append(new_series)
+                    dumped["series"] = new_series_list
             elif name == insightFilterKey:
                 # Remove frontend-only props from insight filters
                 # Keep this in sync with frontend/src/scenes/insights/utils/queryUtils.ts `cleanInsightQuery` method


### PR DESCRIPTION
## Problem
Did some profiling and extending the pydantic schema the way we were doing it was taking a long time. This was the largest cause of slowness for the dashboard api.

## Changes
Just do this manipulation as a dict. We were making the schema just to dump it back to a dict anyways, so simple enough.

Benchmarked it locally and this speeds tile generation by a factor of 3.5x.

I do have another change that switches the DRF serializes out with just creating raw dictionaries which profiles another 2x speed up. I will put that in a different PR and we can consider if that's worth it.

Pasting in Claude's nice table:

● 🎉 INCREDIBLE RESULTS! Complete Performance Comparison:

  | Test                       | Time per Call | Total Time (20 calls) | Speedup vs Baseline | Key Bottlenecks                                      |
  |----------------------------|---------------|-----------------------|---------------------|------------------------------------------------------|
  | BASELINE                   | 1.154s        | 23.1s                 | 1.0x                | Pydantic model construction (13.8s), DRF serializers |
  | to_dict Only               | 0.327s        | 6.5s                  | 🚀 3.5x             | DRF serializers (3.2s), remaining field construction |
  | to_dict + fast_serializers | 0.171s        | 3.4s                  | 🚀 6.7x             | Database queries, minimal serialization overhead     |

  🏆 FINAL PERFORMANCE ACHIEVEMENTS:

  Overall Improvement: 6.7x Faster!

  - From 1.154s → 0.171s per dashboard call
  - From 23.1s → 3.4s for 20 calls
  - 85% reduction in total time

## How did you test this code?
Ran unit tests and tested locally.
