### PR TITLE
feat(hogql): add a $virt_path_cleaned_pathname virtual field

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -438,7 +438,6 @@ def _use_virtual_fields(database: Database, modifiers: HogQLQueryModifiers, timi
                 database.persons.fields[field_name] = ast.FieldTraverser(chain=chain)
                 poe.fields[field_name] = ast.FieldTraverser(chain=chain)
 
-    # Add path cleaning virtual field for events
     with timings.measure("path_cleaned_pathname"):
         field_name = "$virt_path_cleaned_pathname"
         database.events.fields[field_name] = create_path_cleaned_pathname(

--- a/posthog/hogql/database/schema/path_cleaning.py
+++ b/posthog/hogql/database/schema/path_cleaning.py
@@ -1,0 +1,36 @@
+from typing import TYPE_CHECKING, Optional
+
+from posthog.hogql import ast
+from posthog.hogql.database.models import ExpressionField
+
+if TYPE_CHECKING:
+    from posthog.models import Team
+
+
+def create_path_cleaned_pathname(
+    name: str,
+    team: "Team",
+    properties_path: Optional[list[str]] = None
+) -> ExpressionField:
+    """
+    Create a virtual field that applies team's path cleaning rules to pathname.
+
+    This field applies the same path cleaning logic used in web analytics
+    to clean up pathname values by applying regex replacements configured
+    in the team's path_cleaning_filters.
+    """
+    if not properties_path:
+        properties_path = ["properties"]
+
+    # Import here to avoid circular import
+    from posthog.hogql.property import apply_path_cleaning
+
+    # Build the expression using the team's path cleaning rules
+    path_expr = ast.Field(chain=[*properties_path, "$pathname"])
+    cleaned_expr = apply_path_cleaning(path_expr, team)
+
+    return ExpressionField(
+        name=name,
+        expr=cleaned_expr,
+        isolate_scope=True,
+    )

--- a/posthog/hogql/database/schema/path_cleaning.py
+++ b/posthog/hogql/database/schema/path_cleaning.py
@@ -12,20 +12,11 @@ def create_path_cleaned_pathname(
     team: "Team",
     properties_path: Optional[list[str]] = None
 ) -> ExpressionField:
-    """
-    Create a virtual field that applies team's path cleaning rules to pathname.
-
-    This field applies the same path cleaning logic used in web analytics
-    to clean up pathname values by applying regex replacements configured
-    in the team's path_cleaning_filters.
-    """
     if not properties_path:
         properties_path = ["properties"]
 
-    # Import here to avoid circular import
     from posthog.hogql.property import apply_path_cleaning
 
-    # Build the expression using the team's path cleaning rules
     path_expr = ast.Field(chain=[*properties_path, "$pathname"])
     cleaned_expr = apply_path_cleaning(path_expr, team)
 

--- a/posthog/hogql/database/schema/test/test_path_cleaning.py
+++ b/posthog/hogql/database/schema/test/test_path_cleaning.py
@@ -1,15 +1,15 @@
 import uuid
-from uuid import uuid4
 
-from posthog.test.base import ClickhouseTestMixin
-from posthog.models.utils import uuid7
+from posthog.test.base import BaseTest, _create_event
+
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
-from posthog.test.test_utils import _create_event
+
+from posthog.models.utils import uuid7
 
 
-class TestPathCleaningVirtualField(ClickhouseTestMixin):
+class TestPathCleaningVirtualField(BaseTest):
     def setUp(self):
         super().setUp()
         # Set up default path cleaning filters
@@ -19,14 +19,13 @@ class TestPathCleaningVirtualField(ClickhouseTestMixin):
                 "alias": "/product/*"
             },
             {
-                "regex": r"/users/[^/]+/profile", 
+                "regex": r"/users/[^/]+/profile",
                 "alias": "/users/*/profile"
             }
         ]
         self.team.save()
 
     def _get_event_path_cleaned_pathname(self, pathname: str):
-        """Helper to create event and query the virtual field"""
         person_id = str(uuid.uuid4())
 
         _create_event(
@@ -39,11 +38,9 @@ class TestPathCleaningVirtualField(ClickhouseTestMixin):
             },
         )
 
