### PR TITLE
feat: make ai convo header toggle content

### DIFF
--- a/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
+++ b/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
@@ -483,7 +483,18 @@ export const LLMMessageDisplay = React.memo(
                 )}
             >
                 {!minimal && (
-                    <div className="flex items-center gap-1 w-full px-2 h-6 text-xs font-medium">
+                    <div
+                        className={clsx(
+                            'flex items-center gap-1 w-full px-2 h-6 text-xs font-medium select-none',
+                            onToggle && 'cursor-pointer'
+                        )}
+                        onClick={(e) => {
+                            const clickedButton = (e.target as Element).closest('button')
+                            if (!clickedButton) {
+                                onToggle?.()
+                            }
+                        }}
+                    >
                         <span className="grow">{role}</span>
                         {(content || Object.keys(additionalKwargsEntries).length > 0) && (
                             <>


### PR DESCRIPTION
The expected behaviour would be that clicking on the message header toggles the message visibility, but currently has no effect. Not sure about the design system yet, so don't know how/if we should style the header on hover.

Also didn't find any tests for this file, I take it it's because it's a relatively simple presentational component, or did I miss them somewhere else?

![header-collapse](https://github.com/user-attachments/assets/a2d961c9-bb4b-4d80-b825-e223eff66df5)
