### PR TITLE
feat: adding timezone into insight footer

### DIFF
--- a/frontend/src/scenes/insights/views/CalendarHeatMap/TrendsCalendarHeatMap.tsx
+++ b/frontend/src/scenes/insights/views/CalendarHeatMap/TrendsCalendarHeatMap.tsx
@@ -1,8 +1,11 @@
 import { useValues } from 'kea'
 
-import { LemonBanner } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
 
+import { humanTzOffset } from 'lib/utils'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
 import { CalendarHeatMap } from 'scenes/web-analytics/CalendarHeatMap/CalendarHeatMap'
 
 import { ChartParams } from '~/types'
@@ -21,6 +24,7 @@ import {
 export function TrendsCalendarHeatMap(_props: ChartParams): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { processedData, rowLabels, columnLabels } = useValues(calendarHeatMapLogic(insightProps))
+    const { timezone } = useValues(teamLogic)
 
     return (
         <>
@@ -47,6 +51,20 @@ export function TrendsCalendarHeatMap(_props: ChartParams): JSX.Element {
                 showColumnAggregations={true}
                 showRowAggregations={true}
             />
+            <div className="flex items-center justify-center gap-2 text-muted text-xs mt-2">
+                <span>
+                    Data shown in timezone: {timezone.replace(/\//g, ' / ').replace(/_/g, ' ')} (
+                    {humanTzOffset(timezone)})
+                </span>
+                <LemonButton
+                    size="xsmall"
+                    type="tertiary"
+                    to={urls.settings('environment', 'date-and-time')}
+                    targetBlank={false}
+                >
+                    Change
+                </LemonButton>
+            </div>
         </>
     )
 }

--- a/frontend/src/scenes/insights/views/CalendarHeatMap/TrendsCalendarHeatMap.tsx
+++ b/frontend/src/scenes/insights/views/CalendarHeatMap/TrendsCalendarHeatMap.tsx
@@ -2,7 +2,8 @@ import { useValues } from 'kea'
 
 import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
 
-import { humanTzOffset } from 'lib/utils'
+import { dayjs } from 'lib/dayjs'
+import { timeZoneLabel } from 'lib/utils'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -25,6 +26,7 @@ export function TrendsCalendarHeatMap(_props: ChartParams): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { processedData, rowLabels, columnLabels } = useValues(calendarHeatMapLogic(insightProps))
     const { timezone } = useValues(teamLogic)
+    const offset = dayjs().tz(timezone).utcOffset() / 60
 
     return (
         <>
@@ -52,10 +54,7 @@ export function TrendsCalendarHeatMap(_props: ChartParams): JSX.Element {
                 showRowAggregations={true}
             />
             <div className="flex items-center justify-center gap-2 text-muted text-xs mt-2">
-                <span>
-                    Data shown in timezone: {timezone.replace(/\//g, ' / ').replace(/_/g, ' ')} (
-                    {humanTzOffset(timezone)})
-                </span>
+                <span>Data shown in timezone: {timeZoneLabel(timezone, offset)}</span>
                 <LemonButton
                     size="xsmall"
                     type="tertiary"


### PR DESCRIPTION
## Problem

We received user feedback to add the timezone in the insight itself

## Changes

We did that

## How did you test this code?
<img width="1216" height="438" alt="image" src="https://github.com/user-attachments/assets/5eeeaf44-883d-47a1-8820-1297af1e0f32" />
