### PR TITLE
feat: Evaluate replay-related routing

### DIFF
--- a/ee/hogai/eval/ci/eval_root.py
+++ b/ee/hogai/eval/ci/eval_root.py
@@ -490,46 +490,6 @@ async def eval_root(mock_feature_enabled, call_root, pytestconfig):
                     id="call_doc_search_35",
                 ),
             ),
-            # Session summarization tests - positive cases (should call session_summarization)
-            EvalCase(
-                input="summarize sessions from yesterday",
-                expected=AssistantToolCall(
-                    name="session_summarization",
-                    args={
-                        "session_summarization_query": "summarize sessions from yesterday",
-                    },
-                    id="call_session_summary_1",
-                ),
-            ),
-            EvalCase(
-                input="watch what user did in the last 7 days",
-                expected=AssistantToolCall(
-                    name="session_summarization",
-                    args={
-                        "session_summarization_query": "watch what user did in the last 7 days",
-                    },
-                    id="call_session_summary_2",
-                ),
-            ),
-            EvalCase(
-                input="analyze mobile user sessions from last week",
-                expected=AssistantToolCall(
-                    name="session_summarization",
-                    args={
-                        "session_summarization_query": "analyze mobile user sessions from last week",
-                    },
-                    id="call_session_summary_3",
-                ),
-            ),
-            # Session summarization tests - negative cases (should NOT call session_summarization)
-            EvalCase(
-                input="show me recordings from mobile users",
-                expected=None,
-            ),
-            EvalCase(
-                input="filter sessions by browser type",
-                expected=None,
-            ),
             # Ensure calls insights, not documentation
             EvalCase(
                 input="Show me all events where the default $browser property equals Chrome",
@@ -552,6 +512,46 @@ async def eval_root(mock_feature_enabled, call_root, pytestconfig):
                     },
                     id="call_insight_default_props_2",
                 ),
+            ),
+            # Session summarization tests - positive cases (should call session_summarization)
+            EvalCase(
+                input="summarize sessions from yesterday (session_summarization)",
+                expected=AssistantToolCall(
+                    name="session_summarization",
+                    args={
+                        "session_summarization_query": "summarize sessions from yesterday",
+                    },
+                    id="call_session_summary_1",
+                ),
+            ),
+            EvalCase(
+                input="watch what user did in the last 7 days (session_summarization)",
+                expected=AssistantToolCall(
+                    name="session_summarization",
+                    args={
+                        "session_summarization_query": "watch what user did in the last 7 days",
+                    },
+                    id="call_session_summary_2",
+                ),
+            ),
+            EvalCase(
+                input="analyze mobile user sessions from last week (session_summarization)",
+                expected=AssistantToolCall(
+                    name="session_summarization",
+                    args={
+                        "session_summarization_query": "analyze mobile user sessions from last week",
+                    },
+                    id="call_session_summary_3",
+                ),
+            ),
+            # Session summarization tests - negative cases (should NOT call session_summarization)
+            EvalCase(
+                input="show me recordings from mobile users (session_summarization)",
+                expected=None,
+            ),
+            EvalCase(
+                input="filter sessions by browser type (session_summarization)",
+                expected=None,
             ),
         ],
         pytestconfig=pytestconfig,

--- a/ee/hogai/eval/ci/eval_root.py
+++ b/ee/hogai/eval/ci/eval_root.py
@@ -1,7 +1,6 @@
 import json
 
 import pytest
-from unittest.mock import patch
 
 from braintrust import EvalCase
 
@@ -48,16 +47,7 @@ def call_root(demo_org_team_user):
 
 
 @pytest.mark.django_db
