### PR TITLE
fix(crm): Groups related people

### DIFF
--- a/frontend/src/scenes/groups/RelatedGroups.tsx
+++ b/frontend/src/scenes/groups/RelatedGroups.tsx
@@ -15,11 +15,14 @@ interface Props {
     groupTypeIndex: number | null
     id: string
     type?: 'person' | 'group'
-    limit?: number
+    pageSize?: number
 }
 
-export function RelatedGroups({ groupTypeIndex, id, type, limit }: Props): JSX.Element {
-    const { relatedActors, relatedActorsLoading } = useValues(relatedGroupsLogic({ groupTypeIndex, id, type, limit }))
+export function RelatedGroups({ groupTypeIndex, id, type, pageSize }: Props): JSX.Element {
+    const { relatedActors, relatedPeople, relatedActorsLoading } = useValues(
+        relatedGroupsLogic({ groupTypeIndex, id, type })
+    )
+    const dataSource = type === 'person' ? relatedPeople : relatedActors
     const { aggregationLabel } = useValues(groupsModel)
 
     const columns: LemonTableColumns<ActorType> = [
@@ -49,14 +52,17 @@ export function RelatedGroups({ groupTypeIndex, id, type, limit }: Props): JSX.E
         },
     ]
 
+    const nouns: [string, string] =
+        type === 'person' ? ['related person', 'related people'] : ['related group', 'related groups']
+
     return (
         <LemonTable
-            dataSource={relatedActors}
+            dataSource={dataSource}
             columns={columns}
             rowKey="id"
-            pagination={{ pageSize: 30, hideOnSinglePage: true }}
+            pagination={{ pageSize: pageSize || 30, hideOnSinglePage: true }}
             loading={relatedActorsLoading}
-            nouns={['related group', 'related groups']}
+            nouns={nouns}
             emptyState="No related groups found"
         />
     )

--- a/frontend/src/scenes/groups/cards/GroupPeopleCard.tsx
+++ b/frontend/src/scenes/groups/cards/GroupPeopleCard.tsx
@@ -12,7 +12,7 @@ export function GroupPeopleCard({ groupData }: { groupData: Group }): JSX.Elemen
                 groupTypeIndex={groupData.group_type_index}
                 id={groupData.group_key}
                 type="person"
-                limit={5}
+                pageSize={5}
             />
             <div className="flex justify-end">
                 <LemonButton

--- a/frontend/src/scenes/groups/relatedGroupsLogic.ts
+++ b/frontend/src/scenes/groups/relatedGroupsLogic.ts
@@ -1,4 +1,4 @@
-import { actions, connect, events, kea, key, path, props } from 'kea'
+import { actions, connect, events, kea, key, path, props, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
@@ -15,7 +15,6 @@ export const relatedGroupsLogic = kea<relatedGroupsLogicType>([
             groupTypeIndex: number | null
             id: string
             type?: 'person' | 'group'
-            limit?: number
         }
     ),
     key((props) => `${props.groupTypeIndex ?? 'person'}-${props.id}`),
@@ -33,17 +32,16 @@ export const relatedGroupsLogic = kea<relatedGroupsLogicType>([
                         group_type_index: props.groupTypeIndex,
                         id: props.id,
                     })}`
-                    let response = await api.get(url)
-                    if (props.type) {
-                        response = response.filter((actor: ActorType) => actor.type === props.type)
-                    }
-                    if (props.limit) {
-                        response = response.slice(0, props.limit)
-                    }
-                    return response
+                    return await api.get(url)
                 },
                 setGroup: () => [],
             },
+        ],
+    })),
+    selectors(({ selectors }) => ({
+        relatedPeople: [
+            () => [selectors.relatedActors],
+            (relatedActors: ActorType[]) => relatedActors.filter((actor) => actor.type === 'person'),
         ],
     })),
     events(({ actions }) => ({


### PR DESCRIPTION
## Problem
Related people section in group overview only shows 5 people. The problem is that, even after expanding to see all people, the list still shows only 5, regardless of how many there are.

This is happening because, instead of paginating the results when displaying, the loader is being set with a sliced subset of the results. When opening the full list, the state was not being re-fetched, as it already contains (incomplete) data.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Related to https://github.com/PostHog/posthog/issues/36460
## Changes
- Remove `limit` prop from `relatedGroupsLogic` and do not slice the api response when setting the state
- Repurpose `limit` prop in `RelatedGroups` component to be `pageSize`, adding pagination to the list that is displayed in Group Overview.
- Derive `relatedPeople` from `relatedActors`, so that we can fetch data for related people card and related groups + people tab with a single api call
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

### Before
https://github.com/user-attachments/assets/dff23c01-b19a-413b-8a9e-85687d617146

### After
https://github.com/user-attachments/assets/f0e6e4fc-5c10-4b43-8eda-6aabc1437784



## How did you test this code?
Locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
