### PR TITLE
fix: timezone simplification for timestamp filter

### DIFF
--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -10,7 +10,7 @@ import api from 'lib/api'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { FeatureFlagsSet, featureFlagLogic as enabledFlagLogic } from 'lib/logic/featureFlagLogic'
-import { allOperatorsMapping, dateStringToDayJs, debounce, hasFormErrors, isObject } from 'lib/utils'
+import { allOperatorsMapping, debounce, hasFormErrors, isObject } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { ProductIntentContext } from 'lib/utils/product-intents'
 import { Scene } from 'scenes/sceneTypes'
@@ -77,6 +77,7 @@ import { surveysLogic } from './surveysLogic'
 import {
     DATE_FORMAT,
     buildPartialResponsesFilter,
+    buildSurveyTimestampFilter,
     calculateSurveyRates,
     createAnswerFilterHogQLExpression,
     getResponseFieldWithId,
@@ -1229,38 +1230,7 @@ export const surveyLogic = kea<surveyLogicType>([
         timestampFilter: [
             (s) => [s.survey, s.dateRange],
             (survey: Survey, dateRange: SurveyDateRange): string => {
-                // If no date range provided, use the survey's default date range
-                if (!dateRange) {
-                    return `AND timestamp >= '${getSurveyStartDateForQuery(survey)}'
-                AND timestamp <= '${getSurveyEndDateForQuery(survey)}'`
-                }
-
-                // ----- Handle FROM date -----
-                // Parse the date string to a dayjs object
-                let fromDateDayjs = dateStringToDayJs(dateRange.date_from)
-
-                // Use survey creation date as lower bound if needed
-                const surveyStartDayjs = dayjs(getSurveyStartDateForQuery(survey))
-                if (surveyStartDayjs && fromDateDayjs && fromDateDayjs.isBefore(surveyStartDayjs)) {
-                    fromDateDayjs = surveyStartDayjs
-                }
-
-                // Fall back to survey start date if no valid from date
-                const fromDate = fromDateDayjs
-                    ? fromDateDayjs.utc().format(DATE_FORMAT)
-                    : getSurveyStartDateForQuery(survey)
-
-                // ----- Handle TO date -----
-                // Parse the date string or use current time
-                const toDateDayjs = dateStringToDayJs(dateRange.date_to) || dayjs()
-
-                // Use survey end date as upper bound if it exists
-                const toDate = survey.end_date
-                    ? getSurveyEndDateForQuery(survey)
-                    : toDateDayjs.utc().format(DATE_FORMAT)
-
-                return `AND timestamp >= '${fromDate}'
-                AND timestamp <= '${toDate}'`
+                return buildSurveyTimestampFilter(survey, dateRange)
             },
         ],
         partialResponsesFilter: [

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -533,3 +533,42 @@ export function getSurveyEndDateForQuery(survey: Pick<Survey, 'end_date'>): stri
         ? dayjs.utc(survey.end_date).endOf('day').format(DATE_FORMAT)
         : dayjs.utc().endOf('day').format(DATE_FORMAT)
 }
+
+export interface SurveyDateRange {
+    date_from: string | null
+    date_to: string | null
+}
+
+export function buildSurveyTimestampFilter(
+    survey: Pick<Survey, 'created_at' | 'end_date'>,
+    dateRange?: SurveyDateRange | null
+): string {
+    // If no date range provided, use the survey's default date range
+    let fromDate = getSurveyStartDateForQuery(survey)
+    let toDate = getSurveyEndDateForQuery(survey)
+
+    if (!dateRange) {
+        return `AND timestamp >= '${fromDate}'
+        AND timestamp <= '${toDate}'`
+    }
+
+    // ----- Handle FROM date -----
+    if (dateRange.date_from) {
+        // Parse user-provided date and ensure it's not before survey creation
+        const userFromDate = dayjs.utc(dateRange.date_from).startOf('day')
+        const surveyStartDate = dayjs.utc(fromDate)
+
+        if (userFromDate.isAfter(surveyStartDate)) {
+            fromDate = userFromDate.format(DATE_FORMAT)
+        }
+    }
+
+    // ----- Handle TO date -----
+    if (dateRange.date_to) {
+        const userToDate = dayjs.utc(dateRange.date_to).endOf('day')
+        toDate = userToDate.format(DATE_FORMAT)
+    }
+
+    return `AND timestamp >= '${fromDate}'
+    AND timestamp <= '${toDate}'`
+}


### PR DESCRIPTION
## Problem

follow up to https://github.com/PostHog/posthog/pull/37126

we still need to change apply the timezone changes in the `timestampFilter`, not only on the helper functions

## Changes

applies the same logic we did in the last PR. plus refactor to make reading easier, and add tests

## How did you test this code?

unit tests, tested locally