### PR TITLE
fix(funnels): fix breakdown overrides

### DIFF
--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -3791,3 +3791,71 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         updated_metadata = insight.query_metadata
         self.assertIsNotNone(updated_metadata)
         self.assertEqual(initial_metadata, updated_metadata)
+
+    def test_funnel_breakdown_override(self):
+        _create_person(team=self.team, distinct_ids=["person_1"])
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="person_1",
+            properties={"$browser": "Chrome", "$geoip_country_code": "US"},
+        )
+
+        insight = Insight.objects.create(
+            query={
+                "kind": NodeKind.INSIGHT_VIZ_NODE.value,
+                "source": {
+                    "kind": InsightNodeKind.FUNNELS_QUERY.value,
+                    "series": [
+                        {
+                            "kind": NodeKind.EVENTS_NODE.value,
+                            "event": "$pageview",
+                            "name": "$pageview",
+                        },
+                        {
+                            "kind": NodeKind.EVENTS_NODE.value,
+                            "event": "$pageview",
+                            "name": "$pageview",
+                        },
+                    ],
+                    # "interval": "day",
+                    "breakdownFilter": {
+                        "breakdown": "$geoip_country_code",
+                        "breakdown_type": "event",
+                    },
+                },
+            },
+            team=self.team,
+            created_by=self.user,
+        )
+
+        dashboard = Dashboard.objects.create(
+            team=self.team,
+            name="Test Dashboard",
+            created_by=self.user,
+            filters={
+                "breakdown_filter": {
+                    "breakdown": "$browser",
+                    "breakdown_type": "event",
+                }
+            },
+        )
+
+        DashboardTile.objects.create(dashboard=dashboard, insight=insight)
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/insights/{insight.id}/?refresh=force_blocking&from_dashboard={dashboard.id}"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        response_data = response.json()
+        query_source = response_data["query"]["source"]
+
+        # Verify breakdown filter is applied correctly
+        breakdown_filter = query_source["breakdownFilter"]
+        self.assertEqual(breakdown_filter.get("breakdown"), "$browser")
+        self.assertEqual(breakdown_filter.get("breakdown_type"), "event")
+
+        # Verify the breakdown filter is applied in the result
+        self.assertIn("result", response_data)
+        self.assertEqual(response_data["result"][0][0]["breakdown"], ["Chrome"])

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -3818,7 +3818,6 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                             "name": "$pageview",
                         },
                     ],
-                    # "interval": "day",
                     "breakdownFilter": {
                         "breakdown": "$geoip_country_code",
                         "breakdown_type": "event",

--- a/posthog/hogql_queries/insights/funnels/funnel_query_context.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_query_context.py
@@ -22,16 +22,6 @@ from posthog.models.team.team import Team
 
 class FunnelQueryContext(QueryContext):
     query: FunnelsQuery
-    funnelsFilter: FunnelsFilter
-
-    interval: IntervalType
-
-    breakdownType: BreakdownType
-    breakdownAttributionType: BreakdownAttributionType
-
-    funnelWindowInterval: int
-    funnelWindowIntervalUnit: FunnelConversionWindowTimeUnit
-
     actorsQuery: FunnelsActorsQuery | None
 
     includeTimestamp: Optional[bool]
@@ -54,20 +44,6 @@ class FunnelQueryContext(QueryContext):
         include_final_matching_events: Optional[bool] = None,
     ):
         super().__init__(query=query, team=team, timings=timings, modifiers=modifiers, limit_context=limit_context)
-
-        self.funnelsFilter = self.query.funnelsFilter or FunnelsFilter()
-
-        # defaults
-        self.interval = self.query.interval or IntervalType.DAY
-
-        self.breakdownType = self.breakdownFilter.breakdown_type or BreakdownType.EVENT
-        self.breakdownAttributionType = (
-            self.funnelsFilter.breakdownAttributionType or BreakdownAttributionType.FIRST_TOUCH
-        )
-        self.funnelWindowInterval = self.funnelsFilter.funnelWindowInterval or 14
-        self.funnelWindowIntervalUnit = (
-            self.funnelsFilter.funnelWindowIntervalUnit or FunnelConversionWindowTimeUnit.DAY
-        )
 
         self.includeTimestamp = include_timestamp
         self.includePrecedingTimestamp = include_preceding_timestamp
