### PR TITLE
feat(ux): new tab filtering

### DIFF
--- a/frontend/src/layout/scenes/SceneTabs.tsx
+++ b/frontend/src/layout/scenes/SceneTabs.tsx
@@ -11,6 +11,7 @@ import { cn } from 'lib/utils/css-classes'
 import { SceneTab } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
+import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
 import { SceneTabContextMenu } from '~/layout/scenes/SceneTabContextMenu'
 import { sceneLogic } from '~/scenes/sceneLogic'
 
@@ -68,6 +69,11 @@ export function SceneTabs({ className }: SceneTabsProps): JSX.Element {
                                         'p-1 flex flex-row items-center gap-1 cursor-pointer rounded-tr rounded-tl border-b',
                                     iconOnly: true,
                                 }}
+                                tooltip={
+                                    <>
+                                        New tab <KeyboardShortcut command b />
+                                    </>
+                                }
                             >
                                 <IconPlus className="!ml-0" fontSize={14} />
                             </Link>
@@ -151,6 +157,15 @@ function SceneTabComponent({ tab, className, isDragging }: SceneTabProps): JSX.E
                     }}
                     iconOnly
                     size="xs"
+                    tooltip={
+                        tab.active ? (
+                            <>
+                                Close active tab <KeyboardShortcut shift command b />
+                            </>
+                        ) : (
+                            'Close tab'
+                        )
+                    }
                 >
                     <IconX />
                 </ButtonPrimitive>

--- a/frontend/src/scenes/new-tab/NewTabScene.tsx
+++ b/frontend/src/scenes/new-tab/NewTabScene.tsx
@@ -1,20 +1,30 @@
-import { useValues } from 'kea'
-import { useState } from 'react'
+import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Link } from 'lib/lemon-ui/Link'
+import { cn } from 'lib/utils/css-classes'
 import { newTabSceneLogic } from 'scenes/new-tab/newTabSceneLogic'
 import { SceneExport } from 'scenes/sceneTypes'
