### PR TITLE
feat(experiments): add support for unique users and groups

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -11598,7 +11598,7 @@
             "type": "object"
         },
         "ExperimentMetricMathType": {
-            "enum": ["total", "sum", "unique_session", "min", "max", "avg", "hogql"],
+            "enum": ["total", "sum", "unique_session", "min", "max", "avg", "dau", "unique_group", "hogql"],
             "type": "string"
         },
         "ExperimentMetricOutlierHandling": {

--- a/frontend/src/scenes/experiments/metricQueryUtils.ts
+++ b/frontend/src/scenes/experiments/metricQueryUtils.ts
@@ -346,6 +346,7 @@ export function filterToMetricSource(
             math: events[0].math || ExperimentMetricMathType.TotalCount,
             math_property: events[0].math_property,
             math_hogql: events[0].math_hogql,
+            math_group_type_index: events[0].math_group_type_index,
             properties: events[0].properties,
         }
     }
@@ -358,6 +359,7 @@ export function filterToMetricSource(
             math: actions[0].math || ExperimentMetricMathType.TotalCount,
             math_property: actions[0].math_property,
             math_hogql: actions[0].math_hogql,
+            math_group_type_index: actions[0].math_group_type_index,
             properties: actions[0].properties,
         }
     }
@@ -373,6 +375,7 @@ export function filterToMetricSource(
             math: data_warehouse[0].math || ExperimentMetricMathType.TotalCount,
             math_property: data_warehouse[0].math_property,
             math_hogql: data_warehouse[0].math_hogql,
+            math_group_type_index: data_warehouse[0].math_group_type_index,
             properties: data_warehouse[0].properties,
         }
     }

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -564,6 +564,8 @@ export function getAllowedMathTypes(metricType: ExperimentMetricType): Experimen
             return [
                 ExperimentMetricMathType.TotalCount,
                 ExperimentMetricMathType.Sum,
+                ExperimentMetricMathType.UniqueUsers,
+                ExperimentMetricMathType.UniqueGroup,
                 ExperimentMetricMathType.Avg,
                 ExperimentMetricMathType.Min,
                 ExperimentMetricMathType.Max,
@@ -574,6 +576,8 @@ export function getAllowedMathTypes(metricType: ExperimentMetricType): Experimen
             return [
                 ExperimentMetricMathType.TotalCount,
                 ExperimentMetricMathType.Sum,
+                ExperimentMetricMathType.UniqueUsers,
+                ExperimentMetricMathType.UniqueGroup,
                 ExperimentMetricMathType.Avg,
                 ExperimentMetricMathType.Min,
                 ExperimentMetricMathType.Max,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4173,6 +4173,8 @@ export enum ExperimentMetricMathType {
     Min = 'min',
     Max = 'max',
     Avg = 'avg',
+    UniqueUsers = 'dau',
+    UniqueGroup = 'unique_group',
     HogQL = 'hogql',
 }
 

--- a/posthog/hogql_queries/experiments/base_query_utils.py
+++ b/posthog/hogql_queries/experiments/base_query_utils.py
@@ -575,9 +575,7 @@ def get_source_aggregation_expr(
             ExperimentMetricMathType.UNIQUE_GROUP,
         ]:
             # Clickhouse count NULL and empty values as distinct, so need to explicitly exclude them here
-            return parse_expr(
-                f"toFloat(countDistinctIf({table_alias}.value, {table_alias}.value is not null and {table_alias}.value != ''))"
-            )
+            return parse_expr(f"toFloat(countDistinctIf({table_alias}.value, notEmpty(toString({table_alias}.value))))")
         elif math_type == ExperimentMetricMathType.MIN:
             return parse_expr(f"min(coalesce(toFloat({table_alias}.value), 0))")
         elif math_type == ExperimentMetricMathType.MAX:

--- a/posthog/hogql_queries/experiments/base_query_utils.py
+++ b/posthog/hogql_queries/experiments/base_query_utils.py
@@ -87,6 +87,14 @@ def get_source_value_expr(source: Union[EventsNode, ActionsNode, ExperimentDataW
                 return ast.Call(name="toFloat", args=[ast.Field(chain=["properties", metric_property])])
         elif hasattr(source, "math") and source.math == ExperimentMetricMathType.UNIQUE_SESSION:
             return ast.Field(chain=["$session_id"])
+        elif hasattr(source, "math") and source.math == ExperimentMetricMathType.DAU:
+            return ast.Field(chain=["person_id"])
+        elif (
+            hasattr(source, "math")
+            and source.math == ExperimentMetricMathType.UNIQUE_GROUP
+            and source.math_group_type_index
+        ):
+            return ast.Field(chain=[f"$group_{int(source.math_group_type_index)}"])
         elif (
             hasattr(source, "math")
             and source.math == ExperimentMetricMathType.HOGQL
@@ -561,7 +569,11 @@ def get_source_aggregation_expr(
     """
     if isinstance(source, EventsNode) or isinstance(source, ActionsNode):
         math_type = getattr(source, "math", None)
-        if math_type == ExperimentMetricMathType.UNIQUE_SESSION:
+        if math_type in [
+            ExperimentMetricMathType.UNIQUE_SESSION,
+            ExperimentMetricMathType.DAU,
+            ExperimentMetricMathType.UNIQUE_GROUP,
+        ]:
             # Clickhouse count NULL and empty values as distinct, so need to explicitly exclude them here
             return parse_expr(
                 f"toFloat(countDistinctIf({table_alias}.value, {table_alias}.value is not null and {table_alias}.value != ''))"

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_base.ambr
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_base.ambr
@@ -2566,6 +2566,121 @@
                      allow_experimental_join_condition=1
   '''
 # ---
+# name: TestExperimentQueryRunner.test_query_runner_with_unique_group_metric
+  '''
+  SELECT metric_events.variant AS variant,
+         count(metric_events.entity_id) AS num_users,
+         sum(metric_events.value) AS total_sum,
+         sum(power(metric_events.value, 2)) AS total_sum_of_squares
+  FROM
+    (SELECT exposures.variant AS variant,
+            exposures.entity_id AS entity_id,
+            accurateCastOrNull(count(DISTINCT multiIf(and(ifNull(equals(toTypeName(metric_events.value), 'UUID'), 0), ifNull(equals(reinterpretAsUInt128(metric_events.value), 0), 0)), NULL, equals(toString(metric_events.value), ''), NULL, metric_events.value)), 'Float64') AS value
+     FROM
+       (SELECT if(less(toTimeZone(events.timestamp, 'UTC'), '2020-01-01 12:00:00'), '', events.`$group_0`) AS entity_id,
+               if(ifNull(greater(count(DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+               min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time
+        FROM events
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC')), equals(events.event, '$feature_flag_called'), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0))
+        GROUP BY entity_id) AS exposures
+     LEFT JOIN
+       (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp,
+               if(less(toTimeZone(events.timestamp, 'UTC'), '2020-01-01 12:00:00'), '', events.`$group_0`) AS entity_id,
+               exposure_data.variant AS variant,
+               events.event AS event,
+               1 AS value
+        FROM events
+        INNER JOIN
+          (SELECT if(less(toTimeZone(events.timestamp, 'UTC'), '2020-01-01 12:00:00'), '', events.`$group_0`) AS entity_id,
+                  if(ifNull(greater(count(DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+                  min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time
+           FROM events
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC')), equals(events.event, '$feature_flag_called'), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0))
+           GROUP BY entity_id) AS exposure_data ON equals(if(less(toTimeZone(events.timestamp, 'UTC'), '2020-01-01 12:00:00'), '', events.`$group_0`), exposure_data.entity_id)
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), exposure_data.first_exposure_time), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC')), equals(events.event, 'purchase'))) AS metric_events ON equals(toString(exposures.entity_id), toString(metric_events.entity_id))
+     GROUP BY exposures.variant,
+              exposures.entity_id) AS metric_events
+  GROUP BY metric_events.variant
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=600,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestExperimentQueryRunner.test_query_runner_with_unique_users_metric
+  '''
+  SELECT metric_events.variant AS variant,
+         count(metric_events.entity_id) AS num_users,
+         sum(metric_events.value) AS total_sum,
+         sum(power(metric_events.value, 2)) AS total_sum_of_squares
+  FROM
+    (SELECT exposures.variant AS variant,
+            exposures.entity_id AS entity_id,
+            accurateCastOrNull(count(DISTINCT multiIf(and(ifNull(equals(toTypeName(metric_events.value), 'UUID'), 0), ifNull(equals(reinterpretAsUInt128(metric_events.value), 0), 0)), NULL, ifNull(equals(toString(metric_events.value), ''), 0), NULL, metric_events.value)), 'Float64') AS value
+     FROM
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+               if(ifNull(greater(count(DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+               min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), equals(events.event, '$feature_flag_called'), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0))
+        GROUP BY entity_id) AS exposures
+     LEFT JOIN
+       (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp,
+               if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+               exposure_data.variant AS variant,
+               events.event AS event,
+               if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS value
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        INNER JOIN
+          (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+                  if(ifNull(greater(count(DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+                  min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time
+           FROM events
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), equals(events.event, '$feature_flag_called'), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0))
+           GROUP BY entity_id) AS exposure_data ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposure_data.entity_id)
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), exposure_data.first_exposure_time), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), equals(events.event, 'purchase'))) AS metric_events ON equals(toString(exposures.entity_id), toString(metric_events.entity_id))
+     GROUP BY exposures.variant,
+              exposures.entity_id) AS metric_events
+  GROUP BY metric_events.variant
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=600,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1
+  '''
+# ---
 # name: TestExperimentQueryRunner.test_query_runner_without_feature_flag_property
   '''
   SELECT metric_events.variant AS variant,

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_mean_metric.ambr
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_mean_metric.ambr
@@ -528,7 +528,7 @@
   FROM
     (SELECT exposures.variant AS variant,
             exposures.entity_id AS entity_id,
-            accurateCastOrNull(countDistinctIf(metric_events.value, and(isNotNull(metric_events.value), ifNull(notEquals(metric_events.value, ''), 1))), 'Float64') AS value
+            accurateCastOrNull(count(DISTINCT multiIf(and(ifNull(equals(toTypeName(metric_events.value), 'UUID'), 0), ifNull(equals(reinterpretAsUInt128(metric_events.value), 0), 0)), NULL, equals(toString(metric_events.value), ''), NULL, metric_events.value)), 'Float64') AS value
      FROM
        (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
                if(ifNull(greater(count(DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_ratio_metric.ambr
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_ratio_metric.ambr
@@ -315,7 +315,7 @@
      LEFT JOIN
        (SELECT exposures.variant AS variant,
                exposures.entity_id AS entity_id,
-               accurateCastOrNull(countDistinctIf(denominator_events.value, and(isNotNull(denominator_events.value), ifNull(notEquals(denominator_events.value, ''), 1))), 'Float64') AS denominator_value
+               accurateCastOrNull(count(DISTINCT multiIf(and(ifNull(equals(toTypeName(denominator_events.value), 'UUID'), 0), ifNull(equals(reinterpretAsUInt128(denominator_events.value), 0), 0)), NULL, equals(toString(denominator_events.value), ''), NULL, denominator_events.value)), 'Float64') AS denominator_value
         FROM
           (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
                   if(ifNull(greater(count(DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_base.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_base.py
@@ -1929,3 +1929,131 @@ class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
         # Test: sum(60, 80, 100) = 240
         self.assertEqual(test_variant.sum, 240)
         self.assertEqual(test_variant.number_of_samples, 3)
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    @snapshot_clickhouse_queries
+    def test_query_runner_with_unique_users_metric(self):
+        """Test basic structure for unique users metric."""
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(
+            feature_flag=feature_flag, start_date=datetime(2020, 1, 1), end_date=datetime(2020, 1, 10)
+        )
+        experiment.save()
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        metric = ExperimentMeanMetric(
+            source=EventsNode(
+                event="purchase",
+                math=ExperimentMetricMathType.DAU,
+            ),
+        )
+
+        experiment_query = ExperimentQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentQuery",
+            metric=metric,
+        )
+
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        # Create test data
+        person_number = 0
+        for variant, prices in [("control", [50, 75]), ("test", [60, 80, 100])]:
+            person_number += 1
+            for i, price in enumerate(prices):
+                _create_person(distinct_ids=[f"user_{variant}_{i}"], team_id=self.team.pk)
+                # Create exposure event
+                _create_event(
+                    team=self.team,
+                    event="$feature_flag_called",
+                    distinct_id=f"user_{variant}_{i}",
+                    timestamp="2020-01-02T12:00:00Z",
+                    properties={
+                        feature_flag_property: variant,
+                        "$feature_flag_response": variant,
+                        "$feature_flag": feature_flag.key,
+                    },
+                )
+                # Create purchase event
+                _create_event(
+                    team=self.team,
+                    event="purchase",
+                    distinct_id=f"user_{variant}_{i}",
+                    timestamp="2020-01-02T12:01:00Z",
+                    properties={
+                        feature_flag_property: variant,
+                        "price": price,
+                    },
+                )
+
+        flush_persons_and_events()
+
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+        result = query_runner.calculate()
+        assert result.variant_results is not None
+
+        self.assertEqual(len(result.variant_results), 1)
+
+        control_variant = result.baseline
+        assert control_variant is not None
+        test_variant = result.variant_results[0]
+        assert test_variant is not None
+
+        self.assertEqual(control_variant.sum, 2)
+        self.assertEqual(control_variant.number_of_samples, 2)
+
+        self.assertEqual(test_variant.sum, 3)
+        self.assertEqual(test_variant.number_of_samples, 3)
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    @snapshot_clickhouse_queries
+    def test_query_runner_with_unique_group_metric(self):
+        """Test unique group metric counts unique groups that performed the target event."""
+        feature_flag = self.create_feature_flag()
+        feature_flag.filters["aggregation_group_type_index"] = 0
+        feature_flag.save()
+        experiment = self.create_experiment(
+            feature_flag=feature_flag, start_date=datetime(2020, 1, 1), end_date=datetime(2020, 1, 10)
+        )
+        experiment.save()
+
+        metric = ExperimentMeanMetric(
+            source=EventsNode(
+                event="purchase",
+                math="unique_group",
+                math_group_type_index=0,
+            ),
+        )
+
+        experiment_query = ExperimentQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentQuery",
+            metric=metric,
+        )
+
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        create_standard_group_test_events(self.team, feature_flag)
+
+        flush_persons_and_events()
+
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+        result = query_runner.calculate()
+        assert result.variant_results is not None
+
+        self.assertEqual(len(result.variant_results), 1)
+
+        control_variant = result.baseline
+        assert control_variant is not None
+        test_variant = result.variant_results[0]
+        assert test_variant is not None
+
+        # Control: groups 0 and 1 have purchase events (first 6 users: 0→0, 1→1, 2→0, 3→1, 4→0, 5→1)
+        # Test: groups 2, 3, and 4 have purchase events (first 8 users: 0→2, 1→3, 2→4, 3→2, 4→3, 5→4, 6→2, 7→3)
+        self.assertEqual(control_variant.sum, 2)  # 2 unique groups with purchase events
+        self.assertEqual(control_variant.number_of_samples, 2)  # 2 unique groups exposed to control
+        self.assertEqual(test_variant.sum, 3)  # 3 unique groups with purchase events
+        self.assertEqual(test_variant.number_of_samples, 3)  # 3 unique groups exposed to test

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_base.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_base.py
@@ -2030,8 +2030,8 @@ class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
         test_variant = result.variant_results[0]
         assert test_variant is not None
 
-        # DAU should count unique users, not total events
-        # Control: 3 unique users (even though total events = 3+2+1 = 6)
+        # should count unique users, not total events
+        # Control: 2 unique users (even though total events = 2+1 = 3)
         self.assertEqual(control_variant.sum, 2)
         self.assertEqual(control_variant.number_of_samples, 3)
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1149,6 +1149,8 @@ class ExperimentMetricMathType(StrEnum):
     MIN = "min"
     MAX = "max"
     AVG = "avg"
+    DAU = "dau"
+    UNIQUE_GROUP = "unique_group"
     HOGQL = "hogql"
 
 


### PR DESCRIPTION
## Problem

We currently don't support counting unique users and groups in experiment metrics.

## Changes
<img width="276" height="353" alt="Screenshot 2025-08-27 at 4 02 25 PM" src="https://github.com/user-attachments/assets/783ce28c-a5a7-4427-87c1-d1d1ef879234" />

## How did you test this code?
- manually tested
- added new unit tests for the query runner to cover these cases
