### PR TITLE
fix(devex): avoid extra actions

### DIFF
--- a/frontend/src/lib/KeaDevTools.tsx
+++ b/frontend/src/lib/KeaDevTools.tsx
@@ -1176,6 +1176,8 @@ function ActionsTab({
     onClear: () => void
 }): JSX.Element {
     const [q, setQ] = useState('')
+    const [expanded, setExpanded] = useState<Set<number>>(new Set())
+
     const filtered = useMemo(() => {
         const s = q.trim().toLowerCase()
         if (!s) {
@@ -1187,6 +1189,35 @@ function ActionsTab({
                 (typeof a.payload === 'string' && a.payload.toLowerCase().includes(s))
         )
     }, [actions, q])
+
+    const toggleExpanded = (id: number): void => {
+        setExpanded((prev) => {
+            const next = new Set(prev)
+            if (next.has(id)) {
+                next.delete(id)
+            } else {
+                next.add(id)
+            }
+            return next
+        })
+    }
+
+    const oneLine = (x: unknown): string => {
+        try {
+            // compact JSON to a single line; do not add ellipsis here
+            return JSON.stringify(x)
+        } catch {
+            return String(x)
+        }
+    }
+
+    const pretty = (x: unknown): string => {
+        try {
+            return JSON.stringify(x, null, 2)
+        } catch {
+            return String(x)
+        }
+    }
 
     return (
         <div style={{ display: 'flex', flexDirection: 'column', minHeight: 0, gap: 8, padding: 10, flex: 1 }}>
@@ -1205,6 +1236,7 @@ function ActionsTab({
                     Clear
                 </button>
             </div>
+
             <div
                 style={{
                     flex: 1,
@@ -1217,49 +1249,101 @@ function ActionsTab({
                 {filtered.length === 0 ? (
                     <div style={{ padding: 12, color: 'rgba(0,0,0,0.6)' }}>No actions yet.</div>
                 ) : (
-                    <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
-                        {filtered
-                            .slice()
-                            .reverse()
-                            .map((a) => (
-                                <li
-                                    key={a.id}
-                                    style={{ borderBottom: '1px solid rgba(0,0,0,0.05)', padding: '10px 12px' }}
+                    <table style={{ width: '100%', borderCollapse: 'collapse', tableLayout: 'fixed' }}>
+                        <thead style={{ position: 'sticky', top: 0, background: '#fafafa', zIndex: 1 }}>
+                            <tr>
+                                <th
+                                    style={{
+                                        textAlign: 'left',
+                                        padding: '10px 12px',
+                                        borderBottom: '1px solid rgba(0,0,0,0.06)',
+                                        width: '40%',
+                                    }}
                                 >
-                                    <div style={{ display: 'flex', gap: 8, alignItems: 'baseline' }}>
-                                        <code
-                                            style={{
-                                                fontWeight: 700,
-                                                fontFamily:
-                                                    'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
-                                            }}
-                                        >
-                                            {a.type}
-                                        </code>
-                                        <span
-                                            style={{
-                                                color: 'rgba(0,0,0,0.5)',
-                                                fontSize: 12,
-                                            }}
-                                        >
-                                            {new Date(a.ts).toLocaleTimeString()}
-                                        </span>
-                                    </div>
-                                    {a.payload !== undefined ? (
-                                        <pre
-                                            style={{
-                                                margin: '6px 0 0',
-                                                whiteSpace: 'pre-wrap',
-                                                fontFamily:
-                                                    'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
-                                            }}
-                                        >
-                                            {compactJSON(a.payload)}
-                                        </pre>
-                                    ) : null}
-                                </li>
-                            ))}
-                    </ul>
+                                    Action • Date
+                                </th>
+                                <th
+                                    style={{
+                                        textAlign: 'left',
+                                        padding: '10px 12px',
+                                        borderBottom: '1px solid rgba(0,0,0,0.06)',
+                                    }}
+                                >
+                                    Payload
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {filtered
+                                .slice()
+                                .reverse()
+                                .map((a) => {
+                                    const isOpen = expanded.has(a.id)
+                                    return (
+                                        <tr key={a.id} style={{ borderBottom: '1px solid rgba(0,0,0,0.05)' }}>
+                                            {/* Left cell: action + time below (no truncation) */}
+                                            <td style={{ padding: '10px 12px', verticalAlign: 'top' }}>
+                                                <div>
+                                                    <code
+                                                        style={{
+                                                            fontWeight: 700,
+                                                            fontFamily:
+                                                                'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+                                                            wordBreak: 'break-word',
+                                                        }}
+                                                    >
+                                                        {a.type}
+                                                    </code>
+                                                </div>
+                                                <div
+                                                    style={{
+                                                        marginTop: 4,
+                                                        color: 'rgba(0,0,0,0.6)',
+                                                        fontSize: 12,
+                                                    }}
+                                                    title={new Date(a.ts).toISOString()}
+                                                >
+                                                    {new Date(a.ts).toLocaleString()}
+                                                </div>
+                                            </td>
+
+                                            {/* Right cell: payload one-line unless expanded */}
+                                            <td style={{ padding: '10px 12px', verticalAlign: 'top' }}>
+                                                <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start' }}>
+                                                    <div
+                                                        style={{
+                                                            flex: 1,
+                                                            // one line by default; no truncation requested for left column only,
+                                                            // right column remains single-line unless expanded:
+                                                            whiteSpace: isOpen ? 'pre-wrap' : 'nowrap',
+                                                            overflow: isOpen ? 'visible' : 'hidden',
+                                                            textOverflow: isOpen ? 'clip' : 'ellipsis',
+                                                            wordBreak: isOpen ? 'break-word' : 'normal',
+                                                            fontFamily:
+                                                                'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+                                                        }}
+                                                    >
+                                                        {a.payload === undefined
+                                                            ? '—'
+                                                            : isOpen
+                                                              ? pretty(a.payload)
+                                                              : oneLine(a.payload)}
+                                                    </div>
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => toggleExpanded(a.id)}
+                                                        style={simpleBtnStyle}
+                                                        title={isOpen ? 'Collapse payload' : 'Expand payload'}
+                                                    >
+                                                        {isOpen ? 'Collapse' : 'Expand'}
+                                                    </button>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    )
+                                })}
+                        </tbody>
+                    </table>
                 )}
             </div>
         </div>

--- a/frontend/src/lib/components/CommandBar/CommandBar.tsx
+++ b/frontend/src/lib/components/CommandBar/CommandBar.tsx
@@ -42,7 +42,15 @@ export function CommandBar(): JSX.Element | null {
     const { barStatus } = useValues(commandBarLogic)
     const { hideCommandBar } = useActions(commandBarLogic)
 
-    useOutsideClickHandler([containerRef], hideCommandBar, [])
+    useOutsideClickHandler(
+        [containerRef],
+        () => {
+            if (barStatus !== BarStatus.HIDDEN) {
+                hideCommandBar()
+            }
+        },
+        [barStatus]
+    )
 
     if (barStatus === BarStatus.HIDDEN) {
         return null

--- a/frontend/src/scenes/billing/billingLogic.tsx
+++ b/frontend/src/scenes/billing/billingLogic.tsx
@@ -151,8 +151,8 @@ export const billingLogic = kea<billingLogicType>([
         reportBillingShown: true,
         registerInstrumentationProps: true,
         reportCreditsCTAShown: (creditOverview: any) => ({ creditOverview }),
-        setRedirectPath: true,
-        setIsOnboarding: true,
+        setRedirectPath: (redirectPath: string) => ({ redirectPath }),
+        setIsOnboarding: (isOnboarding: boolean) => ({ isOnboarding }),
         determineBillingAlert: true,
         setUnsubscribeError: (error: null | UnsubscribeError) => ({ error }),
         resetUnsubscribeError: true,
@@ -212,17 +212,13 @@ export const billingLogic = kea<billingLogicType>([
         redirectPath: [
             '' as string,
             {
-                setRedirectPath: () => {
-                    return window.location.pathname.includes('/onboarding')
-                        ? window.location.pathname + window.location.search
-                        : ''
-                },
+                setRedirectPath: (_, { redirectPath }) => redirectPath,
             },
         ],
         isOnboarding: [
             false,
             {
-                setIsOnboarding: () => window.location.pathname.includes('/onboarding'),
+                setIsOnboarding: (_, { isOnboarding }) => isOnboarding,
             },
         ],
         unsubscribeError: [
@@ -902,7 +898,7 @@ export const billingLogic = kea<billingLogicType>([
             })
         },
     })),
-    urlToAction(({ actions }) => ({
+    urlToAction(({ actions, values }) => ({
         // IMPORTANT: This needs to be above the "*" so it takes precedence
         '/*/billing': (_params, _search, hash) => {
             if (hash.license) {
@@ -923,12 +919,28 @@ export const billingLogic = kea<billingLogicType>([
                 })
             }
 
-            actions.setRedirectPath()
-            actions.setIsOnboarding()
+            const redirectPath = window.location.pathname.includes('/onboarding')
+                ? window.location.pathname + window.location.search
+                : ''
+            if (values.redirectPath !== redirectPath) {
+                actions.setRedirectPath(redirectPath)
+            }
+            const isOnboarding = window.location.pathname.includes('/onboarding')
+            if (values.isOnboarding !== isOnboarding) {
+                actions.setIsOnboarding(isOnboarding)
+            }
         },
         '*': () => {
-            actions.setRedirectPath()
-            actions.setIsOnboarding()
+            const redirectPath = window.location.pathname.includes('/onboarding')
+                ? window.location.pathname + window.location.search
+                : ''
+            if (values.redirectPath !== redirectPath) {
+                actions.setRedirectPath(redirectPath)
+            }
+            const isOnboarding = window.location.pathname.includes('/onboarding')
+            if (values.isOnboarding !== isOnboarding) {
+                actions.setIsOnboarding(isOnboarding)
+            }
         },
     })),
 ])


### PR DESCRIPTION
## Problem

We had a lot of noise in Kea's actions panel. Every click or pageview would trigger some noise from `commandBarLogic`, and every pageview would have `billingLogic` fire things.

## Changes

- Add "if" statements before the actions in `commandBarLogic` and `billingLogic` to trigger them only if we need to
- Update the devtools to make the actions page a bit nicer (two columns)

<img width="1728" height="1037" alt="image" src="https://github.com/user-attachments/assets/c786f28a-0277-486b-b96a-beace690db97" />

## How did you test this code?

Clicked around...