### PR TITLE
refactor: Some refactorings to prepare for cached authentication

### DIFF
--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -179,7 +179,7 @@ class TeamMemberAccessPermission(BasePermission):
     message = "You don't have access to the project."
 
     def has_permission(self, request, view) -> bool:
-        if isinstance(request.successful_authenticator, ProjectSecretAPIKeyAuthentication):
+        if is_authenticated_via_project_secret_api_token(request):
             # Ignore the team check for project secret API keys. It's handled by the ProjectSecretAPITokenPermission
             return True
 
@@ -192,6 +192,10 @@ class TeamMemberAccessPermission(BasePermission):
         # - not the "current_team" property of the user
         requesting_level = view.user_permissions.current_team.effective_membership_level
         return requesting_level is not None
+
+
+def is_authenticated_via_project_secret_api_token(request: Request) -> bool:
+    return isinstance(request.successful_authenticator, ProjectSecretAPIKeyAuthentication)
 
 
 def _is_request_for_project_secret_api_token_secured_endpoint(request: Request) -> bool:
@@ -555,7 +559,7 @@ class AccessControlPermission(ScopeBasePermission):
         # Primarily we are checking the user's access to the parent resource type (i.e. project, organization)
         # as well as enforcing any global restrictions (e.g. generically only editing of a flag is allowed)
 
-        if isinstance(request.successful_authenticator, ProjectSecretAPIKeyAuthentication):
+        if is_authenticated_via_project_secret_api_token(request):
             # Ignore the team check for project secret API keys. It's handled by the ProjectSecretAPITokenPermission
             return True
 

--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -201,6 +201,7 @@ def _is_request_for_project_secret_api_token_secured_endpoint(request: Request) 
         in {
             "featureflag-local-evaluation",
             "project_feature_flags-remote-config",
+            "project_feature_flags-local-evaluation",
         }
     )
 
@@ -661,11 +662,7 @@ class ProjectSecretAPITokenPermission(BasePermission):
             return True
 
         # Check that the endpoint is allowed for secret API keys
-        if request.resolver_match.view_name not in (
-            "featureflag-local-evaluation",
-            "project_feature_flags-remote-config",
-            "project_feature_flags-local-evaluation",
-        ):
+        if not _is_request_for_project_secret_api_token_secured_endpoint(request):
             return False
 
         # Check team consistency: authenticated team must match resolved team

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -4427,54 +4427,6 @@
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending.10
   '''
-  SELECT "posthog_datawarehousetable"."created_by_id",
-         "posthog_datawarehousetable"."created_at",
-         "posthog_datawarehousetable"."updated_at",
-         "posthog_datawarehousetable"."deleted",
-         "posthog_datawarehousetable"."deleted_at",
-         "posthog_datawarehousetable"."id",
-         "posthog_datawarehousetable"."name",
-         "posthog_datawarehousetable"."format",
-         "posthog_datawarehousetable"."team_id",
-         "posthog_datawarehousetable"."url_pattern",
-         "posthog_datawarehousetable"."credential_id",
-         "posthog_datawarehousetable"."external_data_source_id",
-         "posthog_datawarehousetable"."columns",
-         "posthog_datawarehousetable"."row_count",
-         "posthog_datawarehousetable"."size_in_s3_mib",
-         "posthog_datawarehousecredential"."created_by_id",
-         "posthog_datawarehousecredential"."created_at",
-         "posthog_datawarehousecredential"."id",
-         "posthog_datawarehousecredential"."access_key",
-         "posthog_datawarehousecredential"."access_secret",
-         "posthog_datawarehousecredential"."team_id",
-         "posthog_externaldatasource"."created_by_id",
-         "posthog_externaldatasource"."created_at",
-         "posthog_externaldatasource"."updated_at",
-         "posthog_externaldatasource"."deleted",
-         "posthog_externaldatasource"."deleted_at",
-         "posthog_externaldatasource"."id",
-         "posthog_externaldatasource"."source_id",
-         "posthog_externaldatasource"."connection_id",
-         "posthog_externaldatasource"."destination_id",
-         "posthog_externaldatasource"."team_id",
-         "posthog_externaldatasource"."sync_frequency",
-         "posthog_externaldatasource"."status",
-         "posthog_externaldatasource"."source_type",
-         "posthog_externaldatasource"."job_inputs",
-         "posthog_externaldatasource"."are_tables_created",
-         "posthog_externaldatasource"."prefix",
-         "posthog_externaldatasource"."revenue_analytics_enabled"
-  FROM "posthog_datawarehousetable"
-  LEFT OUTER JOIN "posthog_datawarehousecredential" ON ("posthog_datawarehousetable"."credential_id" = "posthog_datawarehousecredential"."id")
-  LEFT OUTER JOIN "posthog_externaldatasource" ON ("posthog_datawarehousetable"."external_data_source_id" = "posthog_externaldatasource"."id")
-  WHERE ("posthog_datawarehousetable"."team_id" = 99999
-         AND NOT ("posthog_datawarehousetable"."deleted"
-                  AND "posthog_datawarehousetable"."deleted" IS NOT NULL))
-  '''
-# ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending.11
-  '''
   SELECT "posthog_datawarehousejoin"."created_by_id",
          "posthog_datawarehousejoin"."created_at",
          "posthog_datawarehousejoin"."deleted",
@@ -4493,7 +4445,7 @@
                   AND "posthog_datawarehousejoin"."deleted" IS NOT NULL))
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending.12
+# name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending.11
   '''
   SELECT "posthog_sessionrecording"."id",
          "posthog_sessionrecording"."session_id",
