### PR TITLE
fix(ux): title in session replay screen, collection scroll

### DIFF
--- a/frontend/src/scenes/session-recordings/SessionRecordings.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordings.tsx
@@ -28,8 +28,6 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
-import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
-import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey, ReplayTab, ReplayTabs } from '~/types'
 
 import { SessionRecordingsPlaylist } from './playlist/SessionRecordingsPlaylist'
@@ -93,15 +91,6 @@ function Header(): JSX.Element {
                     </>
                 }
             />
-            <SceneTitleSection
-                name="Session replay"
-                description="See how users interact with your product."
-                resourceType={{
-                    type: 'session_recording_playlist',
-                    typePlural: 'Session Recordings',
-                }}
-            />
-            <SceneDivider />
         </>
     )
 }

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistScene.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistScene.tsx
@@ -96,8 +96,7 @@ export function SessionRecordingsPlaylistScene(): JSX.Element {
     }
 
     return (
-        // Margin bottom hacks the fact that our wrapping container has an annoyingly large padding
-        <div className="-mb-14">
+        <div>
             <PageHeader
                 buttons={
                     <div className="flex justify-between items-center gap-2">


### PR DESCRIPTION

## Problem
Scene title in session replay didn't fly well
Realized collections page had a negative margin bottom which prevented from clicking fullscreen with max in the way

## Changes
Remove titles from main session replay screen
Removed negative margin bottom from collection component.

## How did you test this code?
Clicking around