### PR TITLE
feat(activity-logs): Remove status from being tracked on import schemas

### DIFF
--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -456,6 +456,7 @@ field_exclusions: dict[ActivityScope, list[str]] = {
         "are_tables_created",
     ],
     "ExternalDataSchema": [
+        "status",
         "sync_type_config",
         "latest_error",
         "last_synced_at",

--- a/posthog/test/activity_logging/test_external_data_schema_activity_logging.py
+++ b/posthog/test/activity_logging/test_external_data_schema_activity_logging.py
@@ -17,7 +17,8 @@ class TestExternalDataSchemaActivityLogging(ActivityLogTestHelper):
         self.assertIn("sync_type_config", external_data_schema_exclusions)
         self.assertIn("latest_error", external_data_schema_exclusions)
         self.assertIn("last_synced_at", external_data_schema_exclusions)
-        self.assertEqual(len(external_data_schema_exclusions), 3)
+        self.assertIn("status", external_data_schema_exclusions)
+        self.assertEqual(len(external_data_schema_exclusions), 4)
 
     def test_external_data_schema_scope_in_activity_log_types(self):
         self.assertIn("ExternalDataSchema", get_args(ActivityScope))


### PR DESCRIPTION
## Problem

- Currently activity logs track the `status` field on `ExternalDataSchema` which unfortunately changes with every sync job, so this creates a bunch of unnecessary activity logs.

## Changes

- Added `status` to excluded fields

## How did you test this code?

- Tests