@@ -4522,7 +4474,7 @@
          AND "posthog_sessionrecording"."team_id" = 99999)
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending.13
+# name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending.12
   '''
   SELECT "posthog_sessionrecordingviewed"."session_id"
   FROM "posthog_sessionrecordingviewed"
@@ -4532,7 +4484,7 @@
                                                                'at_base_time_plus_20'))
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending.14
+# name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending.13
   '''
   SELECT "posthog_sessionrecordingviewed"."session_id",
          "posthog_user"."email"
@@ -4542,6 +4494,30 @@
                                                            'at_base_time_plus_20')
          AND "posthog_sessionrecordingviewed"."team_id" = 99999
          AND NOT ("posthog_sessionrecordingviewed"."user_id" = 99999))
+  '''
+# ---
+# name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending.14
+  '''
+  SELECT "posthog_persondistinctid"."id",
+         "posthog_persondistinctid"."team_id",
+         "posthog_persondistinctid"."person_id",
+         "posthog_persondistinctid"."distinct_id",
+         "posthog_persondistinctid"."version",
+         "posthog_person"."id",
+         "posthog_person"."created_at",
+         "posthog_person"."properties_last_updated_at",
+         "posthog_person"."properties_last_operation",
+         "posthog_person"."team_id",
+         "posthog_person"."properties",
+         "posthog_person"."is_user_id",
+         "posthog_person"."is_identified",
+         "posthog_person"."uuid",
+         "posthog_person"."version"
+  FROM "posthog_persondistinctid"
+  INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
+  WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
+                                                      'user_one_0')
+         AND "posthog_persondistinctid"."team_id" = 99999)
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending.15
@@ -4777,19 +4753,6 @@
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending.8
   '''
-  SELECT "posthog_teamrevenueanalyticsconfig"."team_id",
-         "posthog_teamrevenueanalyticsconfig"."filter_test_accounts",
-         "posthog_teamrevenueanalyticsconfig"."notified_first_sync",
-         "posthog_teamrevenueanalyticsconfig"."events",
-         "posthog_teamrevenueanalyticsconfig"."goals",
-         "posthog_teamrevenueanalyticsconfig"."base_currency"
-  FROM "posthog_teamrevenueanalyticsconfig"
-  WHERE "posthog_teamrevenueanalyticsconfig"."team_id" = 99999
-  LIMIT 21
-  '''
-# ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending.9
-  '''
   SELECT "posthog_externaldatasource"."created_by_id",
          "posthog_externaldatasource"."created_at",
          "posthog_externaldatasource"."updated_at",
@@ -4812,6 +4775,54 @@
          AND "posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL))
+  '''
+# ---
+# name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending.9
+  '''
+  SELECT "posthog_datawarehousetable"."created_by_id",
+         "posthog_datawarehousetable"."created_at",
+         "posthog_datawarehousetable"."updated_at",
+         "posthog_datawarehousetable"."deleted",
+         "posthog_datawarehousetable"."deleted_at",
+         "posthog_datawarehousetable"."id",
+         "posthog_datawarehousetable"."name",
+         "posthog_datawarehousetable"."format",
+         "posthog_datawarehousetable"."team_id",
+         "posthog_datawarehousetable"."url_pattern",
+         "posthog_datawarehousetable"."credential_id",
+         "posthog_datawarehousetable"."external_data_source_id",
+         "posthog_datawarehousetable"."columns",
+         "posthog_datawarehousetable"."row_count",
+         "posthog_datawarehousetable"."size_in_s3_mib",
+         "posthog_datawarehousecredential"."created_by_id",
+         "posthog_datawarehousecredential"."created_at",
+         "posthog_datawarehousecredential"."id",
+         "posthog_datawarehousecredential"."access_key",
+         "posthog_datawarehousecredential"."access_secret",
+         "posthog_datawarehousecredential"."team_id",
+         "posthog_externaldatasource"."created_by_id",
+         "posthog_externaldatasource"."created_at",
+         "posthog_externaldatasource"."updated_at",
+         "posthog_externaldatasource"."deleted",
+         "posthog_externaldatasource"."deleted_at",
+         "posthog_externaldatasource"."id",
+         "posthog_externaldatasource"."source_id",
+         "posthog_externaldatasource"."connection_id",
+         "posthog_externaldatasource"."destination_id",
+         "posthog_externaldatasource"."team_id",
+         "posthog_externaldatasource"."sync_frequency",
+         "posthog_externaldatasource"."status",
+         "posthog_externaldatasource"."source_type",
+         "posthog_externaldatasource"."job_inputs",
+         "posthog_externaldatasource"."are_tables_created",
+         "posthog_externaldatasource"."prefix",
+         "posthog_externaldatasource"."revenue_analytics_enabled"
+  FROM "posthog_datawarehousetable"
+  LEFT OUTER JOIN "posthog_datawarehousecredential" ON ("posthog_datawarehousetable"."credential_id" = "posthog_datawarehousecredential"."id")
+  LEFT OUTER JOIN "posthog_externaldatasource" ON ("posthog_datawarehousetable"."external_data_source_id" = "posthog_externaldatasource"."id")
+  WHERE ("posthog_datawarehousetable"."team_id" = 99999
+         AND NOT ("posthog_datawarehousetable"."deleted"
+                  AND "posthog_datawarehousetable"."deleted" IS NOT NULL))
   '''
 # ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons

