### PR TITLE
fix(plugin-server): limits size of memory rate limiter Map

### DIFF
--- a/plugin-server/src/ingestion/utils/overflow-detector.test.ts
+++ b/plugin-server/src/ingestion/utils/overflow-detector.test.ts
@@ -12,7 +12,7 @@ describe('MemoryRateLimiter', () => {
         }
 
         beforeEach(() => {
-            limiter = new MemoryRateLimiter(10, 2)
+            limiter = new MemoryRateLimiter(10, 2, 1000)
             jest.useFakeTimers().setSystemTime(now)
         })
 
@@ -35,15 +35,41 @@ describe('MemoryRateLimiter', () => {
             expect(limiter.consume(key, 1)).toEqual(false)
 
             advanceTime(1)
-            // Now that we have advanced 1 second, we can consume 1 token
             expect(limiter.consume(key, 1)).toEqual(true)
         })
 
         it('consumes when tokens have been replenished with now argument', () => {
             limiter.consume(key, 10, now.valueOf())
             expect(limiter.consume(key, 1)).toEqual(false)
-            // Even though we are not advancing time, we are passing the time to use with now
             expect(limiter.consume(key, 1, now.valueOf() + 1000)).toEqual(true)
+        })
+
+        it('evicts oldest bucket when max buckets exceeded', () => {
+            const smallLimiter = new MemoryRateLimiter(10, 2, 2)
+
+            expect(smallLimiter.consume('key1', 5)).toEqual(true)
+            expect(smallLimiter.consume('key2', 5)).toEqual(true)
+            expect(smallLimiter.buckets.size).toEqual(2)
+
+            expect(smallLimiter.consume('key3', 5)).toEqual(true)
+            expect(smallLimiter.buckets.size).toEqual(2)
+            expect(smallLimiter.buckets.has('key1')).toEqual(false)
+            expect(smallLimiter.buckets.has('key2')).toEqual(true)
+            expect(smallLimiter.buckets.has('key3')).toEqual(true)
+        })
+
+        it('cache hits do not affect eviction order', () => {
+            const smallLimiter = new MemoryRateLimiter(10, 2, 2)
+
+            expect(smallLimiter.consume('key1', 5)).toEqual(true)
+            expect(smallLimiter.consume('key2', 5)).toEqual(true)
+
+            expect(smallLimiter.consume('key1', 1)).toEqual(true)
+
+            expect(smallLimiter.consume('key3', 5)).toEqual(true)
+            expect(smallLimiter.buckets.has('key1')).toEqual(false)
+            expect(smallLimiter.buckets.has('key2')).toEqual(true)
+            expect(smallLimiter.buckets.has('key3')).toEqual(true)
         })
     })
 })


### PR DESCRIPTION
## Problem

If a ingestion-consumer instance runs for long enough it can accumulate enough keys in the memory rate limiter map to breach the limit of entries into a Map.

## Changes

Uses Map's insertion order implementation to naively evict keys based on FIFO entry if we breach 10M entries into the rate limiter Map.

## How did you test this code?

Unit tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
