### PR TITLE
feat: Update cookieless mode setting feature flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -288,6 +288,7 @@ export const FEATURE_FLAGS = {
     EXPERIMENTS_RATIO_METRIC: 'experiments-ratio-metric', // owner: @andehen #team-experiments
     CDP_NEW_PRICING: 'cdp-new-pricing', // owner: #team-messaging
     COMMENT_TEXT_FILTERING: 'comment-text-filtering', // owner: @pauldambra #team-replay
+    IMPROVED_COOKIELESS_MODE: 'improved-cookieless-mode', // owner: @robbie-c #team-web-analytics
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -310,7 +310,7 @@ export const SETTINGS_MAP: SettingSection[] = [
                 id: 'cookieless-server-hash-mode',
                 title: 'Cookieless server hash mode',
                 component: <CookielessServerHashModeSetting />,
-                flag: 'COOKIELESS_SERVER_HASH_MODE_SETTING',
+                flag: 'IMPROVED_COOKIELESS_MODE',
             },
             {
                 id: 'bounce-rate-duration',


### PR DESCRIPTION
## Problem

This should have been on the newer feature flag, which is attached to the early access feature.

The early access feature is here https://us.posthog.com/project/2/early_access_features/01967bf6-e14d-0000-a9f9-97b1ccf31665

<img width="270" height="81" alt="Screenshot 2025-08-28 at 10 44 39" src="https://github.com/user-attachments/assets/013e728e-20a9-433d-8346-b275e2c51e68" />



## Changes

Change the flag.

## How did you test this code?

n/a
