### PR TITLE
chore(api): env var for disabling bulk deletes during migration

### DIFF
--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -1,9 +1,8 @@
 from datetime import timedelta
 from functools import cached_property
 from typing import Any, Optional, cast
-from django.conf import settings
-from django.db import transaction
 
+from django.conf import settings
 from django.db import transaction
 from django.shortcuts import get_object_or_404
 

--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -1,6 +1,8 @@
 from datetime import timedelta
 from functools import cached_property
 from typing import Any, Optional, cast
+from django.conf import settings
+from django.db import transaction
 
 from django.db import transaction
 from django.shortcuts import get_object_or_404
@@ -519,6 +521,13 @@ class ProjectViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets
         return project.teams.get(id=project.id)
 
     def perform_destroy(self, project: Project):
+        # Check if bulk deletion operations are disabled via environment variable
+        # Projects contain teams, so we need to block project deletion too
+        if settings.DISABLE_BULK_DELETES:
+            raise exceptions.ValidationError(
+                "Project deletion is temporarily disabled during database migration. Please try again later."
+            )
+
         project_id = project.pk
         organization_id = project.organization_id
         project_name = project.name

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -4,6 +4,7 @@ from functools import cached_property
 from typing import Any, Literal, Optional, cast
 from uuid import UUID
 
+from django.conf import settings
 from django.shortcuts import get_object_or_404
 
 from loginas.utils import is_impersonated_session
@@ -762,6 +763,12 @@ class TeamViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.Mo
         return self.get_object()
 
     def perform_destroy(self, team: Team):
+        # Check if bulk deletion operations are disabled via environment variable
+        if settings.DISABLE_BULK_DELETES:
+            raise exceptions.ValidationError(
+                "Team deletion is temporarily disabled during database migration. Please try again later."
+            )
+
         team_id = team.pk
         organization_id = team.organization_id
         team_name = team.name

