### PR TITLE
chore(insights): remove reliance on insightSceneLogic

### DIFF
--- a/frontend/src/exporter/ExportedInsight/ExportedInsight.tsx
+++ b/frontend/src/exporter/ExportedInsight/ExportedInsight.tsx
@@ -117,7 +117,7 @@ export function ExportedInsight({
                     )}
                     {showDetailedResultsTable && (
                         <div className="border-t mt-2">
-                            <InsightsTable filterKey={short_id} isLegend embedded />
+                            <InsightsTable filterKey={short_id} isLegend embedded editMode={false} />
                         </div>
                     )}
                 </div>

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -230,6 +230,7 @@ function InsightCardInternal(
                                     embedded
                                     inSharedMode={placement === DashboardPlacement.Public}
                                     variablesOverride={variablesOverride}
+                                    editMode={false}
                                 />
                             )}
                         </div>
@@ -247,4 +248,5 @@ function InsightCardInternal(
         </div>
     )
 }
+
 export const InsightCard = React.forwardRef(InsightCardInternal) as typeof InsightCardInternal

--- a/frontend/src/queries/Query/Query.tsx
+++ b/frontend/src/queries/Query/Query.tsx
@@ -147,7 +147,7 @@ export function Query<Q extends Node>(props: QueryProps<Q>): JSX.Element | null 
                 uniqueKey={uniqueKey}
                 context={queryContext}
                 readOnly={readOnly}
-                editMode={editMode}
+                editMode={!!editMode}
                 variablesOverride={props.variablesOverride}
             />
         )
@@ -158,7 +158,7 @@ export function Query<Q extends Node>(props: QueryProps<Q>): JSX.Element | null 
                 query={query}
                 context={queryContext}
                 readOnly={readOnly}
-                editMode={editMode}
+                editMode={!!editMode}
                 embedded={embedded}
             />
         )
@@ -170,7 +170,7 @@ export function Query<Q extends Node>(props: QueryProps<Q>): JSX.Element | null 
                 setQuery={setQuery as unknown as (query: InsightVizNode) => void}
                 context={queryContext}
                 readOnly={readOnly}
-                editMode={editMode}
+                editMode={!!editMode}
                 uniqueKey={uniqueKey}
                 embedded={embedded}
                 inSharedMode={inSharedMode}

--- a/frontend/src/queries/Query/Query.tsx
+++ b/frontend/src/queries/Query/Query.tsx
@@ -70,6 +70,8 @@ export interface QueryProps<Q extends Node> {
     embedded?: boolean
     /** Disables modals and other things */
     inSharedMode?: boolean
+    /** Can you edit the insight */
+    editMode?: boolean
     /** Dashboard filters to override the ones in the query */
     filtersOverride?: DashboardFilter | null
     /** Dashboard variables to override the ones in the query */
@@ -90,6 +92,7 @@ export function Query<Q extends Node>(props: QueryProps<Q>): JSX.Element | null 
         variablesOverride,
         inSharedMode,
         dataAttr,
+        editMode,
     } = props
 
     const [localQuery, localSetQuery] = useState(propsQuery)
@@ -144,6 +147,7 @@ export function Query<Q extends Node>(props: QueryProps<Q>): JSX.Element | null 
                 uniqueKey={uniqueKey}
                 context={queryContext}
                 readOnly={readOnly}
+                editMode={editMode}
                 variablesOverride={props.variablesOverride}
             />
         )
@@ -154,6 +158,7 @@ export function Query<Q extends Node>(props: QueryProps<Q>): JSX.Element | null 
                 query={query}
                 context={queryContext}
                 readOnly={readOnly}
+                editMode={editMode}
                 embedded={embedded}
             />
         )
@@ -165,6 +170,7 @@ export function Query<Q extends Node>(props: QueryProps<Q>): JSX.Element | null 
                 setQuery={setQuery as unknown as (query: InsightVizNode) => void}
                 context={queryContext}
                 readOnly={readOnly}
+                editMode={editMode}
                 uniqueKey={uniqueKey}
                 embedded={embedded}
                 inSharedMode={inSharedMode}

