### PR TITLE
ci(max): Reduce evals' trial count because costs

### DIFF
--- a/ee/hogai/eval/conftest.py
+++ b/ee/hogai/eval/conftest.py
@@ -66,7 +66,6 @@ async def MaxEval(
         data=data,
         task=task,
         scores=scores,
-        trial_count=3 if os.getenv("CI") else 1,
         timeout=60 * 8,
         max_concurrency=100,
         is_public=True,


### PR DESCRIPTION
## Problem

It's nice for CI runs of evals to average 3 trials, instead of running just 1 – but the costs in LLMs rack up. And the benefits are probably minimal.

## Changes

Let's save $900+/month by running evals once, not thrice.