### PR TITLE
fix: linear double escape

### DIFF
--- a/frontend/src/scenes/hog-functions/configuration/HogFunctionConfiguration.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/HogFunctionConfiguration.tsx
@@ -61,6 +61,7 @@ export function HogFunctionConfiguration({ templateId, id, logicKey }: HogFuncti
         mightDropEvents,
         showFilters,
         showExpectedVolume,
+        canEditSource,
         showTesting,
     } = useValues(logic)
 
@@ -295,7 +296,7 @@ export function HogFunctionConfiguration({ templateId, id, logicKey }: HogFuncti
 
                             <HogFunctionMappings />
 
-                            <HogFunctionCode />
+                            {canEditSource && <HogFunctionCode />}
                             {showTesting ? <HogFunctionTest /> : null}
                             {type === 'source_webhook' && <HogFunctionSourceWebhookTest />}
                             <div className="flex gap-2 justify-end">{saveButtons}</div>

--- a/frontend/src/scenes/hog-functions/configuration/HogFunctionConfiguration.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/HogFunctionConfiguration.tsx
@@ -61,7 +61,6 @@ export function HogFunctionConfiguration({ templateId, id, logicKey }: HogFuncti
         mightDropEvents,
         showFilters,
         showExpectedVolume,
-        canEditSource,
         showTesting,
     } = useValues(logic)
 
@@ -296,7 +295,7 @@ export function HogFunctionConfiguration({ templateId, id, logicKey }: HogFuncti
 
                             <HogFunctionMappings />
 
-                            {canEditSource && <HogFunctionCode />}
+                            <HogFunctionCode />
                             {showTesting ? <HogFunctionTest /> : null}
                             {type === 'source_webhook' && <HogFunctionSourceWebhookTest />}
                             <div className="flex gap-2 justify-end">{saveButtons}</div>

--- a/plugin-server/src/cdp/templates/_destinations/linear/linear.template.ts
+++ b/plugin-server/src/cdp/templates/_destinations/linear/linear.template.ts
@@ -23,7 +23,7 @@ export const template: HogFunctionTemplate = {
     })
 }
 
-let issue_mutation := f'mutation IssueCreate \{ issueCreate(input: \{ title: "{event.properties.name}" description: "{event.properties.description}" teamId: "{inputs.team}" }) \{ success issue \{ identifier } } }';
+let issue_mutation := f'mutation IssueCreate \\{ issueCreate(input: \\{ title: "{event.properties.name}" description: "{event.properties.description}" teamId: "{inputs.team}" }) \\{ success issue \\{ identifier } } }';
 
 let issue_response := query(issue_mutation);
 
@@ -34,7 +34,7 @@ if (issue_response.status != 200) {
 let linear_issue_id := issue_response.body.data.issueCreate.issue.identifier;
 
 let attachment_url := f'{project.url}/error_tracking/{event.distinct_id}';
-let attachment_mutation := f'mutation AttachmentCreate \{ attachmentCreate(input: \{ issueId: "{linear_issue_id}", title: "PostHog issue", url: "{attachment_url}" }) \{ success } }';
+let attachment_mutation := f'mutation AttachmentCreate \\{ attachmentCreate(input: \\{ issueId: "{linear_issue_id}", title: "PostHog issue", url: "{attachment_url}" }) \\{ success } }';
 
 query(attachment_mutation);`,
     inputs_schema: [


### PR DESCRIPTION
## Problem

Hog code is stripping the `\` when inserted from a template

## Changes

Escape the escaped character