### PR TITLE
refactor: move remaining persons db queries to repositories

### DIFF
--- a/plugin-server/src/cdp/consumers/cdp-base.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-base.consumer.ts
@@ -68,7 +68,7 @@ export abstract class CdpConsumerBase {
             this.recipientPreferencesService
         )
 
-        this.personsManager = new PersonsManagerService(this.hub)
+        this.personsManager = new PersonsManagerService(this.hub.personRepository)
         this.groupsManager = new GroupsManagerService(this.hub)
         this.hogFunctionMonitoringService = new HogFunctionMonitoringService(this.hub)
         this.pluginDestinationExecutorService = new LegacyPluginExecutorService(this.hub)

--- a/plugin-server/src/cdp/services/managers/persons-manager.service.test.ts
+++ b/plugin-server/src/cdp/services/managers/persons-manager.service.test.ts
@@ -20,7 +20,7 @@ describe('PersonsManager', () => {
         hub = await createHub()
         personRepository = new PostgresPersonRepository(hub.db.postgres)
         await resetTestDatabase()
-        manager = new PersonsManagerService(hub)
+        manager = new PersonsManagerService(hub.personRepository)
         team = await getFirstTeam(hub)
         const team2Id = await createTeam(hub.postgres, team.organization_id)
         team2 = (await getTeam(hub, team2Id))!

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -31,8 +31,6 @@ import { BatchWritingGroupStore } from '../worker/ingestion/groups/batch-writing
 import { GroupStoreForBatch } from '../worker/ingestion/groups/group-store-for-batch.interface'
 import { BatchWritingPersonsStore } from '../worker/ingestion/persons/batch-writing-person-store'
 import { FlushResult, PersonsStoreForBatch } from '../worker/ingestion/persons/persons-store-for-batch'
-import { PostgresDualWritePersonRepository } from '../worker/ingestion/persons/repositories/postgres-dualwrite-person-repository'
-import { PostgresPersonRepository } from '../worker/ingestion/persons/repositories/postgres-person-repository'
 import { deduplicateEvents } from './deduplication/events'
 import { DeduplicationRedis, createDeduplicationRedis } from './deduplication/redis-client'
 import {
@@ -153,20 +151,7 @@ export class IngestionConsumer {
         this.ingestionWarningLimiter = new MemoryRateLimiter(1, 1.0 / 3600)
         this.hogTransformer = new HogTransformerService(hub)
 
-        const personRepositoryOptions = {
-            calculatePropertiesSize: this.hub.PERSON_UPDATE_CALCULATE_PROPERTIES_SIZE,
-            comparisonEnabled: this.hub.PERSONS_DUAL_WRITE_COMPARISON_ENABLED,
-        }
-
-        const personRepository = this.hub.PERSONS_DUAL_WRITE_ENABLED
-            ? new PostgresDualWritePersonRepository(
-                  this.hub.db.postgres,
-                  this.hub.db.postgresPersonMigration,
-                  personRepositoryOptions
-              )
-            : new PostgresPersonRepository(this.hub.db.postgres, personRepositoryOptions)
-
-        this.personStore = new BatchWritingPersonsStore(personRepository, this.hub.db.kafkaProducer, {
+        this.personStore = new BatchWritingPersonsStore(this.hub.personRepository, this.hub.db.kafkaProducer, {
             dbWriteMode: this.hub.PERSON_BATCH_WRITING_DB_WRITE_MODE,
             maxConcurrentUpdates: this.hub.PERSON_BATCH_WRITING_MAX_CONCURRENT_UPDATES,
             maxOptimisticUpdateRetries: this.hub.PERSON_BATCH_WRITING_MAX_OPTIMISTIC_UPDATE_RETRIES,

--- a/plugin-server/src/ingestion/ingestion-e2e.test.ts
+++ b/plugin-server/src/ingestion/ingestion-e2e.test.ts
@@ -12,6 +12,7 @@ import { closeHub, createHub } from '../utils/db/hub'
 import { parseRawClickHouseEvent } from '../utils/event'
 import { parseJSON } from '../utils/json-parse'
 import { UUIDT } from '../utils/utils'
+import { fetchDistinctIds } from '../worker/ingestion/persons/repositories/test-helpers'
 import { IngestionConsumer } from './ingestion-consumer'
 
 // Mock the limiter so it always returns true
@@ -1301,7 +1302,7 @@ describe('Event Pipeline E2E tests', () => {
                     test_name: testName,
                 })
             )
-            const distinctIdsPersons = await hub.db.fetchDistinctIds({
+            const distinctIdsPersons = await fetchDistinctIds(hub.db.postgres, {
                 id: persons[0].id,
                 team_id: team.id,
             } as InternalPerson)
@@ -1416,7 +1417,7 @@ describe('Event Pipeline E2E tests', () => {
                     test_name: testName,
                 })
             )
-            const distinctIdsPersons = await hub.db.fetchDistinctIds({
+            const distinctIdsPersons = await fetchDistinctIds(hub.db.postgres, {
                 id: persons[0].id,
                 team_id: team.id,
             } as InternalPerson)
@@ -1532,7 +1533,7 @@ describe('Event Pipeline E2E tests', () => {
                     test_name: testName,
                 })
             )
-            const distinctIdsPersons = await hub.db.fetchDistinctIds({
+            const distinctIdsPersons = await fetchDistinctIds(hub.db.postgres, {
                 id: persons[0].id,
                 team_id: team.id,
             } as InternalPerson)
@@ -1676,7 +1677,7 @@ describe('Event Pipeline E2E tests', () => {
                 )
                 const person1 = persons.find((person) => person.properties.name === 'User 1')!
                 const person2 = persons.find((person) => person.properties.name === 'User 2')!
-                const distinctIdsPersons1 = await hub.db.fetchDistinctIds({
+                const distinctIdsPersons1 = await fetchDistinctIds(hub.db.postgres, {
                     id: person1.id,
                     team_id: team.id,
                 } as InternalPerson)
@@ -1685,7 +1686,7 @@ describe('Event Pipeline E2E tests', () => {
                 expect(distinctIdsPersons1.map((distinctId) => distinctId.distinct_id)).toEqual(
                     expect.arrayContaining([user1DistinctId])
                 )
-                const distinctIdsPersons2 = await hub.db.fetchDistinctIds({
+                const distinctIdsPersons2 = await fetchDistinctIds(hub.db.postgres, {
                     id: person2.id,
                     team_id: team.id,
                 } as InternalPerson)

--- a/plugin-server/src/main/ingestion-queues/on-event-handler-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/on-event-handler-consumer.ts
@@ -17,7 +17,17 @@ export const startAsyncWebhooksHandlerConsumer = async (hub: Hub): Promise<Plugi
     */
     logger.info('🔁', `Starting webhooks handler consumer`)
 
-    const { kafka, postgres, teamManager, actionMatcher, actionManager, rustyHook, appMetrics, groupTypeManager } = hub
+    const {
+        kafka,
+        postgres,
+        teamManager,
+        actionMatcher,
+        actionManager,
+        rustyHook,
+        appMetrics,
+        groupTypeManager,
+        groupRepository,
+    } = hub
 
     const consumer = kafka.consumer({
         // NOTE: This should never clash with the group ID specified for the kafka engine posthog/ee/clickhouse/sql/clickhouse.py
@@ -42,7 +52,7 @@ export const startAsyncWebhooksHandlerConsumer = async (hub: Hub): Promise<Plugi
                 concurrency,
                 groupTypeManager,
                 teamManager,
-                postgres
+                groupRepository
             ),
     })
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -40,6 +40,7 @@ import { AppMetrics } from './worker/ingestion/app-metrics'
 import { GroupTypeManager } from './worker/ingestion/group-type-manager'
 import { ClickhouseGroupRepository } from './worker/ingestion/groups/repositories/clickhouse-group-repository'
 import { GroupRepository } from './worker/ingestion/groups/repositories/group-repository.interface'
+import { PersonRepository } from './worker/ingestion/persons/repositories/person-repository'
 import { RustyHook } from './worker/rusty-hook'
 import { PluginsApiKeyManager } from './worker/vm/extensions/helpers/api-key-manager'
 import { RootAccessManager } from './worker/vm/extensions/helpers/root-acess-manager'
@@ -429,6 +430,7 @@ export interface Hub extends PluginsServerConfig {
     groupTypeManager: GroupTypeManager
     groupRepository: GroupRepository
     clickhouseGroupRepository: ClickhouseGroupRepository
+    personRepository: PersonRepository
     celery: Celery
     // geoip database, setup in workers
     geoipService: GeoIPService

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -136,7 +136,7 @@ export async function createHub(
               comparisonEnabled: serverConfig.GROUPS_DUAL_WRITE_COMPARISON_ENABLED,
           })
         : new PostgresGroupRepository(postgres)
-    const groupTypeManager = new GroupTypeManager(postgres, teamManager, groupRepository)
+    const groupTypeManager = new GroupTypeManager(groupRepository, teamManager)
     const clickhouseGroupRepository = new ClickhouseGroupRepository(kafkaProducer)
     const cookielessManager = new CookielessManager(serverConfig, cookielessRedisPool, teamManager)
     const geoipService = new GeoIPService(serverConfig)

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -21,6 +21,8 @@ import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
 import { ClickhouseGroupRepository } from '../../worker/ingestion/groups/repositories/clickhouse-group-repository'
 import { PostgresDualWriteGroupRepository } from '../../worker/ingestion/groups/repositories/postgres-dualwrite-group-repository'
 import { PostgresGroupRepository } from '../../worker/ingestion/groups/repositories/postgres-group-repository'
+import { PostgresDualWritePersonRepository } from '../../worker/ingestion/persons/repositories/postgres-dualwrite-person-repository'
+import { PostgresPersonRepository } from '../../worker/ingestion/persons/repositories/postgres-person-repository'
 import { RustyHook } from '../../worker/rusty-hook'
 import { ActionManagerCDP } from '../action-manager-cdp'
 import { isTestEnv } from '../env-utils'
@@ -131,12 +133,22 @@ export async function createHub(
     const actionManager = new ActionManager(postgres, pubSub)
     const actionManagerCDP = new ActionManagerCDP(postgres)
     const actionMatcher = new ActionMatcher(postgres, actionManager)
+
     const groupRepository = serverConfig.GROUPS_DUAL_WRITE_ENABLED
         ? new PostgresDualWriteGroupRepository(postgres, postgresPersonMigration, {
               comparisonEnabled: serverConfig.GROUPS_DUAL_WRITE_COMPARISON_ENABLED,
           })
         : new PostgresGroupRepository(postgres)
     const groupTypeManager = new GroupTypeManager(groupRepository, teamManager)
+
+    const personRepositoryOptions = {
+        calculatePropertiesSize: serverConfig.PERSON_UPDATE_CALCULATE_PROPERTIES_SIZE,
+        comparisonEnabled: serverConfig.PERSONS_DUAL_WRITE_COMPARISON_ENABLED,
+    }
+    const personRepository = serverConfig.PERSONS_DUAL_WRITE_ENABLED
+        ? new PostgresDualWritePersonRepository(postgres, postgresPersonMigration, personRepositoryOptions)
+        : new PostgresPersonRepository(postgres, personRepositoryOptions)
+
     const clickhouseGroupRepository = new ClickhouseGroupRepository(kafkaProducer)
     const cookielessManager = new CookielessManager(serverConfig, cookielessRedisPool, teamManager)
     const geoipService = new GeoIPService(serverConfig)
@@ -173,6 +185,7 @@ export async function createHub(
         actionMatcher,
         groupRepository,
         clickhouseGroupRepository,
+        personRepository,
         actionManager,
         actionManagerCDP,
         geoipService,

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -131,12 +131,12 @@ export async function createHub(
     const actionManager = new ActionManager(postgres, pubSub)
     const actionManagerCDP = new ActionManagerCDP(postgres)
     const actionMatcher = new ActionMatcher(postgres, actionManager)
-    const groupTypeManager = new GroupTypeManager(postgres, teamManager)
     const groupRepository = serverConfig.GROUPS_DUAL_WRITE_ENABLED
         ? new PostgresDualWriteGroupRepository(postgres, postgresPersonMigration, {
               comparisonEnabled: serverConfig.GROUPS_DUAL_WRITE_COMPARISON_ENABLED,
           })
         : new PostgresGroupRepository(postgres)
+    const groupTypeManager = new GroupTypeManager(postgres, teamManager, groupRepository)
     const clickhouseGroupRepository = new ClickhouseGroupRepository(kafkaProducer)
     const cookielessManager = new CookielessManager(serverConfig, cookielessRedisPool, teamManager)
     const geoipService = new GeoIPService(serverConfig)

--- a/plugin-server/src/worker/ingestion/group-type-manager.test.ts
+++ b/plugin-server/src/worker/ingestion/group-type-manager.test.ts
@@ -15,7 +15,7 @@ describe('GroupTypeManager()', () => {
     beforeEach(async () => {
         hub = await createHub()
         await resetTestDatabase()
-        groupTypeManager = new GroupTypeManager(hub.postgres, hub.teamManager, hub.groupRepository)
+        groupTypeManager = new GroupTypeManager(hub.groupRepository, hub.teamManager)
 
         jest.spyOn(hub.db.postgres, 'query')
         jest.spyOn(hub.groupRepository, 'insertGroupType')

--- a/plugin-server/src/worker/ingestion/group-type-manager.test.ts
+++ b/plugin-server/src/worker/ingestion/group-type-manager.test.ts
@@ -15,10 +15,10 @@ describe('GroupTypeManager()', () => {
     beforeEach(async () => {
         hub = await createHub()
         await resetTestDatabase()
-        groupTypeManager = new GroupTypeManager(hub.postgres, hub.teamManager)
+        groupTypeManager = new GroupTypeManager(hub.postgres, hub.teamManager, hub.groupRepository)
 
         jest.spyOn(hub.db.postgres, 'query')
-        jest.spyOn(groupTypeManager, 'insertGroupType')
+        jest.spyOn(hub.groupRepository, 'insertGroupType')
     })
     afterEach(async () => {
         await closeHub(hub)
@@ -32,8 +32,8 @@ describe('GroupTypeManager()', () => {
             expect(groupTypes).toEqual({})
 
             jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:25').getTime())
-            await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'foo', 0)
-            await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'bar', 1)
+            await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'foo', 0)
+            await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'bar', 1)
 
             jest.mocked(hub.db.postgres.query).mockClear()
 
@@ -55,20 +55,20 @@ describe('GroupTypeManager()', () => {
 
         it('fetches group types that have been inserted', async () => {
             expect(await groupTypeManager.fetchGroupTypes(2 as ProjectId)).toEqual({})
-            expect(await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'g0', 0)).toEqual([0, true])
-            expect(await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'g1', 1)).toEqual([1, true])
+            expect(await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'g0', 0)).toEqual([0, true])
+            expect(await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'g1', 1)).toEqual([1, true])
             groupTypeManager['loader'].markForRefresh('2')
             expect(await groupTypeManager.fetchGroupTypes(2 as ProjectId)).toEqual({ g0: 0, g1: 1 })
         })
 
         it('handles conflicting by index when inserting and limits', async () => {
-            expect(await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'g0', 0)).toEqual([0, true])
-            expect(await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'g1', 0)).toEqual([1, true])
-            expect(await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'g2', 0)).toEqual([2, true])
-            expect(await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'g3', 1)).toEqual([3, true])
-            expect(await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'g4', 0)).toEqual([4, true])
-            expect(await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'g5', 0)).toEqual([null, false])
-            expect(await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'g6', 0)).toEqual([null, false])
+            expect(await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'g0', 0)).toEqual([0, true])
+            expect(await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'g1', 0)).toEqual([1, true])
+            expect(await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'g2', 0)).toEqual([2, true])
+            expect(await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'g3', 1)).toEqual([3, true])
+            expect(await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'g4', 0)).toEqual([4, true])
+            expect(await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'g5', 0)).toEqual([null, false])
+            expect(await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'g6', 0)).toEqual([null, false])
 
             expect(await groupTypeManager.fetchGroupTypes(2 as ProjectId)).toEqual({
                 g0: 0,
@@ -80,11 +80,11 @@ describe('GroupTypeManager()', () => {
         })
 
         it('handles conflict by name when inserting', async () => {
-            expect(await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'group_name', 0)).toEqual([0, true])
-            expect(await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'group_name', 0)).toEqual([0, false])
-            expect(await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'group_name', 0)).toEqual([0, false])
-            expect(await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'foo', 0)).toEqual([1, true])
-            expect(await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'foo', 0)).toEqual([1, false])
+            expect(await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'group_name', 0)).toEqual([0, true])
+            expect(await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'group_name', 0)).toEqual([0, false])
+            expect(await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'group_name', 0)).toEqual([0, false])
+            expect(await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'foo', 0)).toEqual([1, true])
+            expect(await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'foo', 0)).toEqual([1, false])
 
             expect(await groupTypeManager.fetchGroupTypes(2 as ProjectId)).toEqual({ group_name: 0, foo: 1 })
         })
@@ -92,29 +92,29 @@ describe('GroupTypeManager()', () => {
 
     describe('fetchGroupTypeIndex()', () => {
         it('fetches an already existing value', async () => {
-            await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'foo', 0)
-            await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'bar', 1)
+            await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'foo', 0)
+            await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'bar', 1)
 
             jest.mocked(hub.db.postgres.query).mockClear()
-            jest.mocked(groupTypeManager.insertGroupType).mockClear()
+            jest.mocked(hub.groupRepository.insertGroupType).mockClear()
 
             expect(await groupTypeManager.fetchGroupTypeIndex(2, 2 as ProjectId, 'foo')).toEqual(0)
             expect(await groupTypeManager.fetchGroupTypeIndex(2, 2 as ProjectId, 'bar')).toEqual(1)
 
             expect(hub.db.postgres.query).toHaveBeenCalledTimes(1)
-            expect(groupTypeManager.insertGroupType).toHaveBeenCalledTimes(0)
+            expect(hub.groupRepository.insertGroupType).toHaveBeenCalledTimes(0)
             expect(captureTeamEvent).not.toHaveBeenCalled()
         })
 
         it('inserts value if it does not exist yet at next index, resets cache', async () => {
-            await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'foo', 0)
+            await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'foo', 0)
 
-            jest.mocked(groupTypeManager.insertGroupType).mockClear()
+            jest.mocked(hub.groupRepository.insertGroupType).mockClear()
             jest.mocked(hub.db.postgres.query).mockClear()
 
             expect(await groupTypeManager.fetchGroupTypeIndex(2, 2 as ProjectId, 'second')).toEqual(1)
 
-            expect(groupTypeManager.insertGroupType).toHaveBeenCalledTimes(1)
+            expect(hub.groupRepository.insertGroupType).toHaveBeenCalledTimes(1)
             expect(hub.db.postgres.query).toHaveBeenCalledTimes(3) // FETCH + INSERT + Team lookup
 
             const team = await getTeam(hub, 2)
@@ -144,7 +144,7 @@ describe('GroupTypeManager()', () => {
         it('handles raciness for inserting a new group', async () => {
             expect(await groupTypeManager.fetchGroupTypes(2 as ProjectId)).toEqual({})
 
-            await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'foo', 0) // Emulate another thread inserting foo
+            await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'foo', 0) // Emulate another thread inserting foo
             expect(await groupTypeManager.fetchGroupTypeIndex(2, 2 as ProjectId, 'second')).toEqual(1)
             expect(await groupTypeManager.fetchGroupTypes(2 as ProjectId)).toEqual({
                 foo: 0,
@@ -156,8 +156,8 @@ describe('GroupTypeManager()', () => {
             expect(await groupTypeManager.fetchGroupTypes(2 as ProjectId)).toEqual({})
 
             // Emulate another thread inserting group types, with both team and project the same
-            await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'foo', 0)
-            await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'bar', 0)
+            await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'foo', 0)
+            await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'bar', 0)
 
             expect(await groupTypeManager.fetchGroupTypeIndex(2, 2 as ProjectId, 'bar')).toEqual(1)
             expect(await groupTypeManager.fetchGroupTypes(2 as ProjectId)).toEqual({
@@ -172,8 +172,8 @@ describe('GroupTypeManager()', () => {
             expect(await groupTypeManager.fetchGroupTypes(2 as ProjectId)).toEqual({})
 
             // Emulate another thread inserting group types, with the project the same
-            await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'foo', 0)
-            await groupTypeManager.insertGroupType(otherTeamId, 2 as ProjectId, 'bar', 0)
+            await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'foo', 0)
+            await hub.groupRepository.insertGroupType(otherTeamId, 2 as ProjectId, 'bar', 0)
 
             expect(await groupTypeManager.fetchGroupTypeIndex(2, 2 as ProjectId, 'bar')).toEqual(1)
             expect(await groupTypeManager.fetchGroupTypes(2 as ProjectId)).toEqual({
@@ -183,11 +183,11 @@ describe('GroupTypeManager()', () => {
         })
 
         it('returns null once limit is met', async () => {
-            await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'g0', 0)
-            await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'g1', 1)
-            await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'g2', 2)
-            await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'g3', 3)
-            await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'g4', 4)
+            await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'g0', 0)
+            await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'g1', 1)
+            await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'g2', 2)
+            await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'g3', 3)
+            await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'g4', 4)
 
             expect(await groupTypeManager.fetchGroupTypeIndex(2, 2 as ProjectId, 'new')).toEqual(null)
             expect(await groupTypeManager.fetchGroupTypes(2 as ProjectId)).toEqual({

--- a/plugin-server/src/worker/ingestion/group-type-manager.ts
+++ b/plugin-server/src/worker/ingestion/group-type-manager.ts
@@ -1,5 +1,4 @@
 import { GroupTypeIndex, GroupTypeToColumnIndex, ProjectId, Team, TeamId } from '../../types'
-import { PostgresRouter } from '../../utils/db/postgres'
 import { timeoutGuard } from '../../utils/db/utils'
 import { LazyLoader } from '../../utils/lazy-loader'
 import { captureTeamEvent } from '../../utils/posthog'
@@ -15,9 +14,8 @@ export class GroupTypeManager {
     private loader: LazyLoader<GroupTypeToColumnIndex>
 
     constructor(
-        private postgres: PostgresRouter,
-        private teamManager: TeamManager,
-        private groupRepository: GroupRepository
+        private groupRepository: GroupRepository,
+        private teamManager: TeamManager
     ) {
         this.loader = new LazyLoader({
             name: 'GroupTypeManager',

--- a/plugin-server/src/worker/ingestion/groups/repositories/dualwrite-group-repository-transaction.ts
+++ b/plugin-server/src/worker/ingestion/groups/repositories/dualwrite-group-repository-transaction.ts
@@ -157,6 +157,13 @@ export class DualWriteGroupRepositoryTransaction implements GroupRepositoryTrans
         }
     }
 
+    async fetchGroupTypesByProjectIds(
+        projectIds: ProjectId[]
+    ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>> {
+        // For read operations, only query the primary repository
+        return await this.primaryRepo.fetchGroupTypesByProjectIds(projectIds, this.lTx)
+    }
+
     async insertGroupType(
         teamId: TeamId,
         projectId: ProjectId,

--- a/plugin-server/src/worker/ingestion/groups/repositories/dualwrite-group-repository-transaction.ts
+++ b/plugin-server/src/worker/ingestion/groups/repositories/dualwrite-group-repository-transaction.ts
@@ -33,6 +33,22 @@ export class DualWriteGroupRepositoryTransaction implements GroupRepositoryTrans
         return await this.primaryRepo.fetchGroup(teamId, groupTypeIndex, groupKey, options, this.lTx)
     }
 
+    async fetchGroupsByKeys(
+        teamIds: TeamId[],
+        groupTypeIndexes: GroupTypeIndex[],
+        groupKeys: string[]
+    ): Promise<
+        {
+            team_id: TeamId
+            group_type_index: GroupTypeIndex
+            group_key: string
+            group_properties: Record<string, any>
+        }[]
+    > {
+        // For read operations, only query the primary repository
+        return await this.primaryRepo.fetchGroupsByKeys(teamIds, groupTypeIndexes, groupKeys, this.lTx)
+    }
+
     async insertGroup(
         teamId: TeamId,
         groupTypeIndex: GroupTypeIndex,
@@ -162,6 +178,13 @@ export class DualWriteGroupRepositoryTransaction implements GroupRepositoryTrans
     ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>> {
         // For read operations, only query the primary repository
         return await this.primaryRepo.fetchGroupTypesByProjectIds(projectIds, this.lTx)
+    }
+
+    async fetchGroupTypesByTeamIds(
+        teamIds: TeamId[]
+    ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>> {
+        // For read operations, only query the primary repository
+        return await this.primaryRepo.fetchGroupTypesByTeamIds(teamIds, this.lTx)
     }
 
     async insertGroupType(

--- a/plugin-server/src/worker/ingestion/groups/repositories/group-repository-transaction.interface.ts
+++ b/plugin-server/src/worker/ingestion/groups/repositories/group-repository-transaction.interface.ts
@@ -40,6 +40,12 @@ export interface GroupRepositoryTransaction {
         tag: string
     ): Promise<number | undefined>
 
+    // Group Type Methods
+
+    fetchGroupTypesByProjectIds(
+        projectIds: ProjectId[]
+    ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>>
+
     insertGroupType(
         teamId: TeamId,
         projectId: ProjectId,

--- a/plugin-server/src/worker/ingestion/groups/repositories/group-repository-transaction.interface.ts
+++ b/plugin-server/src/worker/ingestion/groups/repositories/group-repository-transaction.interface.ts
@@ -2,7 +2,14 @@ import { DateTime } from 'luxon'
 
 import { Properties } from '@posthog/plugin-scaffold'
 
-import { Group, GroupTypeIndex, PropertiesLastOperation, PropertiesLastUpdatedAt, TeamId } from '../../../../types'
+import {
+    Group,
+    GroupTypeIndex,
+    ProjectId,
+    PropertiesLastOperation,
+    PropertiesLastUpdatedAt,
+    TeamId,
+} from '../../../../types'
 
 export interface GroupRepositoryTransaction {
     fetchGroup(
@@ -32,4 +39,11 @@ export interface GroupRepositoryTransaction {
         propertiesLastOperation: PropertiesLastOperation,
         tag: string
     ): Promise<number | undefined>
+
+    insertGroupType(
+        teamId: TeamId,
+        projectId: ProjectId,
+        groupType: string,
+        index: number
+    ): Promise<[GroupTypeIndex | null, boolean]>
 }

--- a/plugin-server/src/worker/ingestion/groups/repositories/group-repository-transaction.interface.ts
+++ b/plugin-server/src/worker/ingestion/groups/repositories/group-repository-transaction.interface.ts
@@ -19,6 +19,19 @@ export interface GroupRepositoryTransaction {
         options?: { forUpdate?: boolean; useReadReplica?: boolean }
     ): Promise<Group | undefined>
 
+    fetchGroupsByKeys(
+        teamIds: TeamId[],
+        groupTypeIndexes: GroupTypeIndex[],
+        groupKeys: string[]
+    ): Promise<
+        {
+            team_id: TeamId
+            group_type_index: GroupTypeIndex
+            group_key: string
+            group_properties: Record<string, any>
+        }[]
+    >
+
     insertGroup(
         teamId: TeamId,
         groupTypeIndex: GroupTypeIndex,
@@ -44,6 +57,10 @@ export interface GroupRepositoryTransaction {
 
     fetchGroupTypesByProjectIds(
         projectIds: ProjectId[]
+    ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>>
+
+    fetchGroupTypesByTeamIds(
+        teamIds: TeamId[]
     ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>>
 
     insertGroupType(

--- a/plugin-server/src/worker/ingestion/groups/repositories/group-repository.interface.ts
+++ b/plugin-server/src/worker/ingestion/groups/repositories/group-repository.interface.ts
@@ -2,7 +2,14 @@ import { DateTime } from 'luxon'
 
 import { Properties } from '@posthog/plugin-scaffold'
 
-import { Group, GroupTypeIndex, PropertiesLastOperation, PropertiesLastUpdatedAt, TeamId } from '../../../../types'
+import {
+    Group,
+    GroupTypeIndex,
+    ProjectId,
+    PropertiesLastOperation,
+    PropertiesLastUpdatedAt,
+    TeamId,
+} from '../../../../types'
 import { GroupRepositoryTransaction } from './group-repository-transaction.interface'
 
 export interface GroupRepository {
@@ -44,6 +51,13 @@ export interface GroupRepository {
         propertiesLastUpdatedAt: PropertiesLastUpdatedAt,
         propertiesLastOperation: PropertiesLastOperation
     ): Promise<number | undefined>
+
+    insertGroupType(
+        teamId: TeamId,
+        projectId: ProjectId,
+        groupType: string,
+        index: number
+    ): Promise<[GroupTypeIndex | null, boolean]>
 
     inTransaction<T>(description: string, transaction: (tx: GroupRepositoryTransaction) => Promise<T>): Promise<T>
 }

--- a/plugin-server/src/worker/ingestion/groups/repositories/group-repository.interface.ts
+++ b/plugin-server/src/worker/ingestion/groups/repositories/group-repository.interface.ts
@@ -20,6 +20,19 @@ export interface GroupRepository {
         options?: { forUpdate?: boolean; useReadReplica?: boolean }
     ): Promise<Group | undefined>
 
+    fetchGroupsByKeys(
+        teamIds: TeamId[],
+        groupTypeIndexes: GroupTypeIndex[],
+        groupKeys: string[]
+    ): Promise<
+        {
+            team_id: TeamId
+            group_type_index: GroupTypeIndex
+            group_key: string
+            group_properties: Record<string, any>
+        }[]
+    >
+
     insertGroup(
         teamId: TeamId,
         groupTypeIndex: GroupTypeIndex,
@@ -56,6 +69,10 @@ export interface GroupRepository {
 
     fetchGroupTypesByProjectIds(
         projectIds: ProjectId[]
+    ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>>
+
+    fetchGroupTypesByTeamIds(
+        teamIds: TeamId[]
     ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>>
 
     insertGroupType(

--- a/plugin-server/src/worker/ingestion/groups/repositories/group-repository.interface.ts
+++ b/plugin-server/src/worker/ingestion/groups/repositories/group-repository.interface.ts
@@ -52,12 +52,20 @@ export interface GroupRepository {
         propertiesLastOperation: PropertiesLastOperation
     ): Promise<number | undefined>
 
+    // Group Type Methods
+
+    fetchGroupTypesByProjectIds(
+        projectIds: ProjectId[]
+    ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>>
+
     insertGroupType(
         teamId: TeamId,
         projectId: ProjectId,
         groupType: string,
         index: number
     ): Promise<[GroupTypeIndex | null, boolean]>
+
+    // Transaction Methods
 
     inTransaction<T>(description: string, transaction: (tx: GroupRepositoryTransaction) => Promise<T>): Promise<T>
 }

--- a/plugin-server/src/worker/ingestion/groups/repositories/postgres-dualwrite-group-repository.ts
+++ b/plugin-server/src/worker/ingestion/groups/repositories/postgres-dualwrite-group-repository.ts
@@ -54,6 +54,22 @@ export class PostgresDualWriteGroupRepository implements GroupRepository {
         return await this.primaryRepo.fetchGroup(teamId, groupTypeIndex, groupKey, options)
     }
 
+    async fetchGroupsByKeys(
+        teamIds: TeamId[],
+        groupTypeIndexes: GroupTypeIndex[],
+        groupKeys: string[]
+    ): Promise<
+        {
+            team_id: TeamId
+            group_type_index: GroupTypeIndex
+            group_key: string
+            group_properties: Record<string, any>
+        }[]
+    > {
+        // For read operations, only query the primary repository
+        return await this.primaryRepo.fetchGroupsByKeys(teamIds, groupTypeIndexes, groupKeys)
+    }
+
     async insertGroup(
         teamId: TeamId,
         groupTypeIndex: GroupTypeIndex,
@@ -293,6 +309,13 @@ export class PostgresDualWriteGroupRepository implements GroupRepository {
     ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>> {
         // For read operations, only query the primary repository
         return await this.primaryRepo.fetchGroupTypesByProjectIds(projectIds)
+    }
+
+    async fetchGroupTypesByTeamIds(
+        teamIds: TeamId[]
+    ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>> {
+        // For read operations, only query the primary repository
+        return await this.primaryRepo.fetchGroupTypesByTeamIds(teamIds)
     }
 
     private compareUpdateGroupResults(primary: number | undefined, secondary: number | undefined, tag: string): void {

--- a/plugin-server/src/worker/ingestion/groups/repositories/postgres-dualwrite-group-repository.ts
+++ b/plugin-server/src/worker/ingestion/groups/repositories/postgres-dualwrite-group-repository.ts
@@ -288,6 +288,13 @@ export class PostgresDualWriteGroupRepository implements GroupRepository {
         }
     }
 
+    async fetchGroupTypesByProjectIds(
+        projectIds: ProjectId[]
+    ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>> {
+        // For read operations, only query the primary repository
+        return await this.primaryRepo.fetchGroupTypesByProjectIds(projectIds)
+    }
+
     private compareUpdateGroupResults(primary: number | undefined, secondary: number | undefined, tag: string): void {
         if (primary !== secondary) {
             if (primary === undefined || secondary === undefined) {

--- a/plugin-server/src/worker/ingestion/groups/repositories/postgres-group-repository-transaction.ts
+++ b/plugin-server/src/worker/ingestion/groups/repositories/postgres-group-repository-transaction.ts
@@ -73,6 +73,12 @@ export class PostgresGroupRepositoryTransaction implements GroupRepositoryTransa
         )
     }
 
+    async fetchGroupTypesByProjectIds(
+        projectIds: ProjectId[]
+    ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>> {
+        return await this.repository.fetchGroupTypesByProjectIds(projectIds, this.tx)
+    }
+
     async insertGroupType(
         teamId: TeamId,
         projectId: ProjectId,

--- a/plugin-server/src/worker/ingestion/groups/repositories/postgres-group-repository-transaction.ts
+++ b/plugin-server/src/worker/ingestion/groups/repositories/postgres-group-repository-transaction.ts
@@ -29,6 +29,21 @@ export class PostgresGroupRepositoryTransaction implements GroupRepositoryTransa
         return await this.repository.fetchGroup(teamId, groupTypeIndex, groupKey, options, this.tx)
     }
 
+    async fetchGroupsByKeys(
+        teamIds: TeamId[],
+        groupTypeIndexes: GroupTypeIndex[],
+        groupKeys: string[]
+    ): Promise<
+        {
+            team_id: TeamId
+            group_type_index: GroupTypeIndex
+            group_key: string
+            group_properties: Record<string, any>
+        }[]
+    > {
+        return await this.repository.fetchGroupsByKeys(teamIds, groupTypeIndexes, groupKeys, this.tx)
+    }
+
     async insertGroup(
         teamId: TeamId,
         groupTypeIndex: GroupTypeIndex,
@@ -77,6 +92,12 @@ export class PostgresGroupRepositoryTransaction implements GroupRepositoryTransa
         projectIds: ProjectId[]
     ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>> {
         return await this.repository.fetchGroupTypesByProjectIds(projectIds, this.tx)
+    }
+
+    async fetchGroupTypesByTeamIds(
+        teamIds: TeamId[]
+    ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>> {
+        return await this.repository.fetchGroupTypesByTeamIds(teamIds, this.tx)
     }
 
     async insertGroupType(

--- a/plugin-server/src/worker/ingestion/groups/repositories/postgres-group-repository-transaction.ts
+++ b/plugin-server/src/worker/ingestion/groups/repositories/postgres-group-repository-transaction.ts
@@ -2,7 +2,14 @@ import { DateTime } from 'luxon'
 
 import { Properties } from '@posthog/plugin-scaffold'
 
-import { Group, GroupTypeIndex, PropertiesLastOperation, PropertiesLastUpdatedAt, TeamId } from '../../../../types'
+import {
+    Group,
+    GroupTypeIndex,
+    ProjectId,
+    PropertiesLastOperation,
+    PropertiesLastUpdatedAt,
+    TeamId,
+} from '../../../../types'
 import { TransactionClient } from '../../../../utils/db/postgres'
 import { GroupRepositoryTransaction } from './group-repository-transaction.interface'
 import { RawPostgresGroupRepository } from './raw-postgres-group-repository.interface'
@@ -64,5 +71,14 @@ export class PostgresGroupRepositoryTransaction implements GroupRepositoryTransa
             tag,
             this.tx
         )
+    }
+
+    async insertGroupType(
+        teamId: TeamId,
+        projectId: ProjectId,
+        groupType: string,
+        index: number
+    ): Promise<[GroupTypeIndex | null, boolean]> {
+        return await this.repository.insertGroupType(teamId, projectId, groupType, index, this.tx)
     }
 }

--- a/plugin-server/src/worker/ingestion/groups/repositories/postgres-group-repository.ts
+++ b/plugin-server/src/worker/ingestion/groups/repositories/postgres-group-repository.ts
@@ -80,12 +80,20 @@ export class PostgresGroupRepository
             'fetchGroupsByKeys'
         )
 
-        return rows.map((row) => ({
-            team_id: row.team_id as TeamId,
-            group_type_index: row.group_type_index as GroupTypeIndex,
-            group_key: row.group_key,
-            group_properties: row.group_properties,
-        }))
+        return rows.map((row) => {
+            if (row.group_type_index < 0 || row.group_type_index > 4) {
+                throw new Error(
+                    `Invalid group_type_index ${row.group_type_index} for team ${row.team_id}. Must be between 0 and 4.`
+                )
+            }
+
+            return {
+                team_id: row.team_id as TeamId,
+                group_type_index: row.group_type_index as GroupTypeIndex,
+                group_key: row.group_key,
+                group_properties: row.group_properties,
+            }
+        })
     }
 
     async insertGroup(
@@ -238,6 +246,13 @@ export class PostgresGroupRepository
             if (!response[projectIdStr]) {
                 response[projectIdStr] = []
             }
+
+            if (row.group_type_index < 0 || row.group_type_index > 4) {
+                throw new Error(
+                    `Invalid group_type_index ${row.group_type_index} for team ${row.team_id}, project ${row.project_id}. Must be between 0 and 4.`
+                )
+            }
+
             response[projectIdStr].push({
                 group_type: row.group_type,
                 group_type_index: row.group_type_index as GroupTypeIndex,
@@ -273,6 +288,13 @@ export class PostgresGroupRepository
             if (!response[teamIdStr]) {
                 response[teamIdStr] = []
             }
+
+            if (row.group_type_index < 0 || row.group_type_index > 4) {
+                throw new Error(
+                    `Invalid group_type_index ${row.group_type_index} for team ${row.team_id}. Must be between 0 and 4.`
+                )
+            }
+
             response[teamIdStr].push({
                 group_type: row.group_type,
                 group_type_index: row.group_type_index as GroupTypeIndex,
@@ -291,7 +313,7 @@ export class PostgresGroupRepository
     ): Promise<[GroupTypeIndex | null, boolean]> {
         const MAX_GROUP_TYPES_PER_TEAM = 5
 
-        if (index >= MAX_GROUP_TYPES_PER_TEAM) {
+        if (index < 0 || index >= MAX_GROUP_TYPES_PER_TEAM) {
             return [null, false]
         }
 

--- a/plugin-server/src/worker/ingestion/groups/repositories/postgres-group-repository.ts
+++ b/plugin-server/src/worker/ingestion/groups/repositories/postgres-group-repository.ts
@@ -19,6 +19,8 @@ import { GroupRepository } from './group-repository.interface'
 import { PostgresGroupRepositoryTransaction } from './postgres-group-repository-transaction'
 import { RawPostgresGroupRepository } from './raw-postgres-group-repository.interface'
 
+const MAX_GROUP_TYPES_PER_TEAM = 5
+
 export class PostgresGroupRepository
     implements GroupRepository, RawPostgresGroupRepository, GroupRepositoryTransaction
 {
@@ -311,8 +313,6 @@ export class PostgresGroupRepository
         index: number,
         tx?: TransactionClient
     ): Promise<[GroupTypeIndex | null, boolean]> {
-        const MAX_GROUP_TYPES_PER_TEAM = 5
-
         if (index < 0 || index >= MAX_GROUP_TYPES_PER_TEAM) {
             return [null, false]
         }

--- a/plugin-server/src/worker/ingestion/groups/repositories/raw-postgres-group-repository.interface.ts
+++ b/plugin-server/src/worker/ingestion/groups/repositories/raw-postgres-group-repository.interface.ts
@@ -2,7 +2,14 @@ import { DateTime } from 'luxon'
 
 import { Properties } from '@posthog/plugin-scaffold'
 
-import { Group, GroupTypeIndex, PropertiesLastOperation, PropertiesLastUpdatedAt, TeamId } from '../../../../types'
+import {
+    Group,
+    GroupTypeIndex,
+    ProjectId,
+    PropertiesLastOperation,
+    PropertiesLastUpdatedAt,
+    TeamId,
+} from '../../../../types'
 import { TransactionClient } from '../../../../utils/db/postgres'
 
 export interface RawPostgresGroupRepository {
@@ -47,6 +54,14 @@ export interface RawPostgresGroupRepository {
         propertiesLastUpdatedAt: PropertiesLastUpdatedAt,
         propertiesLastOperation: PropertiesLastOperation
     ): Promise<number | undefined>
+
+    insertGroupType(
+        teamId: TeamId,
+        projectId: ProjectId,
+        groupType: string,
+        index: number,
+        tx?: TransactionClient
+    ): Promise<[GroupTypeIndex | null, boolean]>
 
     inRawTransaction<T>(description: string, transaction: (tx: TransactionClient) => Promise<T>): Promise<T>
 }

--- a/plugin-server/src/worker/ingestion/groups/repositories/raw-postgres-group-repository.interface.ts
+++ b/plugin-server/src/worker/ingestion/groups/repositories/raw-postgres-group-repository.interface.ts
@@ -55,6 +55,13 @@ export interface RawPostgresGroupRepository {
         propertiesLastOperation: PropertiesLastOperation
     ): Promise<number | undefined>
 
+    // Group Type Methods
+
+    fetchGroupTypesByProjectIds(
+        projectIds: ProjectId[],
+        tx?: TransactionClient
+    ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>>
+
     insertGroupType(
         teamId: TeamId,
         projectId: ProjectId,
@@ -62,6 +69,8 @@ export interface RawPostgresGroupRepository {
         index: number,
         tx?: TransactionClient
     ): Promise<[GroupTypeIndex | null, boolean]>
+
+    // Transaction Methods
 
     inRawTransaction<T>(description: string, transaction: (tx: TransactionClient) => Promise<T>): Promise<T>
 }

--- a/plugin-server/src/worker/ingestion/groups/repositories/raw-postgres-group-repository.interface.ts
+++ b/plugin-server/src/worker/ingestion/groups/repositories/raw-postgres-group-repository.interface.ts
@@ -21,6 +21,20 @@ export interface RawPostgresGroupRepository {
         tx?: TransactionClient
     ): Promise<Group | undefined>
 
+    fetchGroupsByKeys(
+        teamIds: TeamId[],
+        groupTypeIndexes: GroupTypeIndex[],
+        groupKeys: string[],
+        tx?: TransactionClient
+    ): Promise<
+        {
+            team_id: TeamId
+            group_type_index: GroupTypeIndex
+            group_key: string
+            group_properties: Record<string, any>
+        }[]
+    >
+
     insertGroup(
         teamId: TeamId,
         groupTypeIndex: GroupTypeIndex,
@@ -59,6 +73,11 @@ export interface RawPostgresGroupRepository {
 
     fetchGroupTypesByProjectIds(
         projectIds: ProjectId[],
+        tx?: TransactionClient
+    ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>>
+
+    fetchGroupTypesByTeamIds(
+        teamIds: TeamId[],
         tx?: TransactionClient
     ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>>
 

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
@@ -89,6 +89,7 @@ describe('BatchWritingPersonStore', () => {
         const mockRepo = {
             fetchPerson: jest.fn().mockResolvedValue(person),
             fetchPersonDistinctIds: jest.fn().mockResolvedValue([]),
+            fetchPersonsByDistinctIds: jest.fn().mockResolvedValue([]),
             createPerson: jest.fn().mockResolvedValue([person, []]),
             updatePerson: jest.fn().mockResolvedValue([person, [], false]),
             updatePersonAssertVersion: jest.fn().mockResolvedValue([person.version + 1, []]),

--- a/plugin-server/src/worker/ingestion/persons/repositories/person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/person-repository.ts
@@ -3,10 +3,14 @@ import { DateTime } from 'luxon'
 import { Properties } from '@posthog/plugin-scaffold'
 
 import { TopicMessage } from '../../../../kafka/producer'
-import { InternalPerson, PropertiesLastOperation, PropertiesLastUpdatedAt, Team } from '../../../../types'
+import { InternalPerson, PropertiesLastOperation, PropertiesLastUpdatedAt, Team, TeamId } from '../../../../types'
 import { CreatePersonResult } from '../../../../utils/db/db'
 import { PersonUpdate } from '../person-update-batch'
 import { PersonRepositoryTransaction } from './person-repository-transaction'
+
+export type InternalPersonWithDistinctId = InternalPerson & {
+    distinct_id: string
+}
 
 export class PersonPropertiesSizeViolationError extends Error {
     constructor(
@@ -26,6 +30,10 @@ export interface PersonRepository {
         distinctId: string,
         options?: { forUpdate?: boolean; useReadReplica?: boolean }
     ): Promise<InternalPerson | undefined>
+
+    fetchPersonsByDistinctIds(
+        teamPersons: { teamId: TeamId; distinctId: string }[]
+    ): Promise<InternalPersonWithDistinctId[]>
 
     createPerson(
         createdAt: DateTime,

--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-dualwrite-person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-dualwrite-person-repository.ts
@@ -3,7 +3,7 @@ import { DateTime } from 'luxon'
 import { Properties } from '@posthog/plugin-scaffold'
 
 import { TopicMessage } from '../../../../kafka/producer'
-import { InternalPerson, PropertiesLastOperation, PropertiesLastUpdatedAt, Team } from '../../../../types'
+import { InternalPerson, PropertiesLastOperation, PropertiesLastUpdatedAt, Team, TeamId } from '../../../../types'
 import { CreatePersonResult, MoveDistinctIdsResult } from '../../../../utils/db/db'
 import { PostgresRouter, PostgresUse } from '../../../../utils/db/postgres'
 import { TwoPhaseCommitCoordinator } from '../../../../utils/db/two-phase'
@@ -11,7 +11,7 @@ import { logger as _logger } from '../../../../utils/logger'
 import { dualWriteComparisonCounter, dualWriteDataMismatchCounter } from '../metrics'
 import { PersonUpdate } from '../person-update-batch'
 import { DualWritePersonRepositoryTransaction } from './dualwrite-person-repository-transaction'
-import { PersonRepository } from './person-repository'
+import { InternalPersonWithDistinctId, PersonRepository } from './person-repository'
 import { PersonRepositoryTransaction } from './person-repository-transaction'
 import type { PostgresPersonRepositoryOptions } from './postgres-person-repository'
 import { PostgresPersonRepository } from './postgres-person-repository'
@@ -48,6 +48,13 @@ export class PostgresDualWritePersonRepository implements PersonRepository {
         options?: { forUpdate?: boolean; useReadReplica?: boolean }
     ): Promise<InternalPerson | undefined> {
         return await this.primaryRepo.fetchPerson(teamId, distinctId, options)
+    }
+
+    // a read, just use the primary as the source of truth
+    async fetchPersonsByDistinctIds(
+        teamPersons: { teamId: TeamId; distinctId: string }[]
+    ): Promise<InternalPersonWithDistinctId[]> {
+        return await this.primaryRepo.fetchPersonsByDistinctIds(teamPersons)
     }
 
     /*

--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.test.ts
@@ -796,17 +796,17 @@ describe('PostgresPersonRepository', () => {
 
         it('should fetch persons by distinct IDs from multiple teams', async () => {
             const team1 = await getFirstTeam(hub)
-            const team2 = await createTeam(postgres, team1.organization_id)
+            const team2Id = await createTeam(postgres, team1.organization_id)
 
             // Create persons in different teams
             const person1 = await createTestPerson(team1.id, 'distinct-1', { name: 'Person 1' })
             const person2 = await createTestPerson(team1.id, 'distinct-2', { name: 'Person 2' })
-            const person3 = await createTestPerson(team2, 'distinct-3', { name: 'Person 3' })
+            const person3 = await createTestPerson(team2Id, 'distinct-3', { name: 'Person 3' })
 
             const teamPersons = [
-                { teamId: team1.id as any, distinctId: 'distinct-1' },
-                { teamId: team1.id as any, distinctId: 'distinct-2' },
-                { teamId: team2 as any, distinctId: 'distinct-3' },
+                { teamId: team1.id, distinctId: 'distinct-1' },
+                { teamId: team1.id, distinctId: 'distinct-2' },
+                { teamId: team2Id, distinctId: 'distinct-3' },
             ]
 
             const result = await repository.fetchPersonsByDistinctIds(teamPersons)
@@ -829,7 +829,7 @@ describe('PostgresPersonRepository', () => {
             const person3Result = result.find((p) => p.distinct_id === 'distinct-3')
             expect(person3Result).toBeDefined()
             expect(person3Result!.uuid).toBe(person3.uuid)
-            expect(person3Result!.team_id).toBe(team2)
+            expect(person3Result!.team_id).toBe(team2Id)
             expect(person3Result!.properties.name).toBe('Person 3')
         })
 

--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.test.ts
@@ -788,6 +788,126 @@ describe('PostgresPersonRepository', () => {
         })
     })
 
+    describe('fetchPersonsByDistinctIds()', () => {
+        it('should return empty array when no team persons provided', async () => {
+            const result = await repository.fetchPersonsByDistinctIds([])
+            expect(result).toEqual([])
+        })
+
+        it('should fetch persons by distinct IDs from multiple teams', async () => {
+            const team1 = await getFirstTeam(hub)
+            const team2 = await createTeam(postgres, team1.organization_id)
+
+            // Create persons in different teams
+            const person1 = await createTestPerson(team1.id, 'distinct-1', { name: 'Person 1' })
+            const person2 = await createTestPerson(team1.id, 'distinct-2', { name: 'Person 2' })
+            const person3 = await createTestPerson(team2, 'distinct-3', { name: 'Person 3' })
+
+            const teamPersons = [
+                { teamId: team1.id as any, distinctId: 'distinct-1' },
+                { teamId: team1.id as any, distinctId: 'distinct-2' },
+                { teamId: team2 as any, distinctId: 'distinct-3' },
+            ]
+
+            const result = await repository.fetchPersonsByDistinctIds(teamPersons)
+
+            expect(result).toHaveLength(3)
+
+            // Check that we got the right persons with distinct_id included
+            const person1Result = result.find((p) => p.distinct_id === 'distinct-1')
+            expect(person1Result).toBeDefined()
+            expect(person1Result!.uuid).toBe(person1.uuid)
+            expect(person1Result!.team_id).toBe(team1.id)
+            expect(person1Result!.properties.name).toBe('Person 1')
+
+            const person2Result = result.find((p) => p.distinct_id === 'distinct-2')
+            expect(person2Result).toBeDefined()
+            expect(person2Result!.uuid).toBe(person2.uuid)
+            expect(person2Result!.team_id).toBe(team1.id)
+            expect(person2Result!.properties.name).toBe('Person 2')
+
+            const person3Result = result.find((p) => p.distinct_id === 'distinct-3')
+            expect(person3Result).toBeDefined()
+            expect(person3Result!.uuid).toBe(person3.uuid)
+            expect(person3Result!.team_id).toBe(team2)
+            expect(person3Result!.properties.name).toBe('Person 3')
+        })
+
+        it('should handle non-existent distinct IDs gracefully', async () => {
+            const team = await getFirstTeam(hub)
+            const person = await createTestPerson(team.id, 'existing-distinct', { name: 'Existing Person' })
+
+            const teamPersons = [
+                { teamId: team.id as any, distinctId: 'existing-distinct' },
+                { teamId: team.id as any, distinctId: 'non-existent-distinct' },
+            ]
+
+            const result = await repository.fetchPersonsByDistinctIds(teamPersons)
+
+            // Should only return the existing person
+            expect(result).toHaveLength(1)
+            expect(result[0].distinct_id).toBe('existing-distinct')
+            expect(result[0].uuid).toBe(person.uuid)
+        })
+
+        it('should handle single team person lookup', async () => {
+            const team = await getFirstTeam(hub)
+            const person = await createTestPerson(team.id, 'single-distinct', { name: 'Single Person' })
+
+            const teamPersons = [{ teamId: team.id as any, distinctId: 'single-distinct' }]
+
+            const result = await repository.fetchPersonsByDistinctIds(teamPersons)
+
+            expect(result).toHaveLength(1)
+            expect(result[0].distinct_id).toBe('single-distinct')
+            expect(result[0].uuid).toBe(person.uuid)
+            expect(result[0].team_id).toBe(team.id)
+            expect(result[0].properties.name).toBe('Single Person')
+        })
+
+        it('should handle duplicate team/distinctId pairs', async () => {
+            const team = await getFirstTeam(hub)
+            const person = await createTestPerson(team.id, 'duplicate-distinct', { name: 'Duplicate Person' })
+
+            const teamPersons = [
+                { teamId: team.id as any, distinctId: 'duplicate-distinct' },
+                { teamId: team.id as any, distinctId: 'duplicate-distinct' }, // Same pair
+            ]
+
+            const result = await repository.fetchPersonsByDistinctIds(teamPersons)
+
+            // Should only return one result even though we queried twice
+            expect(result).toHaveLength(1)
+            expect(result[0].distinct_id).toBe('duplicate-distinct')
+            expect(result[0].uuid).toBe(person.uuid)
+        })
+
+        it('should include all required fields in InternalPersonWithDistinctId', async () => {
+            const team = await getFirstTeam(hub)
+            const person = await createTestPerson(team.id, 'fields-test', { name: 'Fields Test', age: 25 })
+
+            const teamPersons = [{ teamId: team.id as any, distinctId: 'fields-test' }]
+
+            const result = await repository.fetchPersonsByDistinctIds(teamPersons)
+
+            expect(result).toHaveLength(1)
+            const personResult = result[0]
+
+            // Check all InternalPerson fields are present
+            expect(personResult.id).toBe(person.id)
+            expect(personResult.uuid).toBe(person.uuid)
+            expect(personResult.properties).toEqual({ name: 'Fields Test', age: 25 })
+            expect(personResult.created_at).toEqual(person.created_at)
+            expect(personResult.version).toBe(person.version)
+            expect(personResult.is_user_id).toBe(person.is_user_id)
+            expect(personResult.is_identified).toBe(person.is_identified)
+            expect(personResult.team_id).toBe(person.team_id)
+
+            // Check the additional distinct_id field
+            expect(personResult.distinct_id).toBe('fields-test')
+        })
+    })
+
     describe('addPersonlessDistinctId', () => {
         it('should insert personless distinct ID successfully', async () => {
             const team = await getFirstTeam(hub)

--- a/plugin-server/src/worker/ingestion/persons/repositories/raw-postgres-person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/raw-postgres-person-repository.ts
@@ -3,10 +3,11 @@ import { DateTime } from 'luxon'
 import { Properties } from '@posthog/plugin-scaffold'
 
 import { TopicMessage } from '../../../../kafka/producer'
-import { InternalPerson, PropertiesLastOperation, PropertiesLastUpdatedAt, Team } from '../../../../types'
+import { InternalPerson, PropertiesLastOperation, PropertiesLastUpdatedAt, Team, TeamId } from '../../../../types'
 import { CreatePersonResult, MoveDistinctIdsResult } from '../../../../utils/db/db'
 import { TransactionClient } from '../../../../utils/db/postgres'
 import { PersonUpdate } from '../person-update-batch'
+import { InternalPersonWithDistinctId } from './person-repository'
 
 export interface RawPostgresPersonRepository {
     fetchPerson(
@@ -14,6 +15,10 @@ export interface RawPostgresPersonRepository {
         distinctId: string,
         options?: { forUpdate?: boolean; useReadReplica?: boolean }
     ): Promise<InternalPerson | undefined>
+
+    fetchPersonsByDistinctIds(
+        teamPersons: { teamId: TeamId; distinctId: string }[]
+    ): Promise<InternalPersonWithDistinctId[]>
 
     createPerson(
         createdAt: DateTime,

--- a/plugin-server/tests/main/ingestion-queues/each-batch-webhooks.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/each-batch-webhooks.test.ts
@@ -92,8 +92,8 @@ describe('eachMessageWebhooksHandlers', () => {
             hub.appMetrics,
             hub.EXTERNAL_REQUEST_TIMEOUT_MS
         )
-        const groupTypeManager = new GroupTypeManager(hub.postgres, hub.teamManager)
-        await groupTypeManager.insertGroupType(2, 2 as ProjectId, 'organization', 0)
+        const groupTypeManager = new GroupTypeManager(hub.postgres, hub.teamManager, hub.groupRepository)
+        await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'organization', 0)
 
         const team = await hub.teamManager.getTeam(2)
         team!.available_features = ['group_analytics'] // NOTE: Hacky but this will be removed soon

--- a/plugin-server/tests/main/ingestion-queues/each-batch-webhooks.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/each-batch-webhooks.test.ts
@@ -92,7 +92,7 @@ describe('eachMessageWebhooksHandlers', () => {
             hub.appMetrics,
             hub.EXTERNAL_REQUEST_TIMEOUT_MS
         )
-        const groupTypeManager = new GroupTypeManager(hub.postgres, hub.teamManager, hub.groupRepository)
+        const groupTypeManager = new GroupTypeManager(hub.groupRepository, hub.teamManager)
         await hub.groupRepository.insertGroupType(2, 2 as ProjectId, 'organization', 0)
 
         const team = await hub.teamManager.getTeam(2)

--- a/plugin-server/tests/main/ingestion-queues/each-batch-webhooks.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/each-batch-webhooks.test.ts
@@ -1,10 +1,14 @@
+import { DateTime } from 'luxon'
+
 import { eachMessageWebhooksHandlers } from '../../../src/main/ingestion-queues/batch-processing/each-batch-webhooks'
 import {
     ClickHouseTimestamp,
     ClickHouseTimestampSecondPrecision,
+    GroupTypeIndex,
     Hub,
     ProjectId,
     RawKafkaEvent,
+    TeamId,
 } from '../../../src/types'
 import { closeHub, createHub } from '../../../src/utils/db/hub'
 import { PostgresUse } from '../../../src/utils/db/postgres'
@@ -52,23 +56,14 @@ describe('eachMessageWebhooksHandlers', () => {
             [],
             'testTag'
         )
-        await hub.db.postgres.query(
-            PostgresUse.PERSONS_WRITE,
-            `
-            INSERT INTO posthog_group (team_id, group_key, group_type_index, group_properties, created_at, properties_last_updated_at, properties_last_operation, version)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-            `,
-            [
-                2,
-                'org_posthog',
-                0,
-                JSON.stringify({ name: 'PostHog' }),
-                new Date().toISOString(),
-                JSON.stringify({}),
-                JSON.stringify({}),
-                1,
-            ],
-            'upsertGroup'
+        await hub.groupRepository.insertGroup(
+            2 as TeamId,
+            0 as GroupTypeIndex,
+            'org_posthog',
+            { name: 'PostHog' },
+            DateTime.now(),
+            {},
+            {}
         )
         await hub.db.postgres.query(
             PostgresUse.COMMON_WRITE,
@@ -142,7 +137,7 @@ describe('eachMessageWebhooksHandlers', () => {
             hookCannon,
             groupTypeManager,
             hub.teamManager,
-            hub.postgres
+            hub.groupRepository
         )
 
         // NOTE: really it would be nice to verify that fire has been called

--- a/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
@@ -1,5 +1,5 @@
-import { PostgresRouter } from '~/utils/db/postgres'
 import { TeamManager } from '~/utils/team-manager'
+import { GroupRepository } from '~/worker/ingestion/groups/repositories/group-repository.interface'
 
 import {
     eachBatchWebhooksHandlers,
@@ -133,6 +133,11 @@ describe('eachBatchX', () => {
             const matchSpy = jest.spyOn(actionMatcher, 'match')
             // mock hasWebhooks to return true
             actionMatcher.hasWebhooks = jest.fn(() => true)
+
+            const groupRepository: GroupRepository = {
+                fetchGroup: jest.fn(() => Promise.resolve(undefined)),
+            } as unknown as GroupRepository
+
             await eachBatchWebhooksHandlers(
                 createKafkaJSBatch(kafkaEvent),
                 actionMatcher,
@@ -140,9 +145,7 @@ describe('eachBatchX', () => {
                 10,
                 groupTypeManager,
                 teamManager,
-
-                // @ts-expect-error this is not being used in the function, so just passing null here
-                null as PostgresRouter
+                groupRepository
             )
 
             // NOTE: really it would be nice to verify that fire has been called

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -25,6 +25,7 @@ import { PostgresUse } from '../../src/utils/db/postgres'
 import { UUIDT } from '../../src/utils/utils'
 import { EventPipelineRunner } from '../../src/worker/ingestion/event-pipeline/runner'
 import { PostgresPersonRepository } from '../../src/worker/ingestion/persons/repositories/postgres-person-repository'
+import { fetchDistinctIdValues, fetchPersons } from '../../src/worker/ingestion/persons/repositories/test-helpers'
 import { EventsProcessor } from '../../src/worker/ingestion/process-event'
 import { resetKafka } from '../helpers/kafka'
 import { createUserTeamAndOrganization, getFirstTeam, getTeams, resetTestDatabase } from '../helpers/sql'
@@ -172,14 +173,14 @@ describe('processEvent', () => {
     const getEventsByPerson = async (hub: Hub): Promise<EventsByPerson[]> => {
         // Helper function to retrieve events paired with their associated distinct
         // ids
-        const persons = await hub.db.fetchPersons()
+        const persons = await fetchPersons(hub.db.postgres)
         const events = getEventsFromKafka()
 
         return await Promise.all(
             persons
                 .sort((p1, p2) => p1.created_at.diff(p2.created_at).toMillis())
                 .map(async (person) => {
-                    const distinctIds = await hub.db.fetchDistinctIdValues(person)
+                    const distinctIds = await fetchDistinctIdValues(hub.db.postgres, person)
 
                     return [
                         distinctIds,
@@ -368,7 +369,7 @@ describe('processEvent', () => {
             new UUIDT().toString()
         )
 
-        expect(await hub.db.fetchDistinctIdValues((await hub.db.fetchPersons())[0])).toEqual([
+        expect(await fetchDistinctIdValues(hub.db.postgres, (await fetchPersons(hub.db.postgres))[0])).toEqual([
             'old_distinct_id',
             'new_distinct_id',
         ])
@@ -390,7 +391,7 @@ describe('processEvent', () => {
             new UUIDT().toString()
         )
 
-        expect(await hub.db.fetchDistinctIdValues((await hub.db.fetchPersons())[0])).toEqual([
+        expect(await fetchDistinctIdValues(hub.db.postgres, (await fetchPersons(hub.db.postgres))[0])).toEqual([
             'old_distinct_id',
             'new_distinct_id',
         ])
@@ -412,7 +413,7 @@ describe('processEvent', () => {
             new UUIDT().toString()
         )
 
-        expect(await hub.db.fetchDistinctIdValues((await hub.db.fetchPersons())[0])).toEqual([
+        expect(await fetchDistinctIdValues(hub.db.postgres, (await fetchPersons(hub.db.postgres))[0])).toEqual([
             'old_distinct_id',
             'new_distinct_id',
         ])
@@ -434,14 +435,14 @@ describe('processEvent', () => {
             new UUIDT().toString()
         )
 
-        expect((await hub.db.fetchPersons()).length).toBe(1)
-        expect(await hub.db.fetchDistinctIdValues((await hub.db.fetchPersons())[0])).toEqual([
+        expect((await fetchPersons(hub.db.postgres)).length).toBe(1)
+        expect(await fetchDistinctIdValues(hub.db.postgres, (await fetchPersons(hub.db.postgres))[0])).toEqual([
             'old_distinct_id',
             'new_distinct_id',
         ])
 
         await createPerson(hub, team, ['old_distinct_id_2'])
-        expect((await hub.db.fetchPersons()).length).toBe(2)
+        expect((await fetchPersons(hub.db.postgres)).length).toBe(2)
 
         await processEvent(
             'new_distinct_id',
@@ -455,8 +456,8 @@ describe('processEvent', () => {
             now,
             new UUIDT().toString()
         )
-        expect((await hub.db.fetchPersons()).length).toBe(1)
-        expect(await hub.db.fetchDistinctIdValues((await hub.db.fetchPersons())[0])).toEqual([
+        expect((await fetchPersons(hub.db.postgres)).length).toBe(1)
+        expect(await fetchDistinctIdValues(hub.db.postgres, (await fetchPersons(hub.db.postgres))[0])).toEqual([
             'old_distinct_id',
             'new_distinct_id',
             'old_distinct_id_2',
@@ -477,8 +478,8 @@ describe('processEvent', () => {
             new UUIDT().toString()
         )
 
-        expect((await hub.db.fetchPersons()).length).toBe(1)
-        expect(await hub.db.fetchDistinctIdValues((await hub.db.fetchPersons())[0])).toEqual([
+        expect((await fetchPersons(hub.db.postgres)).length).toBe(1)
+        expect(await fetchDistinctIdValues(hub.db.postgres, (await fetchPersons(hub.db.postgres))[0])).toEqual([
             'new_distinct_id',
             'old_distinct_id',
         ])
@@ -501,7 +502,7 @@ describe('processEvent', () => {
             new UUIDT().toString()
         )
 
-        expect(await hub.db.fetchDistinctIdValues((await hub.db.fetchPersons())[0])).toEqual([
+        expect(await fetchDistinctIdValues(hub.db.postgres, (await fetchPersons(hub.db.postgres))[0])).toEqual([
             'old_distinct_id',
             'new_distinct_id',
         ])
@@ -530,9 +531,12 @@ describe('processEvent', () => {
             new UUIDT().toString()
         )
 
-        expect((await hub.db.fetchPersons()).length).toBe(1)
-        const [person] = await hub.db.fetchPersons()
-        expect((await hub.db.fetchDistinctIdValues(person)).sort()).toEqual(['new_distinct_id', 'old_distinct_id'])
+        expect((await fetchPersons(hub.db.postgres)).length).toBe(1)
+        const [person] = await fetchPersons(hub.db.postgres)
+        expect((await fetchDistinctIdValues(hub.db.postgres, person)).sort()).toEqual([
+            'new_distinct_id',
+            'old_distinct_id',
+        ])
         expect(person.properties).toEqual({
             key_on_both: 'new value both',
             key_on_new: 'new value',
@@ -618,7 +622,7 @@ describe('processEvent', () => {
 
     test('identify with illegal (generic) id', async () => {
         await createPerson(hub, team, ['im an anonymous id'])
-        expect((await hub.db.fetchPersons()).length).toBe(1)
+        expect((await fetchPersons(hub.db.postgres)).length).toBe(1)
 
         const createPersonAndSendIdentify = async (distinctId: string): Promise<void> => {
             await createPerson(hub, team, [distinctId])
@@ -643,34 +647,34 @@ describe('processEvent', () => {
 
         // try to merge, the merge should fail
         await createPersonAndSendIdentify('distinctId')
-        expect((await hub.db.fetchPersons()).length).toBe(2)
+        expect((await fetchPersons(hub.db.postgres)).length).toBe(2)
 
         await createPersonAndSendIdentify('  ')
-        expect((await hub.db.fetchPersons()).length).toBe(3)
+        expect((await fetchPersons(hub.db.postgres)).length).toBe(3)
 
         await createPersonAndSendIdentify('NaN')
-        expect((await hub.db.fetchPersons()).length).toBe(4)
+        expect((await fetchPersons(hub.db.postgres)).length).toBe(4)
 
         await createPersonAndSendIdentify('undefined')
-        expect((await hub.db.fetchPersons()).length).toBe(5)
+        expect((await fetchPersons(hub.db.postgres)).length).toBe(5)
 
         await createPersonAndSendIdentify('None')
-        expect((await hub.db.fetchPersons()).length).toBe(6)
+        expect((await fetchPersons(hub.db.postgres)).length).toBe(6)
 
         await createPersonAndSendIdentify('0')
-        expect((await hub.db.fetchPersons()).length).toBe(7)
+        expect((await fetchPersons(hub.db.postgres)).length).toBe(7)
 
         // 'Nan' is an allowed id, so the merge should work
         // as such, no extra person is created
         await createPersonAndSendIdentify('Nan')
-        expect((await hub.db.fetchPersons()).length).toBe(7)
+        expect((await fetchPersons(hub.db.postgres)).length).toBe(7)
     })
 
     test('Alias with illegal (generic) id', async () => {
         const legal_id = 'user123'
         const illegal_id = 'null'
         await createPerson(hub, team, [legal_id])
-        expect((await hub.db.fetchPersons()).length).toBe(1)
+        expect((await fetchPersons(hub.db.postgres)).length).toBe(1)
 
         await processEvent(
             illegal_id,
@@ -689,7 +693,7 @@ describe('processEvent', () => {
             new UUIDT().toString()
         )
         // person with illegal id got created but not merged
-        expect((await hub.db.fetchPersons()).length).toBe(2)
+        expect((await fetchPersons(hub.db.postgres)).length).toBe(2)
     })
 
     // This case is likely to happen after signup, for example:
@@ -718,8 +722,8 @@ describe('processEvent', () => {
             new UUIDT().toString()
         )
 
-        const [person] = await hub.db.fetchPersons()
-        expect(await hub.db.fetchDistinctIdValues(person)).toEqual(['anonymous_id', 'new_distinct_id'])
+        const [person] = await fetchPersons(hub.db.postgres)
+        expect(await fetchDistinctIdValues(hub.db.postgres, person)).toEqual(['anonymous_id', 'new_distinct_id'])
         expect(person.properties['email']).toEqual('someone@gmail.com')
         expect(person.is_identified).toEqual(true)
     })
@@ -744,8 +748,8 @@ describe('processEvent', () => {
             new UUIDT().toString()
         )
 
-        const [person] = await hub.db.fetchPersons()
-        expect(await hub.db.fetchDistinctIdValues(person)).toEqual(['anonymous_id'])
+        const [person] = await fetchPersons(hub.db.postgres)
+        expect(await fetchDistinctIdValues(hub.db.postgres, person)).toEqual(['anonymous_id'])
         expect(person.is_identified).toEqual(false)
     })
 
@@ -770,9 +774,9 @@ describe('processEvent', () => {
             new UUIDT().toString()
         )
 
-        const persons1 = await hub.db.fetchPersons()
+        const persons1 = await fetchPersons(hub.db.postgres)
         expect(persons1.length).toBe(1)
-        expect(await hub.db.fetchDistinctIdValues(persons1[0])).toEqual(['anonymous_id', 'new_distinct_id'])
+        expect(await fetchDistinctIdValues(hub.db.postgres, persons1[0])).toEqual(['anonymous_id', 'new_distinct_id'])
         expect(persons1[0].properties['email']).toEqual('someone@gmail.com')
         expect(persons1[0].is_identified).toEqual(true)
 
@@ -795,9 +799,9 @@ describe('processEvent', () => {
             new UUIDT().toString()
         )
 
-        const persons2 = await hub.db.fetchPersons()
+        const persons2 = await fetchPersons(hub.db.postgres)
         expect(persons2.length).toBe(1)
-        expect(await hub.db.fetchDistinctIdValues(persons2[0])).toEqual([
+        expect(await fetchDistinctIdValues(hub.db.postgres, persons2[0])).toEqual([
             'anonymous_id',
             'new_distinct_id',
             'anonymous_id_2',
@@ -836,13 +840,13 @@ describe('processEvent', () => {
             new UUIDT().toString()
         )
 
-        const people = (await hub.db.fetchPersons()).sort((p1, p2) => p2.team_id - p1.team_id)
+        const people = (await fetchPersons(hub.db.postgres)).sort((p1, p2) => p2.team_id - p1.team_id)
         expect(people.length).toEqual(2)
         expect(people[1].team_id).toEqual(team.id)
         expect(people[1].properties).toEqual({})
-        expect(await hub.db.fetchDistinctIdValues(people[1])).toEqual(['1', '2'])
+        expect(await fetchDistinctIdValues(hub.db.postgres, people[1])).toEqual(['1', '2'])
         expect(people[0].team_id).toEqual(team2.id)
-        expect(await hub.db.fetchDistinctIdValues(people[0])).toEqual(['2'])
+        expect(await fetchDistinctIdValues(hub.db.postgres, people[0])).toEqual(['2'])
     })
 
     describe('when handling $identify', () => {
@@ -892,7 +896,7 @@ describe('processEvent', () => {
             ])
 
             // Make sure the persons are identified
-            const persons = await hub.db.fetchPersons()
+            const persons = await fetchPersons(hub.db.postgres)
             expect(persons.map((person) => person.is_identified)).toEqual([true, true])
         })
 
@@ -942,7 +946,7 @@ describe('processEvent', () => {
             ])
 
             // Make sure the persons are identified
-            const persons = await hub.db.fetchPersons()
+            const persons = await fetchPersons(hub.db.postgres)
             expect(persons.map((person) => person.is_identified)).toEqual([true, true])
         })
 
@@ -965,7 +969,7 @@ describe('processEvent', () => {
             //  3. check that the persons remain distinct
 
             // Check the db is empty to start with
-            expect(await hub.db.fetchPersons()).toEqual([])
+            expect(await fetchPersons(hub.db.postgres)).toEqual([])
 
             const anonymousId = 'anonymous_id'
             const initialDistinctId = 'initial-distinct-id'
@@ -1002,7 +1006,7 @@ describe('processEvent', () => {
 
             // Now make sure that we have one person in the db that has been
             // identified
-            const persons = await hub.db.fetchPersons()
+            const persons = await fetchPersons(hub.db.postgres)
             expect(persons.length).toEqual(2)
             expect(persons.map((person) => person.is_identified)).toEqual([true, true])
         })
@@ -1036,7 +1040,7 @@ describe('processEvent', () => {
             ])
 
             // Make sure there is one identified person
-            const persons = await hub.db.fetchPersons()
+            const persons = await fetchPersons(hub.db.postgres)
             expect(persons.map((person) => person.is_identified)).toEqual([true])
         })
 
@@ -1064,7 +1068,7 @@ describe('processEvent', () => {
             ])
 
             // Make sure there is one identified person
-            const persons = await hub.db.fetchPersons()
+            const persons = await fetchPersons(hub.db.postgres)
             expect(persons.map((person) => person.is_identified)).toEqual([true])
         })
 
@@ -1092,7 +1096,7 @@ describe('processEvent', () => {
             ])
 
             // Make sure there is one identified person
-            const persons = await hub.db.fetchPersons()
+            const persons = await fetchPersons(hub.db.postgres)
             expect(persons.map((person) => person.is_identified)).toEqual([true])
         })
 
@@ -1121,7 +1125,7 @@ describe('processEvent', () => {
             ])
 
             // Make sure there is one identified person
-            const persons = await hub.db.fetchPersons()
+            const persons = await fetchPersons(hub.db.postgres)
             expect(persons.map((person) => person.is_identified)).toEqual([true])
         })
 
@@ -1139,7 +1143,7 @@ describe('processEvent', () => {
             // There should just be one person, to which all events are associated
             expect(eventsByPerson).toEqual([[[anonymous1, anonymous2], ['$create_alias']]])
 
-            const persons = await hub.db.fetchPersons()
+            const persons = await fetchPersons(hub.db.postgres)
             expect(persons.map((person) => person.is_identified)).toEqual([true])
         })
     })
@@ -1358,8 +1362,8 @@ describe('processEvent', () => {
         expect(event.properties['$set']).toEqual({ a_prop: 'test-set' })
         expect(event.properties['$set_once']).toEqual({ a_prop: 'test-set_once' })
 
-        const [person] = await hub.db.fetchPersons()
-        expect(await hub.db.fetchDistinctIdValues(person)).toEqual(['distinct_id1'])
+        const [person] = await fetchPersons(hub.db.postgres)
+        expect(await fetchDistinctIdValues(hub.db.postgres, person)).toEqual(['distinct_id1'])
         expect(person.properties).toEqual({ a_prop: 'test-set' })
     })
 
@@ -1386,8 +1390,8 @@ describe('processEvent', () => {
         const [event] = getEventsFromKafka()
         expect(event.properties['$unset']).toEqual(['a', 'c'])
 
-        const [person] = await hub.db.fetchPersons()
-        expect(await hub.db.fetchDistinctIdValues(person)).toEqual(['distinct_id1'])
+        const [person] = await fetchPersons(hub.db.postgres)
+        expect(await fetchDistinctIdValues(hub.db.postgres, person)).toEqual(['distinct_id1'])
         expect(person.properties).toEqual({ b: 2 })
     })
 
@@ -1414,8 +1418,8 @@ describe('processEvent', () => {
         const [event] = getEventsFromKafka()
         expect(event.properties['$unset']).toEqual({})
 
-        const [person] = await hub.db.fetchPersons()
-        expect(await hub.db.fetchDistinctIdValues(person)).toEqual(['distinct_id1'])
+        const [person] = await fetchPersons(hub.db.postgres)
+        expect(await fetchDistinctIdValues(hub.db.postgres, person)).toEqual(['distinct_id1'])
         expect(person.properties).toEqual({ a: 1, b: 2, c: 3 })
     })
 
@@ -1442,8 +1446,8 @@ describe('processEvent', () => {
         })
 
         async function verifyPersonPropertiesSetCorrectly() {
-            const [person] = await hub.db.fetchPersons()
-            expect(await hub.db.fetchDistinctIdValues(person)).toEqual(['distinct_id1'])
+            const [person] = await fetchPersons(hub.db.postgres)
+            expect(await fetchDistinctIdValues(hub.db.postgres, person)).toEqual(['distinct_id1'])
             expect(person.properties).toEqual({
                 s0123o0123: 's3a',
                 s02o13: 's2b',

--- a/plugin-server/tests/worker/ingestion/person-state-batch.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state-batch.test.ts
@@ -35,6 +35,7 @@ import { PersonMergeService } from '../../../src/worker/ingestion/persons/person
 import { PersonPropertyService } from '../../../src/worker/ingestion/persons/person-property-service'
 import { PersonsStoreForBatch } from '../../../src/worker/ingestion/persons/persons-store-for-batch'
 import { PostgresPersonRepository } from '../../../src/worker/ingestion/persons/repositories/postgres-person-repository'
+import { fetchDistinctIdValues } from '../../../src/worker/ingestion/persons/repositories/test-helpers'
 import {
     createOrganization,
     createTeam,
@@ -368,7 +369,7 @@ describe('PersonState.processEvent()', () => {
             expect(persons.length).toEqual(0)
 
             // verify there are no Postgres distinct_ids
-            const distinctIds = await hub.db.fetchDistinctIdValues(fakePerson as InternalPerson)
+            const distinctIds = await fetchDistinctIdValues(hub.db.postgres, fakePerson as InternalPerson)
             expect(distinctIds).toEqual(expect.arrayContaining([]))
         })
 
@@ -574,7 +575,7 @@ describe('PersonState.processEvent()', () => {
             expect(persons[0]).toEqual(person)
 
             // verify Postgres distinct_ids
-            const distinctIds = await hub.db.fetchDistinctIdValues(persons[0])
+            const distinctIds = await fetchDistinctIdValues(hub.db.postgres, persons[0])
             expect(distinctIds).toEqual(expect.arrayContaining([newUserDistinctId]))
         })
 
@@ -606,7 +607,7 @@ describe('PersonState.processEvent()', () => {
             expect(persons[0]).toEqual(person)
 
             // verify Postgres distinct_ids
-            const distinctIds = await hub.db.fetchDistinctIdValues(persons[0])
+            const distinctIds = await fetchDistinctIdValues(hub.db.postgres, persons[0])
             expect(distinctIds).toEqual(expect.arrayContaining([newUserDistinctId]))
 
             // OK, a person now exists with { c: 420 }, let's prove the properties come back out
@@ -669,7 +670,7 @@ describe('PersonState.processEvent()', () => {
             expect(persons[0]).toEqual(person)
 
             // verify Postgres distinct_ids
-            const distinctIds = await hub.db.fetchDistinctIdValues(person)
+            const distinctIds = await fetchDistinctIdValues(hub.db.postgres, person)
             expect(distinctIds).toEqual(expect.arrayContaining([newUserDistinctId]))
         })
 
@@ -734,7 +735,7 @@ describe('PersonState.processEvent()', () => {
             })
 
             // verify Postgres distinct_ids
-            const distinctIds = await hub.db.fetchDistinctIdValues(person)
+            const distinctIds = await fetchDistinctIdValues(hub.db.postgres, person)
             expect(distinctIds).toEqual(expect.arrayContaining([newUserDistinctId]))
         })
 
@@ -768,7 +769,7 @@ describe('PersonState.processEvent()', () => {
             expect(persons[0]).toEqual(person)
 
             // verify Postgres distinct_ids
-            const distinctIds = await hub.db.fetchDistinctIdValues(persons[0])
+            const distinctIds = await fetchDistinctIdValues(hub.db.postgres, persons[0])
             expect(distinctIds).toEqual(expect.arrayContaining([newUserDistinctId]))
         })
     })
@@ -1297,7 +1298,7 @@ describe('PersonState.processEvent()', () => {
             )
 
             // verify Postgres distinct_ids
-            const distinctIds = await hub.db.fetchDistinctIdValues(persons[0])
+            const distinctIds = await fetchDistinctIdValues(hub.db.postgres, persons[0])
             expect(distinctIds).toEqual(expect.arrayContaining([oldUserDistinctId, newUserDistinctId]))
         })
 
@@ -1378,7 +1379,7 @@ describe('PersonState.processEvent()', () => {
             })
 
             // verify Postgres distinct_ids
-            const distinctIds = await hub.db.fetchDistinctIdValues(persons[0])
+            const distinctIds = await fetchDistinctIdValues(hub.db.postgres, persons[0])
             expect(distinctIds).toEqual(expect.arrayContaining([oldUserDistinctId, newUserDistinctId]))
         })
 
@@ -1423,7 +1424,7 @@ describe('PersonState.processEvent()', () => {
             })
 
             // verify Postgres distinct_ids
-            const distinctIds = await hub.db.fetchDistinctIdValues(persons[0])
+            const distinctIds = await fetchDistinctIdValues(hub.db.postgres, persons[0])
             expect(distinctIds).toEqual(expect.arrayContaining([oldUserDistinctId, newUserDistinctId]))
         })
 
@@ -1469,7 +1470,7 @@ describe('PersonState.processEvent()', () => {
             expect([newUserUuid, oldUserUuid]).toContain(persons[0].uuid)
 
             // verify Postgres distinct_ids
-            const distinctIds = await hub.db.fetchDistinctIdValues(persons[0])
+            const distinctIds = await fetchDistinctIdValues(hub.db.postgres, persons[0])
             expect(distinctIds).toEqual(expect.arrayContaining([oldUserDistinctId, newUserDistinctId]))
 
             expect(getPersonEventsFromKafka().filter((x) => x.version >= 1).length).toEqual(2)
@@ -1546,7 +1547,7 @@ describe('PersonState.processEvent()', () => {
             expect([newUserUuid, oldUserUuid]).toContain(persons[0].uuid)
 
             // verify Postgres distinct_ids
-            const distinctIds = await hub.db.fetchDistinctIdValues(persons[0])
+            const distinctIds = await fetchDistinctIdValues(hub.db.postgres, persons[0])
             expect(distinctIds).toEqual(expect.arrayContaining([oldUserDistinctId, newUserDistinctId]))
 
             // verify ClickHouse persons
@@ -1624,9 +1625,9 @@ describe('PersonState.processEvent()', () => {
             expect(persons[1]).toEqual(person)
 
             // verify Postgres distinct_ids
-            const distinctIds = await hub.db.fetchDistinctIdValues(persons[0])
+            const distinctIds = await fetchDistinctIdValues(hub.db.postgres, persons[0])
             expect(distinctIds).toEqual(expect.arrayContaining([oldUserDistinctId]))
-            const distinctIds2 = await hub.db.fetchDistinctIdValues(persons[1])
+            const distinctIds2 = await fetchDistinctIdValues(hub.db.postgres, persons[1])
             expect(distinctIds2).toEqual(expect.arrayContaining([newUserDistinctId]))
         })
 
@@ -1679,9 +1680,9 @@ describe('PersonState.processEvent()', () => {
             })
 
             // verify Postgres distinct_ids
-            const distinctIds = await hub.db.fetchDistinctIdValues(persons[0])
+            const distinctIds = await fetchDistinctIdValues(hub.db.postgres, persons[0])
             expect(distinctIds).toEqual(expect.arrayContaining([oldUserDistinctId]))
-            const distinctIds2 = await hub.db.fetchDistinctIdValues(persons[1])
+            const distinctIds2 = await fetchDistinctIdValues(hub.db.postgres, persons[1])
             expect(distinctIds2).toEqual(expect.arrayContaining([newUserDistinctId]))
         })
 
@@ -1728,7 +1729,7 @@ describe('PersonState.processEvent()', () => {
             expect([newUserUuid, oldUserUuid]).toContain(persons[0].uuid)
 
             // verify Postgres distinct_ids
-            const distinctIds = await hub.db.fetchDistinctIdValues(persons[0])
+            const distinctIds = await fetchDistinctIdValues(hub.db.postgres, persons[0])
             expect(distinctIds).toEqual(expect.arrayContaining([oldUserDistinctId, newUserDistinctId]))
 
             // verify ClickHouse persons
@@ -1820,7 +1821,7 @@ describe('PersonState.processEvent()', () => {
             })
 
             // verify Postgres distinct_ids
-            const distinctIds = await hub.db.fetchDistinctIdValues(persons[0])
+            const distinctIds = await fetchDistinctIdValues(hub.db.postgres, persons[0])
             expect(distinctIds).toEqual(expect.arrayContaining([newUserDistinctId]))
         })
     })
@@ -1926,7 +1927,7 @@ describe('PersonState.processEvent()', () => {
             expect([newUserUuid, oldUserUuid]).toContain(persons[0].uuid)
 
             // verify Postgres distinct_ids
-            const distinctIds = await hub.db.fetchDistinctIdValues(persons[0])
+            const distinctIds = await fetchDistinctIdValues(hub.db.postgres, persons[0])
             expect(distinctIds).toEqual(expect.arrayContaining([oldUserDistinctId, newUserDistinctId]))
 
             // verify ClickHouse persons
@@ -2087,7 +2088,7 @@ describe('PersonState.processEvent()', () => {
 
             const [person] = await fetchPostgresPersonsH()
             expect([identifiedPerson.id, anonPerson.id]).toContain(person.id)
-            expect(await hub.db.fetchDistinctIdValues(person)).toEqual(['anonymous_id', 'new_distinct_id'])
+            expect(await fetchDistinctIdValues(hub.db.postgres, person)).toEqual(['anonymous_id', 'new_distinct_id'])
             expect(person.is_identified).toEqual(true)
 
             const result = await hub.db.postgres.query(
@@ -2177,7 +2178,7 @@ describe('PersonState.processEvent()', () => {
 
             const [person] = await fetchPostgresPersonsH()
             expect([identifiedPerson.id, anonPerson.id]).toContain(person.id)
-            expect(await hub.db.fetchDistinctIdValues(person)).toEqual(['anonymous_id', 'new_distinct_id'])
+            expect(await fetchDistinctIdValues(hub.db.postgres, person)).toEqual(['anonymous_id', 'new_distinct_id'])
             expect(person.is_identified).toEqual(true)
 
             const result = await hub.db.postgres.query(
@@ -2254,7 +2255,7 @@ describe('PersonState.processEvent()', () => {
 
             const [person] = await fetchPostgresPersonsH()
             expect([identifiedPerson.id, anonPerson.id]).toContain(person.id)
-            expect(await hub.db.fetchDistinctIdValues(person)).toEqual(['anonymous_id', 'new_distinct_id'])
+            expect(await fetchDistinctIdValues(hub.db.postgres, person)).toEqual(['anonymous_id', 'new_distinct_id'])
             expect(person.is_identified).toEqual(true)
 
             const result = await hub.db.postgres.query(
@@ -2367,7 +2368,7 @@ describe('PersonState.processEvent()', () => {
             })
 
             // verify Postgres distinct_ids
-            const distinctIds = await hub.db.fetchDistinctIdValues(person)
+            const distinctIds = await fetchDistinctIdValues(hub.db.postgres, person)
             expect(distinctIds).toEqual(expect.arrayContaining([firstUserDistinctId, secondUserDistinctId]))
 
             // verify ClickHouse persons
@@ -2435,7 +2436,7 @@ describe('PersonState.processEvent()', () => {
             expect(persons.find((p) => p.uuid === secondUserUuid)).toBeTruthy()
 
             // Distinct IDs should remain on source (we added 2 extra)
-            const sourceDistinctIds = await hub.db.fetchDistinctIdValues(second)
+            const sourceDistinctIds = await fetchDistinctIdValues(hub.db.postgres, second)
             expect(sourceDistinctIds).toEqual(expect.arrayContaining([secondUserDistinctId, 'second-2', 'second-3']))
         })
 


### PR DESCRIPTION
## Problem

We need to run all queries through the repository layer to make sure the persons DB migration works correctly.

## Changes

Moves remaining postgres queries that use `PERSONS_WRITE|READ` to person and group repositories.

## How did you test this code?

- Added new tests
- Updated the existing test

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
