### PR TITLE
chore: order organization members by level in admin inline

### DIFF
--- a/posthog/admin/inlines/organization_member_inline.py
+++ b/posthog/admin/inlines/organization_member_inline.py
@@ -11,3 +11,4 @@ class OrganizationMemberInline(TabularInlinePaginated):
     show_change_link = True
     readonly_fields = ("user", "joined_at", "updated_at")
     autocomplete_fields = ("user", "organization")
+    ordering = ("-level",)  # Order by level descending (Owner -> Admin -> Member)


### PR DESCRIPTION
Added ordering to OrganizationMemberInline to display members by descending level (Owner, Admin, Member) in the Django admin interface for improved clarity.