### PR TITLE
fix(hogql): Ensure we're using a globalIn operator when using property types

### DIFF
--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -902,6 +902,11 @@ class Resolver(CloningVisitor):
                 return isinstance(node.type.table_type.table_type.table, EventsTable)
             if isinstance(node.type.table_type, ast.TableType):
                 return isinstance(node.type.table_type.table, EventsTable)
+        elif isinstance(node, ast.Field) and isinstance(node.type, ast.PropertyType):
+            if isinstance(node.type.field_type.table_type, ast.TableAliasType):
+                return isinstance(node.type.field_type.table_type.table_type.table, EventsTable)
+            if isinstance(node.type.field_type.table_type, ast.TableType):
+                return isinstance(node.type.field_type.table_type.table, EventsTable)
         return False
 
     def _is_s3_cluster(self, node: ast.Expr) -> bool:

--- a/posthog/hogql/test/__snapshots__/test_printer.ambr
+++ b/posthog/hogql/test/__snapshots__/test_printer.ambr
@@ -76,6 +76,9 @@
 # name: TestPrinter.test_s3_tables_global_join_with_cte_nested
   "SELECT some_remote_table.event AS event FROM events GLOBAL JOIN (SELECT e.event AS event, t.id AS id FROM events AS e GLOBAL JOIN (SELECT * FROM s3(%(hogql_val_0_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_3_sensitive)s, 'Parquet', %(hogql_val_1)s)) AS t ON equals(toString(t.id), e.event) WHERE equals(e.team_id, 99999)) AS some_remote_table ON equals(events.event, toString(some_remote_table.id)) WHERE equals(events.team_id, 99999) LIMIT 50000"
 # ---
+# name: TestPrinter.test_s3_tables_global_join_with_in_and_property_type
+  'SELECT events.event AS event FROM events WHERE and(equals(events.team_id, 99999), ifNull(globalIn(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), \'\'), \'null\'), \'^"|"$\', \'\'), (SELECT test_table.id AS id FROM s3(%(hogql_val_1_sensitive)s, %(hogql_val_3_sensitive)s, %(hogql_val_4_sensitive)s, \'Parquet\', %(hogql_val_2)s) AS test_table)), 0)) LIMIT 50000'
+# ---
 # name: TestPrinter.test_s3_tables_global_join_with_multiple_joins
   "SELECT e.event, s.event AS event, t.id AS id FROM events AS e GLOBAL JOIN (SELECT events.event AS event FROM events WHERE equals(events.team_id, 99999)) AS s ON equals(e.event, s.event) GLOBAL LEFT JOIN (SELECT * FROM s3(%(hogql_val_0_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_3_sensitive)s, 'Parquet', %(hogql_val_1)s)) AS t ON equals(e.event, toString(t.id)) WHERE equals(e.team_id, 99999) LIMIT 50000"
 # ---

--- a/posthog/models/group_usage_metric.py
+++ b/posthog/models/group_usage_metric.py
@@ -1,6 +1,6 @@
 from django.db import models
 
-from posthog.models.utils import UUIDModel, BytecodeModelMixin
+from posthog.models.utils import BytecodeModelMixin, UUIDModel
 
 
 class GroupUsageMetric(UUIDModel, BytecodeModelMixin):

--- a/posthog/models/test/test_group_usage_metric_model.py
+++ b/posthog/models/test/test_group_usage_metric_model.py
@@ -1,5 +1,6 @@
-from posthog.models import GroupUsageMetric
 from posthog.test.base import BaseTest
+
+from posthog.models import GroupUsageMetric
 
 
 class GroupUsageMetricTestCase(BaseTest):

--- a/posthog/models/utils.py
+++ b/posthog/models/utils.py
@@ -17,8 +17,9 @@ from django.db.models import Q, UniqueConstraint
 from django.db.models.constraints import BaseConstraint
 from django.utils.text import slugify
 
-from posthog.constants import MAX_SLUG_LENGTH
 from posthog.hogql import ast
+
+from posthog.constants import MAX_SLUG_LENGTH
 
 if TYPE_CHECKING:
     from random import Random


### PR DESCRIPTION
## Problem
- another follow up to https://github.com/PostHog/posthog/pull/36977
- When using a `IN` operator with event properties, we were missing using the `globalIn` operator instead of just `in`

**Example hogql query:**
```sql
SELECT event FROM events
WHERE properties.$browser IN (
    SELECT id FROM test_table
)
```

## Changes
- Ensure we take into account `PropertyType` when applying the `globalIn` operator

## How did you test this code?
- Added a unit test for this 
