### PR TITLE
fix(experiments): Holdouts on the wrong scope.

### DIFF
--- a/ee/clickhouse/views/experiment_holdouts.py
+++ b/ee/clickhouse/views/experiment_holdouts.py
@@ -126,30 +126,14 @@ def handle_experiment_holdout_change(
         user=user or after_update.created_by,
         was_impersonated=was_impersonated,
         item_id=after_update.id,
-        scope=scope,
+        scope="Experiment",  # log under Experiment scope so it appears in experiment activity log
         activity=activity,
         detail=Detail(
             changes=changes_between(scope, previous=before_update, current=after_update),
             name=after_update.name,
+            type="holdout",
         ),
     )
-
-    # Also log activity for each experiment that uses this holdout
-    for experiment in after_update.experiment_set.all():
-        log_activity(
-            organization_id=after_update.team.organization_id,
-            team_id=after_update.team_id,
-            user=user or after_update.created_by,
-            was_impersonated=was_impersonated,
-            item_id=experiment.id,
-            scope="Experiment",  # log under Experiment scope so it appears in experiment activity log
-            activity=activity,
-            detail=Detail(
-                changes=changes_between("ExperimentHoldout", previous=before_update, current=after_update),
-                name=after_update.name,
-                type="holdout",
-            ),
-        )
 
 
 @receiver(pre_delete, sender=ExperimentHoldout)
@@ -163,20 +147,7 @@ def handle_experiment_holdout_delete(sender, instance, **kwargs):
         user=activity_storage.get_user() or getattr(instance, "last_modified_by", instance.created_by),
         was_impersonated=activity_storage.get_was_impersonated(),
         item_id=instance.id,
-        scope="ExperimentHoldout",
+        scope="Experiment",
         activity="deleted",
-        detail=Detail(name=instance.name),
+        detail=Detail(name=instance.name, type="holdout"),
     )
-
-    # Also log activity for each experiment that uses this holdout
-    for experiment in instance.experiment_set.all():
-        log_activity(
-            organization_id=instance.team.organization_id,
-            team_id=instance.team_id,
-            user=activity_storage.get_user() or getattr(instance, "last_modified_by", instance.created_by),
-            was_impersonated=activity_storage.get_was_impersonated(),
-            item_id=experiment.id,
-            scope="Experiment",  # log under Experiment scope so it appears in experiment activity log
-            activity="deleted",
-            detail=Detail(name=instance.name, type="holdout"),
-        )

--- a/frontend/src/lib/components/ActivityLog/humanizeActivity.tsx
+++ b/frontend/src/lib/components/ActivityLog/humanizeActivity.tsx
@@ -31,7 +31,7 @@ export interface ActivityLogDetail {
     name: string | null
     short_id?: InsightShortId | null
     /** e.g. for property definition carries event, person, or group */
-    type?: string | null
+    type?: string
     context?: Record<string, any> | null
 }
 

--- a/frontend/src/lib/components/ActivityLog/humanizeActivity.tsx
+++ b/frontend/src/lib/components/ActivityLog/humanizeActivity.tsx
@@ -31,7 +31,7 @@ export interface ActivityLogDetail {
     name: string | null
     short_id?: InsightShortId | null
     /** e.g. for property definition carries event, person, or group */
-    type?: string
+    type?: string | null
     context?: Record<string, any> | null
 }
 

--- a/frontend/src/scenes/experiments/activity-descriptions/holdoutChangeDescription.tsx
+++ b/frontend/src/scenes/experiments/activity-descriptions/holdoutChangeDescription.tsx
@@ -1,0 +1,24 @@
+import { match } from 'ts-pattern'
+
+import { ActivityChange } from 'lib/components/ActivityLog/humanizeActivity'
+
+import { ExperimentHoldoutType } from '~/types'
+
+type AllowedHoldoutFields = Pick<ExperimentHoldoutType, 'name' | 'description' | 'filters'>
+
+export const getHoldoutChangeDescription = (holdoutChange: ActivityChange): string | JSX.Element | null => {
+    /**
+     * a little type assertion to force field into the allowed holdout fields
+     */
+    return match(holdoutChange as ActivityChange & { field: keyof AllowedHoldoutFields })
+        .with({ field: 'name' }, () => {
+            return 'updated experiment holdout name:'
+        })
+        .with({ field: 'description' }, () => {
+            return 'updated experiment holdout description:'
+        })
+        .with({ field: 'filters' }, () => {
+            return 'updated experiment holdout filters:'
+        })
+        .otherwise(() => null)
+}

--- a/frontend/src/scenes/experiments/activity-descriptions/holdoutChangeDescription.tsx
+++ b/frontend/src/scenes/experiments/activity-descriptions/holdoutChangeDescription.tsx
@@ -10,15 +10,15 @@ export const getHoldoutChangeDescription = (holdoutChange: ActivityChange): stri
     /**
      * a little type assertion to force field into the allowed holdout fields
      */
