### PR TITLE
fix(max): fixed suggestions for max tools

### DIFF
--- a/frontend/src/scenes/max/Max.stories.tsx
+++ b/frontend/src/scenes/max/Max.stories.tsx
@@ -29,7 +29,7 @@ import conversationList from './__mocks__/conversationList.json'
 import { ToolRegistration } from './max-constants'
 import { maxContextLogic } from './maxContextLogic'
 import { maxGlobalLogic } from './maxGlobalLogic'
-import { maxLogic } from './maxLogic'
+import { QUESTION_SUGGESTIONS_DATA, maxLogic } from './maxLogic'
 import { maxThreadLogic } from './maxThreadLogic'
 
 const meta: Meta = {
@@ -453,15 +453,11 @@ ChatHistoryLoading.parameters = {
 }
 
 export const ThreadWithOpenedSuggestionsMobile: StoryFn = () => {
-    const { allSuggestions } = useValues(maxLogic)
     const { setActiveGroup } = useActions(maxLogic)
 
     useEffect(() => {
-        // The largest group is the set up group
-        if (allSuggestions[3]) {
-            setActiveGroup(allSuggestions[3])
-        }
-    }, [setActiveGroup, allSuggestions])
+        setActiveGroup(QUESTION_SUGGESTIONS_DATA[3])
+    }, [setActiveGroup])
 
     return <Template sidePanel />
 }
@@ -475,15 +471,11 @@ ThreadWithOpenedSuggestionsMobile.parameters = {
 }
 
 export const ThreadWithOpenedSuggestions: StoryFn = () => {
-    const { allSuggestions } = useValues(maxLogic)
     const { setActiveGroup } = useActions(maxLogic)
 
     useEffect(() => {
-        // The largest group is the set up group
-        if (allSuggestions[3]) {
-            setActiveGroup(allSuggestions[3])
-        }
-    }, [setActiveGroup, allSuggestions])
+        setActiveGroup(QUESTION_SUGGESTIONS_DATA[3])
+    }, [setActiveGroup])
 
     return <Template sidePanel />
 }

--- a/frontend/src/scenes/max/MaxTool.tsx
+++ b/frontend/src/scenes/max/MaxTool.tsx
@@ -14,6 +14,7 @@ import { SidePanelTab } from '~/types'
 
 import { TOOL_DEFINITIONS, ToolRegistration } from './max-constants'
 import { maxGlobalLogic } from './maxGlobalLogic'