-        # Flush events to ensure they're available for querying
         from posthog.test.base import flush_persons_and_events
         flush_persons_and_events()
 
-        # Let's try a simpler approach and just check all available fields on the event
         response = execute_hogql_query(
             parse_select(
                 """
@@ -59,12 +56,10 @@ class TestPathCleaningVirtualField(ClickhouseTestMixin):
         )
 
         if response.results and len(response.results[0]) >= 2:
-            return response.results[0][1]  # Return the cleaned pathname
+            return response.results[0][1]
         return None
 
     def test_no_path_cleaning_rules(self):
-        """Test that when there are no path cleaning rules, original pathname is returned"""
-        # Clear path cleaning filters
         self.team.path_cleaning_filters = []
         self.team.save()
 
@@ -74,22 +69,18 @@ class TestPathCleaningVirtualField(ClickhouseTestMixin):
         self.assertEqual(cleaned_path, original_path)
 
     def test_single_rule_match(self):
-        """Test path cleaning with a single matching rule"""
         original_path = "/product/123"
         cleaned_path = self._get_event_path_cleaned_pathname(original_path)
 
         self.assertEqual(cleaned_path, "/product/*")
 
     def test_no_rule_match(self):
-        """Test path that doesn't match any cleaning rules"""
         original_path = "/about/us"
         cleaned_path = self._get_event_path_cleaned_pathname(original_path)
 
         self.assertEqual(cleaned_path, "/about/us")
 
     def test_multiple_rules_applied_sequentially(self):
-        """Test that all matching rules are applied sequentially"""
-        # Add overlapping rules - both will be applied in order
         self.team.path_cleaning_filters = [
             {
                 "regex": r"/product/\d+",
@@ -105,13 +96,9 @@ class TestPathCleaningVirtualField(ClickhouseTestMixin):
         original_path = "/product/123/details"
         cleaned_path = self._get_event_path_cleaned_pathname(original_path)
 
-        # All rules are applied sequentially:
-        # 1. /product/123/details -> /product/*/details (first rule)
-        # 2. /product/*/details -> /product/*/details (second rule matches and replaces)
         self.assertEqual(cleaned_path, "/product/*/details")
 
     def test_complex_regex_patterns(self):
-        """Test more complex regex patterns"""
         self.team.path_cleaning_filters = [
             {
                 "regex": r"/api/v\d+/users/[^/]+",
@@ -124,32 +111,27 @@ class TestPathCleaningVirtualField(ClickhouseTestMixin):
         ]
         self.team.save()
 
-        # Test API pattern
         api_path = "/api/v2/users/john_doe"
         cleaned_api = self._get_event_path_cleaned_pathname(api_path)
         self.assertEqual(cleaned_api, "/api/v*/users/*")
 
-        # Test UUID pattern
         uuid_path = f"/dashboard/{str(uuid.uuid4())}/settings/billing"
         cleaned_uuid = self._get_event_path_cleaned_pathname(uuid_path)
         self.assertEqual(cleaned_uuid, "/dashboard/*/...")
 
     def test_user_profile_pattern(self):
-        """Test the user profile pattern from setUp"""
         original_path = "/users/johndoe/profile"
         cleaned_path = self._get_event_path_cleaned_pathname(original_path)
 
         self.assertEqual(cleaned_path, "/users/*/profile")
 
     def test_empty_pathname(self):
-        """Test behavior with empty pathname"""
         original_path = ""
         cleaned_path = self._get_event_path_cleaned_pathname(original_path)
 
         self.assertEqual(cleaned_path, "")
 
     def test_null_pathname(self):
-        """Test behavior when pathname is None"""
         person_id = str(uuid.uuid4())
 
         _create_event(
@@ -158,7 +140,6 @@ class TestPathCleaningVirtualField(ClickhouseTestMixin):
             distinct_id=person_id,
             properties={
                 "$session_id": str(uuid7()),
-                # No $pathname property
             },
         )
 
@@ -170,11 +151,9 @@ class TestPathCleaningVirtualField(ClickhouseTestMixin):
             self.team,
         )
 
-        # Should be None/null when no pathname is present
         self.assertIsNone(response.results[0][0])
 
     def test_special_characters_in_path(self):
-        """Test paths with special characters"""
         self.team.path_cleaning_filters = [
             {
                 "regex": r"/search\?.*",
@@ -189,8 +168,6 @@ class TestPathCleaningVirtualField(ClickhouseTestMixin):
         self.assertEqual(cleaned_path, "/search")
 
     def test_can_query_in_sql_editor_context(self):
-        """Test that the virtual field works in SQL Editor context with multiple events"""
-        # Create multiple events with different pathnames
         paths = ["/product/123", "/product/456", "/about", "/users/alice/profile"]
         person_ids = []
 
@@ -224,10 +201,10 @@ class TestPathCleaningVirtualField(ClickhouseTestMixin):
         )
 
         expected_results = [
-            ("/about", "/about"),  # No cleaning rule
-            ("/product/123", "/product/*"),  # Cleaned
-            ("/product/456", "/product/*"),  # Cleaned
-            ("/users/alice/profile", "/users/*/profile"),  # Cleaned
+            ("/about", "/about"),
+            ("/product/123", "/product/*"),
+            ("/product/456", "/product/*"),
+            ("/users/alice/profile", "/users/*/profile"),
         ]
 
         self.assertEqual(len(response.results), 4)

--- a/posthog/hogql/database/schema/test/test_path_cleaning.py
+++ b/posthog/hogql/database/schema/test/test_path_cleaning.py
@@ -1,0 +1,234 @@
+import uuid
+from uuid import uuid4
+
+from posthog.test.base import ClickhouseTestMixin
+from posthog.models.utils import uuid7
+from posthog.hogql import ast
+from posthog.hogql.parser import parse_select
+from posthog.hogql.query import execute_hogql_query
+from posthog.test.test_utils import _create_event
+
+
+class TestPathCleaningVirtualField(ClickhouseTestMixin):
+    def setUp(self):
+        super().setUp()
+        # Set up default path cleaning filters
+        self.team.path_cleaning_filters = [
+            {
+                "regex": r"/product/\d+",
+                "alias": "/product/*"
+            },
+            {
+                "regex": r"/users/[^/]+/profile", 
+                "alias": "/users/*/profile"
+            }
+        ]
+        self.team.save()
+
+    def _get_event_path_cleaned_pathname(self, pathname: str):
+        """Helper to create event and query the virtual field"""
+        person_id = str(uuid.uuid4())
+
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id=person_id,
+            properties={
+                "$session_id": str(uuid7()),
+                "$pathname": pathname,
+            },
+        )
+
+        # Flush events to ensure they're available for querying
+        from posthog.test.base import flush_persons_and_events
+        flush_persons_and_events()
+
+        # Let's try a simpler approach and just check all available fields on the event
+        response = execute_hogql_query(
+            parse_select(
+                """
+                select
+                    properties.$pathname as original_pathname,
+                    $virt_path_cleaned_pathname as cleaned_pathname
+                from events
+                where distinct_id = {person_id}
+                """,
+                placeholders={"person_id": ast.Constant(value=person_id)},
+            ),
+            self.team,
+        )
+
+        if response.results and len(response.results[0]) >= 2:
+            return response.results[0][1]  # Return the cleaned pathname
+        return None
+
+    def test_no_path_cleaning_rules(self):
+        """Test that when there are no path cleaning rules, original pathname is returned"""
+        # Clear path cleaning filters
+        self.team.path_cleaning_filters = []
+        self.team.save()
+
+        original_path = "/product/123/details"
+        cleaned_path = self._get_event_path_cleaned_pathname(original_path)
+
+        self.assertEqual(cleaned_path, original_path)
+
+    def test_single_rule_match(self):
+        """Test path cleaning with a single matching rule"""
+        original_path = "/product/123"
+        cleaned_path = self._get_event_path_cleaned_pathname(original_path)
+
+        self.assertEqual(cleaned_path, "/product/*")
+
+    def test_no_rule_match(self):
+        """Test path that doesn't match any cleaning rules"""
+        original_path = "/about/us"
+        cleaned_path = self._get_event_path_cleaned_pathname(original_path)
+
+        self.assertEqual(cleaned_path, "/about/us")
+
+    def test_multiple_rules_applied_sequentially(self):
+        """Test that all matching rules are applied sequentially"""
+        # Add overlapping rules - both will be applied in order
+        self.team.path_cleaning_filters = [
+            {
+                "regex": r"/product/\d+",
+                "alias": "/product/*"
+            },
+            {
+                "regex": r"/product/\d+/.*",
+                "alias": "/product/*/details"
+            }
+        ]
+        self.team.save()
+
+        original_path = "/product/123/details"
+        cleaned_path = self._get_event_path_cleaned_pathname(original_path)
+
+        # All rules are applied sequentially:
+        # 1. /product/123/details -> /product/*/details (first rule)
+        # 2. /product/*/details -> /product/*/details (second rule matches and replaces)
+        self.assertEqual(cleaned_path, "/product/*/details")
+
+    def test_complex_regex_patterns(self):
+        """Test more complex regex patterns"""
+        self.team.path_cleaning_filters = [
+            {
+                "regex": r"/api/v\d+/users/[^/]+",
+                "alias": "/api/v*/users/*"
+            },
+            {
+                "regex": r"/dashboard/[0-9a-f-]{36}/.*",
+                "alias": "/dashboard/*/..."
+            }
+        ]
+        self.team.save()
+
+        # Test API pattern
+        api_path = "/api/v2/users/john_doe"
+        cleaned_api = self._get_event_path_cleaned_pathname(api_path)
+        self.assertEqual(cleaned_api, "/api/v*/users/*")
+
+        # Test UUID pattern
+        uuid_path = f"/dashboard/{str(uuid.uuid4())}/settings/billing"
+        cleaned_uuid = self._get_event_path_cleaned_pathname(uuid_path)
+        self.assertEqual(cleaned_uuid, "/dashboard/*/...")
+
+    def test_user_profile_pattern(self):
+        """Test the user profile pattern from setUp"""
+        original_path = "/users/johndoe/profile"
+        cleaned_path = self._get_event_path_cleaned_pathname(original_path)
+
+        self.assertEqual(cleaned_path, "/users/*/profile")
+
+    def test_empty_pathname(self):
+        """Test behavior with empty pathname"""
+        original_path = ""
+        cleaned_path = self._get_event_path_cleaned_pathname(original_path)
+
+        self.assertEqual(cleaned_path, "")
+
+    def test_null_pathname(self):
+        """Test behavior when pathname is None"""
+        person_id = str(uuid.uuid4())
+
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id=person_id,
+            properties={
+                "$session_id": str(uuid7()),
+                # No $pathname property
+            },
+        )
+
+        response = execute_hogql_query(
+            parse_select(
+                "select $virt_path_cleaned_pathname as cleaned_pathname from events where distinct_id = {person_id}",
+                placeholders={"person_id": ast.Constant(value=person_id)},
+            ),
+            self.team,
+        )
+
+        # Should be None/null when no pathname is present
+        self.assertIsNone(response.results[0][0])
+
+    def test_special_characters_in_path(self):
+        """Test paths with special characters"""
+        self.team.path_cleaning_filters = [
+            {
+                "regex": r"/search\?.*",
+                "alias": "/search"
+            }
+        ]
+        self.team.save()
+
+        original_path = "/search?query=test&category=books"
+        cleaned_path = self._get_event_path_cleaned_pathname(original_path)
+
+        self.assertEqual(cleaned_path, "/search")
+
+    def test_can_query_in_sql_editor_context(self):
+        """Test that the virtual field works in SQL Editor context with multiple events"""
+        # Create multiple events with different pathnames
+        paths = ["/product/123", "/product/456", "/about", "/users/alice/profile"]
+        person_ids = []
+
+        for path in paths:
+            person_id = str(uuid.uuid4())
+            person_ids.append(person_id)
+            _create_event(
+                event="$pageview",
+                team=self.team,
+                distinct_id=person_id,
+                properties={
+                    "$session_id": str(uuid7()),
+                    "$pathname": path,
+                },
+            )
+
+        # Query all events with the virtual field
+        response = execute_hogql_query(
+            parse_select(
+                """
+                select
+                    properties.$pathname as original_path,
+                    $virt_path_cleaned_pathname as cleaned_path
+                from events
+                where distinct_id in {person_ids}
+                order by properties.$pathname
+                """,
+                placeholders={"person_ids": ast.Constant(value=person_ids)},
+            ),
+            self.team,
+        )
+
+        expected_results = [
+            ("/about", "/about"),  # No cleaning rule
+            ("/product/123", "/product/*"),  # Cleaned
+            ("/product/456", "/product/*"),  # Cleaned
+            ("/users/alice/profile", "/users/*/profile"),  # Cleaned
+        ]
+
+        self.assertEqual(len(response.results), 4)
+        self.assertEqual(response.results, expected_results)

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -1411,6 +1411,16 @@
                   "schema_valid": true,
                   "table": null,
                   "type": "expression"
+              },
+              "$virt_path_cleaned_pathname": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "`$virt_path_cleaned_pathname`",
+                  "id": null,
+                  "name": "$virt_path_cleaned_pathname",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
               }
           },
           "id": "events",