-    return match(holdoutChange as ActivityChange & { field: keyof AllowedHoldoutFields })
-        .with({ field: 'name' }, () => {
+    return match(holdoutChange.field as keyof AllowedHoldoutFields)
+        .with('name', () => {
             return 'updated experiment holdout name:'
         })
-        .with({ field: 'description' }, () => {
+        .with('description', () => {
             return 'updated experiment holdout description:'
         })
-        .with({ field: 'filters' }, () => {
+        .with('filters', () => {
             return 'updated experiment holdout filters:'
         })
-        .otherwise(() => null)
+        .exhaustive()
 }

--- a/frontend/src/scenes/experiments/activity-descriptions/holdoutChangeDescription.tsx
+++ b/frontend/src/scenes/experiments/activity-descriptions/holdoutChangeDescription.tsx
@@ -6,11 +6,8 @@ import { ExperimentHoldoutType } from '~/types'
 
 type AllowedHoldoutFields = Pick<ExperimentHoldoutType, 'name' | 'description' | 'filters'>
 
-export const getHoldoutChangeDescription = (holdoutChange: ActivityChange): string | JSX.Element | null => {
-    /**
-     * a little type assertion to force field into the allowed holdout fields
-     */
-    return match(holdoutChange.field as keyof AllowedHoldoutFields)
+export const getHoldoutChangeDescription = (holdoutChange: ActivityChange): string =>
+    match(holdoutChange.field as keyof AllowedHoldoutFields)
         .with('name', () => {
             return 'updated experiment holdout name:'
         })
@@ -21,4 +18,3 @@ export const getHoldoutChangeDescription = (holdoutChange: ActivityChange): stri
             return 'updated experiment holdout filters:'
         })
         .exhaustive()
-}

--- a/frontend/src/scenes/experiments/activity-descriptions/index.ts
+++ b/frontend/src/scenes/experiments/activity-descriptions/index.ts
@@ -1,2 +1,3 @@
 export * from './experimentChangeDescription'
+export * from './holdoutChangeDescription'
 export * from './sharedMetricChangeDescription'

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
@@ -132,7 +132,7 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
                 ),
             }
         })
-        .with({ activity: 'updated' }, (updateLogItem) => {
+        .with({ activity: 'updated' }, ({ detail: updateLogDetail }) => {
             const changes = logItem.detail.changes || []
             /**
              * if there are no changes, we don't need to describe the update.
@@ -143,10 +143,17 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
                         <SentenceList
                             prefix={<strong>{userNameForLogItem(logItem)}</strong>}
                             listParts={['updated']}
-                            suffix={(isSharedMetric ? nameOrLinkToSharedMetric : nameOrLinkToExperiment)(
-                                logItem.detail.name,
-                                logItem.item_id
-                            )}
+                            suffix={match(updateLogDetail)
+                                .with({ type: null }, () =>
+                                    nameOrLinkToExperiment(updateLogDetail.name, logItem.item_id)
+                                )
+                                .with({ type: 'shared_metric' }, () =>
+                                    nameOrLinkToSharedMetric(updateLogDetail.name, logItem.item_id)
+                                )
+                                .with({ type: 'holdout' }, () => <strong>{updateLogDetail.name}</strong>)
+                                .otherwise(() => {
+                                    return null
+                                })}
                         />
                     ),
                 }

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
@@ -121,7 +121,7 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
         })
         .with({ activity: 'deleted', detail: { type: 'holdout' } }, () => {
             /**
-             * Shared metrics are not soft deleted.
+             * Holdouts are not soft deleted.
              */
             return {
                 description: (

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
@@ -53,6 +53,17 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
     const isSharedMetric = logItem.detail.type === 'shared_metric'
 
     return match(logItem)
+        .with({ activity: 'created', detail: { type: 'holdout' } }, () => {
+            return {
+                description: (
+                    <SentenceList
+                        prefix={<strong>{userNameForLogItem(logItem)}</strong>}
+                        listParts={['created a new experiment holdout:']}
+                        suffix={<strong>{logItem.detail.name}</strong>}
+                    />
+                ),
+            }
+        })
         .with({ activity: 'created' }, () => {
             /**
              * we handle both experiments and shared metrics creation here.
@@ -107,7 +118,21 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
                 ),
             }
         })
-        .with({ activity: 'updated' }, () => {
+        .with({ activity: 'deleted', detail: { type: 'holdout' } }, () => {
+            /**
+             * Shared metrics are not soft deleted.
+             */
+            return {
+                description: (
+                    <SentenceList
+                        prefix={<strong>{userNameForLogItem(logItem)}</strong>}
+                        listParts={['deleted experiment holdout:']}
+                        suffix={<strong>{logItem.detail.name}</strong>}
+                    />
+                ),
+            }
+        })
+        .with({ activity: 'updated' }, (updateLogItem) => {
             const changes = logItem.detail.changes || []
             /**
              * if there are no changes, we don't need to describe the update.


### PR DESCRIPTION
## Problem

Some of the holdout activities were logged under the `ExperimentHoldouts` scope, so they weren't showing up on the Experiment's dashboard.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We are unifying the scope of the Holdouts so that all activities are logged under `Experiments`, and improving the descriptions so that all main events display nicely.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/26a9c277-3836-45a8-8967-709cb74c49c9)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
