### PR TITLE
chore: add custom metrics to ingestion and shufflehog layers

### DIFF
--- a/posthog/clickhouse/custom_metrics.py
+++ b/posthog/clickhouse/custom_metrics.py
@@ -26,6 +26,14 @@ def CUSTOM_METRICS_VIEW(include_counters: bool = False) -> str:
     return statement
 
 
+def CUSTOM_METRICS_INGESTION_LAYER_VIEW():
+    return """
+    CREATE OR REPLACE VIEW custom_metrics
+    AS SELECT * REPLACE (toFloat64(value) as value)
+    FROM custom_metrics_test
+    """
+
+
 def CUSTOM_METRICS_REPLICATION_QUEUE_VIEW():
     return f"""
     CREATE OR REPLACE VIEW custom_metrics_replication_queue

--- a/posthog/clickhouse/migrations/0139_add_custom_metric_test_ingestion_layer.py
+++ b/posthog/clickhouse/migrations/0139_add_custom_metric_test_ingestion_layer.py
@@ -1,0 +1,10 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.clickhouse.custom_metrics import CUSTOM_METRICS_INGESTION_LAYER_VIEW
+
+operations = [
+    run_sql_with_exceptions(
+        CUSTOM_METRICS_INGESTION_LAYER_VIEW(),
+        node_roles=[NodeRole.INGESTION_EVENTS, NodeRole.SHUFFLEHOG],
+    ),
+]


### PR DESCRIPTION
## Problem

We want to find out if migrations are actually applied in those layers.

## Changes

Create one migration to add the custom metric test view.

## How did you test this code?

This is the test.

![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExajIzZm8za2VjOWNlaHlpYm1lMnp0bHNxNngyMzJ4cW5qMmVxcmFjMSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/kspVl6FzbdblOMKRmM/giphy.gif)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