@@ -2807,6 +2817,16 @@
                   "schema_valid": true,
                   "table": null,
                   "type": "expression"
+              },
+              "$virt_path_cleaned_pathname": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "`$virt_path_cleaned_pathname`",
+                  "id": null,
+                  "name": "$virt_path_cleaned_pathname",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
               }
           },
           "id": "events",

--- a/posthog/hogql/test/__snapshots__/test_resolver.ambr
+++ b/posthog/hogql/test/__snapshots__/test_resolver.ambr
@@ -40,6 +40,9 @@
                           $session_id: {
                             hidden: False
                           },
+                          $virt_path_cleaned_pathname: {
+                            hidden: False
+                          },
                           $window_id: {
                             hidden: False
                           },
@@ -178,6 +181,21 @@
                   type: {
                     name: "$session_id"
                     table_type: <recursion ...>
+                  }
+                },
+                $virt_path_cleaned_pathname: {
+                  alias: "$virt_path_cleaned_pathname"
+                  type: {
+                    alias: "$pathname"
+                    type: {
+                      chain: [
+                        "$pathname"
+                      ]
+                      field_type: {
+                        name: "properties"
+                        table_type: <recursion ...>
+                      }
+                    }
                   }
                 },
                 $window_id: {
@@ -704,6 +722,23 @@
         hidden: True
         type: {
           alias: "issue_id"
+          type: <recursion ...>
+        }
+      },
+      {
+        alias: "$virt_path_cleaned_pathname"
+        expr: {
+          chain: [
+            "$virt_path_cleaned_pathname"
+          ]
+          type: {
+            name: "$virt_path_cleaned_pathname"
+            table_type: <recursion ...>
+          }
+        }
+        hidden: True
+        type: {
+          alias: "$virt_path_cleaned_pathname"
           type: <recursion ...>
         }
       }
