### PR TITLE
fix(ux): new info panel icon, new panel title

### DIFF
--- a/frontend/src/layout/scenes/SceneHeader.tsx
+++ b/frontend/src/layout/scenes/SceneHeader.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import React, { useState } from 'react'
 
-import { IconChevronDown, IconGear, IconInfo, IconPencil, IconX } from '@posthog/icons'
+import { IconChevronDown, IconEllipsis, IconGear, IconPencil, IconX } from '@posthog/icons'
 import { LemonButton, LemonTag } from '@posthog/lemon-ui'
 
 import { EditableField } from 'lib/components/EditableField/EditableField'
@@ -93,20 +93,20 @@ export function SceneHeader({ className }: { className?: string }): JSX.Element 
                                         ? setForceScenePanelClosedWhenRelative(!forceScenePanelClosedWhenRelative)
                                         : setScenePanelOpen(!scenePanelOpen)
                                 }
-                                icon={<IconInfo className="text-primary" />}
+                                icon={<IconEllipsis className="text-primary" />}
                                 tooltip={
                                     !scenePanelOpen
-                                        ? 'Open info panel'
+                                        ? 'Open Info & actions panel'
                                         : scenePanelIsRelative
-                                          ? 'Force close info panel'
-                                          : 'Close info panel'
+                                          ? 'Force close Info & actions panel'
+                                          : 'Close Info & actions panel'
                                 }
                                 aria-label={
                                     !scenePanelOpen
-                                        ? 'Open info panel'
+                                        ? 'Open Info & actions panel'
                                         : scenePanelIsRelative
-                                          ? 'Force close info panel'
-                                          : 'Close info panel'
+                                          ? 'Force close Info & actions panel'
+                                          : 'Close Info & actions panel'
                                 }
                                 active={scenePanelOpen}
                                 size="small"

--- a/frontend/src/layout/scenes/SceneLayout.tsx
+++ b/frontend/src/layout/scenes/SceneLayout.tsx
@@ -4,7 +4,7 @@ import { useActions, useValues } from 'kea'
 import React, { PropsWithChildren, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 
-import { IconInfo, IconX } from '@posthog/icons'
+import { IconListCheck, IconX } from '@posthog/icons'
 import { LemonDivider } from '@posthog/lemon-ui'
 
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
@@ -160,8 +160,8 @@ export function SceneLayout({ children, className, layoutConfig }: SceneLayoutPr
                         >
                             <div className="h-[var(--scene-layout-header-height)] flex items-center justify-between gap-2 -mx-2 px-4 py-1 border-b border-primary shrink-0">
                                 <div className="flex items-center gap-2">
-                                    <IconInfo className="size-5 text-tertiary" />
-                                    <h4 className="text-base font-medium text-primary m-0">Info</h4>
+                                    <IconListCheck className="size-5 text-tertiary" />
+                                    <h4 className="text-base font-medium text-primary m-0">Info & actions</h4>
                                 </div>
 
                                 {scenePanelOpen && (
@@ -174,17 +174,17 @@ export function SceneLayout({ children, className, layoutConfig }: SceneLayoutPr
                                         }
                                         tooltip={
                                             !scenePanelOpen
-                                                ? 'Open info panel'
+                                                ? 'Open Info & actions panel'
                                                 : scenePanelIsRelative
-                                                  ? 'Force close info panel'
-                                                  : 'Close info panel'
+                                                  ? 'Force close Info & actions panel'
+                                                  : 'Close Info & actions panel'
                                         }
                                         aria-label={
                                             !scenePanelOpen
-                                                ? 'Open info panel'
+                                                ? 'Open Info & actions panel'
                                                 : scenePanelIsRelative
-                                                  ? 'Force close info panel'
-                                                  : 'Close info panel'
+                                                  ? 'Force close Info & actions panel'
+                                                  : 'Close Info & actions panel'
                                         }
                                     >
                                         <IconX className="size-4" />


### PR DESCRIPTION
## Problem
People were confused between gear icon and info icon by which to choose to see the panel.

## Changes
Change info panel trigger icon to `Ellipsis`, 
Change info panel title "Info & actions"

#### The changes
![2025-08-27 06 47 03](https://github.com/user-attachments/assets/69519532-8e03-4014-9238-9febe9538ca8)

This solution works well because some apps don't have enough actions/more items to warrant the whole panel, and these already use the Ellipsis icon (see Web analytics pictured below)

<img width="396" height="219" alt="image" src="https://github.com/user-attachments/assets/eb7dc9eb-cc7b-4ccd-9e65-422b7faa745b" />

## How did you test this code?
Clickin'