### PR TITLE
fix(ux): key tabs in sessionStorage by team id

### DIFF
--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -8,6 +8,7 @@ import { commandBarLogic } from 'lib/components/CommandBar/commandBarLogic'
 import { BarStatus } from 'lib/components/CommandBar/types'
 import { TeamMembershipLevel } from 'lib/constants'
 import { getRelativeNextPath, identifierToHuman } from 'lib/utils'
+import { getCurrentTeamIdOrNone } from 'lib/utils/getAppContext'
 import { addProjectIdIfMissing, removeProjectIdIfPresent } from 'lib/utils/router-utils'
 import { withForwardedSearchParams } from 'lib/utils/sceneLogicUtils'
 import {
@@ -43,10 +44,12 @@ import { userLogic } from './userLogic'
 
 const TAB_STATE_KEY = 'scene-tabs-state'
 const persistTabs = (tabs: SceneTab[]): void => {
-    sessionStorage.setItem(TAB_STATE_KEY, JSON.stringify(tabs))
+    const teamId = getCurrentTeamIdOrNone()
+    sessionStorage.setItem(`${TAB_STATE_KEY}-${teamId}`, JSON.stringify(tabs))
 }
-const getPersistedTabs: () => SceneTab[] | null = () => {
-    const savedTabs = sessionStorage.getItem(TAB_STATE_KEY)
+const getPersistedTabs: (teamId: number) => SceneTab[] | null = () => {
+    const teamId = getCurrentTeamIdOrNone()
+    const savedTabs = sessionStorage.getItem(`${TAB_STATE_KEY}-${teamId}`)
     if (savedTabs) {
         try {
             return JSON.parse(savedTabs)

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -47,7 +47,7 @@ const persistTabs = (tabs: SceneTab[]): void => {
     const teamId = getCurrentTeamIdOrNone()
     sessionStorage.setItem(`${TAB_STATE_KEY}-${teamId}`, JSON.stringify(tabs))
 }
-const getPersistedTabs: (teamId: number) => SceneTab[] | null = () => {
+const getPersistedTabs: () => SceneTab[] | null = () => {
     const teamId = getCurrentTeamIdOrNone()
     const savedTabs = sessionStorage.getItem(`${TAB_STATE_KEY}-${teamId}`)
     if (savedTabs) {


### PR DESCRIPTION
## Problem

[Tabs persist across projects](https://posthog.slack.com/archives/C08499A7REU/p1755885505211309).

## Changes

Key them by the project ID

## How did you test this code?

Nothing blew up when clicking around locally. Tabs were split by project.

![2025-08-25 10 42 59](https://github.com/user-attachments/assets/7eb9162c-1eea-45e2-b933-4c5f8ff4aa9d)