@@ -1292,6 +1327,23 @@
             }
             hidden: True
             type: <recursion ...>
+          },
+          {
+            alias: "$virt_path_cleaned_pathname"
+            expr: {
+              alias: "$pathname"
+              expr: {
+                chain: [
+                  "properties",
+                  "$pathname"
+                ]
+                type: <recursion ...>
+              }
+              hidden: True
+              type: <recursion ...>
+            }
+            hidden: True
+            type: <recursion ...>
           }
         ]
         select_from: {
@@ -1319,6 +1371,7 @@
         $group_3: <recursion ...>,
         $group_4: <recursion ...>,
         $session_id: <recursion ...>,
+        $virt_path_cleaned_pathname: <recursion ...>,
         $window_id: <recursion ...>,
         created_at: <recursion ...>,
         distinct_id: <recursion ...>,
@@ -1374,6 +1427,9 @@
                     hidden: False
                   },
                   $session_id: {
+                    hidden: False
+                  },
+                  $virt_path_cleaned_pathname: {
                     hidden: False
                   },
                   $window_id: {
@@ -2229,6 +2285,37 @@
           alias: "issue_id"
           type: <recursion ...>
         }
+      },
+      {
+        alias: "$virt_path_cleaned_pathname"
+        expr: {
+          alias: "$pathname"
+          expr: {
+            chain: [
+              "properties",
+              "$pathname"
+            ]
+            type: {
+              chain: [
+                "$pathname"
+              ]
+              field_type: {
+                name: "properties"
+                table_type: <recursion ...>
+              }
+            }
+          }
+          hidden: True
+          type: {
+            alias: "$pathname"
+            type: <recursion ...>
+          }
+        }
+        hidden: True
+        type: {
+          alias: "$virt_path_cleaned_pathname"
+          type: <recursion ...>
+        }
       }
     ]
     select_from: {
@@ -2250,6 +2337,7 @@
         $group_3: <recursion ...>,
         $group_4: <recursion ...>,
         $session_id: <recursion ...>,
+        $virt_path_cleaned_pathname: <recursion ...>,
         $window_id: <recursion ...>,
         created_at: <recursion ...>,
         distinct_id: <recursion ...>,
@@ -3182,6 +3270,9 @@
                           $session_id: {
                             hidden: False
                           },
+                          $virt_path_cleaned_pathname: {
+                            hidden: False
+                          },
                           $window_id: {
                             hidden: False
                           },
@@ -3320,6 +3411,21 @@
                   type: {
                     name: "$session_id"
                     table_type: <recursion ...>
+                  }
+                },
+                $virt_path_cleaned_pathname: {
+                  alias: "$virt_path_cleaned_pathname"
+                  type: {
+                    alias: "$pathname"
+                    type: {
+                      chain: [
+                        "$pathname"
+                      ]
+                      field_type: {
+                        name: "properties"
+                        table_type: <recursion ...>
+                      }
+                    }
                   }
                 },
                 $window_id: {
@@ -3846,6 +3952,23 @@
         hidden: True
         type: {
           alias: "issue_id"
+          type: <recursion ...>
+        }
+      },
+      {
+        alias: "$virt_path_cleaned_pathname"
+        expr: {
+          chain: [
+            "$virt_path_cleaned_pathname"
+          ]
+          type: {
+            name: "$virt_path_cleaned_pathname"
+            table_type: <recursion ...>
+          }
+        }
+        hidden: True
+        type: {
+          alias: "$virt_path_cleaned_pathname"
           type: <recursion ...>
         }
       }
