### PR TITLE
feat(messaging): UX improvements to editor panel

### DIFF
--- a/products/messaging/frontend/Campaigns/campaignSceneLogic.ts
+++ b/products/messaging/frontend/Campaigns/campaignSceneLogic.ts
@@ -1,5 +1,5 @@
 import { actions, kea, path, props, reducers, selectors } from 'kea'
-import { actionToUrl, urlToAction } from 'kea-router'
+import { actionToUrl, router, urlToAction } from 'kea-router'
 
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
@@ -54,7 +54,13 @@ export const campaignSceneLogic = kea<campaignSceneLogicType>([
         ],
     }),
     actionToUrl(({ props, values }) => ({
-        setCurrentTab: () => [urls.messagingCampaign(props.id || 'new', values.currentTab)],
+        setCurrentTab: () => {
+            return [
+                urls.messagingCampaign(props.id || 'new', values.currentTab),
+                router.values.searchParams,
+                router.values.hashParams,
+            ]
+        },
     })),
     urlToAction(({ actions, values }) => ({
         '/messaging/campaigns/:id/:tab': ({ tab }) => {

--- a/products/messaging/frontend/Campaigns/hogflows/HogFlowEditorDetailsPanel.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/HogFlowEditorDetailsPanel.tsx
@@ -1,7 +1,7 @@
-import { getOutgoers, useReactFlow } from '@xyflow/react'
+import { useReactFlow } from '@xyflow/react'
 import { useActions, useValues } from 'kea'
 
-import { IconExternal, IconTrash, IconX } from '@posthog/icons'
+import { IconExternal } from '@posthog/icons'
 import { LemonButton, LemonDivider, LemonLabel, LemonSwitch } from '@posthog/lemon-ui'
 
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
@@ -24,47 +24,11 @@ export function HogFlowEditorDetailsPanel(): JSX.Element | null {
         return null
     }
 
-    const canBeDeleted = (): boolean => {
-        const outgoingNodes = getOutgoers(selectedNode, nodes, edges)
-        if (outgoingNodes.length === 1) {
-            return true
-        }
-
-        return new Set(outgoingNodes.map((node) => node.id)).size === 1
-    }
-
     const action = selectedNode.data
     const Step = getHogFlowStep(action.type)
 
     return (
-        <div className="flex flex-col h-full w-140 overflow-hidden">
-            <div className="flex justify-between items-center px-2 my-2">
-                <h3 className="flex gap-1 items-center mb-0 font-semibold">
-                    <span className="text-lg">{Step?.icon}</span> Edit {selectedNode.data.name} step
-                </h3>
-                <div className="flex gap-1 items-center">
-                    {selectedNode.deletable && (
-                        <LemonButton
-                            size="xsmall"
-                            status="danger"
-                            onClick={() => {
-                                void deleteElements({ nodes: [selectedNode] })
-                                setSelectedNodeId(null)
-                            }}
-                            icon={<IconTrash />}
-                            disabledReason={canBeDeleted() ? undefined : 'Clean up branching steps first'}
-                        />
-                    )}
-                    <LemonButton
-                        size="xsmall"
-                        icon={<IconX />}
-                        onClick={() => setSelectedNodeId(null)}
-                        aria-label="close"
-                    />
-                </div>
-            </div>
-            <LemonDivider className="my-0" />
-
+        <div className="flex flex-col h-full overflow-hidden">
             <ScrollableShadows
                 direction="vertical"
                 className="flex-1 min-h-0"

--- a/products/messaging/frontend/Campaigns/hogflows/HogFlowEditorDetailsPanel.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/HogFlowEditorDetailsPanel.tsx
@@ -1,4 +1,3 @@
-import { useReactFlow } from '@xyflow/react'
 import { useActions, useValues } from 'kea'
 
 import { IconExternal } from '@posthog/icons'
@@ -15,10 +14,8 @@ import { isOptOutEligibleAction } from './steps/types'
 import { HogFlowAction } from './types'
 
 export function HogFlowEditorDetailsPanel(): JSX.Element | null {
-    const { selectedNode, nodes, edges, categories, categoriesLoading } = useValues(hogFlowEditorLogic)
-    const { setSelectedNodeId, setCampaignAction } = useActions(hogFlowEditorLogic)
-
-    const { deleteElements } = useReactFlow()
+    const { selectedNode, categories, categoriesLoading } = useValues(hogFlowEditorLogic)
+    const { setCampaignAction } = useActions(hogFlowEditorLogic)
 
     if (!selectedNode) {
         return null

--- a/products/messaging/frontend/Campaigns/hogflows/HogFlowEditorRightPanel.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/HogFlowEditorRightPanel.tsx
@@ -75,15 +75,3 @@ export function HogFlowEditorRightPanel(): JSX.Element | null {
         </HogFlowEditorPanel>
     )
 }
-// {selectedNode.deletable && (
-//     <LemonButton
-//         size="xsmall"
-//         status="danger"
-//         onClick={() => {
-//             void deleteElements({ nodes: [selectedNode] })
-//             setSelectedNodeId(null)
-//         }}
-//         icon={<IconTrash />}
-//         disabledReason={canBeDeleted() ? undefined : 'Clean up branching steps first'}
-//     />
-// )}

--- a/products/messaging/frontend/Campaigns/hogflows/HogFlowEditorRightPanel.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/HogFlowEditorRightPanel.tsx
@@ -1,35 +1,89 @@
+import { useReactFlow } from '@xyflow/react'
+import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 
-import { LemonTab, LemonTabs } from '@posthog/lemon-ui'
+import { IconArrowLeft, IconTrash } from '@posthog/icons'
+import { LemonButton, LemonTab, LemonTabs } from '@posthog/lemon-ui'
 
 import { HogFlowEditorDetailsPanel } from './HogFlowEditorDetailsPanel'
 import { HogFlowEditorToolbar } from './HogFlowEditorToolbar'
 import { HogFlowEditorPanel } from './components/HogFlowEditorPanel'
 import { HogFlowEditorMode, hogFlowEditorLogic } from './hogFlowEditorLogic'
+import { getHogFlowStep } from './steps/HogFlowSteps'
 import { HogFlowEditorTestPanel, HogFlowTestPanelNonSelected } from './testing/HogFlowEditorTestPanel'
 
 export function HogFlowEditorRightPanel(): JSX.Element | null {
-    const { selectedNode, mode } = useValues(hogFlowEditorLogic)
-    const { setMode } = useActions(hogFlowEditorLogic)
+    const { selectedNode, mode, selectedNodeCanBeDeleted } = useValues(hogFlowEditorLogic)
+    const { setMode, setSelectedNodeId } = useActions(hogFlowEditorLogic)
+    const { deleteElements } = useReactFlow()
 
     const tabs: LemonTab<HogFlowEditorMode>[] = [
         { label: 'Build', key: 'build' },
         { label: 'Test', key: 'test' },
     ]
 
-    return (
-        <HogFlowEditorPanel position="right-top">
-            {!selectedNode ? (
-                <>
-                    <LemonTabs activeKey={mode} onChange={(key) => setMode(key)} tabs={tabs} barClassName="mb-0 pl-3" />
+    let width = selectedNode ? '36rem' : '22rem'
+    if (mode === 'test') {
+        width = '36rem'
+    }
 
-                    {mode === 'test' ? <HogFlowTestPanelNonSelected /> : <HogFlowEditorToolbar />}
-                </>
-            ) : mode === 'build' ? (
-                <HogFlowEditorDetailsPanel />
-            ) : (
-                <HogFlowEditorTestPanel />
-            )}
+    const Step = selectedNode ? getHogFlowStep(selectedNode.data.type) : null
+
+    return (
+        <HogFlowEditorPanel position="right-top" width={width}>
+            <div className="flex gap-2 border-b items-center">
+                <div
+                    className={clsx(
+                        'transition-all overflow-hidden flex p-1',
+                        !selectedNode ? 'w-2 opacity-0' : 'w-10 opacity-100'
+                    )}
+                >
+                    <LemonButton
+                        size="small"
+                        icon={<IconArrowLeft />}
+                        onClick={() => setSelectedNodeId(null)}
+                        disabled={!selectedNode}
+                    />
+                </div>
+
+                <div className="flex-1">
+                    <LemonTabs activeKey={mode} onChange={(key) => setMode(key)} tabs={tabs} barClassName="-mb-px " />
+                </div>
+
+                {selectedNode && (
+                    <span className="flex gap-1 items-center font-medium rounded-md mr-3">
+                        <span className="text-lg">{Step?.icon}</span>
+                        <span className="font-semibold">{selectedNode.data.name}</span> step
+                        {selectedNode.deletable && (
+                            <LemonButton
+                                size="xsmall"
+                                status="danger"
+                                icon={<IconTrash />}
+                                onClick={() => {
+                                    void deleteElements({ nodes: [selectedNode] })
+                                    setSelectedNodeId(null)
+                                }}
+                                disabledReason={selectedNodeCanBeDeleted ? undefined : 'Clean up branching steps first'}
+                            />
+                        )}
+                    </span>
+                )}
+            </div>
+
+            {mode === 'build' && <>{!selectedNode ? <HogFlowEditorToolbar /> : <HogFlowEditorDetailsPanel />}</>}
+            {mode === 'test' && <>{!selectedNode ? <HogFlowTestPanelNonSelected /> : <HogFlowEditorTestPanel />}</>}
         </HogFlowEditorPanel>
     )
 }
+// {selectedNode.deletable && (
+//     <LemonButton
+//         size="xsmall"
+//         status="danger"
+//         onClick={() => {
+//             void deleteElements({ nodes: [selectedNode] })
+//             setSelectedNodeId(null)
+//         }}
+//         icon={<IconTrash />}
+//         disabledReason={canBeDeleted() ? undefined : 'Clean up branching steps first'}
+//     />
+// )}

--- a/products/messaging/frontend/Campaigns/hogflows/components/HogFlowEditorPanel.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/components/HogFlowEditorPanel.tsx
@@ -10,23 +10,21 @@ export function HogFlowEditorPanel({ position, children, width }: HogFlowEditorP
     return (
         <div
             className={clsx(
-                'react-flow__panel flex flex-col top-2 bottom-2 right-2 m-0 pb-2 overflow-hidden transition-[width]',
+                'absolute flex flex-col m-0 p-2 overflow-hidden transition-[width] max-h-full right-0',
                 position.includes('right') ? 'right' : 'left',
                 position.includes('bottom') ? 'justify-end' : 'justify-start'
             )}
             style={{ width }}
         >
-            <div className="relative flex flex-col z-10 rounded bg-surface-primary max-h-full">
-                <div
-                    className="flex flex-col rounded-md overflow-hidden"
-                    style={{
-                        border: '1px solid var(--border)',
-                        boxShadow: '0 3px 0 var(--border)',
-                        zIndex: 0,
-                    }}
-                >
-                    {children}
-                </div>
+            <div
+                className="relative flex flex-col rounded-md overflow-hidden bg-surface-primary max-h-full z-10"
+                style={{
+                    border: '1px solid var(--border)',
+                    boxShadow: '0 3px 0 var(--border)',
+                    zIndex: 0,
+                }}
+            >
+                {children}
             </div>
         </div>
     )

--- a/products/messaging/frontend/Campaigns/hogflows/components/HogFlowEditorPanel.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/components/HogFlowEditorPanel.tsx
@@ -10,8 +10,8 @@ export function HogFlowEditorPanel({ position, children, width }: HogFlowEditorP
     return (
         <div
             className={clsx(
-                'absolute flex flex-col m-0 p-2 overflow-hidden transition-[width] max-h-full right-0',
-                position.includes('right') ? 'right' : 'left',
+                'absolute flex flex-col m-0 p-2 overflow-hidden transition-[width] max-h-full',
+                position.includes('right') ? 'right-0' : 'left-0',
                 position.includes('bottom') ? 'justify-end' : 'justify-start'
             )}
             style={{ width }}

--- a/products/messaging/frontend/Campaigns/hogflows/components/HogFlowEditorPanel.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/components/HogFlowEditorPanel.tsx
@@ -3,16 +3,18 @@ import clsx from 'clsx'
 export type HogFlowEditorPanelProps = {
     position: 'right-bottom' | 'left-bottom' | 'right-top' | 'left-top'
     children: React.ReactNode
+    width?: number | string
 }
 
-export function HogFlowEditorPanel({ position, children }: HogFlowEditorPanelProps): JSX.Element {
+export function HogFlowEditorPanel({ position, children, width }: HogFlowEditorPanelProps): JSX.Element {
     return (
         <div
             className={clsx(
-                'react-flow__panel flex flex-col top-2 bottom-2 right-2 m-0 pb-2 overflow-hidden',
+                'react-flow__panel flex flex-col top-2 bottom-2 right-2 m-0 pb-2 overflow-hidden transition-[width]',
                 position.includes('right') ? 'right' : 'left',
                 position.includes('bottom') ? 'justify-end' : 'justify-start'
             )}
+            style={{ width }}
         >
             <div className="relative flex flex-col z-10 rounded bg-surface-primary max-h-full">
                 <div

--- a/products/messaging/frontend/Campaigns/hogflows/hogFlowEditorLogic.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/hogFlowEditorLogic.tsx
@@ -411,20 +411,27 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
         },
     })),
 
-    actionToUrl(({ values }) => ({
-        setSelectedNodeId: () => {
-            console.log('setSelectedNodeId', values.selectedNodeId)
+    actionToUrl(({ values }) => {
+        const syncProperty = (
+            key: string,
+            value: string | null
+        ): [string, Record<string, any>, Record<string, any>] => {
             return [
                 router.values.location.pathname,
                 {
                     ...router.values.searchParams,
-                    selectedNodeId: values.selectedNodeId,
+                    [key]: value,
                 },
                 router.values.hashParams,
             ]
-        },
-    })),
-    urlToAction(({ actions, values }) => {
+        }
+
+        return {
+            setSelectedNodeId: () => syncProperty('selectedNodeId', values.selectedNodeId ?? null),
+            setMode: () => syncProperty('mode', values.mode),
+        }
+    }),
+    urlToAction(({ actions }) => {
         const reactToTabChange = (_: any, search: Record<string, string>): void => {
             actions.setSelectedNodeId(search.selectedNodeId ?? null)
         }

--- a/products/messaging/frontend/Campaigns/hogflows/hogFlowEditorLogic.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/hogFlowEditorLogic.tsx
@@ -144,6 +144,21 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
                 return nodes.find((node) => node.id === selectedNodeId) ?? null
             },
         ],
+        selectedNodeCanBeDeleted: [
+            (s) => [s.selectedNode, s.nodes, s.edges],
+            (selectedNode, nodes, edges) => {
+                if (!selectedNode) {
+                    return false
+                }
+
+                const outgoingNodes = getOutgoers(selectedNode, nodes, edges)
+                if (outgoingNodes.length === 1) {
+                    return true
+                }
+
+                return new Set(outgoingNodes.map((node) => node.id)).size === 1
+            },
+        ],
     }),
     listeners(({ values, actions }) => ({
         onEdgesChange: ({ edges }) => {

--- a/products/messaging/frontend/Campaigns/hogflows/hogFlowEditorLogic.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/hogFlowEditorLogic.tsx
@@ -1,6 +1,8 @@
 import {
+    Edge,
     EdgeChange,
     MarkerType,
+    Node,
     NodeChange,
     Position,
     ReactFlowInstance,
@@ -8,14 +10,15 @@ import {
     applyNodeChanges,
     getOutgoers,
 } from '@xyflow/react'
-import { Edge, Node } from '@xyflow/react'
 import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actionToUrl, router, urlToAction } from 'kea-router'
 import { subscriptions } from 'kea-subscriptions'
 import type { DragEvent } from 'react'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
 import { uuid } from 'lib/utils'
+import { urls } from 'scenes/urls'
 
 import { optOutCategoriesLogic } from '../../OptOuts/optOutCategoriesLogic'
 import { CampaignLogicProps, campaignLogic } from '../campaignLogic'
@@ -407,4 +410,28 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
             }
         },
     })),
+
+    actionToUrl(({ values }) => ({
+        setSelectedNodeId: () => {
+            console.log('setSelectedNodeId', values.selectedNodeId)
+            return [
+                router.values.location.pathname,
+                {
+                    ...router.values.searchParams,
+                    selectedNodeId: values.selectedNodeId,
+                },
+                router.values.hashParams,
+            ]
+        },
+    })),
+    urlToAction(({ actions, values }) => {
+        const reactToTabChange = (_: any, search: Record<string, string>): void => {
+            actions.setSelectedNodeId(search.selectedNodeId ?? null)
+        }
+
+        return {
+            // All possible routes for this scene need to be listed here
+            [urls.messagingCampaign(':id', ':tab')]: reactToTabChange,
+        }
+    }),
 ])

--- a/products/messaging/frontend/Campaigns/hogflows/hogFlowEditorLogic.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/hogFlowEditorLogic.tsx
@@ -32,7 +32,8 @@ import type { HogFlow, HogFlowAction, HogFlowActionNode } from './types'
 
 const getEdgeId = (edge: HogFlow['edges'][number]): string => `${edge.from}->${edge.to} ${edge.index ?? ''}`.trim()
 
-export type HogFlowEditorMode = 'build' | 'test'
+export const HOG_FLOW_EDITOR_MODES = ['build', 'test'] as const
+export type HogFlowEditorMode = (typeof HOG_FLOW_EDITOR_MODES)[number]
 
 export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
     props({} as CampaignLogicProps),
@@ -448,11 +449,14 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
     }),
     urlToAction(({ actions }) => {
         const reactToTabChange = (_: any, search: Record<string, string>): void => {
-            actions.setSelectedNodeId(search.selectedNodeId ?? null)
+            const { selectedNodeId, mode } = search
+            actions.setSelectedNodeId(selectedNodeId ?? null)
+            if (mode && HOG_FLOW_EDITOR_MODES.includes(mode as HogFlowEditorMode)) {
+                actions.setMode(mode as HogFlowEditorMode)
+            }
         }
 
         return {
-            // All possible routes for this scene need to be listed here
             [urls.messagingCampaign(':id', ':tab')]: reactToTabChange,
         }
     }),

--- a/products/messaging/frontend/Campaigns/hogflows/steps/components/StepView.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/steps/components/StepView.tsx
@@ -1,4 +1,3 @@
-import clsx from 'clsx'
 import { useValues } from 'kea'
 
 import { NODE_HEIGHT, NODE_WIDTH } from '../../constants'
@@ -14,9 +13,7 @@ export function StepView({ action, children }: { action: HogFlowAction; children
 
     return (
         <div
-            className={clsx(
-                'relative flex cursor-pointer rounded pointer-events-none bg-surface-primary hover:bg-surface-secondary'
-            )}
+            className="relative flex cursor-pointer rounded pointer-events-none bg-surface-primary hover:bg-surface-secondary"
             style={{
                 width: NODE_WIDTH,
                 height: NODE_HEIGHT,

--- a/products/messaging/frontend/Campaigns/hogflows/steps/components/StepView.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/steps/components/StepView.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx'
 import { useValues } from 'kea'
 
 import { NODE_HEIGHT, NODE_WIDTH } from '../../constants'
@@ -13,11 +14,19 @@ export function StepView({ action, children }: { action: HogFlowAction; children
 
     return (
         <div
-            className="relative flex cursor-pointer rounded pointer-events-none bg-surface-primary hover:bg-surface-secondary"
+            className={clsx(
+                'relative flex cursor-pointer rounded pointer-events-none bg-surface-primary hover:bg-surface-secondary'
+            )}
             style={{
                 width: NODE_WIDTH,
                 height: NODE_HEIGHT,
-                border: `${isSelected ? '1px' : '0.5px'} solid var(--border)`,
+                border: Step?.color
+                    ? isSelected
+                        ? `${Step?.color} solid 1px`
+                        : `${Step?.color}20 solid 1px`
+                    : isSelected
+                      ? 'var(--border-primary) solid 1px'
+                      : 'var(--border) solid 1px',
                 boxShadow: `0px 2px 0px 0px ${Step?.color ? `${Step.color}20` : 'var(--border-primary)'}`,
                 zIndex: 0,
             }}

--- a/products/messaging/frontend/Campaigns/hogflows/testing/HogFlowEditorTestPanel.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/testing/HogFlowEditorTestPanel.tsx
@@ -21,7 +21,6 @@ import { urls } from 'scenes/urls'
 
 import { campaignLogic } from '../../campaignLogic'
 import { hogFlowEditorLogic } from '../hogFlowEditorLogic'
-import { getHogFlowStep } from '../steps/HogFlowSteps'
 import { hogFlowEditorTestLogic } from './hogFlowEditorTestLogic'
 
 export function HogFlowTestPanelNonSelected(): JSX.Element {
@@ -36,7 +35,6 @@ export function HogFlowTestPanelNonSelected(): JSX.Element {
 
 export function HogFlowEditorTestPanel(): JSX.Element | null {
     const { selectedNode } = useValues(hogFlowEditorLogic)
-    const { setSelectedNodeId } = useActions(hogFlowEditorLogic)
     const { logicProps } = useValues(campaignLogic)
     const { sampleGlobals, isTestInvocationSubmitting, testResult, shouldLoadSampleGlobals } = useValues(
         hogFlowEditorTestLogic(logicProps)
@@ -50,8 +48,6 @@ export function HogFlowEditorTestPanel(): JSX.Element | null {
         // NOTE: This shouldn't ever happen as the parent checks it
         return null
     }
-
-    const Step = getHogFlowStep(selectedNode.data.type)
 
     return (
         <Form

--- a/products/messaging/frontend/Campaigns/hogflows/testing/HogFlowEditorTestPanel.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/testing/HogFlowEditorTestPanel.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 
-import { IconInfo, IconPlay, IconRedo, IconTestTube, IconX } from '@posthog/icons'
+import { IconInfo, IconPlay, IconRedo } from '@posthog/icons'
 import {
     LemonBanner,
     LemonButton,
@@ -26,7 +26,7 @@ import { hogFlowEditorTestLogic } from './hogFlowEditorTestLogic'
 
 export function HogFlowTestPanelNonSelected(): JSX.Element {
     return (
-        <div className="p-2 w-120">
+        <div className="p-2">
             <div className="p-8 text-center rounded border bg-surface-secondary">
                 <div className="text-muted">Please select a node...</div>
             </div>
@@ -59,25 +59,8 @@ export function HogFlowEditorTestPanel(): JSX.Element | null {
             props={logicProps}
             formKey="testInvocation"
             enableFormOnSubmit
-            className="flex overflow-hidden flex-col flex-1 w-180"
+            className="flex overflow-hidden flex-col flex-1"
         >
-            {/* Header */}
-            <div className="flex justify-between items-center px-2 my-2 w-full">
-                <h3 className="flex gap-1 items-center mb-0 font-semibold">
-                    <IconTestTube className="text-lg" />
-                    Testing - <span className="text-lg">{Step?.icon}</span> {selectedNode.data.name}
-                </h3>
-                <div className="flex gap-2 items-center">
-                    <LemonButton
-                        size="xsmall"
-                        icon={<IconX />}
-                        onClick={() => setSelectedNodeId(null)}
-                        aria-label="close"
-                    />
-                </div>
-            </div>
-
-            <LemonDivider className="my-0" />
             {/* Body */}
             <div className="flex overflow-y-auto flex-col flex-1 gap-2 p-2">
                 {/* Event Information */}

--- a/products/messaging/frontend/MessagingScene.tsx
+++ b/products/messaging/frontend/MessagingScene.tsx
@@ -65,7 +65,6 @@ export const messagingSceneLogic = kea<messagingSceneLogicType>([
     }),
     urlToAction(({ actions, values }) => {
         return {
-            // All possible routes for this scene need to be listed here
             [urls.messaging(':tab' as MessagingSceneTab)]: ({ tab }) => {
                 let possibleTab: MessagingSceneTab = (tab as MessagingSceneTab) ?? 'campaigns'
                 possibleTab = MESSAGING_SCENE_TABS.includes(possibleTab) ? possibleTab : 'campaigns'


### PR DESCRIPTION
## Problem

UX work to enable adding a 3rd tab for metrics & logs

## Changes

- [x] It was annoying to swap between building and testing (and soon logs and metrics...) so moved the header to always be present with the options and a little indicator for the selected node
- [x] Made the selection of a node way more obvious with brighter selection line
- [x] Added selection and mode to url params tracking (reloading stays where you were and allows us to link back and forth between the other tabs
- [x] Changed the widths and added a small transition to make it less janky
- [x] Fixed the layout issues so now there isnt an invisible window blocking clicks 

 
![2025-08-29 11 01 10](https://github.com/user-attachments/assets/ab4e2e82-008f-4f03-a8ab-20a48e2bd8ab)


| Before | After |
|-----|-----|
| <img width="614" height="417" alt="Screenshot 2025-08-29 at 11 02 45" src="https://github.com/user-attachments/assets/493087af-240e-42bf-b912-b8a19067d36c" /> | <img width="518" height="417" alt="Screenshot 2025-08-29 at 11 01 27" src="https://github.com/user-attachments/assets/49ed2f28-e3e0-4f79-9641-d4cf95306a67" /> |
| <img width="612" height="331" alt="Screenshot 2025-08-29 at 11 02 56" src="https://github.com/user-attachments/assets/967304e1-20c6-4150-8937-6e263de35cdb" /> | <img width="588" height="366" alt="Screenshot 2025-08-29 at 11 00 54" src="https://github.com/user-attachments/assets/82387eb4-0b5b-4200-b099-e3a2e3d059b2" />|







<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
