### PR TITLE
fix(flags): Use token-based key for local evaluation hypercache

### DIFF
--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -5805,7 +5805,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # Check that cache is now populated (using HyperCache format)
-        cache_key = f"cache/teams/{self.team.id}/feature_flags/flags_without_cohorts.json"
+        cache_key = f"cache/team_tokens/{self.team.api_token}/feature_flags/flags_without_cohorts.json"
         cached_data = cache.get(cache_key)
         self.assertIsNotNone(cached_data)
         cached_json = json.loads(cached_data)
@@ -5848,8 +5848,8 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # Check separate cache key for cohorts version (using HyperCache format)
-        cache_key_cohorts = f"cache/teams/{self.team.id}/feature_flags/flags_with_cohorts.json"
-        cache_key_regular = f"cache/teams/{self.team.id}/feature_flags/flags_without_cohorts.json"
+        cache_key_cohorts = f"cache/team_tokens/{self.team.api_token}/feature_flags/flags_with_cohorts.json"
+        cache_key_regular = f"cache/team_tokens/{self.team.api_token}/feature_flags/flags_without_cohorts.json"
 
         cached_cohorts = cache.get(cache_key_cohorts)
         cached_regular = cache.get(cache_key_regular)
@@ -5881,8 +5881,8 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # Verify cache is populated and get original content
-        cache_key = f"cache/teams/{self.team.id}/feature_flags/flags_without_cohorts.json"
-        cache_key_cohorts = f"cache/teams/{self.team.id}/feature_flags/flags_with_cohorts.json"
+        cache_key = f"cache/team_tokens/{self.team.api_token}/feature_flags/flags_without_cohorts.json"
+        cache_key_cohorts = f"cache/team_tokens/{self.team.api_token}/feature_flags/flags_with_cohorts.json"
         original_cache = cache.get(cache_key)
         self.assertIsNotNone(original_cache)
 

--- a/posthog/models/feature_flag/local_evaluation.py
+++ b/posthog/models/feature_flag/local_evaluation.py
@@ -307,12 +307,14 @@ flags_hypercache = HyperCache(
     namespace="feature_flags",
     value="flags_with_cohorts.json",
     load_fn=lambda key: _get_flags_response_for_local_evaluation(HyperCache.team_from_key(key), include_cohorts=True),
+    token_based=True,
 )
 
 flags_without_cohorts_hypercache = HyperCache(
     namespace="feature_flags",
     value="flags_without_cohorts.json",
     load_fn=lambda key: _get_flags_response_for_local_evaluation(HyperCache.team_from_key(key), include_cohorts=False),
+    token_based=True,
 )
 
 

--- a/posthog/models/feature_flag/test/test_local_evaluation.py
+++ b/posthog/models/feature_flag/test/test_local_evaluation.py
@@ -5,6 +5,7 @@ from posthog.models.feature_flag.feature_flag import FeatureFlag
 from posthog.models.feature_flag.local_evaluation import (
     clear_flag_caches,
     flags_hypercache,
+    flags_without_cohorts_hypercache,
     get_flags_response_for_local_evaluation,
     update_flag_caches,
 )
@@ -190,3 +191,14 @@ class TestLocalEvaluationCache(BaseTest):
         response, source = flags_hypercache.get_from_cache_with_source(self.team)
         assert source == "redis"
         self._assert_payload_valid_with_cohorts(response)
+
+    def test_flag_keys(self):
+        flags_hypercache.get_from_cache(self.team)
+        assert (
+            flags_hypercache.get_cache_key(self.team)
+            == f"cache/team_tokens/{self.team.api_token}/feature_flags/flags_with_cohorts.json"
+        )
+        assert (
+            flags_without_cohorts_hypercache.get_cache_key(self.team.api_token)
+            == f"cache/team_tokens/{self.team.api_token}/feature_flags/flags_without_cohorts.json"
+        )

--- a/posthog/storage/hypercache.py
+++ b/posthog/storage/hypercache.py
@@ -58,6 +58,17 @@ class HyperCache:
         cache_ttl: int = DEFAULT_CACHE_TTL,
         cache_miss_ttl: int = DEFAULT_CACHE_MISS_TTL,
     ):
+        """
+        Initialize the HyperCache instance.
+
+        Args:
+            namespace: The namespace for the cache.
+            value: Specific data/file within the namespace. Similar to a filename such as "flags_with_cohorts.json".
+            load_fn: The function to load the cache.
+            token_based: True when the calling code only knows the team's API token (like SDK requests).
+            cache_ttl: The TTL for items in the cache.
+            cache_miss_ttl: The TTL for the cache when the value is missing.
+        """
         self.namespace = namespace
         self.value = value
         self.load_fn = load_fn


### PR DESCRIPTION
## Problem

The `local_evaluation` endpoint is called by the SDKs which use the project api key to identify the project.

Since the SDKs don't know the team id, we need to support cache keys using the project api token, otherwise we'll need a database lookup defeating the purpose of this caching work.

## Changes

Update the hypercaches used by local evaluation to set `token_based` to `true`

## How did you test this code?

Unit tests.
Manual tests.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