+import { maxLogic } from './maxLogic'
 import { generateBurstPoints } from './utils'
 
 interface MaxToolProps extends Omit<ToolRegistration, 'name' | 'description'> {
@@ -45,6 +46,7 @@ export function MaxTool({
     const { user } = useValues(userLogic)
     const { openSidePanel } = useActions(sidePanelLogic)
     const { sidePanelOpen, selectedTab } = useValues(sidePanelLogic)
+    const { setActiveGroup } = useActions(maxLogic)
 
     const definition = TOOL_DEFINITIONS[identifier as keyof typeof TOOL_DEFINITIONS]
 
@@ -75,7 +77,7 @@ export function MaxTool({
         icon,
         JSON.stringify(context),
         introOverride,
-        JSON.stringify(suggestions),
+        suggestions,
         callback,
         registerTool,
         deregisterTool,
@@ -116,15 +118,16 @@ export function MaxTool({
                         )}
                         type="button"
                         onClick={() => {
-                            // Include both initial prompt and suggestions
-                            let options = initialMaxPrompt
+                            openSidePanel(SidePanelTab.Max, initialMaxPrompt)
+                            // Show the suggestions from this specific tool
                             if (suggestions && suggestions.length > 0) {
-                                options = JSON.stringify({
-                                    prompt: initialMaxPrompt,
-                                    suggestions: suggestions,
-                                })
+                                const suggestionGroup = {
+                                    label: definition.name,
+                                    icon: <IconWrench />,
+                                    suggestions: suggestions.map((sugg: string) => ({ content: sugg })),
+                                }
+                                setActiveGroup(suggestionGroup)
                             }
-                            openSidePanel(SidePanelTab.Max, options)
                             onMaxOpen?.()
                         }}
                     >

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -22,6 +22,7 @@ import { Conversation, ConversationDetail, ConversationStatus, SidePanelTab } fr
 import { maxContextLogic } from './maxContextLogic'
 import { maxGlobalLogic } from './maxGlobalLogic'
 import type { maxLogicType } from './maxLogicType'
+import { handleCommandString } from './utils'
 
 export type MessageStatus = 'loading' | 'completed' | 'error'
 
@@ -47,52 +48,6 @@ const HEADLINES = [
     'How can I help you understand users?',
     'What do you want to know today?',
 ]
-
-/**
- * Setting the initial prompt from side panel options when clicking the MaxTool button.
- */
-function handleInitialPrompt(
-    actions: {
-        setQuestion: (question: string) => void
-        setAutoRun: (autoRun: boolean) => void
-        setActiveGroup: (group: SuggestionGroup | null) => void
-    },
-    options: string,
-    allSuggestions: readonly SuggestionGroup[]
-): void {
-    try {
-        const parsed = JSON.parse(options)
-        if (parsed.prompt !== undefined) {
-            const cleanedQuestion = parsed.prompt.replace(/^!/, '')
-            actions.setQuestion(cleanedQuestion)
-            if (parsed.prompt.startsWith('!')) {
-                actions.setAutoRun(true)
-            }
-
-            // Handle suggestions (if provided)
-            if (parsed.suggestions && parsed.suggestions.length > 0) {
-                const matchingGroup = allSuggestions.find((group) =>
-                    parsed.suggestions.some((suggestion: string) =>
-                        group.suggestions?.some((groupSuggestion) => groupSuggestion.content === suggestion)
-                    )
-                )
-                if (matchingGroup) {
-                    actions.setActiveGroup(matchingGroup)
-                }
-            }
-            return
-        }
-    } catch {
-        // Fallback
-    }
-
-    // Legacy handling for simple string options
-    const cleanedQuestion = options.replace(/^!/, '')
-    actions.setQuestion(cleanedQuestion)
-    if (options.startsWith('!')) {
-        actions.setAutoRun(true)
-    }
-}
 
 export const maxLogic = kea<maxLogicType>([
     path(['scenes', 'max', 'maxLogic']),
@@ -333,30 +288,13 @@ export const maxLogic = kea<maxLogicType>([
                 return frontendConversationId
             },
         ],
-        allSuggestions: [
-            (s) => [s.toolSuggestions],
-            (toolSuggestions: string[]): readonly SuggestionGroup[] => {
-                // If we have MaxTool suggestions, show only those
-                if (toolSuggestions && toolSuggestions.length > 0) {
-                    return [
-                        {
-                            label: 'Suggestions',
-                            icon: <IconGraph />,
-                            suggestions: toolSuggestions.map((content: string) => ({ content })),
-                        },
-                    ]
-                }
-
-                return QUESTION_SUGGESTIONS_DATA
-            },
-        ],
     }),
 
     listeners(({ actions, values }) => ({
-        // Listen for when the side panel state changes and check for initial prompt and suggestions
+        // Listen for when the side panel state changes and check for initial prompt
         [sidePanelStateLogic.actionTypes.openSidePanel]: ({ tab, options }) => {
             if (tab === SidePanelTab.Max && options && typeof options === 'string') {
-                handleInitialPrompt(actions, options, values.allSuggestions)
+                handleCommandString(options, actions)
             }
         },
         scrollThreadToBottom: ({ behavior }) => {
@@ -472,7 +410,7 @@ export const maxLogic = kea<maxLogicType>([
             sidePanelStateLogic.values.selectedTabOptions &&
             typeof sidePanelStateLogic.values.selectedTabOptions === 'string'
         ) {
-            handleInitialPrompt(actions, sidePanelStateLogic.values.selectedTabOptions, values.allSuggestions)
+            handleCommandString(sidePanelStateLogic.values.selectedTabOptions, actions)
         }
 
         // Load conversation history on mount

--- a/frontend/src/scenes/max/utils.ts
+++ b/frontend/src/scenes/max/utils.ts
@@ -20,6 +20,7 @@ import { FunnelsQuery, HogQLQuery, RetentionQuery, TrendsQuery } from '~/queries
 import { isFunnelsQuery, isHogQLQuery, isRetentionQuery, isTrendsQuery } from '~/queries/utils'
 import { ActionType, DashboardType, EventDefinition, QueryBasedInsightModel, SidePanelTab } from '~/types'
 
+import { maxLogicType } from './maxLogicType'
 import { MaxActionContext, MaxContextType, MaxDashboardContext, MaxEventContext, MaxInsightContext } from './maxTypes'
 
 export function isReasoningMessage(message: RootAssistantMessage | undefined | null): message is ReasoningMessage {
@@ -157,6 +158,14 @@ export function generateBurstPoints(spikeCount: number, spikiness: number): stri
     }
 
     return points.trim()
+}
+
+export function handleCommandString(options: string, actions: maxLogicType['actions']): void {
+    if (options.startsWith('!')) {
+        actions.setAutoRun(true)
+    }
+    const cleanedQuestion = options.replace(/^!/, '')
+    actions.setQuestion(cleanedQuestion)
 }
 
 // Utility functions for transforming data to max context


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Suggestions were now hashed and passed into the URL, even though just the `MaxInitialPrompt` was to be there since we support the initial prompt to be accessible from our docs.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

* suggestions are not passed to the URL anymore

## How did you test this code?

https://github.com/user-attachments/assets/18056bcf-6ff3-4519-a303-5d38de4dd282

