### PR TITLE
feat(MA): adding redirect to settings if no sources are config

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
@@ -424,7 +424,7 @@ const MarketingDashboard = (): JSX.Element => {
         return (
             <>
                 {feedbackBanner}
-                <LemonBanner type="info">
+                <LemonBanner type="warning">
                     You need to configure your marketing data sources in the settings{' '}
                     <Link to={urls.settings('environment-marketing-analytics')}>here</Link>.
                 </LemonBanner>

--- a/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
@@ -19,6 +19,7 @@ import { IconOpenInNew, IconTableChart } from 'lib/lemon-ui/icons'
 import { FeatureFlagsSet, featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { isNotNil } from 'lib/utils'
 import { ProductIntentContext, addProductIntentForCrossSell } from 'lib/utils/product-intents'
+import { urls } from 'scenes/urls'
 import { PageReports, PageReportsFilters } from 'scenes/web-analytics/PageReports'
 import { WebAnalyticsHealthCheck } from 'scenes/web-analytics/WebAnalyticsHealthCheck'
 import { WebAnalyticsModal } from 'scenes/web-analytics/WebAnalyticsModal'
@@ -45,6 +46,7 @@ import { ProductKey } from '~/types'
 import { WebAnalyticsFilters } from './WebAnalyticsFilters'
 import { WebAnalyticsPageReportsCTA } from './WebAnalyticsPageReportsCTA'
 import { MarketingAnalyticsFilters } from './tabs/marketing-analytics/frontend/components/MarketingAnalyticsFilters/MarketingAnalyticsFilters'
+import { marketingAnalyticsLogic } from './tabs/marketing-analytics/frontend/logic/marketingAnalyticsLogic'
 import { webAnalyticsModalLogic } from './webAnalyticsModalLogic'
 
 export const Tiles = (props: { tiles?: WebAnalyticsTile[]; compact?: boolean }): JSX.Element => {
@@ -404,28 +406,48 @@ const MainContent = (): JSX.Element => {
 
 const MarketingDashboard = (): JSX.Element => {
     const { featureFlags } = useValues(featureFlagLogic)
+    const { createMarketingDataWarehouseNodes } = useValues(marketingAnalyticsLogic)
+
+    const feedbackBanner = (
+        <LemonBanner
+            type="info"
+            dismissKey="marketing-analytics-beta-banner"
+            className="mb-2 mt-4"
+            action={{ children: 'Send feedback', id: 'marketing-analytics-feedback-button' }}
+        >
+            Marketing analytics is in beta. Please let us know what you'd like to see here and/or report any issues
+            directly to us!
+        </LemonBanner>
+    )
+
+    if (createMarketingDataWarehouseNodes.length === 0) {
+        return (
+            <>
+                {feedbackBanner}
+                <LemonBanner type="info">
+                    You need to configure your marketing data sources in the settings{' '}
+                    <Link to={urls.settings('environment-marketing-analytics')}>here</Link>.
+                </LemonBanner>
+            </>
+        )
+    }
 
     if (!featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_MARKETING]) {
         // fallback in case the user is able to access the page but the feature flag is not enabled
         return (
-            <LemonBanner type="info">
-                You can enable marketing analytics in the feature preview settings{' '}
-                <Link to="https://app.posthog.com/settings/user-feature-previews#marketing-analytics">here</Link>.
-            </LemonBanner>
+            <>
+                {feedbackBanner}
+                <LemonBanner type="info">
+                    You can enable marketing analytics in the feature preview settings{' '}
+                    <Link to="https://app.posthog.com/settings/user-feature-previews#marketing-analytics">here</Link>.
+                </LemonBanner>
+            </>
         )
     }
 
     return (
         <>
-            <LemonBanner
-                type="info"
-                dismissKey="marketing-analytics-beta-banner"
-                className="mb-2 mt-4"
-                action={{ children: 'Send feedback', id: 'marketing-analytics-feedback-button' }}
-            >
-                Marketing analytics is in beta. Please let us know what you'd like to see here and/or report any issues
-                directly to us!
-            </LemonBanner>
+            {feedbackBanner}
             <Tiles />
         </>
     )

--- a/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
@@ -420,35 +420,32 @@ const MarketingDashboard = (): JSX.Element => {
         </LemonBanner>
     )
 
-    if (validExternalTables.length === 0 && validNativeSources.length === 0) {
-        return (
-            <>
-                {feedbackBanner}
-                <LemonBanner type="warning">
-                    You need to configure your marketing data sources in the settings{' '}
-                    <Link to={urls.settings('environment-marketing-analytics')}>here</Link>.
-                </LemonBanner>
-            </>
-        )
-    }
-
+    let component: JSX.Element | null = null
     if (!featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_MARKETING]) {
         // fallback in case the user is able to access the page but the feature flag is not enabled
-        return (
-            <>
-                {feedbackBanner}
-                <LemonBanner type="info">
-                    You can enable marketing analytics in the feature preview settings{' '}
-                    <Link to="https://app.posthog.com/settings/user-feature-previews#marketing-analytics">here</Link>.
-                </LemonBanner>
-            </>
+        component = (
+            <LemonBanner type="info">
+                You can enable marketing analytics in the feature preview settings{' '}
+                <Link to="https://app.posthog.com/settings/user-feature-previews#marketing-analytics">here</Link>.
+            </LemonBanner>
         )
+    } else if (validExternalTables.length === 0 && validNativeSources.length === 0) {
+        // if the user has no sources configured, show a warning instead of an empty state
+        component = (
+            <LemonBanner type="warning">
+                You need to configure your marketing data sources in the settings{' '}
+                <Link to={urls.settings('environment-marketing-analytics')}>here</Link>.
+            </LemonBanner>
+        )
+    } else {
+        // if the user has sources configured and the feature flag is enabled, show the tiles
+        component = <Tiles />
     }
 
     return (
         <>
             {feedbackBanner}
-            <Tiles />
+            {component}
         </>
     )
 }

--- a/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
@@ -406,7 +406,7 @@ const MainContent = (): JSX.Element => {
 
 const MarketingDashboard = (): JSX.Element => {
     const { featureFlags } = useValues(featureFlagLogic)
-    const { createMarketingDataWarehouseNodes } = useValues(marketingAnalyticsLogic)
+    const { validExternalTables, validNativeSources } = useValues(marketingAnalyticsLogic)
 
     const feedbackBanner = (
         <LemonBanner
@@ -420,7 +420,7 @@ const MarketingDashboard = (): JSX.Element => {
         </LemonBanner>
     )
 
-    if (createMarketingDataWarehouseNodes.length === 0) {
+    if (validExternalTables.length === 0 && validNativeSources.length === 0) {
         return (
             <>
                 {feedbackBanner}


### PR DESCRIPTION
## Problem

If there user doesn't have any source configured, we should an empty view without letting the user know that the reason is because there aren't any sources configured.

## Changes

We now show a redirect to make the user set up sources so he can actually do something and configured his sources to be able to see any marketing information.

## How did you test this code?
Manually:
<img width="1299" height="414" alt="image" src="https://github.com/user-attachments/assets/9732526c-069f-43c4-bf1e-fb5b373a46ab" />
