### PR TITLE
fix(msg): change oauth placeholder source

### DIFF
--- a/plugin-server/src/cdp/services/hog-executor.service.test.ts
+++ b/plugin-server/src/cdp/services/hog-executor.service.test.ts
@@ -1073,7 +1073,6 @@ describe('Hog Executor', () => {
                         access_token_raw: 'actual_secret_token_12345',
                     },
                 },
-
             }
 
             jest.spyOn(executor['hogInputsService'], 'loadIntegrationInputs').mockResolvedValue(mockIntegrationInputs)
@@ -1081,7 +1080,7 @@ describe('Hog Executor', () => {
             const invocation = createExampleInvocation()
             invocation.state.globals.inputs = mockIntegrationInputs
             invocation.hogFunction.inputs = {
-                oauth: { value: 123 }
+                oauth: { value: 123 },
             }
             invocation.state.vmState = { stack: [] } as any
             invocation.queueParameters = {

--- a/plugin-server/src/cdp/services/hog-executor.service.test.ts
+++ b/plugin-server/src/cdp/services/hog-executor.service.test.ts
@@ -1070,26 +1070,29 @@ describe('Hog Executor', () => {
             const mockIntegrationInputs = {
                 oauth: {
                     value: {
-                        access_token: '$$_access_token_placeholder_123$$',
                         access_token_raw: 'actual_secret_token_12345',
                     },
                 },
+
             }
 
             jest.spyOn(executor['hogInputsService'], 'loadIntegrationInputs').mockResolvedValue(mockIntegrationInputs)
 
             const invocation = createExampleInvocation()
             invocation.state.globals.inputs = mockIntegrationInputs
+            invocation.hogFunction.inputs = {
+                oauth: { value: 123 }
+            }
             invocation.state.vmState = { stack: [] } as any
             invocation.queueParameters = {
                 type: 'fetch',
-                url: 'https://example.com/test?q=$$_access_token_placeholder_123$$',
+                url: 'https://example.com/test?q=$$_access_token_placeholder_123',
                 method: 'POST',
                 headers: {
-                    'X-Test': '$$_access_token_placeholder_123$$',
-                    Authorization: 'Bearer $$_access_token_placeholder_123$$',
+                    'X-Test': '$$_access_token_placeholder_123',
+                    Authorization: 'Bearer $$_access_token_placeholder_123',
                 },
-                body: '$$_access_token_placeholder_123$$',
+                body: '$$_access_token_placeholder_123',
             } as any
 
             await executor.executeFetch(invocation)

--- a/plugin-server/src/cdp/services/hog-executor.service.ts
+++ b/plugin-server/src/cdp/services/hog-executor.service.ts
@@ -34,6 +34,7 @@ import { convertToHogFunctionFilterGlobal, filterFunctionInstrumented } from '..
 import { createInvocation, createInvocationResult } from '../utils/invocation-utils'
 import { HogInputsService } from './hog-inputs.service'
 import { EmailService } from './messaging/email.service'
+import { ACCESS_TOKEN_PLACEHOLDER } from '~/config/constants'
 
 const cdpHttpRequests = new Counter({
     name: 'cdp_http_requests',
@@ -567,9 +568,9 @@ export class HogExecutorService {
         const integrationInputs = await this.hogInputsService.loadIntegrationInputs(invocation.hogFunction)
 
         if (Object.keys(integrationInputs).length > 0) {
-            for (const [, value] of Object.entries(integrationInputs)) {
+            for (const [key, value] of Object.entries(integrationInputs)) {
                 const accessToken: string = value.value.access_token_raw
-                const placeholder: string = value.value.access_token
+                const placeholder: string = ACCESS_TOKEN_PLACEHOLDER + invocation.hogFunction.inputs?.[key]?.value
 
                 if (placeholder && accessToken) {
                     const replace = (val: string) => val.replaceAll(placeholder, accessToken)

--- a/plugin-server/src/cdp/services/hog-executor.service.ts
+++ b/plugin-server/src/cdp/services/hog-executor.service.ts
@@ -5,6 +5,7 @@ import { Counter, Histogram } from 'prom-client'
 import { ExecResult, convertHogToJS } from '@posthog/hogvm'
 
 import { instrumented } from '~/common/tracing/tracing-utils'
+import { ACCESS_TOKEN_PLACEHOLDER } from '~/config/constants'
 import {
     CyclotronInvocationQueueParametersEmailSchema,
     CyclotronInvocationQueueParametersFetchSchema,
@@ -34,7 +35,6 @@ import { convertToHogFunctionFilterGlobal, filterFunctionInstrumented } from '..
 import { createInvocation, createInvocationResult } from '../utils/invocation-utils'
 import { HogInputsService } from './hog-inputs.service'
 import { EmailService } from './messaging/email.service'
-import { ACCESS_TOKEN_PLACEHOLDER } from '~/config/constants'
 
 const cdpHttpRequests = new Counter({
     name: 'cdp_http_requests',


### PR DESCRIPTION
## Problem

With the previous implementation, I would need to pause the deployment of the `cdp-events-consumer`, while the `hog-executor` is being deployed for [this PR](https://github.com/PostHog/posthog/pull/37275), which I don't like.

for context https://github.com/PostHog/posthog/pull/37274

## Changes

- Generate the placeholder with the hog function instead of expecting the `cdp-events-consumer` to provide it

## How did you test this code?

updated tests