### PR TITLE
feat(web-analytics): Always show cookieless settings

### DIFF
--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -310,7 +310,6 @@ export const SETTINGS_MAP: SettingSection[] = [
                 id: 'cookieless-server-hash-mode',
                 title: 'Cookieless server hash mode',
                 component: <CookielessServerHashModeSetting />,
-                flag: 'IMPROVED_COOKIELESS_MODE',
             },
             {
                 id: 'bounce-rate-duration',


### PR DESCRIPTION
## Problem

We don't really need to have both a setting AND a feature flag. Let's always show this setting.

## Changes

Remove the setting

## How did you test this code?

n/a