### PR TITLE
fix(experiments): allow ratio metrics in shared metrics

### DIFF
--- a/ee/clickhouse/views/experiment_saved_metrics.py
+++ b/ee/clickhouse/views/experiment_saved_metrics.py
@@ -11,6 +11,7 @@ from posthog.schema import (
     ExperimentFunnelsQuery,
     ExperimentMeanMetric,
     ExperimentMetricType,
+    ExperimentRatioMetric,
     ExperimentTrendsQuery,
 )
 
@@ -85,8 +86,10 @@ class ExperimentSavedMetricSerializer(TaggedItemSerializerMixin, serializers.Mod
                     ExperimentMeanMetric(**metric_query)
                 elif metric_query["metric_type"] == ExperimentMetricType.FUNNEL:
                     ExperimentFunnelMetric(**metric_query)
+                elif metric_query["metric_type"] == ExperimentMetricType.RATIO:
+                    ExperimentRatioMetric(**metric_query)
                 else:
-                    raise ValidationError("ExperimentMetric metric_type must be 'mean' or 'funnel'")
+                    raise ValidationError("ExperimentMetric metric_type must be 'mean', 'funnel', or 'ratio'")
             elif metric_query["kind"] == "ExperimentTrendsQuery":
                 ExperimentTrendsQuery(**metric_query)
             elif metric_query["kind"] == "ExperimentFunnelsQuery":

--- a/ee/clickhouse/views/test/test_experiment_saved_metrics.py
+++ b/ee/clickhouse/views/test/test_experiment_saved_metrics.py
@@ -259,7 +259,80 @@ class TestExperimentSavedMetricsCRUD(APILicensedTest):
         )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("ExperimentMetric metric_type must be 'mean' or 'funnel'", response.json()["detail"])
+        self.assertIn("ExperimentMetric metric_type must be 'mean', 'funnel', or 'ratio'", response.json()["detail"])
+
+    def test_create_saved_metric_with_experiment_metric_ratio(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiment_saved_metrics/",
+            data={
+                "name": "Test Experiment ratio metric",
+                "description": "Test description for ratio",
+                "query": {
+                    "kind": "ExperimentMetric",
+                    "metric_type": "ratio",
+                    "numerator": {
+                        "kind": "EventsNode",
+                        "event": "$purchase",
+                    },
+                    "denominator": {
+                        "kind": "EventsNode",
+                        "event": "$pageview",
+                    },
+                },
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.json()["name"], "Test Experiment ratio metric")
+        self.assertEqual(response.json()["description"], "Test description for ratio")
+        self.assertEqual(response.json()["query"]["kind"], "ExperimentMetric")
+        self.assertEqual(response.json()["query"]["metric_type"], "ratio")
+        self.assertEqual(response.json()["query"]["numerator"]["event"], "$purchase")
+        self.assertEqual(response.json()["query"]["denominator"]["event"], "$pageview")
+
+    def test_create_saved_metric_with_experiment_metric_ratio_missing_fields(self):
+        # Test missing numerator
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiment_saved_metrics/",
+            data={
+                "name": "Test Experiment ratio metric",
+                "description": "Test description",
+                "query": {
+                    "kind": "ExperimentMetric",
+                    "metric_type": "ratio",
+                    "denominator": {
+                        "kind": "EventsNode",
+                        "event": "$pageview",
+                    },
+                },
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertTrue("'loc': ('numerator',), 'msg': 'Field required'" in response.json()["detail"])
+
+        # Test missing denominator
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiment_saved_metrics/",
+            data={
+                "name": "Test Experiment ratio metric",
+                "description": "Test description",
+                "query": {
+                    "kind": "ExperimentMetric",
+                    "metric_type": "ratio",
+                    "numerator": {
+                        "kind": "EventsNode",
+                        "event": "$purchase",
+                    },
+                },
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertTrue("'loc': ('denominator',), 'msg': 'Field required'" in response.json()["detail"])
 
     def test_invalid_create(self):
         response = self.client.post(


### PR DESCRIPTION
## Problem
We currently only allow mean of funnel metrics when creating shared metrics.

## Changes

Allow ratio metrics in the shared metrics CRUD view

## How did you test this code?
- manually created a shared metric
- added a test
