### PR TITLE
feat(experiments): add support for metric goal

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -11301,8 +11301,7 @@
                     "$ref": "#/definitions/StepOrderValue"
                 },
                 "goal": {
-                    "enum": ["increase", "decrease"],
-                    "type": "string"
+                    "$ref": "#/definitions/ExperimentMetricGoal"
                 },
                 "kind": {
                     "const": "ExperimentMetric",
@@ -11514,8 +11513,7 @@
                     "$ref": "#/definitions/FunnelConversionWindowTimeUnit"
                 },
                 "goal": {
-                    "enum": ["increase", "decrease"],
-                    "type": "string"
+                    "$ref": "#/definitions/ExperimentMetricGoal"
                 },
                 "kind": {
                     "const": "ExperimentMetric",
@@ -11594,8 +11592,7 @@
                     "$ref": "#/definitions/FunnelConversionWindowTimeUnit"
                 },
                 "goal": {
-                    "enum": ["increase", "decrease"],
-                    "type": "string"
+                    "$ref": "#/definitions/ExperimentMetricGoal"
                 },
                 "kind": {
                     "const": "ExperimentMetric",
@@ -11617,6 +11614,10 @@
             },
             "required": ["kind"],
             "type": "object"
+        },
+        "ExperimentMetricGoal": {
+            "enum": ["increase", "decrease"],
+            "type": "string"
         },
         "ExperimentMetricMathType": {
             "enum": ["total", "sum", "unique_session", "min", "max", "avg", "dau", "unique_group", "hogql"],
@@ -11794,8 +11795,7 @@
                     "$ref": "#/definitions/ExperimentMetricSource"
                 },
                 "goal": {
-                    "enum": ["increase", "decrease"],
-                    "type": "string"
+                    "$ref": "#/definitions/ExperimentMetricGoal"
                 },
                 "kind": {
                     "const": "ExperimentMetric",

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -11300,6 +11300,10 @@
                 "funnel_order_type": {
                     "$ref": "#/definitions/StepOrderValue"
                 },
+                "goal": {
+                    "enum": ["increase", "decrease"],
+                    "type": "string"
+                },
                 "kind": {
                     "const": "ExperimentMetric",
                     "type": "string"
@@ -11509,6 +11513,10 @@
                 "conversion_window_unit": {
                     "$ref": "#/definitions/FunnelConversionWindowTimeUnit"
                 },
+                "goal": {
+                    "enum": ["increase", "decrease"],
+                    "type": "string"
+                },
                 "kind": {
                     "const": "ExperimentMetric",
                     "type": "string"
@@ -11584,6 +11592,10 @@
                 },
                 "conversion_window_unit": {
                     "$ref": "#/definitions/FunnelConversionWindowTimeUnit"
+                },
+                "goal": {
+                    "enum": ["increase", "decrease"],
+                    "type": "string"
                 },
                 "kind": {
                     "const": "ExperimentMetric",
@@ -11780,6 +11792,10 @@
                 },
                 "denominator": {
                     "$ref": "#/definitions/ExperimentMetricSource"
+                },
+                "goal": {
+                    "enum": ["increase", "decrease"],
+                    "type": "string"
                 },
                 "kind": {
                     "const": "ExperimentMetric",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2516,6 +2516,7 @@ export interface ExperimentMetricBaseProperties extends Node {
     name?: string
     conversion_window?: integer
     conversion_window_unit?: FunnelConversionWindowTimeUnit
+    goal?: 'increase' | 'decrease'
 }
 
 export type ExperimentMetricOutlierHandling = {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -18,6 +18,7 @@ import {
     EventPropertyFilter,
     EventType,
     ExperimentHoldoutType,
+    ExperimentMetricGoal,
     ExperimentMetricMathType,
     FilterLogicalOperator,
     FilterType,
@@ -2516,7 +2517,7 @@ export interface ExperimentMetricBaseProperties extends Node {
     name?: string
     conversion_window?: integer
     conversion_window_unit?: FunnelConversionWindowTimeUnit
-    goal?: 'increase' | 'decrease'
+    goal?: ExperimentMetricGoal
 }
 
 export type ExperimentMetricOutlierHandling = {

--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -21,7 +21,7 @@ import {
     isExperimentMeanMetric,
     isExperimentRatioMetric,
 } from '~/queries/schema/schema-general'
-import { ExperimentMetricMathType, FilterType } from '~/types'
+import { ExperimentMetricGoal, ExperimentMetricMathType, FilterType } from '~/types'
 
 import { ExperimentMetricConversionWindowFilter } from './ExperimentMetricConversionWindowFilter'
 import { ExperimentMetricFunnelOrderSelector } from './ExperimentMetricFunnelOrderSelector'
@@ -308,12 +308,12 @@ export function ExperimentMetricForm({
             </div>
             <div>
                 <LemonLabel className="mb-1">Goal</LemonLabel>
-                <LemonSelect<'increase' | 'decrease'>
-                    value={metric.goal || 'increase'}
+                <LemonSelect<ExperimentMetricGoal>
+                    value={metric.goal || ExperimentMetricGoal.Increase}
                     onChange={(value) => handleSetMetric({ ...metric, goal: value })}
                     options={[
-                        { value: 'increase' as const, label: 'Increase (higher is better)' },
-                        { value: 'decrease' as const, label: 'Decrease (lower is better)' },
+                        { value: ExperimentMetricGoal.Increase, label: 'Increase' },
+                        { value: ExperimentMetricGoal.Decrease, label: 'Decrease' },
                     ]}
                     fullWidth
                 />

--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -308,12 +308,12 @@ export function ExperimentMetricForm({
             </div>
             <div>
                 <LemonLabel className="mb-1">Goal</LemonLabel>
-                <LemonSelect
+                <LemonSelect<'increase' | 'decrease'>
                     value={metric.goal || 'increase'}
-                    onChange={(value) => handleSetMetric({ ...metric, goal: value as 'increase' | 'decrease' })}
+                    onChange={(value) => handleSetMetric({ ...metric, goal: value })}
                     options={[
-                        { value: 'increase', label: 'Increase (higher is better)' },
-                        { value: 'decrease', label: 'Decrease (lower is better)' },
+                        { value: 'increase' as const, label: 'Increase (higher is better)' },
+                        { value: 'decrease' as const, label: 'Decrease (lower is better)' },
                     ]}
                     fullWidth
                 />

--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -4,6 +4,7 @@ import { DataWarehousePopoverField } from 'lib/components/TaxonomicFilter/types'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonLabel } from 'lib/lemon-ui/LemonLabel'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
+import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { Link } from 'lib/lemon-ui/Link'
 import { Spinner } from 'lib/lemon-ui/Spinner'
@@ -304,6 +305,22 @@ export function ExperimentMetricForm({
                         </div>
                     </div>
                 )}
+            </div>
+            <div>
+                <LemonLabel className="mb-1">Goal</LemonLabel>
+                <LemonSelect
+                    value={metric.goal || 'increase'}
+                    onChange={(value) => handleSetMetric({ ...metric, goal: value as 'increase' | 'decrease' })}
+                    options={[
+                        { value: 'increase', label: 'Increase (higher is better)' },
+                        { value: 'decrease', label: 'Decrease (lower is better)' },
+                    ]}
+                    fullWidth
+                />
+                <div className="text-muted text-sm mt-1">
+                    Choose whether you want this metric to increase or decrease. For example, conversion rates should
+                    increase, while bounce rates should decrease.
+                </div>
             </div>
             <ExperimentMetricConversionWindowFilter metric={metric} handleSetMetric={handleSetMetric} />
             {isExperimentFunnelMetric(metric) && (

--- a/frontend/src/scenes/experiments/MetricsView/new/ChartCell.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/ChartCell.tsx
@@ -1,3 +1,5 @@
+import { ExperimentMetric } from '~/queries/schema/schema-general'
+
 import { generateViolinPath } from '../legacy/violinUtils'
 import { useChartColors } from '../shared/colors'
 import {
@@ -23,6 +25,7 @@ import { useAxisScale } from './useAxisScale'
 
 interface ChartCellProps {
     variantResult: ExperimentVariantResult
+    metric: ExperimentMetric
     axisRange: number
     metricUuid?: string
     showGridLines?: boolean

--- a/frontend/src/scenes/experiments/MetricsView/new/ChartCell.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/ChartCell.tsx
@@ -36,6 +36,7 @@ interface ChartCellProps {
 
 export function ChartCell({
     variantResult,
+    metric,
     axisRange,
     metricUuid,
     showGridLines = true,
@@ -96,6 +97,7 @@ export function ChartCell({
                             <ChartGradients
                                 lower={lower}
                                 upper={upper}
+                                metric={metric}
                                 gradientId={`gradient-${isSecondary ? 'secondary' : 'primary'}-${metricUuid ? metricUuid.slice(-8) : 'default'}-${
                                     variantResult.key
                                 }`}

--- a/frontend/src/scenes/experiments/MetricsView/new/ChartGradients.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/ChartGradients.tsx
@@ -1,6 +1,7 @@
 import { ExperimentMetric } from '~/queries/schema/schema-general'
 
 import { useChartColors } from '../shared/colors'
+import { getGoalAwareColors } from '../shared/utils'
 
 interface ChartGradientsProps {
     lower?: number
@@ -20,34 +21,17 @@ export function ChartGradients({
     metric,
 }: ChartGradientsProps): JSX.Element {
     const colors = useChartColors()
-
-    // Determine colors based on goal
-    const getNegativeColor = (): string => {
-        if (!metric?.goal) {
-            return colors.BAR_NEGATIVE
-        }
-        return metric.goal === 'decrease' ? colors.BAR_POSITIVE : colors.BAR_NEGATIVE
-    }
-
-    const getPositiveColor = (): string => {
-        if (!metric?.goal) {
-            return colors.BAR_POSITIVE
-        }
-        return metric.goal === 'decrease' ? colors.BAR_NEGATIVE : colors.BAR_POSITIVE
-    }
-
-    const negativeColor = getNegativeColor()
-    const positiveColor = getPositiveColor()
+    const goalColors = getGoalAwareColors(metric, colors)
 
     if (lower < 0 && upper > 0) {
         const zeroOffset = (-lower / (upper - lower)) * 100
         return (
             <defs>
                 <linearGradient id={gradientId} x1="0" x2="1" y1="0" y2="0">
-                    <stop offset="0%" stopColor={negativeColor} />
-                    <stop offset={`${zeroOffset}%`} stopColor={negativeColor} />
-                    <stop offset={`${zeroOffset}%`} stopColor={positiveColor} />
-                    <stop offset="100%" stopColor={positiveColor} />
+                    <stop offset="0%" stopColor={goalColors.negative} />
+                    <stop offset={`${zeroOffset}%`} stopColor={goalColors.negative} />
+                    <stop offset={`${zeroOffset}%`} stopColor={goalColors.positive} />
+                    <stop offset="100%" stopColor={goalColors.positive} />
                 </linearGradient>
             </defs>
         )
@@ -56,7 +40,7 @@ export function ChartGradients({
     return (
         <defs>
             <linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="0">
-                <stop offset="100%" stopColor={upper <= 0 ? negativeColor : positiveColor} />
+                <stop offset="100%" stopColor={upper <= 0 ? goalColors.negative : goalColors.positive} />
             </linearGradient>
         </defs>
     )

--- a/frontend/src/scenes/experiments/MetricsView/new/ChartGradients.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/ChartGradients.tsx
@@ -21,7 +21,7 @@ export function ChartGradients({
     metric,
 }: ChartGradientsProps): JSX.Element {
     const colors = useChartColors()
-    const goalColors = getMetricColors(metric?.goal, colors)
+    const goalColors = getMetricColors(colors, metric?.goal)
 
     if (lower < 0 && upper > 0) {
         const zeroOffset = (-lower / (upper - lower)) * 100

--- a/frontend/src/scenes/experiments/MetricsView/new/ChartGradients.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/ChartGradients.tsx
@@ -21,7 +21,7 @@ export function ChartGradients({
     metric,
 }: ChartGradientsProps): JSX.Element {
     const colors = useChartColors()
-    const goalColors = getGoalAwareColors(metric, colors)
+    const goalColors = getGoalAwareColors(metric?.goal, colors)
 
     if (lower < 0 && upper > 0) {
         const zeroOffset = (-lower / (upper - lower)) * 100

--- a/frontend/src/scenes/experiments/MetricsView/new/ChartGradients.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/ChartGradients.tsx
@@ -1,7 +1,7 @@
 import { ExperimentMetric } from '~/queries/schema/schema-general'
 
 import { useChartColors } from '../shared/colors'
-import { getGoalAwareColors } from '../shared/utils'
+import { getMetricColors } from '../shared/utils'
 
 interface ChartGradientsProps {
     lower?: number
@@ -21,7 +21,7 @@ export function ChartGradients({
     metric,
 }: ChartGradientsProps): JSX.Element {
     const colors = useChartColors()
-    const goalColors = getGoalAwareColors(metric?.goal, colors)
+    const goalColors = getMetricColors(metric?.goal, colors)
 
     if (lower < 0 && upper > 0) {
         const zeroOffset = (-lower / (upper - lower)) * 100

--- a/frontend/src/scenes/experiments/MetricsView/new/ChartGradients.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/ChartGradients.tsx
@@ -1,9 +1,12 @@
+import { ExperimentMetric } from '~/queries/schema/schema-general'
+
 import { useChartColors } from '../shared/colors'
 
 interface ChartGradientsProps {
     lower?: number
     upper?: number
     gradientId?: string
+    metric?: ExperimentMetric
 }
 
 /**
@@ -14,18 +17,37 @@ export function ChartGradients({
     lower = 0,
     upper = 0,
     gradientId = 'chart-gradient',
+    metric,
 }: ChartGradientsProps): JSX.Element {
     const colors = useChartColors()
+
+    // Determine colors based on goal
+    const getNegativeColor = (): string => {
+        if (!metric?.goal) {
+            return colors.BAR_NEGATIVE
+        }
+        return metric.goal === 'decrease' ? colors.BAR_POSITIVE : colors.BAR_NEGATIVE
+    }
+
+    const getPositiveColor = (): string => {
+        if (!metric?.goal) {
+            return colors.BAR_POSITIVE
+        }
+        return metric.goal === 'decrease' ? colors.BAR_NEGATIVE : colors.BAR_POSITIVE
+    }
+
+    const negativeColor = getNegativeColor()
+    const positiveColor = getPositiveColor()
 
     if (lower < 0 && upper > 0) {
         const zeroOffset = (-lower / (upper - lower)) * 100
         return (
             <defs>
                 <linearGradient id={gradientId} x1="0" x2="1" y1="0" y2="0">
-                    <stop offset="0%" stopColor={colors.BAR_NEGATIVE} />
-                    <stop offset={`${zeroOffset}%`} stopColor={colors.BAR_NEGATIVE} />
-                    <stop offset={`${zeroOffset}%`} stopColor={colors.BAR_POSITIVE} />
-                    <stop offset="100%" stopColor={colors.BAR_POSITIVE} />
+                    <stop offset="0%" stopColor={negativeColor} />
+                    <stop offset={`${zeroOffset}%`} stopColor={negativeColor} />
+                    <stop offset={`${zeroOffset}%`} stopColor={positiveColor} />
+                    <stop offset="100%" stopColor={positiveColor} />
                 </linearGradient>
             </defs>
         )
@@ -34,7 +56,7 @@ export function ChartGradients({
     return (
         <defs>
             <linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="0">
-                <stop offset="100%" stopColor={upper <= 0 ? colors.BAR_NEGATIVE : colors.BAR_POSITIVE} />
+                <stop offset="100%" stopColor={upper <= 0 ? negativeColor : positiveColor} />
             </linearGradient>
         </defs>
     )

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -25,8 +25,8 @@ import {
     getMetricSubtitleValues,
     getNiceTickValues,
     isDeltaPositive,
-    isGoalAwareWinning,
     isSignificant,
+    isWinning,
 } from '../shared/utils'
 import { ChartCell } from './ChartCell'
 import { DetailsButton } from './DetailsButton'
@@ -382,7 +382,7 @@ export function MetricRowGroup({
                 const isLastRow = index === variantResults.length - 1
                 const significant = isSignificant(variant)
                 const deltaPositive = isDeltaPositive(variant)
-                const isWinning = isGoalAwareWinning(variant, metric.goal)
+                const winning = isWinning(variant, metric.goal)
                 const deltaText = formatDeltaPercent(variant)
 
                 return (
@@ -428,7 +428,7 @@ export function MetricRowGroup({
                                 <span
                                     className={`${
                                         significant
-                                            ? isWinning
+                                            ? winning
                                                 ? 'text-success font-semibold'
                                                 : 'text-danger font-semibold'
                                             : 'text-text-primary'
@@ -437,7 +437,7 @@ export function MetricRowGroup({
                                     {deltaText}
                                 </span>
                                 {significant && deltaPositive !== undefined && (
-                                    <span className={`flex-shrink-0 ${isWinning ? 'text-success' : 'text-danger'}`}>
+                                    <span className={`flex-shrink-0 ${winning ? 'text-success' : 'text-danger'}`}>
                                         {deltaPositive ? (
                                             <IconTrending className="w-4 h-4" />
                                         ) : (

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -25,6 +25,7 @@ import {
     getMetricSubtitleValues,
     getNiceTickValues,
     isDeltaPositive,
+    isGoalAwareWinning,
     isSignificant,
 } from '../shared/utils'
 import { ChartCell } from './ChartCell'
@@ -252,7 +253,7 @@ export function MetricRowGroup({
                             visibility: tooltipState.isPositioned ? 'visible' : 'hidden',
                         }}
                     >
-                        {renderTooltipContent(tooltipState.variantResult)}
+                        {renderTooltipContent(tooltipState.variantResult, metric)}
                     </div>,
                     document.body
                 )}
@@ -381,6 +382,7 @@ export function MetricRowGroup({
                 const isLastRow = index === variantResults.length - 1
                 const significant = isSignificant(variant)
                 const deltaPositive = isDeltaPositive(variant)
+                const isWinning = isGoalAwareWinning(variant, metric)
                 const deltaText = formatDeltaPercent(variant)
 
                 return (
@@ -426,7 +428,7 @@ export function MetricRowGroup({
                                 <span
                                     className={`${
                                         significant
-                                            ? deltaPositive
+                                            ? isWinning
                                                 ? 'text-success font-semibold'
                                                 : 'text-danger font-semibold'
                                             : 'text-text-primary'
@@ -435,7 +437,7 @@ export function MetricRowGroup({
                                     {deltaText}
                                 </span>
                                 {significant && deltaPositive !== undefined && (
-                                    <span className={`flex-shrink-0 ${deltaPositive ? 'text-success' : 'text-danger'}`}>
+                                    <span className={`flex-shrink-0 ${isWinning ? 'text-success' : 'text-danger'}`}>
                                         {deltaPositive ? (
                                             <IconTrending className="w-4 h-4" />
                                         ) : (
@@ -449,6 +451,7 @@ export function MetricRowGroup({
                         {/* Chart */}
                         <ChartCell
                             variantResult={variant}
+                            metric={metric}
                             axisRange={axisRange}
                             metricUuid={metric.uuid}
                             isAlternatingRow={isAlternatingRow}

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -382,7 +382,7 @@ export function MetricRowGroup({
                 const isLastRow = index === variantResults.length - 1
                 const significant = isSignificant(variant)
                 const deltaPositive = isDeltaPositive(variant)
-                const isWinning = isGoalAwareWinning(variant, metric)
+                const isWinning = isGoalAwareWinning(variant, metric.goal)
                 const deltaText = formatDeltaPercent(variant)
 
                 return (

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroupTooltip.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroupTooltip.tsx
@@ -5,14 +5,14 @@ import { ExperimentMetric } from '~/queries/schema/schema-general'
 
 import {
     type ExperimentVariantResult,
+    formatChanceToWinForGoal,
     formatDeltaPercent,
-    formatGoalAwareChanceToWin,
     formatIntervalPercent,
     formatPValue,
     getIntervalLabel,
     isBayesianResult,
-    isGoalAwareWinning,
     isSignificant,
+    isWinning,
 } from '../shared/utils'
 
 export const renderTooltipContent = (variantResult: ExperimentVariantResult, metric: ExperimentMetric): JSX.Element => {
@@ -20,15 +20,15 @@ export const renderTooltipContent = (variantResult: ExperimentVariantResult, met
     const intervalLabel = getIntervalLabel(variantResult)
     const significant = isSignificant(variantResult)
 
-    const isWinning = isGoalAwareWinning(variantResult, metric.goal)
+    const winning = isWinning(variantResult, metric.goal)
 
     return (
         <div className="flex flex-col gap-1">
             <div className="flex justify-between items-center">
                 <div className="font-semibold pb-2">{variantResult.key}</div>
                 {variantResult.key !== 'control' && (
-                    <LemonTag type={!significant ? 'muted' : isWinning ? 'success' : 'danger'} size="medium">
-                        {!significant ? 'Not significant' : isWinning ? 'Won' : 'Lost'}
+                    <LemonTag type={!significant ? 'muted' : winning ? 'success' : 'danger'} size="medium">
+                        {!significant ? 'Not significant' : winning ? 'Won' : 'Lost'}
                     </LemonTag>
                 )}
             </div>
@@ -46,7 +46,7 @@ export const renderTooltipContent = (variantResult: ExperimentVariantResult, met
             {isBayesianResult(variantResult) ? (
                 <div className="flex justify-between items-center">
                     <span className="text-muted-alt font-semibold">Chance to win:</span>
-                    <span className="font-semibold">{formatGoalAwareChanceToWin(variantResult, metric.goal)}</span>
+                    <span className="font-semibold">{formatChanceToWinForGoal(variantResult, metric.goal)}</span>
                 </div>
             ) : (
                 <div className="flex justify-between items-center">
@@ -61,7 +61,7 @@ export const renderTooltipContent = (variantResult: ExperimentVariantResult, met
                     {variantResult.key === 'control' ? (
                         <em className="text-muted-alt">Baseline</em>
                     ) : (
-                        <span className={isWinning ? 'text-success' : 'text-danger'}>
+                        <span className={winning ? 'text-success' : 'text-danger'}>
                             {formatDeltaPercent(variantResult)}
                         </span>
                     )}

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroupTooltip.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroupTooltip.tsx
@@ -1,31 +1,34 @@
 import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { humanFriendlyNumber } from 'lib/utils'
 
+import { ExperimentMetric } from '~/queries/schema/schema-general'
+
 import {
     type ExperimentVariantResult,
-    formatChanceToWin,
     formatDeltaPercent,
+    formatGoalAwareChanceToWin,
     formatIntervalPercent,
     formatPValue,
     getIntervalLabel,
     isBayesianResult,
-    isDeltaPositive,
+    isGoalAwareWinning,
     isSignificant,
 } from '../shared/utils'
 
-export const renderTooltipContent = (variantResult: ExperimentVariantResult): JSX.Element => {
+export const renderTooltipContent = (variantResult: ExperimentVariantResult, metric: ExperimentMetric): JSX.Element => {
     const intervalPercent = formatIntervalPercent(variantResult)
     const intervalLabel = getIntervalLabel(variantResult)
     const significant = isSignificant(variantResult)
-    const deltaPositive = isDeltaPositive(variantResult)
+
+    const isWinning = isGoalAwareWinning(variantResult, metric)
 
     return (
         <div className="flex flex-col gap-1">
             <div className="flex justify-between items-center">
                 <div className="font-semibold pb-2">{variantResult.key}</div>
                 {variantResult.key !== 'control' && (
-                    <LemonTag type={!significant ? 'muted' : deltaPositive ? 'success' : 'danger'} size="medium">
-                        {!significant ? 'Not significant' : deltaPositive ? 'Won' : 'Lost'}
+                    <LemonTag type={!significant ? 'muted' : isWinning ? 'success' : 'danger'} size="medium">
+                        {!significant ? 'Not significant' : isWinning ? 'Won' : 'Lost'}
                     </LemonTag>
                 )}
             </div>
@@ -43,7 +46,7 @@ export const renderTooltipContent = (variantResult: ExperimentVariantResult): JS
             {isBayesianResult(variantResult) ? (
                 <div className="flex justify-between items-center">
                     <span className="text-muted-alt font-semibold">Chance to win:</span>
-                    <span className="font-semibold">{formatChanceToWin(variantResult.chance_to_win)}</span>
+                    <span className="font-semibold">{formatGoalAwareChanceToWin(variantResult, metric)}</span>
                 </div>
             ) : (
                 <div className="flex justify-between items-center">
@@ -58,7 +61,7 @@ export const renderTooltipContent = (variantResult: ExperimentVariantResult): JS
                     {variantResult.key === 'control' ? (
                         <em className="text-muted-alt">Baseline</em>
                     ) : (
-                        <span className={deltaPositive ? 'text-success' : 'text-danger'}>
+                        <span className={isWinning ? 'text-success' : 'text-danger'}>
                             {formatDeltaPercent(variantResult)}
                         </span>
                     )}

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroupTooltip.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroupTooltip.tsx
@@ -20,7 +20,7 @@ export const renderTooltipContent = (variantResult: ExperimentVariantResult, met
     const intervalLabel = getIntervalLabel(variantResult)
     const significant = isSignificant(variantResult)
 
-    const isWinning = isGoalAwareWinning(variantResult, metric)
+    const isWinning = isGoalAwareWinning(variantResult, metric.goal)
 
     return (
         <div className="flex flex-col gap-1">
@@ -46,7 +46,7 @@ export const renderTooltipContent = (variantResult: ExperimentVariantResult, met
             {isBayesianResult(variantResult) ? (
                 <div className="flex justify-between items-center">
                     <span className="text-muted-alt font-semibold">Chance to win:</span>
-                    <span className="font-semibold">{formatGoalAwareChanceToWin(variantResult, metric)}</span>
+                    <span className="font-semibold">{formatGoalAwareChanceToWin(variantResult, metric.goal)}</span>
                 </div>
             ) : (
                 <div className="flex justify-between items-center">

--- a/frontend/src/scenes/experiments/MetricsView/shared/utils.test.ts
+++ b/frontend/src/scenes/experiments/MetricsView/shared/utils.test.ts
@@ -2,7 +2,16 @@ import type { ExperimentFunnelsQuery, ExperimentMetric, ExperimentTrendsQuery } 
 import { ExperimentMetricType, NodeKind } from '~/queries/schema/schema-general'
 import { ExperimentMetricMathType } from '~/types'
 
-import { getDefaultMetricTitle, getMetricTag } from './utils'
+import {
+    type ExperimentVariantResult,
+    applyGoalDirection,
+    formatChanceToWinForGoal,
+    getChanceToWin,
+    getDefaultMetricTitle,
+    getMetricColors,
+    getMetricTag,
+    isWinning,
+} from './utils'
 
 describe('getMetricTag', () => {
     it('handles different metric types correctly', () => {
@@ -78,5 +87,184 @@ describe('getDefaultMetricTitle', () => {
             },
         }
         expect(getDefaultMetricTitle(metric)).toBe('purchase_events')
+    })
+})
+
+describe('applyGoalDirection', () => {
+    it('returns whenIncrease value for increase goal', () => {
+        expect(applyGoalDirection('increase', 'up', 'down')).toBe('up')
+        expect(applyGoalDirection('increase', 100, -100)).toBe(100)
+        expect(applyGoalDirection('increase', true, false)).toBe(true)
+    })
+
+    it('returns whenDecrease value for decrease goal', () => {
+        expect(applyGoalDirection('decrease', 'up', 'down')).toBe('down')
+        expect(applyGoalDirection('decrease', 100, -100)).toBe(-100)
+        expect(applyGoalDirection('decrease', true, false)).toBe(false)
+    })
+
+    it('returns whenIncrease value for undefined goal (default)', () => {
+        expect(applyGoalDirection(undefined, 'up', 'down')).toBe('up')
+        expect(applyGoalDirection(undefined, 100, -100)).toBe(100)
+        expect(applyGoalDirection(undefined, true, false)).toBe(true)
+    })
+})
+
+describe('isWinning', () => {
+    const createResult = (credible_interval: [number, number] | null): ExperimentVariantResult => ({
+        key: 'test',
+        sum: 100,
+        absolute_value: 100,
+        relative_value: 0.1,
+        number_of_samples: 100,
+        significant: true,
+        method: 'bayesian',
+        credible_interval,
+        chance_to_win: 0.75,
+    })
+
+    it('returns true for positive delta with increase goal', () => {
+        const result = createResult([0.05, 0.15])
+        expect(isWinning(result, 'increase')).toBe(true)
+    })
+
+    it('returns false for positive delta with decrease goal', () => {
+        const result = createResult([0.05, 0.15])
+        expect(isWinning(result, 'decrease')).toBe(false)
+    })
+
+    it('returns false for negative delta with increase goal', () => {
+        const result = createResult([-0.15, -0.05])
+        expect(isWinning(result, 'increase')).toBe(false)
+    })
+
+    it('returns true for negative delta with decrease goal', () => {
+        const result = createResult([-0.15, -0.05])
+        expect(isWinning(result, 'decrease')).toBe(true)
+    })
+
+    it('returns undefined when no interval is present', () => {
+        const result = createResult(null)
+        expect(isWinning(result, 'increase')).toBeUndefined()
+        expect(isWinning(result, 'decrease')).toBeUndefined()
+    })
+
+    it('handles undefined goal as increase', () => {
+        const result = createResult([0.05, 0.15])
+        expect(isWinning(result, undefined)).toBe(true)
+    })
+})
+
+describe('getChanceToWin', () => {
+    const createBayesianResult = (chance_to_win: number | null): ExperimentVariantResult => ({
+        key: 'test',
+        sum: 100,
+        absolute_value: 100,
+        relative_value: 0.1,
+        number_of_samples: 100,
+        significant: true,
+        method: 'bayesian',
+        credible_interval: [0.05, 0.15],
+        chance_to_win,
+    })
+
+    const createFrequentistResult = (): ExperimentVariantResult => ({
+        key: 'test',
+        sum: 100,
+        absolute_value: 100,
+        relative_value: 0.1,
+        number_of_samples: 100,
+        significant: true,
+        method: 'frequentist',
+        confidence_interval: [0.05, 0.15],
+        p_value: 0.03,
+    })
+
+    it('returns chance to win as-is for increase goal', () => {
+        const result = createBayesianResult(0.75)
+        expect(getChanceToWin(result, 'increase')).toBe(0.75)
+    })
+
+    it('inverts chance to win for decrease goal', () => {
+        const result = createBayesianResult(0.75)
+        expect(getChanceToWin(result, 'decrease')).toBe(0.25)
+    })
+
+    it('handles null chance to win', () => {
+        const result = createBayesianResult(null)
+        expect(getChanceToWin(result, 'increase')).toBeNull()
+        expect(getChanceToWin(result, 'decrease')).toBeNull()
+    })
+
+    it('returns null for frequentist results', () => {
+        const result = createFrequentistResult()
+        expect(getChanceToWin(result, 'increase')).toBeNull()
+        expect(getChanceToWin(result, 'decrease')).toBeNull()
+    })
+
+    it('handles undefined goal as increase', () => {
+        const result = createBayesianResult(0.6)
+        expect(getChanceToWin(result, undefined)).toBe(0.6)
+    })
+})
+
+describe('formatChanceToWinForGoal', () => {
+    const createResult = (chance_to_win: number): ExperimentVariantResult => ({
+        key: 'test',
+        sum: 100,
+        absolute_value: 100,
+        relative_value: 0.1,
+        number_of_samples: 100,
+        significant: true,
+        method: 'bayesian',
+        credible_interval: [0.05, 0.15],
+        chance_to_win,
+    })
+
+    it('formats chance to win for increase goal', () => {
+        const result = createResult(0.756)
+        expect(formatChanceToWinForGoal(result, 'increase')).toBe('75.6%')
+    })
+
+    it('formats inverted chance to win for decrease goal', () => {
+        const result = createResult(0.756)
+        expect(formatChanceToWinForGoal(result, 'decrease')).toBe('24.4%')
+    })
+
+    it('handles very high chances', () => {
+        const result = createResult(0.9995)
+        expect(formatChanceToWinForGoal(result, 'increase')).toBe('> 99.9%')
+        expect(formatChanceToWinForGoal(result, 'decrease')).toBe('< 0.1%')
+    })
+
+    it('handles very low chances', () => {
+        const result = createResult(0.0005)
+        expect(formatChanceToWinForGoal(result, 'increase')).toBe('< 0.1%')
+        expect(formatChanceToWinForGoal(result, 'decrease')).toBe('> 99.9%')
+    })
+})
+
+describe('getMetricColors', () => {
+    const colors = {
+        BAR_POSITIVE: '#00FF00',
+        BAR_NEGATIVE: '#FF0000',
+    }
+
+    it('returns normal colors for increase goal', () => {
+        const result = getMetricColors('increase', colors)
+        expect(result.positive).toBe('#00FF00')
+        expect(result.negative).toBe('#FF0000')
+    })
+
+    it('swaps colors for decrease goal', () => {
+        const result = getMetricColors('decrease', colors)
+        expect(result.positive).toBe('#FF0000')
+        expect(result.negative).toBe('#00FF00')
+    })
+
+    it('returns normal colors for undefined goal', () => {
+        const result = getMetricColors(undefined, colors)
+        expect(result.positive).toBe('#00FF00')
+        expect(result.negative).toBe('#FF0000')
     })
 })

--- a/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
+++ b/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
@@ -283,7 +283,7 @@ export function applyGoalDirection<T>(goal: 'increase' | 'decrease' | undefined,
     return goal === 'decrease' ? whenDecrease : whenIncrease
 }
 
-export function isGoalAwareWinning(
+export function isWinning(
     result: ExperimentVariantResult,
     goal: 'increase' | 'decrease' | undefined
 ): boolean | undefined {
@@ -294,7 +294,7 @@ export function isGoalAwareWinning(
     return applyGoalDirection(goal, deltaPositive, !deltaPositive)
 }
 
-export function getGoalAwareChanceToWin(
+export function getChanceToWin(
     result: ExperimentVariantResult,
     goal: 'increase' | 'decrease' | undefined
 ): number | null | undefined {
@@ -309,15 +309,15 @@ export function getGoalAwareChanceToWin(
     return applyGoalDirection(goal, chanceToWin, 1 - chanceToWin)
 }
 
-export function formatGoalAwareChanceToWin(
+export function formatChanceToWinForGoal(
     result: ExperimentVariantResult,
     goal: 'increase' | 'decrease' | undefined
 ): string {
-    const chanceToWin = getGoalAwareChanceToWin(result, goal)
+    const chanceToWin = getChanceToWin(result, goal)
     return formatChanceToWin(chanceToWin)
 }
 
-export interface GoalAwareColors {
+export interface MetricColors {
     positive: string
     negative: string
 }
@@ -326,10 +326,10 @@ export interface GoalAwareColors {
  * Returns colors mapped according to the metric goal.
  * When goal is decrease, positive and negative colors are swapped.
  */
-export function getGoalAwareColors(
+export function getMetricColors(
     goal: 'increase' | 'decrease' | undefined,
     colors: { BAR_POSITIVE: string; BAR_NEGATIVE: string }
-): GoalAwareColors {
+): MetricColors {
     if (!goal || goal === 'increase') {
         return {
             positive: colors.BAR_POSITIVE,

--- a/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
+++ b/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
@@ -277,9 +277,9 @@ export function getMetricSubtitleValues(
 
 /**
  * Applies goal direction logic to return the appropriate value based on metric goal.
- * Returns whenDecrease if goal is 'decrease', otherwise whenIncrease.
+ * Returns whenIncrease if goal is 'increase' (or undefined), otherwise whenDecrease.
  */
-export function applyGoalDirection<T>(metric: ExperimentMetric, whenDecrease: T, whenIncrease: T): T {
+export function applyGoalDirection<T>(metric: ExperimentMetric, whenIncrease: T, whenDecrease: T): T {
     return metric.goal === 'decrease' ? whenDecrease : whenIncrease
 }
 
@@ -288,7 +288,7 @@ export function isGoalAwareWinning(result: ExperimentVariantResult, metric: Expe
     if (deltaPositive === undefined) {
         return undefined
     }
-    return applyGoalDirection(metric, !deltaPositive, deltaPositive)
+    return applyGoalDirection(metric, deltaPositive, !deltaPositive)
 }
 
 export function getGoalAwareChanceToWin(
@@ -303,7 +303,7 @@ export function getGoalAwareChanceToWin(
         return chanceToWin
     }
     // When goal is to decrease, invert chance to win because lower values are better
-    return applyGoalDirection(metric, 1 - chanceToWin, chanceToWin)
+    return applyGoalDirection(metric, chanceToWin, 1 - chanceToWin)
 }
 
 export function formatGoalAwareChanceToWin(result: ExperimentVariantResult, metric: ExperimentMetric): string {

--- a/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
+++ b/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
@@ -274,3 +274,37 @@ export function getMetricSubtitleValues(
         denominator: variant.number_of_samples || 0,
     }
 }
+
+// Goal-aware utility functions that consider metric goals
+// These functions keep the actual values unchanged but invert the interpretation of whether it's positive (winning)
+export function isGoalAwareWinning(result: ExperimentVariantResult, metric: ExperimentMetric): boolean | undefined {
+    const deltaPositive = isDeltaPositive(result)
+    if (deltaPositive === undefined) {
+        return undefined
+    }
+    // For decrease goals, negative delta is winning
+    // For increase goals, positive delta is winning
+    return metric.goal === 'decrease' ? !deltaPositive : deltaPositive
+}
+
+export function getGoalAwareChanceToWin(
+    result: ExperimentVariantResult,
+    metric: ExperimentMetric
+): number | null | undefined {
+    if (!isBayesianResult(result)) {
+        return null
+    }
+    const chanceToWin = result.chance_to_win
+    if (chanceToWin == null) {
+        return chanceToWin
+    }
+    // Invert chance to win if goal is to decrease
+    // If we want to decrease the metric, then the "chance to win" is actually the chance to lose (have lower values)
+    // So we invert it: 1 - chanceToWin
+    return metric.goal === 'decrease' ? 1 - chanceToWin : chanceToWin
+}
+
+export function formatGoalAwareChanceToWin(result: ExperimentVariantResult, metric: ExperimentMetric): string {
+    const chanceToWin = getGoalAwareChanceToWin(result, metric)
+    return formatChanceToWin(chanceToWin)
+}

--- a/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
+++ b/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
@@ -279,21 +279,24 @@ export function getMetricSubtitleValues(
  * Applies goal direction logic to return the appropriate value based on metric goal.
  * Returns whenIncrease if goal is 'increase' (or undefined), otherwise whenDecrease.
  */
-export function applyGoalDirection<T>(metric: ExperimentMetric, whenIncrease: T, whenDecrease: T): T {
-    return metric.goal === 'decrease' ? whenDecrease : whenIncrease
+export function applyGoalDirection<T>(goal: 'increase' | 'decrease' | undefined, whenIncrease: T, whenDecrease: T): T {
+    return goal === 'decrease' ? whenDecrease : whenIncrease
 }
 
-export function isGoalAwareWinning(result: ExperimentVariantResult, metric: ExperimentMetric): boolean | undefined {
+export function isGoalAwareWinning(
+    result: ExperimentVariantResult,
+    goal: 'increase' | 'decrease' | undefined
+): boolean | undefined {
     const deltaPositive = isDeltaPositive(result)
     if (deltaPositive === undefined) {
         return undefined
     }
-    return applyGoalDirection(metric, deltaPositive, !deltaPositive)
+    return applyGoalDirection(goal, deltaPositive, !deltaPositive)
 }
 
 export function getGoalAwareChanceToWin(
     result: ExperimentVariantResult,
-    metric: ExperimentMetric
+    goal: 'increase' | 'decrease' | undefined
 ): number | null | undefined {
     if (!isBayesianResult(result)) {
         return null
@@ -303,11 +306,14 @@ export function getGoalAwareChanceToWin(
         return chanceToWin
     }
     // When goal is to decrease, invert chance to win because lower values are better
-    return applyGoalDirection(metric, chanceToWin, 1 - chanceToWin)
+    return applyGoalDirection(goal, chanceToWin, 1 - chanceToWin)
 }
 
-export function formatGoalAwareChanceToWin(result: ExperimentVariantResult, metric: ExperimentMetric): string {
-    const chanceToWin = getGoalAwareChanceToWin(result, metric)
+export function formatGoalAwareChanceToWin(
+    result: ExperimentVariantResult,
+    goal: 'increase' | 'decrease' | undefined
+): string {
+    const chanceToWin = getGoalAwareChanceToWin(result, goal)
     return formatChanceToWin(chanceToWin)
 }
 
@@ -321,10 +327,10 @@ export interface GoalAwareColors {
  * When goal is decrease, positive and negative colors are swapped.
  */
 export function getGoalAwareColors(
-    metric: ExperimentMetric | undefined,
+    goal: 'increase' | 'decrease' | undefined,
     colors: { BAR_POSITIVE: string; BAR_NEGATIVE: string }
 ): GoalAwareColors {
-    if (!metric?.goal || metric.goal === 'increase') {
+    if (!goal || goal === 'increase') {
         return {
             positive: colors.BAR_POSITIVE,
             negative: colors.BAR_NEGATIVE,

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -24,6 +24,7 @@ import { isFunnelsQuery, isNodeWithSource, isTrendsQuery, isValidQueryForExperim
 import {
     ChartDisplayType,
     Experiment,
+    ExperimentMetricGoal,
     ExperimentMetricMathType,
     FeatureFlagFilters,
     FeatureFlagType,
@@ -386,7 +387,7 @@ export function getDefaultFunnelMetric(): ExperimentMetric {
         kind: NodeKind.ExperimentMetric,
         uuid: uuid(),
         metric_type: ExperimentMetricType.FUNNEL,
-        goal: 'increase',
+        goal: ExperimentMetricGoal.Increase,
         series: [
             {
                 kind: NodeKind.EventsNode,
@@ -405,7 +406,7 @@ export function getDefaultCountMetric(): ExperimentMetric {
         kind: NodeKind.ExperimentMetric,
         uuid: uuid(),
         metric_type: ExperimentMetricType.MEAN,
-        goal: 'increase',
+        goal: ExperimentMetricGoal.Increase,
         source: {
             kind: NodeKind.EventsNode,
             event: '$pageview',
@@ -419,7 +420,7 @@ export function getDefaultRatioMetric(): ExperimentMetric {
         kind: NodeKind.ExperimentMetric,
         uuid: uuid(),
         metric_type: ExperimentMetricType.RATIO,
-        goal: 'increase',
+        goal: ExperimentMetricGoal.Increase,
         numerator: {
             kind: NodeKind.EventsNode,
             event: '$pageview',
@@ -458,7 +459,7 @@ export function getExperimentMetricFromInsight(insight: QueryBasedInsightModel |
             kind: NodeKind.ExperimentMetric,
             uuid: uuid(),
             metric_type: ExperimentMetricType.FUNNEL,
-            goal: 'increase',
+            goal: ExperimentMetricGoal.Increase,
             name: metricName,
             series: insight.query.source.series.map((series) => ({
                 ...series,
@@ -486,7 +487,7 @@ export function getExperimentMetricFromInsight(insight: QueryBasedInsightModel |
             kind: NodeKind.ExperimentMetric,
             uuid: uuid(),
             metric_type: ExperimentMetricType.MEAN,
-            goal: 'increase',
+            goal: ExperimentMetricGoal.Increase,
             name: metricName,
             source: {
                 ...firstSeries,

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -386,6 +386,7 @@ export function getDefaultFunnelMetric(): ExperimentMetric {
         kind: NodeKind.ExperimentMetric,
         uuid: uuid(),
         metric_type: ExperimentMetricType.FUNNEL,
+        goal: 'increase',
         series: [
             {
                 kind: NodeKind.EventsNode,
@@ -404,6 +405,7 @@ export function getDefaultCountMetric(): ExperimentMetric {
         kind: NodeKind.ExperimentMetric,
         uuid: uuid(),
         metric_type: ExperimentMetricType.MEAN,
+        goal: 'increase',
         source: {
             kind: NodeKind.EventsNode,
             event: '$pageview',
@@ -417,6 +419,7 @@ export function getDefaultRatioMetric(): ExperimentMetric {
         kind: NodeKind.ExperimentMetric,
         uuid: uuid(),
         metric_type: ExperimentMetricType.RATIO,
+        goal: 'increase',
         numerator: {
             kind: NodeKind.EventsNode,
             event: '$pageview',
@@ -455,6 +458,7 @@ export function getExperimentMetricFromInsight(insight: QueryBasedInsightModel |
             kind: NodeKind.ExperimentMetric,
             uuid: uuid(),
             metric_type: ExperimentMetricType.FUNNEL,
+            goal: 'increase',
             name: metricName,
             series: insight.query.source.series.map((series) => ({
                 ...series,
@@ -482,6 +486,7 @@ export function getExperimentMetricFromInsight(insight: QueryBasedInsightModel |
             kind: NodeKind.ExperimentMetric,
             uuid: uuid(),
             metric_type: ExperimentMetricType.MEAN,
+            goal: 'increase',
             name: metricName,
             source: {
                 ...firstSeries,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4185,6 +4185,11 @@ export enum ExperimentMetricMathType {
     HogQL = 'hogql',
 }
 
+export enum ExperimentMetricGoal {
+    Increase = 'increase',
+    Decrease = 'decrease',
+}
+
 export enum ActorGroupType {
     Person = 'person',
     GroupPrefix = 'group',

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1142,7 +1142,7 @@ class ExperimentExposureTimeSeries(BaseModel):
     variant: str
 
 
-class Goal(StrEnum):
+class ExperimentMetricGoal(StrEnum):
     INCREASE = "increase"
     DECREASE = "decrease"
 
@@ -3701,7 +3701,7 @@ class ExperimentMetricBaseProperties(BaseModel):
     )
     conversion_window: Optional[int] = None
     conversion_window_unit: Optional[FunnelConversionWindowTimeUnit] = None
-    goal: Optional[Goal] = None
+    goal: Optional[ExperimentMetricGoal] = None
     kind: Literal["ExperimentMetric"] = "ExperimentMetric"
     name: Optional[str] = None
     response: Optional[dict[str, Any]] = None
@@ -11503,7 +11503,7 @@ class ExperimentRatioMetric(BaseModel):
     conversion_window: Optional[int] = None
     conversion_window_unit: Optional[FunnelConversionWindowTimeUnit] = None
     denominator: Union[EventsNode, ActionsNode, ExperimentDataWarehouseNode]
-    goal: Optional[Goal] = None
+    goal: Optional[ExperimentMetricGoal] = None
     kind: Literal["ExperimentMetric"] = "ExperimentMetric"
     metric_type: Literal["ratio"] = "ratio"
     name: Optional[str] = None
@@ -12366,7 +12366,7 @@ class ExperimentFunnelMetric(BaseModel):
     conversion_window: Optional[int] = None
     conversion_window_unit: Optional[FunnelConversionWindowTimeUnit] = None
     funnel_order_type: Optional[StepOrderValue] = None
-    goal: Optional[Goal] = None
+    goal: Optional[ExperimentMetricGoal] = None
     kind: Literal["ExperimentMetric"] = "ExperimentMetric"
     metric_type: Literal["funnel"] = "funnel"
     name: Optional[str] = None
@@ -12382,7 +12382,7 @@ class ExperimentMeanMetric(BaseModel):
     )
     conversion_window: Optional[int] = None
     conversion_window_unit: Optional[FunnelConversionWindowTimeUnit] = None
-    goal: Optional[Goal] = None
+    goal: Optional[ExperimentMetricGoal] = None
     kind: Literal["ExperimentMetric"] = "ExperimentMetric"
     lower_bound_percentile: Optional[float] = None
     metric_type: Literal["mean"] = "mean"

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1142,6 +1142,11 @@ class ExperimentExposureTimeSeries(BaseModel):
     variant: str
 
 
+class Goal(StrEnum):
+    INCREASE = "increase"
+    DECREASE = "decrease"
+
+
 class ExperimentMetricMathType(StrEnum):
     TOTAL = "total"
     SUM = "sum"
@@ -3696,6 +3701,7 @@ class ExperimentMetricBaseProperties(BaseModel):
     )
     conversion_window: Optional[int] = None
     conversion_window_unit: Optional[FunnelConversionWindowTimeUnit] = None
+    goal: Optional[Goal] = None
     kind: Literal["ExperimentMetric"] = "ExperimentMetric"
     name: Optional[str] = None
     response: Optional[dict[str, Any]] = None
@@ -11497,6 +11503,7 @@ class ExperimentRatioMetric(BaseModel):
     conversion_window: Optional[int] = None
     conversion_window_unit: Optional[FunnelConversionWindowTimeUnit] = None
     denominator: Union[EventsNode, ActionsNode, ExperimentDataWarehouseNode]
+    goal: Optional[Goal] = None
     kind: Literal["ExperimentMetric"] = "ExperimentMetric"
     metric_type: Literal["ratio"] = "ratio"
     name: Optional[str] = None
@@ -12359,6 +12366,7 @@ class ExperimentFunnelMetric(BaseModel):
     conversion_window: Optional[int] = None
     conversion_window_unit: Optional[FunnelConversionWindowTimeUnit] = None
     funnel_order_type: Optional[StepOrderValue] = None
+    goal: Optional[Goal] = None
     kind: Literal["ExperimentMetric"] = "ExperimentMetric"
     metric_type: Literal["funnel"] = "funnel"
     name: Optional[str] = None
@@ -12374,6 +12382,7 @@ class ExperimentMeanMetric(BaseModel):
     )
     conversion_window: Optional[int] = None
     conversion_window_unit: Optional[FunnelConversionWindowTimeUnit] = None
+    goal: Optional[Goal] = None
     kind: Literal["ExperimentMetric"] = "ExperimentMetric"
     lower_bound_percentile: Optional[float] = None
     metric_type: Literal["mean"] = "mean"


### PR DESCRIPTION
## Problem

It's currently not possible to specify that your goal is to _decrease_ a metric.

## Changes

Allow users to specify the goal of the metric.
<img width="983" height="111" alt="Screenshot 2025-09-02 at 13 35 13" src="https://github.com/user-attachments/assets/3c0aa5c0-5ff7-40f4-a163-ec7425cc233d" />

When decrease is selected, the chance to win is inverted along with the colors for delta and the chart, such that negative becomes green.

<img width="1281" height="258" alt="Screenshot 2025-08-29 at 12 34 02 PM" src="https://github.com/user-attachments/assets/9b65cc1f-8145-428e-a978-7da1a90f1ff6" />

## How did you test this code?
- manually tested
- added unit tests for goal aware functions

