### PR TITLE
chore(hogql): Add a kill switch for global joins

### DIFF
--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -35,7 +35,7 @@ from posthog.models.utils import UUIDT
 
 # https://github.com/ClickHouse/ClickHouse/issues/23194 - "Describe how identifiers in SELECT queries are resolved"
 
-# To quickly diable global joins, switch this to False
+# To quickly disable global joins, switch this to False
 USE_GLOBAL_JOINS = True
 
 

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -35,6 +35,9 @@ from posthog.models.utils import UUIDT
 
 # https://github.com/ClickHouse/ClickHouse/issues/23194 - "Describe how identifiers in SELECT queries are resolved"
 
+# To quickly diable global joins, switch this to False
+USE_GLOBAL_JOINS = True
+
 
 def resolve_constant_data_type(constant: Any) -> ConstantType:
     if constant is None:
@@ -365,35 +368,36 @@ class Resolver(CloningVisitor):
             node.next_join = self.visit(node.next_join)
 
             # Look ahead if current is events table and next is s3 table, global join must be used for distributed query on external data to work
-            global_table: ast.TableType | None = None
+            if USE_GLOBAL_JOINS:
+                global_table: ast.TableType | None = None
 
-            if isinstance(node.type, ast.TableAliasType) and isinstance(node.type.table_type, ast.TableType):
-                global_table = node.type.table_type
-            elif isinstance(node.type, ast.TableType):
-                global_table = node.type
+                if isinstance(node.type, ast.TableAliasType) and isinstance(node.type.table_type, ast.TableType):
+                    global_table = node.type.table_type
+                elif isinstance(node.type, ast.TableType):
+                    global_table = node.type
 
-            if global_table and isinstance(global_table.table, EventsTable):
-                next_join = node.next_join
-                is_global = False
-
-                while next_join:
-                    if self._is_next_s3(next_join):
-                        is_global = True
-                    # Use GLOBAL joins for nested subqueries for S3 tables until https://github.com/ClickHouse/ClickHouse/pull/85839 is in
-                    elif isinstance(next_join.type, ast.SelectQueryAliasType):
-                        select_query_type = next_join.type.select_query_type
-                        tables = self._extract_tables_from_query_type(select_query_type)
-                        if any(self._is_s3_table(table) for table in tables):
-                            is_global = True
-
-                    next_join = next_join.next_join
-
-                # If there exists a S3 table in the chain, then all joins require to be a GLOBAL join
-                if is_global:
+                if global_table and isinstance(global_table.table, EventsTable):
                     next_join = node.next_join
+                    is_global = False
+
                     while next_join:
-                        next_join.join_type = f"GLOBAL {next_join.join_type}"
+                        if self._is_next_s3(next_join):
+                            is_global = True
+                        # Use GLOBAL joins for nested subqueries for S3 tables until https://github.com/ClickHouse/ClickHouse/pull/85839 is in
+                        elif isinstance(next_join.type, ast.SelectQueryAliasType):
+                            select_query_type = next_join.type.select_query_type
+                            tables = self._extract_tables_from_query_type(select_query_type)
+                            if any(self._is_s3_table(table) for table in tables):
+                                is_global = True
+
                         next_join = next_join.next_join
+
+                    # If there exists a S3 table in the chain, then all joins require to be a GLOBAL join
+                    if is_global:
+                        next_join = node.next_join
+                        while next_join:
+                            next_join.join_type = f"GLOBAL {next_join.join_type}"
+                            next_join = next_join.next_join
 
             if node.constraint and node.constraint.constraint_type == "ON":
                 node.constraint = self.visit_join_constraint(node.constraint)
@@ -868,7 +872,8 @@ class Resolver(CloningVisitor):
         node.type = ast.BooleanType(nullable=False)
 
         if (
-            (node.op == ast.CompareOperationOp.In or node.op == ast.CompareOperationOp.NotIn)
+            USE_GLOBAL_JOINS
+            and (node.op == ast.CompareOperationOp.In or node.op == ast.CompareOperationOp.NotIn)
             and self._is_events_table(node.left)
             and self._is_s3_cluster(node.right)
         ):

