### PR TITLE
fix(actions): Add missing route to manifest for duplicate action

### DIFF
--- a/products/actions/manifest.tsx
+++ b/products/actions/manifest.tsx
@@ -42,6 +42,7 @@ export const manifest: ProductManifest = {
         '/data-management/actions': ['Actions', 'actions'],
         '/data-management/actions/new': ['ActionNew', 'actionNew'],
         '/data-management/actions/:id': ['Action', 'action'],
+        '/data-management/actions/new/': ['ActionNew', 'actionNew'],
     },
     fileSystemTypes: {
         action: {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
Closes #37058

## Changes

The route for `duplicateAction` is `/data-management/actions/new/`, which will lead to 404 because its different from `/data-management/actions/new`.


https://github.com/user-attachments/assets/7408cc42-e787-4bec-9156-7898bb88b1ac



## How did you test this code?

Locally:
1) Go to http://localhost:8010/project/1/data-management/actions
2) Duplicate an action by clicking on the side menu of an action (create an action if you don't have 1)
3) It should route you to a creation page with the existing action info and not 404

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
