### PR TITLE
fix(experiments): set new query.uuid value

### DIFF
--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
@@ -79,8 +79,15 @@ export const sharedMetricLogic = kea<sharedMetricLogicType>([
          */
         loadSharedMetricSuccess: () => {
             if (props.action === 'duplicate' && values.sharedMetric) {
+                // Generate a new UUID for the duplicated metric's query
+                const duplicatedQuery = {
+                    ...values.sharedMetric.query,
+                    uuid: crypto.randomUUID(),
+                }
+
                 actions.setSharedMetric({
                     ...values.sharedMetric,
+                    query: duplicatedQuery,
                     name: `${values.sharedMetric.name} (duplicate)`,
                     id: undefined,
                 })


### PR DESCRIPTION
## Problem
Prompted by: https://posthog.slack.com/archives/C06V9J0082W/p1756460028461859

When duplicating a shared metric, we are not generating a new `query.uuid` value.

## Changes
Set a new `query.uuid` value.

For the affected records, I will manually:
- Set new `query.uuid`. This is safe to do, as the uuid is only used for frontend operations and not backend linking.
- Set `primary_metrics_ordered_uuids` and `secondary_metrics_ordered_uuids` to NULL. This will wipe out the order (and the default order will be set when a record is loaded), but this is necessary since these fields will include now non-existing uuids. Unlikely to affect many records since we only shipped metrics reordering a few hours ago.