### PR TITLE
fix: close filters if in collections

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/playlistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/playlistLogic.ts
@@ -43,6 +43,9 @@ export const playlistLogic = kea<playlistLogicType>([
                 actions.setIsFiltersExpanded(true)
             }
         },
+        [urls.replay(ReplayTabs.Playlists)]: () => {
+            actions.setIsFiltersExpanded(false)
+        },
     })),
     actionToUrl(({ values }) => ({
         setIsFiltersExpanded: () => {


### PR DESCRIPTION
## Problem

If Filters were open on the Home page they stay open if you open a collection.

### Before
<img width="1682" height="862" alt="Screenshot 2025-08-25 at 13 49 33" src="https://github.com/user-attachments/assets/512d2cf5-72f7-4319-9ace-e3dfb5572599" />


### After
![ezgif-88cdd02ba720cc](https://github.com/user-attachments/assets/eb9b94f7-6f6c-4c15-97c1-22f0a9fc44f6)

