### PR TITLE
fix: filter out nulls from authorizedUrls

### DIFF
--- a/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
+++ b/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
@@ -286,11 +286,11 @@ export const authorizedUrlListLogic = kea<authorizedUrlListLogicType>([
     })),
     subscriptions(({ props, actions }) => ({
         currentTeam: (currentTeam) => {
-            actions.setAuthorizedUrls(
+            const urls =
                 (props.type === AuthorizedUrlListType.RECORDING_DOMAINS
                     ? currentTeam.recording_domains
                     : currentTeam.app_urls) || []
-            )
+            actions.setAuthorizedUrls(urls.filter(Boolean))
         },
     })),
     afterMount(({ actions }) => {


### PR DESCRIPTION
## Changes

- This is a follow up to #36901, which prevented nulls from getting added to `app_urls` and `recording_domains`
- There are still `posthog_team` rows where these columns include nulls so as a quick fix to unblock the users, this PR filters them out when setting `authorizedUrls`
- Removing null values from DB will follow as a separate PR

## How did you test this code?

Manually
