### PR TITLE
fix(tooltip): improve visibility handling for line chart tooltips

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -98,6 +98,7 @@ const getYAxisSettings = (
 // LineGraph displays a graph using either x and y data or series breakdown data
 export const LineGraph = (): JSX.Element => {
     const canvasRef = useRef<HTMLCanvasElement | null>(null)
+    const chartId = useRef(`linegraph-dataviz-${Math.random().toString(36).substring(2, 11)}`)
     const { ref: containerRef, height } = useResizeObserver()
     const colors = getGraphColors()
 
@@ -350,7 +351,7 @@ export const LineGraph = (): JSX.Element => {
                             return
                         }
 
-                        const [tooltipRoot, tooltipEl] = ensureTooltip()
+                        const [tooltipRoot, tooltipEl] = ensureTooltip(chartId.current)
                         if (tooltip.opacity === 0) {
                             tooltipEl.style.opacity = '0'
                             return

--- a/frontend/src/scenes/funnels/FunnelBarVertical/FunnelBarVertical.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarVertical/FunnelBarVertical.tsx
@@ -26,7 +26,8 @@ export function FunnelBarVertical({ showPersonsModal: showPersonsModalProp = tru
     const { visibleStepsWithConversionMetrics } = useValues(funnelDataLogic(insightProps))
     const { canOpenPersonModal } = useValues(funnelPersonsModalLogic(insightProps))
     const showPersonsModal = canOpenPersonModal && showPersonsModalProp
-    const vizRef = useFunnelTooltip(showPersonsModal)
+    const chartId = useRef(`funnel-vertical-${Math.random().toString(36).substring(2, 11)}`)
+    const vizRef = useFunnelTooltip(showPersonsModal, chartId.current)
 
     const { height: availableHeight } = useResizeObserver({ ref: vizRef })
     const [scrollbarHeightPx, setScrollbarHeightPx] = useState(0)

--- a/frontend/src/scenes/funnels/FunnelTooltip.tsx
+++ b/frontend/src/scenes/funnels/FunnelTooltip.tsx
@@ -106,7 +106,7 @@ export function FunnelTooltip({
     )
 }
 
-export function useFunnelTooltip(showPersonsModal: boolean): React.RefObject<HTMLDivElement> {
+export function useFunnelTooltip(showPersonsModal: boolean, chartId: string): React.RefObject<HTMLDivElement> {
     const { insightProps } = useValues(insightLogic)
     const { breakdownFilter, querySource } = useValues(funnelDataLogic(insightProps))
     const { isTooltipShown, currentTooltip, tooltipOrigin } = useValues(funnelTooltipLogic(insightProps))
@@ -116,7 +116,7 @@ export function useFunnelTooltip(showPersonsModal: boolean): React.RefObject<HTM
 
     useEffect(() => {
         const svgRect = vizRef.current?.getBoundingClientRect()
-        const [tooltipRoot, tooltipEl] = ensureTooltip()
+        const [tooltipRoot, tooltipEl] = ensureTooltip(chartId)
         tooltipEl.style.opacity = isTooltipShown ? '1' : '0'
         const tooltipRect = tooltipEl.getBoundingClientRect()
         if (tooltipOrigin) {

--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -33,10 +33,12 @@ function useBoldNumberTooltip({
     showPersonsModal,
     isTooltipShown,
     groupTypeLabel,
+    chartId,
 }: {
     showPersonsModal: boolean
     isTooltipShown: boolean
     groupTypeLabel?: string
+    chartId: string
 }): React.RefObject<HTMLDivElement> {
     const { insightProps } = useValues(insightLogic)
     const { series, insightData, trendsFilter, breakdownFilter } = useValues(insightVizDataLogic(insightProps))
@@ -45,7 +47,7 @@ function useBoldNumberTooltip({
     const divRef = useRef<HTMLDivElement>(null)
 
     const divRect = divRef.current?.getBoundingClientRect()
-    const [tooltipRoot, tooltipEl] = ensureTooltip()
+    const [tooltipRoot, tooltipEl] = ensureTooltip(chartId)
 
     useLayoutEffect(() => {
         tooltipEl.style.opacity = isTooltipShown ? '1' : '0'
@@ -95,7 +97,13 @@ export function BoldNumber({ showPersonsModal = true, context }: ChartParams): J
     )
 
     const [isTooltipShown, setIsTooltipShown] = useState(false)
-    const valueRef = useBoldNumberTooltip({ showPersonsModal, isTooltipShown, groupTypeLabel: context?.groupTypeLabel })
+    const chartId = useRef(`boldnumber-${Math.random().toString(36).substring(2, 11)}`)
+    const valueRef = useBoldNumberTooltip({
+        showPersonsModal,
+        isTooltipShown,
+        groupTypeLabel: context?.groupTypeLabel,
+        chartId: chartId.current,
+    })
 
     const showComparison = !!compareFilter?.compare && insightData?.result?.length > 1
     const resultSeries = insightData?.result?.[0] as TrendResult | undefined

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -83,7 +83,8 @@ export function ensureTooltip(): [Root, HTMLElement] {
                     isMouseOverTooltip = false
                     hideTooltipTimeout = setTimeout(() => {
                         if (tooltipEl && !isMouseOverTooltip) {
-                            tooltipEl.classList.add('opacity-0', 'invisible')
+                            tooltipEl.style.opacity = '0'
+                            tooltipEl.style.visibility = 'hidden'
                         }
                     }, 100)
                 },
@@ -108,7 +109,8 @@ export function hideTooltip(): void {
     hideTooltipTimeout = setTimeout(() => {
         const tooltipEl = document.getElementById('InsightTooltipWrapper')
         if (tooltipEl && !isMouseOverTooltip) {
-            tooltipEl.classList.add('opacity-0', 'invisible')
+            tooltipEl.style.opacity = '0'
+            tooltipEl.style.visibility = 'hidden'
         }
     }, 100)
 }
@@ -749,7 +751,8 @@ export function LineGraph_({
                         if (tooltip.opacity === 0) {
                             // Don't hide if mouse is over tooltip
                             if (!isMouseOverTooltip) {
-                                tooltipEl.classList.add('opacity-0', 'invisible')
+                                tooltipEl.style.opacity = '0'
+                                tooltipEl.style.visibility = 'hidden'
                             }
                             return
                         }
@@ -763,7 +766,8 @@ export function LineGraph_({
                         // Reference: https://www.chartjs.org/docs/master/configuration/tooltip.html
                         tooltipEl.classList.remove('above', 'below', 'no-transform')
                         tooltipEl.classList.add(tooltip.yAlign || 'no-transform')
-                        tooltipEl.classList.remove('opacity-0', 'invisible')
+                        tooltipEl.style.opacity = '1'
+                        tooltipEl.style.visibility = 'visible'
 
                         if (tooltip.body) {
                             const referenceDataPoint = tooltip.dataPoints[0] // Use this point as reference to get the date

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -51,68 +51,100 @@ import { GoalLine, TrendsFilter } from '~/queries/schema/schema-general'
 import { isInsightVizNode } from '~/queries/utils'
 import { GraphDataset, GraphPoint, GraphPointPayload, GraphType } from '~/types'
 
-let tooltipRoot: Root
-let isMouseOverTooltip = false
-let hideTooltipTimeout: NodeJS.Timeout | null = null
+const tooltipInstances = new Map<
+    string,
+    { root: Root; element: HTMLElement; isMouseOver: boolean; hideTimeout: NodeJS.Timeout | null }
+>()
 
-export function ensureTooltip(): [Root, HTMLElement] {
-    let tooltipEl = document.getElementById('InsightTooltipWrapper')
+export function ensureTooltip(chartId: string): [Root, HTMLElement] {
+    let instance = tooltipInstances.get(chartId)
 
-    if (!tooltipEl || !tooltipRoot) {
-        if (!tooltipEl) {
-            tooltipEl = document.createElement('div')
-            tooltipEl.id = 'InsightTooltipWrapper'
-            tooltipEl.classList.add('InsightTooltipWrapper')
-            document.body.appendChild(tooltipEl)
+    if (!instance) {
+        const tooltipEl = document.createElement('div')
+        tooltipEl.id = `InsightTooltipWrapper-${chartId}`
+        tooltipEl.classList.add('InsightTooltipWrapper')
+        document.body.appendChild(tooltipEl)
 
-            // Add mouse tracking
-            tooltipEl.addEventListener(
-                'mouseenter',
-                () => {
-                    isMouseOverTooltip = true
-                    if (hideTooltipTimeout) {
-                        clearTimeout(hideTooltipTimeout)
-                        hideTooltipTimeout = null
-                    }
-                },
-                { passive: true }
-            )
-            tooltipEl.addEventListener(
-                'mouseleave',
-                () => {
-                    isMouseOverTooltip = false
-                    hideTooltipTimeout = setTimeout(() => {
-                        if (tooltipEl && !isMouseOverTooltip) {
-                            tooltipEl.style.opacity = '0'
-                            tooltipEl.style.visibility = 'hidden'
-                        }
-                    }, 100)
-                },
-                { passive: true }
-            )
+        const root = createRoot(tooltipEl)
+
+        instance = {
+            root,
+            element: tooltipEl,
+            isMouseOver: false,
+            hideTimeout: null,
         }
 
-        tooltipRoot = createRoot(tooltipEl)
+        tooltipInstances.set(chartId, instance)
+
+        // Add mouse tracking for this specific tooltip
+        tooltipEl.addEventListener(
+            'mouseenter',
+            () => {
+                instance!.isMouseOver = true
+                if (instance!.hideTimeout) {
+                    clearTimeout(instance!.hideTimeout)
+                    instance!.hideTimeout = null
+                }
+            },
+            { passive: true }
+        )
+
+        tooltipEl.addEventListener(
+            'mouseleave',
+            () => {
+                instance!.isMouseOver = false
+                instance!.hideTimeout = setTimeout(() => {
+                    if (!instance!.isMouseOver) {
+                        instance!.element.classList.add('opacity-0', 'invisible')
+                    }
+                }, 100)
+            },
+            { passive: true }
+        )
     }
-    return [tooltipRoot, tooltipEl]
+
+    return [instance.root, instance.element]
 }
 
-export function hideTooltip(): void {
-    if (hideTooltipTimeout) {
-        clearTimeout(hideTooltipTimeout)
-        hideTooltipTimeout = null
-    }
-    if (isMouseOverTooltip) {
+export function hideTooltip(chartId?: string): void {
+    if (!chartId) {
+        // Fallback to old behavior - hide all tooltips
+        tooltipInstances.forEach((instance) => {
+            instance.element.style.opacity = '0'
+        })
         return
     }
 
-    hideTooltipTimeout = setTimeout(() => {
-        const tooltipEl = document.getElementById('InsightTooltipWrapper')
-        if (tooltipEl && !isMouseOverTooltip) {
-            tooltipEl.style.opacity = '0'
-            tooltipEl.style.visibility = 'hidden'
+    const instance = tooltipInstances.get(chartId)
+    if (!instance) {
+        return
+    }
+
+    if (instance.hideTimeout) {
+        clearTimeout(instance.hideTimeout)
+        instance.hideTimeout = null
+    }
+
+    if (instance.isMouseOver) {
+        return
+    }
+
+    instance.hideTimeout = setTimeout(() => {
+        if (!instance.isMouseOver) {
+            instance.element.classList.add('opacity-0', 'invisible')
         }
     }, 100)
+}
+
+export function cleanupTooltip(chartId: string): void {
+    const instance = tooltipInstances.get(chartId)
+    if (instance) {
+        if (instance.hideTimeout) {
+            clearTimeout(instance.hideTimeout)
+        }
+        instance.element.remove()
+        tooltipInstances.delete(chartId)
+    }
 }
 
 function truncateString(str: string, num: number): string {
@@ -357,6 +389,9 @@ export function LineGraph_({
     const canvasRef = useRef<HTMLCanvasElement | null>(null)
     const [lineChart, setLineChart] = useState<Chart<ChartType, any, string>>()
 
+    // Generate unique chart ID based on insight ID and data attributes
+    const chartId = useRef(`chart-${insight.id || 'new'}-${Math.random().toString(36).substr(2, 9)}`)
+
     // Relying on useResizeObserver instead of Chart's onResize because the latter was not reliable
     const { width: chartWidth, height: chartHeight } = useResizeObserver({ ref: canvasRef })
 
@@ -379,17 +414,19 @@ export function LineGraph_({
             return
         }
 
+        const handleScrollEnd = (): void => hideTooltip(chartId.current)
+
         // Scroll events happen on the main element due to overflow-y: scroll
         // but we need to make sure it exists before adding the event listener,
         // e.g: it does not exist in the shared pages
         const main = document.getElementsByTagName('main')[0]
         if (main) {
-            main.addEventListener('scrollend', hideTooltip)
+            main.addEventListener('scrollend', handleScrollEnd)
         }
 
         return () => {
             if (main) {
-                main.removeEventListener('scrollend', hideTooltip)
+                main.removeEventListener('scrollend', handleScrollEnd)
             }
         }
     }, [hideTooltipOnScroll])
@@ -397,8 +434,7 @@ export function LineGraph_({
     // Remove tooltip element on unmount
     useOnMountEffect(() => {
         return () => {
-            const tooltipEl = document.getElementById('InsightTooltipWrapper')
-            tooltipEl?.remove()
+            cleanupTooltip(chartId.current)
         }
     })
 
@@ -747,27 +783,18 @@ export function LineGraph_({
                             return
                         }
 
-                        const [tooltipRoot, tooltipEl] = ensureTooltip()
+                        const [tooltipRoot, tooltipEl] = ensureTooltip(chartId.current)
                         if (tooltip.opacity === 0) {
-                            // Don't hide if mouse is over tooltip
-                            if (!isMouseOverTooltip) {
-                                tooltipEl.style.opacity = '0'
-                                tooltipEl.style.visibility = 'hidden'
-                            }
+                            // Use the new hide logic that respects mouse hover
+                            hideTooltip(chartId.current)
                             return
-                        }
-
-                        if (hideTooltipTimeout) {
-                            clearTimeout(hideTooltipTimeout)
-                            hideTooltipTimeout = null
                         }
 
                         // Set caret position
                         // Reference: https://www.chartjs.org/docs/master/configuration/tooltip.html
-                        tooltipEl.classList.remove('above', 'below', 'no-transform')
+                        tooltipEl.classList.remove('above', 'below', 'no-transform', 'opacity-0', 'invisible')
                         tooltipEl.classList.add(tooltip.yAlign || 'no-transform')
                         tooltipEl.style.opacity = '1'
-                        tooltipEl.style.visibility = 'visible'
 
                         if (tooltip.body) {
                             const referenceDataPoint = tooltip.dataPoints[0] // Use this point as reference to get the date

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -390,7 +390,7 @@ export function LineGraph_({
     const [lineChart, setLineChart] = useState<Chart<ChartType, any, string>>()
 
     // Generate unique chart ID based on insight ID and data attributes
-    const chartId = useRef(`chart-${insight.id || 'new'}-${Math.random().toString(36).substr(2, 9)}`)
+    const chartId = useRef(`chart-${insight.id || 'new'}-${Math.random().toString(36).substring(2, 11)}`)
 
     // Relying on useResizeObserver instead of Chart's onResize because the latter was not reliable
     const { width: chartWidth, height: chartHeight } = useResizeObserver({ ref: canvasRef })

--- a/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
@@ -84,6 +84,7 @@ export function PieChart({
     const { aggregationLabel } = useValues(groupsModel)
     const { highlightSeries } = useActions(insightLogic)
     const canvasRef = useRef<HTMLCanvasElement | null>(null)
+    const chartId = useRef(`pie-${Math.random().toString(36).substring(2, 11)}`)
 
     // Remove tooltip element on unmount
     useOnMountEffect(() => {
@@ -178,7 +179,7 @@ export function PieChart({
                                 return
                             }
 
-                            const [tooltipRoot, tooltipEl] = ensureTooltip()
+                            const [tooltipRoot, tooltipEl] = ensureTooltip(chartId.current)
                             if (tooltip.opacity === 0) {
                                 // remove highlight from the legend
                                 if (trendsFilter?.showLegend) {

--- a/frontend/src/scenes/insights/views/WorldMap/WorldMap.tsx
+++ b/frontend/src/scenes/insights/views/WorldMap/WorldMap.tsx
@@ -26,7 +26,7 @@ const SATURATION_FLOOR = 0.2
 /** The tooltip is offset by a few pixels from the cursor to give it some breathing room. */
 const WORLD_MAP_TOOLTIP_OFFSET_PX = 8
 
-function useWorldMapTooltip(showPersonsModal: boolean): React.RefObject<SVGSVGElement> {
+function useWorldMapTooltip(showPersonsModal: boolean, chartId: string): React.RefObject<SVGSVGElement> {
     const { insightProps } = useValues(insightLogic)
     const { series, trendsFilter, breakdownFilter, isTooltipShown, currentTooltip, tooltipCoordinates } = useValues(
         worldMapLogic(insightProps)
@@ -36,7 +36,7 @@ function useWorldMapTooltip(showPersonsModal: boolean): React.RefObject<SVGSVGEl
     const svgRef = useRef<SVGSVGElement>(null)
 
     const svgRect = svgRef.current?.getBoundingClientRect()
-    const [tooltipRoot, tooltipEl] = ensureTooltip()
+    const [tooltipRoot, tooltipEl] = ensureTooltip(chartId)
 
     useEffect(() => {
         tooltipEl.style.opacity = isTooltipShown ? '1' : '0'
@@ -211,7 +211,8 @@ export function WorldMap({ showPersonsModal = true, context }: ChartParams): JSX
     const { countryCodeToSeries, maxAggregatedValue, querySource, theme } = useValues(worldMapLogic(insightProps))
     const { showTooltip, hideTooltip, updateTooltipCoordinates } = useActions(worldMapLogic(insightProps))
 
-    const svgRef = useWorldMapTooltip(showPersonsModal)
+    const chartId = useRef(`worldmap-${Math.random().toString(36).substring(2, 11)}`)
+    const svgRef = useWorldMapTooltip(showPersonsModal, chartId.current)
 
     const backgroundColor = theme?.['preset-1'] || '#000000' // Default to black if no color found
 


### PR DESCRIPTION
## Problem

There was an issue with the tooltips on dashboards where multiple instances of LineChart were being rendered and the tooltip intermittently showed up or got hidden.

All charts share the same tooltip element. However, other charts did not have the code to track mouse movements so the tooltip would get hidden while the mouse was out of the Line Chart.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

props to @jabahamondes 

uses a map to store separate instances of tooltip for every chart. this allows us to handle the mouse tracking separately for every tooltip element.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Go to a dashboard where multiple charts are placed. Hover over them to see tooltips.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
