### PR TITLE
feat(msg): add management command for resaving hog functions

### DIFF
--- a/posthog/management/commands/refresh_hog_functions.py
+++ b/posthog/management/commands/refresh_hog_functions.py
@@ -1,0 +1,100 @@
+import time
+
+from django.core.management.base import BaseCommand
+from django.core.paginator import Paginator
+
+import structlog
+
+from posthog.models.hog_functions.hog_function import HogFunction
+
+logger = structlog.get_logger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Refresh HogFunctions (both enabled and disabled) by re-saving them to trigger filter recompilation"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--team-id", type=int, help="Team ID to refresh HogFunctions for (if not provided, processes all teams)"
+        )
+        parser.add_argument(
+            "--hog-function-id",
+            type=str,
+            help="Specific HogFunction ID to refresh (if provided, only this function is processed)",
+        )
+
+    def handle(self, *args, **options):
+        start_time = time.time()
+        total_processed = 0
+        total_updated = 0
+        error_count = 0
+
+        team_id = options.get("team_id")
+        hog_function_id = options.get("hog_function_id")
+        page_size = 1000
+
+        self.stdout.write("Starting HogFunction refresh...")
+
+        queryset = HogFunction.objects.filter(deleted=False).select_related("team")
+
+        if hog_function_id:
+            queryset = queryset.filter(id=hog_function_id)
+            self.stdout.write(f"Processing single HogFunction: {hog_function_id}")
+        elif team_id:
+            queryset = queryset.filter(team_id=team_id)
+            self.stdout.write(f"Processing HogFunctions for team: {team_id}")
+        else:
+            self.stdout.write("Processing HogFunctions for all teams")
+
+        total_count = queryset.count()
+        self.stdout.write(f"Found {total_count} HogFunctions to process (includes both enabled and disabled functions)")
+
+        if total_count == 0:
+            self.stdout.write(self.style.WARNING("No HogFunctions found matching criteria"))
+            return
+
+        paginator = Paginator(queryset.order_by("id"), page_size)
+
+        for page_num in paginator.page_range:
+            page = paginator.page(page_num)
+
+            self.stdout.write(
+                f"Processing page {page_num}/{paginator.num_pages} ({len(page.object_list)} functions)..."
+            )
+
+            for hog_function in page.object_list:
+                try:
+                    total_processed += 1
+
+                    # Re-save the HogFunction to trigger filter recompilation
+                    # This will call the save() method which should regenerate filters
+                    hog_function.save()
+                    total_updated += 1
+
+                    self.stdout.write(
+                        f"Refreshed HogFunction {hog_function.id} "
+                        f"(team: {hog_function.team_id}, name: '{hog_function.name}', "
+                        f"enabled: {hog_function.enabled})"
+                    )
+
+                except Exception as e:
+                    error_count += 1
+                    logger.error(
+                        "Error refreshing HogFunction",
+                        hog_function_id=hog_function.id,
+                        team_id=hog_function.team_id,
+                        error=str(e),
+                        exc_info=True,
+                    )
+                    self.stdout.write(self.style.ERROR(f"Error refreshing HogFunction {hog_function.id}: {str(e)}"))
+
+        # Output summary
+        duration = time.time() - start_time
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Refresh completed in {duration:.2f}s. "
+                f"Processed: {total_processed}, "
+                f"Updated: {total_updated}, "
+                f"Errors: {error_count}"
+            )
+        )