--- a/posthog/test/test_permissions.py
+++ b/posthog/test/test_permissions.py
@@ -1,9 +1,11 @@
 from posthog.test.base import BaseTest
 from unittest.mock import Mock
 
+from parameterized import parameterized
 from rest_framework.test import APIRequestFactory
 
 from posthog.constants import AvailableFeature
+from posthog.models import Team
 from posthog.models.organization import OrganizationMembership
 from posthog.permissions import AccessControlPermission
 from posthog.rbac.user_access_control import UserAccessControl
@@ -196,3 +198,200 @@ class TestAccessControlPermission(BaseTest):
 
         # Should have permission to create
         assert self.permission.has_permission(request, view) is True
+
+
+class TestProjectSecretAPITokenPermission(BaseTest):
+    """Direct unit tests for ProjectSecretAPITokenPermission.has_permission method"""
+
+    def setUp(self):
+        super().setUp()
+        from posthog.permissions import ProjectSecretAPITokenPermission
+
+        self.permission = ProjectSecretAPITokenPermission()
+
+    def _create_mock_request(self, authenticator_class=None, view_name="featureflag-local-evaluation", user=None):
+        """Helper to create a mock request with specified authenticator and view name"""
+        request = Mock()
+
+        # Mock the authenticator
+        mock_authenticator = Mock()
+        if authenticator_class:
+            mock_authenticator.__class__ = authenticator_class
+        request.successful_authenticator = mock_authenticator
+
+        # Mock resolver_match with view_name
+        request.resolver_match = Mock()
+        request.resolver_match.view_name = view_name
+
+        # Set user if provided
+        if user:
+            request.user = user
+
+        return request
+
+    def _create_mock_view(self, team=None, raise_exception=None):
+        """Helper to create a mock view with specified team or exception"""
+        view = Mock()
+
+        if raise_exception:
+            # Configure the mock to raise the exception when team is accessed
+            view.team = Mock(side_effect=raise_exception)
+        else:
+            view.team = team
+
+        return view
+
+    def _create_mock_team(self, team_id=1):
+        """Helper to create a mock team with specified ID"""
+        team = Mock()
+        team.id = team_id
+        return team
+
+    def _create_mock_user(self, team):
+        """Helper to create a mock user with specified team"""
+        user = Mock()
+        user.team = team
+        return user
+
+    def test_has_permission_with_non_project_secret_authenticator(self):
+        """Should return True when not using ProjectSecretAPIKeyAuthentication"""
+        from posthog.auth import PersonalAPIKeyAuthentication
+
+        request = self._create_mock_request(authenticator_class=PersonalAPIKeyAuthentication)
+        view = self._create_mock_view()
+
+        result = self.permission.has_permission(request, view)
+
+        self.assertTrue(result)
+
+    def test_has_permission_with_project_secret_authenticator_disallowed_endpoint(self):
+        """Should return False for disallowed endpoints"""
+        from posthog.auth import ProjectSecretAPIKeyAuthentication
+
+        request = self._create_mock_request(
+            authenticator_class=ProjectSecretAPIKeyAuthentication, view_name="some-other-endpoint"
+        )
+        view = self._create_mock_view()
+
+        result = self.permission.has_permission(request, view)
+
+        self.assertFalse(result)
+
+    @parameterized.expand(
+        [
+            ("featureflag-local-evaluation",),
+            ("project_feature_flags-remote-config",),
+            ("project_feature_flags-local-evaluation",),
+        ]
+    )
+    def test_has_permission_to_secret_api_token_secured_endpoints(self, endpoint_name):
+        """Should allow project_feature_flags endpoints with matching teams"""
+        from posthog.auth import ProjectSecretAPIKeyAuthentication
+
+        team = self._create_mock_team(team_id=1)
+        user = self._create_mock_user(team)
+
+        request = self._create_mock_request(
+            authenticator_class=ProjectSecretAPIKeyAuthentication,
+            view_name=endpoint_name,
+            user=user,
+        )
+        view = self._create_mock_view(team=team)
+
+        result = self.permission.has_permission(request, view)
+
+        self.assertTrue(result)
+
+    def test_has_permission_unknown_endpoint(self):
+        """Should reject unknown endpoints"""
+        from posthog.auth import ProjectSecretAPIKeyAuthentication
+
+        request = self._create_mock_request(
+            authenticator_class=ProjectSecretAPIKeyAuthentication, view_name="unknown-endpoint"
+        )
+        view = self._create_mock_view()
+
+        result = self.permission.has_permission(request, view)
+
+        self.assertFalse(result)
+
+    def test_has_permission_matching_teams(self):
+        """Should return True when authenticated team matches resolved team"""
+        from posthog.auth import ProjectSecretAPIKeyAuthentication
+
+        team = self._create_mock_team(team_id=1)
+        user = self._create_mock_user(team)
+
+        request = self._create_mock_request(authenticator_class=ProjectSecretAPIKeyAuthentication, user=user)
+        view = self._create_mock_view(team=team)
+
+        result = self.permission.has_permission(request, view)
+
+        self.assertTrue(result)
+
+    def test_has_permission_mismatched_teams(self):
+        """Should return False when authenticated team doesn't match resolved team"""
+        from posthog.auth import ProjectSecretAPIKeyAuthentication
+
+        team1 = self._create_mock_team(team_id=1)
+        team2 = self._create_mock_team(team_id=2)
+        user = self._create_mock_user(team1)
+
+        request = self._create_mock_request(authenticator_class=ProjectSecretAPIKeyAuthentication, user=user)
+        view = self._create_mock_view(team=team2)
+
+        result = self.permission.has_permission(request, view)
+
+        self.assertFalse(result)
+
+    def test_has_permission_view_team_resolution_fails_with_team_does_not_exist(self):
+        """Should return True when view.team raises Team.DoesNotExist"""
+        from posthog.auth import ProjectSecretAPIKeyAuthentication
+
+        team = self._create_mock_team(team_id=1)
+        user = self._create_mock_user(team)
+
+        request = self._create_mock_request(authenticator_class=ProjectSecretAPIKeyAuthentication, user=user)
+
+        # Create a view class that raises Team.DoesNotExist when team is accessed
+        class MockView:
+            @property
+            def team(self):
+                raise Team.DoesNotExist("Team not found")
+
+        view = MockView()
+        result = self.permission.has_permission(request, view)
+
+        self.assertTrue(result)
+
+    def test_has_permission_view_missing_team_attribute(self):
+        """Should return True when view.team raises AttributeError"""
+        from posthog.auth import ProjectSecretAPIKeyAuthentication
+
+        team = self._create_mock_team(team_id=1)
+        user = self._create_mock_user(team)
+
+        request = self._create_mock_request(authenticator_class=ProjectSecretAPIKeyAuthentication, user=user)
+
+        # Create a view class that raises AttributeError when team is accessed
+        class MockView:
+            @property
+            def team(self):
+                raise AttributeError("'view' object has no attribute 'team'")
+
+        view = MockView()
+        result = self.permission.has_permission(request, view)
+
+        self.assertTrue(result)
+
+    def test_has_permission_no_view_name(self):
+        """Should handle missing view_name gracefully"""
+        from posthog.auth import ProjectSecretAPIKeyAuthentication
+
+        request = self._create_mock_request(authenticator_class=ProjectSecretAPIKeyAuthentication, view_name=None)
+        view = self._create_mock_view()
+
+        result = self.permission.has_permission(request, view)
+
+        # None is not in the allowed endpoints tuple, so this should return False
+        self.assertFalse(result)

