### PR TITLE
fix(msg): dont run pre-filter when actions are present

### DIFF
--- a/plugin-server/src/cdp/utils/hog-function-filtering.test.ts
+++ b/plugin-server/src/cdp/utils/hog-function-filtering.test.ts
@@ -293,6 +293,30 @@ describe('hog-function-filtering', () => {
             expect(result.match).toBe(true)
         })
 
+        it('should not run pre-filter when actions are present', async () => {
+            mockHogFunction.filters = {
+                events: [
+                    { id: 'change_order_generated', name: 'change_order_generated', type: 'events', order: 0 },
+                    {
+                        id: 'project_create_change_order_clicked',
+                        name: 'project_create_change_order_clicked',
+                        type: 'events',
+                        order: 1,
+                    },
+                ],
+                actions: [{ id: 'change_order_generated', name: 'change_order_generated', type: 'actions', order: 0 }],
+                bytecode: ['_H', 1, 29], // Simple bytecode that returns true
+            }
+
+            mockFilterGlobals.event = 'change_order_generated'
+            const result = await filterFunctionInstrumented({
+                fn: mockHogFunction,
+                filters: mockHogFunction.filters,
+                filterGlobals: mockFilterGlobals,
+            })
+            expect(result.match).toBe(true)
+        })
+
         it('should return true and skip bytecode when no filters are configured', async () => {
             // This is what we actually get in the database when no filters are configured
             mockHogFunction.filters = {

--- a/plugin-server/src/cdp/utils/hog-function-filtering.ts
+++ b/plugin-server/src/cdp/utils/hog-function-filtering.ts
@@ -353,7 +353,8 @@ export async function filterFunctionInstrumented(options: {
         }
 
         // check whether we have a match with our pre-filter
-        if (filters?.events?.length) {
+        // Only run if we have event filters and NO action filters (as actions are pre-saved event filters)
+        if (filters?.events?.length && !filters?.actions?.length) {
             preFilterMatch = preFilterResult(filters, filterGlobals)
         }
 


### PR DESCRIPTION
## Problem

c.f. https://posthog.slack.com/archives/C06GG249PR6/p1756359244330999

The pre-filter looks good but we still have roughly 10-20 events that would have been filtered out although they should have not. This is likely due to actions being present (actions are pre-saved event filters). That means we only check the event filter but do not check action filters.

As we are talking about 10-20 events per minute we for now ignore actions and come back to them later if we feel we need to shave off those marginal gains. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- do not run the pre-filter when actions are present (for now) 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- local dev 
- added test

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