@@ -4435,6 +4558,23 @@
               }
               hidden: True
               type: <recursion ...>
+            },
+            {
+              alias: "$virt_path_cleaned_pathname"
+              expr: {
+                alias: "$pathname"
+                expr: {
+                  chain: [
+                    "properties",
+                    "$pathname"
+                  ]
+                  type: <recursion ...>
+                }
+                hidden: True
+                type: <recursion ...>
+              }
+              hidden: True
+              type: <recursion ...>
             }
           ]
           select_from: {
@@ -4479,6 +4619,9 @@
                               hidden: False
                             },
                             $session_id: {
+                              hidden: False
+                            },
+                            $virt_path_cleaned_pathname: {
                               hidden: False
                             },
                             $window_id: {
@@ -5331,6 +5474,37 @@
                     alias: "issue_id"
                     type: <recursion ...>
                   }
+                },
+                {
+                  alias: "$virt_path_cleaned_pathname"
+                  expr: {
+                    alias: "$pathname"
+                    expr: {
+                      chain: [
+                        "properties",
+                        "$pathname"
+                      ]
+                      type: {
+                        chain: [
+                          "$pathname"
+                        ]
+                        field_type: {
+                          name: "properties"
+                          table_type: <recursion ...>
+                        }
+                      }
+                    }
+                    hidden: True
+                    type: {
+                      alias: "$pathname"
+                      type: <recursion ...>
+                    }
+                  }
+                  hidden: True
+                  type: {
+                    alias: "$virt_path_cleaned_pathname"
+                    type: <recursion ...>
+                  }
                 }
               ]
               select_from: {
@@ -5352,6 +5526,7 @@
                   $group_3: <recursion ...>,
                   $group_4: <recursion ...>,
                   $session_id: <recursion ...>,
+                  $virt_path_cleaned_pathname: <recursion ...>,
                   $window_id: <recursion ...>,
                   created_at: <recursion ...>,
                   distinct_id: <recursion ...>,
@@ -5400,6 +5575,7 @@
         $group_3: <recursion ...>,
         $group_4: <recursion ...>,
         $session_id: <recursion ...>,
+        $virt_path_cleaned_pathname: <recursion ...>,
         $window_id: <recursion ...>,
         created_at: <recursion ...>,
         distinct_id: <recursion ...>,
@@ -5673,6 +5849,9 @@
                     hidden: False
                   },
                   $session_id: {
+                    hidden: False
+                  },
+                  $virt_path_cleaned_pathname: {
                     hidden: False
                   },
                   $window_id: {
@@ -6525,6 +6704,37 @@
           alias: "issue_id"
           type: <recursion ...>
         }
