### PR TITLE
chore(msg): change integration key to oauth

### DIFF
--- a/plugin-server/src/cdp/templates/_destinations/linear/linear.template.ts
+++ b/plugin-server/src/cdp/templates/_destinations/linear/linear.template.ts
@@ -24,7 +24,7 @@ let res := fetch('https://api.linear.app/graphql', {
   },
   'method': 'POST',
   'headers': {
-    'Authorization': f'Bearer {inputs.linear_workspace.access_token}',
+    'Authorization': f'Bearer {inputs.oauth.access_token}',
     'Content-Type': 'application/json'
   }
 });
@@ -34,7 +34,7 @@ if (res.status != 200 or res.body.success == false) {
 }`,
     inputs_schema: [
         {
-            key: 'linear_workspace',
+            key: 'oauth',
             type: 'integration',
             integration: 'linear',
             label: 'Linear workspace',
@@ -45,7 +45,7 @@ if (res.status != 200 or res.body.success == false) {
         {
             key: 'team',
             type: 'integration_field',
-            integration_key: 'linear_workspace',
+            integration_key: 'oauth',
             integration_field: 'linear_team',
             label: 'Team',
             secret: false,

--- a/plugin-server/src/cdp/templates/_destinations/twilio/twilio.template.test.ts
+++ b/plugin-server/src/cdp/templates/_destinations/twilio/twilio.template.test.ts
@@ -15,9 +15,9 @@ describe('twilio template', () => {
     it('should invoke the function', async () => {
         const response = await tester.invoke(
             {
-                twilio_account: {
+                oauth: {
                     account_sid: 'sid_12345',
-                    auth_token: 'auth_12345',
+                    auth_token_raw: 'auth_12345',
                 },
                 from_number: '+1234567891',
             },

--- a/plugin-server/src/cdp/templates/_destinations/twilio/twilio.template.ts
+++ b/plugin-server/src/cdp/templates/_destinations/twilio/twilio.template.ts
@@ -26,9 +26,9 @@ if (not message) {
 let encodedTo := encodeURLComponent(toNumber)
 let encodedFrom := encodeURLComponent(fromNumber)
 let encodedSmsBody := encodeURLComponent(message)
-let base64EncodedAuth := base64Encode(f'{inputs.twilio_account.account_sid}:{inputs.twilio_account.auth_token}')
+let base64EncodedAuth := base64Encode(f'{inputs.oauth.account_sid}:{inputs.oauth.auth_token_raw}')
 
-let url := f'https://api.twilio.com/2010-04-01/Accounts/{inputs.twilio_account.account_sid}/Messages.json'
+let url := f'https://api.twilio.com/2010-04-01/Accounts/{inputs.oauth.account_sid}/Messages.json'
 let body := f'To={encodedTo}&From={encodedFrom}&Body={encodedSmsBody}'
 
 let payload := {
@@ -57,7 +57,7 @@ if (inputs.debug) {
 `,
     inputs_schema: [
         {
-            key: 'twilio_account',
+            key: 'oauth',
             type: 'integration',
             integration: 'twilio',
             label: 'Twilio account',
@@ -69,7 +69,7 @@ if (inputs.debug) {
         {
             key: 'from_number',
             type: 'integration_field',
-            integration_key: 'twilio_account',
+            integration_key: 'oauth',
             integration_field: 'twilio_phone_number',
             label: 'From Phone Number',
             description: 'Your Twilio phone number',

--- a/posthog/api/test/test_hog_function.py
+++ b/posthog/api/test/test_hog_function.py
@@ -93,7 +93,7 @@ class TestHogFunctionAPIWithoutAvailableFeature(ClickhouseTestMixin, APIBaseTest
             "template_id": template_slack.id,
             "type": "destination",
             "inputs": {
-                "slack_workspace": {"value": 1},
+                "oauth": {"value": 1},
                 "channel": {"value": "#general"},
             },
         }
@@ -193,7 +193,7 @@ class TestHogFunctionAPIWithoutAvailableFeature(ClickhouseTestMixin, APIBaseTest
                 "type": "internal_destination",
                 "template_id": "template-slack",
                 "inputs": {
-                    "slack_workspace": {"value": 1},
+                    "oauth": {"value": 1},
                     "channel": {"value": "#general"},
                 },
             },
@@ -1544,7 +1544,7 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 "name": "First Transformation",
                 "template_id": template_slack.id,
                 "inputs": {
-                    "slack_workspace": {"value": 1},
+                    "oauth": {"value": 1},
                     "channel": {"value": "#general"},
                 },
             },
@@ -1560,7 +1560,7 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 "name": "Second Transformation",
                 "template_id": template_slack.id,
                 "inputs": {
-                    "slack_workspace": {"value": 1},
+                    "oauth": {"value": 1},
                     "channel": {"value": "#general"},
                 },
             },
@@ -1859,7 +1859,7 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 "type": "transformation",
                 "template_id": template_slack.id,
                 "inputs": {
-                    "slack_workspace": {"value": 1},
+                    "oauth": {"value": 1},
                     "channel": {"value": "#general"},
                 },
             },
@@ -1873,7 +1873,7 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 "type": "transformation",
                 "template_id": template_slack.id,
                 "inputs": {
-                    "slack_workspace": {"value": 1},
+                    "oauth": {"value": 1},
                     "channel": {"value": "#general"},
                 },
             },
