### PR TITLE
feat(pg): Add groups and grouptypemappings tables to PersonDBRouter

### DIFF
--- a/posthog/person_db_router.py
+++ b/posthog/person_db_router.py
@@ -16,6 +16,8 @@ class PersonDBRouter:
         "flatpersonoverride",  # Assuming app_label 'posthog'
         "featureflaghashkeyoverride",  # Assuming app_label 'posthog'
         "cohortpeople",  # Assuming app_label 'posthog'
+        "groups",  # Assuming app_label 'posthog'
+        "grouptypemapping",  # Assuming app_label 'posthog'
     }
     PERSONS_APP_LABEL = "posthog"  # Assuming all models are in the 'posthog' app
 
@@ -44,11 +46,11 @@ class PersonDBRouter:
         by default, as Django doesn't support cross-database relations natively.
         You might need to adjust this based on specific foreign keys (e.g., Person -> Team).
         """
-        obj1_in_persons_db = (
-            obj1._meta.app_label == self.PERSONS_APP_LABEL and obj1._meta.model_name in self.PERSONS_DB_MODELS
+        obj1_in_persons_db = obj1._meta.app_label == self.PERSONS_APP_LABEL and self.is_persons_model(
+            obj1._meta.model_name
         )
-        obj2_in_persons_db = (
-            obj2._meta.app_label == self.PERSONS_APP_LABEL and obj2._meta.model_name in self.PERSONS_DB_MODELS
+        obj2_in_persons_db = obj2._meta.app_label == self.PERSONS_APP_LABEL and self.is_persons_model(
+            obj2._meta.model_name
         )
 
         if obj1_in_persons_db and obj2_in_persons_db:


### PR DESCRIPTION
## Problem
The `posthog_groups` and `posthog_grouptypemappings` tables will also need to be migrated as part of the Persons DB cutover.

## Changes
* Add the tables to the `PersonDBRouter`
* Related updates to query and test code

## How did you test this code?
Local dev + CI

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