+      },
+      {
+        alias: "$virt_path_cleaned_pathname"
+        expr: {
+          alias: "$pathname"
+          expr: {
+            chain: [
+              "properties",
+              "$pathname"
+            ]
+            type: {
+              chain: [
+                "$pathname"
+              ]
+              field_type: {
+                name: "properties"
+                table_type: <recursion ...>
+              }
+            }
+          }
+          hidden: True
+          type: {
+            alias: "$pathname"
+            type: <recursion ...>
+          }
+        }
+        hidden: True
+        type: {
+          alias: "$virt_path_cleaned_pathname"
+          type: <recursion ...>
+        }
       }
     ]
     select_from: {
@@ -6546,6 +6756,7 @@
         $group_3: <recursion ...>,
         $group_4: <recursion ...>,
         $session_id: <recursion ...>,
+        $virt_path_cleaned_pathname: <recursion ...>,
         $window_id: <recursion ...>,
         created_at: <recursion ...>,
         distinct_id: <recursion ...>,
@@ -6605,6 +6816,9 @@
                       hidden: False
                     },
                     $session_id: {
+                      hidden: False
+                    },
+                    $virt_path_cleaned_pathname: {
                       hidden: False
                     },
                     $window_id: {
@@ -7458,6 +7672,37 @@
           alias: "issue_id"
           type: <recursion ...>
         }
