### PR TITLE
feat: Report run app metrics on finishing

### DIFF
--- a/products/batch_exports/backend/temporal/batch_exports.py
+++ b/products/batch_exports/backend/temporal/batch_exports.py
@@ -590,10 +590,10 @@ async def try_produce_run_status_app_metrics(status: BatchExportRun.Status | str
 
 def configure_default_ssl_context():
     """Setup a default SSL context for Kafka."""
-    context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     context.options |= ssl.OP_NO_SSLv2
     context.options |= ssl.OP_NO_SSLv3
-    context.verify_mode = ssl.CERT_OPTIONAL
+    context.verify_mode = ssl.CERT_REQUIRED
     context.load_default_certs()
     return context
 

--- a/products/batch_exports/backend/temporal/batch_exports.py
+++ b/products/batch_exports/backend/temporal/batch_exports.py
@@ -581,6 +581,7 @@ async def try_produce_run_status_app_metrics(status: BatchExportRun.Status | str
         )
         try:
             await fut
+            await producer.flush()
         except Exception:
             LOGGER.exception(
                 "Metrics production failed", team_id=team_id, batch_export_id=batch_export_id, metric_kind=metric_kind

--- a/products/batch_exports/backend/temporal/batch_exports.py
+++ b/products/batch_exports/backend/temporal/batch_exports.py
@@ -540,7 +540,7 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
     await try_produce_run_status_app_metrics(batch_export_run.status, inputs.team_id, inputs.batch_export_id)
 
 
-async def try_produce_run_status_app_metrics(status: BatchExportRun.Status, team_id: int, batch_export_id: str):
+async def try_produce_run_status_app_metrics(status: BatchExportRun.Status | str, team_id: int, batch_export_id: str):
     """Attempt to produce batch export run status to app_metrics2.
 
     The metric name and kind will depend on the reported status.
@@ -582,7 +582,9 @@ async def try_produce_run_status_app_metrics(status: BatchExportRun.Status, team
         try:
             await fut
         except Exception:
-            LOGGER.exception("Metrics production failed")
+            LOGGER.exception(
+                "Metrics production failed", team_id=team_id, batch_export_id=batch_export_id, metric_kind=metric_kind
+            )
 
 
 def configure_default_ssl_context():

--- a/products/batch_exports/backend/temporal/batch_exports.py
+++ b/products/batch_exports/backend/temporal/batch_exports.py
@@ -570,10 +570,12 @@ async def try_produce_run_status_app_metrics(status: BatchExportRun.Status, team
             json.dumps(
                 {
                     "team_id": team_id,
+                    "app_source": "batch_export",
                     "app_source_id": batch_export_id,
                     "count": 1,
                     "metric_kind": metric_kind,
                     "metric_name": metric_name,
+                    "timestamp": dt.datetime.now(dt.UTC).strftime("%Y-%m-%d %H:%M:%S"),
                 }
             ).encode("utf-8"),
         )

--- a/products/batch_exports/backend/temporal/batch_exports.py
+++ b/products/batch_exports/backend/temporal/batch_exports.py
@@ -559,7 +559,7 @@ async def try_produce_run_status_app_metrics(status: BatchExportRun.Status | str
             metric_name = "succeeded"
         case BatchExportRun.Status.CANCELLED:
             metric_kind = "cancellation"
-            metric_name = "cancelled"
+            metric_name = "canceled"
         case _:
             metric_kind = "failure"
             metric_name = "failed"

--- a/products/batch_exports/backend/temporal/batch_exports.py
+++ b/products/batch_exports/backend/temporal/batch_exports.py
@@ -1,3 +1,5 @@
+import ssl
+import json
 import uuid
 import typing
 import datetime as dt
@@ -8,6 +10,7 @@ import collections.abc
 from django.conf import settings
 
 import pyarrow as pa
+import aiokafka
 from structlog.contextvars import bind_contextvars
 from temporalio import activity, exceptions, workflow
 from temporalio.common import RetryPolicy
@@ -26,6 +29,7 @@ from posthog.batch_exports.service import (
     update_batch_export_backfill_status,
     update_batch_export_run,
 )
+from posthog.kafka_client.topics import KAFKA_APP_METRICS2
 from posthog.settings.base_variables import TEST
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.clickhouse import ClickHouseClient
@@ -532,6 +536,61 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
             batch_export_run.data_interval_end or "END",
             inputs.records_completed if inputs.records_completed is not None else "no",
         )
+
+    await try_produce_run_status_app_metrics(batch_export_run.status, inputs.team_id, inputs.batch_export_id)
+
+
+async def try_produce_run_status_app_metrics(status: BatchExportRun.Status, team_id: int, batch_export_id: str):
+    """Attempt to produce batch export run status to app_metrics2.
+
+    The metric name and kind will depend on the reported status.
+    """
+    producer = aiokafka.AIOKafkaProducer(
+        bootstrap_servers=settings.KAFKA_HOSTS,
+        security_protocol=settings.KAFKA_SECURITY_PROTOCOL or "PLAINTEXT",
+        acks="all",
+        api_version="2.5.0",
+        ssl_context=configure_default_ssl_context() if settings.KAFKA_SECURITY_PROTOCOL == "SSL" else None,
+    )
+
+    match status:
+        case BatchExportRun.Status.COMPLETED:
+            metric_kind = "success"
+            metric_name = "succeeded"
+        case BatchExportRun.Status.CANCELLED:
+            metric_kind = "cancellation"
+            metric_name = "cancelled"
+        case _:
+            metric_kind = "failure"
+            metric_name = "failed"
+
+    async with producer:
+        fut = await producer.send(
+            KAFKA_APP_METRICS2,
+            json.dumps(
+                {
+                    "team_id": team_id,
+                    "app_source_id": batch_export_id,
+                    "count": 1,
+                    "metric_kind": metric_kind,
+                    "metric_name": metric_name,
+                }
+            ).encode("utf-8"),
+        )
+        try:
+            await fut
+        except Exception:
+            LOGGER.exception("Metrics production failed")
+
+
+def configure_default_ssl_context():
+    """Setup a default SSL context for Kafka."""
+    context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+    context.options |= ssl.OP_NO_SSLv2
+    context.options |= ssl.OP_NO_SSLv3
+    context.verify_mode = ssl.CERT_OPTIONAL
+    context.load_default_certs()
+    return context
 
 
 async def check_if_over_failure_threshold(batch_export_id: str, check_window: int, failure_threshold: int):

--- a/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
@@ -223,6 +223,64 @@ async def read_json_file_from_s3(s3_compatible_client, bucket_name, key) -> list
     return data[0]
 
 
+MetricKind = t.Literal["success", "cancellation", "failure"]
+MetricName = t.Literal["succeeded", "canceled", "failed"]
+ExpectedCount = int
+ExpectedMetricsMap = dict[tuple[MetricKind, MetricName], ExpectedCount]
+
+
+async def assert_metrics_in_clickhouse(
+    clickhouse_client: ClickHouseClient,
+    batch_export_id: str,
+    expected_metrics: ExpectedMetricsMap,
+):
+    """Assert metrics are correctly ingested in ClickHouse.
+
+    We read metrics ingested into `sharded_app_metrics2` and compare them with the
+    provided `expected_metrics`.
+    """
+    query = """
+            SELECT metric_kind, metric_name, count
+            FROM sharded_app_metrics2
+            WHERE app_source = 'batch_export'
+            AND app_source_id = {{batch_export_id:String}}
+            FORMAT JSONEachRow \
+            """
+
+    resp = await clickhouse_client.read_query(
+        query,
+        query_parameters={"batch_export_id": batch_export_id, "cluster_name": settings.CLICKHOUSE_CLUSTER},
+    )
+
+    iterations = 0
+    while not resp and iterations < 10:
+        # It may take a bit for CH to ingest.
+        await asyncio.sleep(1)
+        resp = await clickhouse_client.read_query(
+            query,
+            query_parameters={"batch_export_id": batch_export_id, "cluster_name": settings.CLICKHOUSE_CLUSTER},
+        )
+
+        iterations += 1
+
+    if not resp:
+        raise ValueError(f"Metrics for batch export '{batch_export_id}' not found")
+
+    ingested_metrics = [json.loads(line) for line in resp.split(b"\n") if line]
+    for ingested_metric in ingested_metrics:
+        ingested_metric_kind, ingested_metric_name = ingested_metric["metric_kind"], ingested_metric["metric_name"]
+        ingested_count = int(ingested_metric["count"])
+
+        try:
+            expected_count = expected_metrics[(ingested_metric_kind, ingested_metric_name)]
+        except KeyError:
+            raise ValueError(f"Ingested unexpected metric: '{ingested_metric_kind}'")
+
+        assert (
+            ingested_count == expected_count
+        ), f"Ingested metric '{ingested_metric_kind}' with count {ingested_count} does not match expected {expected_count}"
+
+
 async def assert_clickhouse_records_in_s3(
     s3_compatible_client,
     clickhouse_client: ClickHouseClient,
@@ -902,6 +960,8 @@ async def _run_s3_batch_export_workflow(
         sort_key = "person_id"
     elif isinstance(model, BatchExportModel) and model.name == "sessions":
         sort_key = "session_id"
+
+    await assert_metrics_in_clickhouse(clickhouse_client, batch_export_id, {("success", "succeeded"): 1})
 
     await assert_clickhouse_records_in_s3(
         s3_compatible_client=s3_client,


### PR DESCRIPTION
## Problem

We need app metrics for batch exports.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Adds a function that attempts to report run metrics when the batch export finishes. This is called from the `finish_batch_export_run` activity, and produces run status metrics to a kafka topic that is afterwards ingested into `app_metrics2`. 

For now, the only metric emitted is a success/failure/canceled count. So, on every run, we just emit a 1 based on the status to add to the count.

Later on, more metrics will be added.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
