### PR TITLE
fix(ux): show "loading..." with a spinner

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -13813,7 +13813,7 @@
             "required": ["results"],
             "type": "object"
         },
-        "HogQLQueryResponse<def-interface-974149753-110597-110706-974149753-0-118558[]>": {
+        "HogQLQueryResponse<def-interface-974149753-110873-110982-974149753-0-118834[]>": {
             "additionalProperties": false,
             "properties": {
                 "clickhouse": {

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -3,10 +3,12 @@ import { BuiltLogic, actions, afterMount, connect, kea, listeners, path, props, 
 import { combineUrl, router, urlToAction } from 'kea-router'
 import { subscriptions } from 'kea-subscriptions'
 import posthog from 'posthog-js'
+import { useEffect, useState } from 'react'
 
 import { commandBarLogic } from 'lib/components/CommandBar/commandBarLogic'
 import { BarStatus } from 'lib/components/CommandBar/types'
 import { TeamMembershipLevel } from 'lib/constants'
+import { Spinner } from 'lib/lemon-ui/Spinner'
 import { getRelativeNextPath, identifierToHuman } from 'lib/utils'
 import { getCurrentTeamIdOrNone } from 'lib/utils/getAppContext'
 import { addProjectIdIfMissing, removeProjectIdIfPresent } from 'lib/utils/router-utils'
@@ -86,6 +88,15 @@ const pathPrefixesOnboardingNotRequiredFor = [
     urls.activity(),
     urls.oauthAuthorize(),
 ]
+
+const DelayedLoadingSpinner = (): JSX.Element => {
+    const [show, setShow] = useState(false)
+    useEffect(() => {
+        const timeout = window.setTimeout(() => setShow(true), 500)
+        return () => window.clearTimeout(timeout)
+    }, [])
+    return <>{show ? <Spinner /> : null}</>
+}
 
 export const sceneLogic = kea<sceneLogicType>([
     props(
@@ -398,7 +409,7 @@ export const sceneLogic = kea<sceneLogicType>([
             (s) => [s.activeSceneId, s.activeExportedScene, s.sceneParams, s.activeTabId],
             (activeSceneId, activeExportedScene, sceneParams, activeTabId): LoadedScene | null => {
                 return {
-                    ...(activeExportedScene ?? { component: (): JSX.Element => <>Loading...</> }),
+                    ...(activeExportedScene ?? { component: DelayedLoadingSpinner }),
                     id: activeSceneId ?? Scene.Error404,
                     tabId: activeTabId ?? undefined,
                     sceneParams: sceneParams,

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -8619,7 +8619,7 @@ class HogQLQueryResponse(BaseModel):
     types: Optional[list] = Field(default=None, description="Types of returned columns")
 
 
-class HogQLQueryResponseDefInterface9741497531105971107069741497530118558(BaseModel):
+class HogQLQueryResponseDefInterface9741497531108731109829741497530118834(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )


### PR DESCRIPTION
## Problem

(Note: I'm using slow 3G throttling for effect in these videos)

This "Loading..." is throwing people off.

![2025-08-27 16 11 48](https://github.com/user-attachments/assets/89860347-cf2e-42db-a771-e0c63669dc0b)

This loading text is displayed after a) The URL changes from `/insights` to `/dashboards`, b) we need to load the JS for the dashboards scene, c) it's not yet loaded.

Once the JS loads, the dashboards scene might have its own self-enclosed loading logic (table with loading effect, etc)

## Changes

Use a slightly nicer spinner that shows up 0.5sec after the page opens.

![2025-08-27 16 09 38](https://github.com/user-attachments/assets/716bb698-19d4-4260-ba6f-c535c99ec30f)

In most cases the JS should load pretty quickly, so users will just see a 0.5sec flash before the content appears. This is better than having a jarring "Loading..." steal your attention for a brief moment.

## How did you test this code?

Clicky-click.