--- a/posthog/management/commands/test/test_refresh_hog_functions.py
+++ b/posthog/management/commands/test/test_refresh_hog_functions.py
@@ -1,0 +1,140 @@
+from io import StringIO
+
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from django.core.management import call_command
+
+from posthog.models import Team
+from posthog.models.hog_functions.hog_function import HogFunction
+
+
+class TestRefreshHogFunctions(BaseTest):
+    def setUp(self):
+        super().setUp()
+
+        # Create additional teams for testing
+        self.team2 = Team.objects.create(organization=self.organization, name="Test Team 2")
+
+        # Create HogFunctions for testing
+        with patch("posthog.models.hog_functions.hog_function.reload_hog_functions_on_workers"):
+            self.hog_function1 = HogFunction.objects.create(
+                team=self.team,
+                name="Test Function 1",
+                type="destination",
+                description="Test Description 1",
+                hog="return event",
+                enabled=True,
+            )
+
+            self.hog_function2 = HogFunction.objects.create(
+                team=self.team,
+                name="Test Function 2",
+                type="transformation",
+                description="Test Description 2",
+                hog="return event",
+                enabled=True,
+            )
+
+            self.hog_function3 = HogFunction.objects.create(
+                team=self.team2,
+                name="Test Function 3",
+                type="destination",
+                description="Test Description 3",
+                hog="return event",
+                enabled=True,
+            )
+
+            # Create disabled function - should not be processed
+            self.disabled_function = HogFunction.objects.create(
+                team=self.team,
+                name="Disabled Function",
+                type="destination",
+                enabled=False,
+            )
+
+            # Create deleted function - should not be processed
+            self.deleted_function = HogFunction.objects.create(
+                team=self.team,
+                name="Deleted Function",
+                type="destination",
+                enabled=True,
+                deleted=True,
+            )
+
+    @patch("posthog.models.hog_functions.hog_function.reload_hog_functions_on_workers")
+    def test_refresh_all_hog_functions(self, mock_reload):
+        """Test refreshing all non-deleted HogFunctions (both enabled and disabled) across all teams."""
+
+        out = StringIO()
+        call_command("refresh_hog_functions", stdout=out)
+
+        # Should have refreshed 4 non-deleted functions
+        # (hog_function1, hog_function2, hog_function3, disabled_function)
+        # The deleted_function should be excluded
+        assert mock_reload.call_count == 4
+
+        output = out.getvalue()
+        self.assertIn("Found 4 HogFunctions to process", output)
+        self.assertIn("Processed: 4", output)
+        self.assertIn("Updated: 4", output)
+        self.assertIn("Errors: 0", output)
+
+    @patch("posthog.models.hog_functions.hog_function.reload_hog_functions_on_workers")
+    def test_refresh_by_team_id(self, mock_reload):
+        """Test refreshing HogFunctions for a specific team."""
+
+        out = StringIO()
+        call_command("refresh_hog_functions", team_id=self.team.id, stdout=out)
+
+        # Should have refreshed functions from team1 (hog_function1, hog_function2, disabled_function)
+        # The deleted_function should be excluded
+        assert mock_reload.call_count == 3
+
+        output = out.getvalue()
+        self.assertIn(f"Processing HogFunctions for team: {self.team.id}", output)
+        self.assertIn("Found 3 HogFunctions to process", output)
+        self.assertIn("Updated: 3", output)
+
+    @patch("posthog.models.hog_functions.hog_function.reload_hog_functions_on_workers")
+    def test_refresh_by_hog_function_id(self, mock_reload):
+        """Test refreshing a specific HogFunction by ID."""
+
+        out = StringIO()
+        call_command("refresh_hog_functions", hog_function_id=str(self.hog_function1.id), stdout=out)
+
+        # Should have refreshed only the specific function
+        assert mock_reload.call_count == 1
+
+        output = out.getvalue()
+        self.assertIn(f"Processing single HogFunction: {self.hog_function1.id}", output)
+        self.assertIn("Found 1 HogFunctions to process", output)
+        self.assertIn("Updated: 1", output)
+
+    @patch("posthog.models.hog_functions.hog_function.reload_hog_functions_on_workers")
+    def test_nonexistent_team_id(self, mock_reload):
+        """Test handling of nonexistent team ID."""
+
+        out = StringIO()
+        call_command("refresh_hog_functions", team_id=99999, stdout=out)
+
+        assert mock_reload.call_count == 0
+
+        output = out.getvalue()
+        self.assertIn("Found 0 HogFunctions to process", output)
+        self.assertIn("No HogFunctions found matching criteria", output)
+
+    @patch("posthog.models.hog_functions.hog_function.reload_hog_functions_on_workers")
+    def test_nonexistent_hog_function_id(self, mock_reload):
+        """Test handling of nonexistent HogFunction ID."""
+
+        out = StringIO()
+        # Use a valid UUID format that doesn't exist
+        nonexistent_uuid = "00000000-0000-0000-0000-000000000000"
+        call_command("refresh_hog_functions", hog_function_id=nonexistent_uuid, stdout=out)
+
+        assert mock_reload.call_count == 0
+
+        output = out.getvalue()
+        self.assertIn("Found 0 HogFunctions to process", output)
+        self.assertIn("No HogFunctions found matching criteria", output)

--- a/posthog/management/commands/test/test_refresh_hog_functions.py
+++ b/posthog/management/commands/test/test_refresh_hog_functions.py
@@ -45,7 +45,7 @@ class TestRefreshHogFunctions(BaseTest):
                 enabled=True,
             )
 
-            # Create disabled function - should not be processed
+            # Create disabled function - should also be processed
             self.disabled_function = HogFunction.objects.create(
                 team=self.team,
                 name="Disabled Function",


### PR DESCRIPTION
## Problem

we need a way to re-save hog functions to trigger recompilation of bytecode to put the new bytecode generation for filtering out test-users or internal users into place

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- management command in place to re-save hogfunctions per
  - hogfunctionId
  - teamId

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- added tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
