### PR TITLE
chore(ux): scene title for llm ob & rev analytics

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
@@ -12,11 +12,15 @@ import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TestAccountFilterSwitch } from 'lib/components/TestAccountFiltersSwitch'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
+import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { dataNodeCollectionLogic } from '~/queries/nodes/DataNode/dataNodeCollectionLogic'
 import { DataTable } from '~/queries/nodes/DataTable/DataTable'
 import { InsightVizNode, NodeKind } from '~/queries/schema/schema-general'
@@ -84,7 +88,7 @@ const Tiles = (): JSX.Element => {
 
 const IngestionStatusCheck = (): JSX.Element | null => {
     return (
-        <LemonBanner type="warning" className="mt-2">
+        <LemonBanner type="warning">
             <p>
                 <strong>No LLM generation events have been detected!</strong>
             </p>
@@ -251,6 +255,8 @@ export function LLMAnalyticsScene(): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
     const { searchParams } = useValues(router)
 
+    const newSceneLayout = useFeatureFlag('NEW_SCENE_LAYOUT')
+
     const tabs: LemonTab<string>[] = [
         {
             key: 'dashboard',
@@ -310,8 +316,25 @@ export function LLMAnalyticsScene(): JSX.Element {
                 }
             />
 
-            {!hasSentAiGenerationEventLoading && !hasSentAiGenerationEvent && <IngestionStatusCheck />}
-            <LemonTabs activeKey={activeTab} data-attr="llm-analytics-tabs" tabs={tabs} />
+            <SceneContent>
+                {!hasSentAiGenerationEventLoading && !hasSentAiGenerationEvent && <IngestionStatusCheck />}
+                <SceneTitleSection
+                    name="LLM Analytics"
+                    description="Analyze and understand your LLM usage and performance."
+                    resourceType={{
+                        type: 'ai',
+                        typePlural: 'LLM Analytics',
+                    }}
+                />
+                <SceneDivider />
+
+                <LemonTabs
+                    activeKey={activeTab}
+                    data-attr="llm-analytics-tabs"
+                    tabs={tabs}
+                    sceneInset={newSceneLayout}
+                />
+            </SceneContent>
         </BindLogic>
     )
 }

--- a/products/revenue_analytics/frontend/RevenueAnalyticsScene.tsx
+++ b/products/revenue_analytics/frontend/RevenueAnalyticsScene.tsx
@@ -6,11 +6,16 @@ import { LemonBanner, LemonButton, Link, SpinnerOverlay } from '@posthog/lemon-u
 
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { cn } from 'lib/utils/css-classes'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
+import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { dataNodeCollectionLogic } from '~/queries/nodes/DataNode/dataNodeCollectionLogic'
 import { PipelineStage, ProductKey } from '~/types'
 
@@ -33,6 +38,12 @@ const PRODUCT_THING_NAME = 'revenue'
 export function RevenueAnalyticsScene(): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
     const { dataWarehouseSources } = useValues(revenueAnalyticsSettingsLogic)
+    const { revenueEnabledDataWarehouseSources } = useValues(revenueAnalyticsLogic)
+    const newSceneLayout = useFeatureFlag('NEW_SCENE_LAYOUT')
+
+    const sourceRunningForTheFirstTime = revenueEnabledDataWarehouseSources?.find(
+        (source) => source.status === 'Running' && !source.last_run_at
+    )
 
     if (!featureFlags[FEATURE_FLAGS.REVENUE_ANALYTICS]) {
         return (
@@ -69,13 +80,49 @@ export function RevenueAnalyticsScene(): JSX.Element {
 
     return (
         <BindLogic logic={dataNodeCollectionLogic} props={{ key: REVENUE_ANALYTICS_DATA_COLLECTION_NODE_ID }}>
-            <RevenueAnalyticsSceneContent />
+            <SceneContent>
+                <LemonBanner
+                    type="info"
+                    dismissKey="revenue-analytics-beta-banner"
+                    action={{ children: 'Send feedback', id: 'revenue-analytics-feedback-button' }}
+                    className={cn(!newSceneLayout && 'mb-2')}
+                >
+                    Revenue Analytics is in beta. Please let us know what you'd like to see here and/or report any
+                    issues directly to us!
+                </LemonBanner>
+
+                {sourceRunningForTheFirstTime && (
+                    <LemonBanner
+                        type="success"
+                        dismissKey={`revenue-analytics-sync-in-progress-banner-${sourceRunningForTheFirstTime.id}`}
+                        action={{ children: 'Refresh', onClick: () => window.location.reload() }}
+                        className={cn(!newSceneLayout && 'mb-2')}
+                    >
+                        One of your revenue data warehouse sources is running for the first time. <br />
+                        This means you might not see all of your revenue data yet. <br />
+                        We display partial data - most recent months first - while the initial sync is running. <br />
+                        Refresh the page to see the latest data.
+                    </LemonBanner>
+                )}
+                <SceneTitleSection
+                    name="Revenue Analytics"
+                    description="Track and analyze your revenue metrics to understand your business performance and growth."
+                    resourceType={{
+                        type: 'revenue',
+                        typePlural: 'Revenue Analytics',
+                    }}
+                />
+                <SceneDivider />
+                <RevenueAnalyticsSceneContent />
+            </SceneContent>
         </BindLogic>
     )
 }
 
 const RevenueAnalyticsSceneContent = (): JSX.Element => {
-    const { hasRevenueTables, hasRevenueEvents, revenueEnabledDataWarehouseSources } = useValues(revenueAnalyticsLogic)
+    const { hasRevenueTables, hasRevenueEvents } = useValues(revenueAnalyticsLogic)
+
+    const newSceneLayout = useFeatureFlag('NEW_SCENE_LAYOUT')
 
     // Still loading from the server, so we'll show a spinner
     if (hasRevenueTables === null) {
@@ -87,36 +134,8 @@ const RevenueAnalyticsSceneContent = (): JSX.Element => {
         return <RevenueAnalyticsSceneOnboarding />
     }
 
-    const sourceRunningForTheFirstTime = revenueEnabledDataWarehouseSources?.find(
-        (source) => source.status === 'Running' && !source.last_run_at
-    )
-
     return (
-        <div className="RevenueAnalyticsDashboard">
-            <LemonBanner
-                type="info"
-                dismissKey="revenue-analytics-beta-banner"
-                className="mb-2"
-                action={{ children: 'Send feedback', id: 'revenue-analytics-feedback-button' }}
-            >
-                Revenue Analytics is in beta. Please let us know what you'd like to see here and/or report any issues
-                directly to us!
-            </LemonBanner>
-
-            {sourceRunningForTheFirstTime && (
-                <LemonBanner
-                    type="success"
-                    className="mb-2"
-                    dismissKey={`revenue-analytics-sync-in-progress-banner-${sourceRunningForTheFirstTime.id}`}
-                    action={{ children: 'Refresh', onClick: () => window.location.reload() }}
-                >
-                    One of your revenue data warehouse sources is running for the first time. <br />
-                    This means you might not see all of your revenue data yet. <br />
-                    We display partial data - most recent months first - while the initial sync is running. <br />
-                    Refresh the page to see the latest data.
-                </LemonBanner>
-            )}
-
+        <div className={cn('RevenueAnalyticsDashboard', newSceneLayout && '-mt-2')}>
             <RevenueAnalyticsFilters />
             <RevenueAnalyticsTables />
         </div>

--- a/products/revenue_analytics/manifest.tsx
+++ b/products/revenue_analytics/manifest.tsx
@@ -27,6 +27,7 @@ export const manifest: ProductManifest = {
             path: 'Revenue analytics',
             category: 'Analytics',
             href: urls.revenueAnalytics(),
+            type: 'revenue',
             tags: ['beta'],
             flag: FEATURE_FLAGS.REVENUE_ANALYTICS,
         },

--- a/products/revenue_analytics/manifest.tsx
+++ b/products/revenue_analytics/manifest.tsx
@@ -1,3 +1,5 @@
+import { IconPiggyBank } from '@posthog/icons'
+
 import { FEATURE_FLAGS } from 'lib/constants'
 import { urls } from 'scenes/urls'
 
@@ -24,12 +26,20 @@ export const manifest: ProductManifest = {
         {
             path: 'Revenue analytics',
             category: 'Analytics',
-            iconType: 'piggyBank',
             href: urls.revenueAnalytics(),
             tags: ['beta'],
             flag: FEATURE_FLAGS.REVENUE_ANALYTICS,
         },
     ],
+    fileSystemTypes: {
+        revenue: {
+            name: 'Revenue',
+            icon: <IconPiggyBank />,
+            href: () => urls.revenueAnalytics(),
+            iconColor: ['var(--color-product-revenue-analytics-light)', 'var(--color-product-revenue-analytics-dark)'],
+            filterKey: 'revenue',
+        },
+    },
     treeItemsMetadata: [
         {
             path: 'Revenue settings',


### PR DESCRIPTION
## Changes
Added new scene title section to both apps: LLM Obv and Revenue analytics
* Updated revenue analytics manifest file to use `fileSystemTypes`
* Moved rev's beta lemon banner above most of the scene (follows other apps)

#### LLM flag on/off
![2025-08-27 10 56 43](https://github.com/user-attachments/assets/63d613ba-7f3d-4314-ae31-04e2623a395e)

#### Revenue flag on/off
![2025-08-27 10 55 46](https://github.com/user-attachments/assets/817595ea-63f9-4a1d-959e-79e4dada32e9)
##### Tree icon still intact
<img width="432" height="228" alt="image" src="https://github.com/user-attachments/assets/d335a2d3-ffb6-4f96-a182-5609d79ffb57" />



## How did you test this code?
Flag on, flag off, clicked around looks good.