+
+import { SearchHighlight } from 'products/llm_analytics/frontend/SearchHighlight'
 
 export const scene: SceneExport = {
     component: NewTabScene,
 }
 
 export function NewTabScene(): JSX.Element {
-    const { itemsGrid } = useValues(newTabSceneLogic)
+    const { filteredItemsGrid, search } = useValues(newTabSceneLogic)
+    const { setSearch } = useActions(newTabSceneLogic)
 
-    const [question, setQuestion] = useState('')
-    const handleSubmit = (): void => {}
+    const handleSubmit = (): void => {
+        if (filteredItemsGrid.length > 0 && filteredItemsGrid[0].types.length > 0) {
+            const firstItem = filteredItemsGrid[0].types[0]
+            if (firstItem.href) {
+                router.actions.push(firstItem.href)
+            }
+        }
+    }
 
     // pastel palette (cycle through)
     const swatches = [
@@ -25,35 +35,48 @@ export function NewTabScene(): JSX.Element {
         'bg-pink-500/10 text-pink-700 dark:bg-pink-500/20 dark:text-pink-100',
         'bg-stone-500/10 text-stone-700 dark:bg-stone-500/20 dark:text-stone-100',
     ]
+    const darkSwatches = [
+        'bg-sky-800/80 text-sky-300 dark:bg-sky-300/80 dark:text-sky-700',
+        'bg-emerald-800/80 text-emerald-300 dark:bg-emerald-300/80 dark:text-emerald-700',
+        'bg-violet-800/80 text-violet-300 dark:bg-violet-300/80 dark:text-violet-700',
+        'bg-amber-800/80 text-amber-300 dark:bg-amber-300/80 dark:text-amber-700',
+        'bg-pink-800/80 text-pink-300 dark:bg-pink-300/80 dark:text-pink-700',
+        'bg-stone-800/80 text-stone-300 dark:bg-stone-300/80 dark:text-stone-700',
+    ]
 
     return (
         <div className="w-full py-24">
-            <div className="w-full text-center pb-4 text-sm font-medium">Choose a program to run or just ask Max.</div>
-
             <div className="flex gap-2 max-w-[800px] px-8 m-auto mt-2 mb-12">
                 <input
                     type="text"
-                    value={question}
-                    onChange={(e) => setQuestion(e.target.value)}
-                    onClick={() => setQuestion('')}
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    onClick={() => setSearch('')}
                     onKeyDown={(e) => {
                         if (e.key === 'Enter') {
                             handleSubmit()
                         }
                     }}
-                    placeholder="How much wood would a woodchuck chuck if a woodchuck could chuck wood?"
+                    autoFocus
+                    placeholder="Type to filter apps, press ENTER to run the first one."
                     className="flex-1 px-4 py-3 rounded-lg border border-border dark:border-border-dark bg-white dark:bg-gray-900 text-primary dark:text-primary-dark text-base focus:ring-2 focus:ring-red dark:focus:ring-yellow focus:border-transparent transition-all"
                 />
                 <LemonButton
                     type="primary"
-                    disabledReason={!question.trim() ? 'Please ask a question' : null}
+                    disabledReason={
+                        !search.trim()
+                            ? 'Please write a filter'
+                            : Object.keys(filteredItemsGrid).length === 0
+                              ? 'No results'
+                              : ''
+                    }
                     onClick={handleSubmit}
                 >
-                    Ask Max
+                    Take me there
                 </LemonButton>
             </div>
 
-            {itemsGrid.map(({ category, types }, catIndex) => (
+            {filteredItemsGrid.map(({ category, types }, catIndex) => (
                 <div className="w-full overflow-auto p-4 px-12 max-w-[880px] m-auto" key={catIndex}>
                     <div className="px-2 py-8 text-center">{category}</div>
                     <div
@@ -62,21 +85,26 @@ export function NewTabScene(): JSX.Element {
                             gridTemplateColumns: 'repeat(auto-fit, minmax(7rem, 1fr))',
                         }}
                     >
-                        {types.map((qt, i) => (
+                        {types.map((qt, index) => (
                             <div key={qt.name} className="text-center m-auto">
                                 <Link
                                     to={qt.href}
-                                    className="group flex flex-col items-center text-center cursor-pointer select-none focus:outline-none"
+                                    className={cn(
+                                        'group flex flex-col items-center text-center cursor-pointer select-none focus:outline-none',
+                                        index === 0 && catIndex === 0 && search ? 'underline' : ''
+                                    )}
                                 >
                                     <div
                                         className={`flex items-center justify-center w-16 h-16 rounded-xl shadow-sm group-hover:shadow-md transition ${
-                                            swatches[(i + catIndex * 4) % swatches.length]
+                                            index === 0 && catIndex === 0 && search
+                                                ? darkSwatches[(index + catIndex * 4) % darkSwatches.length]
+                                                : swatches[(index + catIndex * 4) % swatches.length]
                                         }`}
                                     >
                                         <span className="text-2xl font-semibold">{qt.icon ?? qt.name[0]}</span>
                                     </div>
                                     <span className="mt-2 w-full text-xs font-medium truncate px-1 text-primary">
-                                        {qt.name}
+                                        {search ? <SearchHighlight string={qt.name} substring={search} /> : qt.name}
                                     </span>
                                 </Link>
                             </div>

--- a/frontend/src/scenes/new-tab/NewTabScene.tsx
+++ b/frontend/src/scenes/new-tab/NewTabScene.tsx
@@ -11,11 +11,12 @@ import { SearchHighlightMultiple } from '~/layout/navigation-3000/components/Sea
 
 export const scene: SceneExport = {
     component: NewTabScene,
+    logic: newTabSceneLogic,
 }
 
-export function NewTabScene(): JSX.Element {
-    const { filteredItemsGrid, search } = useValues(newTabSceneLogic)
-    const { setSearch } = useActions(newTabSceneLogic)
+export function NewTabScene({ tabId }: { tabId?: string } = {}): JSX.Element {
+    const { filteredItemsGrid, search } = useValues(newTabSceneLogic({ tabId }))
+    const { setSearch } = useActions(newTabSceneLogic({ tabId }))
 
     const handleSubmit = (): void => {
         if (filteredItemsGrid.length > 0 && filteredItemsGrid[0].types.length > 0) {

--- a/frontend/src/scenes/new-tab/NewTabScene.tsx
+++ b/frontend/src/scenes/new-tab/NewTabScene.tsx
@@ -7,7 +7,7 @@ import { cn } from 'lib/utils/css-classes'
 import { newTabSceneLogic } from 'scenes/new-tab/newTabSceneLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 
-import { SearchHighlight } from 'products/llm_analytics/frontend/SearchHighlight'
+import { SearchHighlightMultiple } from '~/layout/navigation-3000/components/SearchHighlight'
 
 export const scene: SceneExport = {
     component: NewTabScene,
@@ -78,7 +78,9 @@ export function NewTabScene(): JSX.Element {
 
             {filteredItemsGrid.map(({ category, types }, catIndex) => (
                 <div className="w-full overflow-auto p-4 px-12 max-w-[880px] m-auto" key={catIndex}>
-                    <div className="px-2 py-8 text-center">{category}</div>
+                    <div className="px-2 py-8 text-center">
+                        {search ? <SearchHighlightMultiple string={category} substring={search} /> : category}
+                    </div>
                     <div
                         className="grid gap-12"
                         style={{
@@ -104,7 +106,11 @@ export function NewTabScene(): JSX.Element {
                                         <span className="text-2xl font-semibold">{qt.icon ?? qt.name[0]}</span>
                                     </div>
                                     <span className="mt-2 w-full text-xs font-medium truncate px-1 text-primary">
-                                        {search ? <SearchHighlight string={qt.name} substring={search} /> : qt.name}
+                                        {search ? (
+                                            <SearchHighlightMultiple string={qt.name} substring={search} />
+                                        ) : (
+                                            qt.name
+                                        )}
                                     </span>
                                 </Link>
                             </div>

--- a/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
+++ b/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
@@ -1,4 +1,4 @@
-import { actions, kea, path, reducers, selectors } from 'kea'
+import { actions, kea, key, path, props, reducers, selectors } from 'kea'
 
 import { IconDatabase, IconHogQL } from '@posthog/icons'
 
@@ -18,6 +18,8 @@ export interface ItemsGridItem {
 
 export const newTabSceneLogic = kea<newTabSceneLogicType>([
     path(['scenes', 'new-tab', 'newTabSceneLogic']),
+    props({} as { tabId?: string }),
+    key((props) => props.tabId || 'default'),
     actions({
         setSearch: (search: string) => ({ search }),
     }),

--- a/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
+++ b/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
@@ -98,11 +98,20 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                 if (!search.trim()) {
                     return itemsGrid
                 }
-                const lowerSearch = search.toLowerCase()
+                const lowerSearchChunks = search
+                    .toLowerCase()
+                    .split(' ')
+                    .map((s) => s.trim())
+                    .filter((s) => s)
                 return itemsGrid
                     .map(({ category, types }) => ({
                         category,
-                        types: types.filter((t) => t.name.toLowerCase().includes(lowerSearch)),
+                        types: types.filter(
+                            (t) =>
+                                lowerSearchChunks.filter(
+                                    (lowerSearch) => !`${category} ${t.name}`.toLowerCase().includes(lowerSearch)
+                                ).length === 0
+                        ),
                     }))
                     .filter(({ types }) => types.length > 0)
             },

--- a/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
+++ b/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
@@ -1,4 +1,4 @@
-import { kea, path, selectors } from 'kea'
+import { actions, kea, path, reducers, selectors } from 'kea'
 
 import { IconDatabase, IconHogQL } from '@posthog/icons'
 
@@ -18,7 +18,17 @@ export interface ItemsGridItem {
 
 export const newTabSceneLogic = kea<newTabSceneLogicType>([
     path(['scenes', 'new-tab', 'newTabSceneLogic']),
-
+    actions({
+        setSearch: (search: string) => ({ search }),
+    }),
+    reducers({
+        search: [
+            '',
+            {
+                setSearch: (_, { search }) => search,
+            },
+        ],
+    }),
     selectors({
         itemsGrid: [
             () => [],
@@ -80,6 +90,21 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                     },
                 ]
                 return queryTree
+            },
+        ],
+        filteredItemsGrid: [
+            (s) => [s.itemsGrid, s.search],
+            (itemsGrid, search): ItemsGridItem[] => {
+                if (!search.trim()) {
+                    return itemsGrid
+                }
+                const lowerSearch = search.toLowerCase()
+                return itemsGrid
+                    .map(({ category, types }) => ({
+                        category,
+                        types: types.filter((t) => t.name.toLowerCase().includes(lowerSearch)),
+                    }))
+                    .filter(({ types }) => types.length > 0)
             },
         ],
     }),

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -1,5 +1,17 @@
 import { arrayMove } from '@dnd-kit/sortable'
-import { BuiltLogic, actions, afterMount, connect, kea, listeners, path, props, reducers, selectors } from 'kea'
+import {
+    BuiltLogic,
+    actions,
+    afterMount,
+    beforeUnmount,
+    connect,
+    kea,
+    listeners,
+    path,
+    props,
+    reducers,
+    selectors,
+} from 'kea'
 import { combineUrl, router, urlToAction } from 'kea-router'
 import { subscriptions } from 'kea-subscriptions'
 import posthog from 'posthog-js'
@@ -951,4 +963,21 @@ export const sceneLogic = kea<sceneLogicType>([
             }
         },
     })),
+    afterMount(({ actions, cache, values }) => {
+        cache.onKeyDown = (event: KeyboardEvent) => {
+            if ((event.ctrlKey || event.metaKey) && (event.key === 'b' || event.key === 'B')) {
+                if (event.shiftKey) {
+                    if (values.activeTab) {
+                        actions.removeTab(values.activeTab)
+                    }
+                } else {
+                    actions.newTab()
+                }
+            }
+        }
+        window.addEventListener('keydown', cache.onKeyDown)
+    }),
+    beforeUnmount(({ cache }) => {
+        window.removeEventListener('keydown', cache.onKeyDown)
+    }),
 ])

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -965,7 +965,9 @@ export const sceneLogic = kea<sceneLogicType>([
     })),
     afterMount(({ actions, cache, values }) => {
         cache.onKeyDown = (event: KeyboardEvent) => {
-            if ((event.ctrlKey || event.metaKey) && (event.key === 'b' || event.key === 'B')) {
+            if ((event.ctrlKey || event.metaKey) && event.key === 'b') {
+                event.preventDefault()
+                event.stopPropagation()
                 if (event.shiftKey) {
                     if (values.activeTab) {
                         actions.removeTab(values.activeTab)


### PR DESCRIPTION
## Problem

The new tab page is a big work in progress.

## Changes

Work on it. Add filtering to the new tab page, and keyboard shortcuts for opening closing tabs (CMD+B / CMD+SHIFT+B)

![2025-08-27 17 40 10](https://github.com/user-attachments/assets/8176236f-29f9-448f-9615-53b627c7f794)


## How did you test this code?

See screencast