### PR TITLE
chore(data-warehouse): Optimize postgres queries

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -272,7 +272,7 @@ def _has_duplicate_primary_keys(
 def _get_table_chunk_size(cursor: psycopg.Cursor, inner_query: sql.Composed, logger: FilteringBoundLogger) -> int:
     try:
         query = sql.SQL("""
-            SELECT SUM(pg_column_size(t.*)) / COUNT(t.*) FROM ({}) as t
+            SELECT SUM(pg_column_size(t)) / COUNT(*) FROM ({}) as t
         """).format(inner_query)
 
         cursor.execute(query)
@@ -304,7 +304,7 @@ def _get_table_chunk_size(cursor: psycopg.Cursor, inner_query: sql.Composed, log
 def _get_rows_to_sync(cursor: psycopg.Cursor, inner_query: sql.Composed, logger: FilteringBoundLogger) -> int:
     try:
         query = sql.SQL("""
-            SELECT COUNT(t.*) FROM ({}) as t
+            SELECT COUNT(*) FROM ({}) as t
         """).format(inner_query)
 
         cursor.execute(query)


### PR DESCRIPTION
## Problem
- When using `t.*` in a `count` aggregation, it can't take full advantage of indexes and thus some queries will timeout
- More context here: https://posthog.slack.com/archives/C07KZK0SBFW/p1756206500431149?thread_ts=1756138640.285759&cid=C07KZK0SBFW

## Changes
- Use `count(*)` instead of `count(t.*)` for fast aggregations using indexes - just on postgres

## How did you test this code?
unit tests covering this