### PR TITLE
chore: Add a `--changed` option to `bin/tests`

### DIFF
--- a/bin/tests
+++ b/bin/tests
@@ -7,11 +7,49 @@ then
     exit
 fi
 
+# Check if --changed option is used
+CHANGED_ONLY=false
+FILTERED_ARGS=()
+for arg in "$@"; do
+    if [[ "$arg" == "--changed" ]]; then
+        CHANGED_ONLY=true
+    else
+        FILTERED_ARGS+=("$arg")
+    fi
+done
 
-if [ $# -eq 0 ]; then
+# Handle --changed option
+if [ "$CHANGED_ONLY" = true ]; then
+    CURRENT_BRANCH=$(git branch --show-current)
+    if [ "$CURRENT_BRANCH" = "master" ]; then
+        echo "Cannot use --changed option on master branch"
+        exit 1
+    fi
+    
+    # Get changed test files
+    CHANGED_TEST_FILES=$(
+        (git diff --name-only master...HEAD; git status --porcelain | cut -c4-) | \
+        grep -E '/test_[^/]*\.py$' | \
+        grep -v '__pycache__' | \
+        sort -u
+    )
+    
+    if [ -z "$CHANGED_TEST_FILES" ]; then
+        echo "No changed test files found in branch $CURRENT_BRANCH"
+        exit 0
+    fi
+    
+    echo "Running tests for changed files in branch $CURRENT_BRANCH:"
+    echo "$CHANGED_TEST_FILES"
+    echo ""
+    
+    # Set the test files to run
+    set -- "${FILTERED_ARGS[@]}" $CHANGED_TEST_FILES
+elif [ $# -eq 0 ]; then
     echo "Are you sure you want to run all backend tests? You can run specific tests by doing:"
     echo " "
     echo "bin/tests posthog/api/test/test_user.py::TestUserAPI::test_retrieve_current_user"
+    echo "bin/tests --changed  # Run tests for files changed in current branch"
     echo " "
     read -r -p "Run all tests? [y/N] " response
     if [[ "$response" =~ ^([yY][eE][sS]|[yY])+$ ]]

--- a/bin/tests
+++ b/bin/tests
@@ -7,6 +7,17 @@ then
     exit
 fi
 
+# Function to get changed test files
+get_changed_test_files() {
+    (
+        git diff --name-only master...HEAD; 
+        git status --porcelain | cut -c4-
+    ) | \
+    grep -E '/test_[^/]*\.py$' | \
+    grep -v '__pycache__' | \
+    sort -u
+}
+
 # Check if --changed option is used
 CHANGED_ONLY=false
 FILTERED_ARGS=()
@@ -27,12 +38,7 @@ if [ "$CHANGED_ONLY" = true ]; then
     fi
     
     # Get changed test files
-    CHANGED_TEST_FILES=$(
-        (git diff --name-only master...HEAD; git status --porcelain | cut -c4-) | \
-        grep -E '/test_[^/]*\.py$' | \
-        grep -v '__pycache__' | \
-        sort -u
-    )
+    CHANGED_TEST_FILES=$(get_changed_test_files)
     
     if [ -z "$CHANGED_TEST_FILES" ]; then
         echo "No changed test files found in branch $CURRENT_BRANCH"
@@ -70,12 +76,7 @@ elif [ $# -eq 0 ]; then
             fi
             
             # Get changed test files
-            CHANGED_TEST_FILES=$(
-                (git diff --name-only master...HEAD; git status --porcelain | cut -c4-) | \
-                grep -E '/test_[^/]*\.py$' | \
-                grep -v '__pycache__' | \
-                sort -u
-            )
+            CHANGED_TEST_FILES=$(get_changed_test_files)
             
             if [ -z "$CHANGED_TEST_FILES" ]; then
                 echo "No changed test files found in branch $CURRENT_BRANCH"
@@ -87,7 +88,7 @@ elif [ $# -eq 0 ]; then
             echo ""
             
             # Set the test files to run
-            set -- $CHANGED_TEST_FILES
+            set -- "${FILTERED_ARGS[@]}" $CHANGED_TEST_FILES
             ;;
         3)
             echo "Please specify the tests you want to run:"

--- a/bin/tests
+++ b/bin/tests
@@ -46,18 +46,59 @@ if [ "$CHANGED_ONLY" = true ]; then
     # Set the test files to run
     set -- "${FILTERED_ARGS[@]}" $CHANGED_TEST_FILES
 elif [ $# -eq 0 ]; then
-    echo "Are you sure you want to run all backend tests? You can run specific tests by doing:"
+    echo "What tests would you like to run?"
     echo " "
-    echo "bin/tests posthog/api/test/test_user.py::TestUserAPI::test_retrieve_current_user"
-    echo "bin/tests --changed  # Run tests for files changed in current branch"
+    echo "1. All tests (will take a long time)"
+    echo "2. Changed tests only (files changed in current branch)"
+    echo "3. Specify tests manually"
     echo " "
-    read -r -p "Run all tests? [y/N] " response
-    if [[ "$response" =~ ^([yY][eE][sS]|[yY])+$ ]]
-    then
-        echo "OK!"
-    else
-        exit
-    fi
+    echo "Examples of specifying tests manually:"
+    echo "  bin/tests posthog/api/test/test_user.py"
+    echo "  bin/tests posthog/api/test/test_user.py::TestUserAPI::test_retrieve_current_user"
+    echo " "
+    read -r -p "Choose option [1/2/3]: " choice
+    
+    case $choice in
+        1)
+            echo "Running all tests..."
+            ;;
+        2)
+            CURRENT_BRANCH=$(git branch --show-current)
+            if [ "$CURRENT_BRANCH" = "master" ]; then
+                echo "Cannot run changed tests on master branch"
+                exit 1
+            fi
+            
+            # Get changed test files
+            CHANGED_TEST_FILES=$(
+                (git diff --name-only master...HEAD; git status --porcelain | cut -c4-) | \
+                grep -E '/test_[^/]*\.py$' | \
+                grep -v '__pycache__' | \
+                sort -u
+            )
+            
+            if [ -z "$CHANGED_TEST_FILES" ]; then
+                echo "No changed test files found in branch $CURRENT_BRANCH"
+                exit 0
+            fi
+            
+            echo "Running tests for changed files in branch $CURRENT_BRANCH:"
+            echo "$CHANGED_TEST_FILES"
+            echo ""
+            
+            # Set the test files to run
+            set -- $CHANGED_TEST_FILES
+            ;;
+        3)
+            echo "Please specify the tests you want to run:"
+            echo "  bin/tests <test_path>"
+            exit 0
+            ;;
+        *)
+            echo "Invalid choice. Exiting."
+            exit 1
+            ;;
+    esac
 fi
 
 export REDIS_URL='redis:///'


### PR DESCRIPTION
When specified, only tests changed in the current branch are run.

## Problem

Running `bin/tests` with no arguments will try and run all python tests and that takes a very long time and never fully succeeds on my local machine. I want an option to run any tests that were changed in my current branch if I'm not on `master`. This includes committed tests as well as uncommitted tests.

## Changes

Updates `bin/tests` to accept a `--changed` argument. When specified, it looks at all files changed in the current branch and uses a regex to filter for `test_[^/]*\.py`. Then it runs just those files.

If no argument is passed, it prompts the user like so:

```bash
> bin/tests
What tests would you like to run?

1. All tests (will take a long time)
2. Changed tests only (files changed in current branch)
3. Specify tests manually

Examples of specifying tests manually:
  bin/tests posthog/api/test/test_user.py
  bin/tests posthog/api/test/test_user.py::TestUserAPI::test_retrieve_current_user

Choose option [1/2/3]: 2
No changed test files found in branch haacked/run-changed-tests
```

## How did you test this code?

Manually.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Notes

A helpful git alias is the following:

```bash
git config --global alias.bchanges "!f() { (git diff --name-only master...HEAD; git status --porcelain | cut -c4-) | sort -u; }; f"
```

That shows all the changes in your current branch including uncommitted changes.
