### PR TITLE
fix(plugin-server): awaits stopping process for rejections

### DIFF
--- a/plugin-server/src/server.ts
+++ b/plugin-server/src/server.ts
@@ -314,14 +314,14 @@ export class PluginServer {
             })
         }
 
-        process.on('unhandledRejection', (error: Error | any) => {
+        process.on('unhandledRejection', async (error: Error | any) => {
             logger.error('🤮', `Unhandled Promise Rejection`, { error: String(error) })
 
             captureException(error, {
                 extra: { detected_at: `pluginServer.ts on unhandledRejection` },
             })
 
-            void this.stop(error)
+            await this.stop(error)
         })
 
         process.on('uncaughtException', async (error: Error) => {


### PR DESCRIPTION
## Problem

Unhandled rejections did not await the stop process. I believe this could result in the process failing to shutdown if we keep triggering the stop with unhandled rejections over and over.

## Changes

Await the .stop process to ensure the process fully stops without getting interrupted

## How did you test this code?

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