+      },
+      {
+        alias: "$virt_path_cleaned_pathname"
+        expr: {
+          alias: "$pathname"
+          expr: {
+            chain: [
+              "properties",
+              "$pathname"
+            ]
+            type: {
+              chain: [
+                "$pathname"
+              ]
+              field_type: {
+                name: "properties"
+                table_type: <recursion ...>
+              }
+            }
+          }
+          hidden: True
+          type: {
+            alias: "$pathname"
+            type: <recursion ...>
+          }
+        }
+        hidden: True
+        type: {
+          alias: "$virt_path_cleaned_pathname"
+          type: <recursion ...>
+        }
       }
     ]
     select_from: {
@@ -7480,6 +7725,7 @@
         $group_3: <recursion ...>,
         $group_4: <recursion ...>,
         $session_id: <recursion ...>,
+        $virt_path_cleaned_pathname: <recursion ...>,
         $window_id: <recursion ...>,
         created_at: <recursion ...>,
         distinct_id: <recursion ...>,
@@ -7539,6 +7785,9 @@
                         hidden: False
                       },
                       $session_id: {
+                        hidden: False
+                      },
+                      $virt_path_cleaned_pathname: {
                         hidden: False
                       },
                       $window_id: {
@@ -7729,6 +7978,9 @@
                         hidden: False
                       },
                       $session_id: {
+                        hidden: False
+                      },
+                      $virt_path_cleaned_pathname: {
                         hidden: False
                       },
                       $window_id: {
@@ -8231,6 +8483,9 @@
                   $session_id: {
                     hidden: False
                   },
+                  $virt_path_cleaned_pathname: {
+                    hidden: False
+                  },
                   $window_id: {
                     hidden: False
                   },
@@ -8451,6 +8706,9 @@
                       hidden: False
                     },
                     $session_id: {
+                      hidden: False
+                    },
+                    $virt_path_cleaned_pathname: {
                       hidden: False
                     },
                     $window_id: {
@@ -8677,6 +8935,9 @@
                         hidden: False
                       },
                       $session_id: {
+                        hidden: False
+                      },
+                      $virt_path_cleaned_pathname: {
                         hidden: False
                       },
                       $window_id: {
@@ -8939,6 +9200,9 @@
                                 hidden: False
                               },
                               $session_id: {
+                                hidden: False
+                              },
+                              $virt_path_cleaned_pathname: {
                                 hidden: False
                               },
                               $window_id: {
@@ -9209,6 +9473,9 @@
                   $session_id: {
                     hidden: False
                   },
+                  $virt_path_cleaned_pathname: {
+                    hidden: False
+                  },
                   $window_id: {
                     hidden: False
                   },
@@ -9438,6 +9705,9 @@
                       hidden: False
                     },
                     $session_id: {
+                      hidden: False
+                    },
+                    $virt_path_cleaned_pathname: {
                       hidden: False
                     },
                     $window_id: {
@@ -9672,6 +9942,9 @@
                   $session_id: {
                     hidden: False
                   },
+                  $virt_path_cleaned_pathname: {
+                    hidden: False
+                  },
                   $window_id: {
                     hidden: False
                   },
@@ -9888,6 +10161,9 @@
                       hidden: False
                     },
                     $session_id: {
+                      hidden: False
+                    },
+                    $virt_path_cleaned_pathname: {
                       hidden: False
                     },
                     $window_id: {
@@ -10205,6 +10481,9 @@
                     $session_id: {
                       hidden: False
                     },
+                    $virt_path_cleaned_pathname: {
+                      hidden: False
+                    },
                     $window_id: {
                       hidden: False
                     },
@@ -10388,6 +10667,9 @@
                           hidden: False
                         },
                         $session_id: {
+                          hidden: False
+                        },
+                        $virt_path_cleaned_pathname: {
                           hidden: False
                         },
                         $window_id: {
@@ -10585,6 +10867,9 @@
                     hidden: False
                   },
                   $session_id: {
+                    hidden: False
+                  },
+                  $virt_path_cleaned_pathname: {
                     hidden: False
                   },
                   $window_id: {

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -2007,6 +2007,13 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "type": "String",
             "virtual": True,
         },
