### PR TITLE
fix(data-warehouse): Fix zendesk full refresh ticket syncs

### DIFF
--- a/posthog/temporal/data_imports/sources/zendesk/zendesk.py
+++ b/posthog/temporal/data_imports/sources/zendesk/zendesk.py
@@ -196,9 +196,7 @@ def get_resource(name: str, should_use_incremental_field: bool) -> EndpointResou
                         "type": "incremental",
                         "cursor_path": "generated_timestamp",
                         "initial_value": 0,  # type: ignore
-                    }
-                    if should_use_incremental_field
-                    else None,
+                    },
                 },
             },
             "table_format": "delta",

--- a/posthog/temporal/tests/data_imports/conftest.py
+++ b/posthog/temporal/tests/data_imports/conftest.py
@@ -1277,6 +1277,7 @@ def zendesk_tickets():
             "next_page": "https://{subdomain}.zendesk.com/api/v2/incremental/tickets.json?per_page=3&start_time=1390362485",
             "tickets": [
                 {
+                    "generated_timestamp": 1,
                     "assignee_id": 235323,
                     "collaborator_ids": [
                         35334,


### PR DESCRIPTION
## Problem
- I think full refreshing `tickets` has been broken for a ... while?!

## Changes
- The tickets endpoint requires a `start_time` param, even if just set to 0