### PR TITLE
fix(max): Search docs when user asks for default fields/properties of events/persons

### DIFF
--- a/ee/hogai/eval/eval_root.py
+++ b/ee/hogai/eval/eval_root.py
@@ -455,6 +455,54 @@ async def eval_root(call_root, pytestconfig):
                     id="call_doc_search_32",
                 ),
             ),
+            # Ensure calls docs, not insights
+            EvalCase(
+                input="Is there a field on a person I can use to show the last time they interacted with the platform?",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_33",
+                ),
+            ),
+            EvalCase(
+                input="Can I see which browser or device type a user is using from the default event properties?",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_34",
+                ),
+            ),
+            EvalCase(
+                input="What geographic information does PostHog automatically capture about my users?",
+                expected=AssistantToolCall(
+                    name="search_documentation",
+                    args={},
+                    id="call_doc_search_35",
+                ),
+            ),
+            # Ensure calls insights, not documentation
+            EvalCase(
+                input="Show me all events where the default $browser property equals Chrome",
+                expected=AssistantToolCall(
+                    name="create_and_query_insight",
+                    args={
+                        "query_kind": "sql",
+                        "query_description": "Show all events where the $browser property equals Chrome",
+                    },
+                    id="call_insight_default_props_1",
+                ),
+            ),
+            EvalCase(
+                input="How many unique users have the default $device_type property as mobile?",
+                expected=AssistantToolCall(
+                    name="create_and_query_insight",
+                    args={
+                        "query_kind": "sql",
+                        "query_description": "Count unique users who have the $device_type property set to mobile",
+                    },
+                    id="call_insight_default_props_2",
+                ),
+            ),
         ],
         pytestconfig=pytestconfig,
     )

--- a/ee/hogai/graph/root/prompts.py
+++ b/ee/hogai/graph/root/prompts.py
@@ -92,6 +92,7 @@ You MUST use `search_documentation` when the user asks:
 - How to report bugs
 - How to submit feature requests
 - To troubleshoot something
+- What default fields and properties are available for events and persons
 - …Or anything else PostHog-related
 
 You must also use `search_documentation` when the user:


### PR DESCRIPTION
## Problem

- When the user asks about person/event fields of events/persons -> the root node doesn't search the docs, and hallucinates the fields instead. The users say they are unhappy, so the doc search happens anyway, but it adds frustration.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- If the user asks about fields and properties - search the docs (we have good info on default fields/properties of events/persons)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
