### PR TITLE
fix(hogql): hogql window bug

### DIFF
--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -1871,12 +1871,10 @@ class _Printer(Visitor[str]):
     def _create_default_window_frame(self, node: ast.WindowFunction):
         # For lag/lead functions, we need to order by the first argument by default
         order_by: Optional[list[ast.OrderExpr]] = None
-        if node.over_expr.order_by is None:
-            # if no ORDER BY is provided, we order by the first argument by default
-            if node.exprs is not None and len(node.exprs) > 0:
-                order_by = [ast.OrderExpr(expr=clone_expr(node.exprs[0]), order="ASC")]
-        else:
+        if node.over_expr and node.over_expr.order_by:
             order_by = [cast(ast.OrderExpr, clone_expr(expr)) for expr in node.over_expr.order_by]
+        elif node.exprs is not None and len(node.exprs) > 0:
+            order_by = [ast.OrderExpr(expr=clone_expr(node.exprs[0]), order="ASC")]
 
         # Preserve existing PARTITION BY if provided via an existing OVER () clause
         partition_by: Optional[list[ast.Expr]] = None

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -1871,8 +1871,12 @@ class _Printer(Visitor[str]):
     def _create_default_window_frame(self, node: ast.WindowFunction):
         # For lag/lead functions, we need to order by the first argument by default
         order_by: Optional[list[ast.OrderExpr]] = None
-        if node.exprs is not None and len(node.exprs) > 0:
-            order_by = [ast.OrderExpr(expr=clone_expr(node.exprs[0]), order="ASC")]
+        if node.over_expr.order_by is None:
+            # if no ORDER BY is provided, we order by the first argument by default
+            if node.exprs is not None and len(node.exprs) > 0:
+                order_by = [ast.OrderExpr(expr=clone_expr(node.exprs[0]), order="ASC")]
+        else:
+            order_by = [cast(ast.OrderExpr, clone_expr(expr)) for expr in node.over_expr.order_by]
 
         # Preserve existing PARTITION BY if provided via an existing OVER () clause
         partition_by: Optional[list[ast.Expr]] = None

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -1496,6 +1496,14 @@ class TestPrinter(BaseTest):
             f"SELECT events.distinct_id AS distinct_id, lagInFrame(toNullable(toTimeZone(events.timestamp, %(hogql_val_0)s))) OVER (PARTITION BY events.distinct_id ORDER BY toTimeZone(events.timestamp, %(hogql_val_1)s) ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 50000",
         )
 
+        # No rows but order by exists
+        self.assertEqual(
+            self._select(
+                "SELECT distinct_id, lag(event) OVER (PARTITION BY distinct_id ORDER BY timestamp) FROM events"
+            ),
+            f"SELECT events.distinct_id AS distinct_id, lagInFrame(toNullable(events.event)) OVER (PARTITION BY events.distinct_id ORDER BY toTimeZone(events.timestamp, %(hogql_val_0)s) ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 50000",
+        )
+
     def test_window_functions_with_window(self):
         self.assertEqual(
             self._select(


### PR DESCRIPTION
## Problem

- bad default for window functions without "rows"

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- make sure the existing order by is respected even without "ROWS" explicitly defined

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
