### PR TITLE
feat: Validate batch export destination config in API

### DIFF
--- a/posthog/api/test/batch_exports/test_create.py
+++ b/posthog/api/test/batch_exports/test_create.py
@@ -626,7 +626,7 @@ def test_create_s3_batch_export_validates_file_format_and_compression(
     ],
 )
 def test_create_batch_export_with_invalid_config(client: HttpClient, temporal, type, config, expected_error_message):
-    """Test creating a BatchExport with Snowflake destination validates credentials based on auth type."""
+    """Test creating a BatchExport with an invalid configuration returns an error."""
 
     destination_data = {
         "type": type,

--- a/posthog/api/test/batch_exports/test_create.py
+++ b/posthog/api/test/batch_exports/test_create.py
@@ -567,3 +567,89 @@ def test_create_s3_batch_export_validates_file_format_and_compression(
         else:
             assert response.status_code == status.HTTP_400_BAD_REQUEST
             assert response.json()["detail"] == expected_error_message
+
+
+@pytest.mark.parametrize(
+    "type,config,expected_error_message",
+    [
+        (
+            "Snowflake",
+            {
+                "account": "my-account",
+                "user": "user",
+                "database": "my-db",
+                "warehouse": "COMPUTE_WH",
+                "schema": "public",
+                "table_name": 2,  # Wrong type
+                "authentication_type": "keypair",
+                "private_key": "SECRET_KEY",
+            },
+            "invalid type: got 'int', expected 'str'",
+        ),
+        (
+            "S3",
+            {
+                "bucket_name": "my-s3-bucket",
+                "region": "us-east-1",
+                "prefix": "posthog-events/",
+                "aws_access_key_id": "abc123",
+                "aws_secret_access_key": "secret",
+                "hello": 123,  # Unknown field
+                "hello2": 123,  # Another unknown field
+            },
+            "unknown field/s: 'hello', 'hello2'",
+        ),
+        (
+            "Postgres",
+            {
+                "user": "test",
+                "password": "password",
+                "host": "host",
+                "database": "db",
+                "schema": None,  # Not optional
+                "table_name": "test",
+            },
+            "invalid type: got 'NoneType', expected 'str'",
+        ),
+        (
+            "BigQuery",
+            {
+                "project_id": "test",
+                # Missing required `dataset_id`
+                "private_key": "pkey",
+                "private_key_id": "pkey_id",
+                "token_uri": "token",
+                "client_email": "email",
+            },
+            "missing required field: 'dataset_id'",
+        ),
+    ],
+)
+def test_create_batch_export_with_invalid_config(client: HttpClient, temporal, type, config, expected_error_message):
+    """Test creating a BatchExport with Snowflake destination validates credentials based on auth type."""
+
+    destination_data = {
+        "type": type,
+        "config": config,
+    }
+
+    batch_export_data = {
+        "name": "destination",
+        "destination": destination_data,
+        "interval": "hour",
+    }
+
+    organization = create_organization("Test Org")
+    team = create_team(organization)
+    user = create_user("test@user.com", "Test User", organization)
+    client.force_login(user)
+
+    with start_test_worker(temporal):
+        response = create_batch_export(
+            client,
+            team.pk,
+            batch_export_data,
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert expected_error_message in response.json()["detail"]

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -209,7 +209,9 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
         workflow_fields = dataclasses.fields(workflow_inputs)
         destination_fields = {field for field in workflow_fields if field.name not in base_field_names}
 
-        extra_fields = config.keys() - {field.name for field in destination_fields}
+        extra_fields = {k for k in config.keys() if not k.startswith("destination__")} - {
+            field.name for field in destination_fields
+        }
         if extra_fields:
             str_fields = ", ".join(f"'{extra_field}'" for extra_field in extra_fields)
             raise serializers.ValidationError(f"Configuration has unknown field/s: {str_fields}")

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -213,7 +213,7 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
             field.name for field in destination_fields
         }
         if extra_fields:
-            str_fields = ", ".join(f"'{extra_field}'" for extra_field in extra_fields)
+            str_fields = ", ".join(f"'{extra_field}'" for extra_field in sorted(extra_fields))
             raise serializers.ValidationError(f"Configuration has unknown field/s: {str_fields}")
 
         for destination_field in destination_fields:

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -189,7 +189,6 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data: collections.abc.Mapping[str, typing.Any]) -> BatchExportDestination:
         """Create a BatchExportDestination."""
-        self.create_validate(validated_data)
         export_destination = BatchExportDestination.objects.create(**validated_data)
         return export_destination
 

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -223,7 +223,7 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
                 if is_required and self.instance is None:
                     # Required fields may be missing when patching an existing instance,
                     # (i.e. when `self.instance is not None`). So, when an existing
-                    # instance exists, we allow required fails to be missing.
+                    # instance exists, we allow required fields to be missing.
                     raise serializers.ValidationError(
                         f"Configuration missing required field: '{destination_field.name}'"
                     )

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -211,7 +211,7 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
 
         extra_fields = config.keys() - {field.name for field in destination_fields} - base_field_names
         if extra_fields:
-            str_fields = ", ".join(f"'{extra_field}'" for extra_field in extra_fields)
+            str_fields = ", ".join(f"'{extra_field}'" for extra_field in sorted(extra_fields))
             raise serializers.ValidationError(f"Configuration has unknown field/s: {str_fields}")
 
         for destination_field in destination_fields:

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -209,11 +209,9 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
         workflow_fields = dataclasses.fields(workflow_inputs)
         destination_fields = {field for field in workflow_fields if field.name not in base_field_names}
 
-        extra_fields = {k for k in config.keys() if not k.startswith("destination__")} - {
-            field.name for field in destination_fields
-        }
+        extra_fields = config.keys() - {field.name for field in destination_fields} - base_field_names
         if extra_fields:
-            str_fields = ", ".join(f"'{extra_field}'" for extra_field in sorted(extra_fields))
+            str_fields = ", ".join(f"'{extra_field}'" for extra_field in extra_fields)
             raise serializers.ValidationError(f"Configuration has unknown field/s: {str_fields}")
 
         for destination_field in destination_fields:

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -221,9 +221,9 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
             )
             if destination_field.name not in config:
                 if is_required and self.instance is None:
