### PR TITLE
chore: acheck_query - check only last 2 days instead all query_log

### DIFF
--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -527,6 +527,7 @@ class ClickHouseClient:
                 SELECT type, exception
                 FROM clusterAllReplicas({{cluster_name:String}}, system.query_log)
                 WHERE query_id = {{query_id:String}}
+                    AND event_date >= yesterday() AND event_time >= now() - interval 24 hour
                     FORMAT JSONEachRow \
                 """
 


### PR DESCRIPTION
granules to read: 3500 (and growing) vs 800


