### PR TITLE
feat: add api key mask to query log

### DIFF
--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -169,6 +169,8 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
             user_id=personal_api_key_object.user.pk,
             team_id=personal_api_key_object.user.current_team_id,
             access_method="personal_api_key",
+            api_key_mask=personal_api_key_object.mask_value,
+            api_key_label=personal_api_key_object.label,
         )
 
         self.personal_api_key = personal_api_key_object

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -77,6 +77,8 @@ class QueryTags(BaseModel):
     team_id: Optional[int] = None
     user_id: Optional[int] = None
     access_method: Optional[AccessMethod] = None
+    api_key_mask: Optional[str] = None
+    api_key_label: Optional[str] = None
     org_id: Optional[uuid.UUID] = None
     product: Optional[Product] = None
 

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -527,6 +527,7 @@ class ClickHouseClient:
                 SELECT type, exception
                 FROM clusterAllReplicas({{cluster_name:String}}, system.query_log)
                 WHERE query_id = {{query_id:String}}
+                    AND event_date >= yesterday() AND event_time >= now() - interval 24 hour
                     FORMAT JSONEachRow \
                 """
 

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -527,7 +527,6 @@ class ClickHouseClient:
                 SELECT type, exception
                 FROM clusterAllReplicas({{cluster_name:String}}, system.query_log)
                 WHERE query_id = {{query_id:String}}
-                    AND event_date >= yesterday() AND event_time >= now() - interval 24 hour
                     FORMAT JSONEachRow \
                 """
 


### PR DESCRIPTION
make query_log audit friendly, add api key mask to it (`phx....124`).