-                    # `self.instance is None` checks that we are creating a new instance
                     # Required fields may be missing when patching an existing instance,
-                    # so we omit this check.
+                    # (i.e. when `self.instance is not None`). So, when an existing
+                    # instance exists, we allow required fails to be missing.
                     raise serializers.ValidationError(
                         f"Configuration missing required field: '{destination_field.name}'"
                     )

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -220,7 +220,10 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
                 and destination_field.default_factory == dataclasses.MISSING
             )
             if destination_field.name not in config:
-                if is_required:
+                if is_required and self.instance is None:
+                    # `self.instance is None` checks that we are creating a new instance
+                    # Required fields may be missing when patching an existing instance,
+                    # so we omit this check.
                     raise serializers.ValidationError(
                         f"Configuration missing required field: '{destination_field.name}'"
                     )

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -220,7 +220,10 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
                 and destination_field.default_factory == dataclasses.MISSING
             )
             if destination_field.name not in config:
-                if is_required:
+                is_patch = self.context["request"].method == "PATCH"
+                if is_required and not is_patch:
+                    # When patching we expect a partial configuration. So, we don't
+                    # error on missing required fields.
                     raise serializers.ValidationError(
                         f"Configuration missing required field: '{destination_field.name}'"
                     )

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -189,10 +189,13 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data: dict) -> BatchExportDestination:
         """Create a BatchExportDestination."""
+        validated_data = self.create_validate(validated_data)
         export_destination = BatchExportDestination.objects.create(**validated_data)
         return export_destination
 
-    def validate(self, data: collections.abc.Mapping[str, typing.Any]) -> collections.abc.Mapping[str, typing.Any]:
+    def create_validate(
+        self, data: collections.abc.Mapping[str, typing.Any]
+    ) -> collections.abc.Mapping[str, typing.Any]:
         """Validate the destination configuration based on workflow inputs.
 
         Ensure that the submitted destination configuration passes the following checks:
@@ -220,10 +223,7 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
                 and destination_field.default_factory == dataclasses.MISSING
             )
             if destination_field.name not in config:
-                if is_required and self.instance is None:
-                    # Required fields may be missing when patching an existing instance,
-                    # (i.e. when `self.instance is not None`). So, when an existing
-                    # instance exists, we allow required fields to be missing.
+                if is_required:
                     raise serializers.ValidationError(
                         f"Configuration missing required field: '{destination_field.name}'"
                     )


### PR DESCRIPTION
## Problem

We do not validate the destination configuration when using the API. This can lead to incorrect values being inputted if users call the API directly.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Added `validate` method to check provided configuration on creating a `BatchExportDestination` to ensure the keys and types in the configuration match those required by the batch export workflow inputs.

If any of the checks fail, a `ValidationError` is raised with a message indicating what went wrong.

I have also updated the `run_test_step` method to run the serializer validate with the full request data + data from an existing destination. These two configs were already mixed after the validation ran, but now we need them mixed first so that the validation of the destination config can pass.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Added a unit test.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
