### PR TITLE
fix(cdp): Ensure no fetch or capture in transforms

### DIFF
--- a/plugin-server/src/cdp/hog-transformations/hog-transformer.service.test.ts
+++ b/plugin-server/src/cdp/hog-transformations/hog-transformer.service.test.ts
@@ -4,8 +4,6 @@ import { DateTime } from 'luxon'
 
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
-import { parseJSON } from '~/utils/json-parse'
-
 import { posthogFilterOutPlugin } from '../../../src/cdp/legacy-plugins/_transformations/posthog-filter-out-plugin/template'
 import { template as defaultTemplate } from '../../../src/cdp/templates/_transformations/default/default.template'
 import { template as geoipTemplate } from '../../../src/cdp/templates/_transformations/geoip/geoip.template'
@@ -1673,7 +1671,7 @@ describe('HogTransformer', () => {
             executeHogFunctionSpy.mockRestore()
         })
 
-        it('should capture events with correct Kafka headers', async () => {
+        it('should throw when trying to capture events in transformations', async () => {
             // Create a transformation function that captures an event
             const captureTemplate: HogFunctionTemplate = {
                 free: true,
@@ -1718,44 +1716,9 @@ describe('HogTransformer', () => {
             hogTransformer['hogFunctionManager']['onHogFunctionsReloaded'](teamId, [hogFunction.id])
 
             const event = createPluginEvent({ event: 'original-event', distinct_id: 'original_user' }, teamId)
-            await hogTransformer.transformEventAndProduceMessages(event)
-            await hogTransformer.processInvocationResults()
+            const result = await hogTransformer.transformEventAndProduceMessages(event)
 
-            const messages = mockProducerObserver.getProducedKafkaMessages()
-
-            // Find the captured event message
-            const capturedEventMessage = messages.find((msg) => {
-                try {
-                    const data = parseJSON(msg.value.data as string)
-                    return data.event === 'captured_event' && data.distinct_id === 'captured_user'
-                } catch {
-                    return false
-                }
-            })
-
-            expect(capturedEventMessage).toBeDefined()
-
-            const capturedEventData = parseJSON(capturedEventMessage!.value.data as string)
-
-            expect(capturedEventData).toMatchObject({
-                event: 'captured_event',
-                distinct_id: 'captured_user',
-                properties: {
-                    source: 'hog_function',
-                    original_event: 'original-event',
-                    original_distinct_id: 'original_user',
-                    captured_at: '2024-01-01T00:00:00Z',
-                    $hog_function_execution_count: 1,
-                },
-                timestamp: '2025-01-01T00:00:00.000Z',
-            })
-
-            // Check that the Kafka headers are correct
-            expect(capturedEventMessage?.headers).toBeDefined()
-            expect(capturedEventMessage?.headers).toMatchObject({
-                distinct_id: 'captured_user',
-                token: 'THIS IS NOT A TOKEN FOR TEAM 2',
-            })
+            expect(result.invocationResults[0].error).toContain('posthogCapture is not supported in transformations')
         })
     })
 })

--- a/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -107,7 +107,7 @@ export class HogTransformerService {
                 return typeof val === 'string' ? geoipLookup.city(val) : null
             },
             cleanNullValues,
-            posthogCapture: () => {
+            postHogCapture: () => {
                 throw new Error('posthogCapture is not supported in transformations')
             },
         }

--- a/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -107,6 +107,9 @@ export class HogTransformerService {
                 return typeof val === 'string' ? geoipLookup.city(val) : null
             },
             cleanNullValues,
+            posthogCapture: () => {
+                throw new Error('posthogCapture is not supported in transformations')
+            },
         }
     }
 
@@ -336,7 +339,10 @@ export class HogTransformerService {
 
         const result = isLegacyPluginHogFunction(hogFunction)
             ? await this.pluginExecutor.execute(invocation)
-            : await this.hogExecutor.execute(invocation, { functions: transformationFunctions })
+            : await this.hogExecutor.execute(invocation, {
+                  functions: transformationFunctions,
+                  asyncFunctionsNames: [],
+              })
         return result
     }
 


### PR DESCRIPTION
## Problem

Somewhere along the line we forgot to disable fetching and capturing events in transforms. Fetching wouldnt have worked anyways as we dont do the fetch part but scheduling events would have 

## Changes

* Removes it

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
