### PR TITLE
fix(sql editor): Keep variables that are unused when we run a query

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -1034,11 +1034,6 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
             const newSource = {
                 ...values.sourceQuery.source,
                 query,
-                variables: Object.fromEntries(
-                    Object.entries(values.sourceQuery.source.variables ?? {}).filter(([_, variable]) =>
-                        query.includes(`variables.${variable.code_name}`)
-                    )
-                ),
             }
 
             actions.setSourceQuery({


### PR DESCRIPTION
## Problem

Related to https://github.com/PostHog/posthog/issues/36504 and https://github.com/PostHog/posthog/issues/37065

Doesn't solve both of the issues completely, but I realised that the users are confused when their variables disappear.

When the run button is clicked, a new source is created and currently we are filtering out variables that are not in the query.

## Changes

When the run button is clicked, we don't want to filter out the variables.

https://github.com/user-attachments/assets/105a749d-b840-44ec-a0c1-8942c85901d0

### Reviewer Notes
It might be a concern that we are sending extra variables to the backend. (I have not looked into this yet)

## How did you test this code?

Locally:
1) Go to http://localhost:8010/project/1/sql
2) Click on the variable tab
3) Create a query variable if you have not
4) Add the query variable to your query
5) In the query editor, paste `SELECT * FROM events`
6) Your query variable should not be removed

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
