### PR TITLE
feat: added CH migration to enable TTL on session replay tables

### DIFF
--- a/posthog/clickhouse/migrations/0140_session_replay_events_add_ttl.py
+++ b/posthog/clickhouse/migrations/0140_session_replay_events_add_ttl.py
@@ -15,8 +15,10 @@ operations = [
     run_sql_with_exceptions(DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL(on_cluster=False)),
     run_sql_with_exceptions(DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL(on_cluster=False)),
     # alter the target tables
-    run_sql_with_exceptions(SET_TTL_ONLY_DROP_PARTS_SESSION_REPLAY_EVENTS_TABLE_SQL(), sharded=True),
-    run_sql_with_exceptions(ADD_TTL_SESSION_REPLAY_EVENTS_TABLE_SQL(), sharded=True),
+    run_sql_with_exceptions(
+        SET_TTL_ONLY_DROP_PARTS_SESSION_REPLAY_EVENTS_TABLE_SQL(), sharded=True, is_alter_on_replicated_table=True
+    ),
+    run_sql_with_exceptions(ADD_TTL_SESSION_REPLAY_EVENTS_TABLE_SQL(), sharded=True, is_alter_on_replicated_table=True),
     # and then recreate the materialized views and kafka tables
     run_sql_with_exceptions(KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL(on_cluster=False)),
     run_sql_with_exceptions(SESSION_REPLAY_EVENTS_TABLE_MV_SQL(on_cluster=False)),

--- a/posthog/clickhouse/migrations/0140_session_replay_events_add_ttl.py
+++ b/posthog/clickhouse/migrations/0140_session_replay_events_add_ttl.py
@@ -1,3 +1,4 @@
+from posthog.clickhouse.client.connection import NodeRole
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
 from posthog.session_recordings.sql.session_replay_event_migrations_sql import (
     ADD_TTL_SESSION_REPLAY_EVENTS_TABLE_SQL,
@@ -12,14 +13,22 @@ from posthog.session_recordings.sql.session_replay_event_sql import (
 
 operations = [
     # looking at past migrations we have to drop materialized views and kafka tables first
-    run_sql_with_exceptions(DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL(on_cluster=False)),
-    run_sql_with_exceptions(DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL(on_cluster=False)),
+    run_sql_with_exceptions(DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL(on_cluster=False), node_roles=[NodeRole.DATA]),
+    run_sql_with_exceptions(DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL(on_cluster=False), node_roles=[NodeRole.DATA]),
     # alter the target tables
     run_sql_with_exceptions(
-        SET_TTL_ONLY_DROP_PARTS_SESSION_REPLAY_EVENTS_TABLE_SQL(), sharded=True, is_alter_on_replicated_table=True
+        SET_TTL_ONLY_DROP_PARTS_SESSION_REPLAY_EVENTS_TABLE_SQL(),
+        node_roles=[NodeRole.DATA],
+        sharded=True,
+        is_alter_on_replicated_table=True,
     ),
-    run_sql_with_exceptions(ADD_TTL_SESSION_REPLAY_EVENTS_TABLE_SQL(), sharded=True, is_alter_on_replicated_table=True),
+    run_sql_with_exceptions(
+        ADD_TTL_SESSION_REPLAY_EVENTS_TABLE_SQL(),
+        node_roles=[NodeRole.DATA],
+        sharded=True,
+        is_alter_on_replicated_table=True,
+    ),
     # and then recreate the materialized views and kafka tables
-    run_sql_with_exceptions(KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL(on_cluster=False)),
-    run_sql_with_exceptions(SESSION_REPLAY_EVENTS_TABLE_MV_SQL(on_cluster=False)),
+    run_sql_with_exceptions(KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL(on_cluster=False), node_roles=[NodeRole.DATA]),
+    run_sql_with_exceptions(SESSION_REPLAY_EVENTS_TABLE_MV_SQL(on_cluster=False), node_roles=[NodeRole.DATA]),
 ]

--- a/posthog/clickhouse/migrations/0140_session_replay_events_add_ttl.py
+++ b/posthog/clickhouse/migrations/0140_session_replay_events_add_ttl.py
@@ -1,0 +1,23 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.session_recordings.sql.session_replay_event_migrations_sql import (
+    ADD_TTL_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL,
+    SET_TTL_ONLY_DROP_PARTS_SESSION_REPLAY_EVENTS_TABLE_SQL,
+)
+from posthog.session_recordings.sql.session_replay_event_sql import (
+    KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    SESSION_REPLAY_EVENTS_TABLE_MV_SQL,
+)
+
+operations = [
+    # looking at past migrations we have to drop materialized views and kafka tables first
+    run_sql_with_exceptions(DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL(on_cluster=False)),
+    run_sql_with_exceptions(DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL(on_cluster=False)),
+    # alter the target tables
+    run_sql_with_exceptions(SET_TTL_ONLY_DROP_PARTS_SESSION_REPLAY_EVENTS_TABLE_SQL(), sharded=True),
+    run_sql_with_exceptions(ADD_TTL_SESSION_REPLAY_EVENTS_TABLE_SQL(), sharded=True),
+    # and then recreate the materialized views and kafka tables
+    run_sql_with_exceptions(KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL(on_cluster=False)),
+    run_sql_with_exceptions(SESSION_REPLAY_EVENTS_TABLE_MV_SQL(on_cluster=False)),
+]

--- a/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
@@ -225,7 +225,7 @@ DROP_RETENTION_PERIOD_SESSION_REPLAY_EVENTS_TABLE_SQL = (
 # migration to add a TTL policy to the session replay tables
 ALTER_SESSION_REPLAY_ADD_TTL = """
     ALTER TABLE {table_name}
-        MODIFY TTL dateTrunc('day', min_first_timestamp) + toIntervalDay(coalesce(retention_period_days, 365))
+        MODIFY TTL addDays(dateTrunc('day', min_first_timestamp), 1) + toIntervalDay(coalesce(retention_period_days, 365))
 """
 
 ADD_TTL_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_TTL.format(

--- a/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
@@ -222,6 +222,25 @@ DROP_RETENTION_PERIOD_SESSION_REPLAY_EVENTS_TABLE_SQL = (
     )
 )
 
+# migration to add a TTL policy to the session replay tables
+ALTER_SESSION_REPLAY_ADD_TTL = """
+    ALTER TABLE {table_name}
+        MODIFY TTL dateTrunc('day', min_first_timestamp) + toIntervalDay(coalesce(retention_period_days, 365))
+"""
+
+ADD_TTL_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_TTL.format(
+    table_name=SESSION_REPLAY_EVENTS_DATA_TABLE(),
+)
+
+ALTER_SESSION_REPLAY_SET_TTL_ONLY_DROP_PARTS = """
+    ALTER TABLE {table_name}
+        MODIFY SETTING ttl_only_drop_parts=1
+"""
+
+SET_TTL_ONLY_DROP_PARTS_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_SET_TTL_ONLY_DROP_PARTS.format(
+    table_name=SESSION_REPLAY_EVENTS_DATA_TABLE(),
+)
+
 # =========================
 # MIGRATION: Add block columns to support session recording v2 implementation
 # This migration adds block_url to the kafka table, and block_first_timestamps, block_last_timestamps, and block_urls


### PR DESCRIPTION
## Problem

We need to get rid of the replay metadata stored in ClickHouse when the recording expires. This is much simpler than trying to filter out expired rows at query-time and should help keep the number of rows in check.

## Changes

This PR adds a ClickHouse migration that sets a TTL policy on the replay events table.