--- a/posthog/hogql/test/__snapshots__/test_printer.ambr
+++ b/posthog/hogql/test/__snapshots__/test_printer.ambr
@@ -70,18 +70,33 @@
   LIMIT 50000
   '''
 # ---
-# name: TestPrinter.test_s3_tables_global_join_anonymous_tables
+# name: TestPrinter.test_s3_tables_global_join_anonymous_tables_0
   "SELECT e.event AS event, ij.remote_id AS remote_id FROM events AS e GLOBAL INNER JOIN (SELECT person_id AS person_id, remote_id AS remote_id FROM (SELECT p.id AS person_id, rt.id AS remote_id FROM (SELECT person.id AS id FROM person WHERE equals(person.team_id, 99999) GROUP BY person.id HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, %(hogql_val_0)s), person.version), plus(now64(6, %(hogql_val_1)s), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS p LEFT JOIN (SELECT test_table.id AS id FROM s3(%(hogql_val_2_sensitive)s, %(hogql_val_4_sensitive)s, %(hogql_val_5_sensitive)s, 'Parquet', %(hogql_val_3)s) AS test_table) AS rt ON equals(rt.id, p.id))) AS ij ON equals(e.event, ij.remote_id) WHERE equals(e.team_id, 99999) LIMIT 50000"
 # ---
-# name: TestPrinter.test_s3_tables_global_join_with_cte
+# name: TestPrinter.test_s3_tables_global_join_anonymous_tables_1
+  "SELECT e.event AS event, ij.remote_id AS remote_id FROM events AS e INNER JOIN (SELECT person_id AS person_id, remote_id AS remote_id FROM (SELECT p.id AS person_id, rt.id AS remote_id FROM (SELECT person.id AS id FROM person WHERE equals(person.team_id, 99999) GROUP BY person.id HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, %(hogql_val_0)s), person.version), plus(now64(6, %(hogql_val_1)s), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS p LEFT JOIN (SELECT test_table.id AS id FROM s3(%(hogql_val_2_sensitive)s, %(hogql_val_4_sensitive)s, %(hogql_val_5_sensitive)s, 'Parquet', %(hogql_val_3)s) AS test_table) AS rt ON equals(rt.id, p.id))) AS ij ON equals(e.event, ij.remote_id) WHERE equals(e.team_id, 99999) LIMIT 50000"
+# ---
+# name: TestPrinter.test_s3_tables_global_join_with_cte_0
   "SELECT events.event AS event FROM events GLOBAL JOIN (SELECT test_table.id AS id FROM s3(%(hogql_val_0_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_3_sensitive)s, 'Parquet', %(hogql_val_1)s) AS test_table) AS some_remote_table ON equals(events.event, toString(some_remote_table.id)) WHERE equals(events.team_id, 99999) LIMIT 50000"
 # ---
-# name: TestPrinter.test_s3_tables_global_join_with_cte_nested
+# name: TestPrinter.test_s3_tables_global_join_with_cte_1
+  "SELECT events.event AS event FROM events JOIN (SELECT test_table.id AS id FROM s3(%(hogql_val_0_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_3_sensitive)s, 'Parquet', %(hogql_val_1)s) AS test_table) AS some_remote_table ON equals(events.event, toString(some_remote_table.id)) WHERE equals(events.team_id, 99999) LIMIT 50000"
+# ---
+# name: TestPrinter.test_s3_tables_global_join_with_cte_nested_0
   "SELECT some_remote_table.event AS event FROM events GLOBAL JOIN (SELECT e.event AS event, t.id AS id FROM events AS e GLOBAL JOIN (SELECT * FROM s3(%(hogql_val_0_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_3_sensitive)s, 'Parquet', %(hogql_val_1)s)) AS t ON equals(toString(t.id), e.event) WHERE equals(e.team_id, 99999)) AS some_remote_table ON equals(events.event, toString(some_remote_table.id)) WHERE equals(events.team_id, 99999) LIMIT 50000"
 # ---
-# name: TestPrinter.test_s3_tables_global_join_with_in_and_property_type
+# name: TestPrinter.test_s3_tables_global_join_with_cte_nested_1
+  "SELECT some_remote_table.event AS event FROM events JOIN (SELECT e.event AS event, t.id AS id FROM events AS e JOIN (SELECT * FROM s3(%(hogql_val_0_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_3_sensitive)s, 'Parquet', %(hogql_val_1)s)) AS t ON equals(toString(t.id), e.event) WHERE equals(e.team_id, 99999)) AS some_remote_table ON equals(events.event, toString(some_remote_table.id)) WHERE equals(events.team_id, 99999) LIMIT 50000"
+# ---
+# name: TestPrinter.test_s3_tables_global_join_with_in_and_property_type_0
   'SELECT events.event AS event FROM events WHERE and(equals(events.team_id, 99999), ifNull(globalIn(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), \'\'), \'null\'), \'^"|"$\', \'\'), (SELECT test_table.id AS id FROM s3(%(hogql_val_1_sensitive)s, %(hogql_val_3_sensitive)s, %(hogql_val_4_sensitive)s, \'Parquet\', %(hogql_val_2)s) AS test_table)), 0)) LIMIT 50000'
 # ---
-# name: TestPrinter.test_s3_tables_global_join_with_multiple_joins
+# name: TestPrinter.test_s3_tables_global_join_with_in_and_property_type_1
+  'SELECT events.event AS event FROM events WHERE and(equals(events.team_id, 99999), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), \'\'), \'null\'), \'^"|"$\', \'\'), (SELECT test_table.id AS id FROM s3(%(hogql_val_1_sensitive)s, %(hogql_val_3_sensitive)s, %(hogql_val_4_sensitive)s, \'Parquet\', %(hogql_val_2)s) AS test_table))) LIMIT 50000'
+# ---
+# name: TestPrinter.test_s3_tables_global_join_with_multiple_joins_0
   "SELECT e.event, s.event AS event, t.id AS id FROM events AS e GLOBAL JOIN (SELECT events.event AS event FROM events WHERE equals(events.team_id, 99999)) AS s ON equals(e.event, s.event) GLOBAL LEFT JOIN (SELECT * FROM s3(%(hogql_val_0_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_3_sensitive)s, 'Parquet', %(hogql_val_1)s)) AS t ON equals(e.event, toString(t.id)) WHERE equals(e.team_id, 99999) LIMIT 50000"
+# ---
+# name: TestPrinter.test_s3_tables_global_join_with_multiple_joins_1
+  "SELECT e.event, s.event AS event, t.id AS id FROM events AS e JOIN (SELECT events.event AS event FROM events WHERE equals(events.team_id, 99999)) AS s ON equals(e.event, s.event) LEFT JOIN s3(%(hogql_val_0_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_3_sensitive)s, 'Parquet', %(hogql_val_1)s) AS t ON equals(e.event, toString(t.id)) WHERE equals(e.team_id, 99999) LIMIT 50000"
 # ---

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -4,9 +4,12 @@ from typing import Any, Literal, Optional, cast
 
 import pytest
 from posthog.test.base import APIBaseTest, BaseTest, _create_event, clean_varying_query_parts, materialized
+from unittest import mock
 from unittest.mock import patch
 
 from django.test import override_settings
+
+from parameterized import parameterized
 
 from posthog.schema import (
     HogQLQueryModifiers,
@@ -2495,126 +2498,162 @@ class TestPrinter(BaseTest):
                 dialect="clickhouse",
             )
 
+    @parameterized.expand([[True], [False]])
     @pytest.mark.usefixtures("unittest_snapshot")
-    def test_s3_tables_global_join_with_cte(self):
-        credential = DataWarehouseCredential.objects.create(team=self.team, access_key="key", access_secret="secret")
-        DataWarehouseTable.objects.create(
-            team=self.team,
-            name="test_table",
-            format=DataWarehouseTable.TableFormat.DeltaS3Wrapper,
-            url_pattern="http://s3/folder/",
-            credential=credential,
-            columns={"id": {"hogql": "StringDatabaseField", "clickhouse": "String", "schema_valid": True}},
-        )
-        printed = self._select("""
-            WITH some_remote_table AS
-            (
-                SELECT * FROM test_table
+    def test_s3_tables_global_join_with_cte(self, using_global_joins):
+        with mock.patch("posthog.hogql.resolver.USE_GLOBAL_JOINS", using_global_joins):
+            credential = DataWarehouseCredential.objects.create(
+                team=self.team, access_key="key", access_secret="secret"
             )
-            SELECT event FROM events
-            JOIN some_remote_table ON events.event = toString(some_remote_table.id)""")
-
-        assert "GLOBAL JOIN" in printed
-
-        assert clean_varying_query_parts(printed, replace_all_numbers=False) == self.snapshot  # type: ignore
-
-    @pytest.mark.usefixtures("unittest_snapshot")
-    def test_s3_tables_global_join_with_cte_nested(self):
-        credential = DataWarehouseCredential.objects.create(team=self.team, access_key="key", access_secret="secret")
-        DataWarehouseTable.objects.create(
-            team=self.team,
-            name="test_table",
-            format=DataWarehouseTable.TableFormat.DeltaS3Wrapper,
-            url_pattern="http://s3/folder/",
-            credential=credential,
-            columns={"id": {"hogql": "StringDatabaseField", "clickhouse": "String", "schema_valid": True}},
-        )
-        printed = self._select("""
-            WITH some_remote_table AS
-            (
-                SELECT e.event, t.id FROM events e
-                JOIN test_table t on toString(t.id) = e.event
+            DataWarehouseTable.objects.create(
+                team=self.team,
+                name="test_table",
+                format=DataWarehouseTable.TableFormat.DeltaS3Wrapper,
+                url_pattern="http://s3/folder/",
+                credential=credential,
+                columns={"id": {"hogql": "StringDatabaseField", "clickhouse": "String", "schema_valid": True}},
             )
-            SELECT some_remote_table.event FROM events
-            JOIN some_remote_table ON events.event = toString(some_remote_table.id)""")
-
-        assert "GLOBAL JOIN" in printed
-
-        assert clean_varying_query_parts(printed, replace_all_numbers=False) == self.snapshot  # type: ignore
-
-    @pytest.mark.usefixtures("unittest_snapshot")
-    def test_s3_tables_global_join_with_multiple_joins(self):
-        credential = DataWarehouseCredential.objects.create(team=self.team, access_key="key", access_secret="secret")
-        DataWarehouseTable.objects.create(
-            team=self.team,
-            name="test_table",
-            format=DataWarehouseTable.TableFormat.DeltaS3Wrapper,
-            url_pattern="http://s3/folder/",
-            credential=credential,
-            columns={"id": {"hogql": "StringDatabaseField", "clickhouse": "String", "schema_valid": True}},
-        )
-        printed = self._select("""
-            SELECT e.event, s.event, t.id
-            FROM events e
-            JOIN (SELECT event from events) as s ON e.event = s.event
-            LEFT JOIN test_table t on e.event = toString(t.id)""")
-
-        assert "GLOBAL JOIN" in printed  # Join #1
-        assert "GLOBAL LEFT JOIN" in printed  # Join #2
-
-        assert clean_varying_query_parts(printed, replace_all_numbers=False) == self.snapshot  # type: ignore
-
-    @pytest.mark.usefixtures("unittest_snapshot")
-    def test_s3_tables_global_join_with_in_and_property_type(self):
-        credential = DataWarehouseCredential.objects.create(team=self.team, access_key="key", access_secret="secret")
-        DataWarehouseTable.objects.create(
-            team=self.team,
-            name="test_table",
-            format=DataWarehouseTable.TableFormat.DeltaS3Wrapper,
-            url_pattern="http://s3/folder/",
-            credential=credential,
-            columns={"id": {"hogql": "StringDatabaseField", "clickhouse": "String", "schema_valid": True}},
-        )
-
-        printed = self._select("""
-            SELECT event FROM events
-            WHERE properties.$browser IN (
-                SELECT id FROM test_table
-            )""")
-
-        assert "globalIn" in printed
-
-        assert clean_varying_query_parts(printed, replace_all_numbers=False) == self.snapshot  # type: ignore
-
-    @pytest.mark.usefixtures("unittest_snapshot")
-    def test_s3_tables_global_join_anonymous_tables(self):
-        credential = DataWarehouseCredential.objects.create(team=self.team, access_key="key", access_secret="secret")
-        DataWarehouseTable.objects.create(
-            team=self.team,
-            name="test_table",
-            format=DataWarehouseTable.TableFormat.DeltaS3Wrapper,
-            url_pattern="http://s3/folder/",
-            credential=credential,
-            columns={"id": {"hogql": "StringDatabaseField", "clickhouse": "String", "schema_valid": True}},
-        )
-
-        printed = self._select("""
-            select e.event, ij.remote_id
-            from events e
-            inner join (
-                select *
-                from (
-                    select p.id as person_id, rt.id as remote_id
-                    from persons p
-                    left join (
-                        select * from test_table
-                    ) rt on rt.id = p.id
+            printed = self._select("""
+                WITH some_remote_table AS
+                (
+                    SELECT * FROM test_table
                 )
-            ) as ij on e.event = ij.remote_id""")
+                SELECT event FROM events
+                JOIN some_remote_table ON events.event = toString(some_remote_table.id)""")
 
-        assert "GLOBAL INNER JOIN" in printed
+            if using_global_joins:
+                assert "GLOBAL JOIN" in printed
+            else:
+                assert "GLOBAL JOIN" not in printed
 
-        assert clean_varying_query_parts(printed, replace_all_numbers=False) == self.snapshot  # type: ignore
+            assert clean_varying_query_parts(printed, replace_all_numbers=False) == self.snapshot  # type: ignore
+
+    @parameterized.expand([[True], [False]])
+    @pytest.mark.usefixtures("unittest_snapshot")
+    def test_s3_tables_global_join_with_cte_nested(self, using_global_joins):
+        with mock.patch("posthog.hogql.resolver.USE_GLOBAL_JOINS", using_global_joins):
+            credential = DataWarehouseCredential.objects.create(
+                team=self.team, access_key="key", access_secret="secret"
+            )
+            DataWarehouseTable.objects.create(
+                team=self.team,
+                name="test_table",
+                format=DataWarehouseTable.TableFormat.DeltaS3Wrapper,
+                url_pattern="http://s3/folder/",
+                credential=credential,
+                columns={"id": {"hogql": "StringDatabaseField", "clickhouse": "String", "schema_valid": True}},
+            )
+            printed = self._select("""
+                WITH some_remote_table AS
+                (
+                    SELECT e.event, t.id FROM events e
+                    JOIN test_table t on toString(t.id) = e.event
+                )
+                SELECT some_remote_table.event FROM events
+                JOIN some_remote_table ON events.event = toString(some_remote_table.id)""")
+
+            if using_global_joins:
+                assert "GLOBAL JOIN" in printed
+            else:
+                assert "GLOBAL JOIN" not in printed
+
+            assert clean_varying_query_parts(printed, replace_all_numbers=False) == self.snapshot  # type: ignore
+
+    @parameterized.expand([[True], [False]])
+    @pytest.mark.usefixtures("unittest_snapshot")
+    def test_s3_tables_global_join_with_multiple_joins(self, using_global_joins):
+        with mock.patch("posthog.hogql.resolver.USE_GLOBAL_JOINS", using_global_joins):
+            credential = DataWarehouseCredential.objects.create(
+                team=self.team, access_key="key", access_secret="secret"
+            )
+            DataWarehouseTable.objects.create(
+                team=self.team,
+                name="test_table",
+                format=DataWarehouseTable.TableFormat.DeltaS3Wrapper,
+                url_pattern="http://s3/folder/",
+                credential=credential,
+                columns={"id": {"hogql": "StringDatabaseField", "clickhouse": "String", "schema_valid": True}},
+            )
+            printed = self._select("""
+                SELECT e.event, s.event, t.id
+                FROM events e
+                JOIN (SELECT event from events) as s ON e.event = s.event
+                LEFT JOIN test_table t on e.event = toString(t.id)""")
+
+            if using_global_joins:
+                assert "GLOBAL JOIN" in printed  # Join #1
+                assert "GLOBAL LEFT JOIN" in printed  # Join #2
+            else:
+                assert "GLOBAL JOIN" not in printed  # Join #1
+                assert "GLOBAL LEFT JOIN" not in printed  # Join #2
+
+            assert clean_varying_query_parts(printed, replace_all_numbers=False) == self.snapshot  # type: ignore
+
+    @parameterized.expand([[True], [False]])
+    @pytest.mark.usefixtures("unittest_snapshot")
+    def test_s3_tables_global_join_with_in_and_property_type(self, using_global_joins):
+        with mock.patch("posthog.hogql.resolver.USE_GLOBAL_JOINS", using_global_joins):
+            credential = DataWarehouseCredential.objects.create(
+                team=self.team, access_key="key", access_secret="secret"
+            )
+            DataWarehouseTable.objects.create(
+                team=self.team,
+                name="test_table",
+                format=DataWarehouseTable.TableFormat.DeltaS3Wrapper,
+                url_pattern="http://s3/folder/",
+                credential=credential,
+                columns={"id": {"hogql": "StringDatabaseField", "clickhouse": "String", "schema_valid": True}},
+            )
+
+            printed = self._select("""
+                SELECT event FROM events
+                WHERE properties.$browser IN (
+                    SELECT id FROM test_table
+                )""")
+
+            if using_global_joins:
+                assert "globalIn" in printed
+            else:
+                assert "globalIn" not in printed
+
+            assert clean_varying_query_parts(printed, replace_all_numbers=False) == self.snapshot  # type: ignore
+
+    @parameterized.expand([[True], [False]])
+    @pytest.mark.usefixtures("unittest_snapshot")
+    def test_s3_tables_global_join_anonymous_tables(self, using_global_joins):
+        with mock.patch("posthog.hogql.resolver.USE_GLOBAL_JOINS", using_global_joins):
+            credential = DataWarehouseCredential.objects.create(
+                team=self.team, access_key="key", access_secret="secret"
+            )
+            DataWarehouseTable.objects.create(
+                team=self.team,
+                name="test_table",
+                format=DataWarehouseTable.TableFormat.DeltaS3Wrapper,
+                url_pattern="http://s3/folder/",
+                credential=credential,
+                columns={"id": {"hogql": "StringDatabaseField", "clickhouse": "String", "schema_valid": True}},
+            )
+
+            printed = self._select("""
+                select e.event, ij.remote_id
+                from events e
+                inner join (
+                    select *
+                    from (
+                        select p.id as person_id, rt.id as remote_id
+                        from persons p
+                        left join (
+                            select * from test_table
+                        ) rt on rt.id = p.id
+                    )
+                ) as ij on e.event = ij.remote_id""")
+
+            if using_global_joins:
+                assert "GLOBAL INNER JOIN" in printed
+            else:
+                assert "GLOBAL INNER JOIN" not in printed
+
+            assert clean_varying_query_parts(printed, replace_all_numbers=False) == self.snapshot  # type: ignore
 
 
 class TestPrinted(APIBaseTest):


### PR DESCRIPTION
## Changes
- Added a single kill switch to enable/disable global joins for the clickhouse team to toggle as and when they upgrade/downgrade the cluster
- This is so that they dont need to piss around with a bunch of branches of logic and unit tests ✌️ 
