### PR TITLE
chore(propdefs): swap cfg var to source from WRITE_BATCH_SIZE

### DIFF
--- a/rust/property-defs-rs/src/config.rs
+++ b/rust/property-defs-rs/src/config.rs
@@ -104,7 +104,7 @@ pub struct Config {
     pub enable_mirror: bool,
 
     // TODO: rename deploy cfg var to "write_batch_size" and update this after to complete the cutover!
-    #[envconfig(from = "V2_INGEST_BATCH_SIZE", default = "100")]
+    #[envconfig(default = "100")]
     pub write_batch_size: usize,
 }
 


### PR DESCRIPTION
## Problem
Now that we've populated `WRITE_BATCH_SIZE` in deploy cfgs, we can eliminate `V2_INGEST_BATCH_SIZE` dependency in `property-defs-rs` code.

## Changes
Remove cfg var env name alias.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
