### PR TITLE
fix(hogql): Handle anonymous tables in global joins

### DIFF
--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -944,7 +944,14 @@ class Resolver(CloningVisitor):
     ) -> list[ast.TableOrSelectType]:
         tables: list[ast.TableOrSelectType] = []
         if isinstance(select_query_type, ast.SelectQueryType):
-            tables.extend(list(select_query_type.tables.values()))
+            for t in select_query_type.tables.values():
+                if isinstance(t, ast.SelectQueryAliasType):
+                    tables.extend(self._extract_tables_from_query_type(t.select_query_type))
+                else:
+                    tables.append(t)
+
+            for at in select_query_type.anonymous_tables:
+                tables.extend(self._extract_tables_from_query_type(at))
         else:
             for sqt in select_query_type.types:
                 tables.extend(self._extract_tables_from_query_type(sqt))

--- a/posthog/hogql/test/__snapshots__/test_printer.ambr
+++ b/posthog/hogql/test/__snapshots__/test_printer.ambr
@@ -70,6 +70,9 @@
   LIMIT 50000
   '''
 # ---
+# name: TestPrinter.test_s3_tables_global_join_anonymous_tables
+  "SELECT e.event AS event, ij.remote_id AS remote_id FROM events AS e GLOBAL INNER JOIN (SELECT person_id AS person_id, remote_id AS remote_id FROM (SELECT p.id AS person_id, rt.id AS remote_id FROM (SELECT person.id AS id FROM person WHERE equals(person.team_id, 99999) GROUP BY person.id HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, %(hogql_val_0)s), person.version), plus(now64(6, %(hogql_val_1)s), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS p LEFT JOIN (SELECT test_table.id AS id FROM s3(%(hogql_val_2_sensitive)s, %(hogql_val_4_sensitive)s, %(hogql_val_5_sensitive)s, 'Parquet', %(hogql_val_3)s) AS test_table) AS rt ON equals(rt.id, p.id))) AS ij ON equals(e.event, ij.remote_id) WHERE equals(e.team_id, 99999) LIMIT 50000"
+# ---
 # name: TestPrinter.test_s3_tables_global_join_with_cte
   "SELECT events.event AS event FROM events GLOBAL JOIN (SELECT test_table.id AS id FROM s3(%(hogql_val_0_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_3_sensitive)s, 'Parquet', %(hogql_val_1)s) AS test_table) AS some_remote_table ON equals(events.event, toString(some_remote_table.id)) WHERE equals(events.team_id, 99999) LIMIT 50000"
 # ---

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -2586,6 +2586,36 @@ class TestPrinter(BaseTest):
 
         assert clean_varying_query_parts(printed, replace_all_numbers=False) == self.snapshot  # type: ignore
 
+    @pytest.mark.usefixtures("unittest_snapshot")
+    def test_s3_tables_global_join_anonymous_tables(self):
+        credential = DataWarehouseCredential.objects.create(team=self.team, access_key="key", access_secret="secret")
+        DataWarehouseTable.objects.create(
+            team=self.team,
+            name="test_table",
+            format=DataWarehouseTable.TableFormat.DeltaS3Wrapper,
+            url_pattern="http://s3/folder/",
+            credential=credential,
+            columns={"id": {"hogql": "StringDatabaseField", "clickhouse": "String", "schema_valid": True}},
+        )
+
+        printed = self._select("""
+            select e.event, ij.remote_id
+            from events e
+            inner join (
+                select *
+                from (
+                    select p.id as person_id, rt.id as remote_id
+                    from persons p
+                    left join (
+                        select * from test_table
+                    ) rt on rt.id = p.id
+                )
+            ) as ij on e.event = ij.remote_id""")
+
+        assert "GLOBAL INNER JOIN" in printed
+
+        assert clean_varying_query_parts(printed, replace_all_numbers=False) == self.snapshot  # type: ignore
+
 
 class TestPrinted(APIBaseTest):
     def test_can_call_parametric_function(self):


### PR DESCRIPTION
## Problem
- yet another follow-up to https://github.com/PostHog/posthog/pull/36977
- Joining nested anonymous tables onto `events` wasn't generating a `GLOBAL` join

## Changes
- handle anonymous tables

## How did you test this code?
Unit test + snapshot