### PR TITLE
feat(ux): open in posthog tab in project tree

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -6,12 +6,14 @@ import { IconCheckbox, IconChevronRight, IconExternal, IconFolderPlus, IconPlusS
 
 import { moveToLogic } from 'lib/components/FileSystem/MoveTo/moveToLogic'
 import { ResizableElement } from 'lib/components/ResizeElement/ResizeElement'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { LemonTree, LemonTreeRef, LemonTreeSize, TreeDataItem } from 'lib/lemon-ui/LemonTree/LemonTree'
 import { TreeNodeDisplayIcon } from 'lib/lemon-ui/LemonTree/LemonTreeUtils'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture/ProfilePicture'
 import { Tooltip } from 'lib/lemon-ui/Tooltip/Tooltip'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import {
     ContextMenuGroup,
@@ -126,7 +128,9 @@ export function ProjectTree({
     const treeRef = useRef<LemonTreeRef>(null)
     const { projectTreeMode } = useValues(projectTreeLogic({ key: PROJECT_TREE_KEY }))
     const { setProjectTreeMode } = useActions(projectTreeLogic({ key: PROJECT_TREE_KEY }))
+    const { featureFlags } = useValues(featureFlagLogic)
 
+    const canOpenInPostHogTab = !!featureFlags[FEATURE_FLAGS.SCENE_TABS]
     const showFilterDropdown = root === 'project://'
     const showSortDropdown = root === 'project://'
 
@@ -255,7 +259,12 @@ export function ProjectTree({
 
                 {item.record?.path && item.record?.type !== 'folder' && item.record?.href ? (
                     <>
-                        <BrowserLikeMenuItems href={item.record?.href} MenuItem={MenuItem} />
+                        <BrowserLikeMenuItems
+                            href={item.record?.href}
+                            MenuItem={MenuItem}
+                            canOpenInPostHogTab={canOpenInPostHogTab}
+                            resetPanelLayout={resetPanelLayout}
+                        />
                         <MenuSeparator />
                     </>
                 ) : null}

--- a/frontend/src/layout/panel-layout/ProjectTree/menus/BrowserLikeMenuItems.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/menus/BrowserLikeMenuItems.tsx
@@ -1,15 +1,36 @@
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { DropdownMenuItem } from 'lib/ui/DropdownMenu/DropdownMenu'
+import { sceneLogic } from 'scenes/sceneLogic'
 
 import { CustomMenuProps } from '../types'
 
 interface BrowserLikeMenuProps extends CustomMenuProps {
     href: string
+    canOpenInPostHogTab: boolean
+    resetPanelLayout: (animate: boolean) => void
 }
 
-export function BrowserLikeMenuItems({ MenuItem = DropdownMenuItem, href }: BrowserLikeMenuProps): JSX.Element {
+export function BrowserLikeMenuItems({
+    MenuItem = DropdownMenuItem,
+    href,
+    canOpenInPostHogTab,
+    resetPanelLayout,
+}: BrowserLikeMenuProps): JSX.Element {
     return (
         <>
+            {canOpenInPostHogTab ? (
+                <MenuItem
+                    asChild
+                    onClick={(e) => {
+                        e.stopPropagation()
+                        sceneLogic.findMounted()?.actions.newTab(href)
+                        resetPanelLayout(false)
+                    }}
+                    data-attr="tree-item-menu-open-link-button"
+                >
+                    <ButtonPrimitive menuItem>Open link in new PostHog tab</ButtonPrimitive>
+                </MenuItem>
+            ) : null}
             <MenuItem
                 asChild
                 onClick={(e) => {
@@ -18,7 +39,7 @@ export function BrowserLikeMenuItems({ MenuItem = DropdownMenuItem, href }: Brow
                 }}
                 data-attr="tree-item-menu-open-link-button"
             >
-                <ButtonPrimitive menuItem>Open link in new tab</ButtonPrimitive>
+                <ButtonPrimitive menuItem>Open link in new {canOpenInPostHogTab ? 'browser ' : ''}tab</ButtonPrimitive>
             </MenuItem>
             <MenuItem
                 asChild

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -168,7 +168,7 @@ export const sceneLogic = kea<sceneLogicType>([
         setLoadedSceneLogic: (logic: BuiltLogic) => ({ logic }),
         reloadBrowserDueToImportError: true,
 
-        newTab: true,
+        newTab: (href?: string | null) => ({ href }),
         setTabs: (tabs: SceneTab[]) => ({ tabs }),
         removeTab: (tab: SceneTab) => ({ tab }),
         activateTab: (tab: SceneTab) => ({ tab }),
@@ -183,15 +183,16 @@ export const sceneLogic = kea<sceneLogicType>([
             [] as SceneTab[],
             {
                 setTabs: (_, { tabs }) => tabs,
-                newTab: (state) => {
+                newTab: (state, { href }) => {
+                    const { pathname, search, hash } = combineUrl(href || '/new')
                     return [
                         ...state.map((tab) => (tab.active ? { ...tab, active: false } : tab)),
                         {
                             id: generateTabId(),
                             active: true,
-                            pathname: addProjectIdIfMissing('/new'),
-                            search: '',
-                            hash: '',
+                            pathname: addProjectIdIfMissing(pathname),
+                            search,
+                            hash,
                             title: 'New tab',
                         },
                     ]
@@ -488,9 +489,9 @@ export const sceneLogic = kea<sceneLogicType>([
         ],
     }),
     listeners(({ values, actions, cache, props, selectors }) => ({
-        newTab: () => {
+        newTab: ({ href }) => {
             persistTabs(values.tabs)
-            router.actions.push(urls.newTab())
+            router.actions.push(href || urls.newTab())
         },
         setTabs: () => persistTabs(values.tabs),
         activateTab: () => persistTabs(values.tabs),


### PR DESCRIPTION
## Problem

Project tree items couldn't be opened in a new tab easily.

## Changes

![2025-08-25 10 59 55](https://github.com/user-attachments/assets/8c666910-599e-4c0d-b75c-7f0c31163bc0)

There's no change if the tabs feature flag is disabled.

## How did you test this code?

Clicked around