### PR TITLE
fix(frontend): Set ESBuild target to same as TypeScript's

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
-COPY turbo.json package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY turbo.json package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
 COPY ./bin/turbo ./bin/turbo
 COPY ./patches ./patches
 COPY ./rust ./rust

--- a/common/esbuilder/utils.mjs
+++ b/common/esbuilder/utils.mjs
@@ -9,7 +9,8 @@ import { sassPlugin } from 'esbuild-sass-plugin'
 import express from 'express'
 import fse from 'fs-extra'
 import fs from 'node:fs/promises'
-import * as path from 'path'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import postcss from 'postcss'
 import postcssPresetEnv from 'postcss-preset-env'
 import ts from 'typescript'
@@ -125,7 +126,11 @@ export function createHashlessEntrypoints(absWorkingDir, entrypoints) {
 }
 
 const tsconfigPath = isDev ? 'tsconfig.dev.json' : 'tsconfig.json'
-const { config: tsconfig } = ts.readConfigFile(path.resolve(process.cwd(), '..', tsconfigPath), ts.sys.readFile)
+
+const { config: tsconfig } = ts.readConfigFile(
+    path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', tsconfigPath),
+    ts.sys.readFile
+)
 
 /** @type {import('esbuild').BuildOptions} */
 export const commonConfig = {

--- a/common/esbuilder/utils.mjs
+++ b/common/esbuilder/utils.mjs
@@ -12,6 +12,7 @@ import fs from 'node:fs/promises'
 import * as path from 'path'
 import postcss from 'postcss'
 import postcssPresetEnv from 'postcss-preset-env'
+import ts from 'typescript'
 
 const defaultHost = process.argv.includes('--host') && process.argv.includes('0.0.0.0') ? '0.0.0.0' : 'localhost'
 const defaultPort = 8234
@@ -123,10 +124,14 @@ export function createHashlessEntrypoints(absWorkingDir, entrypoints) {
     }
 }
 
+const tsconfigPath = isDev ? 'tsconfig.dev.json' : 'tsconfig.json'
+const { config: tsconfig } = ts.readConfigFile(path.resolve(process.cwd(), '..', tsconfigPath), ts.sys.readFile)
+
 /** @type {import('esbuild').BuildOptions} */
 export const commonConfig = {
     sourcemap: true,
     minify: !isDev,
+    target: tsconfig.compilerOptions.target,
     resolveExtensions: ['.ts', '.tsx', '.js', '.jsx', '.scss', '.css', '.less'],
     publicPath: '/static',
     assetNames: 'assets/[name]-[hash]',
@@ -151,7 +156,7 @@ export const commonConfig = {
             },
         }),
     ],
-    tsconfig: isDev ? 'tsconfig.dev.json' : 'tsconfig.json',
+    tsconfig: tsconfigPath,
     define: {
         global: 'globalThis',
         'process.env.NODE_ENV': isDev ? '"development"' : '"production"',

--- a/common/esbuilder/utils.mjs
+++ b/common/esbuilder/utils.mjs
@@ -131,7 +131,7 @@ const { config: tsconfig } = ts.readConfigFile(path.resolve(process.cwd(), '..',
 export const commonConfig = {
     sourcemap: true,
     minify: !isDev,
-    target: tsconfig.compilerOptions.target,
+    target: tsconfig.compilerOptions.target, // We want the same target as tsconfig, should fail if tsconfig not found
     resolveExtensions: ['.ts', '.tsx', '.js', '.jsx', '.scss', '.css', '.less'],
     publicPath: '/static',
     assetNames: 'assets/[name]-[hash]',


### PR DESCRIPTION
## Problem

It looks like we haven't had an ECMAScript target set on our frontend builds! It _looked_ like we had one, `es2021` in tsconfig.json – but that one had no effect, because it wasn't used by ESBuild. This means we have been emitting syntax that's too modern for some browsers still out there, like in this Max AI ticket: ZEN-36613.

![err](https://us.posthog.com/uploaded_media/0198df42-2af4-0000-2129-dc3bba1c7f8a)

## Changes

Updated `common/esbuilder/utils.mjs` to use the target defined in `tsconfig.json`.

## How did you test this code?

If Docker builds and E2E tests work here, we're good to go.