### PR TITLE
addd temporal host environment to worker

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -209,6 +209,7 @@ services:
             PGPASSWORD: posthog
             DEPLOYMENT: hobby
             CDP_API_URL: 'http://plugins:6738'
+            TEMPORAL_HOST: temporal
 
     web:
         <<: *worker


### PR DESCRIPTION
## Problem

While running the service, the following error occurred:
RuntimeError: Failed client connect: Server connection error: tonic::transport::Error(Transport, ConnectError(ConnectError("tcp connect error", 127.0.0.1:7233, Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })))

After investigation, it turned out that the `TEMPORAL_HOST` environment variable was not set, which caused the connection to fail.

## Changes

- Added proper configuration for the `TEMPORAL_HOST` environment variable.  
- With this change, the client can connect to the server successfully.  

## How did you test this code?

- Reproduced the error by running the service without setting `TEMPORAL_HOST`.  
- Set the `TEMPORAL_HOST` environment variable and re-ran the service.  
- Verified that the connection was successful and the error was resolved.  
