### PR TITLE
fix(cli):  avoid uploading already existing chunks

### DIFF
--- a/cli/src/utils/fetch.rs
+++ b/cli/src/utils/fetch.rs
@@ -1,0 +1,36 @@
+use reqwest::blocking::Client;
+use serde::de::DeserializeOwned;
+
+pub trait Paginated<T>: DeserializeOwned {
+    fn next(&self) -> Option<&str>;
+    fn into_items(self) -> Vec<T>;
+}
+
+pub fn fetch_paginated<T, R>(client: &Client, start_url: &str, token: &str) -> Result<Vec<T>, anyhow::Error>
+where
+    T: DeserializeOwned,
+    R: Paginated<T>,
+{
+    let mut items = Vec::new();
+    let mut next = Some(start_url.to_string());
+
+    while let Some(url) = next {
+        let resp = client
+            .get(&url)
+            .header("Authorization", format!("Bearer {}", token))
+            .header("Content-Type", "application/json")
+            .send()?;
+
+        if !resp.status().is_success() {
+            let e = resp.text()?;
+            return Err(anyhow::anyhow!("Request failed: {}", e));
+        }
+
+        let page: R = resp.json()?;
+        let next_link = page.next().map(|s| s.to_string());
+        items.extend(page.into_items());
+        next = next_link;
+    }
+
+    Ok(items)
+}

--- a/cli/src/utils/mod.rs
+++ b/cli/src/utils/mod.rs
@@ -6,3 +6,4 @@ pub mod posthog;
 pub mod query;
 pub mod release;
 pub mod sourcemaps;
+pub mod fetch;


### PR DESCRIPTION
## Problem

At the moment, the CLI fails to perform an upload in the following scenarios:
- If a release with the same `hash_id` exists
- If a chunk with matching `chunk_id` as `ref` exists

## Changes

Added a symbol sets fetch, to then filter the files to upload and only create a release for the not yet present files in PostHog.

I thought of also adding a similar check for the releases, but as the release is based on the `hash_id`, the filter already takes care of this case.

## How did you test this code?
Initial upload:
```
posthog-cli-dev sourcemap upload -d build/assets/ --skip-ssl-verification
2025-08-29T15:57:10.543630Z  INFO posthog_cli::utils::auth: Using token from: {...}, for environment 1
2025-08-29T15:57:10.545452Z  INFO posthog_cli::utils::sourcemaps: Processing file: {...}
2025-08-29T15:57:11.192522Z  INFO posthog_cli::commands::sourcemap::upload: Found 137 chunks to upload
2025-08-29T15:57:15.093921Z  INFO posthog_cli::utils::release: Release {...} of {...} created successfully! {...}
2025-08-29T15:57:30.879451Z  INFO posthog_cli::commands::sourcemap::upload: Uploading chunk {...}
2025-08-29T15:57:33.490151Z  INFO posthog_cli: All done, happy hogging!
```
Subsequent upload:
```
posthog-cli-dev sourcemap upload -d build/assets/ --skip-ssl-verification
2025-08-29T15:57:45.414170Z  INFO posthog_cli::utils::auth: Using token from: {...}, for environment 1
2025-08-29T15:57:45.416081Z  INFO posthog_cli::utils::sourcemaps: Processing file: {...}
2025-08-29T15:57:46.284147Z  INFO posthog_cli::commands::sourcemap::upload: There is no new data to upload!
2025-08-29T15:57:46.285941Z  INFO posthog_cli: All done, happy hogging!
```
Previously this would have been the result:
```
posthog-cli sourcemap upload -d build/assets/ --skip-ssl-verification
2025-08-29T16:18:00.404133Z  INFO posthog_cli::utils::auth: Using token from: {...}, for environment 1
2025-08-29T16:18:00.404977Z  INFO posthog_cli::utils::sourcemaps: Processing file: {...}
2025-08-29T16:18:00.780845Z  INFO posthog_cli::commands::sourcemap::upload: Found 137 chunks to upload
2025-08-29T16:18:01.121530Z ERROR posthog_cli: msg="Oops! While creating release\n\nCaused by:\n    Failed to create release: {\"type\":\"server_error\",\"code\":\"error\",\"detail\":\"A server error occurred.\",\"attr\":null}"
```

Currently the implementation checks for the length of the upload vector after filtering, and then performs an early return in case there is no files to upload, avoiding both the release creation and file upload.

This would make the files not to be deleted if the `delete_after` flag is passed. 

Would that be OK, or should the deletion be ran even if the files are not uploaded?

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
