### PR TITLE
fix(max): Improve query generation for unique users search

### DIFF
--- a/ee/hogai/eval/max_tools/eval_hogql_generator_tool.py
+++ b/ee/hogai/eval/max_tools/eval_hogql_generator_tool.py
@@ -177,6 +177,25 @@ async def eval_tool_generate_hogql_query(call_generate_hogql_query, database_sch
                 expected="SELECT anyLast(properties.description) AS dispositivo, if(anyLast(event) = 'enter', 'online', 'offline') AS status, anyLast(timestamp) AS last event ts FROM events WHERE properties.description IS NOT NULL AND NOT ( lower(properties.description) LIKE '%piero%' OR lower(properties.description) LIKE '%test%' OR lower(properties.description) LIKE '%local%' OR lower(properties.description) LIKE '%totem%' ) AND timestamp >= now() - INTERVAL 30 DAY GROUP BY lower(properties.description) ORDER BY status DESC, dispositivo ASC",
                 metadata=metadata,
             ),
+            EvalCase(
+                input=EvalInput(instructions="How many unique users visited our site last week?"),
+                expected="SELECT count(DISTINCT distinct_id) FROM events WHERE event = '$pageview' AND timestamp >= now() - INTERVAL 7 DAY",
+                metadata=metadata,
+            ),
+            EvalCase(
+                input=EvalInput(
+                    instructions="Show me the number of unique registered users who performed a purchase event in the last 30 days"
+                ),
+                expected="SELECT count(DISTINCT person_id) FROM events WHERE event = 'purchase' AND timestamp >= now() - INTERVAL 30 DAY",
+                metadata=metadata,
+            ),
+            EvalCase(
+                input=EvalInput(
+                    instructions="Get the daily count of unique users (including anonymous) who triggered any event, broken down by day for the past 2 weeks"
+                ),
+                expected="SELECT toStartOfDay(timestamp) AS day, count(DISTINCT distinct_id) AS unique_users FROM events WHERE timestamp >= now() - INTERVAL 14 DAY GROUP BY day ORDER BY day DESC",
+                metadata=metadata,
+            ),
         ],
         pytestconfig=pytestconfig,
     )

--- a/ee/hogai/graph/sql/prompts.py
+++ b/ee/hogai/graph/sql/prompts.py
@@ -18,7 +18,10 @@ Important HogQL differences versus other SQL dialects:
 - For performance, every SELECT from the `events` table must have a `WHERE` clause narrowing down the timestamp to the relevant period.
 
 Person or event metadata unspecified above (emails, names, etc.) is stored in `properties` fields, accessed like: `properties.foo.bar`.
+
 Note: "persons" means "users" here - instead of a "users" table, we have a "persons" table.
+
+When searching for unique users use `DISTINCT distinct_id` to count all unique users (including anonymous users) or `DISTINCT person_id` to count unique identified users (excludes anonymous users).
 
 Standardized events/properties such as pageview or screen start with `$`. Custom events/properties start with any other character.
 

--- a/ee/hogai/graph/sql/prompts.py
+++ b/ee/hogai/graph/sql/prompts.py
@@ -21,7 +21,10 @@ Person or event metadata unspecified above (emails, names, etc.) is stored in `p
 
 Note: "persons" means "users" here - instead of a "users" table, we have a "persons" table.
 
-When searching for unique users use `DISTINCT distinct_id` to count all unique users (including anonymous users) or `DISTINCT person_id` to count unique identified users (excludes anonymous users).
+<persons>
+When working with persons, default to `events.distinct_id`–it includes all activity.
+Use person_id only when the request is explicitly about identified people/person-profile logic (e.g., person properties), which excludes anonymous users.
+</persons>
 
 Standardized events/properties such as pageview or screen start with `$`. Custom events/properties start with any other character.
 


### PR DESCRIPTION
## Problem

- When users ask for `unique users` queries, Max hallicinates `user_id` property instead of using existing `distinct_id`/`person_id`

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Add instructions how to get unique users

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