-@patch("posthoganalytics.feature_enabled")
-async def eval_root(mock_feature_enabled, call_root, pytestconfig):
-    # Evaluate tool behind feature flags (as root prompt generation is conditional)
-    def feature_enabled_side_effect(flag_name, *args, **kwargs):
-        if flag_name == "max-session-summarization":
-            return True
-        return False
-
-    mock_feature_enabled.side_effect = feature_enabled_side_effect
-
+async def eval_root(call_root, pytestconfig):
     await MaxPublicEval(
         experiment_name="root",
         task=call_root,

--- a/ee/hogai/eval/ci/eval_root.py
+++ b/ee/hogai/eval/ci/eval_root.py
@@ -24,7 +24,6 @@ def call_root(demo_org_team_user):
             {
                 "insights": AssistantNodeName.END,
                 "search_documentation": AssistantNodeName.END,
-                "session_summarization": AssistantNodeName.END,
                 "root": AssistantNodeName.END,
                 "end": AssistantNodeName.END,
             }
@@ -503,46 +502,6 @@ async def eval_root(call_root, pytestconfig):
                     },
                     id="call_insight_default_props_2",
                 ),
-            ),
-            # Session summarization tests - positive cases (should call session_summarization)
-            EvalCase(
-                input="summarize sessions from yesterday (session_summarization)",
-                expected=AssistantToolCall(
-                    name="session_summarization",
-                    args={
-                        "session_summarization_query": "summarize sessions from yesterday",
-                    },
-                    id="call_session_summary_1",
-                ),
-            ),
-            EvalCase(
-                input="watch what user did in the last 7 days (session_summarization)",
-                expected=AssistantToolCall(
-                    name="session_summarization",
-                    args={
-                        "session_summarization_query": "watch what user did in the last 7 days",
-                    },
-                    id="call_session_summary_2",
-                ),
-            ),
-            EvalCase(
-                input="analyze mobile user sessions from last week (session_summarization)",
-                expected=AssistantToolCall(
-                    name="session_summarization",
-                    args={
-                        "session_summarization_query": "analyze mobile user sessions from last week",
-                    },
-                    id="call_session_summary_3",
-                ),
-            ),
-            # Session summarization tests - negative cases (should NOT call session_summarization)
-            EvalCase(
-                input="show me recordings from mobile users (session_summarization)",
-                expected=None,
-            ),
-            EvalCase(
-                input="filter sessions by browser type (session_summarization)",
-                expected=None,
             ),
         ],
         pytestconfig=pytestconfig,

--- a/ee/hogai/eval/ci/eval_root.py
+++ b/ee/hogai/eval/ci/eval_root.py
@@ -25,6 +25,7 @@ def call_root(demo_org_team_user):
             {
                 "insights": AssistantNodeName.END,
                 "search_documentation": AssistantNodeName.END,
+                "session_summarization": AssistantNodeName.END,
                 "root": AssistantNodeName.END,
                 "end": AssistantNodeName.END,
             }

