### PR TITLE
install some more required tools in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -69,5 +69,7 @@
         "ultram4rine.sqltools-clickhouse-driver"
     ],
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
-    "forwardPorts": [8000, 5432, 6379, 8123, 8234, 9000, 9092, 9440, 9009]
+    "forwardPorts": [8000, 5432, 6379, 8123, 8234, 9000, 9092, 9440, 9009],
+    // Install required tools after container creation
+    "postCreateCommand": "bash -c 'curl -LsSf https://astral.sh/uv/install.sh | sh && curl --proto \"=https\" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && source ~/.cargo/env && cargo install sqlx-cli mprocs'"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -71,5 +71,5 @@
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     "forwardPorts": [8000, 5432, 6379, 8123, 8234, 9000, 9092, 9440, 9009],
     // Install required tools after container creation
-    "postCreateCommand": "bash -c 'curl -LsSf https://astral.sh/uv/install.sh | sh && curl --proto \"=https\" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && source ~/.cargo/env && cargo install sqlx-cli mprocs'"
+    "postCreateCommand": "bash .devcontainer/post_create_command.sh"
 }

--- a/.devcontainer/post_create_command.sh
+++ b/.devcontainer/post_create_command.sh
@@ -26,4 +26,4 @@ cargo install sqlx-cli mprocs
 echo "✅ Rust tools installed"
 
 echo "🎉 PostHog development environment setup complete!"
-echo "💡 You can now run: ./ee/bin/docker-ch-dev-web"
+echo "💡 Continue steps here: https://posthog.com/handbook/engineering/developing-locally#option-1-developing-with-codespaces"

--- a/.devcontainer/post_create_command.sh
+++ b/.devcontainer/post_create_command.sh
@@ -6,7 +6,7 @@ echo "🚀 Setting up PostHog development environment..."
 # Install uv (Python package manager)
 echo "📦 Installing uv..."
 curl -LsSf https://astral.sh/uv/install.sh | sh
-source ~/.local/bin/env
+export PATH="$HOME/.local/bin:$PATH"
 echo "✅ uv installed"
 
 # Install uvicorn (ASGI server)

--- a/.devcontainer/post_create_command.sh
+++ b/.devcontainer/post_create_command.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+echo "🚀 Setting up PostHog development environment..."
+
+# Install uv (Python package manager)
+echo "📦 Installing uv..."
+curl -LsSf https://astral.sh/uv/install.sh | sh
+echo "✅ uv installed"
+
+# Install Rust toolchain
+echo "🦀 Installing Rust..."
+curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+source ~/.cargo/env
+echo "✅ Rust installed"
+
+# Install Rust tools
+echo "🔧 Installing Rust tools (sqlx-cli, mprocs)..."
+cargo install sqlx-cli mprocs
+echo "✅ Rust tools installed"
+
+echo "🎉 PostHog development environment setup complete!"
+echo "💡 You can now run: ./ee/bin/docker-ch-dev-web"

--- a/.devcontainer/post_create_command.sh
+++ b/.devcontainer/post_create_command.sh
@@ -6,7 +6,13 @@ echo "🚀 Setting up PostHog development environment..."
 # Install uv (Python package manager)
 echo "📦 Installing uv..."
 curl -LsSf https://astral.sh/uv/install.sh | sh
+source ~/.local/bin/env
 echo "✅ uv installed"
+
+# Install uvicorn (ASGI server)
+echo "🌐 Installing uvicorn..."
+uv tool install uvicorn
+echo "✅ uvicorn installed"
 
 # Install Rust toolchain
 echo "🦀 Installing Rust..."


### PR DESCRIPTION
## Problem

i _think_ not all required tools seem to be installed in the devcontainer when you try and use codespaces and follow instructions here - https://posthog.com/handbook/engineering/developing-locally#option-1-developing-with-codespaces

## Changes

- adds a `post_created_comand.sh` that installs the few things i found i had to manually install.
- ps maybe could have added them to the Dockerfile but wanted to make as minimal changes as possible.

## How did you test this code?

- spun up a gh codespaces on this branch and confirmed that i did not need to manually install the required tools
