### PR TITLE
feat: added CH migration to read retention period from Kafka and stor…

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/retention/retention-aware-batch-writer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/retention/retention-aware-batch-writer.ts
@@ -5,7 +5,7 @@ import { S3SessionBatchFileStorage } from '../sessions/s3-session-batch-writer'
 import {
     SessionBatchFileStorage,
     SessionBatchFileWriter,
-    SessionData,
+    WriteSessionData,
     WriteSessionResult,
 } from '../sessions/session-batch-file-storage'
 import { RetentionPeriod } from '../types'
@@ -27,7 +27,7 @@ class RetentionAwareBatchFileWriter implements SessionBatchFileWriter {
         )
     }
 
-    public async writeSession(sessionData: SessionData): Promise<WriteSessionResult> {
+    public async writeSession(sessionData: WriteSessionData): Promise<WriteSessionResult> {
         const retentionPeriod = await this.retentionService.getSessionRetention(
             sessionData.teamId,
             sessionData.sessionId
@@ -41,7 +41,13 @@ class RetentionAwareBatchFileWriter implements SessionBatchFileWriter {
             this.writerMap[retentionPeriod] = writer
         }
 
-        return writer.writeSession(sessionData)
+        const { bytesWritten, url } = await writer.writeSession(sessionData)
+
+        return {
+            bytesWritten,
+            url,
+            retentionPeriod,
+        }
     }
 
     public async finish(): Promise<void> {

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/blackhole-session-batch-writer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/blackhole-session-batch-writer.ts
@@ -2,16 +2,17 @@ import { logger } from '../../../../utils/logger'
 import {
     SessionBatchFileStorage,
     SessionBatchFileWriter,
-    SessionData,
+    WriteSessionData,
     WriteSessionResult,
 } from './session-batch-file-storage'
 
 class BlackholeBatchFileWriter implements SessionBatchFileWriter {
-    public writeSession(sessionData: SessionData): Promise<WriteSessionResult> {
+    public writeSession(sessionData: WriteSessionData): Promise<WriteSessionResult> {
         logger.debug('🔁', 'blackhole_writer_writing_session', { bytes: sessionData.buffer.length })
         return Promise.resolve({
             bytesWritten: sessionData.buffer.length,
             url: null,
+            retentionPeriod: null,
         })
     }
 

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/s3-session-batch-writer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/s3-session-batch-writer.ts
@@ -8,7 +8,7 @@ import { SessionBatchMetrics } from './metrics'
 import {
     SessionBatchFileStorage,
     SessionBatchFileWriter,
-    SessionData,
+    WriteSessionData,
     WriteSessionResult,
 } from './session-batch-file-storage'
 
@@ -107,7 +107,7 @@ class S3SessionBatchFileWriter implements SessionBatchFileWriter {
         })
     }
 
-    public async writeSession(sessionData: SessionData): Promise<WriteSessionResult> {
+    public async writeSession(sessionData: WriteSessionData): Promise<WriteSessionResult> {
         return await this.withErrorBarrier(async () => {
             const buffer = sessionData.buffer
             const startOffset = this.currentOffset
@@ -125,6 +125,7 @@ class S3SessionBatchFileWriter implements SessionBatchFileWriter {
             return {
                 bytesWritten: buffer.length,
                 url: `s3://${this.bucket}/${this.key}?range=bytes=${startOffset}-${this.currentOffset - 1}`,
+                retentionPeriod: null,
             }
         })
     }

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-file-format.integration.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-file-format.integration.test.ts
@@ -29,7 +29,7 @@ import snappy from 'snappy'
 import { parseJSON } from '../../../../utils/json-parse'
 import { KafkaOffsetManager } from '../kafka/offset-manager'
 import { MessageWithTeam } from '../teams/types'
-import { SessionBatchFileStorage, SessionBatchFileWriter, SessionData } from './session-batch-file-storage'
+import { SessionBatchFileStorage, SessionBatchFileWriter, WriteSessionData } from './session-batch-file-storage'
 import { SessionBatchRecorder } from './session-batch-recorder'
 import { SessionBlockMetadata } from './session-block-metadata'
 import { SessionConsoleLogStore } from './session-console-log-store'
@@ -56,7 +56,7 @@ describe('session recording integration', () => {
         batchBuffer = new Uint8Array()
 
         mockWriter = {
-            writeSession: jest.fn().mockImplementation(async (sessionData: SessionData) => {
+            writeSession: jest.fn().mockImplementation(async (sessionData: WriteSessionData) => {
                 const buffer = sessionData.buffer
                 const startOffset = currentOffset
                 const newBuffer = new Uint8Array(batchBuffer.length + buffer.length)
@@ -67,6 +67,7 @@ describe('session recording integration', () => {
                 return Promise.resolve({
                     bytesWritten: buffer.length,
                     url: `test-url?range=bytes=${startOffset}-${currentOffset - 1}`,
+                    retentionPeriod: null,
                 })
             }),
             finish: jest.fn().mockResolvedValue(undefined),

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-file-storage.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-file-storage.ts
@@ -1,6 +1,7 @@
 import { TeamId } from '../../../../types'
+import { RetentionPeriod } from '../types'
 
-export interface SessionData {
+export interface WriteSessionData {
     /** The serialized session block data */
     buffer: Buffer
 
@@ -14,6 +15,8 @@ export interface WriteSessionResult {
     bytesWritten: number
     /** URL to access this session block, if available */
     url: string | null
+    /** Retention period for this block, if available */
+    retentionPeriod: RetentionPeriod | null
 }
 
 /**
@@ -28,7 +31,7 @@ export interface SessionBatchFileWriter {
      * @returns Promise that resolves with the number of bytes written and URL for the block
      * @throws If there is an error writing the data
      */
-    writeSession(data: SessionData): Promise<WriteSessionResult>
+    writeSession(data: WriteSessionData): Promise<WriteSessionResult>
 
     /**
      * Completes the writing process for the entire batch

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.ts
@@ -211,7 +211,7 @@ export class SessionBatchRecorder {
 
                     const { consoleLogCount, consoleWarnCount, consoleErrorCount } = consoleLogRecorder.end()
 
-                    const { bytesWritten, url } = await writer.writeSession({
+                    const { bytesWritten, url, retentionPeriod } = await writer.writeSession({
                         buffer,
                         teamId: sessionBlockRecorder.teamId,
                         sessionId: sessionBlockRecorder.sessionId,
@@ -240,6 +240,7 @@ export class SessionBatchRecorder {
                         snapshotLibrary,
                         batchId,
                         eventCount,
+                        retentionPeriod,
                     })
 
                     totalEvents += eventCount

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-block-metadata.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-block-metadata.ts
@@ -45,4 +45,6 @@ export interface SessionBlockMetadata {
     snapshotSource: string | null
     /** Library used for the snapshot */
     snapshotLibrary: string | null
+    /** Retention period for this session block */
+    retentionPeriod: string | null
 }

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-metadata-store.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-metadata-store.test.ts
@@ -42,6 +42,7 @@ describe('SessionMetadataStore', () => {
                 messageCount: 50,
                 snapshotSource: 'web',
                 snapshotLibrary: 'rrweb@1.0.0',
+                retentionPeriod: '30d',
             },
             {
                 sessionId: 'different456',
@@ -66,6 +67,7 @@ describe('SessionMetadataStore', () => {
                 messageCount: 30,
                 snapshotSource: 'web',
                 snapshotLibrary: 'rrweb@1.0.0',
+                retentionPeriod: '30d',
             },
             {
                 sessionId: 'session123',
@@ -90,6 +92,7 @@ describe('SessionMetadataStore', () => {
                 messageCount: 70,
                 snapshotSource: 'web',
                 snapshotLibrary: 'rrweb@1.0.0',
+                retentionPeriod: '30d',
             },
         ]
 
@@ -125,6 +128,7 @@ describe('SessionMetadataStore', () => {
                 snapshot_source: 'web',
                 snapshot_library: 'rrweb@1.0.0',
                 event_count: 25,
+                retention_period: '30d',
             },
             {
                 uuid: expect.any(String),
@@ -149,6 +153,7 @@ describe('SessionMetadataStore', () => {
                 snapshot_source: 'web',
                 snapshot_library: 'rrweb@1.0.0',
                 event_count: 15,
+                retention_period: '30d',
             },
             {
                 uuid: expect.any(String),
@@ -173,6 +178,7 @@ describe('SessionMetadataStore', () => {
                 snapshot_source: 'web',
                 snapshot_library: 'rrweb@1.0.0',
                 event_count: 35,
+                retention_period: '30d',
             },
         ])
 
@@ -225,6 +231,7 @@ describe('SessionMetadataStore', () => {
                 messageCount: 25,
                 snapshotSource: 'web',
                 snapshotLibrary: 'rrweb@1.0.0',
+                retentionPeriod: '30d',
             },
         ]
 
@@ -256,6 +263,7 @@ describe('SessionMetadataStore', () => {
                 messageCount: 25,
                 snapshotSource: 'web',
                 snapshotLibrary: 'rrweb@1.0.0',
+                retentionPeriod: '30d',
             },
         ]
 
@@ -307,6 +315,7 @@ describe('SessionMetadataStore', () => {
                 messageCount: 15,
                 snapshotSource: 'web',
                 snapshotLibrary: 'rrweb@1.0.0',
+                retentionPeriod: '30d',
             },
             {
                 sessionId: 'session2',
@@ -331,6 +340,7 @@ describe('SessionMetadataStore', () => {
                 messageCount: 20,
                 snapshotSource: 'web',
                 snapshotLibrary: 'rrweb@1.0.0',
+                retentionPeriod: '30d',
             },
         ]
 
@@ -356,6 +366,7 @@ describe('SessionMetadataStore', () => {
             message_count: 15,
             snapshot_source: 'web',
             snapshot_library: 'rrweb@1.0.0',
+            retention_period: '30d',
         })
         expect(parsedEvents[1]).toMatchObject({
             first_url: 'https://example.com/other',
@@ -372,6 +383,7 @@ describe('SessionMetadataStore', () => {
             message_count: 20,
             snapshot_source: 'web',
             snapshot_library: 'rrweb@1.0.0',
+            retention_period: '30d',
         })
         expect(mockProducer.flush).toHaveBeenCalledTimes(1)
     })
@@ -404,6 +416,7 @@ describe('SessionMetadataStore', () => {
                 messageCount: 25,
                 snapshotSource: 'web',
                 snapshotLibrary: 'rrweb@1.0.0',
+                retentionPeriod: '30d',
             },
         ]
 
@@ -440,6 +453,7 @@ describe('SessionMetadataStore', () => {
                 messageCount: 25,
                 snapshotSource: 'web',
                 snapshotLibrary: 'rrweb@1.0.0',
+                retentionPeriod: '30d',
             },
         ]
 

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-metadata-store.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-metadata-store.ts
@@ -40,6 +40,7 @@ export class SessionMetadataStore {
             snapshot_source: metadata.snapshotSource,
             snapshot_library: metadata.snapshotLibrary,
             event_count: metadata.eventCount || 0,
+            retention_period: metadata.retentionPeriod,
         }))
 
         await this.producer.queueMessages({

--- a/posthog/clickhouse/migrations/0135_session_replay_events_retention_period.py
+++ b/posthog/clickhouse/migrations/0135_session_replay_events_retention_period.py
@@ -13,13 +13,13 @@ from posthog.session_recordings.sql.session_replay_event_sql import (
 
 operations = [
     # looking at past migrations we have to drop materialized views and kafka tables first
-    run_sql_with_exceptions(DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL()),
-    run_sql_with_exceptions(DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    run_sql_with_exceptions(DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL(on_cluster=False)),
+    run_sql_with_exceptions(DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL(on_cluster=False)),
     # alter the target tables
     run_sql_with_exceptions(ADD_RETENTION_PERIOD_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL()),
     run_sql_with_exceptions(ADD_RETENTION_PERIOD_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL()),
     run_sql_with_exceptions(ADD_RETENTION_PERIOD_SESSION_REPLAY_EVENTS_TABLE_SQL()),
     # and then recreate the materialized views and kafka tables
-    run_sql_with_exceptions(KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL()),
-    run_sql_with_exceptions(SESSION_REPLAY_EVENTS_TABLE_MV_SQL()),
+    run_sql_with_exceptions(KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL(on_cluster=False)),
+    run_sql_with_exceptions(SESSION_REPLAY_EVENTS_TABLE_MV_SQL(on_cluster=False)),
 ]

--- a/posthog/clickhouse/migrations/0135_session_replay_events_retention_period.py
+++ b/posthog/clickhouse/migrations/0135_session_replay_events_retention_period.py
@@ -1,0 +1,25 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.session_recordings.sql.session_replay_event_migrations_sql import (
+    ADD_RETENTION_PERIOD_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    ADD_RETENTION_PERIOD_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    ADD_RETENTION_PERIOD_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL,
+)
+from posthog.session_recordings.sql.session_replay_event_sql import (
+    KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    SESSION_REPLAY_EVENTS_TABLE_MV_SQL,
+)
+
+operations = [
+    # looking at past migrations we have to drop materialized views and kafka tables first
+    run_sql_with_exceptions(DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL()),
+    run_sql_with_exceptions(DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    # alter the target tables
+    run_sql_with_exceptions(ADD_RETENTION_PERIOD_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    run_sql_with_exceptions(ADD_RETENTION_PERIOD_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    run_sql_with_exceptions(ADD_RETENTION_PERIOD_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    # and then recreate the materialized views and kafka tables
+    run_sql_with_exceptions(KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    run_sql_with_exceptions(SESSION_REPLAY_EVENTS_TABLE_MV_SQL()),
+]

--- a/posthog/clickhouse/migrations/0135_session_replay_events_retention_period.py
+++ b/posthog/clickhouse/migrations/0135_session_replay_events_retention_period.py
@@ -1,3 +1,4 @@
+from posthog.clickhouse.client.connection import NodeRole
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
 from posthog.session_recordings.sql.session_replay_event_migrations_sql import (
     ADD_RETENTION_PERIOD_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL,
@@ -17,8 +18,8 @@ operations = [
     run_sql_with_exceptions(DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL(on_cluster=False)),
     # alter the target tables
     run_sql_with_exceptions(ADD_RETENTION_PERIOD_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL()),
-    run_sql_with_exceptions(ADD_RETENTION_PERIOD_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL()),
-    run_sql_with_exceptions(ADD_RETENTION_PERIOD_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    run_sql_with_exceptions(ADD_RETENTION_PERIOD_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL(), node_role=NodeRole.ALL),
+    run_sql_with_exceptions(ADD_RETENTION_PERIOD_SESSION_REPLAY_EVENTS_TABLE_SQL(), node_role=NodeRole.DATA, sharded=True),
     # and then recreate the materialized views and kafka tables
     run_sql_with_exceptions(KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL(on_cluster=False)),
     run_sql_with_exceptions(SESSION_REPLAY_EVENTS_TABLE_MV_SQL(on_cluster=False)),

--- a/posthog/clickhouse/migrations/0136_session_replay_events_retention_period.py
+++ b/posthog/clickhouse/migrations/0136_session_replay_events_retention_period.py
@@ -19,7 +19,9 @@ operations = [
     # alter the target tables
     run_sql_with_exceptions(ADD_RETENTION_PERIOD_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL()),
     run_sql_with_exceptions(ADD_RETENTION_PERIOD_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL(), node_role=NodeRole.ALL),
-    run_sql_with_exceptions(ADD_RETENTION_PERIOD_SESSION_REPLAY_EVENTS_TABLE_SQL(), node_role=NodeRole.DATA, sharded=True),
+    run_sql_with_exceptions(
+        ADD_RETENTION_PERIOD_SESSION_REPLAY_EVENTS_TABLE_SQL(), node_role=NodeRole.DATA, sharded=True
+    ),
     # and then recreate the materialized views and kafka tables
     run_sql_with_exceptions(KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL(on_cluster=False)),
     run_sql_with_exceptions(SESSION_REPLAY_EVENTS_TABLE_MV_SQL(on_cluster=False)),

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -2549,8 +2549,7 @@
       -- knowing something is mobile isn't enough, we need to know if e.g. RN or flutter
       snapshot_library AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
       _timestamp SimpleAggregateFunction(max, DateTime),
-      -- CH will pick any value of retention_period for the session
-      -- the retention period should _always_ be the same across all blocks in a session so any will do
+      -- retention period for this session, useful to show TTL for the recording
       retention_period Nullable(String)
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_replay_events', sipHash64(distinct_id))
   
@@ -2576,7 +2575,8 @@
   `event_count` Int64,
   `snapshot_source` AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC')),
   `snapshot_library` AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
-  `_timestamp` Nullable(DateTime)
+  `_timestamp` Nullable(DateTime),
+  `retention_period` Nullable(String)
   )
   AS SELECT
   session_id,
@@ -2612,7 +2612,9 @@
   argMinState(snapshot_source, first_timestamp) as snapshot_source,
   argMinState(snapshot_library, first_timestamp) as snapshot_library,
   max(_timestamp) as _timestamp,
-  anyRespectNulls(retention_period) as retention_period
+  -- CH will pick the retention period here, but only if there is a single unique non-null value across all blocks
+  -- ...otherwise this column will be NULL
+  singleValueOrNull(retention_period) as retention_period
   FROM posthog_test.kafka_session_replay_events
   group by session_id, team_id
   
@@ -3273,8 +3275,7 @@
       -- knowing something is mobile isn't enough, we need to know if e.g. RN or flutter
       snapshot_library AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
       _timestamp SimpleAggregateFunction(max, DateTime),
-      -- CH will pick any value of retention_period for the session
-      -- the retention period should _always_ be the same across all blocks in a session so any will do
+      -- retention period for this session, useful to show TTL for the recording
       retention_period Nullable(String)
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.session_replay_events', '{replica}')
   
@@ -4016,7 +4017,9 @@
       snapshot_source AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC')),
       -- knowing something is mobile isn't enough, we need to know if e.g. RN or flutter
       snapshot_library AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
-      _timestamp SimpleAggregateFunction(max, DateTime)
+      _timestamp SimpleAggregateFunction(max, DateTime),
+      -- retention period for this session, useful to show TTL for the recording
+      retention_period Nullable(String)
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_replay_events', sipHash64(distinct_id))
   
   '''
@@ -5156,8 +5159,7 @@
       -- knowing something is mobile isn't enough, we need to know if e.g. RN or flutter
       snapshot_library AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
       _timestamp SimpleAggregateFunction(max, DateTime),
-      -- CH will pick any value of retention_period for the session
-      -- the retention period should _always_ be the same across all blocks in a session so any will do
+      -- retention period for this session, useful to show TTL for the recording
       retention_period Nullable(String)
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.session_replay_events', '{replica}')
   
@@ -5722,7 +5724,9 @@
       snapshot_source AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC')),
       -- knowing something is mobile isn't enough, we need to know if e.g. RN or flutter
       snapshot_library AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
-      _timestamp SimpleAggregateFunction(max, DateTime)
+      _timestamp SimpleAggregateFunction(max, DateTime),
+      -- retention period for this session, useful to show TTL for the recording
+      retention_period Nullable(String)
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_replay_events', sipHash64(distinct_id))
   
   '''

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -483,7 +483,8 @@
       event_count Int64,
       message_count Int64,
       snapshot_source LowCardinality(Nullable(String)),
-      snapshot_library Nullable(String)
+      snapshot_library Nullable(String),
+      retention_period String,
   ) ENGINE = Kafka('test.kafka.broker:9092', 'clickhouse_session_replay_events_test', 'group1', 'JSONEachRow')
   
   '''
@@ -1559,7 +1560,8 @@
       event_count Int64,
       message_count Int64,
       snapshot_source LowCardinality(Nullable(String)),
-      snapshot_library Nullable(String)
+      snapshot_library Nullable(String),
+      retention_period String,
   ) ENGINE = Kafka('kafka:9092', 'clickhouse_session_replay_events_test', 'group1', 'JSONEachRow')
   
   '''
@@ -2546,7 +2548,10 @@
       snapshot_source AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC')),
       -- knowing something is mobile isn't enough, we need to know if e.g. RN or flutter
       snapshot_library AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
-      _timestamp SimpleAggregateFunction(max, DateTime)
+      _timestamp SimpleAggregateFunction(max, DateTime),
+      -- CH will pick any value of retention_period for the session
+      -- the retention period should _always_ be the same across all blocks in a session so any will do
+      retention_period String
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_replay_events', sipHash64(distinct_id))
   
   '''
@@ -2606,7 +2611,8 @@
   sum(event_count) as event_count,
   argMinState(snapshot_source, first_timestamp) as snapshot_source,
   argMinState(snapshot_library, first_timestamp) as snapshot_library,
-  max(_timestamp) as _timestamp
+  max(_timestamp) as _timestamp,
+  any(retention_period) as retention_period
   FROM posthog_test.kafka_session_replay_events
   group by session_id, team_id
   
@@ -3266,7 +3272,10 @@
       snapshot_source AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC')),
       -- knowing something is mobile isn't enough, we need to know if e.g. RN or flutter
       snapshot_library AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
-      _timestamp SimpleAggregateFunction(max, DateTime)
+      _timestamp SimpleAggregateFunction(max, DateTime),
+      -- CH will pick any value of retention_period for the session
+      -- the retention period should _always_ be the same across all blocks in a session so any will do
+      retention_period String
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.session_replay_events', '{replica}')
   
       PARTITION BY toYYYYMM(min_first_timestamp)
@@ -5146,7 +5155,10 @@
       snapshot_source AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC')),
       -- knowing something is mobile isn't enough, we need to know if e.g. RN or flutter
       snapshot_library AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
-      _timestamp SimpleAggregateFunction(max, DateTime)
+      _timestamp SimpleAggregateFunction(max, DateTime),
+      -- CH will pick any value of retention_period for the session
+      -- the retention period should _always_ be the same across all blocks in a session so any will do
+      retention_period String
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.session_replay_events', '{replica}')
   
       PARTITION BY toYYYYMM(min_first_timestamp)

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -484,7 +484,7 @@
       message_count Int64,
       snapshot_source LowCardinality(Nullable(String)),
       snapshot_library Nullable(String),
-      retention_period String,
+      retention_period Nullable(String),
   ) ENGINE = Kafka('test.kafka.broker:9092', 'clickhouse_session_replay_events_test', 'group1', 'JSONEachRow')
   
   '''
@@ -1561,7 +1561,7 @@
       message_count Int64,
       snapshot_source LowCardinality(Nullable(String)),
       snapshot_library Nullable(String),
-      retention_period String,
+      retention_period Nullable(String),
   ) ENGINE = Kafka('kafka:9092', 'clickhouse_session_replay_events_test', 'group1', 'JSONEachRow')
   
   '''
@@ -2551,7 +2551,7 @@
       _timestamp SimpleAggregateFunction(max, DateTime),
       -- CH will pick any value of retention_period for the session
       -- the retention period should _always_ be the same across all blocks in a session so any will do
-      retention_period String
+      retention_period Nullable(String)
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_replay_events', sipHash64(distinct_id))
   
   '''
@@ -2612,7 +2612,7 @@
   argMinState(snapshot_source, first_timestamp) as snapshot_source,
   argMinState(snapshot_library, first_timestamp) as snapshot_library,
   max(_timestamp) as _timestamp,
-  any(retention_period) as retention_period
+  anyRespectNulls(retention_period) as retention_period
   FROM posthog_test.kafka_session_replay_events
   group by session_id, team_id
   
@@ -3275,7 +3275,7 @@
       _timestamp SimpleAggregateFunction(max, DateTime),
       -- CH will pick any value of retention_period for the session
       -- the retention period should _always_ be the same across all blocks in a session so any will do
-      retention_period String
+      retention_period Nullable(String)
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.session_replay_events', '{replica}')
   
       PARTITION BY toYYYYMM(min_first_timestamp)
@@ -5158,7 +5158,7 @@
       _timestamp SimpleAggregateFunction(max, DateTime),
       -- CH will pick any value of retention_period for the session
       -- the retention period should _always_ be the same across all blocks in a session so any will do
-      retention_period String
+      retention_period Nullable(String)
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.session_replay_events', '{replica}')
   
       PARTITION BY toYYYYMM(min_first_timestamp)

--- a/posthog/session_recordings/queries/test/session_replay_sql.py
+++ b/posthog/session_recordings/queries/test/session_replay_sql.py
@@ -134,6 +134,7 @@ def produce_replay_summary(
     block_urls: list[str] | None = None,
     block_first_timestamps: list[datetime] | None = None,
     block_last_timestamps: list[datetime] | None = None,
+    retention_period: str | None = None,
 ):
     """
     Creates a session replay event in ClickHouse for testing purposes.
@@ -166,6 +167,7 @@ def produce_replay_summary(
         "block_urls": block_urls or [],
         "block_first_timestamps": block_first_timestamps or [],
         "block_last_timestamps": block_last_timestamps or [],
+        "retention_period": retention_period or "30d",
     }
 
     if settings.TEST:

--- a/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
@@ -5,13 +5,13 @@ from posthog.session_recordings.sql.session_replay_event_sql import SESSION_REPL
 
 def DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL(on_cluster=True):
     return "DROP TABLE IF EXISTS session_replay_events_mv" + (
-        f"ON CLUSTER {settings.CLICKHOUSE_CLUSTER}" if on_cluster else ""
+        f" ON CLUSTER {settings.CLICKHOUSE_CLUSTER}" if on_cluster else ""
     )
 
 
 def DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL(on_cluster=True):
     return "DROP TABLE IF EXISTS kafka_session_replay_events" + (
-        f"ON CLUSTER {settings.CLICKHOUSE_CLUSTER}" if on_cluster else ""
+        f" ON CLUSTER {settings.CLICKHOUSE_CLUSTER}" if on_cluster else ""
     )
 
 

--- a/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
@@ -158,7 +158,7 @@ ADD_LIBRARY_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_L
 # migration to add retention_period column to the session replay table
 ALTER_SESSION_REPLAY_ADD_RETENTION_PERIOD_COLUMN = """
     ALTER TABLE {table_name} on CLUSTER '{cluster}'
-    ADD COLUMN IF NOT EXISTS retention_period String
+    ADD COLUMN IF NOT EXISTS retention_period Nullable(String)
 """
 
 ADD_RETENTION_PERIOD_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL = (

--- a/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
@@ -2,17 +2,18 @@ from django.conf import settings
 
 from posthog.session_recordings.sql.session_replay_event_sql import SESSION_REPLAY_EVENTS_DATA_TABLE
 
-DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL = (
-    lambda: "DROP TABLE IF EXISTS session_replay_events_mv ON CLUSTER {cluster}".format(
-        cluster=settings.CLICKHOUSE_CLUSTER,
-    )
-)
 
-DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL = (
-    lambda: "DROP TABLE IF EXISTS kafka_session_replay_events ON CLUSTER {cluster}".format(
-        cluster=settings.CLICKHOUSE_CLUSTER,
+def DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL(on_cluster=True):
+    return "DROP TABLE IF EXISTS session_replay_events_mv" + (
+        f"ON CLUSTER {settings.CLICKHOUSE_CLUSTER}" if on_cluster else ""
     )
-)
+
+
+def DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL(on_cluster=True):
+    return "DROP TABLE IF EXISTS kafka_session_replay_events" + (
+        f"ON CLUSTER {settings.CLICKHOUSE_CLUSTER}" if on_cluster else ""
+    )
+
 
 # this alter command exists because existing installations
 # need to have the columns added, the SESSION_REPLAY_EVENTS_TABLE_BASE_SQL string
@@ -157,27 +158,23 @@ ADD_LIBRARY_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_L
 
 # migration to add retention_period column to the session replay table
 ALTER_SESSION_REPLAY_ADD_RETENTION_PERIOD_COLUMN = """
-    ALTER TABLE {table_name} on CLUSTER '{cluster}'
-    ADD COLUMN IF NOT EXISTS retention_period Nullable(String)
+    ALTER TABLE {table_name} ADD COLUMN IF NOT EXISTS retention_period Nullable(String)
 """
 
 ADD_RETENTION_PERIOD_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL = (
     lambda: ALTER_SESSION_REPLAY_ADD_RETENTION_PERIOD_COLUMN.format(
         table_name="session_replay_events",
-        cluster=settings.CLICKHOUSE_CLUSTER,
     )
 )
 
 ADD_RETENTION_PERIOD_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL = (
     lambda: ALTER_SESSION_REPLAY_ADD_RETENTION_PERIOD_COLUMN.format(
         table_name="writable_session_replay_events",
-        cluster=settings.CLICKHOUSE_CLUSTER,
     )
 )
 
 ADD_RETENTION_PERIOD_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_RETENTION_PERIOD_COLUMN.format(
     table_name=SESSION_REPLAY_EVENTS_DATA_TABLE(),
-    cluster=settings.CLICKHOUSE_CLUSTER,
 )
 
 # =========================

--- a/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
@@ -155,6 +155,31 @@ ADD_LIBRARY_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_L
     cluster=settings.CLICKHOUSE_CLUSTER,
 )
 
+# migration to add retention_period column to the session replay table
+ALTER_SESSION_REPLAY_ADD_RETENTION_PERIOD_COLUMN = """
+    ALTER TABLE {table_name} on CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS retention_period String
+"""
+
+ADD_RETENTION_PERIOD_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL = (
+    lambda: ALTER_SESSION_REPLAY_ADD_RETENTION_PERIOD_COLUMN.format(
+        table_name="session_replay_events",
+        cluster=settings.CLICKHOUSE_CLUSTER,
+    )
+)
+
+ADD_RETENTION_PERIOD_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL = (
+    lambda: ALTER_SESSION_REPLAY_ADD_RETENTION_PERIOD_COLUMN.format(
+        table_name="writable_session_replay_events",
+        cluster=settings.CLICKHOUSE_CLUSTER,
+    )
+)
+
+ADD_RETENTION_PERIOD_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_RETENTION_PERIOD_COLUMN.format(
+    table_name=SESSION_REPLAY_EVENTS_DATA_TABLE(),
+    cluster=settings.CLICKHOUSE_CLUSTER,
+)
+
 # =========================
 # MIGRATION: Add block columns to support session recording v2 implementation
 # This migration adds block_url to the kafka table, and block_first_timestamps, block_last_timestamps, and block_urls

--- a/posthog/session_recordings/sql/session_replay_event_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_sql.py
@@ -38,7 +38,7 @@ CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     message_count Int64,
     snapshot_source LowCardinality(Nullable(String)),
     snapshot_library Nullable(String),
-    retention_period String,
+    retention_period Nullable(String),
 ) ENGINE = {engine}
 """
 
@@ -89,7 +89,7 @@ CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     _timestamp SimpleAggregateFunction(max, DateTime),
     -- CH will pick any value of retention_period for the session
     -- the retention period should _always_ be the same across all blocks in a session so any will do
-    retention_period String
+    retention_period Nullable(String)
 ) ENGINE = {engine}
 """
 
@@ -169,7 +169,7 @@ sum(event_count) as event_count,
 argMinState(snapshot_source, first_timestamp) as snapshot_source,
 argMinState(snapshot_library, first_timestamp) as snapshot_library,
 max(_timestamp) as _timestamp,
-any(retention_period) as retention_period
+anyRespectNulls(retention_period) as retention_period
 FROM {database}.kafka_session_replay_events
 group by session_id, team_id
 """.format(

--- a/posthog/session_recordings/sql/session_replay_event_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_sql.py
@@ -130,8 +130,8 @@ def KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL(on_cluster=True):
     )
 
 
-SESSION_REPLAY_EVENTS_TABLE_MV_SQL = (
-    lambda: """
+def SESSION_REPLAY_EVENTS_TABLE_MV_SQL(on_cluster=True):
+    return """
 CREATE MATERIALIZED VIEW IF NOT EXISTS session_replay_events_mv {on_cluster_clause}
 TO {database}.{target_table} {explictly_specify_columns}
 AS SELECT
@@ -175,7 +175,7 @@ FROM {database}.kafka_session_replay_events
 group by session_id, team_id
 """.format(
         target_table="writable_session_replay_events",
-        on_cluster_clause=ON_CLUSTER_CLAUSE(),
+        on_cluster_clause=ON_CLUSTER_CLAUSE(on_cluster),
         database=settings.CLICKHOUSE_DATABASE,
         # ClickHouse is incorrectly expanding the type of the snapshot source column
         # Despite it being a LowCardinality(Nullable(String)) in writable_session_replay_events
@@ -200,7 +200,7 @@ group by session_id, team_id
 `retention_period` Nullable(String)
 )""",
     )
-)
+
 
 # Distributed engine tables are only created if CLICKHOUSE_REPLICATED
 


### PR DESCRIPTION
## Problem

We want to display the TTL for a recording as it is being viewed.

To achieve this we need to store the retention period as part of the session metadata in CH so we can query it with the API.

## Changes

1. Added block retention period to the metadata that blobby v2 pushes to Kafka.
2. Added CH migration to account for this new column of data in the Kafka table and the materialized view.