@@ -112,6 +88,30 @@ class FunnelQueryContext(QueryContext):
             return boxed_breakdown
         else:
             return self.breakdownFilter.breakdown
+
+    @property
+    def breakdownType(self) -> BreakdownType:
+        return self.breakdownFilter.breakdown_type or BreakdownType.EVENT
+
+    @property
+    def funnelsFilter(self) -> FunnelsFilter:
+        return self.query.funnelsFilter or FunnelsFilter()
+
+    @property
+    def breakdownAttributionType(self) -> BreakdownAttributionType:
+        return self.funnelsFilter.breakdownAttributionType or BreakdownAttributionType.FIRST_TOUCH
+
+    @property
+    def interval(self) -> IntervalType:
+        return self.query.interval or IntervalType.DAY
+
+    @property
+    def funnelWindowInterval(self) -> int:
+        return self.funnelsFilter.funnelWindowInterval or 14
+
+    @property
+    def funnelWindowIntervalUnit(self) -> FunnelConversionWindowTimeUnit:
+        return self.funnelsFilter.funnelWindowIntervalUnit or FunnelConversionWindowTimeUnit.DAY
 
     @property
     def max_steps(self) -> int:

--- a/posthog/hogql_queries/insights/funnels/funnel_query_context.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_query_context.py
@@ -23,11 +23,9 @@ from posthog.models.team.team import Team
 class FunnelQueryContext(QueryContext):
     query: FunnelsQuery
     funnelsFilter: FunnelsFilter
-    breakdownFilter: BreakdownFilter
 
     interval: IntervalType
 
-    breakdown: list[Union[str, int]] | str | int | None
     breakdownType: BreakdownType
     breakdownAttributionType: BreakdownAttributionType
 
@@ -58,7 +56,6 @@ class FunnelQueryContext(QueryContext):
         super().__init__(query=query, team=team, timings=timings, modifiers=modifiers, limit_context=limit_context)
 
         self.funnelsFilter = self.query.funnelsFilter or FunnelsFilter()
-        self.breakdownFilter = self.query.breakdownFilter or BreakdownFilter()
 
         # defaults
         self.interval = self.query.interval or IntervalType.DAY
@@ -77,6 +74,14 @@ class FunnelQueryContext(QueryContext):
         self.includeProperties = include_properties or []
         self.includeFinalMatchingEvents = include_final_matching_events
 
+        self.actorsQuery = None
+
+    @property
+    def breakdownFilter(self) -> BreakdownFilter:
+        return self.query.breakdownFilter or BreakdownFilter()
+
+    @property
+    def breakdown(self) -> Optional[Union[list[Union[str, int]], str, int]]:
         # the API accepts either:
         #   a string (single breakdown) in parameter "breakdown"
         #   a list of numbers (one or more cohorts) in parameter "breakdown"
@@ -104,11 +109,9 @@ class FunnelQueryContext(QueryContext):
             None,
         ]:
             boxed_breakdown: list[Union[str, int]] = box_value(self.breakdownFilter.breakdown)
-            self.breakdown = boxed_breakdown
+            return boxed_breakdown
         else:
-            self.breakdown = self.breakdownFilter.breakdown
-
-        self.actorsQuery = None
+            return self.breakdownFilter.breakdown
 
     @property
     def max_steps(self) -> int:


### PR DESCRIPTION
## Problem

Dashboard breakdown overrides don't work for funnel insights. See https://posthoghelp.zendesk.com/agent/tickets/36255. (moved to PostHog: https://us.posthog.com/project/2/support/tickets/38179)

## Changes

The overrides are applied after the context is initialized and thus it was referencing stale values. Made the values properties instead of assigning in the initializer.

## How did you test this code?

Added a test case.