### PR TITLE
fix(data-warehouse): Use deltaLake ch function for getting table columns

### DIFF
--- a/posthog/warehouse/models/table.py
+++ b/posthog/warehouse/models/table.py
@@ -164,7 +164,9 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
         placeholder_context = HogQLContext(team_id=self.team.pk)
         s3_table_func = build_function_call(
             url=self.url_pattern,
-            format=self.format,
+            format="Delta"  # Use deltaLake() to get table schema for evolved tables
+            if self.format == "DeltaS3Wrapper"
+            else self.format,
             access_key=self.credential.access_key,
             access_secret=self.credential.access_secret,
             context=placeholder_context,

--- a/products/marketing_analytics/backend/hogql_queries/__snapshots__/test_marketing_analytics_table_query_runner_business.ambr
+++ b/products/marketing_analytics/backend/hogql_queries/__snapshots__/test_marketing_analytics_table_query_runner_business.ambr
@@ -262,6 +262,20 @@
       FROM
               (
       SELECT
+                  toString(campaign3) AS campaign,
+                  toString(source3) AS source,
+                  toFloat(coalesce(impressions3, 0)) AS impressions,
+                  toFloat(coalesce(clicks3, 0)) AS clicks,
+                  toFloat(convertCurrency('USD', 'USD', toFloat(coalesce(spend3, 0)))) AS cost
+              
+      FROM
+                  `bigquery.posthog_test.posthog_test_linkedin_ads_table` AS posthog_test_linkedin_ads_table
+              
+      WHERE
+                  and(greaterOrEquals(toDateTime(date3), toDateTime('2024-01-01 00:00:00')), lessOrEquals(toDateTime(date3), toDateTime('2024-12-31 23:59:59')))
+              UNION ALL
+              
+      SELECT
                   toString(campaign1) AS campaign,
                   toString(source1) AS source,
                   toFloat(coalesce(impressions1, 0)) AS impressions,
@@ -286,21 +300,7 @@
                   `bigquery.posthog_test.posthog_test_tiktok_ads_table` AS posthog_test_tiktok_ads_table
               
       WHERE
-                  and(greaterOrEquals(toDateTime(date2), toDateTime('2024-01-01 00:00:00')), lessOrEquals(toDateTime(date2), toDateTime('2024-12-31 23:59:59')))
-              UNION ALL
-              
-      SELECT
-                  toString(campaign3) AS campaign,
-                  toString(source3) AS source,
-                  toFloat(coalesce(impressions3, 0)) AS impressions,
-                  toFloat(coalesce(clicks3, 0)) AS clicks,
-                  toFloat(convertCurrency('USD', 'USD', toFloat(coalesce(spend3, 0)))) AS cost
-              
-      FROM
-                  `bigquery.posthog_test.posthog_test_linkedin_ads_table` AS posthog_test_linkedin_ads_table
-              
-      WHERE
-                  and(greaterOrEquals(toDateTime(date3), toDateTime('2024-01-01 00:00:00')), lessOrEquals(toDateTime(date3), toDateTime('2024-12-31 23:59:59'))))
+                  and(greaterOrEquals(toDateTime(date2), toDateTime('2024-01-01 00:00:00')), lessOrEquals(toDateTime(date2), toDateTime('2024-12-31 23:59:59'))))
           
       GROUP BY
               campaign,

--- a/products/marketing_analytics/backend/hogql_queries/__snapshots__/test_marketing_analytics_table_query_runner_business.ambr
+++ b/products/marketing_analytics/backend/hogql_queries/__snapshots__/test_marketing_analytics_table_query_runner_business.ambr
@@ -262,20 +262,6 @@
       FROM
               (
       SELECT
-                  toString(campaign3) AS campaign,
-                  toString(source3) AS source,
-                  toFloat(coalesce(impressions3, 0)) AS impressions,
-                  toFloat(coalesce(clicks3, 0)) AS clicks,
-                  toFloat(convertCurrency('USD', 'USD', toFloat(coalesce(spend3, 0)))) AS cost
-              
-      FROM
-                  `bigquery.posthog_test.posthog_test_linkedin_ads_table` AS posthog_test_linkedin_ads_table
-              
-      WHERE
-                  and(greaterOrEquals(toDateTime(date3), toDateTime('2024-01-01 00:00:00')), lessOrEquals(toDateTime(date3), toDateTime('2024-12-31 23:59:59')))
-              UNION ALL
-              
-      SELECT
                   toString(campaign1) AS campaign,
                   toString(source1) AS source,
                   toFloat(coalesce(impressions1, 0)) AS impressions,
@@ -300,7 +286,21 @@
                   `bigquery.posthog_test.posthog_test_tiktok_ads_table` AS posthog_test_tiktok_ads_table
               
       WHERE
-                  and(greaterOrEquals(toDateTime(date2), toDateTime('2024-01-01 00:00:00')), lessOrEquals(toDateTime(date2), toDateTime('2024-12-31 23:59:59'))))
+                  and(greaterOrEquals(toDateTime(date2), toDateTime('2024-01-01 00:00:00')), lessOrEquals(toDateTime(date2), toDateTime('2024-12-31 23:59:59')))
+              UNION ALL
+              
+      SELECT
+                  toString(campaign3) AS campaign,
+                  toString(source3) AS source,
+                  toFloat(coalesce(impressions3, 0)) AS impressions,
+                  toFloat(coalesce(clicks3, 0)) AS clicks,
+                  toFloat(convertCurrency('USD', 'USD', toFloat(coalesce(spend3, 0)))) AS cost
+              
+      FROM
+                  `bigquery.posthog_test.posthog_test_linkedin_ads_table` AS posthog_test_linkedin_ads_table
+              
+      WHERE
+                  and(greaterOrEquals(toDateTime(date3), toDateTime('2024-01-01 00:00:00')), lessOrEquals(toDateTime(date3), toDateTime('2024-12-31 23:59:59'))))
           
       GROUP BY
               campaign,


### PR DESCRIPTION
## Problem
- If a warehouse tables schema evolves on incremental syncs, the earlier parquet files will have missing columns
- when running a `describe table` query, it seems like clickhouse is only reading the first parquet file it sees and returns the structure of this - causing columns to be missing

## Changes
- Read the table structure via querying the `deltaLake` table directly - it takes into account the whole table structure
- We're using `chdb` for this still, so no concerns on the impact on the cluster. Looks like the query performance goes from <1 second to 2-3 secs, but thats fine

## How did you test this code?
Tested this locally 