### PR TITLE
fix(msg): clear integration fields on integration change

### DIFF
--- a/frontend/src/lib/components/CyclotronJob/CyclotronJobInputs.tsx
+++ b/frontend/src/lib/components/CyclotronJob/CyclotronJobInputs.tsx
@@ -346,6 +346,7 @@ type CyclotronJobInputProps = {
     schema: CyclotronJobInputSchemaType
     input: CyclotronJobInputType
     onChange?: (value: CyclotronJobInputType) => void
+    onInputChange?: (key: string, input: CyclotronJobInputType) => void
     disabled?: boolean
     configuration: CyclotronJobInputConfiguration
     parentConfiguration?: CyclotronJobInputConfiguration
@@ -354,6 +355,7 @@ type CyclotronJobInputProps = {
 
 function CyclotronJobInputRenderer({
     onChange,
+    onInputChange,
     schema,
     disabled,
     input,
@@ -412,7 +414,24 @@ function CyclotronJobInputRenderer({
                 <LemonSwitch checked={input.value} onChange={(checked) => onValueChange(checked)} disabled={disabled} />
             )
         case 'integration':
-            return <CyclotronJobInputIntegration schema={schema} value={input.value} onChange={onValueChange} />
+            return (
+                <CyclotronJobInputIntegration
+                    schema={schema}
+                    value={input.value}
+                    onChange={(newValue) => {
+                        onValueChange(newValue)
+
+                        // Clear all integration_field inputs when the integration changes
+                        if (configuration.inputs_schema && onInputChange) {
+                            configuration.inputs_schema
+                                .filter((s: CyclotronJobInputSchemaType) => s.type === 'integration_field')
+                                .forEach((field: CyclotronJobInputSchemaType) => {
+                                    onInputChange(field.key, { value: null })
+                                })
+                        }
+                    }}
+                />
+            )
         case 'integration_field':
             return (
                 <CyclotronJobInputIntegrationField
@@ -710,6 +729,7 @@ function CyclotronJobInputWithSchema({
                                         schema={schema}
                                         input={value ?? { value: '' }}
                                         onChange={onChange}
+                                        onInputChange={onInputChange}
                                         configuration={configuration}
                                         parentConfiguration={parentConfiguration}
                                         sampleGlobalsWithInputs={sampleGlobalsWithInputs}


### PR DESCRIPTION
## Problem

When switching between integrations (e.g., from one googleAds integration to another), the integration-specific
fields like customerId, conversion action remained filled with values from the previous integration. This caused incorrect API calls because the old field values didn't belong to the newly selected integration.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Before (bad bad)

![2025-08-28 17 40 09](https://github.com/user-attachments/assets/b59b19bf-d4b8-4377-975e-88eed9abdf9c)


Now (better better)

![2025-08-28 17 37 31](https://github.com/user-attachments/assets/82d872ce-ac2a-449d-a0bb-5f8ceaee9878)


Now, switching integrations gives you a clean slate for the new integration's settings.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- local dev

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
