### PR TITLE
fix(max): Add current SQL editor contents in root node prompt

### DIFF
--- a/products/data_warehouse/backend/prompts.py
+++ b/products/data_warehouse/backend/prompts.py
@@ -4,16 +4,20 @@ The user is currently editing an SQL query. They expect your help with writing a
 IMPORTANT: This is currently your primary task. Therefore `generate_hogql_query` is currently your primary tool.
 Use `generate_hogql_query` when answering ANY requests remotely related to writing SQL or to querying data (including listing, aggregating, and other operations).
 It's very important to disregard other tools for these purposes - the user expects `generate_hogql_query`.
+When calling the `generate_hogql_query` tool, do not provide any response other than the tool call.
 
-NOTE: When calling the `generate_hogql_query` tool, do not provide any response other than the tool call.
+Do NOT suggest formatting or casing changes unless explicitly requested by the user. Focus only on functional changes to satisfy the user's request.
 
 After the tool completes, do NOT repeat the query, as the user can see it. Only summarize the changes, comprehensively, but in only one brief sentence.
 
-IMPORTANT: Do NOT suggest formatting or casing changes unless explicitly requested by the user. Focus only on functional changes to satisfy the user's request.
+The current HogQL query (which CAN be empty) is:
+<current_query>
+{current_query}
+</current_query>
 """
 
 HOGQL_GENERATOR_USER_PROMPT = """
-The current HogQL query is:
+The current HogQL query (which CAN be empty) is:
 <current_query>
 {current_query}
 </current_query>

--- a/products/data_warehouse/backend/test/test_max_tools.py
+++ b/products/data_warehouse/backend/test/test_max_tools.py
@@ -334,3 +334,13 @@ class TestDataWarehouseMaxTools(NonAtomicBaseTest):
             )
             result = await tool.ainvoke(tool_call.model_dump(), config=cast(RunnableConfig, config))
             self.assertEqual(result.content, "```sql\nSELECT 'hello;world' FROM events\n```")
+
+    def test_current_query_included_in_system_prompt_template(self):
+        """Test that the system prompt template includes the current query section."""
+        tool = HogQLGeneratorTool(team=self.team, user=self.user, state=AssistantState(messages=[]))
+
+        # Verify the system prompt template contains the expected current query section
+        self.assertIn("The current HogQL query", tool.root_system_prompt_template)
+        self.assertIn("<current_query>", tool.root_system_prompt_template)
+        self.assertIn("{current_query}", tool.root_system_prompt_template)
+        self.assertIn("</current_query>", tool.root_system_prompt_template)


### PR DESCRIPTION
## Problem

Turns out the `root_system_prompt_template` of `HogQLGeneratorTool` didn't contain `{current_query}`, so the root node was unaware of the query being edited. Only the tool's subgraph was aware of it. This was [not expected](https://posthog.slack.com/archives/C06NZEZ7V3Q/p1756386456357979).

## Changes

Added `{current_query}`.

## How did you test this code?

Very simple test just so we don't accidentally remove this from `root_system_prompt_template`.
