### PR TITLE
feat(msg): make oauth placeholder not key specific

### DIFF
--- a/plugin-server/src/cdp/services/hog-executor.service.ts
+++ b/plugin-server/src/cdp/services/hog-executor.service.ts
@@ -564,22 +564,25 @@ export class HogExecutorService {
             headers['developer-token'] = this.hub.CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN
         }
 
-        if (!!invocation.state.globals.inputs?.oauth) {
-            const integrationInputs = await this.hogInputsService.loadIntegrationInputs(invocation.hogFunction)
-            const accessToken: string = integrationInputs.oauth.value.access_token_raw
-            const placeholder: string = integrationInputs.oauth.value.access_token
+        const integrationInputs = await this.hogInputsService.loadIntegrationInputs(invocation.hogFunction)
 
-            if (placeholder && accessToken) {
-                const replace = (val: string) => val.replaceAll(placeholder, accessToken)
+        if (Object.keys(integrationInputs).length > 0) {
+            for (const [, value] of Object.entries(integrationInputs)) {
+                const accessToken: string = value.value.access_token_raw
+                const placeholder: string = value.value.access_token
 
-                params.body = params.body ? replace(params.body) : params.body
-                headers = Object.fromEntries(
-                    Object.entries(params.headers ?? {}).map(([key, value]) => [
-                        key,
-                        typeof value === 'string' ? replace(value) : value,
-                    ])
-                )
-                params.url = replace(params.url)
+                if (placeholder && accessToken) {
+                    const replace = (val: string) => val.replaceAll(placeholder, accessToken)
+
+                    params.body = params.body ? replace(params.body) : params.body
+                    headers = Object.fromEntries(
+                        Object.entries(params.headers ?? {}).map(([key, value]) => [
+                            key,
+                            typeof value === 'string' ? replace(value) : value,
+                        ])
+                    )
+                    params.url = replace(params.url)
+                }
             }
         }
 


### PR DESCRIPTION
## Problem

It shouldn't be key-specific. Change that.

Followup:
- [merge the hog-inputs after this PR has been rolled out](https://github.com/PostHog/posthog/pull/37275)

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
