### PR TITLE
fix: Use proper field for data warehouse schema default incremental field

### DIFF
--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -563,8 +563,8 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 "incremental_fields": schema.incremental_fields,
                 "incremental_available": schema.supports_incremental,
                 "append_available": schema.supports_append,
-                "incremental_field": schema.incremental_fields[0]["label"]
-                if len(schema.incremental_fields) > 0 and len(schema.incremental_fields[0]["label"]) > 0
+                "incremental_field": schema.incremental_fields[0]["field"]
+                if len(schema.incremental_fields) > 0 and len(schema.incremental_fields[0]["field"]) > 0
                 else None,
                 "sync_type": None,
                 "rows": schema.row_count,


### PR DESCRIPTION
We use this field in the UI to match against the available "incremental fields" and save the table. We match against the `value` field though, which meant the UI was displaying the right value (right label) but it required the user to click on the select and reselect the field to get the actual value. This wasn't a problem for most integrations since the field/label pair is usually the same, but it affected Stripe more heavily since the field/label are `created`/`created_at`.

https://www.loom.com/share/f830201848304362bc2a8780bcfa4929