### PR TITLE
feat(max): suggestions from MaxTool(s) now showing in UI

### DIFF
--- a/frontend/src/scenes/max/Max.stories.tsx
+++ b/frontend/src/scenes/max/Max.stories.tsx
@@ -29,7 +29,7 @@ import conversationList from './__mocks__/conversationList.json'
 import { ToolRegistration } from './max-constants'
 import { maxContextLogic } from './maxContextLogic'
 import { maxGlobalLogic } from './maxGlobalLogic'
-import { QUESTION_SUGGESTIONS_DATA, maxLogic } from './maxLogic'
+import { maxLogic } from './maxLogic'
 import { maxThreadLogic } from './maxThreadLogic'
 
 const meta: Meta = {
@@ -453,12 +453,15 @@ ChatHistoryLoading.parameters = {
 }
 
 export const ThreadWithOpenedSuggestionsMobile: StoryFn = () => {
+    const { allSuggestions } = useValues(maxLogic)
     const { setActiveGroup } = useActions(maxLogic)
 
     useEffect(() => {
         // The largest group is the set up group
-        setActiveGroup(QUESTION_SUGGESTIONS_DATA[3])
-    }, [setActiveGroup])
+        if (allSuggestions[3]) {
+            setActiveGroup(allSuggestions[3])
+        }
+    }, [setActiveGroup, allSuggestions])
 
     return <Template sidePanel />
 }
@@ -472,12 +475,15 @@ ThreadWithOpenedSuggestionsMobile.parameters = {
 }
 
 export const ThreadWithOpenedSuggestions: StoryFn = () => {
+    const { allSuggestions } = useValues(maxLogic)
     const { setActiveGroup } = useActions(maxLogic)
 
     useEffect(() => {
         // The largest group is the set up group
-        setActiveGroup(QUESTION_SUGGESTIONS_DATA[3])
-    }, [setActiveGroup])
+        if (allSuggestions[3]) {
+            setActiveGroup(allSuggestions[3])
+        }
+    }, [setActiveGroup, allSuggestions])
 
     return <Template sidePanel />
 }

--- a/frontend/src/scenes/max/MaxTool.tsx
+++ b/frontend/src/scenes/max/MaxTool.tsx
@@ -14,7 +14,6 @@ import { SidePanelTab } from '~/types'
 
 import { TOOL_DEFINITIONS, ToolRegistration } from './max-constants'
 import { maxGlobalLogic } from './maxGlobalLogic'
-import { maxLogic } from './maxLogic'
 import { generateBurstPoints } from './utils'
 
 interface MaxToolProps extends Omit<ToolRegistration, 'name' | 'description'> {
@@ -117,26 +116,15 @@ export function MaxTool({
                         )}
                         type="button"
                         onClick={() => {
-                            openSidePanel(SidePanelTab.Max, initialMaxPrompt)
-
-                            // If this tool has suggestions, find and set the appropriate suggestion group
+                            // Include both initial prompt and suggestions
+                            let options = initialMaxPrompt
                             if (suggestions && suggestions.length > 0) {
-                                const { allSuggestions } = maxLogic.values
-                                const matchingGroup = allSuggestions.find((group) =>
-                                    suggestions.some((suggestion) =>
-                                        group.suggestions?.some(
-                                            (groupSuggestion) => groupSuggestion.content === suggestion
-                                        )
-                                    )
-                                )
-                                if (matchingGroup) {
-                                    // Waiting a bit for Max side panel to be opened
-                                    setTimeout(() => {
-                                        maxLogic.actions.setActiveGroup(matchingGroup)
-                                    }, 100)
-                                }
+                                options = JSON.stringify({
+                                    prompt: initialMaxPrompt,
+                                    suggestions: suggestions,
+                                })
                             }
-
+                            openSidePanel(SidePanelTab.Max, options)
                             onMaxOpen?.()
                         }}
                     >

--- a/frontend/src/scenes/max/MaxTool.tsx
+++ b/frontend/src/scenes/max/MaxTool.tsx
@@ -14,6 +14,7 @@ import { SidePanelTab } from '~/types'
 
 import { TOOL_DEFINITIONS, ToolRegistration } from './max-constants'
 import { maxGlobalLogic } from './maxGlobalLogic'
+import { maxLogic } from './maxLogic'
 import { generateBurstPoints } from './utils'
 
 interface MaxToolProps extends Omit<ToolRegistration, 'name' | 'description'> {
@@ -33,6 +34,7 @@ export function MaxTool({
     context,
     introOverride,
     callback,
+    suggestions,
     children: Children,
     active = true,
     initialMaxPrompt,
@@ -59,6 +61,7 @@ export function MaxTool({
                 icon,
                 context,
                 introOverride,
+                suggestions,
                 callback,
             })
             return (): void => {
@@ -73,6 +76,7 @@ export function MaxTool({
         icon,
         JSON.stringify(context),
         introOverride,
+        JSON.stringify(suggestions),
         callback,
         registerTool,
         deregisterTool,
@@ -114,6 +118,25 @@ export function MaxTool({
                         type="button"
                         onClick={() => {
                             openSidePanel(SidePanelTab.Max, initialMaxPrompt)
+
+                            // If this tool has suggestions, find and set the appropriate suggestion group
+                            if (suggestions && suggestions.length > 0) {
+                                const { allSuggestions } = maxLogic.values
+                                const matchingGroup = allSuggestions.find((group) =>
+                                    suggestions.some((suggestion) =>
+                                        group.suggestions?.some(
+                                            (groupSuggestion) => groupSuggestion.content === suggestion
+                                        )
+                                    )
+                                )
+                                if (matchingGroup) {
+                                    // Waiting a bit for Max side panel to be opened
+                                    setTimeout(() => {
+                                        maxLogic.actions.setActiveGroup(matchingGroup)
+                                    }, 100)
+                                }
+                            }
+
                             onMaxOpen?.()
                         }}
                     >

--- a/frontend/src/scenes/max/max-constants.tsx
+++ b/frontend/src/scenes/max/max-constants.tsx
@@ -47,7 +47,7 @@ export interface ToolRegistration extends Pick<ToolDefinition, 'name' | 'descrip
         description: string
     }
     /** Optional: When in context, the tool can add items to the pool of Max's suggested questions */
-    suggestions?: string[] // TODO: Suggestions aren't used yet, pending a refactor of maxLogic's allSuggestions
+    suggestions?: string[]
     /** The callback function that will be executed with the LLM's tool call output */
     callback?: (toolOutput: any) => void | Promise<void>
 }

--- a/frontend/src/scenes/max/maxGlobalLogic.tsx
+++ b/frontend/src/scenes/max/maxGlobalLogic.tsx
@@ -207,5 +207,17 @@ export const maxGlobalLogic = kea<maxGlobalLogicType>([
             (s) => [s.registeredToolMap],
             (registeredToolMap) => !!registeredToolMap.create_and_query_insight,
         ],
+        toolSuggestions: [
+            (s) => [s.tools],
+            (tools): string[] => {
+                const suggestions: string[] = []
+                for (const tool of tools) {
+                    if (tool.suggestions) {
+                        suggestions.push(...tool.suggestions)
+                    }
+                }
+                return suggestions
+            },
+        ],
     }),
 ])

--- a/frontend/src/scenes/max/maxLogic.test.ts
+++ b/frontend/src/scenes/max/maxLogic.test.ts
@@ -4,6 +4,7 @@ import { expectLogic, partial } from 'kea-test-utils'
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
+import { SidePanelTab } from '~/types'
 
 import { maxLogic } from './maxLogic'
 import { maxMocks, mockStream } from './testUtils'
@@ -163,6 +164,183 @@ describe('maxLogic', () => {
             logic.actions.setThreadKey('test-conversation-id', 'custom-thread-key')
         }).toMatchValues({
             threadLogicKey: 'custom-thread-key',
+        })
+    })
+
+    describe('handleInitialPrompt JSON parsing', () => {
+        it('handles JSON options with prompt and suggestions correctly', async () => {
+            logic = maxLogic()
+            logic.mount()
+
+            const jsonOptions = JSON.stringify({
+                prompt: 'Test prompt',
+                suggestions: ['Create a funnel of the Pirate Metrics (AARRR)'],
+            })
+
+            // Simulate opening side panel with JSON options
+            await expectLogic(logic, () => {
+                sidePanelStateLogic.actions.openSidePanel(SidePanelTab.Max, jsonOptions)
+            })
+                .toDispatchActions(['setQuestion', 'setActiveGroup'])
+                .toMatchValues({
+                    question: 'Test prompt',
+                    activeSuggestionGroup: partial({
+                        label: 'Product analytics',
+                    }),
+                })
+        })
+
+        it('handles JSON options with autoRun prompt correctly', async () => {
+            logic = maxLogic()
+            logic.mount()
+
+            const jsonOptions = JSON.stringify({
+                prompt: '!Auto run prompt',
+                suggestions: ['Write an SQL query to…'],
+            })
+
+            await expectLogic(logic, () => {
+                sidePanelStateLogic.actions.openSidePanel(SidePanelTab.Max, jsonOptions)
+            })
+                .toDispatchActions(['setQuestion', 'setAutoRun', 'setActiveGroup'])
+                .toMatchValues({
+                    question: 'Auto run prompt',
+                    autoRun: true,
+                    activeSuggestionGroup: partial({
+                        label: 'SQL',
+                    }),
+                })
+        })
+
+        it('handles JSON options without suggestions gracefully', async () => {
+            logic = maxLogic()
+            logic.mount()
+
+            const jsonOptions = JSON.stringify({
+                prompt: 'Just a prompt',
+            })
+
+            await expectLogic(logic, () => {
+                sidePanelStateLogic.actions.openSidePanel(SidePanelTab.Max, jsonOptions)
+            })
+                .toDispatchActions(['setQuestion'])
+                .toMatchValues({
+                    question: 'Just a prompt',
+                    activeSuggestionGroup: null,
+                })
+        })
+
+        it('handles JSON options with non-matching suggestions gracefully', async () => {
+            logic = maxLogic()
+            logic.mount()
+
+            const jsonOptions = JSON.stringify({
+                prompt: 'Test prompt',
+                suggestions: ['Non-existent suggestion that matches nothing'],
+            })
+
+            await expectLogic(logic, () => {
+                sidePanelStateLogic.actions.openSidePanel(SidePanelTab.Max, jsonOptions)
+            })
+                .toDispatchActions(['setQuestion'])
+                .toMatchValues({
+                    question: 'Test prompt',
+                    activeSuggestionGroup: null,
+                })
+        })
+
+        it('handles JSON options with empty suggestions array gracefully', async () => {
+            logic = maxLogic()
+            logic.mount()
+
+            const jsonOptions = JSON.stringify({
+                prompt: 'Test prompt',
+                suggestions: [],
+            })
+
+            await expectLogic(logic, () => {
+                sidePanelStateLogic.actions.openSidePanel(SidePanelTab.Max, jsonOptions)
+            })
+                .toDispatchActions(['setQuestion'])
+                .toMatchValues({
+                    question: 'Test prompt',
+                    activeSuggestionGroup: null,
+                })
+        })
+
+        it('falls back to legacy string handling for invalid JSON', async () => {
+            logic = maxLogic()
+            logic.mount()
+
+            const invalidJsonOptions = 'Invalid JSON string'
+
+            await expectLogic(logic, () => {
+                sidePanelStateLogic.actions.openSidePanel(SidePanelTab.Max, invalidJsonOptions)
+            })
+                .toDispatchActions(['setQuestion'])
+                .toMatchValues({
+                    question: 'Invalid JSON string',
+                    activeSuggestionGroup: null,
+                })
+        })
+
+        it('falls back to legacy string handling for JSON without prompt field', async () => {
+            logic = maxLogic()
+            logic.mount()
+
+            const jsonWithoutPrompt = JSON.stringify({
+                someOtherField: 'value',
+            })
+
+            await expectLogic(logic, () => {
+                sidePanelStateLogic.actions.openSidePanel(SidePanelTab.Max, jsonWithoutPrompt)
+            })
+                .toDispatchActions(['setQuestion'])
+                .toMatchValues({
+                    question: jsonWithoutPrompt,
+                    activeSuggestionGroup: null,
+                })
+        })
+
+        it('handles legacy string options with autoRun correctly', async () => {
+            logic = maxLogic()
+            logic.mount()
+
+            await expectLogic(logic, () => {
+                sidePanelStateLogic.actions.openSidePanel(SidePanelTab.Max, '!Legacy autorun prompt')
+            })
+                .toDispatchActions(['setQuestion', 'setAutoRun'])
+                .toMatchValues({
+                    question: 'Legacy autorun prompt',
+                    autoRun: true,
+                    activeSuggestionGroup: null,
+                })
+        })
+
+        it('handles multiple suggestion matches correctly (picks first match)', async () => {
+            logic = maxLogic()
+            logic.mount()
+
+            // Use suggestions that could match multiple groups
+            const jsonOptions = JSON.stringify({
+                prompt: 'Test prompt',
+                suggestions: [
+                    'Create a funnel of the Pirate Metrics (AARRR)', // Product analytics
+                    'Write an SQL query to…', // SQL
+                ],
+            })
+
+            await expectLogic(logic, () => {
+                sidePanelStateLogic.actions.openSidePanel(SidePanelTab.Max, jsonOptions)
+            })
+                .toDispatchActions(['setQuestion', 'setActiveGroup'])
+                .toMatchValues({
+                    question: 'Test prompt',
+                    // Should pick the first matching group (Product analytics)
+                    activeSuggestionGroup: partial({
+                        label: 'Product analytics',
+                    }),
+                })
         })
     })
 })

