### PR TITLE
feat: add new retention_period_days column and drop old string column

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/constants.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/constants.ts
@@ -2,6 +2,7 @@ import {
     KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_EVENTS,
     KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_OVERFLOW,
 } from '../../../config/kafka-topics'
+import { RetentionPeriod } from './types'
 
 // WARNING: Do not change these - they will essentially reset the consumer
 export const KAFKA_CONSUMER_GROUP_ID = 'session-recordings-blob-v2'
@@ -12,3 +13,11 @@ export const KAFKA_CONSUMER_SESSION_TIMEOUT_MS = 90_000
 export { KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_EVENTS, KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_OVERFLOW }
 
 export const ValidRetentionPeriods = ['legacy', '30d', '90d', '1y', '5y'] as const
+
+export const RetentionPeriodToDaysMap: { [key in RetentionPeriod]: number | null } = {
+    '30d': 30,
+    '90d': 90,
+    '1y': 365,
+    '5y': 1825,
+    legacy: null,
+}

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/retention/retention-aware-batch-writer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/retention/retention-aware-batch-writer.ts
@@ -1,6 +1,7 @@
 import { S3Client } from '@aws-sdk/client-s3'
 
 import { ValidRetentionPeriods } from '../constants'
+import { RetentionPeriodToDaysMap } from '../constants'
 import { S3SessionBatchFileStorage } from '../sessions/s3-session-batch-writer'
 import {
     SessionBatchFileStorage,
@@ -13,13 +14,6 @@ import { RetentionService } from './retention-service'
 
 class RetentionAwareBatchFileWriter implements SessionBatchFileWriter {
     private writerMap: { [key in RetentionPeriod]: SessionBatchFileWriter | null }
-    private periodToDaysMap: { [key in RetentionPeriod]: number | null } = {
-        '30d': 30,
-        '90d': 90,
-        '1y': 365,
-        '5y': 1825,
-        legacy: null,
-    }
 
     constructor(
         private readonly retentionService: RetentionService,
@@ -53,7 +47,7 @@ class RetentionAwareBatchFileWriter implements SessionBatchFileWriter {
         return {
             bytesWritten,
             url,
-            retentionPeriodDays: this.periodToDaysMap[retentionPeriod],
+            retentionPeriodDays: RetentionPeriodToDaysMap[retentionPeriod],
         }
     }
 

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/retention/retention-aware-batch-writer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/retention/retention-aware-batch-writer.ts
@@ -13,6 +13,13 @@ import { RetentionService } from './retention-service'
 
 class RetentionAwareBatchFileWriter implements SessionBatchFileWriter {
     private writerMap: { [key in RetentionPeriod]: SessionBatchFileWriter | null }
+    private periodToDaysMap: { [key in RetentionPeriod]: number | null } = {
+        '30d': 30,
+        '90d': 90,
+        '1y': 365,
+        '5y': 1825,
+        legacy: null,
+    }
 
     constructor(
         private readonly retentionService: RetentionService,
@@ -46,7 +53,7 @@ class RetentionAwareBatchFileWriter implements SessionBatchFileWriter {
         return {
             bytesWritten,
             url,
-            retentionPeriod,
+            retentionPeriodDays: this.periodToDaysMap[retentionPeriod],
         }
     }
 

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/blackhole-session-batch-writer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/blackhole-session-batch-writer.ts
@@ -12,7 +12,7 @@ class BlackholeBatchFileWriter implements SessionBatchFileWriter {
         return Promise.resolve({
             bytesWritten: sessionData.buffer.length,
             url: null,
-            retentionPeriod: null,
+            retentionPeriodDays: null,
         })
     }
 

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/s3-session-batch-writer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/s3-session-batch-writer.ts
@@ -125,7 +125,7 @@ class S3SessionBatchFileWriter implements SessionBatchFileWriter {
             return {
                 bytesWritten: buffer.length,
                 url: `s3://${this.bucket}/${this.key}?range=bytes=${startOffset}-${this.currentOffset - 1}`,
-                retentionPeriod: null,
+                retentionPeriodDays: null,
             }
         })
     }

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-file-storage.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-file-storage.ts
@@ -1,5 +1,4 @@
 import { TeamId } from '../../../../types'
-import { RetentionPeriod } from '../types'
 
 export interface WriteSessionData {
     /** The serialized session block data */
@@ -15,8 +14,8 @@ export interface WriteSessionResult {
     bytesWritten: number
     /** URL to access this session block, if available */
     url: string | null
-    /** Retention period for this block, if available */
-    retentionPeriod: RetentionPeriod | null
+    /** Retention period, in days, for this block, if available */
+    retentionPeriodDays: number | null
 }
 
 /**

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.ts
@@ -211,7 +211,7 @@ export class SessionBatchRecorder {
 
                     const { consoleLogCount, consoleWarnCount, consoleErrorCount } = consoleLogRecorder.end()
 
-                    const { bytesWritten, url, retentionPeriod } = await writer.writeSession({
+                    const { bytesWritten, url, retentionPeriodDays } = await writer.writeSession({
                         buffer,
                         teamId: sessionBlockRecorder.teamId,
                         sessionId: sessionBlockRecorder.sessionId,
@@ -240,7 +240,7 @@ export class SessionBatchRecorder {
                         snapshotLibrary,
                         batchId,
                         eventCount,
-                        retentionPeriod,
+                        retentionPeriodDays,
                     })
 
                     totalEvents += eventCount

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-block-metadata.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-block-metadata.ts
@@ -46,5 +46,5 @@ export interface SessionBlockMetadata {
     /** Library used for the snapshot */
     snapshotLibrary: string | null
     /** Retention period for this session block */
-    retentionPeriod: string | null
+    retentionPeriodDays: number | null
 }

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-metadata-store.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-metadata-store.test.ts
@@ -42,7 +42,7 @@ describe('SessionMetadataStore', () => {
                 messageCount: 50,
                 snapshotSource: 'web',
                 snapshotLibrary: 'rrweb@1.0.0',
-                retentionPeriod: '30d',
+                retentionPeriodDays: 30,
             },
             {
                 sessionId: 'different456',
@@ -67,7 +67,7 @@ describe('SessionMetadataStore', () => {
                 messageCount: 30,
                 snapshotSource: 'web',
                 snapshotLibrary: 'rrweb@1.0.0',
-                retentionPeriod: '30d',
+                retentionPeriodDays: 30,
             },
             {
                 sessionId: 'session123',
@@ -92,7 +92,7 @@ describe('SessionMetadataStore', () => {
                 messageCount: 70,
                 snapshotSource: 'web',
                 snapshotLibrary: 'rrweb@1.0.0',
-                retentionPeriod: '30d',
+                retentionPeriodDays: 30,
             },
         ]
 
@@ -231,7 +231,7 @@ describe('SessionMetadataStore', () => {
                 messageCount: 25,
                 snapshotSource: 'web',
                 snapshotLibrary: 'rrweb@1.0.0',
-                retentionPeriod: '30d',
+                retentionPeriodDays: 30,
             },
         ]
 
@@ -263,7 +263,7 @@ describe('SessionMetadataStore', () => {
                 messageCount: 25,
                 snapshotSource: 'web',
                 snapshotLibrary: 'rrweb@1.0.0',
-                retentionPeriod: '30d',
+                retentionPeriodDays: 30,
             },
         ]
 
@@ -315,7 +315,7 @@ describe('SessionMetadataStore', () => {
                 messageCount: 15,
                 snapshotSource: 'web',
                 snapshotLibrary: 'rrweb@1.0.0',
-                retentionPeriod: '30d',
+                retentionPeriodDays: 30,
             },
             {
                 sessionId: 'session2',
@@ -340,7 +340,7 @@ describe('SessionMetadataStore', () => {
                 messageCount: 20,
                 snapshotSource: 'web',
                 snapshotLibrary: 'rrweb@1.0.0',
-                retentionPeriod: '30d',
+                retentionPeriodDays: 30,
             },
         ]
 
@@ -416,7 +416,7 @@ describe('SessionMetadataStore', () => {
                 messageCount: 25,
                 snapshotSource: 'web',
                 snapshotLibrary: 'rrweb@1.0.0',
-                retentionPeriod: '30d',
+                retentionPeriodDays: 30,
             },
         ]
 
@@ -453,7 +453,7 @@ describe('SessionMetadataStore', () => {
                 messageCount: 25,
                 snapshotSource: 'web',
                 snapshotLibrary: 'rrweb@1.0.0',
-                retentionPeriod: '30d',
+                retentionPeriodDays: 30,
             },
         ]
 

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-metadata-store.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-metadata-store.test.ts
@@ -128,7 +128,7 @@ describe('SessionMetadataStore', () => {
                 snapshot_source: 'web',
                 snapshot_library: 'rrweb@1.0.0',
                 event_count: 25,
-                retention_period: '30d',
+                retention_period_days: 30,
             },
             {
                 uuid: expect.any(String),
@@ -153,7 +153,7 @@ describe('SessionMetadataStore', () => {
                 snapshot_source: 'web',
                 snapshot_library: 'rrweb@1.0.0',
                 event_count: 15,
-                retention_period: '30d',
+                retention_period_days: 30,
             },
             {
                 uuid: expect.any(String),
@@ -178,7 +178,7 @@ describe('SessionMetadataStore', () => {
                 snapshot_source: 'web',
                 snapshot_library: 'rrweb@1.0.0',
                 event_count: 35,
-                retention_period: '30d',
+                retention_period_days: 30,
             },
         ])
 
@@ -366,7 +366,7 @@ describe('SessionMetadataStore', () => {
             message_count: 15,
             snapshot_source: 'web',
             snapshot_library: 'rrweb@1.0.0',
-            retention_period: '30d',
+            retention_period_days: 30,
         })
         expect(parsedEvents[1]).toMatchObject({
             first_url: 'https://example.com/other',
@@ -383,7 +383,7 @@ describe('SessionMetadataStore', () => {
             message_count: 20,
             snapshot_source: 'web',
             snapshot_library: 'rrweb@1.0.0',
-            retention_period: '30d',
+            retention_period_days: 30,
         })
         expect(mockProducer.flush).toHaveBeenCalledTimes(1)
     })

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-metadata-store.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-metadata-store.ts
@@ -40,7 +40,7 @@ export class SessionMetadataStore {
             snapshot_source: metadata.snapshotSource,
             snapshot_library: metadata.snapshotLibrary,
             event_count: metadata.eventCount || 0,
-            retention_period: metadata.retentionPeriod,
+            retention_period_days: metadata.retentionPeriodDays,
         }))
 
         await this.producer.queueMessages({

--- a/posthog/clickhouse/migrations/0137_session_replay_events_retention_period_days.py
+++ b/posthog/clickhouse/migrations/0137_session_replay_events_retention_period_days.py
@@ -1,0 +1,38 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.session_recordings.sql.session_replay_event_migrations_sql import (
+    ADD_RETENTION_PERIOD_DAYS_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    ADD_RETENTION_PERIOD_DAYS_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    ADD_RETENTION_PERIOD_DAYS_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    DROP_RETENTION_PERIOD_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    DROP_RETENTION_PERIOD_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    DROP_RETENTION_PERIOD_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL,
+)
+from posthog.session_recordings.sql.session_replay_event_sql import (
+    KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    SESSION_REPLAY_EVENTS_TABLE_MV_SQL,
+)
+
+operations = [
+    # looking at past migrations we have to drop materialized views and kafka tables first
+    run_sql_with_exceptions(DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL(on_cluster=False)),
+    run_sql_with_exceptions(DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL(on_cluster=False)),
+    # alter the target tables
+    run_sql_with_exceptions(ADD_RETENTION_PERIOD_DAYS_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    run_sql_with_exceptions(
+        ADD_RETENTION_PERIOD_DAYS_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL(),
+        node_roles=[NodeRole.DATA, NodeRole.COORDINATOR],
+    ),
+    run_sql_with_exceptions(ADD_RETENTION_PERIOD_DAYS_SESSION_REPLAY_EVENTS_TABLE_SQL(), sharded=True),
+    run_sql_with_exceptions(DROP_RETENTION_PERIOD_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    run_sql_with_exceptions(
+        DROP_RETENTION_PERIOD_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL(),
+        node_roles=[NodeRole.DATA, NodeRole.COORDINATOR],
+    ),
+    run_sql_with_exceptions(DROP_RETENTION_PERIOD_SESSION_REPLAY_EVENTS_TABLE_SQL(), sharded=True),
+    # and then recreate the materialized views and kafka tables
+    run_sql_with_exceptions(KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL(on_cluster=False)),
+    run_sql_with_exceptions(SESSION_REPLAY_EVENTS_TABLE_MV_SQL(on_cluster=False)),
+]

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -484,7 +484,7 @@
       message_count Int64,
       snapshot_source LowCardinality(Nullable(String)),
       snapshot_library Nullable(String),
-      retention_period_days Nullable(UInt8),
+      retention_period_days Nullable(Int64),
   ) ENGINE = Kafka('test.kafka.broker:9092', 'clickhouse_session_replay_events_test', 'group1', 'JSONEachRow')
   
   '''
@@ -1561,7 +1561,7 @@
       message_count Int64,
       snapshot_source LowCardinality(Nullable(String)),
       snapshot_library Nullable(String),
-      retention_period_days Nullable(UInt8),
+      retention_period_days Nullable(Int64),
   ) ENGINE = Kafka('kafka:9092', 'clickhouse_session_replay_events_test', 'group1', 'JSONEachRow')
   
   '''
@@ -2550,7 +2550,7 @@
       snapshot_library AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
       _timestamp SimpleAggregateFunction(max, DateTime),
       -- retention period for this session, in days. Useful to show TTL for the recording
-      retention_period_days Nullable(UInt8)
+      retention_period_days Nullable(Int64)
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_replay_events', sipHash64(distinct_id))
   
   '''
@@ -2576,7 +2576,7 @@
   `snapshot_source` AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC')),
   `snapshot_library` AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
   `_timestamp` Nullable(DateTime),
-  `retention_period_days` Nullable(UInt8)
+  `retention_period_days` Nullable(Int64)
   )
   AS SELECT
   session_id,
@@ -3276,7 +3276,7 @@
       snapshot_library AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
       _timestamp SimpleAggregateFunction(max, DateTime),
       -- retention period for this session, in days. Useful to show TTL for the recording
-      retention_period_days Nullable(UInt8)
+      retention_period_days Nullable(Int64)
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.session_replay_events', '{replica}')
   
       PARTITION BY toYYYYMM(min_first_timestamp)
@@ -4019,7 +4019,7 @@
       snapshot_library AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
       _timestamp SimpleAggregateFunction(max, DateTime),
       -- retention period for this session, in days. Useful to show TTL for the recording
-      retention_period_days Nullable(UInt8)
+      retention_period_days Nullable(Int64)
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_replay_events', sipHash64(distinct_id))
   
   '''
@@ -5160,7 +5160,7 @@
       snapshot_library AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
       _timestamp SimpleAggregateFunction(max, DateTime),
       -- retention period for this session, in days. Useful to show TTL for the recording
-      retention_period_days Nullable(UInt8)
+      retention_period_days Nullable(Int64)
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.session_replay_events', '{replica}')
   
       PARTITION BY toYYYYMM(min_first_timestamp)
@@ -5726,7 +5726,7 @@
       snapshot_library AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
       _timestamp SimpleAggregateFunction(max, DateTime),
       -- retention period for this session, in days. Useful to show TTL for the recording
-      retention_period_days Nullable(UInt8)
+      retention_period_days Nullable(Int64)
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_replay_events', sipHash64(distinct_id))
   
   '''

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -484,7 +484,7 @@
       message_count Int64,
       snapshot_source LowCardinality(Nullable(String)),
       snapshot_library Nullable(String),
-      retention_period Nullable(String),
+      retention_period_days Nullable(UInt8),
   ) ENGINE = Kafka('test.kafka.broker:9092', 'clickhouse_session_replay_events_test', 'group1', 'JSONEachRow')
   
   '''
@@ -1561,7 +1561,7 @@
       message_count Int64,
       snapshot_source LowCardinality(Nullable(String)),
       snapshot_library Nullable(String),
-      retention_period Nullable(String),
+      retention_period_days Nullable(UInt8),
   ) ENGINE = Kafka('kafka:9092', 'clickhouse_session_replay_events_test', 'group1', 'JSONEachRow')
   
   '''
@@ -2549,8 +2549,8 @@
       -- knowing something is mobile isn't enough, we need to know if e.g. RN or flutter
       snapshot_library AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
       _timestamp SimpleAggregateFunction(max, DateTime),
-      -- retention period for this session, useful to show TTL for the recording
-      retention_period Nullable(String)
+      -- retention period for this session, in days. Useful to show TTL for the recording
+      retention_period_days Nullable(UInt8)
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_replay_events', sipHash64(distinct_id))
   
   '''
@@ -2576,7 +2576,7 @@
   `snapshot_source` AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC')),
   `snapshot_library` AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
   `_timestamp` Nullable(DateTime),
-  `retention_period` Nullable(String)
+  `retention_period_days` Nullable(UInt8)
   )
   AS SELECT
   session_id,
@@ -2614,7 +2614,7 @@
   max(_timestamp) as _timestamp,
   -- CH will pick the retention period here, but only if there is a single unique non-null value across all blocks
   -- ...otherwise this column will be NULL
-  singleValueOrNull(retention_period) as retention_period
+  singleValueOrNull(retention_period_days) as retention_period_days
   FROM posthog_test.kafka_session_replay_events
   group by session_id, team_id
   
@@ -3275,8 +3275,8 @@
       -- knowing something is mobile isn't enough, we need to know if e.g. RN or flutter
       snapshot_library AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
       _timestamp SimpleAggregateFunction(max, DateTime),
-      -- retention period for this session, useful to show TTL for the recording
-      retention_period Nullable(String)
+      -- retention period for this session, in days. Useful to show TTL for the recording
+      retention_period_days Nullable(UInt8)
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.session_replay_events', '{replica}')
   
       PARTITION BY toYYYYMM(min_first_timestamp)
@@ -4018,8 +4018,8 @@
       -- knowing something is mobile isn't enough, we need to know if e.g. RN or flutter
       snapshot_library AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
       _timestamp SimpleAggregateFunction(max, DateTime),
-      -- retention period for this session, useful to show TTL for the recording
-      retention_period Nullable(String)
+      -- retention period for this session, in days. Useful to show TTL for the recording
+      retention_period_days Nullable(UInt8)
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_replay_events', sipHash64(distinct_id))
   
   '''
@@ -5159,8 +5159,8 @@
       -- knowing something is mobile isn't enough, we need to know if e.g. RN or flutter
       snapshot_library AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
       _timestamp SimpleAggregateFunction(max, DateTime),
-      -- retention period for this session, useful to show TTL for the recording
-      retention_period Nullable(String)
+      -- retention period for this session, in days. Useful to show TTL for the recording
+      retention_period_days Nullable(UInt8)
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.session_replay_events', '{replica}')
   
       PARTITION BY toYYYYMM(min_first_timestamp)
@@ -5725,8 +5725,8 @@
       -- knowing something is mobile isn't enough, we need to know if e.g. RN or flutter
       snapshot_library AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
       _timestamp SimpleAggregateFunction(max, DateTime),
-      -- retention period for this session, useful to show TTL for the recording
-      retention_period Nullable(String)
+      -- retention period for this session, in days. Useful to show TTL for the recording
+      retention_period_days Nullable(UInt8)
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_replay_events', sipHash64(distinct_id))
   
   '''

--- a/posthog/session_recordings/queries/test/session_replay_sql.py
+++ b/posthog/session_recordings/queries/test/session_replay_sql.py
@@ -134,7 +134,7 @@ def produce_replay_summary(
     block_urls: list[str] | None = None,
     block_first_timestamps: list[datetime] | None = None,
     block_last_timestamps: list[datetime] | None = None,
-    retention_period: str | None = None,
+    retention_period_days: int | None = None,
 ):
     """
     Creates a session replay event in ClickHouse for testing purposes.
@@ -167,7 +167,7 @@ def produce_replay_summary(
         "block_urls": block_urls or [],
         "block_first_timestamps": block_first_timestamps or [],
         "block_last_timestamps": block_last_timestamps or [],
-        "retention_period": retention_period or "30d",
+        "retention_period_days": retention_period_days or 30,
     }
 
     if settings.TEST:

--- a/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
@@ -179,7 +179,7 @@ ADD_RETENTION_PERIOD_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REP
 
 # migration to add retention_period column to the session replay table and drop the old string column
 ALTER_SESSION_REPLAY_ADD_RETENTION_PERIOD_DAYS_COLUMN = """
-    ALTER TABLE {table_name} ADD COLUMN IF NOT EXISTS retention_period_days Nullable(UInt8)
+    ALTER TABLE {table_name} ADD COLUMN IF NOT EXISTS retention_period_days Nullable(Int64)
 """
 
 ADD_RETENTION_PERIOD_DAYS_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL = (

--- a/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
@@ -177,6 +177,51 @@ ADD_RETENTION_PERIOD_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REP
     table_name=SESSION_REPLAY_EVENTS_DATA_TABLE(),
 )
 
+# migration to add retention_period column to the session replay table and drop the old string column
+ALTER_SESSION_REPLAY_ADD_RETENTION_PERIOD_DAYS_COLUMN = """
+    ALTER TABLE {table_name} ADD COLUMN IF NOT EXISTS retention_period_days Nullable(UInt8)
+"""
+
+ADD_RETENTION_PERIOD_DAYS_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL = (
+    lambda: ALTER_SESSION_REPLAY_ADD_RETENTION_PERIOD_DAYS_COLUMN.format(
+        table_name="session_replay_events",
+    )
+)
+
+ADD_RETENTION_PERIOD_DAYS_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL = (
+    lambda: ALTER_SESSION_REPLAY_ADD_RETENTION_PERIOD_DAYS_COLUMN.format(
+        table_name="writable_session_replay_events",
+    )
+)
+
+ADD_RETENTION_PERIOD_DAYS_SESSION_REPLAY_EVENTS_TABLE_SQL = (
+    lambda: ALTER_SESSION_REPLAY_ADD_RETENTION_PERIOD_DAYS_COLUMN.format(
+        table_name=SESSION_REPLAY_EVENTS_DATA_TABLE(),
+    )
+)
+
+ALTER_SESSION_REPLAY_DROP_RETENTION_PERIOD_COLUMN = """
+    ALTER TABLE {table_name} DROP COLUMN IF EXISTS retention_period
+"""
+
+DROP_RETENTION_PERIOD_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL = (
+    lambda: ALTER_SESSION_REPLAY_DROP_RETENTION_PERIOD_COLUMN.format(
+        table_name="session_replay_events",
+    )
+)
+
+DROP_RETENTION_PERIOD_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL = (
+    lambda: ALTER_SESSION_REPLAY_DROP_RETENTION_PERIOD_COLUMN.format(
+        table_name="writable_session_replay_events",
+    )
+)
+
+DROP_RETENTION_PERIOD_SESSION_REPLAY_EVENTS_TABLE_SQL = (
+    lambda: ALTER_SESSION_REPLAY_DROP_RETENTION_PERIOD_COLUMN.format(
+        table_name=SESSION_REPLAY_EVENTS_DATA_TABLE(),
+    )
+)
+
 # =========================
 # MIGRATION: Add block columns to support session recording v2 implementation
 # This migration adds block_url to the kafka table, and block_first_timestamps, block_last_timestamps, and block_urls

--- a/posthog/session_recordings/sql/session_replay_event_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_sql.py
@@ -38,7 +38,7 @@ CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     message_count Int64,
     snapshot_source LowCardinality(Nullable(String)),
     snapshot_library Nullable(String),
-    retention_period_days Nullable(UInt8),
+    retention_period_days Nullable(Int64),
 ) ENGINE = {engine}
 """
 
@@ -88,7 +88,7 @@ CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     snapshot_library AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
     _timestamp SimpleAggregateFunction(max, DateTime),
     -- retention period for this session, in days. Useful to show TTL for the recording
-    retention_period_days Nullable(UInt8)
+    retention_period_days Nullable(Int64)
 ) ENGINE = {engine}
 """
 
@@ -197,7 +197,7 @@ group by session_id, team_id
 `snapshot_source` AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC')),
 `snapshot_library` AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
 `_timestamp` Nullable(DateTime),
-`retention_period_days` Nullable(UInt8)
+`retention_period_days` Nullable(Int64)
 )""",
     )
 

--- a/posthog/session_recordings/sql/session_replay_event_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_sql.py
@@ -38,7 +38,7 @@ CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     message_count Int64,
     snapshot_source LowCardinality(Nullable(String)),
     snapshot_library Nullable(String),
-    retention_period Nullable(String),
+    retention_period_days Nullable(UInt8),
 ) ENGINE = {engine}
 """
 
@@ -87,8 +87,8 @@ CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     -- knowing something is mobile isn't enough, we need to know if e.g. RN or flutter
     snapshot_library AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
     _timestamp SimpleAggregateFunction(max, DateTime),
-    -- retention period for this session, useful to show TTL for the recording
-    retention_period Nullable(String)
+    -- retention period for this session, in days. Useful to show TTL for the recording
+    retention_period_days Nullable(UInt8)
 ) ENGINE = {engine}
 """
 
@@ -170,7 +170,7 @@ argMinState(snapshot_library, first_timestamp) as snapshot_library,
 max(_timestamp) as _timestamp,
 -- CH will pick the retention period here, but only if there is a single unique non-null value across all blocks
 -- ...otherwise this column will be NULL
-singleValueOrNull(retention_period) as retention_period
+singleValueOrNull(retention_period_days) as retention_period_days
 FROM {database}.kafka_session_replay_events
 group by session_id, team_id
 """.format(
@@ -197,7 +197,7 @@ group by session_id, team_id
 `snapshot_source` AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC')),
 `snapshot_library` AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
 `_timestamp` Nullable(DateTime),
-`retention_period` Nullable(String)
+`retention_period_days` Nullable(UInt8)
 )""",
     )
 


### PR DESCRIPTION
## Problem

Aside from just showing the TTL of a recording we also need to be able to filter out expired recordings in both CH and PG. This would be needlessly difficult with the retention period represented with a string.

## Changes

1. Add new `retention_period_days` column to CH that represents the retention period for each recording as a number of days.
2. Remove the `retention_period` column for CH as it is now no longer needed.
3. Change blobby v2 to convert retention period setting to the number of days