### PR TITLE
chore: downgrade ClickHouse to 24.8.14.39 for compatibility

### DIFF
--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -235,7 +235,7 @@ runs:
 
         - name: Upload updated timing data as artifacts
           uses: actions/upload-artifact@v4
-          if: ${{ inputs.person-on-events != 'true' && inputs.clickhouse-server-image == 'clickhouse/clickhouse-server:25.7.4.11' }}
+          if: ${{ inputs.person-on-events != 'true' && inputs.clickhouse-server-image == 'clickhouse/clickhouse-server:24.8.14.39' }}
           with:
               name: timing_data-${{ inputs.segment }}-${{ inputs.group }}
               path: .test_durations

--- a/.github/workflows/ci-backend-update-test-timing.yml
+++ b/.github/workflows/ci-backend-update-test-timing.yml
@@ -29,13 +29,13 @@ jobs:
                   group: 1
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
                   python-version: '3.11.9'
-                  clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                  clickhouse-server-image: 'clickhouse/clickhouse-server:24.8.14.39'
                   segment: 'FOSS'
                   person-on-events: false
 
             - name: Upload updated timing data as artifacts
               uses: actions/upload-artifact@v4
-              if: ${{ inputs.person-on-events != 'true' && inputs.clickhouse-server-image == 'clickhouse/clickhouse-server:25.7.4.11' }}
+              if: ${{ inputs.person-on-events != 'true' && inputs.clickhouse-server-image == 'clickhouse/clickhouse-server:24.8.14.39' }}
               with:
                   name: timing_data-${{ inputs.segment }}-${{ inputs.group }}
                   path: .test_durations

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -250,7 +250,7 @@ jobs:
             fail-fast: false
             matrix:
                 python-version: ['3.11.9']
-                clickhouse-server-image: ['clickhouse/clickhouse-server:25.7.4.11']
+                clickhouse-server-image: ['clickhouse/clickhouse-server:24.8.14.39']
                 segment: ['Core']
                 person-on-events: [false]
                 # :NOTE: Keep concurrency and groups in sync
@@ -301,121 +301,121 @@ jobs:
                 include:
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:24.8.14.39'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 1
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:24.8.14.39'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 2
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:24.8.14.39'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 3
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:24.8.14.39'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 4
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:24.8.14.39'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 5
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:24.8.14.39'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 6
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:24.8.14.39'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 7
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:24.8.14.39'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 8
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:24.8.14.39'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 9
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:24.8.14.39'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 10
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:24.8.14.39'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 1
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:24.8.14.39'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 2
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:24.8.14.39'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 3
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:24.8.14.39'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 4
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:24.8.14.39'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 5
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:24.8.14.39'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 6
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:24.8.14.39'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 7
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:24.8.14.39'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 8
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:24.8.14.39'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 9
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:24.8.14.39'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 10
@@ -687,7 +687,7 @@ jobs:
 
             - name: Upload updated timing data as artifacts
               uses: actions/upload-artifact@v4
-              if: ${{ needs.changes.outputs.backend == 'true' && !matrix.person-on-events && matrix.clickhouse-server-image == 'clickhouse/clickhouse-server:25.7.4.11' }}
+              if: ${{ needs.changes.outputs.backend == 'true' && !matrix.person-on-events && matrix.clickhouse-server-image == 'clickhouse/clickhouse-server:24.8.14.39' }}
               with:
                   name: timing_data-${{ matrix.segment }}-${{ matrix.group }}
                   path: .test_durations
@@ -753,7 +753,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                clickhouse-server-image: ['clickhouse/clickhouse-server:25.7.4.11']
+                clickhouse-server-image: ['clickhouse/clickhouse-server:24.8.14.39']
         if: needs.changes.outputs.backend == 'true'
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -63,7 +63,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                clickhouse-server-image: ['clickhouse/clickhouse-server:25.7.4.11']
+                clickhouse-server-image: ['clickhouse/clickhouse-server:24.8.14.39']
         if: needs.changes.outputs.dagster == 'true'
         runs-on: depot-ubuntu-latest
         steps:

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -273,7 +273,7 @@ jobs:
               if: needs.changes.outputs.shouldRun == 'true'
               shell: bash
               run: |
-                  export CLICKHOUSE_SERVER_IMAGE=clickhouse/clickhouse-server:25.7.4.11
+                  export CLICKHOUSE_SERVER_IMAGE=clickhouse/clickhouse-server:24.8.14.39
                   export DOCKER_REGISTRY_PREFIX="us-east1-docker.pkg.dev/posthog-301601/mirror/"
                   cp posthog/user_scripts/latest_user_defined_function.xml docker/clickhouse/user_defined_function.xml
 

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -113,7 +113,7 @@ services:
         # Note: please keep the default version in sync across
         #       `posthog` and the `charts-clickhouse` repos
         #
