### PR TITLE
feat(web-analytics): use hourly tables by default 

### DIFF
--- a/posthog/api/external_web_analytics/test/test_query_adapter.py
+++ b/posthog/api/external_web_analytics/test/test_query_adapter.py
@@ -660,11 +660,15 @@ class TestExternalWebAnalyticsQueryAdapterIntegration(WebAnalyticsPreAggregatedT
             date_start=date_start,
             date_end=date_end,
             team_ids=[self.team.pk],
+            table_name="web_pre_aggregated_bounces",
+            granularity="hourly",
         )
         stats_insert = WEB_STATS_INSERT_SQL(
             date_start=date_start,
             date_end=date_end,
             team_ids=[self.team.pk],
+            table_name="web_pre_aggregated_stats",
+            granularity="hourly",
         )
         sync_execute(stats_insert)
         sync_execute(bounces_insert)

--- a/posthog/hogql/transforms/preaggregated_table_transformation.py
+++ b/posthog/hogql/transforms/preaggregated_table_transformation.py
@@ -34,7 +34,6 @@ from posthog.hogql_queries.web_analytics.pre_aggregated.properties import (
     EVENT_PROPERTY_TO_FIELD,
     SESSION_PROPERTY_TO_FIELD,
 )
-from posthog.hogql_queries.web_analytics.pre_aggregated.query_builder import get_stats_table
 
 _T_AST = TypeVar("_T_AST", bound=AST)
 
@@ -62,7 +61,9 @@ def flatten_and(node: Optional[ast.Expr]) -> list[ast.Expr]:
 
 def is_event_field(field: ast.Field) -> bool:
     """Check if a field represents an event property."""
-    return field.chain == ["event"] or (len(field.chain) == 2 and field.chain[1] == "event")  # table_alias.event
+    return (
+        field.chain == ["event"] or (len(field.chain) == 2 and field.chain[1] == "event")  # table_alias.event
+    )
 
 
 def is_pageview_filter(expr: ast.Expr) -> bool:
@@ -351,8 +352,7 @@ def _shallow_transform_select(node: ast.SelectQuery, context: HogQLContext) -> a
 
     # TODO right now we only have the one preaggregated table that is supported, but in the future could support more.
     # We could even make them unique per team (depending on what the team queries) or allow them to be user-defined.
-    # TODO: We should move this to use the hourly tables but we must also check the required data validity checks.
-    table_name = get_stats_table(False)
+    table_name = "web_stats_daily"
 
     # Bail if any unsupported part of the SELECT query exist
     # Some of these could be supported in the future, if you add them, make sure you add some tests!

--- a/posthog/hogql/transforms/preaggregated_table_transformation.py
+++ b/posthog/hogql/transforms/preaggregated_table_transformation.py
@@ -351,7 +351,8 @@ def _shallow_transform_select(node: ast.SelectQuery, context: HogQLContext) -> a
 
     # TODO right now we only have the one preaggregated table that is supported, but in the future could support more.
     # We could even make them unique per team (depending on what the team queries) or allow them to be user-defined.
-    table_name = get_stats_table(True)
+    # TODO: We should move this to use the hourly tables but we must also check the required data validity checks.
+    table_name = get_stats_table(False)
 
     # Bail if any unsupported part of the SELECT query exist
     # Some of these could be supported in the future, if you add them, make sure you add some tests!

--- a/posthog/hogql/transforms/preaggregated_table_transformation.py
+++ b/posthog/hogql/transforms/preaggregated_table_transformation.py
@@ -34,6 +34,7 @@ from posthog.hogql_queries.web_analytics.pre_aggregated.properties import (
     EVENT_PROPERTY_TO_FIELD,
     SESSION_PROPERTY_TO_FIELD,
 )
+from posthog.hogql_queries.web_analytics.pre_aggregated.query_builder import get_stats_table
 
 _T_AST = TypeVar("_T_AST", bound=AST)
 
@@ -61,9 +62,7 @@ def flatten_and(node: Optional[ast.Expr]) -> list[ast.Expr]:
 
 def is_event_field(field: ast.Field) -> bool:
     """Check if a field represents an event property."""
-    return (
-        field.chain == ["event"] or (len(field.chain) == 2 and field.chain[1] == "event")  # table_alias.event
-    )
+    return field.chain == ["event"] or (len(field.chain) == 2 and field.chain[1] == "event")  # table_alias.event
 
 
 def is_pageview_filter(expr: ast.Expr) -> bool:
@@ -352,7 +351,7 @@ def _shallow_transform_select(node: ast.SelectQuery, context: HogQLContext) -> a
 
     # TODO right now we only have the one preaggregated table that is supported, but in the future could support more.
     # We could even make them unique per team (depending on what the team queries) or allow them to be user-defined.
