### PR TITLE
fix: mock instance status request

### DIFF
--- a/playwright/utils/playwright-test-base.ts
+++ b/playwright/utils/playwright-test-base.ts
@@ -46,6 +46,12 @@ export const test = base.extend<{ loginBeforeTests: void; page: Page }>({
         page.goToMenuItem = async function (name: Identifier): Promise<void> {
             await new Navigation(page).openMenuItem(name)
         }
+
+        await page.route('/api/instance_status', async (route) => {
+            const json = require('./fixtures/_instance_status.json')
+            await route.fulfill({ json })
+        })
+
         // page.resetCapturedEvents = async function () {
         //     await this.evaluate(() => {
         //         ;(window as WindowWithPostHog).capturedEvents = []


### PR DESCRIPTION
## Problem

Working theory is that since we [removed cypress](https://github.com/PostHog/posthog/pull/37310) some requests are not being mocked

## Changes

Trying to mock directly in Playwright to see if I can get the tests to pass (this works locally)