--- a/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.test.ts
@@ -4,7 +4,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { DataVisualizationNode, NodeKind } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
-import { ChartDisplayType, ItemMode } from '~/types'
+import { ChartDisplayType } from '~/types'
 
 import { dataNodeLogic } from '../../DataNode/dataNodeLogic'
 import { DataVisualizationLogicProps, dataVisualizationLogic } from '../dataVisualizationLogic'
@@ -64,7 +64,7 @@ const dummyDataVisualizationLogicProps: DataVisualizationLogicProps = {
     setQuery: (query) => {
         globalQuery = query
     },
-    insightMode: ItemMode.View,
+    editMode: false,
     dataNodeCollectionId: 'new-test-SQL',
 }
 

--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
@@ -10,7 +10,6 @@ import { ExportButton } from 'lib/components/ExportButton/ExportButton'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 import { InsightErrorState, StatelessInsightLoadingState } from 'scenes/insights/EmptyStates'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
-import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { HogQLBoldNumber } from 'scenes/insights/views/BoldNumber/BoldNumber'
 import { urls } from 'scenes/urls'
 
@@ -51,6 +50,7 @@ export interface DataTableVisualizationProps {
     /* Cached Results are provided when shared or exported,
     the data node logic becomes read only implicitly */
     cachedResults?: AnyResponseType
+    editMode?: boolean
     readOnly?: boolean
     exportContext?: ExportContext
     /** Dashboard variables to override the ones in the query */
@@ -70,6 +70,7 @@ export function DataTableVisualization({
     readOnly,
     variablesOverride,
     attachTo,
+    editMode,
 }: DataTableVisualizationProps): JSX.Element {
     const [key] = useState(`DataVisualizationNode.${uniqueKey ?? uniqueNode++}`)
     const insightProps: InsightLogicProps<DataVisualizationNode> = context?.insightProps || {
@@ -81,14 +82,13 @@ export function DataTableVisualization({
 
     const vizKey = insightVizDataNodeKey(insightProps)
     const dataNodeCollectionId = insightVizDataCollectionId(insightProps, key)
-    const { insightMode } = useValues(insightSceneLogic)
     const dataVisualizationLogicProps: DataVisualizationLogicProps = {
         key: vizKey,
         query,
         dashboardId: insightProps.dashboardId,
         dataNodeCollectionId,
         loadPriority: insightProps.loadPriority,
-        insightMode,
+        editMode,
         setQuery,
         cachedResults,
         variablesOverride,
@@ -138,6 +138,7 @@ export function DataTableVisualization({
                                 cachedResults={cachedResults}
                                 readOnly={readOnly}
                                 exportContext={exportContext}
+                                editMode={editMode}
                             />
                         </BindLogic>
                     </BindLogic>

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -20,7 +20,7 @@ import {
     HogQLVariable,
 } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
-import { ChartDisplayType, DashboardType, ItemMode } from '~/types'
+import { ChartDisplayType, DashboardType } from '~/types'
 
 import { dataNodeLogic } from '../DataNode/dataNodeLogic'
 import { QueryFeature, getQueryFeatures } from '../DataTable/queryFeatures'
@@ -65,7 +65,7 @@ export interface AxisSeries<T> {
 export interface DataVisualizationLogicProps {
     key: string
     query: DataVisualizationNode
-    insightMode: ItemMode
+    editMode?: boolean
     dataNodeCollectionId: string
     setQuery?: (node: DataVisualizationNode) => void
     context?: QueryContext<DataVisualizationNode>
@@ -584,19 +584,18 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
         ],
         dashboardId: [() => [(_, props) => props.dashboardId], (dashboardId) => dashboardId ?? null],
         showEditingUI: [
-            (state, props) => [props.insightMode, state.dashboardId],
-            (insightMode, dashboardId) => {
+            (s) => [(_, props: DataVisualizationLogicProps) => props.editMode, s.dashboardId],
+            (editMode, dashboardId) => {
                 if (dashboardId) {
                     return false
                 }
-
-                return insightMode == ItemMode.Edit
+                return !!editMode
             },
         ],
         showResultControls: [
-            (state, props) => [props.insightMode, state.dashboardId],
-            (insightMode, dashboardId) => {
-                if (insightMode === ItemMode.Edit) {
+            (s) => [(_, props: DataVisualizationLogicProps) => props.editMode, s.dashboardId],
+            (editMode, dashboardId) => {
+                if (editMode) {
                     return true
                 }
 

--- a/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
@@ -1,13 +1,12 @@
 import './InsightViz.scss'
 
 import clsx from 'clsx'
-import { BindLogic, BuiltLogic, LogicWrapper, useValues } from 'kea'
+import { BindLogic, BuiltLogic, LogicWrapper } from 'kea'
 import { useState } from 'react'
 
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 
@@ -15,7 +14,7 @@ import { ErrorBoundary } from '~/layout/ErrorBoundary'
 import { DashboardFilter, HogQLVariable, InsightVizNode } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 import { isFunnelsQuery, isRetentionQuery } from '~/queries/utils'
-import { InsightLogicProps, ItemMode } from '~/types'
+import { InsightLogicProps } from '~/types'
 
 import { DataNodeLogicProps, dataNodeLogic } from '../DataNode/dataNodeLogic'
 import { EditorFilters } from './EditorFilters'
@@ -37,6 +36,7 @@ type InsightVizProps = {
     setQuery: (node: InsightVizNode) => void
     context?: QueryContext<InsightVizNode>
     readOnly?: boolean
+    editMode?: boolean
     embedded?: boolean
     inSharedMode?: boolean
     filtersOverride?: DashboardFilter | null
@@ -58,6 +58,7 @@ export function InsightViz({
     filtersOverride,
     variablesOverride,
     attachTo,
+    editMode,
 }: InsightVizProps): JSX.Element {
     const [key] = useState(() => `InsightViz.${uniqueKey || uniqueNode++}`)
     const insightProps =
@@ -88,8 +89,6 @@ export function InsightViz({
         variablesOverride,
     }
 
-    const { insightMode } = useValues(insightSceneLogic)
-
     const isFunnels = isFunnelsQuery(query.source)
     const isHorizontalAlways = useFeatureFlag('INSIGHT_HORIZONTAL_CONTROLS')
     const isRetention = isRetentionQuery(query.source)
@@ -100,13 +99,13 @@ export function InsightViz({
     const disableCorrelationTable = embedded || !(query.showCorrelationTable ?? showIfFull)
     const disableLastComputation = embedded || !(query.showLastComputation ?? showIfFull)
     const disableLastComputationRefresh = embedded || !(query.showLastComputationRefresh ?? showIfFull)
-    const showingFilters = query.showFilters ?? insightMode === ItemMode.Edit
+    const showingFilters = query.showFilters ?? editMode ?? false
     const showingResults = query.showResults ?? true
     const isEmbedded = embedded || (query.embedded ?? false)
 
     const display = (
         <InsightVizDisplay
-            insightMode={insightMode}
+            editMode={editMode}
             context={context}
             disableHeader={disableHeader}
             disableTable={disableTable}

--- a/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
@@ -35,7 +35,7 @@ import { SceneSection } from '~/layout/scenes/components/SceneSection'
 import { InsightVizNode } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 import { shouldQueryBeAsync } from '~/queries/utils'
-import { ExporterFormat, FunnelVizType, InsightType, ItemMode } from '~/types'
+import { ExporterFormat, FunnelVizType, InsightType } from '~/types'
 
 import { InsightDisplayConfig } from './InsightDisplayConfig'
 import { InsightResultMetadata } from './InsightResultMetadata'
@@ -48,10 +48,10 @@ export function InsightVizDisplay({
     disableLastComputation,
     disableLastComputationRefresh,
     showingResults,
-    insightMode,
     context,
     embedded,
     inSharedMode,
+    editMode,
 }: {
     disableHeader?: boolean
     disableTable?: boolean
@@ -59,10 +59,10 @@ export function InsightVizDisplay({
     disableLastComputation?: boolean
     disableLastComputationRefresh?: boolean
     showingResults?: boolean
-    insightMode?: ItemMode
     context?: QueryContext<InsightVizNode>
     embedded: boolean
     inSharedMode?: boolean
+    editMode?: boolean
 }): JSX.Element | null {
     const { insightProps, canEditInsight, isUsingPathsV1, isUsingPathsV2 } = useValues(insightLogic)
 
@@ -109,7 +109,7 @@ export function InsightVizDisplay({
         // Insight specific empty states - note order is important here
         if (activeView === InsightType.FUNNELS) {
             if (!isFunnelWithEnoughSteps) {
-                return <FunnelSingleStepState actionable={!embedded && insightMode === ItemMode.Edit} />
+                return <FunnelSingleStepState actionable={!embedded && editMode} />
             }
             if (!hasFunnelResults && !erroredQueryId && !insightDataLoading) {
                 return <InsightEmptyState heading={context?.emptyStateHeading} detail={context?.emptyStateDetail} />
@@ -141,6 +141,7 @@ export function InsightVizDisplay({
                 return (
                     <TrendInsight
                         view={InsightType.TRENDS}
+                        editMode={editMode}
                         context={context}
                         embedded={embedded}
                         inSharedMode={inSharedMode}
@@ -150,6 +151,7 @@ export function InsightVizDisplay({
                 return (
                     <TrendInsight
                         view={InsightType.STICKINESS}
+                        editMode={editMode}
                         context={context}
                         embedded={embedded}
                         inSharedMode={inSharedMode}
@@ -159,6 +161,7 @@ export function InsightVizDisplay({
                 return (
                     <TrendInsight
                         view={InsightType.LIFECYCLE}
+                        editMode={editMode}
                         context={context}
                         embedded={embedded}
                         inSharedMode={inSharedMode}
@@ -230,13 +233,10 @@ export function InsightVizDisplay({
 
                     <InsightsTable
                         isLegend
+                        editMode={editMode}
                         filterKey={keyForInsightLogicProps('new')(insightProps)}
-                        canEditSeriesNameInline={!hasFormula && insightMode === ItemMode.Edit}
-                        seriesNameTooltip={
-                            hasFormula && insightMode === ItemMode.Edit
-                                ? 'Formula series names are not editable'
-                                : undefined
-                        }
+                        canEditSeriesNameInline={!hasFormula && editMode}
+                        seriesNameTooltip={hasFormula && editMode ? 'Formula series names are not editable' : undefined}
                         canCheckUncheckSeries={canEditInsight}
                     />
                 </>

--- a/frontend/src/queries/nodes/SavedInsight/SavedInsight.tsx
+++ b/frontend/src/queries/nodes/SavedInsight/SavedInsight.tsx
@@ -17,9 +17,17 @@ interface InsightProps {
     readOnly?: boolean
     /** Attach ourselves to another logic, such as the scene logic */
     attachTo?: BuiltLogic | LogicWrapper
+    editMode?: boolean
 }
 
-export function SavedInsight({ query: propsQuery, context, embedded, readOnly, attachTo }: InsightProps): JSX.Element {
+export function SavedInsight({
+    query: propsQuery,
+    context,
+    embedded,
+    readOnly,
+    attachTo,
+    editMode,
+}: InsightProps): JSX.Element {
     const insightProps: InsightLogicProps = { dashboardItemId: propsQuery.shortId }
     const { insight, insightLoading } = useValues(insightLogic(insightProps))
     const { query: dataQuery } = useValues(insightDataLogic(insightProps))
@@ -44,6 +52,7 @@ export function SavedInsight({ query: propsQuery, context, embedded, readOnly, a
             context={{ ...context, insightProps }}
             embedded={embedded}
             readOnly={readOnly}
+            editMode={editMode}
         />
     )
 }

--- a/frontend/src/scenes/data-warehouse/editor/EditorScene.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/EditorScene.tsx
@@ -16,7 +16,6 @@ import {
 import { DataVisualizationLogicProps } from '~/queries/nodes/DataVisualization/dataVisualizationLogic'
 import { dataVisualizationLogic } from '~/queries/nodes/DataVisualization/dataVisualizationLogic'
 import { displayLogic } from '~/queries/nodes/DataVisualization/displayLogic'
-import { ItemMode } from '~/types'
 
 import { ViewLinkModal } from '../ViewLinkModal'
 import { QueryWindow } from './QueryWindow'
@@ -71,7 +70,7 @@ export function EditorScene(): JSX.Element {
         query: sourceQuery,
         dashboardId: undefined,
         dataNodeCollectionId: dataLogicKey,
-        insightMode: ItemMode.Edit,
+        editMode: true,
         loadPriority: undefined,
         cachedResults: undefined,
         variablesOverride: undefined,

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -875,6 +875,7 @@ const Content = ({
                     cachedResults={undefined}
                     exportContext={exportContext}
                     onSaveInsight={saveAsInsight}
+                    editMode
                 />
             </div>
         )

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -36,6 +36,7 @@ import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { entityFilterLogic } from 'scenes/insights/filters/ActionFilter/entityFilterLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { SavedInsightFilters } from 'scenes/saved-insights/savedInsightsLogic'
+import { sceneLogic } from 'scenes/sceneLogic'
 import { Scene } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -457,9 +458,8 @@ export function InsightLoadingState({
     renderEmptyStateAsSkeleton?: boolean
 }): JSX.Element {
     const { suggestedSamplingPercentage, samplingPercentage } = useValues(samplingFilterLogic(insightProps))
-    const { insightPollResponse, insightLoadingTimeSeconds, queryChanged, activeSceneId } = useValues(
-        insightDataLogic(insightProps)
-    )
+    const { insightPollResponse, insightLoadingTimeSeconds, queryChanged } = useValues(insightDataLogic(insightProps))
+    const { activeSceneId } = useValues(sceneLogic)
     const { currentTeam } = useValues(teamLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -96,6 +96,7 @@ export function Insight({ insightId }: InsightSceneProps): JSX.Element | null {
                     query={isInsightVizNode(query) ? { ...query, full: true } : query}
                     setQuery={setQuery}
                     readOnly={insightMode !== ItemMode.Edit}
+                    editMode={insightMode === ItemMode.Edit}
                     context={{
                         showOpenEditorButton: false,
                         showQueryEditor: actuallyShowQueryEditor,

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -473,12 +473,13 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                     ?.actions.loadDashboard({ action: DashboardLoadAction.Update })
             )
 
-            const mountedInsightSceneLogic = insightSceneLogic.findMounted()
             if (redirectToViewMode) {
                 if (!insightNumericId && dashboards?.length === 1) {
                     // redirect new insights added to dashboard to the dashboard
                     router.actions.push(urls.dashboard(dashboards[0], savedInsight.short_id))
                 } else if (insightNumericId) {
+                    // TODO: !!!
+                    const mountedInsightSceneLogic = insightSceneLogic.findMounted()
                     mountedInsightSceneLogic?.actions.setInsightMode(ItemMode.View, InsightEventSource.InsightHeader)
                 } else {
                     router.actions.push(urls.insightView(savedInsight.short_id))

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -478,7 +478,7 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                     // redirect new insights added to dashboard to the dashboard
                     router.actions.push(urls.dashboard(dashboards[0], savedInsight.short_id))
                 } else if (insightNumericId) {
-                    // TODO: !!!
+                    // TODO: we will soon have multiple insightSceneLogics!
                     const mountedInsightSceneLogic = insightSceneLogic.findMounted()
                     mountedInsightSceneLogic?.actions.setInsightMode(ItemMode.View, InsightEventSource.InsightHeader)
                 } else {

--- a/frontend/src/scenes/insights/views/InsightsTable/DashboardInsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/DashboardInsightsTable.tsx
@@ -10,6 +10,11 @@ import { InsightsTable } from './InsightsTable'
 export function DashboardInsightsTable(): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     return (
-        <InsightsTable filterKey={`dashboard_${insightProps.dashboardItemId}`} embedded canCheckUncheckSeries={false} />
+        <InsightsTable
+            filterKey={`dashboard_${insightProps.dashboardItemId}`}
+            embedded
+            canCheckUncheckSeries={false}
+            editMode={false}
+        />
     )
 }

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -7,7 +7,6 @@ import { useMemo } from 'react'
 import { LemonTable, LemonTableColumn } from 'lib/lemon-ui/LemonTable'
 import { COUNTRY_CODE_TO_LONG_NAME } from 'lib/utils/geography/country'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { formatBreakdownLabel } from 'scenes/insights/utils'
 import { teamLogic } from 'scenes/teamLogic'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
@@ -17,7 +16,7 @@ import { cohortsModel } from '~/models/cohortsModel'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { extractExpressionComment } from '~/queries/nodes/DataTable/utils'
 import { isValidBreakdown } from '~/queries/utils'
-import { ChartDisplayType, ItemMode } from '~/types'
+import { ChartDisplayType } from '~/types'
 
 import { entityFilterLogic } from '../../filters/ActionFilter/entityFilterLogic'
 import { AggregationColumnItem, AggregationColumnTitle } from './columns/AggregationColumn'
@@ -57,6 +56,8 @@ export interface InsightsTableProps {
      * @default false
      */
     isMainInsightView?: boolean
+    /** Whether the insight is in edit mode. */
+    editMode?: boolean
 }
 
 export function InsightsTable({
@@ -67,8 +68,8 @@ export function InsightsTable({
     seriesNameTooltip,
     canCheckUncheckSeries = true,
     isMainInsightView = false,
+    editMode,
 }: InsightsTableProps): JSX.Element {
-    const { insightMode } = useValues(insightSceneLogic)
     const { insightProps, isInDashboardContext, insight, editingDisabledReason } = useValues(insightLogic)
     const {
         insightDataLoading,
@@ -332,7 +333,7 @@ export function InsightsTable({
             disableTableWhileLoading={false}
             emptyState="No insight results"
             data-attr="insights-table-graph"
-            useURLForSorting={insightMode !== ItemMode.Edit}
+            useURLForSorting={!editMode}
             rowRibbonColor={
                 isLegend
                     ? (item) => {

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -66,6 +66,7 @@ export function TrendInsight({ view, context, embedded, inSharedMode, editMode }
                     embedded
                     filterKey={`trends_${view}`}
                     canEditSeriesNameInline={editMode}
+                    editMode={editMode}
                     isMainInsightView={true}
                 />
             )

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -3,7 +3,6 @@ import { useActions, useValues } from 'kea'
 import { LemonButton } from '@posthog/lemon-ui'
 
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { BoldNumber } from 'scenes/insights/views/BoldNumber'
 import { TrendsCalendarHeatMap } from 'scenes/insights/views/CalendarHeatMap'
 import { InsightsTable } from 'scenes/insights/views/InsightsTable/InsightsTable'
@@ -11,7 +10,7 @@ import { WorldMap } from 'scenes/insights/views/WorldMap'
 
 import { InsightVizNode } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
-import { ChartDisplayType, InsightType, ItemMode } from '~/types'
+import { ChartDisplayType, InsightType } from '~/types'
 
 import { trendsDataLogic } from './trendsDataLogic'
 import { ActionsHorizontalBar, ActionsLineGraph, ActionsPie } from './viz'
@@ -21,10 +20,10 @@ interface Props {
     context?: QueryContext<InsightVizNode>
     embedded?: boolean
     inSharedMode?: boolean
+    editMode?: boolean
 }
 
-export function TrendInsight({ view, context, embedded, inSharedMode }: Props): JSX.Element {
-    const { insightMode } = useValues(insightSceneLogic)
+export function TrendInsight({ view, context, embedded, inSharedMode, editMode }: Props): JSX.Element {
     const { insightProps, showPersonsModal: insightLogicShowPersonsModal } = useValues(insightLogic)
     const showPersonsModal = insightLogicShowPersonsModal && !inSharedMode
 
@@ -66,7 +65,7 @@ export function TrendInsight({ view, context, embedded, inSharedMode }: Props): 
                 <ActionsTable
                     embedded
                     filterKey={`trends_${view}`}
-                    canEditSeriesNameInline={insightMode === ItemMode.Edit}
+                    canEditSeriesNameInline={editMode}
                     isMainInsightView={true}
                 />
             )


### PR DESCRIPTION
## Problem

Every `insightLogic`, no matter if full screen or on a dashboard, is tightly tied to a global `insightSceneLogic` for just one reason: fetching `insightMode` (view or edit)

## Changes

Remove this connection as part of [the work to make the insight scenes tab-aware](https://github.com/PostHog/posthog/pull/37489/files). 

Now `editMode` is a parameter that's passed in through all query and visualization nodes. It's still controlled by `insightSceneLogic`, but only for the insight that's actually on it. Everyone else is just set to view mode.

## How did you test this code?

Plenty of clicks locally on insights, dashboards and the data warehouse visualizations.