### PR TITLE
fix(node): Remove duplicate spans

### DIFF
--- a/plugin-server/src/common/tracing/config/capped-siblings-exporter.ts
+++ b/plugin-server/src/common/tracing/config/capped-siblings-exporter.ts
@@ -1,3 +1,4 @@
+import { SpanStatusCode } from '@opentelemetry/api'
 import { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-node'
 
 function durationMs(s: ReadableSpan): number {
@@ -7,7 +8,7 @@ function durationMs(s: ReadableSpan): number {
 }
 
 function hasError(s: ReadableSpan): boolean {
-    return s.status?.code === 2 /* SpanStatusCode.ERROR */
+    return s.status?.code === SpanStatusCode.ERROR
 }
 
 type Key = string // `${traceId}:${parentSpanId}:${name}`

--- a/plugin-server/src/common/tracing/config/capped-siblings-exporter.ts
+++ b/plugin-server/src/common/tracing/config/capped-siblings-exporter.ts
@@ -1,0 +1,65 @@
+// CappedSiblingsExporter.ts
+import { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-node'
+
+function durationMs(s: ReadableSpan): number {
+    const [s0, n0] = s.startTime
+    const [s1, n1] = s.endTime!
+    return (s1 - s0) * 1_000 + (n1 - n0) / 1_000_000
+}
+
+function hasError(s: ReadableSpan): boolean {
+    return s.status?.code === 2 /* SpanStatusCode.ERROR */
+}
+
+type Key = string // `${traceId}:${parentSpanId}:${name}`
+
+export class CappedSiblingsExporter implements SpanExporter {
+    private counts = new Map<Key, number>()
+    private lastFlush = Date.now()
+
+    constructor(
+        private delegate: SpanExporter,
+        private opts: { maxPerGroup: number; minDurationMs?: number; ttlMs?: number } = { maxPerGroup: 2 }
+    ) {}
+
+    export(spans: ReadableSpan[], done: (r: { code: any }) => void): void {
+        const now = Date.now()
+        const ttl = this.opts.ttlMs ?? 30_000
+        if (now - this.lastFlush > ttl) {
+            this.counts.clear()
+            this.lastFlush = now
+        }
+
+        const keep: ReadableSpan[] = []
+
+        for (const s of spans) {
+            // always keep roots
+            if (!s.parentSpanContext?.spanId) {
+                keep.push(s)
+                continue
+            }
+
+            // keep by exception or latency
+            if (hasError(s) || (this.opts.minDurationMs && durationMs(s) >= this.opts.minDurationMs)) {
+                keep.push(s)
+                continue
+            }
+
+            const key: Key = `${s.spanContext().traceId}:${s.parentSpanContext?.spanId}:${s.name}`
+            const n = (this.counts.get(key) ?? 0) + 1
+            if (n <= this.opts.maxPerGroup) {
+                keep.push(s)
+            }
+            this.counts.set(key, n)
+        }
+
+        if (keep.length === 0) {
+            return done({ code: 0 })
+        }
+        this.delegate.export(keep, done)
+    }
+
+    shutdown(): Promise<void> {
+        return this.delegate.shutdown()
+    }
+}

--- a/plugin-server/src/common/tracing/otel.ts
+++ b/plugin-server/src/common/tracing/otel.ts
@@ -15,9 +15,8 @@ const baseExporter = new OTLPTraceExporter({
 })
 
 const traceExporter = new CappedSiblingsExporter(baseExporter, {
-    maxPerGroup: 2, // keep 2 siblings per (traceId,parent,name)
-    minDurationMs: 50, // always keep >=50ms
-    ttlMs: 60000, // state GC window
+    maxPerGroup: defaultConfig.OTEL_MAX_SPANS_PER_GROUP, // keep 2 siblings per (traceId,parent,name)
+    minDurationMs: defaultConfig.OTEL_MIN_SPAN_DURATION_MS, // always keep >=50ms
 })
 
 // W3C is default; keep it for header interop

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -21,6 +21,8 @@ export function getDefaultConfig(): PluginsServerConfig {
         OTEL_EXPORTER_OTLP_ENDPOINT: isDevEnv() ? 'http://localhost:4317' : '',
         OTEL_SDK_DISABLED: isDevEnv() ? false : true,
         OTEL_TRACES_SAMPLER_ARG: 1,
+        OTEL_MAX_SPANS_PER_GROUP: 2,
+        OTEL_MIN_SPAN_DURATION_MS: 50,
         DATABASE_URL: isTestEnv()
             ? 'postgres://posthog:posthog@localhost:5432/test_posthog'
             : isDevEnv()

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -19,7 +19,7 @@ export function getDefaultConfig(): PluginsServerConfig {
     return {
         INSTRUMENT_THREAD_PERFORMANCE: false,
         OTEL_EXPORTER_OTLP_ENDPOINT: isDevEnv() ? 'http://localhost:4317' : '',
-        OTEL_SDK_DISABLED: isDevEnv() ? true : false,
+        OTEL_SDK_DISABLED: isDevEnv() ? false : true,
         OTEL_TRACES_SAMPLER_ARG: 1,
         DATABASE_URL: isTestEnv()
             ? 'postgres://posthog:posthog@localhost:5432/test_posthog'

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -185,6 +185,8 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
     OTEL_EXPORTER_OTLP_ENDPOINT: string
     OTEL_SDK_DISABLED: boolean
     OTEL_TRACES_SAMPLER_ARG: number
+    OTEL_MAX_SPANS_PER_GROUP: number
+    OTEL_MIN_SPAN_DURATION_MS: number
     TASKS_PER_WORKER: number // number of parallel tasks per worker thread
     INGESTION_CONCURRENCY: number // number of parallel event ingestion queues per batch
     INGESTION_BATCH_SIZE: number // kafka consumer batch size


### PR DESCRIPTION
## Problem

Our spans are super noisy, often for a batch of sibling things that happen in parallel like the lazyloader. We dont really care about the fast ones so added a class to "dedupe" siblings that are the same unless they are slow

## Changes

* Adds the capped exporter (mostly thanks to chatgpt)

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
