### PR TITLE
fix: endless loading in blobby v2

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -740,14 +740,19 @@ AND properties.$lib != 'web'`
         ],
 
         snapshotsLoading: [
-            (s) => [s.snapshotSourcesLoading, s.snapshotsForSourceLoading, s.featureFlags],
+            (s) => [s.snapshotSourcesLoading, s.snapshotsForSourceLoading, s.featureFlags, s.snapshots],
             (
                 snapshotSourcesLoading: boolean,
                 snapshotsForSourceLoading: boolean,
-                featureFlags: FeatureFlagsSet
+                featureFlags: FeatureFlagsSet,
+                snapshots: RecordingSnapshot[]
             ): boolean => {
                 // For v2 recordings, only show loading if we have no snapshots yet
                 if (featureFlags[FEATURE_FLAGS.RECORDINGS_BLOBBY_V2_REPLAY]) {
+                    if (snapshots?.length > 0) {
+                        return false
+                    }
+
                     return snapshotSourcesLoading || snapshotsForSourceLoading
                 }
 

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -747,13 +747,9 @@ AND properties.$lib != 'web'`
                 featureFlags: FeatureFlagsSet,
                 snapshots: RecordingSnapshot[]
             ): boolean => {
-                // For v2 recordings, only show loading if we have no snapshots yet
+                // For v2 recordings, only show loading if we have no snapshots AND we're actually loading something.
                 if (featureFlags[FEATURE_FLAGS.RECORDINGS_BLOBBY_V2_REPLAY]) {
-                    if (snapshots?.length > 0) {
-                        return false
-                    }
-
-                    return snapshotSourcesLoading || snapshotsForSourceLoading
+                    return snapshots?.length === 0 && (snapshotSourcesLoading || snapshotsForSourceLoading)
                 }
 
                 // Default behavior for non-v2 recordings


### PR DESCRIPTION
## Problem

1. V2 recordings have continuous polling for new sources
2. Every 10 seconds, loadSnapshotSources gets called again
3. This makes snapshotSourcesLoading become true again
4. Which makes snapshotsLoading become true again
5. Which makes fullyLoaded become false again
6. Export gets stuck in infinite loop waiting for fullyLoaded

Initially was done here: https://github.com/PostHog/posthog/pull/30031

but that broke shared recordings with endless "Buffering..." and was fixed here: https://github.com/PostHog/posthog/pull/36910

However, that broke export to json 🫠

Let's fix them all now.