-    table_name = "web_stats_daily"
+    table_name = get_stats_table(True)
 
     # Bail if any unsupported part of the SELECT query exist
     # Some of these could be supported in the future, if you add them, make sure you add some tests!

--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -37,7 +37,7 @@ class WebStatsTableQueryRunner(WebAnalyticsQueryRunner[WebStatsTableQueryRespons
     preaggregated_query_builder: StatsTablePreAggregatedQueryBuilder
     used_preaggregated_tables: bool
 
-    def __init__(self, *args, use_v2_tables: bool = False, **kwargs):
+    def __init__(self, *args, use_v2_tables: bool = True, **kwargs):
         super().__init__(*args, **kwargs)
         self.use_v2_tables = use_v2_tables
         self.used_preaggregated_tables = False
@@ -470,9 +470,11 @@ GROUP BY session_id, breakdown_value
             expr
             for expr in [
                 # use order from query
-                ast.OrderExpr(expr=ast.Field(chain=[column]), order=direction)
-                if column is not None and column in columns
-                else None,
+                (
+                    ast.OrderExpr(expr=ast.Field(chain=[column]), order=direction)
+                    if column is not None and column in columns
+                    else None
+                ),
                 f("context.columns.unique_conversions"),
                 f("context.columns.total_conversions"),
                 f("context.columns.visitors"),

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_pre_aggregated.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_pre_aggregated.ambr
@@ -1,12 +1,12 @@
 # serializer version: 1
 # name: TestWebStatsPreAggregated.test_breakdown_consistency_preagg_vs_regular
   '''
-  SELECT nullIf(nullIf(web_stats_combined.device_type, ''), 'null') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(nullIf(web_pre_aggregated_stats.device_type, ''), 'null') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
-  WHERE and(equals(web_stats_combined.team_id, 99999), greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))
+  FROM web_pre_aggregated_stats
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101
@@ -74,12 +74,12 @@
 # ---
 # name: TestWebStatsPreAggregated.test_breakdown_consistency_preagg_vs_regular.2
   '''
-  SELECT nullIf(nullIf(web_stats_combined.browser, ''), 'null') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(nullIf(web_pre_aggregated_stats.browser, ''), 'null') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
-  WHERE and(equals(web_stats_combined.team_id, 99999), greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))
+  FROM web_pre_aggregated_stats
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101
@@ -147,12 +147,12 @@
 # ---
 # name: TestWebStatsPreAggregated.test_breakdown_consistency_preagg_vs_regular.4
   '''
-  SELECT nullIf(nullIf(web_stats_combined.country_code, ''), 'null') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(nullIf(web_pre_aggregated_stats.country_code, ''), 'null') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
-  WHERE and(equals(web_stats_combined.team_id, 99999), greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))
+  FROM web_pre_aggregated_stats
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101
@@ -220,12 +220,12 @@
 # ---
 # name: TestWebStatsPreAggregated.test_breakdown_consistency_preagg_vs_regular.6
   '''
-  SELECT nullIf(nullIf(web_stats_combined.utm_source, ''), 'null') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(nullIf(web_pre_aggregated_stats.utm_source, ''), 'null') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
-  WHERE and(equals(web_stats_combined.team_id, 99999), greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))
+  FROM web_pre_aggregated_stats
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101
@@ -294,12 +294,12 @@
 # ---
 # name: TestWebStatsPreAggregated.test_browser_breakdown
   '''
-  SELECT nullIf(nullIf(web_stats_combined.browser, ''), 'null') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(nullIf(web_pre_aggregated_stats.browser, ''), 'null') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
-  WHERE and(equals(web_stats_combined.team_id, 99999), greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))
+  FROM web_pre_aggregated_stats
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101
@@ -317,12 +317,12 @@
 # ---
 # name: TestWebStatsPreAggregated.test_country_breakdown
   '''
-  SELECT nullIf(nullIf(web_stats_combined.country_code, ''), 'null') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(nullIf(web_pre_aggregated_stats.country_code, ''), 'null') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
-  WHERE and(equals(web_stats_combined.team_id, 99999), greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))
+  FROM web_pre_aggregated_stats
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101
@@ -340,12 +340,12 @@
 # ---
 # name: TestWebStatsPreAggregated.test_device_type_breakdown
   '''
-  SELECT nullIf(nullIf(web_stats_combined.device_type, ''), 'null') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(nullIf(web_pre_aggregated_stats.device_type, ''), 'null') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
-  WHERE and(equals(web_stats_combined.team_id, 99999), greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))
+  FROM web_pre_aggregated_stats
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101
@@ -363,21 +363,21 @@
 # ---
 # name: TestWebStatsPreAggregated.test_page_breakdown
   '''
