### PR TITLE
feat: progressive streaming

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -308,9 +308,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         // onMessage callback - handles both metadata and tiles
                         (data) => {
                             if (data.type === 'metadata') {
-                                const dashboardWithTiles = { ...data.dashboard, tiles: [] }
                                 actions.loadDashboardMetadataSuccess(
-                                    getQueryBasedDashboard(dashboardWithTiles as DashboardType<InsightModel>)
+                                    getQueryBasedDashboard(data.dashboard as DashboardType<InsightModel>)
                                 )
                             } else if (data.type === 'tile') {
                                 actions.receiveTileFromStream(data)
@@ -627,11 +626,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     if (!dashboard) {
                         return state
                     }
-                    // Merge metadata with existing state, preserving tiles
-                    return {
-                        ...dashboard,
-                        tiles: state?.tiles || [],
-                    }
+                    return dashboard
                 },
                 receiveTileFromStream: (state, { tile }) => {
                     if (!state || !state.tiles) {


### PR DESCRIPTION
## Problem
SSE chunking on prod puts a long delay between the dashboard metadata and the first tiles. This somewhat ruins the progressive experience.
<img width="881" height="694" alt="image" src="https://github.com/user-attachments/assets/32b86eaa-fb2b-41ae-a525-370d33169f8d" />


## Changes
Modify the stream so that it always returns the first two tiles with the metadata. This should be the best of both worlds.