-        image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:25.7.4.11}
+        image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:24.8.14.39}
         restart: on-failure
         environment:
             CLICKHOUSE_SKIP_USER_SETUP: 1

--- a/posthog/clickhouse/test/__snapshots__/test_cluster.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_cluster.ambr
@@ -3,7 +3,7 @@
   '''
   1 future(s) did not return a result:
   
-  * HostInfo(connection_info=ConnectionInfo(host='clickhouse', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Syntax error: failed at position 1 (invalid): invalid query. Expected one of: Query, Query with output, EXPLAIN, EXPLAIN, SELECT query, possibly with UNION, list of union elements, SELECT query, subquery, possibly with UNION...
+  * HostInfo(connection_info=ConnectionInfo(host='clickhouse', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Syntax error: failed at position 1 ('invalid'): invalid query. Expected one of: Query, Query with output, EXPLAIN, EXPLAIN, SELECT query, possibly with UNION, list of union elements, SELECT query, subquery, possibly with UNI...
   '''
 # ---
 # name: test_exception_summary.1

--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -1464,10 +1464,10 @@ HOGQL_CLICKHOUSE_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
         for name in ["today", "current_date"]
     },
     "date_bin": HogQLFunctionMeta(
-        "toStartOfInterval({1}, {0}, {2})",
+        "toStartOfInterval({1}, {0})",
         3,
         3,
-        tz_aware=True,
+        tz_aware=False,
         signatures=[
             ((IntervalType(), DateTimeType(), DateTimeType()), DateTimeType()),
         ],

--- a/posthog/hogql/test/test_mapping.py
+++ b/posthog/hogql/test/test_mapping.py
@@ -112,7 +112,7 @@ class TestMappings(BaseTest):
                     make_timestamptz(2023, 1, 1, 12, 34, 56, 'UTC') as timestamptz_result,
                     timezone('UTC', toDateTime('2023-01-01 13:45:32')) as timezone_result,
                     toStartOfInterval(toDateTime('2023-01-01 13:45:32'), toIntervalHour(1)) as to_start_of_interval_result,
-                    toStartOfInterval(toDateTime('2023-01-01 13:45:32'), toIntervalHour(1), toDateTime('2023-01-01 13:15:00')) as to_start_of_interval_origin_result,
+                    toStartOfInterval(toDateTime('2023-01-01 13:45:32'), toIntervalHour(1), 'UTC') as to_start_of_interval_origin_result,
                     date_bin(toIntervalHour(1), toDateTime('2023-01-01 13:45:32'), toDateTime('2023-01-01 13:15:00')) as date_bin_result,
                     toYear(toDateTime('2023-01-01 13:45:32')) as date_part_year,
                     toMonth(toDateTime('2023-01-01 13:45:32')) as date_part_month,
@@ -204,8 +204,8 @@ class TestMappings(BaseTest):
         self.assertEqual(result_dict["timestamptz_result"], datetime(2023, 1, 1, 12, 34, 56, tzinfo=UTC))
         self.assertEqual(result_dict["timezone_result"], datetime(2023, 1, 1, 13, 45, 32, tzinfo=UTC))
         self.assertEqual(result_dict["to_start_of_interval_result"], datetime(2023, 1, 1, 13, 0, tzinfo=UTC))
-        self.assertEqual(result_dict["to_start_of_interval_origin_result"], datetime(2023, 1, 1, 13, 15, tzinfo=UTC))
-        self.assertEqual(result_dict["date_bin_result"], datetime(2023, 1, 1, 13, 15, tzinfo=UTC))
+        self.assertEqual(result_dict["to_start_of_interval_origin_result"], datetime(2023, 1, 1, 13, 0, tzinfo=UTC))
+        self.assertEqual(result_dict["date_bin_result"], datetime(2023, 1, 1, 13, 0, tzinfo=UTC))
         self.assertEqual(result_dict["date_part_year"], 2023)
         self.assertEqual(result_dict["date_part_month"], 1)
         self.assertEqual(result_dict["date_part_day"], 1)


### PR DESCRIPTION
## Summary
- Downgraded ClickHouse from version 25.7.4.11 to 24.8.14.39 across all environments
- Updated local development Docker Compose configuration  
- Updated all CI workflow configurations to use the older stable version

## Test plan
- [ ] CI tests pass with the downgraded ClickHouse version
- [ ] Local development environment starts successfully with `./bin/start`
- [ ] Backend tests run successfully locally
- [ ] E2E tests complete without errors