--- a/posthog/api/test/test_bulk_deletion_disabled.py
+++ b/posthog/api/test/test_bulk_deletion_disabled.py
@@ -1,0 +1,66 @@
+"""Test that bulk deletion operations can be disabled via environment variable."""
+
+from unittest.mock import patch
+
+from rest_framework import status
+
+from posthog.models import Team, Organization
+from posthog.models.project import Project
+from posthog.test.base import APIBaseTest
+
+
+class TestBulkDeletionDisabled(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        # Create additional team for testing
+        self.additional_team = Team.objects.create(organization=self.organization, name="Test Team for Deletion")
+
+    @patch("posthog.api.team.settings.DISABLE_BULK_DELETES", True)
+    def test_team_deletion_disabled(self):
+        """Test that team deletion returns 400 when DISABLE_BULK_DELETES is True."""
+        response = self.client.delete(f"/api/environments/{self.additional_team.id}/")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("temporarily disabled", response.json()["detail"])
+
+        # Verify team still exists
+        self.assertTrue(Team.objects.filter(id=self.additional_team.id).exists())
+
+    @patch("posthog.api.team.settings.DISABLE_BULK_DELETES", False)
+    def test_team_deletion_enabled(self):
+        """Test that team deletion works when DISABLE_BULK_DELETES is False."""
+        response = self.client.delete(f"/api/environments/{self.additional_team.id}/")
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Verify team is deleted
+        self.assertFalse(Team.objects.filter(id=self.additional_team.id).exists())
+
+    @patch("posthog.api.project.settings.DISABLE_BULK_DELETES", True)
+    def test_project_deletion_disabled(self):
+        """Test that project deletion returns 400 when DISABLE_BULK_DELETES is True."""
+        # Create a test project
+        test_project = Project.objects.create(organization=self.organization, name="Test Project for Deletion")
+
+        response = self.client.delete(f"/api/projects/{test_project.id}/")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("temporarily disabled", response.json()["detail"])
+
+        # Verify project still exists
+        self.assertTrue(Project.objects.filter(id=test_project.id).exists())
+
+    @patch("posthog.api.organization.settings.DISABLE_BULK_DELETES", True)
+    def test_organization_deletion_disabled(self):
+        """Test that organization deletion returns 400 when DISABLE_BULK_DELETES is True."""
+        # Create a test organization
+        test_org = Organization.objects.create(name="Test Org for Deletion")
+        self.organization_membership = test_org.add_user(self.user, level=15)
+
+        response = self.client.delete(f"/api/organizations/{test_org.id}/")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("temporarily disabled", response.json()["detail"])
+
+        # Verify organization still exists
+        self.assertTrue(Organization.objects.filter(id=test_org.id).exists())

--- a/posthog/api/test/test_bulk_deletion_disabled.py
+++ b/posthog/api/test/test_bulk_deletion_disabled.py
@@ -42,6 +42,10 @@ class TestBulkDeletionDisabled(APIBaseTest):
     @patch("posthog.api.project.settings.DISABLE_BULK_DELETES", True)
     def test_project_deletion_disabled(self):
         """Test that project deletion returns 400 when DISABLE_BULK_DELETES is True."""
+        # Set user as org admin first to ensure proper permissions
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+
         project_id = Team.objects.increment_id_sequence()
         test_project = Project.objects.create(
             id=project_id, organization=self.organization, name="Test Project for Deletion"

--- a/posthog/api/test/test_bulk_deletion_disabled.py
+++ b/posthog/api/test/test_bulk_deletion_disabled.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from rest_framework import status
 
-from posthog.models import Team, Organization
+from posthog.models import Team, Organization, OrganizationMembership
 from posthog.models.project import Project
 from posthog.test.base import APIBaseTest
 
@@ -12,55 +12,56 @@ from posthog.test.base import APIBaseTest
 class TestBulkDeletionDisabled(APIBaseTest):
     def setUp(self):
         super().setUp()
-        # Create additional team for testing
         self.additional_team = Team.objects.create(organization=self.organization, name="Test Team for Deletion")
 
     @patch("posthog.api.team.settings.DISABLE_BULK_DELETES", True)
     def test_team_deletion_disabled(self):
         """Test that team deletion returns 400 when DISABLE_BULK_DELETES is True."""
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+
         response = self.client.delete(f"/api/environments/{self.additional_team.id}/")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("temporarily disabled", response.json()["detail"])
 
-        # Verify team still exists
         self.assertTrue(Team.objects.filter(id=self.additional_team.id).exists())
 
     @patch("posthog.api.team.settings.DISABLE_BULK_DELETES", False)
     def test_team_deletion_enabled(self):
         """Test that team deletion works when DISABLE_BULK_DELETES is False."""
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+
         response = self.client.delete(f"/api/environments/{self.additional_team.id}/")
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
-        # Verify team is deleted
         self.assertFalse(Team.objects.filter(id=self.additional_team.id).exists())
 
     @patch("posthog.api.project.settings.DISABLE_BULK_DELETES", True)
     def test_project_deletion_disabled(self):
         """Test that project deletion returns 400 when DISABLE_BULK_DELETES is True."""
-        # Create a test project
-        test_project = Project.objects.create(organization=self.organization, name="Test Project for Deletion")
+        project_id = Team.objects.increment_id_sequence()
+        test_project = Project.objects.create(
+            id=project_id, organization=self.organization, name="Test Project for Deletion"
+        )
 
         response = self.client.delete(f"/api/projects/{test_project.id}/")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("temporarily disabled", response.json()["detail"])
 
-        # Verify project still exists
         self.assertTrue(Project.objects.filter(id=test_project.id).exists())
 
     @patch("posthog.api.organization.settings.DISABLE_BULK_DELETES", True)
     def test_organization_deletion_disabled(self):
         """Test that organization deletion returns 400 when DISABLE_BULK_DELETES is True."""
-        # Create a test organization
-        test_org = Organization.objects.create(name="Test Org for Deletion")
-        self.organization_membership = test_org.add_user(self.user, level=15)
+        test_org, org_membership, _ = Organization.objects.bootstrap(self.user, name="Test Org for Deletion")
 
         response = self.client.delete(f"/api/organizations/{test_org.id}/")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("temporarily disabled", response.json()["detail"])
 
-        # Verify organization still exists
         self.assertTrue(Organization.objects.filter(id=test_org.id).exists())

--- a/posthog/api/test/test_bulk_deletion_disabled.py
+++ b/posthog/api/test/test_bulk_deletion_disabled.py
@@ -1,12 +1,12 @@
 """Test that bulk deletion operations can be disabled via environment variable."""
 
+from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
 from rest_framework import status
 
-from posthog.models import Team, Organization, OrganizationMembership
+from posthog.models import Organization, OrganizationMembership, Team
 from posthog.models.project import Project
-from posthog.test.base import APIBaseTest
 
 
 class TestBulkDeletionDisabled(APIBaseTest):
@@ -45,6 +45,10 @@ class TestBulkDeletionDisabled(APIBaseTest):
         project_id = Team.objects.increment_id_sequence()
         test_project = Project.objects.create(
             id=project_id, organization=self.organization, name="Test Project for Deletion"
+        )
+        # Create the associated Team with the same ID so the user has permission to access the project
+        Team.objects.create(
+            id=project_id, project=test_project, organization=self.organization, name="Test Team for Deletion"
         )
 
         response = self.client.delete(f"/api/projects/{test_project.id}/")

--- a/posthog/settings/base_variables.py
+++ b/posthog/settings/base_variables.py
@@ -38,6 +38,9 @@ if E2E_TESTING:
 IS_COLLECT_STATIC = len(sys.argv) > 1 and sys.argv[1] == "collectstatic"
 SERVER_GATEWAY_INTERFACE = get_from_env("SERVER_GATEWAY_INTERFACE", "WSGI", type_cast=str)
 
+# Bulk deletion operations can be disabled during database migrations
+DISABLE_BULK_DELETES: bool = get_from_env("DISABLE_BULK_DELETES", False, type_cast=str_to_bool)
+
 if DEBUG and not TEST:
     logger.warning(
         [


### PR DESCRIPTION
## Problem

When we migrate tables out of the default database and into Persons we would like to be able to disable the bulk delete functionality. This functionality makes writes to the database that we won't be able to replicate to the DB we are migrating to, after we've turned the migration job off and are testing out dual write capability in the ingestion side.

## Changes

Adds an env var that will disable the delete endpoint for Teams, Projects and Organizations

## How did you test this code?

API unit tests were written to test this code

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
