### PR TITLE
feat: paralelize kafka-dedup processing

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -8,7 +8,7 @@ on:
             - '.github/workflows/rust-docker-build.yml'
         branches:
             - 'master'
-
+            - 'jose-sequeira/paralellize-kafka-dedup'
 jobs:
     build:
         name: build ${{ matrix.image }}

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -8,7 +8,7 @@ on:
             - '.github/workflows/rust-docker-build.yml'
         branches:
             - 'master'
-            - 'jose-sequeira/paralellize-kafka-dedup'
+
 jobs:
     build:
         name: build ${{ matrix.image }}

--- a/rust/kafka-deduplicator/src/deduplication_processor.rs
+++ b/rust/kafka-deduplicator/src/deduplication_processor.rs
@@ -52,7 +52,7 @@ impl DeduplicationProcessor {
     pub fn new(
         config: DeduplicationConfig,
         stores: Arc<DashMap<Partition, DeduplicationStore>>,
-    ) -> Result<Arc<Self>> {
+    ) -> Result<Self> {
         let producer: Option<FutureProducer> = match &config.output_topic {
             Some(topic) => Some(config.producer_config.create().with_context(|| {
                 format!("Failed to create Kafka producer for output topic '{topic}'")
@@ -60,11 +60,11 @@ impl DeduplicationProcessor {
             None => None,
         };
 
-        Ok(Arc::new(Self {
+        Ok(Self {
             config,
             producer,
             stores,
-        }))
+        })
     }
 
     /// Get or create a deduplication store for a specific partition
@@ -342,8 +342,6 @@ impl DeduplicationProcessor {
     pub async fn get_active_store_count(&self) -> usize {
         self.stores.len()
     }
-
-
 }
 
 #[cfg(test)]

--- a/rust/kafka-deduplicator/src/kafka/stateful_consumer.rs
+++ b/rust/kafka-deduplicator/src/kafka/stateful_consumer.rs
@@ -3,25 +3,23 @@ use rdkafka::consumer::{CommitMode, Consumer, StreamConsumer};
 use rdkafka::Message;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot;
 use tokio::time::timeout;
 use tracing::{debug, error, info, warn};
 
 use crate::kafka::types::Partition;
 
-use super::message::MessageProcessor;
+use super::message::AckableMessage;
 use super::rebalance_handler::RebalanceHandler;
 use super::stateful_context::StatefulConsumerContext;
 use super::tracker::{InFlightTracker, TrackerStats};
 
 /// Stateful Kafka consumer that coordinates with external state systems
 /// This consumer ensures sequential offset commits and coordinated partition revocation
-pub struct StatefulKafkaConsumer<P: MessageProcessor> {
+pub struct StatefulKafkaConsumer {
     /// Kafka consumer instance with stateful context
     consumer: StreamConsumer<StatefulConsumerContext>,
-
-    /// Message processor for handling business logic
-    message_processor: Arc<P>,
 
     /// In-flight message tracker (owns the semaphore for backpressure)
     tracker: Arc<InFlightTracker>,
@@ -31,15 +29,19 @@ pub struct StatefulKafkaConsumer<P: MessageProcessor> {
 
     /// Shutdown signal for graceful shutdown
     shutdown_rx: oneshot::Receiver<()>,
+
+    /// Channel to send messages to the processor pool
+    /// The pool handles routing and parallel processing
+    message_sender: UnboundedSender<AckableMessage>,
 }
 
-impl<P: MessageProcessor> StatefulKafkaConsumer<P> {
+impl StatefulKafkaConsumer {
     /// Create a new stateful Kafka consumer with integrated tracker and context
-    /// This is the recommended way to create consumers for production use
+    /// The message_sender channel connects to a processor pool that handles the actual processing
     pub fn from_config(
         config: &rdkafka::ClientConfig,
         rebalance_handler: Arc<dyn RebalanceHandler>,
-        message_processor: Arc<P>,
+        message_sender: UnboundedSender<AckableMessage>,
         max_in_flight_messages: usize,
         commit_interval: Duration,
         shutdown_rx: oneshot::Receiver<()>,
@@ -52,10 +54,10 @@ impl<P: MessageProcessor> StatefulKafkaConsumer<P> {
 
         Ok(Self {
             consumer,
-            message_processor,
             tracker,
             commit_interval,
             shutdown_rx,
+            message_sender,
         })
     }
 
@@ -79,7 +81,8 @@ impl<P: MessageProcessor> StatefulKafkaConsumer<P> {
                 msg_result = timeout(Duration::from_secs(1), self.consumer.recv()) => {
                     match msg_result {
                         Ok(Ok(msg)) => {
-                            self.handle_message(msg).await?;
+                            // Send message to processor pool
+                            self.send_to_processor(msg).await?;
                         }
                         Ok(Err(e)) => {
                             error!("Error receiving message: {}", e);
@@ -136,6 +139,7 @@ impl<P: MessageProcessor> StatefulKafkaConsumer<P> {
 
         // Graceful shutdown: wait for in-flight messages to complete
         info!("Waiting for in-flight messages to complete");
+
         let final_offsets = self.tracker.wait_for_completion().await;
         info!(
             "All in-flight messages completed. Final offsets: {:?}",
@@ -149,110 +153,63 @@ impl<P: MessageProcessor> StatefulKafkaConsumer<P> {
             info!("Final offsets committed successfully");
         }
 
+        // Drop the sender to signal no more messages
+        drop(self.message_sender);
+
         info!("Graceful shutdown completed");
         Ok(())
     }
 
-    async fn handle_message<'a>(&self, msg: rdkafka::message::BorrowedMessage<'a>) -> Result<()> {
+    /// Send a message to the processor pool
+    async fn send_to_processor<'a>(
+        &self,
+        msg: rdkafka::message::BorrowedMessage<'a>,
+    ) -> Result<()> {
+        // First check if we should process this message (partition not revoked)
         let topic = msg.topic();
-        let partition = msg.partition();
+        let partition_num = msg.partition();
         let offset = msg.offset();
-        let partition = Partition::new(topic.to_string(), partition);
+        let partition = Partition::new(topic.to_string(), partition_num);
 
-        // Check if partition is still active (not revoked)
         if !self.tracker.is_partition_active(&partition).await {
             warn!(
                 "Skipping message from revoked partition {}:{} offset {}",
-                partition.topic(),
-                partition.partition_number(),
-                offset
+                topic, partition_num, offset
             );
             return Ok(());
         }
 
-        // Calculate size before detaching
+        // Acquire permit from tracker before sending
+        // This provides backpressure - we won't send more than max_in_flight_messages
+        let permit = self
+            .tracker
+            .in_flight_semaphore_clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| anyhow::anyhow!("Semaphore closed"))?;
+
+        // Calculate message size for tracking
         let estimated_size = msg.payload().map(|p| p.len()).unwrap_or(0)
             + msg.key().map(|k| k.len()).unwrap_or(0)
             + topic.len();
 
-        // Try to acquire a permit BEFORE detaching the message
-        // Use try_acquire_owned for immediate response, avoiding blocking
-        let permit = match self.tracker.in_flight_semaphore_clone().try_acquire_owned() {
-            Ok(permit) => permit,
-            Err(_) => {
-                // No permits available - process completions and try once more
-                debug!(
-                    "No permits available, processing completions. Topic {} partition {} offset {}. In-flight: {}",
-                    partition.topic(), partition.partition_number(), offset,
-                    self.tracker.in_flight_count().await
-                );
-
-                // Give PartitionTrackers a moment to process completions
-                tokio::time::sleep(Duration::from_millis(10)).await;
-
-                // Try once more with a short timeout
-                match tokio::time::timeout(
-                    Duration::from_millis(100),
-                    self.tracker.in_flight_semaphore_clone().acquire_owned(),
-                )
-                .await
-                {
-                    Ok(Ok(permit)) => permit,
-                    Ok(Err(_)) => {
-                        error!("Semaphore was closed - this is a fatal error");
-                        return Err(anyhow::anyhow!("Semaphore closed"));
-                    }
-                    Err(_) => {
-                        // Still no permits - apply backpressure
-                        debug!(
-                            "Still no permits after processing completions, applying backpressure. Topic {} partition {} offset {}",
-                            partition.topic(), partition.partition_number(), offset
-                        );
-                        return Ok(());
-                    }
-                }
-            }
-        };
-
-        // NOW we can safely detach since we have the permit
+        // Detach the message and track it
         let owned_msg = msg.detach();
-
-        // Track the message and get back an AckableMessage that owns everything
         let ackable_msg = self
             .tracker
             .track_message(owned_msg, estimated_size, permit)
             .await;
 
-        debug!(
-            "Tracking message from topic {} partition {} offset {} (available permits: {})",
-            partition.topic(),
-            partition.partition_number(),
-            offset,
-            self.tracker.available_permits()
-        );
-
-        // Process message through user's processor
-        match self.message_processor.process_message(ackable_msg).await {
-            Ok(_) => {
-                debug!(
-                    "Successfully processed message from topic {} partition {} offset {}",
-                    partition.topic(),
-                    partition.partition_number(),
-                    offset
-                );
-                // Note: AckableMessage handles the actual acking
-            }
-            Err(e) => {
-                error!(
-                    "Failed to process message from topic {} partition {} offset {}: {}",
-                    partition.topic(),
-                    partition.partition_number(),
-                    offset,
-                    e
-                );
-                // Note: AckableMessage should handle nacking in this case
-            }
+        // Send to processor pool - they handle the actual processing
+        if let Err(_) = self.message_sender.send(ackable_msg) {
+            error!("Processor pool channel closed, cannot send message");
+            return Err(anyhow::anyhow!("Processor pool is dead"));
         }
+
+        debug!(
+            "Sent message to processor pool (topic: {}, partition: {}, offset: {})",
+            topic, partition_num, offset
+        );
 
         Ok(())
     }

--- a/rust/kafka-deduplicator/src/kafka/stateful_consumer.rs
+++ b/rust/kafka-deduplicator/src/kafka/stateful_consumer.rs
@@ -201,7 +201,7 @@ impl StatefulKafkaConsumer {
             .await;
 
         // Send to processor pool - they handle the actual processing
-        if let Err(_) = self.message_sender.send(ackable_msg) {
+        if self.message_sender.send(ackable_msg).is_err() {
             error!("Processor pool channel closed, cannot send message");
             return Err(anyhow::anyhow!("Processor pool is dead"));
         }

--- a/rust/kafka-deduplicator/src/lib.rs
+++ b/rust/kafka-deduplicator/src/lib.rs
@@ -6,6 +6,7 @@ pub mod duplicate_metrics;
 pub mod event;
 pub mod kafka;
 pub mod metrics;
+pub mod processor_pool;
 pub mod processor_rebalance_handler;
 pub mod rocksdb;
 pub mod service;

--- a/rust/kafka-deduplicator/src/processor_pool.rs
+++ b/rust/kafka-deduplicator/src/processor_pool.rs
@@ -1,0 +1,104 @@
+use rdkafka::Message;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tracing::{error, info};
+use crate::kafka::message::{AckableMessage, MessageProcessor};
+
+/// A pool of workers that process messages in parallel
+/// Messages with the same key are routed to the same worker to maintain ordering
+pub struct ProcessorPool<P: MessageProcessor> {
+    /// Receiver for messages from the consumer
+    receiver: mpsc::UnboundedReceiver<AckableMessage>,
+    
+    /// The processor instances for each worker
+    processors: Vec<Arc<P>>,
+    
+    /// Handles for worker tasks
+    worker_handles: Vec<JoinHandle<()>>,
+}
+
+impl<P: MessageProcessor + Clone + 'static> ProcessorPool<P> {
+    /// Create a new processor pool with the specified number of workers
+    pub fn new(
+        processor: Arc<P>,
+        num_workers: usize,
+    ) -> (mpsc::UnboundedSender<AckableMessage>, Self) {
+        let (sender, receiver) = mpsc::unbounded_channel();
+        
+        // Clone processor for each worker
+        let processors = (0..num_workers)
+            .map(|_| processor.clone())
+            .collect();
+        
+        let pool = Self {
+            receiver,
+            processors,
+            worker_handles: Vec::with_capacity(num_workers),
+        };
+        
+        (sender, pool)
+    }
+    
+    /// Start the worker pool
+    pub fn start(mut self) -> Vec<JoinHandle<()>> {
+        let num_workers = self.processors.len();
+        info!("Starting processor pool with {} workers", num_workers);
+        
+        // Create channels for each worker
+        let mut worker_senders = Vec::with_capacity(num_workers);
+        for i in 0..num_workers {
+            let (tx, mut rx) = mpsc::unbounded_channel::<AckableMessage>();
+            worker_senders.push(tx);
+            
+            let processor = self.processors[i].clone();
+            
+            // Spawn worker task
+            let handle = tokio::spawn(async move {
+                info!("Worker {} started", i);
+                while let Some(msg) = rx.recv().await {
+                    if let Err(e) = processor.process_message(msg).await {
+                        error!("Worker {} failed to process message: {}", i, e);
+                    }
+                }
+                info!("Worker {} shutting down", i);
+            });
+            
+            self.worker_handles.push(handle);
+        }
+        
+        // Spawn router task that distributes messages to workers
+        let router_handle = tokio::spawn(async move {
+            info!("Message router started");
+            while let Some(msg) = self.receiver.recv().await {
+                // Determine which worker should handle this message
+                let worker_id = if let Some(key_bytes) = msg.kafka_message().key() {
+                    // Hash the key to determine the worker
+                    let mut hasher = DefaultHasher::new();
+                    key_bytes.hash(&mut hasher);
+                    let hash = hasher.finish();
+                    (hash as usize) % num_workers
+                } else {
+                    // No key - use round-robin based on offset
+                    (msg.kafka_message().offset() as usize) % num_workers
+                };
+                
+                // Send to the selected worker
+                if let Err(_) = worker_senders[worker_id].send(msg) {
+                    error!("Worker {} channel closed", worker_id);
+                    break;
+                }
+            }
+            
+            // Close all worker channels
+            drop(worker_senders);
+            info!("Message router shutting down");
+        });
+        
+        // Add router handle to the list
+        self.worker_handles.push(router_handle);
+        self.worker_handles
+    }
+}

--- a/rust/kafka-deduplicator/src/processor_pool.rs
+++ b/rust/kafka-deduplicator/src/processor_pool.rs
@@ -1,60 +1,54 @@
+use crate::kafka::message::{AckableMessage, MessageProcessor};
 use rdkafka::Message;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tracing::{error, info};
-use crate::kafka::message::{AckableMessage, MessageProcessor};
 
 /// A pool of workers that process messages in parallel
 /// Messages with the same key are routed to the same worker to maintain ordering
 pub struct ProcessorPool<P: MessageProcessor> {
     /// Receiver for messages from the consumer
     receiver: mpsc::UnboundedReceiver<AckableMessage>,
-    
+
     /// The processor instances for each worker
-    processors: Vec<Arc<P>>,
-    
+    processors: Vec<P>,
+
     /// Handles for worker tasks
     worker_handles: Vec<JoinHandle<()>>,
 }
 
 impl<P: MessageProcessor + Clone + 'static> ProcessorPool<P> {
     /// Create a new processor pool with the specified number of workers
-    pub fn new(
-        processor: Arc<P>,
-        num_workers: usize,
-    ) -> (mpsc::UnboundedSender<AckableMessage>, Self) {
+    pub fn new(processor: P, num_workers: usize) -> (mpsc::UnboundedSender<AckableMessage>, Self) {
         let (sender, receiver) = mpsc::unbounded_channel();
-        
+
         // Clone processor for each worker
-        let processors = (0..num_workers)
-            .map(|_| processor.clone())
-            .collect();
-        
+        let processors = (0..num_workers).map(|_| processor.clone()).collect();
+
         let pool = Self {
             receiver,
             processors,
             worker_handles: Vec::with_capacity(num_workers),
         };
-        
+
         (sender, pool)
     }
-    
+
     /// Start the worker pool
     pub fn start(mut self) -> Vec<JoinHandle<()>> {
         let num_workers = self.processors.len();
         info!("Starting processor pool with {} workers", num_workers);
-        
+
         // Create channels for each worker
         let mut worker_senders = Vec::with_capacity(num_workers);
         for i in 0..num_workers {
             let (tx, mut rx) = mpsc::unbounded_channel::<AckableMessage>();
             worker_senders.push(tx);
-            
+
             let processor = self.processors[i].clone();
-            
+
             // Spawn worker task
             let handle = tokio::spawn(async move {
                 info!("Worker {} started", i);
@@ -65,10 +59,10 @@ impl<P: MessageProcessor + Clone + 'static> ProcessorPool<P> {
                 }
                 info!("Worker {} shutting down", i);
             });
-            
+
             self.worker_handles.push(handle);
         }
-        
+
         // Spawn router task that distributes messages to workers
         let router_handle = tokio::spawn(async move {
             info!("Message router started");
@@ -84,21 +78,615 @@ impl<P: MessageProcessor + Clone + 'static> ProcessorPool<P> {
                     // No key - use round-robin based on offset
                     (msg.kafka_message().offset() as usize) % num_workers
                 };
-                
+
                 // Send to the selected worker
-                if let Err(_) = worker_senders[worker_id].send(msg) {
-                    error!("Worker {} channel closed", worker_id);
-                    break;
+                if let Err(send_error) = worker_senders[worker_id].send(msg) {
+                    // This is critical - a worker channel closed unexpectedly
+                    let mut failed_msg = send_error.0;
+                    let msg_offset = failed_msg.kafka_message().offset();
+                    
+                    error!(
+                        "Worker {} channel closed unexpectedly, attempting to redirect message with offset: {}",
+                        worker_id, msg_offset
+                    );
+
+                    // Try to send to another worker as a fallback
+                    let mut sent = false;
+                    for (idx, sender) in worker_senders.iter().enumerate() {
+                        if idx != worker_id {
+                            match sender.send(failed_msg) {
+                                Ok(()) => {
+                                    error!("Successfully redirected message {} to worker {}", msg_offset, idx);
+                                    sent = true;
+                                    break;
+                                }
+                                Err(e) => {
+                                    // Get the message back to try the next worker
+                                    failed_msg = e.0;
+                                }
+                            }
+                        }
+                    }
+
+                    if !sent {
+                        error!(
+                            "CRITICAL: Unable to deliver message with offset {}, all workers unavailable",
+                            msg_offset
+                        );
+                        // Message is lost - in production this should trigger an alert
+                        break;
+                    }
                 }
             }
-            
+
             // Close all worker channels
             drop(worker_senders);
             info!("Message router shutting down");
         });
-        
+
         // Add router handle to the list
         self.worker_handles.push(router_handle);
         self.worker_handles
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kafka::message::MessageProcessor;
+    use async_trait::async_trait;
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+    use tokio::sync::RwLock;
+    use tokio::time::sleep;
+
+    /// Test processor that tracks which worker processed each message
+    struct TestProcessor {
+        worker_id: usize,
+        worker_counts: Arc<RwLock<HashMap<usize, AtomicUsize>>>,
+        key_orders: Arc<RwLock<HashMap<Vec<u8>, Vec<i64>>>>,
+        processing_delay: Duration,
+        concurrent_count: Arc<AtomicUsize>,
+        max_concurrent: Arc<AtomicUsize>,
+        next_worker_id: Arc<AtomicUsize>, // Per-processor instance counter
+    }
+
+    impl Clone for TestProcessor {
+        fn clone(&self) -> Self {
+            // Each clone gets a unique worker ID from the parent's counter
+            Self {
+                worker_id: self.next_worker_id.fetch_add(1, Ordering::SeqCst),
+                worker_counts: self.worker_counts.clone(),
+                key_orders: self.key_orders.clone(),
+                processing_delay: self.processing_delay,
+                concurrent_count: self.concurrent_count.clone(),
+                max_concurrent: self.max_concurrent.clone(),
+                next_worker_id: self.next_worker_id.clone(),
+            }
+        }
+    }
+
+    impl TestProcessor {
+        fn new(processing_delay: Duration) -> Self {
+            Self {
+                worker_id: 0, // Initial processor gets ID 0
+                worker_counts: Arc::new(RwLock::new(HashMap::new())),
+                key_orders: Arc::new(RwLock::new(HashMap::new())),
+                processing_delay,
+                concurrent_count: Arc::new(AtomicUsize::new(0)),
+                max_concurrent: Arc::new(AtomicUsize::new(0)),
+                next_worker_id: Arc::new(AtomicUsize::new(1)), // Start at 1 for clones
+            }
+        }
+
+        async fn get_stats(&self) -> (HashMap<usize, usize>, usize, HashMap<Vec<u8>, Vec<i64>>) {
+            let counts = self.worker_counts.read().await;
+            let mut worker_counts = HashMap::new();
+            for (worker_id, count) in counts.iter() {
+                worker_counts.insert(*worker_id, count.load(Ordering::SeqCst));
+            }
+
+            let key_orders = self.key_orders.read().await.clone();
+
+            (
+                worker_counts,
+                self.max_concurrent.load(Ordering::SeqCst),
+                key_orders,
+            )
+        }
+    }
+
+    #[async_trait]
+    impl MessageProcessor for TestProcessor {
+        async fn process_message(&self, message: AckableMessage) -> anyhow::Result<()> {
+            let current = self.concurrent_count.fetch_add(1, Ordering::SeqCst) + 1;
+
+            loop {
+                let max = self.max_concurrent.load(Ordering::SeqCst);
+                if current <= max {
+                    break;
+                }
+                if self
+                    .max_concurrent
+                    .compare_exchange(max, current, Ordering::SeqCst, Ordering::SeqCst)
+                    .is_ok()
+                {
+                    break;
+                }
+            }
+
+            // Use the worker ID assigned during clone
+            {
+                let mut counts = self.worker_counts.write().await;
+                counts
+                    .entry(self.worker_id)
+                    .or_insert_with(|| AtomicUsize::new(0))
+                    .fetch_add(1, Ordering::SeqCst);
+            }
+
+            if let Some(key) = message.kafka_message().key() {
+                let mut orders = self.key_orders.write().await;
+                orders
+                    .entry(key.to_vec())
+                    .or_insert_with(Vec::new)
+                    .push(message.kafka_message().offset());
+            }
+
+            sleep(self.processing_delay).await;
+            message.ack().await;
+            self.concurrent_count.fetch_sub(1, Ordering::SeqCst);
+
+            Ok(())
+        }
+    }
+
+    /// Processor that can fail on specific messages
+    #[derive(Clone)]
+    struct FailingProcessor {
+        fail_on_offset: Option<i64>,
+        processed_count: Arc<AtomicUsize>,
+        failed_count: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl MessageProcessor for FailingProcessor {
+        async fn process_message(&self, message: AckableMessage) -> anyhow::Result<()> {
+            let offset = message.kafka_message().offset();
+
+            if let Some(fail_offset) = self.fail_on_offset {
+                if offset == fail_offset {
+                    self.failed_count.fetch_add(1, Ordering::SeqCst);
+                    message.ack().await;
+                    return Err(anyhow::anyhow!("Simulated failure at offset {}", offset));
+                }
+            }
+
+            self.processed_count.fetch_add(1, Ordering::SeqCst);
+            message.ack().await;
+            Ok(())
+        }
+    }
+
+    async fn create_test_message(key: Option<&[u8]>, offset: i64) -> AckableMessage {
+        use crate::kafka::tracker::InFlightTracker;
+        use rdkafka::message::{OwnedHeaders, OwnedMessage};
+        use rdkafka::Timestamp;
+
+        let tracker = Arc::new(InFlightTracker::new());
+        let permit = tracker
+            .in_flight_semaphore_clone()
+            .acquire_owned()
+            .await
+            .unwrap();
+
+        let message = OwnedMessage::new(
+            Some(b"test payload".to_vec()),
+            key.map(|k| k.to_vec()),
+            "test-topic".to_string(),
+            Timestamp::NotAvailable,
+            0,
+            offset,
+            Some(OwnedHeaders::new()),
+        );
+
+        tracker.track_message(message, 1024, permit).await
+    }
+
+    #[tokio::test]
+    async fn test_parallel_processing() {
+        let processor = TestProcessor::new(Duration::from_millis(50));
+        let (sender, pool) = ProcessorPool::new(processor.clone(), 4);
+
+        let handles = pool.start();
+
+        let num_messages = 100;
+        for i in 0..num_messages {
+            let msg = create_test_message(None, i).await;
+            sender.send(msg).unwrap();
+        }
+
+        sleep(Duration::from_secs(2)).await;
+
+        let (worker_counts, max_concurrent, _) = processor.get_stats().await;
+
+        assert!(
+            worker_counts.len() > 1,
+            "Expected multiple workers, got {}",
+            worker_counts.len()
+        );
+        assert!(
+            max_concurrent > 1,
+            "Expected concurrent processing, max was {}",
+            max_concurrent
+        );
+
+        let total_processed: usize = worker_counts.values().sum();
+        assert_eq!(total_processed, num_messages as usize);
+
+        drop(sender);
+        for handle in handles {
+            handle.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_key_based_routing() {
+        let processor = TestProcessor::new(Duration::from_millis(10));
+        let (sender, pool) = ProcessorPool::new(processor.clone(), 4);
+
+        let handles = pool.start();
+
+        let keys = vec![b"key1", b"key2", b"key3", b"key4"];
+        let messages_per_key = 10;
+
+        for (key_idx, key) in keys.iter().enumerate() {
+            for i in 0..messages_per_key {
+                let offset = (key_idx * messages_per_key + i) as i64;
+                let msg = create_test_message(Some(*key), offset).await;
+                sender.send(msg).unwrap();
+            }
+        }
+
+        sleep(Duration::from_secs(1)).await;
+
+        let (_, _, key_orders) = processor.get_stats().await;
+
+        for key in keys {
+            let orders = key_orders
+                .get(&key.to_vec())
+                .expect("Key should have been processed");
+            let mut sorted_orders = orders.clone();
+            sorted_orders.sort();
+            assert_eq!(
+                orders, &sorted_orders,
+                "Messages for key {:?} were not processed in order: {:?}",
+                key, orders
+            );
+        }
+
+        drop(sender);
+        for handle in handles {
+            handle.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_high_concurrency() {
+        let processor = TestProcessor::new(Duration::from_millis(100));
+        let num_workers = 8;
+        let (sender, pool) = ProcessorPool::new(processor.clone(), num_workers);
+
+        let handles = pool.start();
+
+        let burst_size = 50;
+        for i in 0..burst_size {
+            let msg = create_test_message(None, i).await;
+            sender.send(msg).unwrap();
+        }
+
+        sleep(Duration::from_secs(2)).await;
+
+        let (worker_counts, max_concurrent, _) = processor.get_stats().await;
+
+        assert!(
+            max_concurrent >= num_workers / 2,
+            "Expected at least {} concurrent processing, got {}",
+            num_workers / 2,
+            max_concurrent
+        );
+
+        assert!(
+            worker_counts.len() >= num_workers * 3 / 4,
+            "Expected at least {} workers to be used, got {}",
+            num_workers * 3 / 4,
+            worker_counts.len()
+        );
+
+        drop(sender);
+        for handle in handles {
+            handle.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_graceful_shutdown() {
+        let processor = TestProcessor::new(Duration::from_millis(10));
+        let (sender, pool) = ProcessorPool::new(processor.clone(), 4);
+
+        let handles = pool.start();
+
+        for i in 0..10 {
+            let msg = create_test_message(None, i).await;
+            sender.send(msg).unwrap();
+        }
+
+        sleep(Duration::from_millis(50)).await;
+
+        drop(sender);
+
+        let start = std::time::Instant::now();
+        for handle in handles {
+            match tokio::time::timeout(Duration::from_secs(1), handle).await {
+                Ok(Ok(())) => {}
+                Ok(Err(_)) => {}
+                Err(_) => panic!("Worker didn't shut down within timeout"),
+            }
+        }
+
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "Shutdown took too long: {:?}",
+            start.elapsed()
+        );
+    }
+
+    /// Processor that delays specific keys to test worker independence
+    #[derive(Clone)]
+    struct SlowKeyProcessor {
+        slow_key: Vec<u8>,
+        slow_delay: Duration,
+        normal_delay: Duration,
+        processing_times: Arc<RwLock<HashMap<Vec<u8>, Vec<Instant>>>>,
+    }
+
+    #[async_trait]
+    impl MessageProcessor for SlowKeyProcessor {
+        async fn process_message(&self, message: AckableMessage) -> anyhow::Result<()> {
+            let key = message
+                .kafka_message()
+                .key()
+                .map(|k| k.to_vec())
+                .unwrap_or_default();
+
+            // Record when we started processing
+            {
+                let mut times = self.processing_times.write().await;
+                times
+                    .entry(key.clone())
+                    .or_insert_with(Vec::new)
+                    .push(Instant::now());
+            }
+
+            // Slow down specific key
+            if key == self.slow_key {
+                sleep(self.slow_delay).await;
+            } else {
+                sleep(self.normal_delay).await;
+            }
+
+            message.ack().await;
+            Ok(())
+        }
+    }
+
+    /// Processor that verifies message ordering for each key
+    #[derive(Clone)]
+    struct OrderCheckProcessor {
+        last_offset_per_key: Arc<RwLock<HashMap<Vec<u8>, i64>>>,
+        ordering_violations: Arc<AtomicUsize>,
+        processing_delay: Duration,
+    }
+
+    #[async_trait]
+    impl MessageProcessor for OrderCheckProcessor {
+        async fn process_message(&self, message: AckableMessage) -> anyhow::Result<()> {
+            if let Some(key) = message.kafka_message().key() {
+                let offset = message.kafka_message().offset();
+
+                let mut last_offsets = self.last_offset_per_key.write().await;
+                if let Some(&last_offset) = last_offsets.get(key) {
+                    if offset <= last_offset {
+                        self.ordering_violations.fetch_add(1, Ordering::SeqCst);
+                        eprintln!(
+                            "Order violation: key {:?} processed offset {} after {}",
+                            key, offset, last_offset
+                        );
+                    }
+                }
+                last_offsets.insert(key.to_vec(), offset);
+            }
+
+            // Simulate variable processing time
+            sleep(self.processing_delay).await;
+            message.ack().await;
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_worker_independence() {
+        // Test that one slow message doesn't block other workers
+
+        let slow_key = b"slow_key".to_vec();
+        let processor = SlowKeyProcessor {
+            slow_key: slow_key.clone(),
+            slow_delay: Duration::from_millis(500),
+            normal_delay: Duration::from_millis(10),
+            processing_times: Arc::new(RwLock::new(HashMap::new())),
+        };
+
+        let (sender, pool) = ProcessorPool::new(processor.clone(), 4);
+        let handles = pool.start();
+
+        // Send slow key messages and fast key messages
+        for i in 0..5 {
+            // Slow messages
+            let msg = create_test_message(Some(&slow_key), i * 2).await;
+            sender.send(msg).unwrap();
+
+            // Fast messages with different keys
+            let fast_key = format!("fast_{}", i).into_bytes();
+            let msg = create_test_message(Some(&fast_key), i * 2 + 1).await;
+            sender.send(msg).unwrap();
+        }
+
+        // Wait for processing
+        sleep(Duration::from_secs(3)).await;
+
+        // Verify that fast messages didn't wait for slow ones
+        let times = processor.processing_times.read().await;
+
+        // Get the first slow message start time
+        let slow_start = times.get(&slow_key).and_then(|t| t.first()).copied();
+
+        // Check that some fast messages completed before the first slow message
+        let mut fast_completed_during_slow = 0;
+        for (key, timestamps) in times.iter() {
+            if key != &slow_key {
+                if let Some(slow) = slow_start {
+                    for &fast_time in timestamps {
+                        // If a fast message started after slow but within the slow processing window
+                        if fast_time > slow && fast_time < slow + Duration::from_millis(400) {
+                            fast_completed_during_slow += 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        assert!(
+            fast_completed_during_slow > 0,
+            "Fast messages should process while slow message is blocking its worker"
+        );
+
+        drop(sender);
+        for handle in handles {
+            handle.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_same_key_ordering_under_load() {
+        // Verify ordering is maintained even under high load with delays
+        let processor = OrderCheckProcessor {
+            last_offset_per_key: Arc::new(RwLock::new(HashMap::new())),
+            ordering_violations: Arc::new(AtomicUsize::new(0)),
+            processing_delay: Duration::from_millis(5),
+        };
+
+        let (sender, pool) = ProcessorPool::new(processor.clone(), 8);
+        let handles = pool.start();
+
+        // Send many messages with overlapping keys
+        let keys = vec![b"key_a", b"key_b", b"key_c", b"key_d"];
+        for offset in 0..100 {
+            let key = keys[offset % keys.len()];
+            let msg = create_test_message(Some(key), offset as i64).await;
+            sender.send(msg).unwrap();
+        }
+
+        // Wait for all processing
+        sleep(Duration::from_secs(2)).await;
+
+        // Check no ordering violations occurred
+        let violations = processor.ordering_violations.load(Ordering::SeqCst);
+        assert_eq!(
+            violations, 0,
+            "Found {} ordering violations - same key messages processed out of order",
+            violations
+        );
+
+        drop(sender);
+        for handle in handles {
+            handle.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_error_handling() {
+        // Test that processor errors don't crash workers
+        let processor = FailingProcessor {
+            fail_on_offset: Some(5),
+            processed_count: Arc::new(AtomicUsize::new(0)),
+            failed_count: Arc::new(AtomicUsize::new(0)),
+        };
+
+        let (sender, pool) = ProcessorPool::new(processor.clone(), 4);
+        let handles = pool.start();
+
+        // Send messages including the failing one
+        for i in 0..10 {
+            let msg = create_test_message(None, i).await;
+            sender.send(msg).unwrap();
+        }
+
+        // Wait for processing
+        sleep(Duration::from_millis(500)).await;
+
+        // Verify that the error was handled gracefully
+        let processed = processor.processed_count.load(Ordering::SeqCst);
+        let failed = processor.failed_count.load(Ordering::SeqCst);
+
+        assert_eq!(failed, 1, "Should have failed exactly once");
+        assert_eq!(processed, 9, "Should have processed all other messages");
+
+        drop(sender);
+        for handle in handles {
+            handle.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_channel_resilience() {
+        // Test that messages can be redirected if a worker fails
+        let processor = TestProcessor::new(Duration::from_millis(10));
+        let (sender, pool) = ProcessorPool::new(processor.clone(), 4);
+        let handles = pool.start();
+
+        // Send some messages
+        for i in 0..5 {
+            let msg = create_test_message(None, i).await;
+            sender.send(msg).unwrap();
+        }
+
+        // Abort one worker to simulate failure
+        handles[0].abort();
+
+        // Send more messages
+        for i in 5..10 {
+            let msg = create_test_message(None, i).await;
+            sender.send(msg).unwrap();
+        }
+
+        // Wait for processing
+        sleep(Duration::from_millis(500)).await;
+
+        let (worker_counts, _, _) = processor.get_stats().await;
+        let total_processed: usize = worker_counts.values().sum();
+
+        // Some messages might be lost due to the aborted worker,
+        // but we should still process most of them
+        assert!(
+            total_processed >= 7,
+            "Should have processed at least 7 messages despite worker failure, got {}",
+            total_processed
+        );
+
+        drop(sender);
+        for handle in handles {
+            let _ = handle.await; // Some might be already aborted
+        }
     }
 }

--- a/rust/kafka-deduplicator/src/utils/mod.rs
+++ b/rust/kafka-deduplicator/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod throttled_log;

--- a/rust/kafka-deduplicator/tests/consumer_error_recovery_tests.rs
+++ b/rust/kafka-deduplicator/tests/consumer_error_recovery_tests.rs
@@ -186,7 +186,7 @@ async fn test_consumer_error_recovery() -> Result<()> {
     produce_test_messages(&test_topic, 20).await?;
 
     // Create mock processor with 20% failure rate
-    let processor = Arc::new(MockMessageProcessor::new());
+    let processor = MockMessageProcessor::new();
     processor.set_failure_rate(20);
 
     // Create consumer
@@ -248,7 +248,7 @@ async fn test_consumer_processing_delay_resilience() -> Result<()> {
     produce_test_messages(&test_topic, 50).await?;
 
     // Create mock processor with 100ms delay per message
-    let processor = Arc::new(MockMessageProcessor::new());
+    let processor = MockMessageProcessor::new();
     processor.set_processing_delay(100);
 
     // Create consumer with high concurrency
@@ -313,7 +313,7 @@ async fn test_consumer_failure_notification() -> Result<()> {
     let (failure_tx, mut failure_rx) = mpsc::unbounded_channel();
 
     // Create mock processor that fails every other message
-    let processor = Arc::new(MockMessageProcessor::new());
+    let processor = MockMessageProcessor::new();
     processor.set_failure_rate(50);
     processor.set_failure_sender(failure_tx);
 

--- a/rust/kafka-deduplicator/tests/kafka_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/kafka_integration_tests.rs
@@ -6,6 +6,7 @@ use kafka_deduplicator::kafka::{
     stateful_consumer::StatefulKafkaConsumer,
     types::Partition,
 };
+use kafka_deduplicator::processor_pool::ProcessorPool;
 use rdkafka::{
     config::ClientConfig,
     consumer::Consumer,
@@ -105,14 +106,15 @@ impl RebalanceHandler for TestRebalanceHandler {
     }
 }
 
-/// Helper to create a StatefulKafkaConsumer using our abstractions
-fn create_stateful_kafka_consumer(
+/// Helper to create a StatefulKafkaConsumer and ProcessorPool using our abstractions
+fn create_stateful_kafka_consumer_with_pool(
     topic: &str,
     group_id: &str,
     processor: Arc<TestProcessor>,
     rebalance_handler: Arc<dyn RebalanceHandler>,
 ) -> Result<(
-    StatefulKafkaConsumer<TestProcessor>,
+    StatefulKafkaConsumer,
+    Vec<tokio::task::JoinHandle<()>>,
     tokio::sync::oneshot::Sender<()>,
 )> {
     let mut config = ClientConfig::new();
@@ -127,10 +129,14 @@ fn create_stateful_kafka_consumer(
     // Create shutdown channel - return sender so test can control shutdown
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
 
+    // Create processor pool with one worker for testing
+    let (message_sender, processor_pool) = ProcessorPool::new(processor, 1);
+    let pool_handles = processor_pool.start();
+
     let kafka_consumer = StatefulKafkaConsumer::from_config(
         &config,
         rebalance_handler,
-        processor,
+        message_sender,
         10,
         Duration::from_secs(1),
         shutdown_rx,
@@ -138,7 +144,7 @@ fn create_stateful_kafka_consumer(
 
     kafka_consumer.inner_consumer().subscribe(&[topic])?;
 
-    Ok((kafka_consumer, shutdown_tx))
+    Ok((kafka_consumer, pool_handles, shutdown_tx))
 }
 
 /// Helper to send test messages
@@ -185,7 +191,7 @@ async fn test_generic_kafka_consumer_message_processing() -> Result<()> {
     let processor = Arc::new(TestProcessor::new());
     let rebalance_handler = Arc::new(TestRebalanceHandler::default());
 
-    let (kafka_consumer, shutdown_tx) = create_stateful_kafka_consumer(
+    let (kafka_consumer, _pool_handles, shutdown_tx) = create_stateful_kafka_consumer_with_pool(
         &test_topic,
         &group_id,
         processor.clone(),
@@ -249,7 +255,7 @@ async fn test_generic_kafka_consumer_error_handling() -> Result<()> {
 
     let rebalance_handler = Arc::new(TestRebalanceHandler::default());
 
-    let (kafka_consumer, shutdown_tx) = create_stateful_kafka_consumer(
+    let (kafka_consumer, _pool_handles, shutdown_tx) = create_stateful_kafka_consumer_with_pool(
         &test_topic,
         &group_id,
         processor.clone(),
@@ -298,8 +304,8 @@ async fn test_generic_kafka_consumer_tracker_stats() -> Result<()> {
     let processor = Arc::new(TestProcessor::new());
     let rebalance_handler = Arc::new(TestRebalanceHandler::default());
 
-    let (kafka_consumer, _shutdown_tx) =
-        create_stateful_kafka_consumer(&test_topic, &group_id, processor, rebalance_handler)?;
+    let (kafka_consumer, _pool_handles, _shutdown_tx) =
+        create_stateful_kafka_consumer_with_pool(&test_topic, &group_id, processor, rebalance_handler)?;
 
     // Check initial stats
     let initial_stats = kafka_consumer.get_tracker_stats().await;
@@ -342,10 +348,14 @@ async fn test_partition_aware_message_filtering() -> Result<()> {
     // Create shutdown channel
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
 
+    // Create processor pool with one worker for testing
+    let (message_sender, processor_pool) = ProcessorPool::new(processor.clone(), 1);
+    let _pool_handles = processor_pool.start();
+
     let kafka_consumer = StatefulKafkaConsumer::from_config(
         &config,
         rebalance_handler.clone(),
-        processor.clone(),
+        message_sender,
         10,
         Duration::from_secs(5),
         shutdown_rx,
@@ -435,10 +445,14 @@ async fn test_graceful_shutdown_with_in_flight_messages() -> Result<()> {
     // Create shutdown channel for graceful shutdown
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
 
+    // Create processor pool with one worker for testing
+    let (message_sender, processor_pool) = ProcessorPool::new(processor.clone(), 1);
+    let _pool_handles = processor_pool.start();
+
     let kafka_consumer = StatefulKafkaConsumer::from_config(
         &config,
         rebalance_handler.clone(),
-        processor.clone(),
+        message_sender,
         10,
         Duration::from_secs(1),
         shutdown_rx,
@@ -504,20 +518,24 @@ async fn test_factory_method_integration() -> Result<()> {
 
     // Test both factory methods
     let (_, shutdown_rx1) = tokio::sync::oneshot::channel();
+    let (message_sender1, processor_pool1) = ProcessorPool::new(processor.clone(), 1);
+    let _pool_handles1 = processor_pool1.start();
     let consumer1 = StatefulKafkaConsumer::from_config(
         &config,
         rebalance_handler.clone(),
-        processor.clone(),
+        message_sender1,
         5,
         Duration::from_secs(5),
         shutdown_rx1,
     )?;
 
     let (_, shutdown_rx2) = tokio::sync::oneshot::channel();
+    let (message_sender2, processor_pool2) = ProcessorPool::new(processor.clone(), 1);
+    let _pool_handles2 = processor_pool2.start();
     let consumer2 = StatefulKafkaConsumer::from_config(
         &config,
         rebalance_handler.clone(),
-        processor.clone(),
+        message_sender2,
         10,
         Duration::from_secs(2),
         shutdown_rx2,
@@ -622,10 +640,14 @@ async fn test_rebalance_barrier_with_fencing() -> Result<()> {
     // Create shutdown channel
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
 
+    // Create processor pool with one worker for testing
+    let (message_sender, processor_pool) = ProcessorPool::new(processor.clone(), 1);
+    let _pool_handles = processor_pool.start();
+
     let kafka_consumer = StatefulKafkaConsumer::from_config(
         &config,
         rebalance_handler.clone(),
-        processor.clone(),
+        message_sender,
         5, // limit in-flight messages
         Duration::from_secs(5),
         shutdown_rx,


### PR DESCRIPTION
## Problem

Currently we were not utilizing all of of CPUs, due to only having 1 processor running. 

## Changes

This refactor creates a worker pool for processors, messages are routed by key to each processor guaranteeing order preservation by key