--- a/frontend/src/scenes/max/maxLogic.test.ts
+++ b/frontend/src/scenes/max/maxLogic.test.ts
@@ -5,7 +5,7 @@ import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePane
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
-import { QUESTION_SUGGESTIONS_DATA, maxLogic } from './maxLogic'
+import { maxLogic } from './maxLogic'
 import { maxMocks, mockStream } from './testUtils'
 
 describe('maxLogic', () => {
@@ -86,8 +86,11 @@ describe('maxLogic', () => {
             activeSuggestionGroup: null,
         })
 
+        // Get allSuggestions from the logic values
+        const { allSuggestions } = logic.values
+
         await expectLogic(logic, () => {
-            logic.actions.setActiveGroup(QUESTION_SUGGESTIONS_DATA[1])
+            logic.actions.setActiveGroup(allSuggestions[1])
         })
             .toDispatchActions(['setActiveGroup'])
             .toMatchValues({
@@ -104,7 +107,7 @@ describe('maxLogic', () => {
         })
 
         // Test setting to a different index
-        logic.actions.setActiveGroup(QUESTION_SUGGESTIONS_DATA[0])
+        logic.actions.setActiveGroup(allSuggestions[0])
 
         await expectLogic(logic).toMatchValues({
             activeSuggestionGroup: partial({

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -49,12 +49,44 @@ const HEADLINES = [
 ]
 
 /**
- * Setting the initial prompt from side panel options.
+ * Setting the initial prompt from side panel options when clicking the MaxTool button.
  */
 function handleInitialPrompt(
-    actions: { setQuestion: (question: string) => void; setAutoRun: (autoRun: boolean) => void },
-    options: string
+    actions: {
+        setQuestion: (question: string) => void
+        setAutoRun: (autoRun: boolean) => void
+        setActiveGroup: (group: SuggestionGroup | null) => void
+    },
+    options: string,
+    allSuggestions: readonly SuggestionGroup[]
 ): void {
+    try {
+        const parsed = JSON.parse(options)
+        if (parsed.prompt !== undefined) {
+            const cleanedQuestion = parsed.prompt.replace(/^!/, '')
+            actions.setQuestion(cleanedQuestion)
+            if (parsed.prompt.startsWith('!')) {
+                actions.setAutoRun(true)
+            }
+
+            // Handle suggestions (if provided)
+            if (parsed.suggestions && parsed.suggestions.length > 0) {
+                const matchingGroup = allSuggestions.find((group) =>
+                    parsed.suggestions.some((suggestion: string) =>
+                        group.suggestions?.some((groupSuggestion) => groupSuggestion.content === suggestion)
+                    )
+                )
+                if (matchingGroup) {
+                    actions.setActiveGroup(matchingGroup)
+                }
+            }
+            return
+        }
+    } catch {
+        // Fallback
+    }
+
+    // Legacy handling for simple string options
     const cleanedQuestion = options.replace(/^!/, '')
     actions.setQuestion(cleanedQuestion)
     if (options.startsWith('!')) {
@@ -321,10 +353,10 @@ export const maxLogic = kea<maxLogicType>([
     }),
 
     listeners(({ actions, values }) => ({
-        // Listen for when the side panel state changes and check for initial prompt
+        // Listen for when the side panel state changes and check for initial prompt and suggestions
         [sidePanelStateLogic.actionTypes.openSidePanel]: ({ tab, options }) => {
             if (tab === SidePanelTab.Max && options && typeof options === 'string') {
-                handleInitialPrompt(actions, options)
+                handleInitialPrompt(actions, options, values.allSuggestions)
             }
         },
         scrollThreadToBottom: ({ behavior }) => {
@@ -440,7 +472,7 @@ export const maxLogic = kea<maxLogicType>([
             sidePanelStateLogic.values.selectedTabOptions &&
             typeof sidePanelStateLogic.values.selectedTabOptions === 'string'
         ) {
-            handleInitialPrompt(actions, sidePanelStateLogic.values.selectedTabOptions)
+            handleInitialPrompt(actions, sidePanelStateLogic.values.selectedTabOptions, values.allSuggestions)
         }
 
         // Load conversation history on mount

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -54,7 +54,7 @@ export const maxLogic = kea<maxLogicType>([
     connect(() => ({
         values: [
             maxGlobalLogic,
-            ['dataProcessingAccepted', 'tools'],
+            ['dataProcessingAccepted', 'tools', 'toolSuggestions'],
             maxSettingsLogic,
             ['coreMemory'],
             // Actions are lazy-loaded. In order to display their names in the UI, we're loading them here.
@@ -285,6 +285,23 @@ export const maxLogic = kea<maxLogicType>([
                     return threadKeys[conversationId] || conversationId
                 }
                 return frontendConversationId
+            },
+        ],
+        allSuggestions: [
+            (s) => [s.toolSuggestions],
+            (toolSuggestions: string[]): readonly SuggestionGroup[] => {
+                // If we have MaxTool suggestions, show only those
+                if (toolSuggestions && toolSuggestions.length > 0) {
+                    return [
+                        {
+                            label: 'Suggestions',
+                            icon: <IconGraph />,
+                            suggestions: toolSuggestions.map((content: string) => ({ content })),
+                        },
+                    ]
+                }
+
+                return QUESTION_SUGGESTIONS_DATA
             },
         ],
     }),


### PR DESCRIPTION
## Problem

Products that used a `MaxTool` didn't have their suggestions correctly shown in Max.

**Note**: there is a bit of overlapping at the moment between `QUESTION_SUGGESTIONS_DATA` and suggestions coming from Max Tools, presumably some of those do not warrant currently a `<Max Tool>` on their own but some may (?). This is not a huge refactor, need to unblock folks.

## Changes

* suggestions from MaxTool are now shown when clicking on a `<MaxTool>`

## How did you test this code?

- [x] unit tests
- [x] manual tests

**before**:

https://github.com/user-attachments/assets/a5347b51-2cc5-4893-9066-871cdbefb66d

**after**:

https://github.com/user-attachments/assets/0a011612-e87e-4652-be2f-c4fc3e86e8ec