### PR TITLE
fix(insights): disable filter editing when dashboard overrides are applied

### DIFF
--- a/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
+++ b/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
@@ -19,7 +19,7 @@ function ChartFilterOptionLabel(props: { label: string; description?: string }):
 }
 
 export function ChartFilter(): JSX.Element {
-    const { insightProps } = useValues(insightLogic)
+    const { insightProps, editingDisabledReason } = useValues(insightLogic)
     const { display } = useValues(insightVizDataLogic(insightProps))
     const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
 
@@ -154,6 +154,7 @@ export function ChartFilter(): JSX.Element {
             data-attr="chart-filter"
             options={options}
             size="small"
+            disabledReason={editingDisabledReason}
         />
     )
 }

--- a/frontend/src/lib/components/CompareFilter/CompareFilter.tsx
+++ b/frontend/src/lib/components/CompareFilter/CompareFilter.tsx
@@ -13,7 +13,7 @@ type CompareFilterProps = {
     compareFilter?: CompareFilterType | null
     updateCompareFilter: (compareFilter: CompareFilterType) => void
     disabled?: boolean
-    disableReason?: string
+    disableReason?: string | null
 }
 
 export function CompareFilter({

--- a/frontend/src/lib/components/CompareFilter/CompareFilter.tsx
+++ b/frontend/src/lib/components/CompareFilter/CompareFilter.tsx
@@ -13,12 +13,14 @@ type CompareFilterProps = {
     compareFilter?: CompareFilterType | null
     updateCompareFilter: (compareFilter: CompareFilterType) => void
     disabled?: boolean
+    disableReason?: string
 }
 
 export function CompareFilter({
     compareFilter,
     updateCompareFilter,
     disabled,
+    disableReason,
 }: CompareFilterProps): JSX.Element | null {
     // This keeps the state of the rolling date range filter, even when different drop down options are selected
     // The default value for this is one month
@@ -32,11 +34,6 @@ export function CompareFilter({
             setTentativeCompareTo(newCompareTo)
         }
     }, [compareFilter?.compare_to]) // oxlint-disable-line react-hooks/exhaustive-deps
-
-    // Hide compare filter control when disabled to avoid states where control is "disabled but checked"
-    if (disabled) {
-        return null
-    }
 
     const options = [
         {
@@ -113,6 +110,8 @@ export function CompareFilter({
             data-attr="compare-filter"
             options={options}
             size="small"
+            disabled={disabled}
+            disabledReason={disableReason}
         />
     )
 }

--- a/frontend/src/lib/components/DateFilter/DateFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.tsx
@@ -33,7 +33,7 @@ export interface DateFilterProps {
     className?: string
     onChange?: (fromDate: string | null, toDate: string | null, explicitDate?: boolean) => void
     disabled?: boolean
-    disabledReason?: string
+    disabledReason?: string | null
     dateOptions?: DateMappingOption[]
     isDateFormatted?: boolean
     size?: LemonButtonProps['size']

--- a/frontend/src/lib/components/InsightLegend/InsightLegendRow.tsx
+++ b/frontend/src/lib/components/InsightLegend/InsightLegendRow.tsx
@@ -23,7 +23,7 @@ export function InsightLegendRow({ item }: InsightLegendRowProps): JSX.Element {
     const { allCohorts } = useValues(cohortsModel)
     const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
 
-    const { insightProps, highlightedSeries } = useValues(insightLogic)
+    const { insightProps, highlightedSeries, editingDisabledReason } = useValues(insightLogic)
     const {
         display,
         trendsFilter,
@@ -89,6 +89,7 @@ export function InsightLegendRow({ item }: InsightLegendRowProps): JSX.Element {
                             hideIcon
                         />
                     }
+                    disabledReason={editingDisabledReason}
                 />
             </div>
             {display === ChartDisplayType.ActionsPie && (

--- a/frontend/src/lib/components/IntervalFilter/IntervalFilter.tsx
+++ b/frontend/src/lib/components/IntervalFilter/IntervalFilter.tsx
@@ -14,7 +14,7 @@ interface IntervalFilterProps {
 }
 
 export function IntervalFilter({ disabled }: IntervalFilterProps): JSX.Element {
-    const { insightProps } = useValues(insightLogic)
+    const { insightProps, editingDisabledReason } = useValues(insightLogic)
     const { interval, enabledIntervals, isIntervalManuallySet } = useValues(insightVizDataLogic(insightProps))
     const { updateQuerySource, setIsIntervalManuallySet } = useActions(insightVizDataLogic(insightProps))
 
@@ -34,12 +34,14 @@ export function IntervalFilter({ disabled }: IntervalFilterProps): JSX.Element {
                     center
                     size="small"
                     icon={<IconPin color="var(--content-warning)" />}
+                    disabledReason={editingDisabledReason}
                 >
                     {interval || 'day'}
                 </LemonButton>
             ) : (
                 <IntervalFilterStandalone
                     disabled={disabled}
+                    disabledReason={editingDisabledReason}
                     interval={interval || 'day'}
                     onIntervalChange={(value) => {
                         updateQuerySource({ interval: value } as Partial<InsightQueryNode>)
@@ -58,6 +60,7 @@ export function IntervalFilter({ disabled }: IntervalFilterProps): JSX.Element {
 
 interface IntervalFilterStandaloneProps {
     disabled?: boolean
+    disabledReason?: string
     interval: IntervalType | undefined
     onIntervalChange: (interval: IntervalType) => void
     options?: LemonSelectOption<IntervalType>[]
@@ -72,6 +75,7 @@ const DEFAULT_OPTIONS: LemonSelectOption<IntervalType>[] = [
 
 export function IntervalFilterStandalone({
     disabled,
+    disabledReason,
     interval,
     onIntervalChange,
     options = DEFAULT_OPTIONS,
@@ -80,6 +84,7 @@ export function IntervalFilterStandalone({
         <LemonSelect
             size="small"
             disabled={disabled}
+            disabledReason={disabledReason}
             value={interval || 'day'}
             dropdownMatchSelectWidth={false}
             onChange={onIntervalChange}

--- a/frontend/src/lib/components/IntervalFilter/IntervalFilter.tsx
+++ b/frontend/src/lib/components/IntervalFilter/IntervalFilter.tsx
@@ -60,7 +60,7 @@ export function IntervalFilter({ disabled }: IntervalFilterProps): JSX.Element {
 
 interface IntervalFilterStandaloneProps {
     disabled?: boolean
-    disabledReason?: string
+    disabledReason?: string | null
     interval: IntervalType | undefined
     onIntervalChange: (interval: IntervalType) => void
     options?: LemonSelectOption<IntervalType>[]

--- a/frontend/src/lib/components/SmoothingFilter/SmoothingFilter.tsx
+++ b/frontend/src/lib/components/SmoothingFilter/SmoothingFilter.tsx
@@ -10,7 +10,7 @@ import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 import { smoothingOptions } from './smoothings'
 
 export function SmoothingFilter(): JSX.Element | null {
-    const { insightProps } = useValues(insightLogic)
+    const { insightProps, editingDisabledReason } = useValues(insightLogic)
     const { isTrends, interval, trendsFilter } = useValues(trendsDataLogic(insightProps))
     const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
 
@@ -48,6 +48,7 @@ export function SmoothingFilter(): JSX.Element | null {
             data-attr="smoothing-filter"
             options={options}
             size="small"
+            disabledReason={editingDisabledReason}
         />
     ) : (
         <></>

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -44,7 +44,7 @@ import { isTrendsQuery } from '~/queries/utils'
 import { ChartDisplayType } from '~/types'
 
 export function InsightDisplayConfig(): JSX.Element {
-    const { insightProps, canEditInsight } = useValues(insightLogic)
+    const { insightProps, canEditInsight, editingDisabledReason } = useValues(insightLogic)
 
     const {
         querySource,
@@ -295,7 +295,7 @@ export function InsightDisplayConfig(): JSX.Element {
             <div className="flex items-center gap-x-2 flex-wrap">
                 {advancedOptions.length > 0 && (
                     <LemonMenu items={advancedOptions} closeOnClickInside={false}>
-                        <LemonButton size="small">
+                        <LemonButton size="small" disabledReason={editingDisabledReason}>
                             <span className="font-medium whitespace-nowrap">
                                 Options
                                 {advancedOptionsCount ? (

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -288,6 +288,7 @@ export function InsightDisplayConfig(): JSX.Element {
                             compareFilter={compareFilter}
                             updateCompareFilter={updateCompareFilter}
                             disabled={!canEditInsight || !supportsCompare}
+                            disableReason={editingDisabledReason}
                         />
                     </ConfigFilter>
                 )}

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -4,7 +4,6 @@ import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
 
 import { AccessDenied } from 'lib/components/AccessDenied'
 import { DebugCHQueries } from 'lib/components/CommandPalette/DebugCHQueries'
-import { isEmptyObject, isObject } from 'lib/utils'
 import { InsightPageHeader } from 'scenes/insights/InsightPageHeader'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { ReloadInsight } from 'scenes/saved-insights/ReloadInsight'

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -27,16 +27,14 @@ export interface InsightSceneProps {
 
 export function Insight({ insightId }: InsightSceneProps): JSX.Element | null {
     // insightSceneLogic
-    const { insightMode, insight, filtersOverride, variablesOverride, freshQuery } = useValues(insightSceneLogic)
+    const { insightMode, insight, filtersOverride, variablesOverride, hasOverrides, freshQuery } =
+        useValues(insightSceneLogic)
 
     // insightLogic
     const logic = insightLogic({
         dashboardItemId: insightId || 'new',
-        // don't use cached insight if we have filtersOverride
-        cachedInsight:
-            (isObject(filtersOverride) || isObject(variablesOverride)) && insight?.short_id === insightId
-                ? insight
-                : null,
+        // don't use cached insight if we have overrides
+        cachedInsight: hasOverrides && insight?.short_id === insightId ? insight : null,
         filtersOverride,
         variablesOverride,
     })
@@ -61,11 +59,6 @@ export function Insight({ insightId }: InsightSceneProps): JSX.Element | null {
         return <AccessDenied object="insight" />
     }
 
-    const dashboardOverridesExist =
-        (isObject(filtersOverride) && !isEmptyObject(filtersOverride)) ||
-        (isObject(variablesOverride) && !isEmptyObject(variablesOverride))
-    const overrideType = isObject(filtersOverride) ? 'filters' : 'variables'
-
     if (!insight?.query) {
         return null
     }
@@ -75,13 +68,13 @@ export function Insight({ insightId }: InsightSceneProps): JSX.Element | null {
             <SceneContent className="Insight">
                 <InsightPageHeader insightLogicProps={insightProps} />
 
-                {dashboardOverridesExist && (
+                {hasOverrides && (
                     <LemonBanner type="warning" className="mb-4">
                         <div className="flex flex-row items-center justify-between gap-2">
-                            <span>You are viewing this insight with {overrideType} from a dashboard</span>
+                            <span>You are viewing this insight with filter/variable overrides</span>
 
                             <LemonButton type="secondary" to={urls.insightView(insightId as InsightShortId)}>
-                                Discard dashboard {overrideType}
+                                Discard overrides
                             </LemonButton>
                         </div>
                     </LemonBanner>

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -70,7 +70,10 @@ export function Insight({ insightId }: InsightSceneProps): JSX.Element | null {
                 {hasOverrides && (
                     <LemonBanner type="warning" className="mb-4">
                         <div className="flex flex-row items-center justify-between gap-2">
-                            <span>You are viewing this insight with filter/variable overrides</span>
+                            <span>
+                                You are viewing this insight with filter/variable overrides. Discard them to edit the
+                                insight.
+                            </span>
 
                             <LemonButton type="secondary" to={urls.insightView(insightId as InsightShortId)}>
                                 Discard overrides

--- a/frontend/src/scenes/insights/RetentionDatePicker.tsx
+++ b/frontend/src/scenes/insights/RetentionDatePicker.tsx
@@ -8,7 +8,7 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 import { retentionLogic } from 'scenes/retention/retentionLogic'
 
 export function RetentionDatePicker(): JSX.Element {
-    const { insightProps } = useValues(insightLogic)
+    const { insightProps, editingDisabledReason } = useValues(insightLogic)
     const { dateRange, dateMappings } = useValues(retentionLogic(insightProps))
     const { updateDateRange } = useActions(retentionLogic(insightProps))
 
@@ -30,6 +30,7 @@ export function RetentionDatePicker(): JSX.Element {
                     )}
                 </>
             )}
+            disabledReason={editingDisabledReason}
         />
     )
 }

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/InsightDateFilter.tsx
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/InsightDateFilter.tsx
@@ -13,7 +13,7 @@ type InsightDateFilterProps = {
 }
 
 export function InsightDateFilter({ disabled }: InsightDateFilterProps): JSX.Element {
-    const { insightProps } = useValues(insightLogic)
+    const { insightProps, editingDisabledReason } = useValues(insightLogic)
 
     const { isTrends, dateRange } = useValues(insightVizDataLogic(insightProps))
     const { updateDateRange } = useActions(insightVizDataLogic(insightProps))
@@ -24,6 +24,7 @@ export function InsightDateFilter({ disabled }: InsightDateFilterProps): JSX.Ele
             dateFrom={dateRange?.date_from ?? '-7d'}
             allowTimePrecision
             disabled={disabled}
+            disabledReason={editingDisabledReason}
             onChange={(date_from, date_to, explicit_date) => {
                 updateDateRange({ date_from, date_to, explicitDate: explicit_date })
             }}

--- a/frontend/src/scenes/insights/filters/RetentionChartPicker.tsx
+++ b/frontend/src/scenes/insights/filters/RetentionChartPicker.tsx
@@ -48,7 +48,7 @@ const OPTIONS: LemonSelectOptions<ChartDisplayType> = [
 ]
 
 export function RetentionChartPicker(): JSX.Element {
-    const { insightProps } = useValues(insightLogic)
+    const { insightProps, editingDisabledReason } = useValues(insightLogic)
     const { retentionFilter } = useValues(insightVizDataLogic(insightProps))
     const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
 
@@ -65,6 +65,7 @@ export function RetentionChartPicker(): JSX.Element {
             data-attr="chart-filter"
             options={OPTIONS}
             size="small"
+            disabledReason={editingDisabledReason}
         />
     )
 }

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -9,7 +9,7 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { objectsEqual } from 'lib/utils'
+import { isEmptyObject, isObject, objectsEqual } from 'lib/utils'
 import { InsightEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { DashboardLoadAction, dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
@@ -399,6 +399,16 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
         ],
         isUsingPathsV1: [(s) => [s.featureFlags], (featureFlags) => !featureFlags[FEATURE_FLAGS.PATHS_V2]],
         isUsingPathsV2: [(s) => [s.featureFlags], (featureFlags) => featureFlags[FEATURE_FLAGS.PATHS_V2]],
+        hasOverrides: [
+            (_, p) => [p.filtersOverride, p.variablesOverride],
+            (filtersOverride, variablesOverride) =>
+                (isObject(filtersOverride) && !isEmptyObject(filtersOverride)) ||
+                (isObject(variablesOverride) && !isEmptyObject(variablesOverride)),
+        ],
+        editingDisabledReason: [
+            (s) => [s.hasOverrides],
+            (hasOverrides) => (hasOverrides ? 'Discard overrides to edit the insight.' : null),
+        ],
     }),
     listeners(({ actions, values }) => ({
         saveInsight: async ({ redirectToViewMode, folder }) => {

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -361,8 +361,11 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
         insightName: [(s) => [s.insight, s.derivedName], (insight, derivedName) => insight.name || derivedName],
         insightId: [(s) => [s.insight], (insight) => insight?.id || null],
         canEditInsight: [
-            (s) => [s.insight],
-            (insight) => {
+            (s) => [s.insight, s.hasOverrides],
+            (insight, hasOverrides) => {
+                if (hasOverrides) {
+                    return false
+                }
                 return insight.user_access_level
                     ? accessLevelSatisfied(AccessControlResourceType.Insight, insight.user_access_level, 'editor')
                     : true

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -60,7 +60,7 @@ export const createEmptyInsight = (
 })
 
 export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType>([
-    props({} as InsightLogicProps),
+    props({ filtersOverride: null, variablesOverride: null } as InsightLogicProps),
     key(keyForInsightLogicProps('new')),
     path((key) => ['scenes', 'insights', 'insightLogic', key]),
     connect(() => ({

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -400,10 +400,10 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
         isUsingPathsV1: [(s) => [s.featureFlags], (featureFlags) => !featureFlags[FEATURE_FLAGS.PATHS_V2]],
         isUsingPathsV2: [(s) => [s.featureFlags], (featureFlags) => featureFlags[FEATURE_FLAGS.PATHS_V2]],
         hasOverrides: [
-            (_, p) => [p.filtersOverride, p.variablesOverride],
-            (filtersOverride, variablesOverride) =>
-                (isObject(filtersOverride) && !isEmptyObject(filtersOverride)) ||
-                (isObject(variablesOverride) && !isEmptyObject(variablesOverride)),
+            () => [(_, props) => props],
+            (props) =>
+                (isObject(props.filtersOverride) && !isEmptyObject(props.filtersOverride)) ||
+                (isObject(props.variablesOverride) && !isEmptyObject(props.variablesOverride)),
         ],
         editingDisabledReason: [
             (s) => [s.hasOverrides],

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -7,7 +7,7 @@ import api from 'lib/api'
 import { AlertType } from 'lib/components/Alerts/types'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { isEmptyObject } from 'lib/utils'
+import { isEmptyObject, isObject } from 'lib/utils'
 import { InsightEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
@@ -255,6 +255,12 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
                 }
                 return [createMaxContextHelpers.insight(insight)]
             },
+        ],
+        hasOverrides: [
+            (s) => [s.filtersOverride, s.variablesOverride],
+            (filtersOverride, variablesOverride) =>
+                (isObject(filtersOverride) && !isEmptyObject(filtersOverride)) ||
+                (isObject(variablesOverride) && !isEmptyObject(variablesOverride)),
         ],
     })),
     sharedListeners(({ actions, values }) => ({

--- a/frontend/src/scenes/insights/views/Funnels/FunnelBinsPicker.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelBinsPicker.tsx
@@ -99,9 +99,14 @@ export function FunnelBinsPicker(): JSX.Element {
                 overlay={overlay}
                 className="w-32"
                 placement="bottom-end"
-                disabledReason={editingDisabledReason}
             >
-                <LemonButton size="small" type="secondary" icon={<IconGraph />} onClick={() => setVisible(true)}>
+                <LemonButton
+                    size="small"
+                    type="secondary"
+                    icon={<IconGraph />}
+                    onClick={() => setVisible(true)}
+                    disabledReason={editingDisabledReason}
+                >
                     {selectedOption?.label}
                 </LemonButton>
             </LemonDropdown>

--- a/frontend/src/scenes/insights/views/Funnels/FunnelBinsPicker.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelBinsPicker.tsx
@@ -36,7 +36,7 @@ const BIN_OPTIONS: BinOption[] = [
 ]
 
 export function FunnelBinsPicker(): JSX.Element {
-    const { insightProps } = useValues(insightLogic)
+    const { insightProps, editingDisabledReason } = useValues(insightLogic)
     const { funnelsFilter, numericBinCount } = useValues(funnelDataLogic(insightProps))
     const { updateInsightFilter } = useActions(funnelDataLogic(insightProps))
     const [visible, setVisible] = useState<boolean>(false)
@@ -99,6 +99,7 @@ export function FunnelBinsPicker(): JSX.Element {
                 overlay={overlay}
                 className="w-32"
                 placement="bottom-end"
+                disabledReason={editingDisabledReason}
             >
                 <LemonButton size="small" type="secondary" icon={<IconGraph />} onClick={() => setVisible(true)}>
                     {selectedOption?.label}

--- a/frontend/src/scenes/insights/views/Funnels/FunnelDisplayLayoutPicker.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelDisplayLayoutPicker.tsx
@@ -8,7 +8,7 @@ import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
 export function FunnelDisplayLayoutPicker(): JSX.Element {
-    const { insightProps } = useValues(insightLogic)
+    const { insightProps, editingDisabledReason } = useValues(insightLogic)
     const { funnelsFilter } = useValues(funnelDataLogic(insightProps))
     const { updateInsightFilter } = useActions(funnelDataLogic(insightProps))
 
@@ -38,6 +38,7 @@ export function FunnelDisplayLayoutPicker(): JSX.Element {
             data-attr="funnel-bar-layout-selector"
             options={options}
             size="small"
+            disabledReason={editingDisabledReason}
         />
     )
 }

--- a/frontend/src/scenes/insights/views/Funnels/FunnelStepsPicker.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelStepsPicker.tsx
@@ -9,7 +9,7 @@ import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { seriesNodeToFilter } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
 
 export function FunnelStepsPicker(): JSX.Element | null {
-    const { insightProps } = useValues(insightLogic)
+    const { insightProps, editingDisabledReason } = useValues(insightLogic)
     const { series, isFunnelWithEnoughSteps, funnelsFilter } = useValues(insightVizDataLogic(insightProps))
     const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
 
@@ -57,6 +57,7 @@ export function FunnelStepsPicker(): JSX.Element | null {
                 onChange={(fromStep: number | null) =>
                     fromStep != null && onChange(fromStep, funnelsFilter?.funnelToStep)
                 }
+                disabledReason={editingDisabledReason}
             />
             <span className="text-secondary">to</span>
             <LemonSelect
@@ -68,6 +69,7 @@ export function FunnelStepsPicker(): JSX.Element | null {
                 options={optionsForRange(toRange)}
                 value={funnelsFilter?.funnelToStep || Math.max(numberOfSeries - 1, 1)}
                 onChange={(toStep: number | null) => toStep != null && onChange(funnelsFilter?.funnelFromStep, toStep)}
+                disabledReason={editingDisabledReason}
             />
         </div>
     )

--- a/frontend/src/scenes/insights/views/Funnels/FunnelStepsTable.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelStepsTable.tsx
@@ -26,7 +26,7 @@ import { resultCustomizationsModalLogic } from '../../../../queries/nodes/Insigh
 import { getActionFilterFromFunnelStep, getSignificanceFromBreakdownStep } from './funnelStepTableUtils'
 
 export function FunnelStepsTable(): JSX.Element | null {
-    const { insightProps, insightLoading } = useValues(insightLogic)
+    const { insightProps, insightLoading, editingDisabledReason } = useValues(insightLogic)
     const { breakdownFilter } = useValues(insightVizDataLogic(insightProps))
     const { steps, flattenedBreakdowns, hiddenLegendBreakdowns, getFunnelsColor } = useValues(
         funnelDataLogic(insightProps)
@@ -76,6 +76,7 @@ export function FunnelStepsTable(): JSX.Element | null {
                             }}
                             label={<span className="font-bold">Breakdown</span>}
                             size="small"
+                            disabledReason={editingDisabledReason}
                         />
                     ),
                     dataIndex: 'breakdown_value',
@@ -131,6 +132,7 @@ export function FunnelStepsTable(): JSX.Element | null {
                                         color={color}
                                         type="tertiary"
                                         size="small"
+                                        disabledReason={editingDisabledReason}
                                     />
                                 )}
                             </div>
@@ -144,6 +146,7 @@ export function FunnelStepsTable(): JSX.Element | null {
                                     toggleLegendBreakdownVisibility(getVisibilityKey(breakdown.breakdown_value))
                                 }
                                 label={label}
+                                disabledReason={editingDisabledReason}
                             />
                         )
                     },

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -69,7 +69,7 @@ export function InsightsTable({
     isMainInsightView = false,
 }: InsightsTableProps): JSX.Element {
     const { insightMode } = useValues(insightSceneLogic)
-    const { insightProps, isInDashboardContext, insight } = useValues(insightLogic)
+    const { insightProps, isInDashboardContext, insight, editingDisabledReason } = useValues(insightLogic)
     const {
         insightDataLoading,
         indexedResults,
@@ -118,6 +118,7 @@ export function InsightsTable({
                         canCheckUncheckSeries={canCheckUncheckSeries}
                         getTrendsHidden={getTrendsHidden}
                         toggleAllResultsHidden={toggleAllResultsHidden}
+                        disabledReason={editingDisabledReason}
                     />
                 )}
                 <span>Series</span>
@@ -142,6 +143,7 @@ export function InsightsTable({
                     isHidden={getTrendsHidden(item)}
                     toggleResultHidden={toggleResultHidden}
                     label={<div className="ml-2 font-normal">{label}</div>}
+                    disabledReason={editingDisabledReason}
                 />
             ) : (
                 label

--- a/frontend/src/scenes/insights/views/InsightsTable/columns/ColorCustomizationColumn.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/columns/ColorCustomizationColumn.tsx
@@ -13,7 +13,7 @@ export function ColorCustomizationColumnTitle(): JSX.Element {
 }
 
 export function ColorCustomizationColumnItem({ item }: { item: IndexedTrendResult }): JSX.Element {
-    const { insightProps } = useValues(insightLogic)
+    const { insightProps, editingDisabledReason } = useValues(insightLogic)
     const { getTrendsColor } = useValues(trendsDataLogic(insightProps))
     const { openModal } = useActions(resultCustomizationsModalLogic(insightProps))
 
@@ -30,6 +30,7 @@ export function ColorCustomizationColumnItem({ item }: { item: IndexedTrendResul
             }}
             type="tertiary"
             size="small"
+            disabledReason={editingDisabledReason}
         />
     )
 }

--- a/frontend/src/scenes/insights/views/InsightsTable/columns/SeriesCheckColumn.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/columns/SeriesCheckColumn.tsx
@@ -6,7 +6,7 @@ type SeriesCheckColumnTitleProps = {
     canCheckUncheckSeries: boolean
     getTrendsHidden: (dataset: IndexedTrendResult) => boolean
     toggleAllResultsHidden: (datasets: IndexedTrendResult[], hidden: boolean) => void
-    disabledReason?: string
+    disabledReason?: string | null
 }
 
 export function SeriesCheckColumnTitle({
@@ -41,7 +41,7 @@ type SeriesCheckColumnItemProps = {
     isHidden: boolean
     toggleResultHidden: (dataset: IndexedTrendResult) => void
     label?: JSX.Element
-    disabledReason?: string
+    disabledReason?: string | null
 }
 
 export function SeriesCheckColumnItem({

--- a/frontend/src/scenes/insights/views/InsightsTable/columns/SeriesCheckColumn.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/columns/SeriesCheckColumn.tsx
@@ -6,6 +6,7 @@ type SeriesCheckColumnTitleProps = {
     canCheckUncheckSeries: boolean
     getTrendsHidden: (dataset: IndexedTrendResult) => boolean
     toggleAllResultsHidden: (datasets: IndexedTrendResult[], hidden: boolean) => void
+    disabledReason?: string
 }
 
 export function SeriesCheckColumnTitle({
@@ -13,6 +14,7 @@ export function SeriesCheckColumnTitle({
     canCheckUncheckSeries,
     getTrendsHidden,
     toggleAllResultsHidden,
+    disabledReason,
 }: SeriesCheckColumnTitleProps): JSX.Element {
     const isAnySeriesChecked = indexedResults.some((dataset) => !getTrendsHidden(dataset))
     const areAllSeriesChecked = indexedResults.every((dataset) => !getTrendsHidden(dataset))
@@ -28,6 +30,7 @@ export function SeriesCheckColumnTitle({
                 }
             }}
             disabled={!canCheckUncheckSeries}
+            disabledReason={disabledReason}
         />
     )
 }
@@ -38,6 +41,7 @@ type SeriesCheckColumnItemProps = {
     isHidden: boolean
     toggleResultHidden: (dataset: IndexedTrendResult) => void
     label?: JSX.Element
+    disabledReason?: string
 }
 
 export function SeriesCheckColumnItem({
@@ -46,12 +50,14 @@ export function SeriesCheckColumnItem({
     isHidden,
     toggleResultHidden,
     label,
+    disabledReason,
 }: SeriesCheckColumnItemProps): JSX.Element {
     return (
         <LemonCheckbox
             checked={!isHidden}
             onChange={() => toggleResultHidden(item)}
             disabled={!canCheckUncheckSeries}
+            disabledReason={disabledReason}
             label={label}
         />
     )

--- a/frontend/src/scenes/insights/views/Paths/PathStepPicker.tsx
+++ b/frontend/src/scenes/insights/views/Paths/PathStepPicker.tsx
@@ -15,7 +15,7 @@ interface StepOption {
 }
 
 export function PathStepPicker(): JSX.Element {
-    const { insightProps } = useValues(insightLogic)
+    const { insightProps, editingDisabledReason } = useValues(insightLogic)
     const { pathsFilter } = useValues(pathsDataLogic(insightProps))
     const { updateInsightFilter } = useActions(pathsDataLogic(insightProps))
     const { hasAvailableFeature } = useValues(userLogic)
@@ -36,6 +36,7 @@ export function PathStepPicker(): JSX.Element {
             value={stepLimit || DEFAULT_STEP_LIMIT}
             onChange={(count) => updateInsightFilter({ stepLimit: count })}
             options={options}
+            disabledReason={editingDisabledReason}
         />
     )
 }

--- a/frontend/src/scenes/retention/RetentionBreakdownFilter.tsx
+++ b/frontend/src/scenes/retention/RetentionBreakdownFilter.tsx
@@ -7,7 +7,7 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 import { retentionLogic } from './retentionLogic'
 
 export function RetentionBreakdownFilter(): JSX.Element | null {
-    const { insightProps } = useValues(insightLogic)
+    const { insightProps, editingDisabledReason } = useValues(insightLogic)
     const { breakdownValues, selectedBreakdownValue, breakdownDisplayNames } = useValues(retentionLogic(insightProps))
     const { setSelectedBreakdownValue } = useActions(retentionLogic(insightProps))
 
@@ -33,6 +33,7 @@ export function RetentionBreakdownFilter(): JSX.Element | null {
             placeholder="Select breakdown value"
             size="small"
             data-attr="retention-breakdown-filter"
+            disabledReason={editingDisabledReason}
         />
     )
 }


### PR DESCRIPTION
## Problem

When visiting an insight from a dashboard that has overrides, the insight can't be edited as we don't have a proper way to derive the state of filters. Closes https://github.com/PostHog/posthog/issues/37143.

## Changes

This PR disables the filter inputs and makes the insight uneditable when there are overrides.

## How did you test this code?

Tested insights locally:
- Trends insight
  - [x] with breakdown
  - [x] without breakdown
  - [x] with legend
- Funnel
  - [x] with breakdown
  - [x] without breakdown
- [x] Funnel time to convert
- [x] Funnel trends
- [?] Retention
  - [x] with breakdown
  - [?] without breakdown // this looks broken with breakdown overrides, investigating separately
- [x] Path
- [x] Stickiness
- [x] Lifecycle