@@ -1896,7 +1896,7 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 "type": "transformation",
                 "template_id": template_slack.id,
                 "inputs": {
-                    "slack_workspace": {"value": 1},
+                    "oauth": {"value": 1},
                     "channel": {"value": "#general"},
                 },
             },
@@ -1943,7 +1943,7 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 "template_id": template_slack.id,
                 "enabled": True,
                 "inputs": {
-                    "slack_workspace": {"value": 1},
+                    "oauth": {"value": 1},
                     "channel": {"value": "#general"},
                 },
             },
@@ -1958,7 +1958,7 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 "template_id": template_slack.id,
                 "enabled": True,
                 "inputs": {
-                    "slack_workspace": {"value": 1},
+                    "oauth": {"value": 1},
                     "channel": {"value": "#general"},
                 },
             },
@@ -1982,7 +1982,7 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 "template_id": template_slack.id,
                 "enabled": True,
                 "inputs": {
-                    "slack_workspace": {"value": 1},
+                    "oauth": {"value": 1},
                     "channel": {"value": "#general"},
                 },
             },
@@ -2032,7 +2032,7 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 "type": "transformation",
                 "template_id": template_slack.id,
                 "inputs": {
-                    "slack_workspace": {"value": 1},
+                    "oauth": {"value": 1},
                     "channel": {"value": "#general"},
                 },
             },
@@ -2046,7 +2046,7 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 "type": "transformation",
                 "template_id": template_slack.id,
                 "inputs": {
-                    "slack_workspace": {"value": 1},
+                    "oauth": {"value": 1},
                     "channel": {"value": "#general"},
                 },
             },
@@ -2061,7 +2061,7 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 "type": "transformation",
                 "template_id": template_slack.id,
                 "inputs": {
-                    "slack_workspace": {"value": 1},
+                    "oauth": {"value": 1},
                     "channel": {"value": "#general"},
                 },
             },

--- a/posthog/cdp/templates/google_cloud_storage/template_google_cloud_storage.py
+++ b/posthog/cdp/templates/google_cloud_storage/template_google_cloud_storage.py
@@ -115,7 +115,7 @@ class TemplateGoogleCloudStorageMigrator(HogFunctionTemplateMigrator):
             "filename": {
                 "value": "{toDate(event.timestamp)}/{replaceAll(replaceAll(replaceAll(toString(event.timestamp), '-', ''), ':', ''), 'T', '-')}-{event.uuid}.csv"
             },
-            "auth": {"value": integration.id},
+            "oauth": {"value": integration.id},
         }
 
         return hf

