### PR TITLE
chore: downgrade local dev to 25.6 to be consistent

### DIFF
--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -45,21 +45,21 @@ runs:
 
               while [ $attempt -le $max_attempts ]; do
                   echo "Attempt $attempt of $max_attempts to start stack..."
-                  
+
                   if docker compose -f docker-compose.dev.yml down && \
                      docker compose -f docker-compose.dev.yml up -d; then
                       echo "Stack started successfully"
                       exit 0
                   fi
-                  
+
                   echo "Failed to start stack on attempt $attempt"
-                  
+
                   if [ $attempt -lt $max_attempts ]; then
                       sleep_time=$((delay * 2 ** (attempt - 1)))
                       echo "Waiting ${sleep_time} seconds before retry..."
                       sleep $sleep_time
                   fi
-                  
+
                   attempt=$((attempt + 1))
               done
 
@@ -235,7 +235,7 @@ runs:
 
         - name: Upload updated timing data as artifacts
           uses: actions/upload-artifact@v4
-          if: ${{ inputs.person-on-events != 'true' && inputs.clickhouse-server-image == 'clickhouse/clickhouse-server:25.7.4.11' }}
+          if: ${{ inputs.person-on-events != 'true' && inputs.clickhouse-server-image == 'clickhouse/clickhouse-server:25.6.9.98' }}
           with:
               name: timing_data-${{ inputs.segment }}-${{ inputs.group }}
               path: .test_durations

--- a/.github/workflows/ci-backend-update-test-timing.yml
+++ b/.github/workflows/ci-backend-update-test-timing.yml
@@ -29,13 +29,13 @@ jobs:
                   group: 1
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
                   python-version: '3.11.9'
-                  clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                  clickhouse-server-image: 'clickhouse/clickhouse-server:25.6.9.98'
                   segment: 'FOSS'
                   person-on-events: false
 
             - name: Upload updated timing data as artifacts
               uses: actions/upload-artifact@v4
-              if: ${{ inputs.person-on-events != 'true' && inputs.clickhouse-server-image == 'clickhouse/clickhouse-server:25.7.4.11' }}
+              if: ${{ inputs.person-on-events != 'true' && inputs.clickhouse-server-image == 'clickhouse/clickhouse-server:25.6.9.98' }}
               with:
                   name: timing_data-${{ inputs.segment }}-${{ inputs.group }}
                   path: .test_durations

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -250,7 +250,7 @@ jobs:
             fail-fast: false
             matrix:
                 python-version: ['3.11.9']
-                clickhouse-server-image: ['clickhouse/clickhouse-server:25.7.4.11']
+                clickhouse-server-image: ['clickhouse/clickhouse-server:25.6.9.98']
                 segment: ['Core']
                 person-on-events: [false]
                 # :NOTE: Keep concurrency and groups in sync
@@ -301,121 +301,121 @@ jobs:
                 include:
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.6.9.98'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 1
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.6.9.98'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 2
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.6.9.98'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 3
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.6.9.98'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 4
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.6.9.98'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 5
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.6.9.98'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 6
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.6.9.98'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 7
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.6.9.98'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 8
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.6.9.98'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 9
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.6.9.98'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 10
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.6.9.98'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 1
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.6.9.98'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 2
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.6.9.98'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 3
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.6.9.98'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 4
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.6.9.98'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 5
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.6.9.98'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 6
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.6.9.98'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 7
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.6.9.98'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 8
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.6.9.98'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 9
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.7.4.11'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.6.9.98'
                       python-version: '3.11.9'
                       concurrency: 10
                       group: 10
@@ -687,7 +687,7 @@ jobs:
 
             - name: Upload updated timing data as artifacts
               uses: actions/upload-artifact@v4
-              if: ${{ needs.changes.outputs.backend == 'true' && !matrix.person-on-events && matrix.clickhouse-server-image == 'clickhouse/clickhouse-server:25.7.4.11' }}
+              if: ${{ needs.changes.outputs.backend == 'true' && !matrix.person-on-events && matrix.clickhouse-server-image == 'clickhouse/clickhouse-server:25.6.9.98' }}
               with:
                   name: timing_data-${{ matrix.segment }}-${{ matrix.group }}
                   path: .test_durations
@@ -753,7 +753,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                clickhouse-server-image: ['clickhouse/clickhouse-server:25.7.4.11']
+                clickhouse-server-image: ['clickhouse/clickhouse-server:25.6.9.98']
         if: needs.changes.outputs.backend == 'true'
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -63,7 +63,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                clickhouse-server-image: ['clickhouse/clickhouse-server:25.7.4.11']
+                clickhouse-server-image: ['clickhouse/clickhouse-server:25.6.9.98']
         if: needs.changes.outputs.dagster == 'true'
         runs-on: depot-ubuntu-latest
         steps:

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -272,7 +272,7 @@ jobs:
               if: needs.changes.outputs.shouldRun == 'true'
               shell: bash
               run: |
-                  export CLICKHOUSE_SERVER_IMAGE=clickhouse/clickhouse-server:25.7.4.11
+                  export CLICKHOUSE_SERVER_IMAGE=clickhouse/clickhouse-server:25.6.9.98
                   export DOCKER_REGISTRY_PREFIX="us-east1-docker.pkg.dev/posthog-301601/mirror/"
                   cp posthog/user_scripts/latest_user_defined_function.xml docker/clickhouse/user_defined_function.xml
 

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -113,7 +113,7 @@ services:
         # Note: please keep the default version in sync across
         #       `posthog` and the `charts-clickhouse` repos
         #
-        image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:25.7.4.11}
+        image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:25.6.9.98}
         restart: on-failure
         environment:
             CLICKHOUSE_SKIP_USER_SETUP: 1


### PR DESCRIPTION
## Problem

Our curent version of ch has quite a few bugs and the version running on local and CI is not the version running in prod. We need to pile all of these onto one version 25.6.9.98

## Changes

Update CH versions to 25.6.9.98


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