+        "$virt_path_cleaned_pathname": {
+            "label": "Path cleaned pathname",
+            "description": "The pathname with path cleaning rules applied. Path cleaning allows you to clean up URL paths by applying regex replacements to group similar paths together.",
+            "examples": ["/products", "/about", "/dashboard"],
+            "type": "String",
+            "virtual": True,
+        },
         "$virt_initial_referring_domain_type": {
             "description": "What type of referring domain this user initially came from.",
             "examples": ["Search", "Video", "Direct"],

--- a/products/data_warehouse/backend/test/__snapshots__/test_hogql_fixer_ai.ambr
+++ b/products/data_warehouse/backend/test/__snapshots__/test_hogql_fixer_ai.ambr
@@ -42,6 +42,7 @@
   - event_issue_id (expression)
   - exception_issue_override (lazy_table)
   - issue_id (expression)
+  - $virt_path_cleaned_pathname (string)
   '''
 # ---
 # name: test_get_system_prompt
@@ -154,6 +155,7 @@
   - event_issue_id (expression)
   - exception_issue_override (lazy_table)
   - issue_id (expression)
+  - $virt_path_cleaned_pathname (string)
   
   Below is the current HogQL query and the error message
   


### PR DESCRIPTION
## Problem

Users want to use PostHog's path cleaning functionality beyond web analytics in the SQL Editor. Currently, path cleaning (which applies regex replacements to group similar URL paths) is only available in web analytics queries, limiting its usefulness for custom analysis and data exploration.

## Changes

- **New virtual field**: Added `$virt_path_cleaned_pathname` which is accessible in SQL Editor queries

Usage example:
```sql
-- Basic usage
SELECT $virt_path_cleaned_pathname FROM events

-- With original pathname for comparison  
SELECT 
    properties.$pathname as original_path,
    $virt_path_cleaned_pathname as cleaned_path
FROM events
```

## How did you test this code?

Technical implementation uses the same path cleaning logic as web analytics, with rules "baked into" the AST expression at database creation time for query efficiency.