### PR TITLE
feat(rust/common): support internal and external within same struct

### DIFF
--- a/rust/batch-import-worker/src/job/mod.rs
+++ b/rust/batch-import-worker/src/job/mod.rs
@@ -1,9 +1,9 @@
 use std::sync::{atomic::Ordering, Arc};
 
 use anyhow::{Context, Error};
+use common_types::CapturedEvent;
 
 use crate::metrics as metric_emit;
-use common_types::InternallyCapturedEvent;
 use model::{JobModel, JobState, PartState};
 use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
@@ -105,7 +105,7 @@ pub struct Job {
 
 struct Checkpoint {
     key: String,
-    data: Parsed<Vec<InternallyCapturedEvent>>,
+    data: Parsed<Vec<CapturedEvent>>,
 }
 
 impl Job {
@@ -308,9 +308,7 @@ impl Job {
         Ok(Some(self))
     }
 
-    async fn get_next_chunk(
-        &self,
-    ) -> Result<Option<(String, Parsed<Vec<InternallyCapturedEvent>>)>, Error> {
+    async fn get_next_chunk(&self) -> Result<Option<(String, Parsed<Vec<CapturedEvent>>)>, Error> {
         let mut state = self.state.lock().await;
 
         let Some(next_part) = state.parts.iter_mut().find(|p| !p.is_done()) else {

--- a/rust/batch-import-worker/src/parse/content/mod.rs
+++ b/rust/batch-import-worker/src/parse/content/mod.rs
@@ -17,7 +17,7 @@ pub enum ContentType {
     Captured, // Each json object structured as if it was going to be sent to the capture endpoint
 }
 
-// All /extra/ information needed to go from any input format to an InternallyCapturedEvent,
+// All /extra/ information needed to go from any input format to an CapturedEvent,
 // e.g. team_id
 #[derive(Debug, Clone)]
 pub struct TransformContext {

--- a/rust/batch-import-worker/src/parse/format.rs
+++ b/rust/batch-import-worker/src/parse/format.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, Error};
 use chrono::Duration;
-use common_types::{InternallyCapturedEvent, RawEvent};
+use common_types::{CapturedEvent, RawEvent};
 use rayon::iter::IntoParallelIterator;
 use rayon::prelude::*;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -26,8 +26,7 @@ pub enum FormatConfig {
     },
 }
 
-pub type ParserFn =
-    Box<dyn Fn(Vec<u8>) -> Result<Parsed<Vec<InternallyCapturedEvent>>, Error> + Send + Sync>;
+pub type ParserFn = Box<dyn Fn(Vec<u8>) -> Result<Parsed<Vec<CapturedEvent>>, Error> + Send + Sync>;
 
 impl FormatConfig {
     pub async fn get_parser(

--- a/rust/capture/src/sinks/fallback.rs
+++ b/rust/capture/src/sinks/fallback.rs
@@ -175,16 +175,16 @@ mod tests {
 
         // Create test event
         let event = ProcessedEvent {
-            event: CapturedEvent {
-                uuid: uuid_v7(),
-                distinct_id: "test_id".to_string(),
-                ip: "127.0.0.1".to_string(),
-                data: "test data".to_string(),
-                now: "2024-01-01T00:00:00Z".to_string(),
-                sent_at: None,
-                token: "test_token".to_string(),
-                is_cookieless_mode: false,
-            },
+            event: CapturedEvent::new_external(
+                uuid_v7(),
+                "test_id".to_string(),
+                "127.0.0.1".to_string(),
+                "test data".to_string(),
+                "2024-01-01T00:00:00Z".to_string(),
+                None,
+                "test_token".to_string(),
+                false,
+            ),
             metadata: ProcessedEventMetadata {
                 data_type: DataType::AnalyticsMain,
                 session_id: None,
@@ -212,16 +212,16 @@ mod tests {
 
         // Create test event
         let event = ProcessedEvent {
-            event: CapturedEvent {
-                uuid: uuid_v7(),
-                distinct_id: "test_id".to_string(),
-                ip: "127.0.0.1".to_string(),
-                data: "test data".to_string(),
-                now: "2024-01-01T00:00:00Z".to_string(),
-                sent_at: None,
-                token: "test_token".to_string(),
-                is_cookieless_mode: false,
-            },
+            event: CapturedEvent::new_external(
+                uuid_v7(),
+                "test_id".to_string(),
+                "127.0.0.1".to_string(),
+                "test data".to_string(),
+                "2024-01-01T00:00:00Z".to_string(),
+                None,
+                "test_token".to_string(),
+                false,
+            ),
             metadata: ProcessedEventMetadata {
                 data_type: DataType::AnalyticsMain,
                 session_id: None,

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -237,11 +237,11 @@ impl KafkaSink {
             CaptureError::NonRetryableSinkError
         })?;
 
-        let token = event.token.clone();
+        let token = event.token().to_string();
         let data_type = metadata.data_type;
         let event_key = event.key();
         let session_id = metadata.session_id.clone();
-        let distinct_id = event.distinct_id.clone();
+        let distinct_id = event.distinct_id().to_string();
 
         drop(event); // Events can be EXTREMELY memory hungry
 
@@ -479,16 +479,16 @@ mod tests {
 
         let (cluster, sink) = start_on_mocked_sink(Some(3000000)).await;
         let distinct_id = "test_distinct_id_123".to_string();
-        let event: CapturedEvent = CapturedEvent {
-            uuid: uuid_v7(),
-            distinct_id: distinct_id.clone(),
-            ip: "".to_string(),
-            data: "".to_string(),
-            now: "".to_string(),
-            sent_at: None,
-            token: "token1".to_string(),
-            is_cookieless_mode: false,
-        };
+        let event = CapturedEvent::new_external(
+            uuid_v7(),
+            distinct_id.clone(),
+            "".to_string(),
+            "".to_string(),
+            "".to_string(),
+            None,
+            "token1".to_string(),
+            false,
+        );
 
         let metadata = ProcessedEventMetadata {
             data_type: DataType::AnalyticsMain,
@@ -521,16 +521,16 @@ mod tests {
             .take(2_000_000)
             .map(char::from)
             .collect();
-        let captured = CapturedEvent {
-            uuid: uuid_v7(),
-            distinct_id: "id1".to_string(),
-            ip: "".to_string(),
-            data: big_data,
-            now: "".to_string(),
-            sent_at: None,
-            token: "token1".to_string(),
-            is_cookieless_mode: false,
-        };
+        let captured = CapturedEvent::new_external(
+            uuid_v7(),
+            "id1".to_string(),
+            "".to_string(),
+            big_data,
+            "".to_string(),
+            None,
+            "token1".to_string(),
+            false,
+        );
 
         let big_event = ProcessedEvent {
             event: captured,
@@ -549,16 +549,16 @@ mod tests {
             .collect();
 
         let big_event = ProcessedEvent {
-            event: CapturedEvent {
-                uuid: uuid_v7(),
-                distinct_id: "id1".to_string(),
-                ip: "".to_string(),
-                data: big_data,
-                now: "".to_string(),
-                sent_at: None,
-                token: "token1".to_string(),
-                is_cookieless_mode: false,
-            },
+            event: CapturedEvent::new_external(
+                uuid_v7(),
+                "id1".to_string(),
+                "".to_string(),
+                big_data,
+                "".to_string(),
+                None,
+                "token1".to_string(),
+                false,
+            ),
             metadata: metadata.clone(),
         };
 

--- a/rust/capture/src/sinks/s3.rs
+++ b/rust/capture/src/sinks/s3.rs
@@ -317,16 +317,16 @@ mod tests {
 
     fn create_test_event() -> ProcessedEvent {
         ProcessedEvent {
-            event: CapturedEvent {
-                uuid: uuid_v7(),
-                distinct_id: "test_id".to_string(),
-                ip: "127.0.0.1".to_string(),
-                data: "test data".to_string(),
-                now: "2024-01-01T00:00:00Z".to_string(),
-                sent_at: None,
-                token: "test_token".to_string(),
-                is_cookieless_mode: false,
-            },
+            event: CapturedEvent::new_external(
+                uuid_v7(),
+                "test_id".to_string(),
+                "127.0.0.1".to_string(),
+                "test data".to_string(),
+                "2024-01-01T00:00:00Z".to_string(),
+                None,
+                "test_token".to_string(),
+                false,
+            ),
             metadata: ProcessedEventMetadata {
                 data_type: DataType::AnalyticsMain,
                 session_id: None,
@@ -356,10 +356,16 @@ mod tests {
         // Create event that will exceed MAX_BUFFER_SIZE
         let large_data = "x".repeat(MAX_BUFFER_SIZE + 1000);
         let event = ProcessedEvent {
-            event: CapturedEvent {
-                data: large_data,
-                ..create_test_event().event
-            },
+            event: CapturedEvent::new_external(
+                uuid_v7(),
+                "test_id".to_string(),
+                "127.0.0.1".to_string(),
+                large_data,
+                "2024-01-01T00:00:00Z".to_string(),
+                None,
+                "test_token".to_string(),
+                false,
+            ),
             metadata: create_test_event().metadata,
         };
 

--- a/rust/capture/tests/common/integration_utils.rs
+++ b/rust/capture/tests/common/integration_utils.rs
@@ -354,36 +354,39 @@ pub fn validate_single_event_payload(title: &str, got_events: Vec<ProcessedEvent
     // introspect on extracted event attributes
     let event = &got.event;
     assert_eq!(
-        "phc_VXRzc3poSG9GZm1JenRianJ6TTJFZGh4OWY2QXzx9f3", &event.token,
+        "phc_VXRzc3poSG9GZm1JenRianJ6TTJFZGh4OWY2QXzx9f3",
+        event.token(),
         "mismatched token in case: {title}",
     );
     assert_eq!(
-        "019833ae-4913-7179-b6bc-019570abb1c9", &event.distinct_id,
+        "019833ae-4913-7179-b6bc-019570abb1c9",
+        event.distinct_id(),
         "mismatched distinct_id in case: {title}",
     );
     assert_eq!(
-        DEFAULT_TEST_TIME, &event.now,
+        DEFAULT_TEST_TIME,
+        event.now(),
         "mismatched 'now' timestamp in case: {title}",
     );
     assert_eq!(
         36_usize,
-        event.uuid.to_string().len(),
+        event.uuid().to_string().len(),
         "invalid UUID in case: {title}",
     );
 
     assert_eq!(
         Some(expected_timestamp),
-        event.sent_at,
+        event.sent_at(),
         "mismatched sent_at in case: {title}",
     );
     assert!(
-        !event.is_cookieless_mode,
+        !event.is_cookieless_mode(),
         "mismatched cookieless flag in case: {title}",
     );
 
     // introspect on event data to be processed by plugin-server
     let event_data_err_msg = format!("failed to hydrate test event.data in case: {title}");
-    let event: Value = from_str(&event.data).expect(&event_data_err_msg);
+    let event: Value = from_str(event.data()).expect(&event_data_err_msg);
 
     assert_eq!(
         "$autocapture",
@@ -470,36 +473,39 @@ pub fn validate_single_engage_event_payload(title: &str, got_events: Vec<Process
     // introspect on extracted event attributes
     let event = &got.event;
     assert_eq!(
-        "phc_VXRzc3poSG9GZm1JenRiZnJ6TTJFZGh4OWY2QXzx9f3", &event.token,
+        "phc_VXRzc3poSG9GZm1JenRiZnJ6TTJFZGh4OWY2QXzx9f3",
+        event.token(),
         "mismatched token in case: {title}",
     );
     assert_eq!(
-        "known_user@example.com", &event.distinct_id,
+        "known_user@example.com",
+        event.distinct_id(),
         "mismatched distinct_id in case: {title}",
     );
     assert_eq!(
-        DEFAULT_TEST_TIME, &event.now,
+        DEFAULT_TEST_TIME,
+        event.now(),
         "mismatched 'now' timestamp in case: {title}",
     );
     assert_eq!(
         36_usize,
-        event.uuid.to_string().len(),
+        event.uuid().to_string().len(),
         "invalid UUID in case: {title}",
     );
 
     assert_eq!(
         Some(expected_timestamp),
-        event.sent_at,
+        event.sent_at(),
         "mismatched sent_at in case: {title}",
     );
     assert!(
-        !event.is_cookieless_mode,
+        !event.is_cookieless_mode(),
         "mismatched cookieless flag in case: {title}",
     );
 
     // introspect on event data to be processed by plugin-server
     let event_data_err_msg = format!("failed to hydrate test event.data in case: {title}");
-    let event: Value = from_str(&event.data).expect(&event_data_err_msg);
+    let event: Value = from_str(event.data()).expect(&event_data_err_msg);
 
     // /engage/ events get post-processed into "$identify" events
     assert_eq!(
@@ -578,33 +584,36 @@ pub fn validate_single_replay_event_payload(title: &str, got_events: Vec<Process
     // introspect on extracted event attributes
     let event = &got.event;
     assert_eq!(
-        "phc_VXRzc3poSG9GZm1JenRianJ6TTJFZGh4OWY2QXzx9f3", &event.token,
+        "phc_VXRzc3poSG9GZm1JenRianJ6TTJFZGh4OWY2QXzx9f3",
+        event.token(),
         "mismatched token in case: {title}",
     );
     assert_eq!(
-        "01983d90-510c-7970-a356-ecd2aa03cb22", &event.distinct_id,
+        "01983d90-510c-7970-a356-ecd2aa03cb22",
+        event.distinct_id(),
         "mismatched distinct_id in case: {title}",
     );
 
     assert_eq!(
-        DEFAULT_TEST_TIME, &event.now,
+        DEFAULT_TEST_TIME,
+        event.now(),
         "mismatched 'now' timestamp in case: {title}",
     );
     assert_eq!(
         36_usize,
-        event.uuid.to_string().len(),
+        event.uuid().to_string().len(),
         "invalid UUID in case: {title}",
     );
 
     assert_eq!(
         Some(expected_timestamp),
-        event.sent_at,
+        event.sent_at(),
         "mismatched sent_at in case: {title}",
     );
 
     // introspect on event data to be processed by plugin-server
     let event_data_err_msg = format!("failed to hydrate test event.data in case: {title}");
-    let event: Value = from_str(&event.data).expect(&event_data_err_msg);
+    let event: Value = from_str(event.data()).expect(&event_data_err_msg);
 
     assert_eq!(
         "$snapshot_items",
@@ -701,37 +710,40 @@ pub fn validate_batch_events_payload(title: &str, got_events: Vec<ProcessedEvent
     // introspect on extracted event attributes
     let event = &pageview.event;
     assert_eq!(
-        "phc_VXRzc3poSG9GZm1JenRianJ6TTJFZGh4OWY2QXzx9f3", &event.token,
+        "phc_VXRzc3poSG9GZm1JenRianJ6TTJFZGh4OWY2QXzx9f3",
+        event.token(),
         "mismatched token on $pageview in case: {title}",
     );
     assert_eq!(
-        "someone@example.com", &event.distinct_id,
+        "someone@example.com",
+        event.distinct_id(),
         "mismatched distinct_id on $pageview in case: {title}",
     );
     assert_eq!(
-        DEFAULT_TEST_TIME, &event.now,
+        DEFAULT_TEST_TIME,
+        event.now(),
         "mismatched 'now' timestamp $pageview in case: {title}",
     );
     assert_eq!(
         36_usize,
-        event.uuid.to_string().len(),
+        event.uuid().to_string().len(),
         "invalid UUID on $pageview in case: {title}",
     );
 
     assert_eq!(
         Some(expected_timestamp),
-        event.sent_at,
+        event.sent_at(),
         "mismatched sent_at on $pageview in case: {title}",
     );
     assert!(
-        !event.is_cookieless_mode,
+        !event.is_cookieless_mode(),
         "mismatched cookieless flag on $pageview in case: {title}",
     );
 
     // introspect on event data to be processed by plugin-server
     let event_data_err_msg =
         format!("failed to hydrate test $pageview event.data in case: {title}");
-    let event: Value = from_str(&event.data).expect(&event_data_err_msg);
+    let event: Value = from_str(event.data()).expect(&event_data_err_msg);
 
     assert_eq!(
         "$pageview",
@@ -821,37 +833,40 @@ pub fn validate_batch_events_payload(title: &str, got_events: Vec<ProcessedEvent
     // introspect on extracted event attributes
     let event = &pageleave.event;
     assert_eq!(
-        "phc_VXRzc3poSG9GZm1JenRianJ6TTJFZGh4OWY2QXzx9f3", &event.token,
+        "phc_VXRzc3poSG9GZm1JenRianJ6TTJFZGh4OWY2QXzx9f3",
+        event.token(),
         "mismatched token on $pageleave in case: {title}",
     );
     assert_eq!(
-        "someone@example.com", &event.distinct_id,
+        "someone@example.com",
+        event.distinct_id(),
         "mismatched distinct_id on $pageleave in case: {title}",
     );
     assert_eq!(
-        DEFAULT_TEST_TIME, &event.now,
+        DEFAULT_TEST_TIME,
+        event.now(),
         "mismatched 'now' timestamp $pageleave in case: {title}",
     );
     assert_eq!(
         36_usize,
-        event.uuid.to_string().len(),
+        event.uuid().to_string().len(),
         "invalid UUID on $pageleave in case: {title}",
     );
 
     assert_eq!(
         Some(expected_timestamp),
-        event.sent_at,
+        event.sent_at(),
         "mismatched sent_at on $pageleave in case: {title}",
     );
     assert!(
-        !event.is_cookieless_mode,
+        !event.is_cookieless_mode(),
         "mismatched cookieless flag on $pageleave in case: {title}",
     );
 
     // introspect on event data to be processed by plugin-server
     let event_data_err_msg =
         format!("failed to hydrate test $pageleave event.data in case: {title}");
-    let event: Value = from_str(&event.data).expect(&event_data_err_msg);
+    let event: Value = from_str(event.data()).expect(&event_data_err_msg);
 
     assert_eq!(
         "$pageleave",

--- a/rust/capture/tests/limiters.rs
+++ b/rust/capture/tests/limiters.rs
@@ -216,7 +216,7 @@ async fn test_billing_limit_retains_only_exception_events() {
     assert_eq!(captured_events.len(), 2);
 
     // Parse the event data to check the event name
-    let event_data: Value = serde_json::from_str(&captured_events[0].event.data).unwrap();
+    let event_data: Value = serde_json::from_str(captured_events[0].event.data()).unwrap();
     assert_eq!(event_data["event"], "$exception");
 }
 
@@ -274,7 +274,7 @@ async fn test_no_billing_limit_retains_all_events() {
     let event_names: Vec<String> = captured_events
         .iter()
         .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
+            let event_data: Value = serde_json::from_str(e.event.data()).unwrap();
             event_data["event"].as_str().unwrap().to_string()
         })
         .collect();
@@ -325,7 +325,7 @@ async fn test_billing_limit_on_i_endpoint() {
     let event_names: Vec<String> = captured_events
         .iter()
         .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
+            let event_data: Value = serde_json::from_str(e.event.data()).unwrap();
             event_data["event"].as_str().unwrap().to_string()
         })
         .collect();
@@ -373,7 +373,7 @@ async fn test_survey_quota_limit_filters_only_survey_events() {
     let event_names: Vec<String> = captured_events
         .iter()
         .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
+            let event_data: Value = serde_json::from_str(e.event.data()).unwrap();
             event_data["event"].as_str().unwrap().to_string()
         })
         .collect();
@@ -416,7 +416,7 @@ async fn test_survey_quota_limit_returns_error_when_only_survey_events() {
     let event_names: Vec<String> = captured_events
         .iter()
         .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
+            let event_data: Value = serde_json::from_str(e.event.data()).unwrap();
             event_data["event"].as_str().unwrap().to_string()
         })
         .collect();
@@ -454,7 +454,7 @@ async fn test_survey_quota_limit_allows_survey_events_when_not_limited() {
     let event_names: Vec<String> = captured_events
         .iter()
         .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
+            let event_data: Value = serde_json::from_str(e.event.data()).unwrap();
             event_data["event"].as_str().unwrap().to_string()
         })
         .collect();
@@ -492,7 +492,7 @@ async fn test_survey_quota_limit_ignores_non_survey_events() {
     let event_names: Vec<String> = captured_events
         .iter()
         .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
+            let event_data: Value = serde_json::from_str(e.event.data()).unwrap();
             event_data["event"].as_str().unwrap().to_string()
         })
         .collect();
@@ -535,7 +535,7 @@ async fn test_both_billing_and_survey_limits_applied() {
     let captured_events = sink.events();
     assert_eq!(captured_events.len(), 1);
 
-    let event_data: Value = serde_json::from_str(&captured_events[0].event.data).unwrap();
+    let event_data: Value = serde_json::from_str(captured_events[0].event.data()).unwrap();
     assert_eq!(event_data["event"], "$exception");
 }
 
@@ -607,7 +607,7 @@ async fn test_survey_quota_groups_events_by_submission_id() {
     let captured_events = sink.events();
     assert_eq!(captured_events.len(), 1);
 
-    let event_data: Value = serde_json::from_str(&captured_events[0].event.data).unwrap();
+    let event_data: Value = serde_json::from_str(captured_events[0].event.data()).unwrap();
     assert_eq!(event_data["event"], "pageview");
 }
 
@@ -641,7 +641,7 @@ async fn test_survey_quota_handles_multiple_submission_groups() {
     let captured_events = sink.events();
     assert_eq!(captured_events.len(), 1);
 
-    let event_data: Value = serde_json::from_str(&captured_events[0].event.data).unwrap();
+    let event_data: Value = serde_json::from_str(captured_events[0].event.data()).unwrap();
     assert_eq!(event_data["event"], "click");
 }
 
@@ -676,7 +676,7 @@ async fn test_survey_quota_backward_compatibility_without_submission_id() {
     let event_names: Vec<String> = captured_events
         .iter()
         .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
+            let event_data: Value = serde_json::from_str(e.event.data()).unwrap();
             event_data["event"].as_str().unwrap().to_string()
         })
         .collect();
@@ -719,7 +719,7 @@ async fn test_survey_quota_mixed_with_and_without_submission_id() {
     let captured_events = sink.events();
     assert_eq!(captured_events.len(), 1);
 
-    let event_data: Value = serde_json::from_str(&captured_events[0].event.data).unwrap();
+    let event_data: Value = serde_json::from_str(captured_events[0].event.data()).unwrap();
     assert_eq!(event_data["event"], "custom_event");
 }
 
@@ -772,7 +772,7 @@ async fn test_survey_quota_empty_submission_id_treated_as_none() {
     let captured_events = sink.events();
     assert_eq!(captured_events.len(), 1);
 
-    let event_data: Value = serde_json::from_str(&captured_events[0].event.data).unwrap();
+    let event_data: Value = serde_json::from_str(captured_events[0].event.data()).unwrap();
     assert_eq!(event_data["event"], "pageview");
 }
 
@@ -808,7 +808,7 @@ async fn test_survey_quota_allows_events_when_not_limited() {
     let event_names: Vec<String> = captured_events
         .iter()
         .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
+            let event_data: Value = serde_json::from_str(e.event.data()).unwrap();
             event_data["event"].as_str().unwrap().to_string()
         })
         .collect();
@@ -914,7 +914,7 @@ async fn test_survey_quota_cross_batch_first_submission_allowed() {
     let captured_events = sink.events();
     assert_eq!(captured_events.len(), 1); // Only pageview should remain
 
-    let event_data: Value = serde_json::from_str(&captured_events[0].event.data).unwrap();
+    let event_data: Value = serde_json::from_str(captured_events[0].event.data()).unwrap();
     assert_eq!(event_data["event"], "pageview");
 }
 
@@ -1011,7 +1011,7 @@ async fn test_survey_quota_cross_batch_duplicate_submission_dropped() {
     let captured_events = sink.events();
     assert_eq!(captured_events.len(), 1);
 
-    let event_data: Value = serde_json::from_str(&captured_events[0].event.data).unwrap();
+    let event_data: Value = serde_json::from_str(captured_events[0].event.data()).unwrap();
     assert_eq!(event_data["event"], "click");
 }
 
@@ -1111,7 +1111,7 @@ async fn test_survey_quota_cross_batch_redis_error_fail_open() {
     let captured_events = sink.events();
     assert_eq!(captured_events.len(), 1);
 
-    let event_data: Value = serde_json::from_str(&captured_events[0].event.data).unwrap();
+    let event_data: Value = serde_json::from_str(captured_events[0].event.data()).unwrap();
     assert_eq!(event_data["event"], "pageview");
 }
 
@@ -1147,7 +1147,7 @@ async fn test_survey_quota_only_limits_survey_sent_events() {
     let event_names: Vec<String> = captured_events
         .iter()
         .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
+            let event_data: Value = serde_json::from_str(e.event.data()).unwrap();
             event_data["event"].as_str().unwrap().to_string()
         })
         .collect();
@@ -1193,7 +1193,7 @@ async fn test_survey_quota_backward_compatibility_survey_sent_only() {
     let event_names: Vec<String> = captured_events
         .iter()
         .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
+            let event_data: Value = serde_json::from_str(e.event.data()).unwrap();
             event_data["event"].as_str().unwrap().to_string()
         })
         .collect();
@@ -1247,7 +1247,7 @@ async fn test_ai_events_quota_limit_filters_only_ai_events() {
     let event_names: Vec<String> = events
         .iter()
         .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
+            let event_data: Value = serde_json::from_str(e.event.data()).unwrap();
             event_data["event"].as_str().unwrap().to_string()
         })
         .collect();
@@ -1313,7 +1313,7 @@ async fn test_ai_events_quota_allows_ai_events_when_not_limited() {
     let event_names: Vec<String> = events
         .iter()
         .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
+            let event_data: Value = serde_json::from_str(e.event.data()).unwrap();
             event_data["event"].as_str().unwrap().to_string()
         })
         .collect();
@@ -1386,7 +1386,7 @@ async fn test_both_billing_and_ai_limits_applied() {
     let event_names: Vec<String> = events
         .iter()
         .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
+            let event_data: Value = serde_json::from_str(e.event.data()).unwrap();
             event_data["event"].as_str().unwrap().to_string()
         })
         .collect();
@@ -1428,7 +1428,7 @@ async fn test_ai_and_survey_limits_interaction() {
     let event_names: Vec<String> = events
         .iter()
         .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
+            let event_data: Value = serde_json::from_str(e.event.data()).unwrap();
             event_data["event"].as_str().unwrap().to_string()
         })
         .collect();
@@ -1469,7 +1469,7 @@ async fn test_all_three_limits_applied() {
     let event_names: Vec<String> = events
         .iter()
         .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
+            let event_data: Value = serde_json::from_str(e.event.data()).unwrap();
             event_data["event"].as_str().unwrap().to_string()
         })
         .collect();
@@ -1524,7 +1524,7 @@ async fn test_ai_event_name_detection() {
         if should_be_filtered {
             // AI event should be filtered, only pageview remains
             assert_eq!(events.len(), 1, "Event '{event_name}' should be filtered");
-            let event_data: Value = serde_json::from_str(&events[0].event.data).unwrap();
+            let event_data: Value = serde_json::from_str(events[0].event.data()).unwrap();
             assert_eq!(event_data["event"], "pageview");
         } else {
             // Non-AI event should pass through with pageview
@@ -1604,7 +1604,7 @@ async fn test_ai_span_event_limited() {
 
     let events = sink.events();
     assert_eq!(events.len(), 1);
-    let event_data: Value = serde_json::from_str(&events[0].event.data).unwrap();
+    let event_data: Value = serde_json::from_str(events[0].event.data()).unwrap();
     assert_eq!(event_data["event"], "custom");
 }
 
@@ -1639,7 +1639,7 @@ async fn test_ai_trace_event_limited() {
 
     let events = sink.events();
     assert_eq!(events.len(), 1);
-    let event_data: Value = serde_json::from_str(&events[0].event.data).unwrap();
+    let event_data: Value = serde_json::from_str(events[0].event.data()).unwrap();
     assert_eq!(event_data["event"], "$autocapture");
 }
 
@@ -1671,7 +1671,7 @@ async fn test_custom_ai_prefixed_events_limited() {
 
     let events = sink.events();
     assert_eq!(events.len(), 1); // Only non-AI event should pass
-    let event_data: Value = serde_json::from_str(&events[0].event.data).unwrap();
+    let event_data: Value = serde_json::from_str(events[0].event.data()).unwrap();
     assert_eq!(event_data["event"], "non_ai_event");
 }
 
@@ -1791,7 +1791,7 @@ async fn test_ai_quota_cross_batch_redis_error_fail_open() {
     // So AI event should be dropped, only pageview remains
     let events = sink.events();
     assert_eq!(events.len(), 1);
-    let event_data: Value = serde_json::from_str(&events[0].event.data).unwrap();
+    let event_data: Value = serde_json::from_str(events[0].event.data()).unwrap();
     assert_eq!(event_data["event"], "pageview");
 }
 
@@ -1844,7 +1844,7 @@ async fn test_ai_quota_cross_batch_consistency() {
     let event_names: Vec<String> = events
         .iter()
         .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
+            let event_data: Value = serde_json::from_str(e.event.data()).unwrap();
             event_data["event"].as_str().unwrap().to_string()
         })
         .collect();
@@ -1892,7 +1892,7 @@ async fn test_ai_quota_all_ai_event_types_count() {
     let event_names: Vec<String> = events
         .iter()
         .map(|e| {
-            let event_data: Value = serde_json::from_str(&e.event.data).unwrap();
+            let event_data: Value = serde_json::from_str(e.event.data()).unwrap();
             event_data["event"].as_str().unwrap().to_string()
         })
         .collect();

--- a/rust/common/types/src/lib.rs
+++ b/rust/common/types/src/lib.rs
@@ -5,7 +5,6 @@ mod team;
 // Events
 pub use event::CapturedEvent;
 pub use event::ClickHouseEvent;
-pub use event::InternallyCapturedEvent;
 pub use event::PersonMode;
 pub use event::RawEngageEvent;
 pub use event::RawEvent;

--- a/rust/cymbal/src/pipeline/billing.rs
+++ b/rust/cymbal/src/pipeline/billing.rs
@@ -21,8 +21,8 @@ pub async fn apply_billing_limits(
             continue;
         };
 
-        if context.billing_limiter.is_limited(&e.token).await {
-            info!("Dropped event for {}", &e.token);
+        if context.billing_limiter.is_limited(e.token()).await {
+            info!("Dropped event for {}", &e.token());
             continue;
         }
         out.push(IncomingEvent::Captured(e));

--- a/rust/cymbal/src/teams.rs
+++ b/rust/cymbal/src/teams.rs
@@ -129,16 +129,12 @@ pub async fn do_team_lookups(
             continue; // We don't need to look up teams that already have a team_id
         };
 
-        if team_lookups.contains_key(&event.token) {
-            team_lookups
-                .get_mut(&event.token)
-                .unwrap()
-                .indices
-                .push(index);
+        let token = sanitize_string(event.token().to_string());
+
+        if team_lookups.contains_key(&token) {
+            team_lookups.get_mut(&token).unwrap().indices.push(index);
             continue;
         }
-
-        let token = sanitize_string(event.token.clone());
 
         let m_ctx = context.clone();
         let m_token = token.clone();

--- a/rust/kafka-deduplicator/src/deduplication_processor.rs
+++ b/rust/kafka-deduplicator/src/deduplication_processor.rs
@@ -246,7 +246,7 @@ impl MessageProcessor for DeduplicationProcessor {
         let raw_event = match serde_json::from_slice::<CapturedEvent>(payload) {
             Ok(captured_event) => {
                 // The RawEvent is serialized in the data field
-                match serde_json::from_str::<RawEvent>(&captured_event.data) {
+                match serde_json::from_str::<RawEvent>(captured_event.data()) {
                     Ok(raw_event) => raw_event,
                     Err(e) => {
                         error!(

--- a/rust/kafka-deduplicator/tests/deduplication_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/deduplication_integration_tests.rs
@@ -87,16 +87,16 @@ fn create_test_captured_event(
     let data = serde_json::to_string(&raw_event)?;
 
     // Create the CapturedEvent wrapper
-    let captured_event = CapturedEvent {
+    let captured_event = CapturedEvent::new_external(
         uuid,
-        distinct_id: distinct_id.to_string(),
-        ip: "127.0.0.1".to_string(),
+        distinct_id.to_string(),
+        "127.0.0.1".to_string(),
         data,
-        now: format!("{timestamp}000"), // timestamp in milliseconds
-        sent_at: None,
-        token: "test_token".to_string(),
-        is_cookieless_mode: false,
-    };
+        format!("{timestamp}000"), // timestamp in milliseconds
+        None,
+        "test_token".to_string(),
+        false,
+    );
 
     Ok(captured_event)
 }


### PR DESCRIPTION
## Problem

If a rust service is reading from the ingestion-events topic it can be hard to parse events as they could be both internally captured and external events, which have different schemas. This PR leverages `serde::untagged` to support sequential schema deserialization under the same Enum.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
