### PR TITLE
feat(dashboards): support same filters as global filters component

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardEditBar.tsx
+++ b/frontend/src/scenes/dashboard/DashboardEditBar.tsx
@@ -116,7 +116,9 @@ export function DashboardEditBar(): JSX.Element {
                             ...groupsTaxonomicTypes,
                             TaxonomicFilterGroupType.Cohorts,
                             TaxonomicFilterGroupType.Elements,
+                            TaxonomicFilterGroupType.SessionProperties,
                             TaxonomicFilterGroupType.HogQLExpression,
+                            TaxonomicFilterGroupType.DataWarehousePersonProperties,
                         ]}
                     />
                 </div>


### PR DESCRIPTION
## Problem

https://posthog.vitally-eu.io/hubs/152ccd4c-c7b2-4508-865b-b08fea5c3dc6/413939d5-0d20-40d5-963e-5987dcbae345/9d310755-7934-409b-a3da-25917de590bc

## Changes

Adds session properties to the dashboard filters.

## How did you test this code?

:eyes: