### PR TITLE
fix: active users should not include anonymous

### DIFF
--- a/frontend/src/scenes/session-recordings/components/replayActiveUsersTableLogic.ts
+++ b/frontend/src/scenes/session-recordings/components/replayActiveUsersTableLogic.ts
@@ -51,6 +51,8 @@ export const replayActiveUsersTableLogic = kea<replayActiveUsersTableLogicType>(
                   -- this won't work for everyone but then that's try with the poorly performing query
                   -- that this replaces, so it's at least no worse 🙈
                   AND event IN ('$pageview', '$screen', '$autocapture', '$feature_flag_called', '$pageleave', '$identify', '$web_vitals', '$set', 'Application Opened', 'Application Backgrounded')
+                  -- exclude anonymous users since we don't care if user "anonymous" watched a gajillion recordings
+                  AND properties.$process_person_profile != false
                 GROUP BY $session_id
             )
             -- now we can count the distinct sessions per person


### PR DESCRIPTION
<img width="720" height="574" alt="image" src="https://github.com/user-attachments/assets/8936a2be-7744-48b6-9d74-814fb91d1468" />

didn't account for anonymous users here 
which means you can get this silly output