### PR TITLE
feat: removing meta ads from new source dropdown

### DIFF
--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/utils.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/utils.ts
@@ -14,7 +14,7 @@ import { googleAdsCostTile } from './marketingCostTile'
 export type NativeMarketingSource = Extract<ExternalDataSourceType, 'GoogleAds' | 'MetaAds'>
 export type NonNativeMarketingSource = Extract<ExternalDataSourceType, 'BigQuery'>
 
-export const VALID_NATIVE_MARKETING_SOURCES: NativeMarketingSource[] = ['GoogleAds', 'MetaAds']
+export const VALID_NATIVE_MARKETING_SOURCES: NativeMarketingSource[] = ['GoogleAds']
 export const VALID_NON_NATIVE_MARKETING_SOURCES: NonNativeMarketingSource[] = ['BigQuery']
 export const VALID_SELF_MANAGED_MARKETING_SOURCES: ManualLinkSourceType[] = [
     'aws',


### PR DESCRIPTION
## Problem

Meta ads is not 100% supported and we want to put Marketing Analytics in Beta.

## Changes

Removed Meta from the Valid sources Array

## How did you test this code?
Manually
<img width="1011" height="248" alt="image" src="https://github.com/user-attachments/assets/ca6c50e4-5a80-4c0a-921e-b2a9a9623637" />

