### PR TITLE
fix(devex): make flox override hosts for IPv6 too

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -99,7 +99,14 @@ if ! grep -q "127.0.0.1 kafka clickhouse clickhouse-coordinator objectstorage" /
   echo
   echo "🚨 Amending /etc/hosts to map hostnames 'kafka', 'clickhouse', 'clickhouse-coordinator' and 'objectstorage' to 127.0.0.1..."
   echo "127.0.0.1 kafka clickhouse clickhouse-coordinator objectstorage" | sudo tee -a /etc/hosts 1> /dev/null
-  echo "✅ /etc/hosts amended"
+  echo "✅ /etc/hosts amended for IPv4"
+fi
+
+if ! grep -q "::1 kafka clickhouse clickhouse-coordinator objectstorage" /etc/hosts; then
+  echo
+  echo "🚨 Amending /etc/hosts to map hostnames 'kafka', 'clickhouse', 'clickhouse-coordinator' and 'objectstorage' to ::1..."
+  echo "::1 kafka clickhouse clickhouse-coordinator objectstorage" | sudo tee -a /etc/hosts 1> /dev/null
+  echo "✅ /etc/hosts amended for IPv6"
 fi
 
 if [ -f "$DOTENV_FILE" ]; then


### PR DESCRIPTION
Under certain circumstances (like your local network using IPv6 or having a local DNS server), resolution for IPv6 can give a bogus result. This can end up making DNS resolution for internal services non-deterministic, failing sometimes and succeeding some others, with no error message pointing to the root cause.

Making sure we also override the IPv6 loopback address in the hosts file prevents this problem.