--- a/ee/hogai/eval/ci/eval_session_summarization.py
+++ b/ee/hogai/eval/ci/eval_session_summarization.py
@@ -1,0 +1,139 @@
+import pytest
+from unittest.mock import patch
+
+from braintrust import EvalCase
+
+from posthog.schema import AssistantMessage, AssistantToolCall, HumanMessage
+
+from ee.hogai.django_checkpoint.checkpointer import DjangoCheckpointer
+from ee.hogai.graph import AssistantGraph
+from ee.hogai.utils.types import AssistantMessageUnion, AssistantNodeName, AssistantState
+from ee.models.assistant import Conversation
+
+from ..base import MaxPublicEval
+from ..scorers import ToolRelevance
+
+
+@pytest.fixture
+def call_root_for_replay_sessions(demo_org_team_user):
+    graph = (
+        AssistantGraph(demo_org_team_user[1], demo_org_team_user[2])
+        .add_edge(AssistantNodeName.START, AssistantNodeName.ROOT)
+        .add_root(
+            {
+                "insights": AssistantNodeName.END,
+                "search_documentation": AssistantNodeName.END,
+                "session_summarization": AssistantNodeName.END,
+                "root": AssistantNodeName.END,
+                "end": AssistantNodeName.END,
+            }
+        )
+        .compile(checkpointer=DjangoCheckpointer())
+    )
+
+    async def callable(messages: str | list[AssistantMessageUnion]) -> AssistantMessage:
+        conversation = await Conversation.objects.acreate(team=demo_org_team_user[1], user=demo_org_team_user[2])
+        initial_state = AssistantState(
+            messages=[HumanMessage(content=messages)] if isinstance(messages, str) else messages
+        )
+        # Simulate session replay page context
+        config = {
+            "configurable": {
+                "thread_id": conversation.id,
+                "contextual_tools": {
+                    "search_session_recordings": {"current_filters": {"date_from": "-7d", "filter_test_accounts": True}}
+                },
+            }
+        }
+        raw_state = await graph.ainvoke(initial_state, config)
+        state = AssistantState.model_validate(raw_state)
+        for message in reversed(state.messages):
+            if isinstance(message, AssistantMessage):
+                return message
+        raise AssertionError(
+            f"No AssistantMessage found in state. Last message was: {state.messages[-1] if state.messages else 'no messages'}"
+        )
+
+    return callable
+
+
+@pytest.mark.django_db
+@patch("posthoganalytics.feature_enabled", return_value=True)
+async def eval_tool_routing_session_replay(patch_feature_enabled, call_root_for_replay_sessions, pytestconfig):
+    """Test routing between search_session_recordings (contextual) and session_summarization (root)."""
+
+    await MaxPublicEval(
+        experiment_name="tool_routing_session_replay",
+        task=call_root_for_replay_sessions,
+        scores=[ToolRelevance(semantic_similarity_args={"change", "session_summarization_query"})],
+        data=[
+            # Cases where search_session_recordings should be used (filtering/searching)
+            EvalCase(
+                input="show me recordings from mobile users",
+                expected=AssistantToolCall(
+                    id="1",
+                    name="search_session_recordings",
+                    args={"change": "show me recordings from mobile users"},
+                ),
+            ),
+            EvalCase(
+                input="filter replay sessions that used chrome browser",
+                expected=AssistantToolCall(
+                    id="2",
+                    name="search_session_recordings",
+                    args={"change": "filter replay sessions that used chrome browser"},
+                ),
+            ),
+            EvalCase(
+                input="show recordings longer than 5 minutes",
+                expected=AssistantToolCall(
+                    id="3",
+                    name="search_session_recordings",
+                    args={"change": "show recordings longer than 5 minutes"},
+                ),
+            ),
+            # Cases where session_summarization should be used (analysis/summary)
+            EvalCase(
+                input="summarize sessions from yesterday",
+                expected=AssistantToolCall(
+                    id="5",
+                    name="session_summarization",
+                    args={"session_summarization_query": "summarize sessions from yesterday"},
+                ),
+            ),
+            EvalCase(
+                input="watch sessions of the user 09081 in the last 7 days",
+                expected=AssistantToolCall(
+                    id="6",
+                    name="session_summarization",
+                    args={"session_summarization_query": "watch sessions of the user 09081 in the last 7 days"},
+                ),
+            ),
+            EvalCase(
+                input="analyze mobile user sessions from last week",
+                expected=AssistantToolCall(
+                    id="7",
+                    name="session_summarization",
+                    args={"session_summarization_query": "analyze mobile user sessions from last week"},
+                ),
+            ),
+            # Edge cases - ambiguous queries
+            EvalCase(
+                input="show me what users did on the checkout page",
+                expected=AssistantToolCall(
+                    id="9",
+                    name="session_summarization",
+                    args={"session_summarization_query": "show me what users did on the checkout page"},
+                ),
+            ),
+            EvalCase(
+                input="replay user sessions from this morning",
+                expected=AssistantToolCall(
+                    id="10",
+                    name="session_summarization",
+                    args={"session_summarization_query": "replay user sessions from this morning"},
+                ),
+            ),
+        ],
+        pytestconfig=pytestconfig,
+    )


### PR DESCRIPTION
## Problem

- No tests on how Max chooses a session summarization VS Replay filters

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Test the routing logic

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
