### PR TITLE
fix(msg): less logs and no transformations for refresh

### DIFF
--- a/posthog/management/commands/refresh_hog_functions.py
+++ b/posthog/management/commands/refresh_hog_functions.py
@@ -35,7 +35,7 @@ class Command(BaseCommand):
 
         self.stdout.write("Starting HogFunction refresh...")
 
-        queryset = HogFunction.objects.filter(deleted=False).select_related("team")
+        queryset = HogFunction.objects.filter(deleted=False, type__in=["destination"]).select_related("team")
 
         if hog_function_id:
             queryset = queryset.filter(id=hog_function_id)
@@ -65,28 +65,16 @@ class Command(BaseCommand):
             for hog_function in page.object_list:
                 try:
                     total_processed += 1
-
-                    # Re-save the HogFunction to trigger filter recompilation
-                    # This will call the save() method which should regenerate filters
                     hog_function.save()
                     total_updated += 1
-
-                    self.stdout.write(
-                        f"Refreshed HogFunction {hog_function.id} "
-                        f"(team: {hog_function.team_id}, name: '{hog_function.name}', "
-                        f"enabled: {hog_function.enabled})"
-                    )
-
                 except Exception as e:
                     error_count += 1
                     logger.error(
                         "Error refreshing HogFunction",
                         hog_function_id=hog_function.id,
-                        team_id=hog_function.team_id,
                         error=str(e),
                         exc_info=True,
                     )
-                    self.stdout.write(self.style.ERROR(f"Error refreshing HogFunction {hog_function.id}: {str(e)}"))
 
         # Output summary
         duration = time.time() - start_time

--- a/posthog/management/commands/test/test_refresh_hog_functions.py
+++ b/posthog/management/commands/test/test_refresh_hog_functions.py
@@ -64,37 +64,37 @@ class TestRefreshHogFunctions(BaseTest):
 
     @patch("posthog.models.hog_functions.hog_function.reload_hog_functions_on_workers")
     def test_refresh_all_hog_functions(self, mock_reload):
-        """Test refreshing all non-deleted HogFunctions (both enabled and disabled) across all teams."""
+        """Test refreshing all non-deleted destination HogFunctions (both enabled and disabled) across all teams."""
 
         out = StringIO()
         call_command("refresh_hog_functions", stdout=out)
 
-        # Should have refreshed 4 non-deleted functions
-        # (hog_function1, hog_function2, hog_function3, disabled_function)
-        # The deleted_function should be excluded
-        assert mock_reload.call_count == 4
+        # Should have refreshed 3 destination functions
+        # (hog_function1, hog_function3, disabled_function)
+        # The transformation hog_function2 and deleted_function should be excluded
+        assert mock_reload.call_count == 3
 
         output = out.getvalue()
-        self.assertIn("Found 4 HogFunctions to process", output)
-        self.assertIn("Processed: 4", output)
-        self.assertIn("Updated: 4", output)
+        self.assertIn("Found 3 HogFunctions to process", output)
+        self.assertIn("Processed: 3", output)
+        self.assertIn("Updated: 3", output)
         self.assertIn("Errors: 0", output)
 
     @patch("posthog.models.hog_functions.hog_function.reload_hog_functions_on_workers")
     def test_refresh_by_team_id(self, mock_reload):
-        """Test refreshing HogFunctions for a specific team."""
+        """Test refreshing destination HogFunctions for a specific team."""
 
         out = StringIO()
         call_command("refresh_hog_functions", team_id=self.team.id, stdout=out)
 
-        # Should have refreshed functions from team1 (hog_function1, hog_function2, disabled_function)
-        # The deleted_function should be excluded
-        assert mock_reload.call_count == 3
+        # Should have refreshed destination functions from team1 (hog_function1, disabled_function)
+        # The transformation hog_function2 and deleted_function should be excluded
+        assert mock_reload.call_count == 2
 
         output = out.getvalue()
         self.assertIn(f"Processing HogFunctions for team: {self.team.id}", output)
-        self.assertIn("Found 3 HogFunctions to process", output)
-        self.assertIn("Updated: 3", output)
+        self.assertIn("Found 2 HogFunctions to process", output)
+        self.assertIn("Updated: 2", output)
 
     @patch("posthog.models.hog_functions.hog_function.reload_hog_functions_on_workers")
     def test_refresh_by_hog_function_id(self, mock_reload):


### PR DESCRIPTION
## Problem

logs polluting and taking forever to print.
transformations do not have the internal user / test user filter

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- only do it for transformations
- remove not needed logs

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- adjusted tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
