### PR TITLE
feat(capture-rs): Refactor Quota Limiter 

### DIFF
--- a/rust/capture/src/limiters.rs
+++ b/rust/capture/src/limiters.rs
@@ -46,24 +46,6 @@ where
             event_matcher,
         }
     }
-
-    #[allow(dead_code)]
-    async fn is_limited(&self, token: &str) -> bool {
-        self.limiter.is_limited(token).await
-    }
-
-    // partition indices in the event map instead of cloning/copying events
-    #[allow(dead_code)]
-    async fn partition_event_indices(
-        &self,
-        indices_to_events: &HashMap<usize, RawEvent>,
-        indices: &[usize],
-    ) -> (Vec<usize>, Vec<usize>) {
-        indices.iter().partition(|&i| {
-            let e: &RawEvent = indices_to_events.get(i).unwrap();
-            (self.event_matcher)(e)
-        })
-    }
 }
 
 #[async_trait::async_trait]
@@ -252,4 +234,20 @@ impl CaptureQuotaLimiter {
             CaptureMode::Recordings => QuotaResource::Recordings,
         }
     }
+}
+
+// Add these predicate functions at the module level
+pub fn is_exception_event(event: &RawEvent) -> bool {
+    event.event.as_str() == "$exception"
+}
+
+pub fn is_survey_event(event: &RawEvent) -> bool {
+    matches!(
+        event.event.as_str(),
+        "survey sent" | "survey shown" | "survey dismissed"
+    )
+}
+
+pub fn is_llm_event(event: &RawEvent) -> bool {
+    event.event.starts_with("$ai_")
 }

