### PR TITLE
fix(data-warehouse): Fix whether you can use incremental replication

### DIFF
--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -561,8 +561,8 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 "table": schema.name,
                 "should_sync": False,
                 "incremental_fields": schema.incremental_fields,
-                "incremental_available": True,
-                "append_available": True,
+                "incremental_available": schema.supports_incremental,
+                "append_available": schema.supports_append,
                 "incremental_field": schema.incremental_fields[0]["label"]
                 if len(schema.incremental_fields) > 0 and len(schema.incremental_fields[0]["label"]) > 0
                 else None,


### PR DESCRIPTION
## Problem
- Users were able to enable incremental schemas even if they shouldn't - only during the source creation though
- 🤦 

## Changes
- Fix it ! 
- TODO: once this hits prod, update all stripe sources to use append only 
