### PR TITLE
refactor: Move tag label over the ellipsis dropdown selector

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -2,7 +2,14 @@ import { BindLogic, useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { RefObject, useEffect, useRef, useState } from 'react'
 
-import { IconCheckbox, IconChevronRight, IconExternal, IconFolderPlus, IconPlusSmall } from '@posthog/icons'
+import {
+    IconCheckbox,
+    IconChevronRight,
+    IconEllipsis,
+    IconExternal,
+    IconFolderPlus,
+    IconPlusSmall,
+} from '@posthog/icons'
 
 import { moveToLogic } from 'lib/components/FileSystem/MoveTo/moveToLogic'
 import { ResizableElement } from 'lib/components/ResizeElement/ResizeElement'
@@ -582,7 +589,26 @@ export function ProjectTree({
                     (root === 'shortcuts://' && item.record?.href && item.record.href.split('/').length - 1 === 1)
 
                 if (showProductMenuItems) {
-                    if (item.name === 'Product analytics') {
+                    if (item.tags && item.tags.length > 0) {
+                        const tag = item.tags[0]
+                        return (
+                            <ButtonPrimitive
+                                iconOnly
+                                isSideActionRight
+                                className="z-2 group justify-end hover:justify-center"
+                            >
+                                <LemonTag
+                                    key={tag}
+                                    type={tag === 'alpha' ? 'completion' : tag === 'beta' ? 'warning' : 'success'}
+                                    size="xsmall"
+                                    className="group-hover:hidden group-data-[state=open]/button-primitive:hidden mr-2"
+                                >
+                                    {tag.toUpperCase()}
+                                </LemonTag>
+                                <IconEllipsis className="size-3 text-tertiary hidden group-hover:block" />
+                            </ButtonPrimitive>
+                        )
+                    } else if (item.name === 'Product analytics') {
                         return (
                             <ButtonPrimitive iconOnly isSideActionRight className="z-2">
                                 <IconPlusSmall className="text-tertiary" />
@@ -792,21 +818,6 @@ export function ProjectTree({
                             <span className="text-tertiary text-xxs pt-[3px] ml-1">
                                 {dayjs(item.record?.created_at).fromNow()}
                             </span>
-                        )}
-
-                        {item.record?.protocol === 'products://' && item.tags?.length && (
-                            <>
-                                {item.tags?.map((tag) => (
-                                    <LemonTag
-                                        key={tag}
-                                        type={tag === 'alpha' ? 'completion' : tag === 'beta' ? 'warning' : 'success'}
-                                        size="small"
-                                        className="ml-2 relative top-[-1px]"
-                                    >
-                                        {tag.toUpperCase()}
-                                    </LemonTag>
-                                ))}
-                            </>
                         )}
 
                         {isExternalLinkItem(item) && <IconExternal className="size-4 text-tertiary relative" />}

--- a/frontend/src/lib/lemon-ui/LemonTag/LemonTag.scss
+++ b/frontend/src/lib/lemon-ui/LemonTag/LemonTag.scss
@@ -11,6 +11,13 @@
     border-width: 1px;
     border-radius: var(--radius-sm);
 
+    &.LemonTag--size-xsmall {
+        padding: 0 0.125rem;
+        font-size: 0.5rem;
+        line-height: 0.625rem;
+        border-radius: var(--radius-xs);
+    }
+
     &.LemonTag--size-small {
         padding: 0 0.1875rem;
         font-size: 0.625rem;

--- a/frontend/src/lib/lemon-ui/LemonTag/LemonTag.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTag/LemonTag.tsx
@@ -24,7 +24,7 @@ export type LemonTagType =
 export interface LemonTagProps {
     type?: LemonTagType
     children: React.ReactNode
-    size?: 'small' | 'medium'
+    size?: 'xsmall' | 'small' | 'medium'
     weight?: 'normal'
     icon?: JSX.Element
     closable?: boolean

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -505,6 +505,8 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                         )
                     }
 
+                    const renderedItemSideAction = itemSideAction?.(item)
+
                     const content = (
                         <AccordionPrimitive.Root
                             type="multiple"
@@ -571,8 +573,7 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                                             button
                                         )}
 
-                                        {itemSideAction &&
-                                            itemSideAction(item) !== undefined &&
+                                        {renderedItemSideAction !== undefined &&
                                             !isEmptyFolder &&
                                             size === 'default' && (
                                                 <DropdownMenu>
@@ -585,16 +586,14 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                                                     </DropdownMenuTrigger>
 
                                                     {/* The Dropdown content menu */}
-                                                    {!!itemSideAction(item) && (
-                                                        <DropdownMenuContent
-                                                            loop
-                                                            align="end"
-                                                            side="bottom"
-                                                            className="max-w-[250px]"
-                                                        >
-                                                            {itemSideAction(item)}
-                                                        </DropdownMenuContent>
-                                                    )}
+                                                    <DropdownMenuContent
+                                                        loop
+                                                        align="end"
+                                                        side="bottom"
+                                                        className="max-w-[250px]"
+                                                    >
+                                                        {renderedItemSideAction}
+                                                    </DropdownMenuContent>
                                                 </DropdownMenu>
                                             )}
                                     </ButtonGroupPrimitive>


### PR DESCRIPTION
Revenue Analytics has a very long name and its `beta` label is hidden behind the `truncate` we have on the sidebar. To circumvent that, let's inside render labels over the `...` ellipsis we use as dropdown selector.
    
Of course, we display the ellipsis on hover with some CSS `group` magic. I'm still in doubt on whether we should center or right-align the ellipsis with the badge, so I'll leave that to the Design gods.

<img width="225" height="354" alt="image" src="https://github.com/user-attachments/assets/cfdfac18-87b0-4ba8-aef7-5299ad3f798d" />

    
https://www.loom.com/share/5497d7a2048f4ac3a7f87ade2b6bbc4c