### PR TITLE
chore(cdp): upgrade linkedin ads destination from hidden to alpha

### DIFF
--- a/posthog/cdp/templates/linkedin_ads/template_linkedin_ads.py
+++ b/posthog/cdp/templates/linkedin_ads/template_linkedin_ads.py
@@ -1,7 +1,7 @@
 from posthog.cdp.templates.hog_function_template import HogFunctionTemplateDC
 
 template: HogFunctionTemplateDC = HogFunctionTemplateDC(
-    status="hidden",
+    status="alpha",
     free=False,
     type="destination",
     id="template-linkedin-ads",


### PR DESCRIPTION
## Problem

Linkedin ads destination previously went from alpha -> hidden when we added the new hidden status. This is probably a mistake and it should be fine to put it back in alpha since it was previously available to users
