### PR TITLE
fix(experiments): allow unique session counts in ratio metrics

### DIFF
--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -578,6 +578,7 @@ export function getAllowedMathTypes(metricType: ExperimentMetricType): Experimen
                 ExperimentMetricMathType.Sum,
                 ExperimentMetricMathType.UniqueUsers,
                 ExperimentMetricMathType.UniqueGroup,
+                ExperimentMetricMathType.UniqueSessions,
                 ExperimentMetricMathType.Avg,
                 ExperimentMetricMathType.Min,
                 ExperimentMetricMathType.Max,


### PR DESCRIPTION
## Problem
Ratio metrics currently do not allow unique session count metrics, but they are supported in the backend.

## Changes

Allow math type for ratio also.

## How did you test this code?

Tested locally.
