### PR TITLE
chore: move propdefs to a new, repartitioned topic on kafka

### DIFF
--- a/rust/property-defs-rs/src/config.rs
+++ b/rust/property-defs-rs/src/config.rs
@@ -161,7 +161,7 @@ impl TeamFilterMode {
 
 impl Config {
     pub fn init_with_defaults() -> Result<Self, envconfig::Error> {
-        ConsumerConfig::set_defaults("property-defs-rs", "clickhouse_events_json", true);
+        ConsumerConfig::set_defaults("property-defs-rs", "propdefs_events_json", true);
         Config::init_from_env()
     }
 }


### PR DESCRIPTION
**⚠️ DO NOT LAND UNTIL PROPDEFS SERVICE IS SCALED TO ZERO AND SHUFFLEHOG SERVICE HAS BEEN CONFIGURED AND IS RUNNING ⚠️** 

## Problem

The partition key for current topic is causing rowlocks due to bad partitioning

## Changes

Create a new partition and have shufflehog produce the correct partitioned data to it

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
