### PR TITLE
feat(msg): skip bytecode execution due to pre-filter outcome

### DIFF
--- a/plugin-server/src/cdp/hog-transformations/hog-transformer.service.test.ts
+++ b/plugin-server/src/cdp/hog-transformations/hog-transformer.service.test.ts
@@ -727,6 +727,7 @@ describe('HogTransformer', () => {
                     bytecode: await compileHog(`
                         return event = 'match-me'
                     `),
+                    events: [{ id: 'match-me', name: 'match-me', type: 'events', order: 0 }],
                 },
             })
 
@@ -810,6 +811,7 @@ describe('HogTransformer', () => {
                     bytecode: await compileHog(`
                         return event = 'match-me'
                     `),
+                    events: [{ id: 'match-me', name: 'match-me', type: 'events', order: 0 }],
                 },
             })
 
@@ -1034,6 +1036,7 @@ describe('HogTransformer', () => {
                     bytecode: await compileHog(`
                         return event = 'match-me'
                     `),
+                    events: [{ id: 'match-me', name: 'match-me', type: 'events', order: 0 }],
                 },
             })
 
@@ -1080,6 +1083,7 @@ describe('HogTransformer', () => {
                         // Filter that matches events with event name 'match-me'
                         return event = 'match-me'
                     `),
+                    events: [{ id: 'match-me', name: 'match-me', type: 'events', order: 0 }],
                 },
             })
 
@@ -1192,6 +1196,7 @@ describe('HogTransformer', () => {
                         // Invalid filter that will throw an error
                         lol
                     `),
+                    events: [{ id: 'test-event', name: 'test-event', type: 'events', order: 0 }],
                 },
             })
 
@@ -1259,6 +1264,10 @@ describe('HogTransformer', () => {
                         // Only transform if at least one filter matches
                         return filter1 or filter2
                     `),
+                    events: [
+                        { id: 'match-me-1', name: 'match-me-1', type: 'events', order: 0 },
+                        { id: 'match-me-2', name: 'match-me-2', type: 'events', order: 1 },
+                    ],
                 },
             })
 

--- a/plugin-server/src/cdp/utils/hog-function-filtering.ts
+++ b/plugin-server/src/cdp/utils/hog-function-filtering.ts
@@ -360,6 +360,13 @@ export async function filterFunctionInstrumented(options: {
             if (preFilterMatch === false) {
                 hogFunctionPreFilterCounter.inc({ result: 'bytecode_execution_skipped__pre_filtered_out' })
                 result.match = false
+                metrics.push({
+                    team_id: fn.team_id,
+                    app_source_id: fn.id,
+                    metric_kind: 'other',
+                    metric_name: 'filtered',
+                    count: 1,
+                })
                 return result
             }
         }

--- a/plugin-server/src/cdp/utils/hog-function-filtering.ts
+++ b/plugin-server/src/cdp/utils/hog-function-filtering.ts
@@ -348,14 +348,20 @@ export async function filterFunctionInstrumented(options: {
         // If there are no filters (only bytecode exists then on the filter object)
         // everything matches no need to execute bytecode (lets save those cpu cycles)
         if (filters && Object.keys(filters).length === 1 && 'bytecode' in filters) {
-            // if we have no filters we assume we match all events hence match = true
-            hogFunctionPreFilterCounter.inc({ result: 'no_filters' })
+            hogFunctionPreFilterCounter.inc({ result: 'bytecode_execution_skipped__no_filters' })
+            result.match = true
+            return result
         }
 
         // check whether we have a match with our pre-filter
         // Only run if we have event filters and NO action filters (as actions are pre-saved event filters)
         if (filters?.events?.length && !filters?.actions?.length) {
             preFilterMatch = preFilterResult(filters, filterGlobals)
+            if (preFilterMatch === false) {
+                hogFunctionPreFilterCounter.inc({ result: 'bytecode_execution_skipped__pre_filtered_out' })
+                result.match = false
+                return result
+            }
         }
 
         if (!filters?.bytecode) {
@@ -388,30 +394,6 @@ export async function filterFunctionInstrumented(options: {
         }
 
         result.match = typeof execHogOutcome.execResult.result === 'boolean' && execHogOutcome.execResult.result
-
-        // if our filter was not used we don't wanna do any comparison
-        if (preFilterMatch !== null) {
-            if (preFilterMatch === false && result.match === true) {
-                // we would have filtered out this event but it actually matched the bytecode filter
-                // this would mean we dropped a valid event
-
-                logger.warn(
-                    '🦔',
-                    `[${fnKind}] Pre-filter mismatch detected - event would have been incorrectly filtered`,
-                    {
-                        functionId: fn.id,
-                        functionName: fn.name,
-                        teamId: fn.team_id,
-                        eventUuid: eventUuid,
-                        eventName: filterGlobals.event,
-                        preFilterMatch,
-                        resultMatch: result.match,
-                    }
-                )
-
-                hogFunctionPreFilterCounter.inc({ result: 'mismatch_unsafe' })
-            }
-        }
 
         if (!result.match) {
             metrics.push({


### PR DESCRIPTION
## Problem

we now want to roll out the filter after having made sure we dont filter out events that should have been kept.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- roll it out 
- metric it out still

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- tests all pass still 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
