### PR TITLE
feat(funnel): add annotation support to historical trend funnel insights

### DIFF
--- a/frontend/src/scenes/funnels/FunnelLineGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelLineGraph.tsx
@@ -112,6 +112,7 @@ export function FunnelLineGraph({
                               })
                           }
                 }
+                hideAnnotations={inSharedMode}
             />
         </LineGraphWrapper>
     )

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -345,7 +345,7 @@ export function LineGraph_({
     const { isDarkModeOn } = useValues(themeLogic)
 
     const { insightProps, insight } = useValues(insightLogic)
-    const { timezone, isTrends, breakdownFilter, query, interval, insightData } = useValues(
+    const { timezone, isTrends, isFunnels, breakdownFilter, query, interval, insightData } = useValues(
         insightVizDataLogic(insightProps)
     )
     const { theme, getTrendsColor, getTrendsHidden } = useValues(trendsDataLogic(insightProps))
@@ -368,7 +368,7 @@ export function LineGraph_({
     const isBar = [GraphType.Bar, GraphType.HorizontalBar, GraphType.Histogram].includes(type)
     const isBackgroundBasedGraphType = [GraphType.Bar].includes(type)
     const isPercentStackView = !!supportsPercentStackView && !!showPercentStackView
-    const showAnnotations = isTrends && !isHorizontal && !hideAnnotations
+    const showAnnotations = ((isTrends && !isHorizontal) || isFunnels) && !hideAnnotations
     const isLog10 = yAxisScaleType === 'log10' // Currently log10 is the only logarithmic scale supported
 
     // Add scrollend event on main element to hide tooltips when scrolling


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/20909.

## Changes

Adds annotation support to historical trend funnel insights.

## How did you test this code?

Manual testing