### PR TITLE
fix: alias team_id in rows exported usage query

### DIFF
--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -56,6 +56,7 @@
                               e."$group_0" as aggregation_target,
                               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               person.person_props as person_props,
+                              person.pmat_email as pmat_email,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -79,6 +80,7 @@
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
                          (SELECT id,
+                                 argMax(pmat_email, version) as pmat_email,
                                  argMax(properties, version) as person_props
                           FROM person
                           WHERE team_id = 99999
@@ -95,7 +97,7 @@
                          AND event IN ['step one', 'step three', 'step two']
                          AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-10 23:59:59', 'UTC')
-                         AND ((replaceRegexpAll(JSONExtractRaw(person_props, 'email'), '^"|"$', '') ILIKE '%g0%'
+                         AND (("pmat_email" ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(e.properties, 'distinct_id'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(group_properties_0, 'name'), '^"|"$', '') ILIKE '%g0%'

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -11,7 +11,7 @@ from typing import Any, Literal, Optional, TypedDict, Union
 
 from django.conf import settings
 from django.db import connection
-from django.db.models import Count, Q, Sum
+from django.db.models import Count, F, Q, Sum
 
 import requests
 import structlog
@@ -943,7 +943,7 @@ def get_teams_with_rows_exported_in_period(begin: datetime, end: datetime) -> li
             batch_export__model=BatchExport.Model.EVENTS,
             batch_export__deleted=False,
         )
-        .values("batch_export__team_id")
+        .values(team_id=F("batch_export__team_id"))
         .annotate(total=Sum("records_completed"))
     )
 


### PR DESCRIPTION
## Problem

- Recently added `get_teams_with_rows_exported_in_period` returns dicts with `batch_export__team_id` key
- `convert_team_usage_rows_to_dict` expected `team_id` key or a tuple, causing [KeyError](https://us.posthog.com/project/2/error_tracking/01990940-477c-75a2-a2a9-d43a578c8a83?timestamp=2025-09-02%2000%3A07%3A10.872000-07%3A00) and leading usage reports runs to fail

## Changes

- Alias `batch_export__team_id` to `team_id` in the query

## How did you test this code?

- Added test