--- a/posthog/cdp/templates/google_cloud_storage/template_google_cloud_storage.py
+++ b/posthog/cdp/templates/google_cloud_storage/template_google_cloud_storage.py
@@ -21,7 +21,7 @@ template: HogFunctionTemplateDC = HogFunctionTemplateDC(
 let res := fetch(f'https://storage.googleapis.com/upload/storage/v1/b/{encodeURLComponent(inputs.bucketName)}/o?uploadType=media&name={encodeURLComponent(inputs.filename)}', {
   'method': 'POST',
   'headers': {
-    'Authorization': f'Bearer {inputs.auth.access_token}',
+    'Authorization': f'Bearer {inputs.oauth.access_token}',
     'Content-Type': 'application/json'
   },
   'body': inputs.payload
@@ -35,7 +35,7 @@ if (res.status >= 200 and res.status < 300) {
 """.strip(),
     inputs_schema=[
         {
-            "key": "auth",
+            "key": "oauth",
             "type": "integration",
             "integration": "google-cloud-storage",
             "label": "Google Cloud service account",

--- a/posthog/cdp/templates/google_cloud_storage/test_template_google_cloud_storage.py
+++ b/posthog/cdp/templates/google_cloud_storage/test_template_google_cloud_storage.py
@@ -37,7 +37,7 @@ class TestTemplateMigration(BaseTest):
         )
 
         template = TemplateGoogleCloudStorageMigrator.migrate(obj)
-        template["inputs"]["auth"]["value"] = 1  # mock the ID
+        template["inputs"]["oauth"]["value"] = 1  # mock the ID
         assert template["inputs"] == snapshot(
             {
                 "auth": {"value": 1},
@@ -82,7 +82,7 @@ class TestTemplateMigration(BaseTest):
         )
 
         template = TemplateGoogleCloudStorageMigrator.migrate(obj)
-        template["inputs"]["auth"]["value"] = 1  # mock the ID
+        template["inputs"]["oauth"]["value"] = 1  # mock the ID
         assert template["inputs"] == snapshot(
             {
                 "auth": {"value": 1},

--- a/posthog/cdp/templates/google_cloud_storage/test_template_google_cloud_storage.py
+++ b/posthog/cdp/templates/google_cloud_storage/test_template_google_cloud_storage.py
@@ -40,7 +40,7 @@ class TestTemplateMigration(BaseTest):
         template["inputs"]["oauth"]["value"] = 1  # mock the ID
         assert template["inputs"] == snapshot(
             {
-                "auth": {"value": 1},
+                "oauth": {"value": 1},
                 "bucketName": {"value": "BUCKET_NAME"},
                 "payload": {
                     "value": "uuid,event,properties,elements,people_set,people_set_once,distinct_id,team_id,ip,site_url,timestamp\n"
@@ -85,7 +85,7 @@ class TestTemplateMigration(BaseTest):
         template["inputs"]["oauth"]["value"] = 1  # mock the ID
         assert template["inputs"] == snapshot(
             {
-                "auth": {"value": 1},
+                "oauth": {"value": 1},
                 "bucketName": {"value": "BUCKET_NAME"},
                 "payload": {
                     "value": "uuid,event,properties,elements,people_set,people_set_once,distinct_id,team_id,ip,site_url,timestamp\n"

--- a/posthog/cdp/templates/google_pubsub/template_google_pubsub.py
+++ b/posthog/cdp/templates/google_pubsub/template_google_pubsub.py
@@ -19,7 +19,7 @@ template: HogFunctionTemplateDC = HogFunctionTemplateDC(
     code_language="hog",
     code="""
 let headers := () -> {
-  'Authorization': f'Bearer {inputs.auth.access_token}',
+  'Authorization': f'Bearer {inputs.oauth.access_token}',
   'Content-Type': 'application/json'
 }
 let message := () -> {
@@ -41,7 +41,7 @@ if (res.status >= 200 and res.status < 300) {
 """.strip(),
     inputs_schema=[
         {
-            "key": "auth",
+            "key": "oauth",
             "type": "integration",
             "integration": "google-pubsub",
             "label": "Google Cloud service account",

--- a/posthog/cdp/templates/google_pubsub/template_google_pubsub.py
+++ b/posthog/cdp/templates/google_pubsub/template_google_pubsub.py
@@ -126,7 +126,7 @@ class TemplateGooglePubSubMigrator(HogFunctionTemplateMigrator):
                     "person_properties": "{person.properties}",
                 }
             },
-            "auth": {"value": integration.id},
+            "oauth": {"value": integration.id},
             "attributes": {"value": {}},
         }
 

--- a/posthog/cdp/templates/google_pubsub/test_template_google_pubsub.py
+++ b/posthog/cdp/templates/google_pubsub/test_template_google_pubsub.py
@@ -40,7 +40,7 @@ class TestTemplateMigration(BaseTest):
         template["inputs"]["oauth"]["value"] = 1  # mock the ID
         assert template["inputs"] == snapshot(
             {
-                "auth": {"value": 1},
+                "oauth": {"value": 1},
                 "topicId": {"value": "TOPIC_ID"},
                 "payload": {
                     "value": {
@@ -91,7 +91,7 @@ class TestTemplateMigration(BaseTest):
         template["inputs"]["oauth"]["value"] = 1  # mock the ID
         assert template["inputs"] == snapshot(
             {
-                "auth": {"value": 1},
+                "oauth": {"value": 1},
                 "topicId": {"value": "TOPIC_ID"},
                 "payload": {
                     "value": {

--- a/posthog/cdp/templates/google_pubsub/test_template_google_pubsub.py
+++ b/posthog/cdp/templates/google_pubsub/test_template_google_pubsub.py
@@ -37,7 +37,7 @@ class TestTemplateMigration(BaseTest):
         )
 
         template = TemplateGooglePubSubMigrator.migrate(obj)
-        template["inputs"]["auth"]["value"] = 1  # mock the ID
+        template["inputs"]["oauth"]["value"] = 1  # mock the ID
         assert template["inputs"] == snapshot(
             {
                 "auth": {"value": 1},
@@ -88,7 +88,7 @@ class TestTemplateMigration(BaseTest):
         )
 
         template = TemplateGooglePubSubMigrator.migrate(obj)
-        template["inputs"]["auth"]["value"] = 1  # mock the ID
+        template["inputs"]["oauth"]["value"] = 1  # mock the ID
         assert template["inputs"] == snapshot(
             {
                 "auth": {"value": 1},

--- a/posthog/cdp/templates/slack/template_slack.py
+++ b/posthog/cdp/templates/slack/template_slack.py
@@ -21,7 +21,7 @@ let res := fetch('https://slack.com/api/chat.postMessage', {
   },
   'method': 'POST',
   'headers': {
-    'Authorization': f'Bearer {inputs.slack_workspace.access_token}',
+    'Authorization': f'Bearer {inputs.oauth.access_token}',
     'Content-Type': 'application/json'
   }
 });
@@ -32,7 +32,7 @@ if (res.status != 200 or res.body.ok == false) {
 """.strip(),
     inputs_schema=[
         {
-            "key": "slack_workspace",
+            "key": "oauth",
             "type": "integration",
             "integration": "slack",
             "label": "Slack workspace",
@@ -44,7 +44,7 @@ if (res.status != 200 or res.body.ok == false) {
         {
             "key": "channel",
             "type": "integration_field",
-            "integration_key": "slack_workspace",
+            "integration_key": "oauth",
             "integration_field": "slack_channel",
             "label": "Channel to post to",
             "description": "Select the channel to post to (e.g. #general). The PostHog app must be installed in the workspace.",

--- a/posthog/cdp/templates/slack/test_template_slack.py
+++ b/posthog/cdp/templates/slack/test_template_slack.py
@@ -11,7 +11,7 @@ class TestTemplateSlack(BaseHogFunctionTemplateTest):
 
     def _inputs(self, **kwargs):
         inputs = {
-            "slack_workspace": {
+            "oauth": {
                 "access_token": "xoxb-1234",
             },
             "icon_emoji": ":hedgehog:",


### PR DESCRIPTION
## Problem

We've implemented oauth token placeholder, and we'll replace them right before the fetch calls. This only works if the key is `oauth`. Change all templates to use the `oauth` key for the integration input field, where possible. ([related pr](https://github.com/PostHog/posthog/pull/37024))

<!-- ## Changes -->

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

updated tests