--- a/rust/capture/src/limiters.rs
+++ b/rust/capture/src/limiters.rs
@@ -171,7 +171,7 @@ impl CaptureQuotaLimiter {
             let dropped_count = filtered_indices.len() as u64;
             let global_resource_tag = Self::get_resource_for_mode(self.capture_mode.clone());
             report_quota_limit_exceeded(&global_resource_tag, dropped_count);
-            let dropped_events_tag = format!("{:?}_over_quota", global_resource_tag.as_str());
+            let dropped_events_tag = format!("{}_over_quota", global_resource_tag.as_str());
             counter!(CAPTURE_EVENTS_DROPPED_TOTAL, "cause" => dropped_events_tag)
                 .increment(dropped_count);
 

--- a/rust/capture/src/limiters.rs
+++ b/rust/capture/src/limiters.rs
@@ -96,7 +96,7 @@ impl CaptureQuotaLimiter {
     where
         F: Fn(&RawEvent) -> bool + Send + Sync + Clone + 'static,
     {
-        let err_msg = format!("failed to create scoped limiter: {:?}", resource);
+        let err_msg = format!("failed to create scoped limiter: {resource:?}");
         let limiter = ScopedLimiter::new(
             resource.clone(),
             RedisLimiter::new(
@@ -199,7 +199,7 @@ impl CaptureQuotaLimiter {
         Ok(filtered_events)
     }
 
-    fn get_resource_for_mode(mode: CaptureMode) -> QuotaResource {
+    pub fn get_resource_for_mode(mode: CaptureMode) -> QuotaResource {
         match mode {
             CaptureMode::Events => QuotaResource::Events,
             CaptureMode::Recordings => QuotaResource::Recordings,

--- a/rust/capture/src/limiters.rs
+++ b/rust/capture/src/limiters.rs
@@ -52,8 +52,7 @@ pub struct CaptureQuotaLimiter {
     redis_client: Arc<dyn Client + Send + Sync>,
 
     // these are scoped to a specific event subset (e.g. survey events, AI events, etc.)
-    // and ONLY filter out those events if the quota is exceeded. Add new scoped limiters
-    // to this list as needed
+    // and ONLY filter out those events if the quota is exceeded
     scoped_limiters: Vec<Box<dyn ScopedLimiterTrait>>,
 
     // this is the global billing limiter - if a token matches this limiter bucket,
@@ -120,7 +119,7 @@ impl CaptureQuotaLimiter {
         context: &ProcessingContext,
         events: Vec<RawEvent>,
     ) -> Result<Vec<RawEvent>, CaptureError> {
-        // in the future, we make bucket quotas by more than token (team)
+        // in the future, we may bucket quotas by more than token (team)
         // so we accept the whole ProcessingContext here
         let token = context.token.as_str();
 

--- a/rust/capture/src/limiters.rs
+++ b/rust/capture/src/limiters.rs
@@ -1,15 +1,17 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
 use common_redis::RedisClient;
 use common_types::RawEvent;
 use limiters::redis::{QuotaResource, RedisLimiter, ServiceName, QUOTA_LIMITER_CACHE_KEY};
+use metrics::counter;
 
 use crate::{
     api::CaptureError,
     config::CaptureMode,
     config::Config,
-    prometheus::{report_dropped_events, report_quota_limit_exceeded},
+    prometheus::{report_quota_limit_exceeded, CAPTURE_EVENTS_DROPPED_TOTAL},
     v0_request::ProcessingContext,
 };
 
@@ -19,14 +21,14 @@ struct ScopedLimiter {
     limiter: RedisLimiter,
     // predicate supplied here should match RawEvents TO BE DROPPED
     // if the limit for this team/token has been exceeded
-    event_matcher: Box<dyn Fn(&RawEvent) -> bool + Send + Sync>,
+    event_matcher: Box<dyn Fn(&RawEvent) -> bool + Send + Sync + Clone>,
 }
 
 impl ScopedLimiter {
     fn new(
         resource: QuotaResource,
-        redis_limiter: RedisLimiter,
-        event_matcher: Box<dyn Fn(&RawEvent) -> bool + Send + Sync>,
+        limiter: RedisLimiter,
+        event_matcher: Box<dyn Fn(&RawEvent) -> bool + Send + Sync + Clone>,
     ) -> Self {
         Self {
             resource,
@@ -39,8 +41,16 @@ impl ScopedLimiter {
         self.limiter.is_limited(token).await
     }
 
-    async fn partition_events(&self, events: &Vec<RawEvent>) -> (Vec<&RawEvent>, Vec<&RawEvent>) {
-        events.iter().partition(|e| (self.event_matcher)(e))
+    // partition indices in the event map instead of cloning/copying events
+    async fn partition_event_indices(
+        &self,
+        indices_to_events: &HashMap<usize, RawEvent>,
+        indices: &Vec<usize>,
+    ) -> (Vec<usize>, Vec<usize>) {
+        indices.iter().partition(|&i| {
+            let e: &RawEvent = indices_to_events.get(i).unwrap();
+            (self.event_matcher)(e)
+        })
     }
 }
 
@@ -70,7 +80,7 @@ impl CaptureQuotaLimiter {
             redis_client.clone(),
             QUOTA_LIMITER_CACHE_KEY.to_string(),
             config.redis_key_prefix.clone(),
-            Self::get_resource_for_mode(config.capture_mode),
+            Self::get_resource_for_mode(config.capture_mode.clone()),
             ServiceName::Capture,
         )
         .expect(&format!(
@@ -79,7 +89,7 @@ impl CaptureQuotaLimiter {
         ));
 
         Self {
-            capture_mode: config.capture_mode,
+            capture_mode: config.capture_mode.clone(),
             redis_key_prefix: config.redis_key_prefix.clone(),
             redis_client: redis_client.clone(),
             global_limiter,
@@ -90,7 +100,7 @@ impl CaptureQuotaLimiter {
     pub fn add_scoped_limiter(
         mut self,
         resource: QuotaResource,
-        event_matcher: Box<dyn Fn(&RawEvent) -> bool + Send + Sync>,
+        event_matcher: Box<dyn Fn(&RawEvent) -> bool + Send + Sync + Clone>,
     ) -> Self {
         let limiter = ScopedLimiter::new(
             resource.clone(),
@@ -119,35 +129,43 @@ impl CaptureQuotaLimiter {
         // so we accept the whole ProcessingContext here
         let token = context.token.as_str();
 
-        let mut filtered_events = events;
-        let mut retained_events: Vec<&RawEvent> = vec![];
+        // avoid undue copying and allocations by caching event batch by index
+        let mut indices_to_events: HashMap<usize, RawEvent> = HashMap::new();
+        let mut filtered_indices: Vec<usize> = vec![];
+        let mut retained_indices: Vec<usize> = vec![];
+        for (i, event) in events.into_iter().enumerate() {
+            indices_to_events.insert(i, event);
+            filtered_indices.push(i);
+        }
 
         // for each scoped limiter, if the token is found in Redis,
         // only drop events matching the limiter's filter predicate
         for limiter in self.scoped_limiters.iter() {
-            let (matched_events, unmatched_events) =
-                limiter.partition_events(&filtered_events).await;
+            let (matched_indices, unmatched_indices) = limiter
+                .partition_event_indices(&indices_to_events, &filtered_indices)
+                .await;
 
             if limiter.limiter.is_limited(token).await {
                 // retain only events that this limiter doesn't drop
-                filtered_events = unmatched_events.into_iter().map(|e| e.to_owned()).collect();
+                filtered_indices = unmatched_indices;
 
                 // report quota limit exceeded for this limiter
-                let dropped_count = matched_events.len() as u64;
+                let dropped_count = matched_indices.len() as u64;
                 if dropped_count > 0 {
-                    let dropped_events_tag = format!("{}_over_quota", limiter.resource.as_str());
                     report_quota_limit_exceeded(&limiter.resource, dropped_count);
-                    report_dropped_events(&dropped_events_tag, dropped_count);
+                    let dropped_events_tag = format!("{}_over_quota", limiter.resource.as_str());
+                    counter!(CAPTURE_EVENTS_DROPPED_TOTAL, "cause" => dropped_events_tag)
+                        .increment(dropped_count);
                 }
             } else {
                 // keep the events this limiter matched around for global limiter
                 // to return in the event the global limit is exceeded for this token (team)
                 // this way each scoped limiter is independent of the all-or-nothing global limit
-                retained_events.extend(matched_events.into_iter());
+                retained_indices.extend(matched_indices.into_iter());
             }
 
             // if this filtering pass resulted in an empty batch, throw sentinel error
-            if filtered_events.is_empty() {
+            if filtered_indices.is_empty() {
                 // TODO(eli): tag these with QuotaResource type?
                 return Err(CaptureError::BillingLimit);
             }
@@ -155,19 +173,23 @@ impl CaptureQuotaLimiter {
 
         // drop everything if this limiter is exceeded after all others have filtered the batch
         if self.global_limiter.is_limited(token).await {
-            let dropped_count = filtered_events.len() as u64;
-            let global_resource_tag = Self::get_resource_for_mode(self.capture_mode);
-            let dropped_events_tag = format!("{:?}_over_quota", global_resource_tag.as_str());
-
+            let dropped_count = filtered_indices.len() as u64;
+            let global_resource_tag = Self::get_resource_for_mode(self.capture_mode.clone());
             report_quota_limit_exceeded(&global_resource_tag, dropped_count);
-            report_dropped_events(&dropped_events_tag, dropped_count);
+            let dropped_events_tag = format!("{:?}_over_quota", global_resource_tag.as_str());
+            counter!(CAPTURE_EVENTS_DROPPED_TOTAL, "cause" => dropped_events_tag)
+                .increment(dropped_count);
 
             // if the global limit was exceeded, we should return only
             // events the scoped limiters didn't already drop, or the
             // sentinel error if there are no retained events
-            if retained_events.is_empty() {
+            if retained_indices.is_empty() {
                 return Err(CaptureError::BillingLimit);
             } else {
+                let retained_events: Vec<RawEvent> = retained_indices
+                    .iter()
+                    .map(|i| indices_to_events.remove(i).unwrap())
+                    .collect();
                 return Ok(retained_events);
             }
         }
@@ -175,6 +197,10 @@ impl CaptureQuotaLimiter {
         // if the scoped limiters didn't empty the batch by this point,
         // and the global billing limit wasn't exceeded, return the
         // remaining events
+        let filtered_events: Vec<RawEvent> = filtered_indices
+            .iter()
+            .map(|i| indices_to_events.remove(i).unwrap())
+            .collect();
         Ok(filtered_events)
     }
 
@@ -183,26 +209,5 @@ impl CaptureQuotaLimiter {
             CaptureMode::Events => QuotaResource::Events,
             CaptureMode::Recordings => QuotaResource::Recordings,
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_is_survey_event() {
-        // Survey events should return true
-        assert!(is_survey_event("survey sent"));
-        assert!(is_survey_event("survey shown"));
-        assert!(is_survey_event("survey dismissed"));
-
-        // Non-survey events should return false
-        assert!(!is_survey_event("pageview"));
-        assert!(!is_survey_event("$pageview"));
-        assert!(!is_survey_event("click"));
-        assert!(!is_survey_event("survey_sent")); // underscore variant
-        assert!(!is_survey_event("Survey Sent")); // case sensitivity
-        assert!(!is_survey_event(""));
     }
 }

--- a/rust/capture/src/limiters.rs
+++ b/rust/capture/src/limiters.rs
@@ -47,11 +47,13 @@ where
         }
     }
 
+    #[allow(dead_code)]
     async fn is_limited(&self, token: &str) -> bool {
         self.limiter.is_limited(token).await
     }
 
     // partition indices in the event map instead of cloning/copying events
+    #[allow(dead_code)]
     async fn partition_event_indices(
         &self,
         indices_to_events: &HashMap<usize, RawEvent>,

--- a/rust/capture/src/limiters.rs
+++ b/rust/capture/src/limiters.rs
@@ -1,42 +1,61 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use common_redis::RedisClient;
 use common_types::RawEvent;
-use limiters::redis::QuotaResource;
+use limiters::redis::{QuotaResource, RedisLimiter, ServiceName, QUOTA_LIMITER_CACHE_KEY};
 
 use crate::{
     api::CaptureError,
+    config::CaptureMode,
+    config::Config,
     prometheus::{report_dropped_events, report_quota_limit_exceeded},
-    router::State,
     v0_request::ProcessingContext,
 };
 
+#[derive(Clone)]
 struct ScopedLimiter {
     resource: QuotaResource,
     limiter: RedisLimiter,
     // predicate supplied here should match RawEvents TO BE DROPPED
     // if the limit for this team/token has been exceeded
-    event_matcher: Fn(&RawEvent) -> bool,
+    event_matcher: Box<dyn Fn(&RawEvent) -> bool + Send + Sync>,
 }
 
 impl ScopedLimiter {
-    fn new(resource: QuotaResource, event_matcher: Fn(&RawEvent) -> bool) -> Self {
-        Self { resource, limiter, event_matcher }
+    fn new(
+        resource: QuotaResource,
+        redis_limiter: RedisLimiter,
+        event_matcher: Box<dyn Fn(&RawEvent) -> bool + Send + Sync>,
+    ) -> Self {
+        Self {
+            resource,
+            limiter,
+            event_matcher,
+        }
     }
 
     async fn is_limited(&self, context: &ProcessingContext) -> bool {
         self.limiter.is_limited(context.token.as_str()).await
     }
 
-    async fn filter_events(&self, events: Vec<RawEvent>) -> Vec<RawEvent> {
-        events.into_iter().partition(|e| !self.event_matcher(context, e)).collect()
+    async fn partition_events(&self, events: &Vec<RawEvent>) -> (Vec<&RawEvent>, Vec<&RawEvent>) {
+        events.iter().partition(|e| (self.event_matcher)(e))
     }
 }
 
+#[derive(Clone)]
 pub struct CaptureQuotaLimiter {
     capture_mode: CaptureMode,
+
+    redis_key_prefix: Option<String>,
+
+    redis_client: Arc<RedisClient>,
 
     // these are scoped to a specific event subset (e.g. survey events, AI events, etc.)
     // and ONLY filter out those events if the quota is exceeded. Add new scoped limiters
     // to this list as needed
-    scoped_limiters: Vec<CaptureLimiter>,
+    scoped_limiters: Vec<ScopedLimiter>,
 
     // this is the global billing limiter - if a token matches this limiter bucket,
     // all events are dropped for the incoming payload. Due to this, this limiter
@@ -54,48 +73,36 @@ impl CaptureQuotaLimiter {
             Self::get_resource_for_mode(config.capture_mode),
             ServiceName::Capture,
         )
-        .expect("failed to create billing limiter");
-
-        // Survey quota limiting - create for all capture modes (won't be used for recordings but required by router)
-        let survey_limiter = RedisLimiter::new(
-            Duration::from_secs(5),
-            redis_client.clone(),
-            QUOTA_LIMITER_CACHE_KEY.to_string(),
-            config.redis_key_prefix.clone(),
-            QuotaResource::Surveys,
-            ServiceName::Capture,
-        )
-        .expect("failed to create survey limiter");
-
-        // LLM events quota limiting - create for all capture modes
-        let llm_events_limiter = RedisLimiter::new(
-            Duration::from_secs(5),
-            redis_client.clone(),
-            QUOTA_LIMITER_CACHE_KEY.to_string(),
-            config.redis_key_prefix.clone(),
-            QuotaResource::LLMEvents,
-            ServiceName::Capture,
-        )
-        .expect("failed to create AI events limiter");
+        .expect(&format!(
+            "failed to create global limiter: {:?}",
+            &config.capture_mode
+        ));
 
         Self {
             capture_mode: config.capture_mode,
+            redis_key_prefix: config.redis_key_prefix.clone(),
+            redis_client: redis_client.clone(),
             billing_limiter,
             scoped_limiters: vec![],
         }
     }
 
-    pub fn add_scoped_limiter(&mut self, resource: QuotaResource, event_matcher: Fn(&RawEvent) -> bool) -> Self {
-        let limiter = CaptureLimiter::new(
-            resource,
+    pub fn add_scoped_limiter(
+        mut self,
+        resource: QuotaResource,
+        event_matcher: Box<dyn Fn(&RawEvent) -> bool + Send + Sync>,
+    ) -> Self {
+        let limiter = ScopedLimiter::new(
+            resource.clone(),
             RedisLimiter::new(
                 Duration::from_secs(5),
-                redis_client.clone(),
+                self.redis_client.clone(),
                 QUOTA_LIMITER_CACHE_KEY.to_string(),
-                config.redis_key_prefix.clone(),
-                resource,
+                self.redis_key_prefix.clone(),
+                resource.clone(),
                 ServiceName::Capture,
-            ),
+            )
+            .expect(&format!("failed to create scoped limiter: {:?}", resource)),
             event_matcher,
         );
         self.scoped_limiters.push(limiter);
@@ -103,28 +110,43 @@ impl CaptureQuotaLimiter {
         self
     }
 
-    pub async fn check_and_filter(&self, token: Option<&str>, events: Vec<RawEvent>) -> Result<Vec<RawEvent>, CaptureError> {
+    pub async fn check_and_filter(
+        &self,
+        token: Option<&str>,
+        events: Vec<RawEvent>,
+    ) -> Result<Vec<RawEvent>, CaptureError> {
         let token = match token {
             Some(token) => token,
             None => return Ok(events),
         };
 
         let mut filtered_events = events;
+        let mut retained_events: Vec<&RawEvent> = vec![];
 
         // for each scoped limiter, if the token is found in Redis,
         // only drop events matching the limiter's filter predicate
         for limiter in self.scoped_limiters.iter() {
-            if !limiter.limiter.is_limited(context.token.as_str()).await {
-                continue;
+            let (matched_events, unmatched_events) =
+                limiter.partition_events(&filtered_events).await;
+
+            if limiter.limiter.is_limited(token).await {
+                // retain only events that this limiter doesn't drop
+                filtered_events = unmatched_events.into_iter().map(|e| e.to_owned()).collect();
+
+                // report quota limit exceeded for this limiter
+                let dropped_count = matched_events.len() as u64;
+                if dropped_count > 0 {
+                    let dropped_events_tag = format!("{}_over_quota", limiter.resource.as_str());
+                    report_quota_limit_exceeded(&limiter.resource, dropped_count);
+                    report_dropped_events(&dropped_events_tag, dropped_count);
+                }
+            } else {
+                // keep the events this limiter matched around for global limiter
+                // to return in the event the global limit is exceeded for this token (team)
+                // this way each scoped limiter is independent of the all-or-nothing global limit
+                retained_events.extend(matched_events.into_iter());
             }
-            let prior_count = filtered_events.len();
-            filtered_events = limiter.filter_events(filtered_events).await;
-            let dropped_count = prior_count - filtered_events.len();
-            if dropped_count > 0 {
-                let dropped_events_tag = format!("{}_over_quota", limiter.resource.to_string());
-                report_quota_limit_exceeded(limiter.resource.to_string(), dropped_count);
-                report_dropped_events(dropped_events_tag, dropped_count);
-            }
+
             // if this filtering pass resulted in an empty batch, throw sentinel error
             if filtered_events.is_empty() {
                 // TODO(eli): tag these with QuotaResource type?
@@ -135,15 +157,25 @@ impl CaptureQuotaLimiter {
         // drop everything if this limiter is exceeded after all others have filtered the batch
         if self.billing_limiter.is_limited(token).await {
             let dropped_count = filtered_events.len() as u64;
-            let global_resource_tag = Self::get_resource_for_mode(self.capture_mode).to_string();
-            let dropped_events_tag = format!("{}_over_quota", global_resource_tag);
+            let global_resource_tag = Self::get_resource_for_mode(self.capture_mode);
+            let dropped_events_tag = format!("{:?}_over_quota", global_resource_tag.as_str());
 
-            report_quota_limit_exceeded(global_resource_tag, dropped_count);
-            report_dropped_events(dropped_events_tag, dropped_count);
+            report_quota_limit_exceeded(&global_resource_tag, dropped_count);
+            report_dropped_events(&dropped_events_tag, dropped_count);
 
-            return Err(CaptureError::BillingLimit);
+            // if the global limit was exceeded, we should return only
+            // events the scoped limiters didn't already drop, or the
+            // sentinel error if there are no retained events
+            if retained_events.is_empty() {
+                return Err(CaptureError::BillingLimit);
+            } else {
+                return Ok(retained_events);
+            }
         }
 
+        // if the scoped limiters didn't empty the batch by this point,
+        // and the global billing limit wasn't exceeded, return the
+        // remaining events
         Ok(filtered_events)
     }
 
@@ -153,16 +185,6 @@ impl CaptureQuotaLimiter {
             CaptureMode::Recordings => QuotaResource::Recordings,
         }
     }
-}
-
-/// Check if an event is a survey-related event that should be subject to survey quota limiting
-fn is_survey_event(event_name: &str) -> bool {
-
-}
-
-/// Check if an event is an AI-related event that should be subject to AI quota limiting
-fn is_ai_event(event_name: &str) -> bool {
-    event_name.starts_with("$ai_")
 }
 
 #[cfg(test)]

--- a/rust/capture/src/prometheus.rs
+++ b/rust/capture/src/prometheus.rs
@@ -8,8 +8,10 @@ use limiters::redis::QuotaResource;
 use metrics::counter;
 use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
 
+pub const CAPTURE_EVENTS_DROPPED_TOTAL: &str = "capture_events_dropped_total";
+
 pub fn report_dropped_events(cause: &'static str, quantity: u64) {
-    counter!("capture_events_dropped_total", "cause" => cause).increment(quantity);
+    counter!(CAPTURE_EVENTS_DROPPED_TOTAL, "cause" => cause).increment(quantity);
 }
 
 pub fn report_overflow_partition(quantity: u64) {

--- a/rust/capture/src/prometheus.rs
+++ b/rust/capture/src/prometheus.rs
@@ -4,6 +4,7 @@ use std::time::Instant;
 
 use axum::body::Body;
 use axum::{extract::MatchedPath, http::Request, middleware::Next, response::IntoResponse};
+use limiters::redis::QuotaResource;
 use metrics::counter;
 use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
 
@@ -15,8 +16,8 @@ pub fn report_overflow_partition(quantity: u64) {
     counter!("capture_partition_key_capacity_exceeded_total").increment(quantity);
 }
 
-pub fn report_quota_limit_exceeded(limiter: &'static str, quantity: u64) {
-    counter!("capture_billing_limit_exceeded_total", "limiter" => limiter).increment(quantity);
+pub fn report_quota_limit_exceeded(resource: &QuotaResource, quantity: u64) {
+    counter!("capture_quota_limit_exceeded", "resource" => resource.as_str()).increment(quantity);
 }
 
 pub fn report_internal_error_metrics(

--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -102,7 +102,7 @@ pub fn router<
     liveness: HealthRegistry,
     sink: S,
     redis: Arc<R>,
-    quota_limiter: QuotaLimiter,
+    quota_limiter: CaptureQuotaLimiter,
     token_dropper: TokenDropper,
     metrics: bool,
     capture_mode: CaptureMode,

--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -31,7 +31,7 @@ pub struct State {
     pub sink: Arc<dyn sinks::Event + Send + Sync>,
     pub timesource: Arc<dyn TimeSource + Send + Sync>,
     pub redis: Arc<dyn Client + Send + Sync>,
-    pub quota_limiter: CaptureQuotaLimiter,
+    pub quota_limiter: Arc<CaptureQuotaLimiter>,
     pub token_dropper: Arc<TokenDropper>,
     pub event_size_limit: usize,
     pub historical_cfg: HistoricalConfig,
@@ -118,7 +118,7 @@ pub fn router<
         sink: Arc::new(sink),
         timesource: Arc::new(timesource),
         redis,
-        quota_limiter,
+        quota_limiter: Arc::new(quota_limiter),
         event_size_limit,
         token_dropper: Arc::new(token_dropper),
         historical_cfg: HistoricalConfig::new(

--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -16,10 +16,10 @@ use tower_http::trace::TraceLayer;
 use crate::test_endpoint;
 use crate::{sinks, time::TimeSource, v0_endpoint};
 use common_redis::Client;
-use limiters::redis::RedisLimiter;
 use limiters::token_dropper::TokenDropper;
 
 use crate::config::CaptureMode;
+use crate::limiters::CaptureQuotaLimiter;
 use crate::prometheus::{setup_metrics_recorder, track_metrics};
 
 const EVENT_BODY_SIZE: usize = 2 * 1024 * 1024; // 2MB
@@ -31,9 +31,7 @@ pub struct State {
     pub sink: Arc<dyn sinks::Event + Send + Sync>,
     pub timesource: Arc<dyn TimeSource + Send + Sync>,
     pub redis: Arc<dyn Client + Send + Sync>,
-    pub billing_limiter: RedisLimiter,
-    pub survey_limiter: RedisLimiter,
-    pub llm_events_limiter: RedisLimiter,
+    pub quota_limiter: CaptureQuotaLimiter,
     pub token_dropper: Arc<TokenDropper>,
     pub event_size_limit: usize,
     pub historical_cfg: HistoricalConfig,
@@ -104,9 +102,7 @@ pub fn router<
     liveness: HealthRegistry,
     sink: S,
     redis: Arc<R>,
-    billing_limiter: RedisLimiter,
-    survey_limiter: RedisLimiter,
-    llm_events_limiter: RedisLimiter,
+    quota_limiter: QuotaLimiter,
     token_dropper: TokenDropper,
     metrics: bool,
     capture_mode: CaptureMode,
@@ -122,9 +118,7 @@ pub fn router<
         sink: Arc::new(sink),
         timesource: Arc::new(timesource),
         redis,
-        billing_limiter,
-        survey_limiter,
-        llm_events_limiter,
+        quota_limiter,
         event_size_limit,
         token_dropper: Arc::new(token_dropper),
         historical_cfg: HistoricalConfig::new(

--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -140,7 +140,8 @@ where
 
     // add new "scoped" quota limiters here as new quota tracking buckets are added
     // to PostHog! Here a "scoped" limiter is one that should be INDEPENDENT of the
-    // global billing limiter applied here to every event batch
+    // global billing limiter applied here to every event batch. You must supply the
+    // QuotaResource type and a predicate function that will match events to be limited
     let quota_limiter =
         CaptureQuotaLimiter::new(&config, redis_client.clone(), Duration::from_secs(5))
             .add_scoped_limiter(

--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -141,24 +141,25 @@ where
     // add new "scoped" quota limiters here as new quota tracking buckets are added
     // to PostHog! Here a "scoped" limiter is one that should be INDEPENDENT of the
     // global billing limiter applied here to every event batch
-    let quota_limiter = CaptureQuotaLimiter::new(&config, redis_client.clone())
-        .add_scoped_limiter(
-            QuotaResource::Exceptions,
-            Box::new(|e: &RawEvent| e.event.as_str() == "$exception"),
-        )
-        .add_scoped_limiter(
-            QuotaResource::Surveys,
-            Box::new(|e: &RawEvent| {
-                matches!(
-                    e.event.as_str(),
-                    "survey sent" | "survey shown" | "survey dismissed"
-                )
-            }),
-        )
-        .add_scoped_limiter(
-            QuotaResource::LLMEvents,
-            Box::new(|e: &RawEvent| e.event.starts_with("$ai_")),
-        );
+    let quota_limiter =
+        CaptureQuotaLimiter::new(&config, redis_client.clone(), Duration::from_secs(5))
+            .add_scoped_limiter(
+                QuotaResource::Exceptions,
+                Box::new(|e: &RawEvent| e.event.as_str() == "$exception"),
+            )
+            .add_scoped_limiter(
+                QuotaResource::Surveys,
+                Box::new(|e: &RawEvent| {
+                    matches!(
+                        e.event.as_str(),
+                        "survey sent" | "survey shown" | "survey dismissed"
+                    )
+                }),
+            )
+            .add_scoped_limiter(
+                QuotaResource::LLMEvents,
+                Box::new(|e: &RawEvent| e.event.starts_with("$ai_")),
+            );
 
     // TODO: remove this once we have a billing limiter
     let token_dropper = config

--- a/rust/capture/tests/common/integration_utils.rs
+++ b/rust/capture/tests/common/integration_utils.rs
@@ -8,11 +8,16 @@ use std::time::Duration;
 use capture::{
     api::{CaptureError, CaptureResponse, CaptureResponseCode},
     config::CaptureMode,
+    limiters::CaptureQuotaLimiter,
     router::router,
     sinks::Event,
     time::TimeSource,
     v0_request::{DataType, ProcessedEvent},
 };
+
+#[path = "./utils.rs"]
+mod test_utils;
+pub use test_utils::DEFAULT_CONFIG;
 
 use async_trait::async_trait;
 use axum::http::StatusCode;
@@ -23,7 +28,6 @@ use common_redis::MockRedisClient;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use health::HealthRegistry;
-use limiters::redis::{QuotaResource, RedisLimiter, ServiceName, QUOTA_LIMITER_CACHE_KEY};
 use limiters::token_dropper::TokenDropper;
 use serde_json::{from_str, Number, Value};
 use time::format_description::well_known::{Iso8601, Rfc3339};
@@ -957,41 +961,11 @@ fn setup_capture_router(unit: &TestCase) -> (Router, MemorySink) {
     };
     let redis = Arc::new(MockRedisClient::new());
 
-    let err_msg = format!("failed create billing limiter in case: {}", unit.title);
-    let quota_resource_mode = match unit.mode {
-        CaptureMode::Events => QuotaResource::Events,
-        CaptureMode::Recordings => QuotaResource::Recordings,
-    };
-    let billing_limiter = RedisLimiter::new(
-        Duration::from_secs(60 * 60 * 24 * 7),
-        redis.clone(),
-        QUOTA_LIMITER_CACHE_KEY.to_string(),
-        None,
-        quota_resource_mode,
-        ServiceName::Capture,
-    )
-    .expect(&err_msg);
+    let mut cfg = DEFAULT_CONFIG.clone();
+    cfg.capture_mode = unit.mode.clone();
 
-    // Create survey limiter (required by router now)
-    let survey_limiter = RedisLimiter::new(
-        Duration::from_secs(60 * 60 * 24 * 7),
-        redis.clone(),
-        QUOTA_LIMITER_CACHE_KEY.to_string(),
-        None,
-        QuotaResource::Surveys,
-        ServiceName::Capture,
-    )
-    .expect("failed to create survey limiter");
-
-    let llm_events_limiter = RedisLimiter::new(
-        Duration::from_secs(60 * 60 * 24 * 7),
-        redis.clone(),
-        QUOTA_LIMITER_CACHE_KEY.to_string(),
-        None,
-        QuotaResource::LLMEvents,
-        ServiceName::Capture,
-    )
-    .expect("failed to create llm events limiter");
+    let quota_limiter =
+        CaptureQuotaLimiter::new(&cfg, redis.clone(), Duration::from_secs(60 * 60 * 24 * 7));
 
     // simple defaults - payload validation isn't the focus of these tests
     let enable_historical_rerouting = false;
@@ -1006,9 +980,7 @@ fn setup_capture_router(unit: &TestCase) -> (Router, MemorySink) {
             liveness.clone(),
             sink.clone(),
             redis,
-            billing_limiter,
-            survey_limiter,
-            llm_events_limiter,
+            quota_limiter,
             TokenDropper::default(),
             false,
             unit.mode.clone(),

--- a/rust/capture/tests/limiters.rs
+++ b/rust/capture/tests/limiters.rs
@@ -294,7 +294,14 @@ async fn test_no_billing_limit_retains_all_events() {
     let (router, sink) = setup_router_with_limits(token, CaptureMode::Events, false, vec![]).await; // Not limited
     let client = TestClient::new(router);
 
-    let events = ["pageview", "$exception", "click", "survey sent", "pageleave", "$ai_foobar"];
+    let events = [
+        "pageview",
+        "$exception",
+        "click",
+        "survey sent",
+        "pageleave",
+        "$ai_foobar",
+    ];
     let payload = create_batch_payload_with_token(&events, token);
 
     let response = client
@@ -850,7 +857,7 @@ async fn test_survey_quota_cross_batch_first_submission_allowed() {
     let mut cfg = DEFAULT_CONFIG.clone();
     cfg.capture_mode = CaptureMode::Events;
 
-    let quota_limiter  = CaptureQuotaLimiter::new(&cfg, redis.clone(), Duration::from_secs(60))
+    let quota_limiter = CaptureQuotaLimiter::new(&cfg, redis.clone(), Duration::from_secs(60))
         .add_scoped_limiter(QuotaResource::Surveys, Box::new(is_survey_event));
 
     let app = router(

--- a/rust/capture/tests/limiters.rs
+++ b/rust/capture/tests/limiters.rs
@@ -10,7 +10,6 @@ use axum::http::StatusCode;
 use axum::Router;
 use axum_test_helper::TestClient;
 use common_redis::MockRedisClient;
-use common_types::RawEvent;
 use health::HealthRegistry;
 use limiters::redis::{QuotaResource, QUOTA_LIMITER_CACHE_KEY};
 use limiters::token_dropper::TokenDropper;
@@ -18,7 +17,7 @@ use serde_json::Value;
 
 use capture::api::CaptureError;
 use capture::config::CaptureMode;
-use capture::limiters::CaptureQuotaLimiter;
+use capture::limiters::{is_exception_event, is_llm_event, is_survey_event, CaptureQuotaLimiter};
 use capture::router::router;
 use capture::sinks::Event;
 use capture::time::TimeSource;
@@ -58,89 +57,66 @@ impl TimeSource for FixedTimeSource {
     }
 }
 
-async fn setup_billing_limited_router(token: &str, is_limited: bool) -> (Router, MemorySink) {
-    setup_router_with_limits(token, is_limited, false, false, false).await
-}
-
-async fn setup_survey_limited_router(token: &str, is_survey_limited: bool) -> (Router, MemorySink) {
-    setup_router_with_limits(token, false, is_survey_limited, false, false).await
-}
-
 async fn setup_router_with_limits(
     token: &str,
-    is_billing_limited: bool,
-    is_survey_limited: bool,
-    is_ai_limited: bool,
-    is_exceptions_limited: bool,
+    // one of CaptureMode::Events or CaptureMode::Recordings
+    //controls global limiter applied to the token
+    capture_mode: CaptureMode,
+    // if true, the global billing limit for the supplied CaptureMode will be set for this token
+    set_global_limit: bool,
+    // resources that will be set limited for the given token for scoped limiters to detect
+    resources_to_limit: Vec<QuotaResource>,
 ) -> (Router, MemorySink) {
-    let liveness = HealthRegistry::new("billing_limit_tests");
+    let liveness = HealthRegistry::new("quota_limit_tests");
     let sink = MemorySink::default();
     let timesource = FixedTimeSource {
         time: "2025-07-31T12:00:00Z".to_string(),
     };
 
+    // bootstrap for the CaptureQuotaLimiter. Defines which
+    // global limiter will be applied for this token ("events" or "recordings")
     let mut cfg = DEFAULT_CONFIG.clone();
-    cfg.capture_mode = CaptureMode::Events;
+    cfg.capture_mode = capture_mode.clone();
 
-    // Set up billing limit for the specific token using zrangebyscore
-    let billing_key = format!("{}{}", QUOTA_LIMITER_CACHE_KEY, "events");
-    let mut redis = if is_billing_limited {
-        MockRedisClient::new().zrangebyscore_ret(&billing_key, vec![token.to_string()])
+    // Set up global billing limit for the specific token using zrangebyscore
+    // using the same CaptureMode (QuotaResource) as set above in the app Config
+    let global_billing_resource = CaptureQuotaLimiter::get_resource_for_mode(capture_mode.clone());
+    let global_billing_key = format!(
+        "{}{}",
+        QUOTA_LIMITER_CACHE_KEY,
+        global_billing_resource.as_str()
+    );
+
+    let mut redis = if set_global_limit {
+        MockRedisClient::new().zrangebyscore_ret(&global_billing_key, vec![token.to_string()])
     } else {
-        MockRedisClient::new()
+        MockRedisClient::new().zrangebyscore_ret(&global_billing_key, vec![])
     };
 
-    // Set up survey limiter - always required now
-    let survey_key = format!("{}{}", QUOTA_LIMITER_CACHE_KEY, "surveys");
-    redis = redis.zrangebyscore_ret(
-        &survey_key,
-        if is_survey_limited {
-            vec![token.to_string()]
-        } else {
-            vec![]
-        },
-    );
+    // TODO: add more scoped limiter resource types here as needed!
+    for resource in &[
+        QuotaResource::Exceptions,
+        QuotaResource::Surveys,
+        QuotaResource::LLMEvents,
+    ] {
+        let key = format!("{}{}", QUOTA_LIMITER_CACHE_KEY, resource.as_str());
 
-    // Set up AI events limiter with its own Redis client
-    let ai_key = format!("{}{}", QUOTA_LIMITER_CACHE_KEY, "llm_events");
-    redis = redis.zrangebyscore_ret(
-        &ai_key,
-        if is_ai_limited {
+        let limited_tokens = if resources_to_limit.contains(resource) {
             vec![token.to_string()]
         } else {
             vec![]
-        },
-    );
+        };
 
-    let exceptions_key = format!("{}{}", QUOTA_LIMITER_CACHE_KEY, "exceptions");
-    redis = redis.zrangebyscore_ret(
-        &exceptions_key,
-        if is_exceptions_limited {
-            vec![token.to_string()]
-        } else {
-            vec![]
-        },
-    );
+        redis = redis.zrangebyscore_ret(&key, limited_tokens)
+    }
+
     let redis = Arc::new(redis);
 
+    // TODO: add more scoped limiters to test helper as needed in the future!
     let quota_limiter = CaptureQuotaLimiter::new(&cfg, redis.clone(), Duration::from_secs(60))
-        .add_scoped_limiter(
-            QuotaResource::Exceptions,
-            Box::new(|e: &RawEvent| e.event.as_str() == "$exception"),
-        )
-        .add_scoped_limiter(
-            QuotaResource::Surveys,
-            Box::new(|e: &RawEvent| {
-                matches!(
-                    e.event.as_str(),
-                    "survey sent" | "survey shown" | "survey dismissed"
-                )
-            }),
-        )
-        .add_scoped_limiter(
-            QuotaResource::LLMEvents,
-            Box::new(|e: &RawEvent| e.event.starts_with("$ai_")),
-        );
+        .add_scoped_limiter(QuotaResource::Exceptions, Box::new(is_exception_event))
+        .add_scoped_limiter(QuotaResource::Surveys, Box::new(is_survey_event))
+        .add_scoped_limiter(QuotaResource::LLMEvents, Box::new(is_llm_event));
 
     let app = router(
         timesource,
@@ -190,17 +166,32 @@ fn create_batch_payload_with_token(events: &[&str], token: &str) -> String {
     }
 }
 
+fn extract_captured_event_names(events: &[ProcessedEvent]) -> Vec<String> {
+    events
+        .iter()
+        .map(|e| {
+            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
+            event_data["event"].as_str().unwrap().to_string()
+        })
+        .collect()
+}
+
 #[tokio::test]
-async fn test_billing_limit_retains_only_exception_events() {
-    let token = "test_token_exception";
-    let (router, sink) = setup_billing_limited_router(token, true).await;
+async fn test_billing_limit_retains_only_scoped_limiter_events() {
+    let token = "test_token_global_limit_only";
+    let (router, sink) = setup_router_with_limits(token, CaptureMode::Events, true, vec![]).await;
     let client = TestClient::new(router);
 
+    // of these events, only the event types that are
+    // associated with a scoped limiter should be retained.
+    // in this case, those should be:
+    // "$exception", "$ai_generation" and "survey sent"
     let events = [
         "$exception",
         "pageview",
-        "$exception",
         "$something_else",
+        "$ai_generation",
+        "survey sent",
         "pageleave",
     ];
     let payload = create_batch_payload_with_token(&events, token);
@@ -218,21 +209,67 @@ async fn test_billing_limit_retains_only_exception_events() {
 
     // Check that only exception events were retained
     let captured_events = sink.events();
-    assert_eq!(captured_events.len(), 2);
+    assert_eq!(captured_events.len(), 3);
 
-    // Parse the event data to check the event name
-    let event_data: Value = serde_json::from_str(&captured_events[0].event.data).unwrap();
-    assert_eq!(event_data["event"], "$exception");
+    // check the events we expect are captured not filtered away
+    let event_names: Vec<String> = extract_captured_event_names(&captured_events);
+    assert!(event_names.contains(&"$exception".to_string()));
+    assert!(event_names.contains(&"$ai_generation".to_string()));
+    assert!(event_names.contains(&"survey sent".to_string()));
 }
 
 #[tokio::test]
 async fn test_billing_limit_returns_ok_when_no_retained_events() {
     let token = "test_token_empty";
-    let (router, sink) = setup_billing_limited_router(token, true).await;
+    let (router, sink) = setup_router_with_limits(token, CaptureMode::Events, true, vec![]).await;
     let client = TestClient::new(router);
 
-    // Only regular events that should be filtered out
+    // Only regular events that should be filtered out if global limit is applied
     let events = ["pageview", "click", "$pageview", "custom_event"];
+    let payload = create_batch_payload_with_token(&events, token);
+
+    let response = client
+        .post("/e")
+        .body(payload)
+        .header("Content-Type", "application/json")
+        .header("X-Forwarded-For", "127.0.0.1")
+        .send()
+        .await;
+
+    // Should return OK even when all events are filtered (legacy behavior)
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // No events should be captured
+    let captured_events = sink.events();
+    assert_eq!(captured_events.len(), 0);
+}
+
+#[tokio::test]
+async fn test_billing_limit_returns_ok_when_no_retained_events_with_scoped_limiters() {
+    let token = "test_token_empty";
+    let (router, sink) = setup_router_with_limits(
+        token,
+        CaptureMode::Events,
+        true,
+        vec![
+            QuotaResource::Exceptions,
+            QuotaResource::Surveys,
+            QuotaResource::LLMEvents,
+        ],
+    )
+    .await;
+    let client = TestClient::new(router);
+
+    // Only regular events that should be filtered out if global limit is applied
+    let events = [
+        "pageview",
+        "$exception",
+        "click",
+        "survey sent",
+        "$pageview",
+        "$ai_generation",
+        "custom_event",
+    ];
     let payload = create_batch_payload_with_token(&events, token);
 
     let response = client
@@ -254,10 +291,10 @@ async fn test_billing_limit_returns_ok_when_no_retained_events() {
 #[tokio::test]
 async fn test_no_billing_limit_retains_all_events() {
     let token = "test_token_no_limit";
-    let (router, sink) = setup_billing_limited_router(token, false).await; // Not limited
+    let (router, sink) = setup_router_with_limits(token, CaptureMode::Events, false, vec![]).await; // Not limited
     let client = TestClient::new(router);
 
-    let events = ["$exception", "pageview", "survey sent", "click"];
+    let events = ["pageview", "$exception", "click", "survey sent", "pageleave", "$ai_foobar"];
     let payload = create_batch_payload_with_token(&events, token);
 
     let response = client
@@ -273,39 +310,34 @@ async fn test_no_billing_limit_retains_all_events() {
 
     // All events should be retained when not billing limited
     let captured_events = sink.events();
-    assert_eq!(captured_events.len(), 4);
+    assert_eq!(captured_events.len(), 6);
 
-    // Parse the event data to check all event names are present
-    let event_names: Vec<String> = captured_events
-        .iter()
-        .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
-            event_data["event"].as_str().unwrap().to_string()
-        })
-        .collect();
-
+    // Parse the event data to check expected events are present
+    let event_names: Vec<String> = extract_captured_event_names(&captured_events);
     assert!(event_names.contains(&"$exception".to_string()));
-    assert!(event_names.contains(&"pageview".to_string()));
+    assert!(event_names.contains(&"$ai_foobar".to_string()));
     assert!(event_names.contains(&"survey sent".to_string()));
+    assert!(event_names.contains(&"pageview".to_string()));
+    assert!(event_names.contains(&"pageleave".to_string()));
     assert!(event_names.contains(&"click".to_string()));
 }
 
-// Test with /i/v0/e endpoint
 #[tokio::test]
 async fn test_billing_limit_on_i_endpoint() {
     let token = "test_token_i_endpoint";
-    let (router, sink) = setup_billing_limited_router(token, true).await;
+    let (router, sink) = setup_router_with_limits(token, CaptureMode::Events, true, vec![]).await;
     let client = TestClient::new(router);
 
+    // only scoped limiter event types should be retained
+    // since only global limiter is active for this test
     let events = [
         "survey sent",
         "$ai_foobar",
         "$exception",
         "pageview",
         "survey dismissed",
-        "$exception",
         "pageleave",
-        "some_other_event",
+        "click",
     ];
     let payload = create_batch_payload_with_token(&events, token);
 
@@ -324,31 +356,26 @@ async fn test_billing_limit_on_i_endpoint() {
     let captured_events = sink.events();
 
     // all but the exception, AI, and survey events should be dropped from the input batch
-    assert_eq!(captured_events.len(), 5);
+    assert_eq!(captured_events.len(), 4);
 
     // Parse the event data to check the event names
-    let event_names: Vec<String> = captured_events
-        .iter()
-        .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
-            event_data["event"].as_str().unwrap().to_string()
-        })
-        .collect();
-
+    let event_names: Vec<String> = extract_captured_event_names(&captured_events);
     assert!(event_names.contains(&"$exception".to_string()));
+    assert!(event_names.contains(&"$ai_foobar".to_string()));
+    assert!(event_names.contains(&"survey sent".to_string()));
+    assert!(event_names.contains(&"survey dismissed".to_string()));
 }
 
-// Tests for check_survey_quota_and_filter function
-//
-// These tests verify that the survey-specific quota limiting works correctly.
-// Survey quota limiting is separate from billing limits:
-// - Billing limits: When exceeded, only $exception and survey events are retained
-// - Survey limits: When exceeded, only survey events are filtered out (other events pass through)
-// Both can be applied simultaneously, with billing limits applied first, then survey limits
 #[tokio::test]
-async fn test_survey_quota_limit_filters_only_survey_events() {
+async fn test_survey_limiter_filters_only_survey_events() {
     let token = "test_token_survey_quota";
-    let (router, sink) = setup_survey_limited_router(token, true).await;
+    let (router, sink) = setup_router_with_limits(
+        token,
+        CaptureMode::Events,
+        false,
+        vec![QuotaResource::Surveys],
+    )
+    .await;
     let client = TestClient::new(router);
 
     let events = [
@@ -375,13 +402,7 @@ async fn test_survey_quota_limit_filters_only_survey_events() {
     let captured_events = sink.events();
     assert_eq!(captured_events.len(), 3); // pageview, click, $exception
 
-    let event_names: Vec<String> = captured_events
-        .iter()
-        .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
-            event_data["event"].as_str().unwrap().to_string()
-        })
-        .collect();
+    let event_names: Vec<String> = extract_captured_event_names(&captured_events);
 
     // Non-survey events should be present
     assert!(event_names.contains(&"pageview".to_string()));
@@ -394,9 +415,15 @@ async fn test_survey_quota_limit_filters_only_survey_events() {
 }
 
 #[tokio::test]
-async fn test_survey_quota_limit_returns_error_when_only_survey_events() {
+async fn test_survey_limiter_returns_ok_when_only_survey_events() {
     let token = "test_token_only_surveys";
-    let (router, sink) = setup_survey_limited_router(token, true).await;
+    let (router, sink) = setup_router_with_limits(
+        token,
+        CaptureMode::Events,
+        false,
+        vec![QuotaResource::Surveys],
+    )
+    .await;
     let client = TestClient::new(router);
 
     // Only survey events in the payload
@@ -417,28 +444,27 @@ async fn test_survey_quota_limit_returns_error_when_only_survey_events() {
     // When quota exceeded, ALL survey events should be filtered out
     let captured_events = sink.events();
     assert_eq!(captured_events.len(), 0);
-
-    let event_names: Vec<String> = captured_events
-        .iter()
-        .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
-            event_data["event"].as_str().unwrap().to_string()
-        })
-        .collect();
-
-    // All survey events should be filtered out when quota exceeded
-    assert!(!event_names.contains(&"survey sent".to_string()));
-    assert!(!event_names.contains(&"survey shown".to_string()));
-    assert!(!event_names.contains(&"survey dismissed".to_string()));
 }
 
 #[tokio::test]
 async fn test_survey_quota_limit_allows_survey_events_when_not_limited() {
     let token = "test_token_survey_not_limited";
-    let (router, sink) = setup_survey_limited_router(token, false).await; // Not survey limited
+    let (router, sink) = setup_router_with_limits(
+        token,
+        CaptureMode::Events,
+        true,
+        vec![QuotaResource::Exceptions, QuotaResource::LLMEvents],
+    )
+    .await; // Not survey limited
     let client = TestClient::new(router);
 
-    let events = ["survey sent", "pageview", "survey shown"];
+    let events = [
+        "$ai_yiss",
+        "survey sent",
+        "pageview",
+        "survey shown",
+        "$exception",
+    ];
     let payload = create_batch_payload_with_token(&events, token);
 
     let response = client
@@ -456,67 +482,28 @@ async fn test_survey_quota_limit_allows_survey_events_when_not_limited() {
     let captured_events = sink.events();
     assert_eq!(captured_events.len(), 3);
 
-    let event_names: Vec<String> = captured_events
-        .iter()
-        .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
-            event_data["event"].as_str().unwrap().to_string()
-        })
-        .collect();
-
+    let event_names: Vec<String> = extract_captured_event_names(&captured_events);
     assert!(event_names.contains(&"survey sent".to_string()));
     assert!(event_names.contains(&"pageview".to_string()));
     assert!(event_names.contains(&"survey shown".to_string()));
 }
 
 #[tokio::test]
-async fn test_survey_quota_limit_ignores_non_survey_events() {
-    let token = "test_token_survey_ignore_non_survey";
-    let (router, sink) = setup_survey_limited_router(token, true).await;
-    let client = TestClient::new(router);
-
-    // No survey events in the payload
-    let events = ["pageview", "click", "$exception", "custom_event"];
-    let payload = create_batch_payload_with_token(&events, token);
-
-    let response = client
-        .post("/e")
-        .body(payload)
-        .header("Content-Type", "application/json")
-        .header("X-Forwarded-For", "127.0.0.1")
-        .send()
-        .await;
-
-    // Should return OK
-    assert_eq!(response.status(), StatusCode::OK);
-
-    // All events should be captured since survey quota doesn't affect non-survey events
-    let captured_events = sink.events();
-    assert_eq!(captured_events.len(), 4);
-
-    let event_names: Vec<String> = captured_events
-        .iter()
-        .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
-            event_data["event"].as_str().unwrap().to_string()
-        })
-        .collect();
-
-    assert!(event_names.contains(&"pageview".to_string()));
-    assert!(event_names.contains(&"click".to_string()));
-    assert!(event_names.contains(&"$exception".to_string()));
-    assert!(event_names.contains(&"custom_event".to_string()));
-}
-
-#[tokio::test]
 async fn test_both_billing_and_survey_limits_applied() {
     let token = "test_token_both_limits";
-    let (router, sink) = setup_router_with_limits(token, true, true, false, false).await; // Both billing and survey limited
+    let (router, sink) = setup_router_with_limits(
+        token,
+        CaptureMode::Events,
+        true,
+        vec![QuotaResource::Surveys],
+    )
+    .await; // Both billing and survey limited
     let client = TestClient::new(router);
 
     let events = [
         "$exception",
         "survey sent",
+        "$ai_generation",
         "pageview",
         "survey shown",
         "click",
@@ -538,10 +525,11 @@ async fn test_both_billing_and_survey_limits_applied() {
     // Then survey limit is applied (filters out survey events)
     // So only $exception should remain
     let captured_events = sink.events();
-    assert_eq!(captured_events.len(), 1);
+    assert_eq!(captured_events.len(), 2);
 
-    let event_data: Value = serde_json::from_str(&captured_events[0].event.data).unwrap();
-    assert_eq!(event_data["event"], "$exception");
+    let event_names: Vec<String> = extract_captured_event_names(&captured_events);
+    assert!(event_names.contains(&"$exception".to_string()));
+    assert!(event_names.contains(&"$ai_generation".to_string()));
 }
 
 // Helper function to create survey events with custom properties including $survey_submission_id
@@ -586,7 +574,13 @@ fn create_survey_events_with_submission_ids(
 #[tokio::test]
 async fn test_survey_quota_groups_events_by_submission_id() {
     let token = "test_token_submission_grouping";
-    let (router, sink) = setup_survey_limited_router(token, true).await;
+    let (router, sink) = setup_router_with_limits(
+        token,
+        CaptureMode::Events,
+        false,
+        vec![QuotaResource::Surveys],
+    )
+    .await;
     let client = TestClient::new(router);
 
     // Create events with same submission_id - should be grouped together
@@ -599,7 +593,7 @@ async fn test_survey_quota_groups_events_by_submission_id() {
     let payload = create_survey_events_with_submission_ids(&events, token);
 
     let response = client
-        .post("/e")
+        .post("/batch")
         .body(payload)
         .header("Content-Type", "application/json")
         .header("X-Forwarded-For", "127.0.0.1")
@@ -619,7 +613,13 @@ async fn test_survey_quota_groups_events_by_submission_id() {
 #[tokio::test]
 async fn test_survey_quota_handles_multiple_submission_groups() {
     let token = "test_token_multiple_submissions";
-    let (router, sink) = setup_survey_limited_router(token, true).await;
+    let (router, sink) = setup_router_with_limits(
+        token,
+        CaptureMode::Events,
+        true,
+        vec![QuotaResource::Surveys],
+    )
+    .await;
     let client = TestClient::new(router);
 
     // Create events with different submission_ids - each group should be filtered separately
@@ -633,7 +633,7 @@ async fn test_survey_quota_handles_multiple_submission_groups() {
     let payload = create_survey_events_with_submission_ids(&events, token);
 
     let response = client
-        .post("/e")
+        .post("/i/v0/e")
         .body(payload)
         .header("Content-Type", "application/json")
         .header("X-Forwarded-For", "127.0.0.1")
@@ -653,7 +653,13 @@ async fn test_survey_quota_handles_multiple_submission_groups() {
 #[tokio::test]
 async fn test_survey_quota_backward_compatibility_without_submission_id() {
     let token = "test_token_backward_compat";
-    let (router, sink) = setup_survey_limited_router(token, true).await;
+    let (router, sink) = setup_router_with_limits(
+        token,
+        CaptureMode::Events,
+        false,
+        vec![QuotaResource::Surveys],
+    )
+    .await;
     let client = TestClient::new(router);
 
     // Create survey events without $survey_submission_id - should count individually
@@ -678,26 +684,21 @@ async fn test_survey_quota_backward_compatibility_without_submission_id() {
     let captured_events = sink.events();
     assert_eq!(captured_events.len(), 1);
 
-    let event_names: Vec<String> = captured_events
-        .iter()
-        .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
-            event_data["event"].as_str().unwrap().to_string()
-        })
-        .collect();
-
-    // All survey events should be filtered out when quota exceeded
-    assert!(!event_names.contains(&"survey sent".to_string()));
-    assert!(!event_names.contains(&"survey shown".to_string()));
-
-    // Non-survey events should be kept
+    let event_names: Vec<String> = extract_captured_event_names(&captured_events);
+    // Non-survey event should be kept
     assert!(event_names.contains(&"pageview".to_string()));
 }
 
 #[tokio::test]
 async fn test_survey_quota_mixed_with_and_without_submission_id() {
     let token = "test_token_mixed_submissions";
-    let (router, sink) = setup_survey_limited_router(token, true).await;
+    let (router, sink) = setup_router_with_limits(
+        token,
+        CaptureMode::Events,
+        false,
+        vec![QuotaResource::Surveys],
+    )
+    .await;
     let client = TestClient::new(router);
 
     // Mix of events with and without submission_id
@@ -724,14 +725,20 @@ async fn test_survey_quota_mixed_with_and_without_submission_id() {
     let captured_events = sink.events();
     assert_eq!(captured_events.len(), 1);
 
-    let event_data: Value = serde_json::from_str(&captured_events[0].event.data).unwrap();
-    assert_eq!(event_data["event"], "custom_event");
+    let event_names: Vec<String> = extract_captured_event_names(&captured_events);
+    assert!(event_names.contains(&"custom_event".to_string()));
 }
 
 #[tokio::test]
 async fn test_survey_quota_empty_submission_id_treated_as_none() {
     let token = "test_token_empty_submission";
-    let (router, sink) = setup_survey_limited_router(token, true).await;
+    let (router, sink) = setup_router_with_limits(
+        token,
+        CaptureMode::Events,
+        false,
+        vec![QuotaResource::Surveys],
+    )
+    .await;
     let client = TestClient::new(router);
 
     // Create events with empty string submission_id - should be treated as None
@@ -764,7 +771,7 @@ async fn test_survey_quota_empty_submission_id_treated_as_none() {
     .to_string();
 
     let response = client
-        .post("/e")
+        .post("/batch")
         .body(payload)
         .header("Content-Type", "application/json")
         .header("X-Forwarded-For", "127.0.0.1")
@@ -777,14 +784,14 @@ async fn test_survey_quota_empty_submission_id_treated_as_none() {
     let captured_events = sink.events();
     assert_eq!(captured_events.len(), 1);
 
-    let event_data: Value = serde_json::from_str(&captured_events[0].event.data).unwrap();
-    assert_eq!(event_data["event"], "pageview");
+    let event_names: Vec<String> = extract_captured_event_names(&captured_events);
+    assert!(event_names.contains(&"pageview".to_string()));
 }
 
 #[tokio::test]
 async fn test_survey_quota_allows_events_when_not_limited() {
     let token = "test_token_not_survey_limited";
-    let (router, sink) = setup_survey_limited_router(token, false).await; // Not survey limited
+    let (router, sink) = setup_router_with_limits(token, CaptureMode::Events, false, vec![]).await; // Not survey limited
     let client = TestClient::new(router);
 
     // Create events with submission_ids - should all pass through when not limited
@@ -810,14 +817,7 @@ async fn test_survey_quota_allows_events_when_not_limited() {
     let captured_events = sink.events();
     assert_eq!(captured_events.len(), 4);
 
-    let event_names: Vec<String> = captured_events
-        .iter()
-        .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
-            event_data["event"].as_str().unwrap().to_string()
-        })
-        .collect();
-
+    let event_names: Vec<String> = extract_captured_event_names(&captured_events);
     assert!(event_names.contains(&"survey sent".to_string()));
     assert!(event_names.contains(&"survey shown".to_string()));
     assert!(event_names.contains(&"survey dismissed".to_string()));
@@ -890,10 +890,11 @@ async fn test_survey_quota_cross_batch_first_submission_allowed() {
     // Since this is the first time seeing submission_first, survey events should be allowed through
     // but then dropped by the main quota system since we're survey limited
     let captured_events = sink.events();
-    assert_eq!(captured_events.len(), 1); // Only pageview should remain
+    assert_eq!(captured_events.len(), 1);
 
-    let event_data: Value = serde_json::from_str(&captured_events[0].event.data).unwrap();
-    assert_eq!(event_data["event"], "pageview");
+    // Only pageview should remain
+    let event_names: Vec<String> = extract_captured_event_names(&captured_events);
+    assert!(event_names.contains(&"pageview".to_string()));
 }
 
 #[tokio::test]
@@ -966,6 +967,7 @@ async fn test_survey_quota_cross_batch_duplicate_submission_dropped() {
     assert_eq!(event_data["event"], "click");
 }
 
+// TODO(eli): REVISIT THIS - SHOULD FAIL ATM
 #[tokio::test]
 async fn test_survey_quota_cross_batch_redis_error_fail_open() {
     let token = "test_token_redis_error";
@@ -1041,9 +1043,15 @@ async fn test_survey_quota_cross_batch_redis_error_fail_open() {
 }
 
 #[tokio::test]
-async fn test_survey_quota_only_limits_survey_sent_events() {
+async fn test_survey_and_global_limited_drops_all_events_when_only_matching_events_in_payload() {
     let token = "test_token_only_survey_sent";
-    let (router, sink) = setup_survey_limited_router(token, true).await;
+    let (router, sink) = setup_router_with_limits(
+        token,
+        CaptureMode::Events,
+        true,
+        vec![QuotaResource::Surveys],
+    )
+    .await;
     let client = TestClient::new(router);
 
     // Mix of all survey event types - when quota exceeded, ALL survey events should be dropped
@@ -1056,7 +1064,7 @@ async fn test_survey_quota_only_limits_survey_sent_events() {
     let payload = create_survey_events_with_submission_ids(&events, token);
 
     let response = client
-        .post("/e")
+        .post("/batch")
         .body(payload)
         .header("Content-Type", "application/json")
         .header("X-Forwarded-For", "127.0.0.1")
@@ -1067,75 +1075,19 @@ async fn test_survey_quota_only_limits_survey_sent_events() {
 
     // When survey quota is exceeded, ALL survey events should be dropped
     let captured_events = sink.events();
-    assert_eq!(captured_events.len(), 1); // only pageview
-
-    let event_names: Vec<String> = captured_events
-        .iter()
-        .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
-            event_data["event"].as_str().unwrap().to_string()
-        })
-        .collect();
-
-    // All survey events should be dropped when quota exceeded
-    assert!(!event_names.contains(&"survey sent".to_string()));
-    assert!(!event_names.contains(&"survey shown".to_string()));
-    assert!(!event_names.contains(&"survey dismissed".to_string()));
-
-    // Non-survey events should be kept
-    assert!(event_names.contains(&"pageview".to_string()));
-}
-
-#[tokio::test]
-async fn test_survey_quota_backward_compatibility_survey_sent_only() {
-    let token = "test_token_survey_sent_backward_compat";
-    let (router, sink) = setup_survey_limited_router(token, true).await;
-    let client = TestClient::new(router);
-
-    // Survey events without submission_id - when quota exceeded, ALL survey events should be dropped
-    let events = [
-        ("survey sent", None),      // Should be dropped due to quota (no submission_id)
-        ("survey shown", None),     // Should also be dropped when quota exceeded
-        ("survey dismissed", None), // Should also be dropped when quota exceeded
-        ("pageview", None),         // Non-survey event
-    ];
-    let payload = create_survey_events_with_submission_ids(&events, token);
-
-    let response = client
-        .post("/e")
-        .body(payload)
-        .header("Content-Type", "application/json")
-        .header("X-Forwarded-For", "127.0.0.1")
-        .send()
-        .await;
-
-    assert_eq!(response.status(), StatusCode::OK);
-
-    // When quota exceeded, ALL survey events should be dropped
-    let captured_events = sink.events();
-    assert_eq!(captured_events.len(), 1);
-
-    let event_names: Vec<String> = captured_events
-        .iter()
-        .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
-            event_data["event"].as_str().unwrap().to_string()
-        })
-        .collect();
-
-    // All survey events should be dropped when quota exceeded
-    assert!(!event_names.contains(&"survey sent".to_string()));
-    assert!(!event_names.contains(&"survey shown".to_string()));
-    assert!(!event_names.contains(&"survey dismissed".to_string()));
-
-    // Non-survey events should be kept
-    assert!(event_names.contains(&"pageview".to_string()));
+    assert_eq!(captured_events.len(), 0); // only pageview
 }
 
 #[tokio::test]
 async fn test_ai_events_quota_limit_filters_only_ai_events() {
     let token = "test_token";
-    let (app, sink) = setup_ai_limited_router(token, true).await;
+    let (app, sink) = setup_router_with_limits(
+        token,
+        CaptureMode::Events,
+        false,
+        vec![QuotaResource::LLMEvents],
+    )
+    .await;
     let client = TestClient::new(app);
 
     let ai_event = serde_json::json!({
@@ -1165,17 +1117,11 @@ async fn test_ai_events_quota_limit_filters_only_ai_events() {
         .await;
     assert_eq!(res.status(), StatusCode::OK);
 
-    let events = sink.events();
-    assert_eq!(events.len(), 2); // Only non-AI events should be kept
+    let captured_events = sink.events();
+    assert_eq!(captured_events.len(), 2); // Only non-AI events should be kept
 
     // Verify only non-AI events were kept
-    let event_names: Vec<String> = events
-        .iter()
-        .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
-            event_data["event"].as_str().unwrap().to_string()
-        })
-        .collect();
+    let event_names: Vec<String> = extract_captured_event_names(&captured_events);
     assert!(event_names.contains(&"pageview".to_string()));
     assert!(event_names.contains(&"custom_event".to_string()));
     assert!(!event_names.contains(&"$ai_generation".to_string()));
@@ -1184,9 +1130,15 @@ async fn test_ai_events_quota_limit_filters_only_ai_events() {
 }
 
 #[tokio::test]
-async fn test_ai_events_quota_limit_returns_error_when_only_ai_events() {
+async fn test_ai_events_quota_limit_returns_ok_with_empty_sink_when_only_ai_events() {
     let token = "test_token";
-    let (app, _) = setup_ai_limited_router(token, true).await;
+    let (app, sink) = setup_router_with_limits(
+        token,
+        CaptureMode::Events,
+        false,
+        vec![QuotaResource::LLMEvents],
+    )
+    .await;
     let client = TestClient::new(app);
 
     let ai_only_event = serde_json::json!({
@@ -1206,12 +1158,15 @@ async fn test_ai_events_quota_limit_returns_error_when_only_ai_events() {
         .send()
         .await;
     assert_eq!(res.status(), StatusCode::OK);
+
+    let captured_events = sink.events();
+    assert_eq!(captured_events.len(), 0);
 }
 
 #[tokio::test]
 async fn test_ai_events_quota_allows_ai_events_when_not_limited() {
     let token = "test_token";
-    let (app, sink) = setup_ai_limited_router(token, false).await;
+    let (app, sink) = setup_router_with_limits(token, CaptureMode::Events, true, vec![]).await;
     let client = TestClient::new(app);
 
     let ai_event = serde_json::json!({
@@ -1232,16 +1187,10 @@ async fn test_ai_events_quota_allows_ai_events_when_not_limited() {
         .await;
     assert_eq!(res.status(), StatusCode::OK);
 
-    let events = sink.events();
-    assert_eq!(events.len(), 3); // All events should be kept when not limited
+    let captured_events = sink.events();
+    assert_eq!(captured_events.len(), 3); // All events should be kept when not limited
 
-    let event_names: Vec<String> = events
-        .iter()
-        .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
-            event_data["event"].as_str().unwrap().to_string()
-        })
-        .collect();
+    let event_names: Vec<String> = extract_captured_event_names(&captured_events);
     assert!(event_names.contains(&"$ai_generation".to_string()));
     assert!(event_names.contains(&"$ai_span".to_string()));
     assert!(event_names.contains(&"pageview".to_string()));
@@ -1250,7 +1199,13 @@ async fn test_ai_events_quota_allows_ai_events_when_not_limited() {
 #[tokio::test]
 async fn test_ai_events_quota_ignores_non_ai_events() {
     let token = "test_token";
-    let (app, sink) = setup_ai_limited_router(token, true).await;
+    let (app, sink) = setup_router_with_limits(
+        token,
+        CaptureMode::Events,
+        false,
+        vec![QuotaResource::LLMEvents],
+    )
+    .await;
     let client = TestClient::new(app);
 
     // Send only non-AI events when AI quota is exceeded
@@ -1272,19 +1227,25 @@ async fn test_ai_events_quota_ignores_non_ai_events() {
         .await;
     assert_eq!(res.status(), StatusCode::OK);
 
-    let events = sink.events();
-    assert_eq!(events.len(), 3); // All non-AI events should pass through
-}
+    let captured_events = sink.events();
+    assert_eq!(captured_events.len(), 3);
 
-// Helper function to set up router with AI limiting
-async fn setup_ai_limited_router(token: &str, is_ai_limited: bool) -> (Router, MemorySink) {
-    setup_router_with_limits(token, false, false, is_ai_limited, false).await
+    let event_names: Vec<String> = extract_captured_event_names(&captured_events);
+    assert!(event_names.contains(&"pageview".to_string()));
+    assert!(event_names.contains(&"custom_event".to_string()));
+    assert!(event_names.contains(&"$autocapture".to_string()));
 }
 
 #[tokio::test]
 async fn test_both_billing_and_ai_limits_applied() {
     let token = "test_token";
-    let (app, sink) = setup_router_with_limits(token, true, false, true, false).await;
+    let (app, sink) = setup_router_with_limits(
+        token,
+        CaptureMode::Events,
+        true,
+        vec![QuotaResource::LLMEvents],
+    )
+    .await;
     let client = TestClient::new(app);
 
     let mixed_event = serde_json::json!({
@@ -1305,25 +1266,23 @@ async fn test_both_billing_and_ai_limits_applied() {
         .await;
     assert_eq!(res.status(), StatusCode::OK);
 
-    let events = sink.events();
-    assert_eq!(events.len(), 1); // Only exception should remain
+    let captured_events = sink.events();
+    assert_eq!(captured_events.len(), 1); // Only exception should remain
 
-    let event_names: Vec<String> = events
-        .iter()
-        .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
-            event_data["event"].as_str().unwrap().to_string()
-        })
-        .collect();
+    let event_names: Vec<String> = extract_captured_event_names(&captured_events);
     assert!(event_names.contains(&"$exception".to_string()));
-    assert!(!event_names.contains(&"$ai_generation".to_string()));
-    assert!(!event_names.contains(&"pageview".to_string()));
 }
 
 #[tokio::test]
 async fn test_ai_and_survey_limits_interaction() {
     let token = "test_token";
-    let (app, sink) = setup_router_with_limits(token, false, true, true, false).await;
+    let (app, sink) = setup_router_with_limits(
+        token,
+        CaptureMode::Events,
+        false,
+        vec![QuotaResource::LLMEvents, QuotaResource::Surveys],
+    )
+    .await;
     let client = TestClient::new(app);
 
     let mixed_event = serde_json::json!({
@@ -1337,7 +1296,7 @@ async fn test_ai_and_survey_limits_interaction() {
     });
 
     let res = client
-        .post("/e")
+        .post("/i/v0/e")
         .body(mixed_event.to_string())
         .header("Content-Type", "application/json")
         .header("X-Forwarded-For", "127.0.0.1")
@@ -1347,26 +1306,28 @@ async fn test_ai_and_survey_limits_interaction() {
 
     assert_eq!(status, StatusCode::OK);
 
-    let events = sink.events();
-    assert_eq!(events.len(), 2); // Only regular events should remain
+    let captured_events = sink.events();
+    assert_eq!(captured_events.len(), 2); // Only regular events should remain
 
-    let event_names: Vec<String> = events
-        .iter()
-        .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
-            event_data["event"].as_str().unwrap().to_string()
-        })
-        .collect();
+    let event_names: Vec<String> = extract_captured_event_names(&captured_events);
     assert!(event_names.contains(&"pageview".to_string()));
     assert!(event_names.contains(&"custom_event".to_string()));
-    assert!(!event_names.contains(&"$ai_generation".to_string()));
-    assert!(!event_names.contains(&"survey sent".to_string()));
 }
 
 #[tokio::test]
-async fn test_all_three_limits_applied() {
+async fn test_all_scoped_limits_applied() {
     let token = "test_token";
-    let (app, sink) = setup_router_with_limits(token, true, true, true, true).await;
+    let (app, sink) = setup_router_with_limits(
+        token,
+        CaptureMode::Events,
+        false,
+        vec![
+            QuotaResource::LLMEvents,
+            QuotaResource::Surveys,
+            QuotaResource::Exceptions,
+        ],
+    )
+    .await;
     let client = TestClient::new(app);
 
     let mixed_event = serde_json::json!({
@@ -1388,222 +1349,23 @@ async fn test_all_three_limits_applied() {
         .await;
     assert_eq!(res.status(), StatusCode::OK);
 
-    let events = sink.events();
-    assert_eq!(events.len(), 1); // Only exception should remain
+    let captured_events = sink.events();
+    assert_eq!(captured_events.len(), 1); // Only exception should remain
 
-    let event_names: Vec<String> = events
-        .iter()
-        .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
-            event_data["event"].as_str().unwrap().to_string()
-        })
-        .collect();
-    assert!(event_names.contains(&"$exception".to_string()));
-    assert!(!event_names.contains(&"$ai_generation".to_string()));
-    assert!(!event_names.contains(&"survey sent".to_string()));
-    assert!(!event_names.contains(&"pageview".to_string()));
+    let event_names: Vec<String> = extract_captured_event_names(&captured_events);
+    assert!(event_names.contains(&"pageview".to_string()));
 }
 
 #[tokio::test]
-async fn test_ai_event_name_detection() {
-    // Test various event names to ensure is_ai_event() works correctly
-    let test_cases = vec![
-        ("$ai_generation", true),
-        ("$ai_completion", true),
-        ("$ai_span", true),
-        ("$ai_trace", true),
-        ("$ai_custom", true),
-        ("$ai_", true),           // Edge case: exactly "$ai_"
-        ("$ai", false),           // No underscore
-        ("$ainotthis", false),    // No underscore after ai
-        ("ai_generation", false), // Missing $
-        ("$pageview", false),
-        ("pageview", false),
-    ];
-
+async fn test_ai_quota_with_empty_batch_returns_bad_request() {
     let token = "test_token";
-
-    for (event_name, should_be_filtered) in test_cases {
-        let (app, sink) = setup_ai_limited_router(token, true).await;
-        let client = TestClient::new(app);
-
-        let event = serde_json::json!({
-            "api_key": token,
-            "batch": [
-                {"event": event_name, "properties": {"distinct_id": "user"}},
-                {"event": "pageview", "properties": {"distinct_id": "user"}}  // Control event
-            ]
-        });
-
-        let res = client
-            .post("/e")
-            .body(event.to_string())
-            .header("Content-Type", "application/json")
-            .header("X-Forwarded-For", "127.0.0.1")
-            .send()
-            .await;
-        assert_eq!(res.status(), StatusCode::OK);
-
-        let events = sink.events();
-
-        if should_be_filtered {
-            // AI event should be filtered, only pageview remains
-            assert_eq!(events.len(), 1, "Event '{event_name}' should be filtered");
-            let event_data: Value = serde_json::from_str(&events[0].event.data).unwrap();
-            assert_eq!(event_data["event"], "pageview");
-        } else {
-            // Non-AI event should pass through with pageview
-            assert_eq!(
-                events.len(),
-                2,
-                "Event '{event_name}' should not be filtered"
-            );
-        }
-    }
-}
-
-#[tokio::test]
-async fn test_ai_generation_event_limited() {
-    let token = "test_token";
-    let (app, sink) = setup_ai_limited_router(token, true).await;
-    let client = TestClient::new(app);
-
-    let event = serde_json::json!({
-        "api_key": token,
-        "batch": [
-            {
-                "event": "$ai_generation",
-                "properties": {
-                    "distinct_id": "user",
-                    "$ai_model": "gpt-4",
-                    "$ai_provider": "openai",
-                    "$ai_input_tokens": 100,
-                    "$ai_output_tokens": 200
-                }
-            }
-        ]
-    });
-
-    let res = client
-        .post("/i/v0/e")
-        .body(event.to_string())
-        .header("Content-Type", "application/json")
-        .header("X-Forwarded-For", "127.0.0.1")
-        .send()
-        .await;
-    assert_eq!(res.status(), StatusCode::OK); // Returns OK even when all events are filtered (legacy behavior)
-
-    let events = sink.events();
-    assert_eq!(events.len(), 0); // AI event should be filtered
-}
-
-#[tokio::test]
-async fn test_ai_span_event_limited() {
-    let token = "test_token";
-    let (app, sink) = setup_ai_limited_router(token, true).await;
-    let client = TestClient::new(app);
-
-    let event = serde_json::json!({
-        "api_key": token,
-        "batch": [
-            {
-                "event": "$ai_span",
-                "properties": {
-                    "distinct_id": "user",
-                    "$ai_trace_id": "trace_123",
-                    "$ai_span_id": "span_456"
-                }
-            },
-            {"event": "custom", "properties": {"distinct_id": "user"}}
-        ]
-    });
-
-    let res = client
-        .post("/i/v0/e")
-        .body(event.to_string())
-        .header("Content-Type", "application/json")
-        .header("X-Forwarded-For", "127.0.0.1")
-        .send()
-        .await;
-    assert_eq!(res.status(), StatusCode::OK);
-
-    let events = sink.events();
-    assert_eq!(events.len(), 1);
-    let event_data: Value = serde_json::from_str(&events[0].event.data).unwrap();
-    assert_eq!(event_data["event"], "custom");
-}
-
-#[tokio::test]
-async fn test_ai_trace_event_limited() {
-    let token = "test_token";
-    let (app, sink) = setup_ai_limited_router(token, true).await;
-    let client = TestClient::new(app);
-
-    let event = serde_json::json!({
-        "api_key": token,
-        "batch": [
-            {
-                "event": "$ai_trace",
-                "properties": {
-                    "distinct_id": "user",
-                    "$ai_trace_id": "trace_789"
-                }
-            },
-            {"event": "$autocapture", "properties": {"distinct_id": "user"}}
-        ]
-    });
-
-    let res = client
-        .post("/i/v0/e")
-        .body(event.to_string())
-        .header("Content-Type", "application/json")
-        .header("X-Forwarded-For", "127.0.0.1")
-        .send()
-        .await;
-    assert_eq!(res.status(), StatusCode::OK);
-
-    let events = sink.events();
-    assert_eq!(events.len(), 1);
-    let event_data: Value = serde_json::from_str(&events[0].event.data).unwrap();
-    assert_eq!(event_data["event"], "$autocapture");
-}
-
-#[tokio::test]
-async fn test_custom_ai_prefixed_events_limited() {
-    let token = "test_token";
-    let (app, sink) = setup_ai_limited_router(token, true).await;
-    let client = TestClient::new(app);
-
-    // Custom AI events that follow the $ai_ pattern should also be limited
-    let event = serde_json::json!({
-        "api_key": token,
-        "batch": [
-            {"event": "$ai_custom_metric", "properties": {"distinct_id": "user"}},
-            {"event": "$ai_user_feedback", "properties": {"distinct_id": "user"}},
-            {"event": "$ai_model_switch", "properties": {"distinct_id": "user"}},
-            {"event": "non_ai_event", "properties": {"distinct_id": "user"}}
-        ]
-    });
-
-    let res = client
-        .post("/i/v0/e")
-        .body(event.to_string())
-        .header("Content-Type", "application/json")
-        .header("X-Forwarded-For", "127.0.0.1")
-        .send()
-        .await;
-    assert_eq!(res.status(), StatusCode::OK);
-
-    let events = sink.events();
-    assert_eq!(events.len(), 1); // Only non-AI event should pass
-    let event_data: Value = serde_json::from_str(&events[0].event.data).unwrap();
-    assert_eq!(event_data["event"], "non_ai_event");
-}
-
-#[tokio::test]
-async fn test_ai_quota_with_empty_batch() {
-    let token = "test_token";
-    let (app, _sink) = setup_ai_limited_router(token, true).await;
+    let (app, _sink) = setup_router_with_limits(
+        token,
+        CaptureMode::Events,
+        false,
+        vec![QuotaResource::LLMEvents],
+    )
+    .await;
     let client = TestClient::new(app);
 
     let empty_event = serde_json::json!({
@@ -1645,7 +1407,8 @@ async fn test_ai_quota_cross_batch_redis_error_fail_open() {
     let mut cfg = DEFAULT_CONFIG.clone();
     cfg.capture_mode = CaptureMode::Events;
 
-    let quota_limiter = CaptureQuotaLimiter::new(&cfg, redis.clone(), Duration::from_secs(60));
+    let quota_limiter = CaptureQuotaLimiter::new(&cfg, redis.clone(), Duration::from_secs(60))
+        .add_scoped_limiter(QuotaResource::LLMEvents, Box::new(is_llm_event));
 
     let app = router(
         timesource,
@@ -1696,7 +1459,13 @@ async fn test_ai_quota_cross_batch_redis_error_fail_open() {
 #[tokio::test]
 async fn test_ai_quota_cross_batch_consistency() {
     let token = "test_token_cross_batch_ai";
-    let (app, sink) = setup_ai_limited_router(token, true).await;
+    let (app, sink) = setup_router_with_limits(
+        token,
+        CaptureMode::Events,
+        false,
+        vec![QuotaResource::LLMEvents],
+    )
+    .await;
     let client = TestClient::new(app);
 
     // First batch - AI events should be filtered
@@ -1736,16 +1505,10 @@ async fn test_ai_quota_cross_batch_consistency() {
     assert_eq!(res.status(), StatusCode::OK);
 
     // Both batches should have AI events filtered out consistently
-    let events = sink.events();
-    assert_eq!(events.len(), 2); // Only non-AI events
+    let captured_events = sink.events();
+    assert_eq!(captured_events.len(), 2); // Only non-AI events
 
-    let event_names: Vec<String> = events
-        .iter()
-        .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
-            event_data["event"].as_str().unwrap().to_string()
-        })
-        .collect();
+    let event_names: Vec<String> = extract_captured_event_names(&captured_events);
     assert!(event_names.contains(&"pageview".to_string()));
     assert!(event_names.contains(&"click".to_string()));
     assert!(!event_names.contains(&"$ai_generation".to_string()));
@@ -1755,7 +1518,13 @@ async fn test_ai_quota_cross_batch_consistency() {
 #[tokio::test]
 async fn test_ai_quota_all_ai_event_types_count() {
     let token = "test_token_all_types";
-    let (app, sink) = setup_ai_limited_router(token, true).await;
+    let (app, sink) = setup_router_with_limits(
+        token,
+        CaptureMode::Events,
+        false,
+        vec![QuotaResource::LLMEvents],
+    )
+    .await;
     let client = TestClient::new(app);
 
     // Test that ALL events starting with "$ai_" count toward quota
@@ -1783,17 +1552,11 @@ async fn test_ai_quota_all_ai_event_types_count() {
         .await;
     assert_eq!(res.status(), StatusCode::OK);
 
-    let events = sink.events();
+    let captured_events = sink.events();
     // Only non-AI events should pass: $ainotcounted, ai_generation, pageview
-    assert_eq!(events.len(), 3);
+    assert_eq!(captured_events.len(), 3);
 
-    let event_names: Vec<String> = events
-        .iter()
-        .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
-            event_data["event"].as_str().unwrap().to_string()
-        })
-        .collect();
+    let event_names: Vec<String> = extract_captured_event_names(&captured_events);
     assert!(event_names.contains(&"$ainotcounted".to_string())); // No underscore after $ai
     assert!(event_names.contains(&"ai_generation".to_string())); // No $ prefix
     assert!(event_names.contains(&"pageview".to_string()));
@@ -1810,7 +1573,13 @@ async fn test_ai_quota_all_ai_event_types_count() {
 #[tokio::test]
 async fn test_ai_quota_empty_null_field_handling() {
     let token = "test_token_empty_fields_ai";
-    let (app, _sink) = setup_ai_limited_router(token, true).await;
+    let (app, _sink) = setup_router_with_limits(
+        token,
+        CaptureMode::Events,
+        true,
+        vec![QuotaResource::LLMEvents],
+    )
+    .await;
     let client = TestClient::new(app);
 
     // Test various empty/null scenarios

--- a/rust/common/limiters/src/redis.rs
+++ b/rust/common/limiters/src/redis.rs
@@ -37,7 +37,7 @@ use tokio::time::interval;
 pub const QUOTA_LIMITER_CACHE_KEY: &str = "@posthog/quota-limits/";
 pub const OVERFLOW_LIMITER_CACHE_KEY: &str = "@posthog/capture-overflow/";
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum QuotaResource {
     Events,
     Exceptions,

--- a/rust/common/limiters/src/redis.rs
+++ b/rust/common/limiters/src/redis.rs
@@ -37,7 +37,7 @@ use tokio::time::interval;
 pub const QUOTA_LIMITER_CACHE_KEY: &str = "@posthog/quota-limits/";
 pub const OVERFLOW_LIMITER_CACHE_KEY: &str = "@posthog/capture-overflow/";
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum QuotaResource {
     Events,
     Exceptions,


### PR DESCRIPTION
## Problem
We've rapidly gone from 1 to 4 (and counting) quota-based event filters in the `capture-rs` service. These scoped limiters' interaction with the global limiter, along with some temporary hacks to push `$exception` limiting downstream, has made this awkward to update and test.

## Changes
* Consolidates and encapsulates all limiter functionality into `CaptureQuotaLimiter`
* Ensures adding new limiters is as simple as adding a `QuotaResource` and a `RawEvent` filtering predicate
* Refactor all associated unit tests and helper code
* **Adds missing exception tracking limiter** and removes global limiter hack to skip the same

## How did you test this code?
Locally and CI

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
