### PR TITLE
chore: Move admin routes to ee

### DIFF
--- a/ee/urls.py
+++ b/ee/urls.py
@@ -3,7 +3,7 @@ from typing import Any
 from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin.sites import NotRegistered  # type: ignore[attr-defined]
-from django.urls import include
+from django.urls import include, re_path
 from django.urls.conf import path
 from django.views.decorators.csrf import csrf_exempt
 
@@ -11,6 +11,7 @@ from django_otp.plugins.otp_static.models import StaticDevice
 from django_otp.plugins.otp_totp.models import TOTPDevice
 
 from posthog.utils import opt_slash_path
+from posthog.views import api_key_search_view, redis_values_view
 
 from ee.api import integration
 from ee.api.mcp.http import mcp_view
@@ -123,7 +124,12 @@ if settings.ADMIN_PORTAL_ENABLED:
         except NotRegistered:
             pass
 
-    admin_urlpatterns = [path("admin/", include("loginas.urls")), path("admin/", admin.site.urls)]
+    admin_urlpatterns = [
+        re_path(r"^admin/redisvalues$", redis_values_view, name="redis_values"),
+        path(r"admin/apikeysearch", api_key_search_view, name="api_key_search"),
+        path("admin/", include("loginas.urls")),
+        path("admin/", admin.site.urls),
+    ]
 else:
     admin_urlpatterns = []
 

--- a/ee/urls.py
+++ b/ee/urls.py
@@ -126,7 +126,7 @@ if settings.ADMIN_PORTAL_ENABLED:
 
     admin_urlpatterns = [
         re_path(r"^admin/redisvalues$", redis_values_view, name="redis_values"),
-        path(r"admin/apikeysearch", api_key_search_view, name="api_key_search"),
+        re_path(r"^admin/apikeysearch$", api_key_search_view, name="api_key_search"),
         path("admin/", include("loginas.urls")),
         path("admin/", admin.site.urls),
     ]

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -45,12 +45,10 @@ from products.early_access_features.backend.api import early_access_features
 
 from .utils import opt_slash_path, render_template
 from .views import (
-    api_key_search_view,
     health,
     login_required,
     preferences_page,
     preflight_check,
-    redis_values_view,
     robots_txt,
     security_txt,
     stats,
@@ -161,8 +159,6 @@ urlpatterns = [
     opt_slash_path("_health", health),
     opt_slash_path("_stats", stats),
     opt_slash_path("_preflight", preflight_check),
-    re_path(r"^admin/redisvalues$", redis_values_view, name="redis_values"),
-    path(r"admin/apikeysearch", api_key_search_view, name="api_key_search"),
     # ee
     *ee_urlpatterns,
     # api


### PR DESCRIPTION
All other admin routes are declared in `ee`, so these should be as well. This will slightly simplify some future work I'm investigating around adding social auth for `/admin` routes.
