### PR TITLE
fix(capture): global quota filter should skip eval on prefiltered events

### DIFF
--- a/rust/capture/src/limiters.rs
+++ b/rust/capture/src/limiters.rs
@@ -37,7 +37,9 @@ pub async fn check_billing_quota_and_filter(
         let (retained_events, dropped_events): (Vec<_>, Vec<_>) = events
             .into_iter()
             // TODO: remove retention of $exception events once we have a billing limiter for exceptions
-            .partition(|e| e.event == "$exception");
+            .partition(|e| {
+                e.event == "$exception" || is_survey_event(&e.event) || is_ai_event(&e.event)
+            });
 
         let dropped_count = dropped_events.len() as u64;
         if dropped_count > 0 {

--- a/rust/capture/tests/limiters.rs
+++ b/rust/capture/tests/limiters.rs
@@ -299,6 +299,8 @@ async fn test_billing_limit_on_i_endpoint() {
         "pageview",
         "survey dismissed",
         "$exception",
+        "pageleave",
+        "some_other_event",
     ];
     let payload = create_batch_payload_with_token(&events, token);
 
@@ -315,7 +317,9 @@ async fn test_billing_limit_on_i_endpoint() {
 
     // Check that only $exception events were retained
     let captured_events = sink.events();
-    assert_eq!(captured_events.len(), 2);
+
+    // all but the exception, AI, and survey events should be dropped from the input batch
+    assert_eq!(captured_events.len(), 5);
 
     // Parse the event data to check the event names
     let event_names: Vec<String> = captured_events


### PR DESCRIPTION
## Problem
I removed a piece of business logic from the global billing quota filter prior to the larger refactor landing today. Let's reapply it.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Skip global billing eval on AI and survey events that are managed in different quota buckets.

## How did you test this code?
Locally and in CI, updated test cases
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
