### PR TITLE
fix(insights): save to last selected folder

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -12,6 +12,7 @@ import { LemonTreeSelectMode, TreeDataItem, TreeMode, TreeTableViewKeys } from '
 import { urls } from 'scenes/urls'
 
 import { breadcrumbsLogic } from '~/layout/navigation/Breadcrumbs/breadcrumbsLogic'
+import { PROJECT_TREE_KEY } from '~/layout/panel-layout/ProjectTree/ProjectTree'
 import { PAGINATION_LIMIT, projectTreeDataLogic } from '~/layout/panel-layout/ProjectTree/projectTreeDataLogic'
 import { FileSystemEntry } from '~/queries/schema/schema-general'
 import { ProjectTreeRef } from '~/types'
@@ -1235,5 +1236,5 @@ export function deleteFromTree(type: string, ref: string): void {
 }
 
 export function getLastNewFolder(): string | undefined {
-    return projectTreeLogic.findMounted()?.values.lastNewFolder ?? undefined
+    return projectTreeLogic.findMounted({ key: PROJECT_TREE_KEY })?.values.lastNewFolder ?? undefined
 }

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -67,6 +67,7 @@ import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
 import { breadcrumbsLogic } from '~/layout/navigation/Breadcrumbs/breadcrumbsLogic'
+import { getLastNewFolder } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
 import {
     ScenePanel,
     ScenePanelActions,
@@ -285,7 +286,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                 saveInsight={(redirectToViewMode) =>
                                     insight.short_id
                                         ? saveInsight(redirectToViewMode)
-                                        : saveInsight(redirectToViewMode, 'Unfiled/Insights')
+                                        : saveInsight(redirectToViewMode, getLastNewFolder() ?? 'Unfiled/Insights')
                                 }
                                 isSaved={hasDashboardItemId}
                                 addingToDashboard={!!insight.dashboards?.length && !insight.id}


### PR DESCRIPTION
## Problem

Saving a new insight to a folder would still save it under "Unfiled/Insights":

<img width="715" height="733" alt="image" src="https://github.com/user-attachments/assets/e7aa9332-3796-4d7d-bd8b-9baafad1663c" />

## Changes

Fix the bug

## How did you test this code?

Locally insights started appearing in the folder I selected.