### PR TITLE
fix(insight): Improve styling for `Save as static cohort` in new scene layout

### DIFF
--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -2,7 +2,7 @@ import { useActions, useMountedLogic, useValues } from 'kea'
 import { router } from 'kea-router'
 import { useState } from 'react'
 
-import { IconCode2, IconInfo, IconPencil, IconShare, IconTrash, IconWarning } from '@posthog/icons'
+import { IconCode2, IconInfo, IconPencil, IconPeople, IconShare, IconTrash, IconWarning } from '@posthog/icons'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { AddToDashboardModal } from 'lib/components/AddToDashboard/AddToDashboardModal'
@@ -490,7 +490,9 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                         },
                                     })
                                 }}
+                                menuItem
                             >
+                                <IconPeople />
                                 Save as static cohort
                             </ButtonPrimitive>
                         )}


### PR DESCRIPTION
## Problem

I believe this layout is a WIP and is hidden behind `FEATURE_FLAGS.NEW_SCENE_LAYOUT`

1) Missing icon
2) Button wasn't full width

<img width="1034" height="825" alt="Screenshot 2025-09-02 at 1 54 11 PM" src="https://github.com/user-attachments/assets/df45f46b-e3cc-4011-84b5-72b2b673cb46" />

## Changes

Updated the styling:

<img width="596" height="823" alt="Screenshot 2025-09-02 at 1 51 28 PM" src="https://github.com/user-attachments/assets/fb2ca85b-e539-4da3-8a59-1c2db3c7f67b" />



## How did you test this code?

Locally:

1) Make sure you have `FEATURE_FLAGS.NEW_SCENE_LAYOUT` turned on
2) Go to an insight 
3) Click on the triple dot in the insight header, top right.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
