### PR TITLE
fix(experiments): don't count empty $session_id's

### DIFF
--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_mean_metric.ambr
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_mean_metric.ambr
@@ -528,7 +528,7 @@
   FROM
     (SELECT exposures.variant AS variant,
             exposures.entity_id AS entity_id,
-            accurateCastOrNull(count(DISTINCT metric_events.value), 'Float64') AS value
+            accurateCastOrNull(countDistinctIf(metric_events.value, and(isNotNull(metric_events.value), ifNull(notEquals(metric_events.value, ''), 1))), 'Float64') AS value
      FROM
        (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
                if(ifNull(greater(count(DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_ratio_metric.ambr
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_ratio_metric.ambr
@@ -315,7 +315,7 @@
      LEFT JOIN
        (SELECT exposures.variant AS variant,
                exposures.entity_id AS entity_id,
-               accurateCastOrNull(count(DISTINCT denominator_events.value), 'Float64') AS denominator_value
+               accurateCastOrNull(countDistinctIf(denominator_events.value, and(isNotNull(denominator_events.value), ifNull(notEquals(denominator_events.value, ''), 1))), 'Float64') AS denominator_value
         FROM
           (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
                   if(ifNull(greater(count(DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_mean_metric.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_mean_metric.py
@@ -339,6 +339,8 @@ class TestExperimentMeanMetric(ExperimentQueryRunnerBaseTest):
                     *_create_events_for_user("control", 3, "c_1_b"),
                 ],
                 "control_2": _create_events_for_user("control", 3, "c_2_a"),
+                # Control 3 has zero pageviews, so this session should not be included in the session metric count
+                "control_3": _create_events_for_user("control", 0, "c_3_a"),
                 # 5 unique sessions in test
                 "test_1": [
                     *_create_events_for_user("test", 3, "t_1_a"),
@@ -383,7 +385,7 @@ class TestExperimentMeanMetric(ExperimentQueryRunnerBaseTest):
 
         self.assertEqual(control_variant.sum, 3)
         self.assertEqual(test_variant.sum, 5)
-        self.assertEqual(control_variant.number_of_samples, 2)
+        self.assertEqual(control_variant.number_of_samples, 3)
         self.assertEqual(test_variant.number_of_samples, 2)
 
     @freeze_time("2024-01-01T12:00:00Z")


### PR DESCRIPTION
## Problem

Clickhouse count NULL and empty values as distinct by default. This inflates the unique session count numbers when using this math property in experiments.

## Changes
* only count values that are not NULL and NOT empty strings
* add test to cover this case

## How did you test this code?
* test added
* existing tests pass
