### PR TITLE
feat(ux): fit all scene tabs into one row

### DIFF
--- a/frontend/src/layout/scenes/SceneTabContextMenu.tsx
+++ b/frontend/src/layout/scenes/SceneTabContextMenu.tsx
@@ -4,7 +4,13 @@ import React from 'react'
 import { IconChevronLeft, IconChevronRight, IconCopy, IconExternal, IconPencil, IconX } from '@posthog/icons'
 
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
-import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from 'lib/ui/ContextMenu/ContextMenu'
+import {
+    ContextMenu,
+    ContextMenuContent,
+    ContextMenuItem,
+    ContextMenuSeparator,
+    ContextMenuTrigger,
+} from 'lib/ui/ContextMenu/ContextMenu'
 import { SceneTab } from 'scenes/sceneTypes'
 
 import { sceneLogic } from '~/scenes/sceneLogic'
@@ -50,9 +56,10 @@ export function SceneTabContextMenu({ tab, children }: { tab: SceneTab; children
                 </ContextMenuItem>
                 <ContextMenuItem asChild>
                     <ButtonPrimitive menuItem onClick={openInNewWindow}>
-                        <IconExternal /> Open in new window
+                        <IconExternal /> Open new browser tab
                     </ButtonPrimitive>
                 </ContextMenuItem>
+                <ContextMenuSeparator />
                 <ContextMenuItem asChild>
                     <ButtonPrimitive menuItem onClick={() => removeTab(tab)}>
                         <IconX /> Close tab

--- a/frontend/src/layout/scenes/SceneTabs.tsx
+++ b/frontend/src/layout/scenes/SceneTabs.tsx
@@ -41,18 +41,20 @@ export function SceneTabs({ className }: SceneTabsProps): JSX.Element {
         >
             <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
                 <SortableContext items={[...tabs.map((t) => t.id), 'new']} strategy={horizontalListSortingStrategy}>
-                    <div className={cn('flex flex-row flex-wrap gap-1 pt-1', className)}>
-                        <div className="flex items-center gap-1">
+                    <div className={cn('flex flex-row gap-1 pt-1 max-w-full', className)}>
+                        <div className="flex items-center gap-1 shrink-0">
                             <ProjectDropdownMenu
                                 buttonProps={{
                                     className: 'h-[32px] mt-[-2px]',
                                 }}
                             />
                         </div>
-                        {tabs.map((tab) => (
-                            <SortableSceneTab key={tab.id} tab={tab} />
-                        ))}
-                        <div className="py-1">
+                        <div className="flex flex-row flex-1 min-w-0">
+                            {tabs.map((tab) => (
+                                <SortableSceneTab key={tab.id} tab={tab} />
+                            ))}
+                        </div>
+                        <div className="py-1 shrink-0">
                             <Link
                                 to={urls.newTab()}
                                 data-attr="scene-tab-new-button"
@@ -86,7 +88,13 @@ function SortableSceneTab({ tab }: { tab: SceneTab }): JSX.Element {
     }
 
     return (
-        <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+        <div
+            ref={setNodeRef}
+            style={style}
+            {...attributes}
+            {...listeners}
+            className="grow-0 shrink basis-auto min-w-[40px] max-w-[200px]"
+        >
             <SceneTabContextMenu tab={tab}>
                 <SceneTabComponent tab={tab} isDragging={isDragging} />
             </SceneTabContextMenu>
@@ -121,6 +129,7 @@ function SceneTabComponent({ tab, className, isDragging }: SceneTabProps): JSX.E
             }}
             to={isDragging ? undefined : `${tab.pathname}${tab.search}${tab.hash}`}
             className={cn(
+                'w-full',
                 'h-[37px] p-0.5 flex flex-row items-center gap-1 rounded-tr rounded-tl border border-transparent bottom-[-1px] relative',
                 tab.active
                     ? 'cursor-default text-primary bg-surface-secondary border-primary border-b-transparent'
@@ -130,7 +139,7 @@ function SceneTabComponent({ tab, className, isDragging }: SceneTabProps): JSX.E
                 className
             )}
         >
-            <div className={cn('flex-grow text-left whitespace-pre', tab.customTitle && 'italic')}>
+            <div className={cn('flex-grow text-left max-w-[200px] truncate', tab.customTitle && 'italic')}>
                 {tab.customTitle || tab.title}
             </div>
             {canRemoveTab && (


### PR DESCRIPTION
## Problem

A bit of band-aid.

## Changes

- Add limits to scene tab width
- Make the full list take up only one row

![2025-08-26 13 45 29](https://github.com/user-attachments/assets/be0fed0d-3a60-4efc-b14d-588b826bf8fb)


## How did you test this code?

Clicked around locally. There are still more things to do (e.g. hide the "X" buttons when the width gets small, like Chrome does), but that's for a different day.