### PR TITLE
chore: Replace KnisterPeter extension with GitHub Pull Requests extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -60,7 +60,7 @@
         "ms-azuretools.vscode-docker",
         "stkb.rewrap",
         "GitHub.copilot",
-        "KnisterPeter.vscode-github",
+        "GitHub.vscode-pull-request-github",
         "eamodio.gitlens",
         "wix.vscode-import-cost",
         "Orta.vscode-jest",


### PR DESCRIPTION
## Problem
[KnisterPeter](https://github.com/KnisterPeter/vscode-github) extension has been deprecated. It is recommended to use [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) instead 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Switched to the Dev Containers extension

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Opened the project in VS Code Dev Container and verified the installed extensions.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
