### PR TITLE
fix(data-warehouse): Try deserializing via json before returning the string version

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/utils.py
@@ -453,10 +453,11 @@ def _convert_uuid_to_string(row: dict) -> dict:
 def _json_dumps(obj: Any) -> str:
     try:
         return orjson.dumps(obj).decode()
-    except TypeError as e:
-        if str(e) == "Integer exceeds 64-bit range":
+    except TypeError:
+        try:
             return json.dumps(obj)
-        raise TypeError(e)
+        except:
+            return str(obj)
 
 
 def table_from_iterator(data_iterator: Iterator[dict], schema: Optional[pa.Schema] = None) -> pa.Table:


### PR DESCRIPTION
## Problem
- We're getting errors thrown when we try to deserialize decimals/ipv4 objects 
- https://us.posthog.com/project/2/error_tracking/0198e0be-b48e-7b91-b6f9-7fe02c618823?timestamp=2025-08-25T03%3A25%3A00.338000-07%3A00

## Changes
- attempt to use the python json package first, then fall back on just stringing the object instead