-  SELECT nullIf(web_stats_combined.pathname, '') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(web_pre_aggregated_stats.pathname, '') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          any(bounces.`context.columns.bounce_rate`) AS `context.columns.bounce_rate`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
+  FROM web_pre_aggregated_stats
   LEFT JOIN
-    (SELECT nullIf(web_bounces_combined.entry_pathname, '') AS `context.columns.breakdown_value`,
-            tuple(uniqMergeIf(web_bounces_combined.persons_uniq_state, and(greaterOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-            tuple(sumMergeIf(web_bounces_combined.pageviews_count_state, and(greaterOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
-            tuple(divide(sumMergeIf(web_bounces_combined.bounces_count_state, and(greaterOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), nullIf(uniqMergeIf(web_bounces_combined.sessions_uniq_state, and(greaterOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), 0)), NULL) AS `context.columns.bounce_rate`
-     FROM web_bounces_combined
-     WHERE and(equals(web_bounces_combined.team_id, 99999), and(and(greaterOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC'))), isNotNull(nullIf(web_bounces_combined.entry_pathname, ''))))
-     GROUP BY `context.columns.breakdown_value`) AS bounces ON equals(web_stats_combined.pathname, bounces.`context.columns.breakdown_value`)
-  WHERE and(equals(web_stats_combined.team_id, 99999), and(and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC'))), isNotNull(nullIf(web_stats_combined.pathname, ''))))
+    (SELECT nullIf(web_pre_aggregated_bounces.entry_pathname, '') AS `context.columns.breakdown_value`,
+            tuple(uniqMergeIf(web_pre_aggregated_bounces.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_bounces.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_bounces.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+            tuple(sumMergeIf(web_pre_aggregated_bounces.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_bounces.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_bounces.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+            tuple(divide(sumMergeIf(web_pre_aggregated_bounces.bounces_count_state, and(greaterOrEquals(web_pre_aggregated_bounces.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_bounces.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), nullIf(uniqMergeIf(web_pre_aggregated_bounces.sessions_uniq_state, and(greaterOrEquals(web_pre_aggregated_bounces.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_bounces.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), 0)), NULL) AS `context.columns.bounce_rate`
+     FROM web_pre_aggregated_bounces
+     WHERE and(equals(web_pre_aggregated_bounces.team_id, 99999), and(and(greaterOrEquals(web_pre_aggregated_bounces.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_bounces.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC'))), isNotNull(nullIf(web_pre_aggregated_bounces.entry_pathname, ''))))
+     GROUP BY `context.columns.breakdown_value`) AS bounces ON equals(web_pre_aggregated_stats.pathname, bounces.`context.columns.breakdown_value`)
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), and(and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC'))), isNotNull(nullIf(web_pre_aggregated_stats.pathname, ''))))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101
@@ -395,21 +395,21 @@
 # ---
 # name: TestWebStatsPreAggregated.test_page_breakdown_with_pathname_filter
   '''
-  SELECT nullIf(web_stats_combined.pathname, '') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(web_pre_aggregated_stats.pathname, '') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          any(bounces.`context.columns.bounce_rate`) AS `context.columns.bounce_rate`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
+  FROM web_pre_aggregated_stats
   LEFT JOIN
-    (SELECT nullIf(web_bounces_combined.entry_pathname, '') AS `context.columns.breakdown_value`,
-            tuple(uniqMergeIf(web_bounces_combined.persons_uniq_state, and(greaterOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-            tuple(sumMergeIf(web_bounces_combined.pageviews_count_state, and(greaterOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
-            tuple(divide(sumMergeIf(web_bounces_combined.bounces_count_state, and(greaterOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), nullIf(uniqMergeIf(web_bounces_combined.sessions_uniq_state, and(greaterOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), 0)), NULL) AS `context.columns.bounce_rate`
-     FROM web_bounces_combined
-     WHERE and(equals(web_bounces_combined.team_id, 99999), and(and(greaterOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_bounces_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC'))), isNotNull(nullIf(web_bounces_combined.entry_pathname, ''))))
-     GROUP BY `context.columns.breakdown_value`) AS bounces ON equals(web_stats_combined.pathname, bounces.`context.columns.breakdown_value`)
-  WHERE and(equals(web_stats_combined.team_id, 99999), and(and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')), ifNull(equals(web_stats_combined.pathname, '/landing'), 0)), isNotNull(nullIf(web_stats_combined.pathname, ''))))
+    (SELECT nullIf(web_pre_aggregated_bounces.entry_pathname, '') AS `context.columns.breakdown_value`,
+            tuple(uniqMergeIf(web_pre_aggregated_bounces.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_bounces.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_bounces.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+            tuple(sumMergeIf(web_pre_aggregated_bounces.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_bounces.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_bounces.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+            tuple(divide(sumMergeIf(web_pre_aggregated_bounces.bounces_count_state, and(greaterOrEquals(web_pre_aggregated_bounces.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_bounces.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), nullIf(uniqMergeIf(web_pre_aggregated_bounces.sessions_uniq_state, and(greaterOrEquals(web_pre_aggregated_bounces.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_bounces.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), 0)), NULL) AS `context.columns.bounce_rate`
+     FROM web_pre_aggregated_bounces
+     WHERE and(equals(web_pre_aggregated_bounces.team_id, 99999), and(and(greaterOrEquals(web_pre_aggregated_bounces.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_bounces.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC'))), isNotNull(nullIf(web_pre_aggregated_bounces.entry_pathname, ''))))
+     GROUP BY `context.columns.breakdown_value`) AS bounces ON equals(web_pre_aggregated_stats.pathname, bounces.`context.columns.breakdown_value`)
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), and(and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')), ifNull(equals(web_pre_aggregated_stats.pathname, '/landing'), 0)), isNotNull(nullIf(web_pre_aggregated_stats.pathname, ''))))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101
@@ -427,12 +427,12 @@
 # ---
 # name: TestWebStatsPreAggregated.test_property_filtering
   '''
-  SELECT nullIf(nullIf(web_stats_combined.device_type, ''), 'null') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(nullIf(web_pre_aggregated_stats.device_type, ''), 'null') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
-  WHERE and(equals(web_stats_combined.team_id, 99999), greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')), ifNull(equals(web_stats_combined.pathname, '/landing'), 0))
+  FROM web_pre_aggregated_stats
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')), ifNull(equals(web_pre_aggregated_stats.pathname, '/landing'), 0))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101
@@ -450,12 +450,12 @@
 # ---
 # name: TestWebStatsPreAggregated.test_utm_source_breakdown
   '''
-  SELECT nullIf(nullIf(web_stats_combined.utm_source, ''), 'null') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(nullIf(web_pre_aggregated_stats.utm_source, ''), 'null') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
-  WHERE and(equals(web_stats_combined.team_id, 99999), greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))
+  FROM web_pre_aggregated_stats
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101
@@ -473,12 +473,12 @@
 # ---
 # name: TestWebStatsPreAggregated.test_viewport_breakdown
   '''
-  SELECT nullIf(nullIf(concat(ifNull(toString(web_stats_combined.viewport_width), ''), 'x', ifNull(toString(web_stats_combined.viewport_height), '')), ''), 'null') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(nullIf(concat(ifNull(toString(web_pre_aggregated_stats.viewport_width), ''), 'x', ifNull(toString(web_pre_aggregated_stats.viewport_height), '')), ''), 'null') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
-  WHERE and(equals(web_stats_combined.team_id, 99999), greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))
+  FROM web_pre_aggregated_stats
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-02 23:59:59.999999', 6, 'UTC')))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
@@ -636,59 +636,6 @@
                     allow_experimental_join_condition=1
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_cohort_test_filters.3
-  '''
-  /* cohort_calculation: */
-  SELECT breakdown_value AS `context.columns.breakdown_value`,
-         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
-         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
-  FROM
-    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-            count() AS filtered_pageview_count,
-            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
-            events__session.session_id AS session_id,
-            any(events__session.`$is_bounce`) AS is_bounce,
-            min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events
-     LEFT JOIN
-       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
-               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-               raw_sessions.session_id_v7 AS session_id_v7
-        FROM raw_sessions
-        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-07-30 00:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2025-01-29 23:59:59', 'UTC')), toIntervalDay(3))))
-        GROUP BY raw_sessions.session_id_v7,
-                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-07-30 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-01-29 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), in(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id),
-                                                                                                                                                                                                                                                                                                                                                                      (SELECT cohortpeople.person_id AS person_id
-                                                                                                                                                                                                                                                                                                                                                                       FROM cohortpeople
-                                                                                                                                                                                                                                                                                                                                                                       WHERE and(equals(cohortpeople.team_id, 99999), equals(cohortpeople.cohort_id, 99999), equals(cohortpeople.version, 0)))), isNotNull(breakdown_value)))
-     GROUP BY session_id,
-              breakdown_value)
-  GROUP BY `context.columns.breakdown_value`
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    format_csv_allow_double_quotes=0,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1
-  '''
-# ---
 # name: TestWebStatsTableQueryRunner.test_comparison
   '''
   SELECT breakdown_value AS `context.columns.breakdown_value`,

--- a/posthog/hogql_queries/web_analytics/test/test_web_overview.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_overview.py
@@ -1067,10 +1067,10 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
         sql_utc = print_ast(hogql_query, context=context_utc, dialect="clickhouse")
 
-        assert "web_bounces_combined.period_bucket, toDateTime64(" in sql_utc
-        assert "toTimeZone(web_bounces_combined.period_bucket," not in sql_utc
+        assert "web_pre_aggregated_bounces.period_bucket, toDateTime64(" in sql_utc
+        assert "toTimeZone(web_pre_aggregated_bounces.period_bucket," not in sql_utc
 
-        assert "toTimeZone(web_bounces_combined.period_bucket," in sql_with_tz
+        assert "toTimeZone(web_pre_aggregated_bounces.period_bucket," in sql_with_tz
         # Simplified approach - just check timezone conversion exists
 
     @snapshot_clickhouse_queries
@@ -1095,8 +1095,8 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         sql_utc = print_ast(hogql_query, context=context_utc, dialect="clickhouse")
 
-        assert "web_bounces_combined.period_bucket, toDateTime64(" in sql_utc
-        assert "toTimeZone(web_bounces_combined.period_bucket, " not in sql_utc
+        assert "web_pre_aggregated_bounces.period_bucket, toDateTime64(" in sql_utc
+        assert "toTimeZone(web_pre_aggregated_bounces.period_bucket, " not in sql_utc
 
     def test_convertToProjectTimezone_affects_date_range_calculation(self):
         # Set team to PST timezone

--- a/posthog/hogql_queries/web_analytics/test/test_web_stats_pre_aggregated.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_stats_pre_aggregated.py
@@ -196,11 +196,15 @@ class TestWebStatsPreAggregated(WebAnalyticsPreAggregatedTestBase):
             date_start=date_start,
             date_end=date_end,
             team_ids=[self.team.pk],
+            table_name="web_pre_aggregated_bounces",
+            granularity="hourly",
         )
         stats_insert = WEB_STATS_INSERT_SQL(
             date_start=date_start,
             date_end=date_end,
             team_ids=[self.team.pk],
+            table_name="web_pre_aggregated_stats",
+            granularity="hourly",
         )
         sync_execute(stats_insert)
         sync_execute(bounces_insert)

--- a/posthog/hogql_queries/web_analytics/test/test_web_stats_pre_aggregated_channel_types.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_stats_pre_aggregated_channel_types.py
@@ -327,10 +327,11 @@ class TestWebStatsPreAggregatedChannelTypes(WebAnalyticsPreAggregatedTestBase):
             date_start="2024-01-01",
             date_end="2024-01-02",
             team_ids=[self.team.pk],
-            table_name="web_stats_daily",
+            table_name="web_pre_aggregated_stats",
+            granularity="hourly",
             select_only=True,
         )
-        insert_sql = f"INSERT INTO web_stats_daily\n{select_sql}"
+        insert_sql = f"INSERT INTO web_pre_aggregated_stats\n{select_sql}"
         sync_execute(insert_sql)
 
     def _calculate_channel_type_query(

--- a/posthog/hogql_queries/web_analytics/web_overview.py
+++ b/posthog/hogql_queries/web_analytics/web_overview.py
@@ -28,7 +28,7 @@ class WebOverviewQueryRunner(WebAnalyticsQueryRunner[WebOverviewQueryResponse]):
     cached_response: CachedWebOverviewQueryResponse
     preaggregated_query_builder: WebOverviewPreAggregatedQueryBuilder
 
-    def __init__(self, *args, use_v2_tables: bool = False, **kwargs):
+    def __init__(self, *args, use_v2_tables: bool = True, **kwargs):
         super().__init__(*args, **kwargs)
         self.use_v2_tables = use_v2_tables
         self.preaggregated_query_builder = WebOverviewPreAggregatedQueryBuilder(self)

--- a/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
+++ b/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
@@ -1,12 +1,12 @@
 # serializer version: 1
 # name: TestTimezonePreAggregatedIntegration.test_india_half_hour_timezone_edge_case
   '''
-  SELECT nullIf(nullIf(web_stats_combined.browser, ''), 'null') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 18:30:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 18:29:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 18:30:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 18:29:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(nullIf(web_pre_aggregated_stats.browser, ''), 'null') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 18:30:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 18:29:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 18:30:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 18:29:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
-  WHERE and(equals(web_stats_combined.team_id, 99999), greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 18:30:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 18:29:59.999999', 6, 'UTC')))
+  FROM web_pre_aggregated_stats
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 18:30:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 18:29:59.999999', 6, 'UTC')))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101
@@ -74,12 +74,12 @@
 # ---
 # name: TestTimezonePreAggregatedIntegration.test_timezone_boundary_behavior_explicit
   '''
-  SELECT nullIf(nullIf(web_stats_combined.browser, ''), 'null') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-15 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-15 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(nullIf(web_pre_aggregated_stats.browser, ''), 'null') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-15 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-15 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
-  WHERE and(equals(web_stats_combined.team_id, 99999), greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-15 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 23:59:59.999999', 6, 'UTC')))
+  FROM web_pre_aggregated_stats
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-15 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 23:59:59.999999', 6, 'UTC')))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101
@@ -147,12 +147,12 @@
 # ---
 # name: TestTimezonePreAggregatedIntegration.test_timezone_boundary_behavior_explicit.2
   '''
-  SELECT nullIf(nullIf(web_stats_combined.browser, ''), 'null') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-15 08:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-17 07:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-15 08:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-17 07:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(nullIf(web_pre_aggregated_stats.browser, ''), 'null') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-15 08:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-17 07:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-15 08:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-17 07:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
-  WHERE and(equals(web_stats_combined.team_id, 99999), greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-15 08:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-17 07:59:59.999999', 6, 'UTC')))
+  FROM web_pre_aggregated_stats
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-15 08:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-17 07:59:59.999999', 6, 'UTC')))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101
@@ -220,12 +220,12 @@
 # ---
 # name: TestTimezonePreAggregatedIntegration.test_timezone_boundary_behavior_explicit.4
   '''
-  SELECT nullIf(nullIf(web_stats_combined.browser, ''), 'null') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 15:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 14:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 15:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 14:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(nullIf(web_pre_aggregated_stats.browser, ''), 'null') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 15:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 14:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 15:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 14:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
-  WHERE and(equals(web_stats_combined.team_id, 99999), greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 15:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 14:59:59.999999', 6, 'UTC')))
+  FROM web_pre_aggregated_stats
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 15:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 14:59:59.999999', 6, 'UTC')))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101
@@ -293,12 +293,12 @@
 # ---
 # name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_00_Pacific_UTC_08_00_
   '''
-  SELECT nullIf(nullIf(web_stats_combined.browser, ''), 'null') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-15 08:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-17 07:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-15 08:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-17 07:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(nullIf(web_pre_aggregated_stats.browser, ''), 'null') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-15 08:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-17 07:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-15 08:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-17 07:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
-  WHERE and(equals(web_stats_combined.team_id, 99999), greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-15 08:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-17 07:59:59.999999', 6, 'UTC')))
+  FROM web_pre_aggregated_stats
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-15 08:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-17 07:59:59.999999', 6, 'UTC')))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101
@@ -366,12 +366,12 @@
 # ---
 # name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_01_New_York_UTC_05_00_
   '''
-  SELECT nullIf(nullIf(web_stats_combined.browser, ''), 'null') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-15 05:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-17 04:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-15 05:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-17 04:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(nullIf(web_pre_aggregated_stats.browser, ''), 'null') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-15 05:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-17 04:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-15 05:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-17 04:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
-  WHERE and(equals(web_stats_combined.team_id, 99999), greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-15 05:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-17 04:59:59.999999', 6, 'UTC')))
+  FROM web_pre_aggregated_stats
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-15 05:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-17 04:59:59.999999', 6, 'UTC')))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101
@@ -439,12 +439,12 @@
 # ---
 # name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_02_Sao_Paulo_UTC_03_00_
   '''
-  SELECT nullIf(nullIf(web_stats_combined.browser, ''), 'null') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-15 03:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-17 02:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-15 03:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-17 02:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(nullIf(web_pre_aggregated_stats.browser, ''), 'null') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-15 03:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-17 02:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-15 03:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-17 02:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
-  WHERE and(equals(web_stats_combined.team_id, 99999), greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-15 03:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-17 02:59:59.999999', 6, 'UTC')))
+  FROM web_pre_aggregated_stats
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-15 03:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-17 02:59:59.999999', 6, 'UTC')))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101
@@ -512,12 +512,12 @@
 # ---
 # name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_03_UTC_UTC_00_00_
   '''
-  SELECT nullIf(nullIf(web_stats_combined.browser, ''), 'null') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-15 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-15 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(nullIf(web_pre_aggregated_stats.browser, ''), 'null') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-15 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-15 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 23:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
-  WHERE and(equals(web_stats_combined.team_id, 99999), greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-15 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 23:59:59.999999', 6, 'UTC')))
+  FROM web_pre_aggregated_stats
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-15 00:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 23:59:59.999999', 6, 'UTC')))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101
@@ -585,12 +585,12 @@
 # ---
 # name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_04_Berlin_UTC_01_00_
   '''
-  SELECT nullIf(nullIf(web_stats_combined.browser, ''), 'null') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 23:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 22:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 23:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 22:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(nullIf(web_pre_aggregated_stats.browser, ''), 'null') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 23:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 22:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 23:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 22:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
-  WHERE and(equals(web_stats_combined.team_id, 99999), greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 23:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 22:59:59.999999', 6, 'UTC')))
+  FROM web_pre_aggregated_stats
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 23:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 22:59:59.999999', 6, 'UTC')))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101
@@ -658,12 +658,12 @@
 # ---
 # name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_05_Cairo_UTC_02_00_
   '''
-  SELECT nullIf(nullIf(web_stats_combined.browser, ''), 'null') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 22:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 21:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 22:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 21:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(nullIf(web_pre_aggregated_stats.browser, ''), 'null') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 22:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 21:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 22:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 21:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
-  WHERE and(equals(web_stats_combined.team_id, 99999), greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 22:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 21:59:59.999999', 6, 'UTC')))
+  FROM web_pre_aggregated_stats
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 22:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 21:59:59.999999', 6, 'UTC')))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101
@@ -731,12 +731,12 @@
 # ---
 # name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_06_Moscow_UTC_03_00_
   '''
-  SELECT nullIf(nullIf(web_stats_combined.browser, ''), 'null') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 21:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 20:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 21:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 20:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(nullIf(web_pre_aggregated_stats.browser, ''), 'null') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 21:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 20:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 21:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 20:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
-  WHERE and(equals(web_stats_combined.team_id, 99999), greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 21:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 20:59:59.999999', 6, 'UTC')))
+  FROM web_pre_aggregated_stats
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 21:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 20:59:59.999999', 6, 'UTC')))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101
@@ -804,12 +804,12 @@
 # ---
 # name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_07_Pakistan_UTC_05_00_
   '''
-  SELECT nullIf(nullIf(web_stats_combined.browser, ''), 'null') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 19:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 18:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 19:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 18:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(nullIf(web_pre_aggregated_stats.browser, ''), 'null') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 19:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 18:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 19:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 18:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
-  WHERE and(equals(web_stats_combined.team_id, 99999), greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 19:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 18:59:59.999999', 6, 'UTC')))
+  FROM web_pre_aggregated_stats
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 19:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 18:59:59.999999', 6, 'UTC')))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101
@@ -877,12 +877,12 @@
 # ---
 # name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_08_Tokyo_UTC_09_00_
   '''
-  SELECT nullIf(nullIf(web_stats_combined.browser, ''), 'null') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 15:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 14:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 15:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 14:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(nullIf(web_pre_aggregated_stats.browser, ''), 'null') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 15:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 14:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 15:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 14:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
-  WHERE and(equals(web_stats_combined.team_id, 99999), greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 15:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 14:59:59.999999', 6, 'UTC')))
+  FROM web_pre_aggregated_stats
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 15:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 14:59:59.999999', 6, 'UTC')))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101
@@ -950,12 +950,12 @@
 # ---
 # name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_09_Sydney_UTC_11_00_
   '''
-  SELECT nullIf(nullIf(web_stats_combined.browser, ''), 'null') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 13:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 12:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 13:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 12:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(nullIf(web_pre_aggregated_stats.browser, ''), 'null') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 13:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 12:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 13:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 12:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
-  WHERE and(equals(web_stats_combined.team_id, 99999), greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 13:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 12:59:59.999999', 6, 'UTC')))
+  FROM web_pre_aggregated_stats
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 13:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 12:59:59.999999', 6, 'UTC')))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101
@@ -1023,12 +1023,12 @@
 # ---
 # name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_10_Auckland_UTC_12_00_
   '''
-  SELECT nullIf(nullIf(web_stats_combined.browser, ''), 'null') AS `context.columns.breakdown_value`,
-         tuple(uniqMergeIf(web_stats_combined.persons_uniq_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 11:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 10:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
-         tuple(sumMergeIf(web_stats_combined.pageviews_count_state, and(greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 11:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 10:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
+  SELECT nullIf(nullIf(web_pre_aggregated_stats.browser, ''), 'null') AS `context.columns.breakdown_value`,
+         tuple(uniqMergeIf(web_pre_aggregated_stats.persons_uniq_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 11:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 10:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.visitors`,
+         tuple(sumMergeIf(web_pre_aggregated_stats.pageviews_count_state, and(greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 11:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 10:59:59.999999', 6, 'UTC')))), NULL) AS `context.columns.views`,
          divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM web_stats_combined
-  WHERE and(equals(web_stats_combined.team_id, 99999), greaterOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-14 11:00:00.000000', 6, 'UTC')), lessOrEquals(web_stats_combined.period_bucket, toDateTime64('2024-01-16 10:59:59.999999', 6, 'UTC')))
+  FROM web_pre_aggregated_stats
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), greaterOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-14 11:00:00.000000', 6, 'UTC')), lessOrEquals(web_pre_aggregated_stats.period_bucket, toDateTime64('2024-01-16 10:59:59.999999', 6, 'UTC')))
   GROUP BY `context.columns.breakdown_value`
   ORDER BY `context.columns.visitors` DESC
   LIMIT 101

--- a/posthog/models/web_preaggregated/test_web_pre_aggregated_timezones.py
+++ b/posthog/models/web_preaggregated/test_web_pre_aggregated_timezones.py
@@ -94,12 +94,14 @@ class TestTimezonePreAggregatedIntegration(WebAnalyticsPreAggregatedTestBase, Fl
             date_start="2024-01-14",  # Start earlier to catch cross-day timezone buckets
             date_end="2024-01-17",  # End later to catch cross-day timezone buckets
             team_ids=[team.pk],
+            table_name="web_pre_aggregated_stats",
             granularity="hourly",
         )
         bounces_insert = WEB_BOUNCES_INSERT_SQL(
             date_start="2024-01-14",
             date_end="2024-01-17",
             team_ids=[team.pk],
+            table_name="web_pre_aggregated_bounces",
             granularity="hourly",
         )
 

--- a/posthog/models/web_preaggregated/test_web_preaggregated_sql.py
+++ b/posthog/models/web_preaggregated/test_web_preaggregated_sql.py
@@ -268,7 +268,7 @@ class TestWebPreaggregatedInserts(WebAnalyticsPreAggregatedTestBase):
             assert f"\n    {column}" in stats_insert
 
         # Verify it has explicit column list format
-        assert "INSERT INTO web_stats_daily\n(" in stats_insert
+        assert "INSERT INTO web_pre_aggregated_stats\n(" in stats_insert
         assert ")\n\n    SELECT" in stats_insert
 
     def test_insert_queries_contain_all_columns_for_bounces(self):
@@ -285,7 +285,7 @@ class TestWebPreaggregatedInserts(WebAnalyticsPreAggregatedTestBase):
             assert f"\n    {column}" in bounces_insert
 
         # Verify it has explicit column list format
-        assert "INSERT INTO web_bounces_daily\n(" in bounces_insert
+        assert "INSERT INTO web_pre_aggregated_bounces\n(" in bounces_insert
         assert ")\n\n    SELECT" in bounces_insert
 
 

--- a/posthog/models/web_preaggregated/test_web_preaggregated_sql.py
+++ b/posthog/models/web_preaggregated/test_web_preaggregated_sql.py
@@ -241,11 +241,13 @@ class TestWebPreaggregatedInserts(WebAnalyticsPreAggregatedTestBase):
             date_start=date_start,
             date_end=date_end,
             team_ids=[self.team.pk],
+            table_name="web_pre_aggregated_bounces",
         )
         stats_insert = WEB_STATS_INSERT_SQL(
             date_start=date_start,
             date_end=date_end,
             team_ids=[self.team.pk],
+            table_name="web_pre_aggregated_stats",
         )
         sync_execute(stats_insert)
         sync_execute(bounces_insert)
@@ -258,6 +260,7 @@ class TestWebPreaggregatedInserts(WebAnalyticsPreAggregatedTestBase):
             date_start="2024-01-01",
             date_end="2024-01-02",
             team_ids=[self.team.pk],
+            table_name="web_pre_aggregated_stats",
         )
 
         expected_stats_columns = get_web_stats_insert_columns()
@@ -274,6 +277,7 @@ class TestWebPreaggregatedInserts(WebAnalyticsPreAggregatedTestBase):
             date_start="2024-01-01",
             date_end="2024-01-02",
             team_ids=[self.team.pk],
+            table_name="web_pre_aggregated_bounces",
         )
 
         expected_bounces_columns = get_web_bounces_insert_columns()


### PR DESCRIPTION
## Problem

We have many problems with the current daily-bucket tables and have been checking the data accuracy for the new hourly ones for a while. 

This is ready to use for the last ~40 days of data in the US and should be completed later today for ~90+ days.

Regarding the EU, we will wait for https://github.com/PostHog/posthog/pull/37268, as it will backfill the new tables with the necessary data.

⚠️ This PR does not change the ast-to-ast transformations to keep things simpler ⚠️ 
The v1 tables are still working, so the AST-to-AST will continue to hit those. We can write a different PR to address it.

## Changes

- Default all query runners to use the hourly tables.

## How did you test this code?

- Manually on local env after materializing everything

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