--- a/posthog/test/test_permissions.py
+++ b/posthog/test/test_permissions.py
@@ -199,6 +199,17 @@ class TestAccessControlPermission(BaseTest):
         # Should have permission to create
         assert self.permission.has_permission(request, view) is True
 
+    def test_has_permission_with_project_secret_api_token_authentication(self):
+        """Test that has_permission returns True when authenticated via project secret API token"""
+        from posthog.auth import ProjectSecretAPIKeyAuthentication
+
+        request = self._create_mock_request()
+        request.successful_authenticator = ProjectSecretAPIKeyAuthentication()
+        view = self._create_real_view(action="list")
+
+        # Should have permission when authenticated via project secret API token
+        assert self.permission.has_permission(request, view) is True
+
 
 class TestProjectSecretAPITokenPermission(BaseTest):
     """Direct unit tests for ProjectSecretAPITokenPermission.has_permission method"""
@@ -395,3 +406,129 @@ class TestProjectSecretAPITokenPermission(BaseTest):
 
         # None is not in the allowed endpoints tuple, so this should return False
         self.assertFalse(result)
+
+
+class TestTeamMemberAccessPermission(BaseTest):
+    """Direct unit tests for TeamMemberAccessPermission.has_permission method"""
+
+    def setUp(self):
+        super().setUp()
+        from posthog.permissions import TeamMemberAccessPermission
+
+        self.permission = TeamMemberAccessPermission()
+
+    def _create_mock_request(self, authenticator_class=None, user=None):
+        """Helper to create a mock request with specified authenticator"""
+        request = Mock()
+
+        # Mock the authenticator
+        mock_authenticator = Mock()
+        if authenticator_class:
+            mock_authenticator.__class__ = authenticator_class
+        request.successful_authenticator = mock_authenticator
+
+        # Set user if provided
+        if user:
+            request.user = user
+
+        return request
+
+    def _create_mock_view(self, team=None, raise_exception=None, user_permissions=None):
+        """Helper to create a mock view with specified team or exception"""
+        view = Mock()
+
+        if raise_exception:
+            # Configure the mock to raise the exception when team is accessed
+            view.team = Mock(side_effect=raise_exception)
+        else:
+            view.team = team
+
+        # Set user_permissions if provided
+        if user_permissions:
+            view.user_permissions = user_permissions
+
+        return view
+
+    def _create_mock_team(self, team_id=1):
+        """Helper to create a mock team with specified ID"""
+        team = Mock()
+        team.id = team_id
+        return team
+
+    def _create_mock_user_permissions(self, effective_membership_level=None):
+        """Helper to create a mock user_permissions with specified effective membership level"""
+        user_permissions = Mock()
+        current_team = Mock()
+        current_team.effective_membership_level = effective_membership_level
+        user_permissions.current_team = current_team
+        return user_permissions
+
+    def test_has_permission_with_project_secret_api_token_authenticator(self):
+        """Should return True when using ProjectSecretAPIKeyAuthentication"""
+        from posthog.auth import ProjectSecretAPIKeyAuthentication
+
+        request = self._create_mock_request(authenticator_class=ProjectSecretAPIKeyAuthentication)
+        view = self._create_mock_view()
+
+        result = self.permission.has_permission(request, view)
+
+        self.assertTrue(result)
+
+    def test_has_permission_with_non_project_secret_authenticator_and_valid_membership(self):
+        """Should return True when not using project secret auth and user has valid membership"""
+        from posthog.auth import PersonalAPIKeyAuthentication
+        from posthog.models.organization import OrganizationMembership
+
+        team = self._create_mock_team()
+        user_permissions = self._create_mock_user_permissions(
+            effective_membership_level=OrganizationMembership.Level.MEMBER
+        )
+
+        request = self._create_mock_request(authenticator_class=PersonalAPIKeyAuthentication)
+        view = self._create_mock_view(team=team, user_permissions=user_permissions)
+
+        result = self.permission.has_permission(request, view)
+
+        self.assertTrue(result)
+
+    def test_has_permission_with_non_project_secret_authenticator_and_no_membership(self):
+        """Should return False when not using project secret auth and user has no membership"""
+        from posthog.auth import PersonalAPIKeyAuthentication
+
+        team = self._create_mock_team()
+        user_permissions = self._create_mock_user_permissions(effective_membership_level=None)
+
+        request = self._create_mock_request(authenticator_class=PersonalAPIKeyAuthentication)
+        view = self._create_mock_view(team=team, user_permissions=user_permissions)
+
+        result = self.permission.has_permission(request, view)
+
+        self.assertFalse(result)
+
+    def test_has_permission_with_team_does_not_exist_exception(self):
+        """Should return True when view.team raises Team.DoesNotExist"""
+        from posthog.auth import PersonalAPIKeyAuthentication
+
+        request = self._create_mock_request(authenticator_class=PersonalAPIKeyAuthentication)
+        view = self._create_mock_view(raise_exception=Team.DoesNotExist("Team not found"))
+
+        result = self.permission.has_permission(request, view)
+
+        self.assertTrue(result)
+
+    def test_has_permission_with_admin_membership(self):
+        """Should return True when user has admin membership level"""
+        from posthog.auth import PersonalAPIKeyAuthentication
+        from posthog.models.organization import OrganizationMembership
+
+        team = self._create_mock_team()
+        user_permissions = self._create_mock_user_permissions(
+            effective_membership_level=OrganizationMembership.Level.ADMIN
+        )
+
+        request = self._create_mock_request(authenticator_class=PersonalAPIKeyAuthentication)
+        view = self._create_mock_view(team=team, user_permissions=user_permissions)
+
+        result = self.permission.has_permission(request, view)
+
+        self.assertTrue(result)


### PR DESCRIPTION
## Problem

No code changes. Just adding unit tests and preparing the code for bigger changes later.

## Changes

Refactors the `ProjectSecretAPITokenPermission .has_permission` method to use `_is_request_for_project_secret_api_token_secured_endpoint`.

## How did you test this code?

Manually
Also adds unit tests

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
