### PR TITLE
chore(data-warehouse): Dont do a shutdown raise if we're resetting the pipeline

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -188,7 +188,11 @@ class PipelineNonDLT:
                 # Only raise if we're not running in descending order, otherwise we'll often not
                 # complete the job before the incremental value can be updated
                 # TODO: raise when we're within `x` time of the worker being forced to shutdown
-                if self._schema.should_use_incremental_field and self._resource.sort_mode != "desc":
+                if (
+                    self._schema.should_use_incremental_field
+                    and self._resource.sort_mode != "desc"
+                    and not self._reset_pipeline  # Raising during a full reset will reset our progress back to 0 rows
+                ):
                     self._shutdown_monitor.raise_if_is_worker_shutdown()
 
             if len(buffer) > 0:


### PR DESCRIPTION
## Problem
- We raise if the worker is shutting down to continue on a different worker, but this is super annoying if we're doing a full reset - it just means we start again from 0 rows and not actually continue

## Changes
- Don't raise when the worker is shutting down and we're in the middle of a reset pipeline sync

