### PR TITLE
SUPPORT SUPERDAY: Add 'Report a bug' to support menu

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import React from 'react'
 
-import { IconFeatures, IconHelmet, IconMap } from '@posthog/icons'
+import { IconBug, IconFeatures, IconHelmet, IconMap } from '@posthog/icons'
 import { LemonButton, Link } from '@posthog/lemon-ui'
 
 import { SupportForm } from 'lib/components/Support/SupportForm'
@@ -400,6 +400,17 @@ export function SidePanelSupport(): JSX.Element {
                                             targetBlank
                                         >
                                             Vote on our roadmap
+                                        </LemonButton>
+                                    </li>
+                                    <li>
+                                        <LemonButton
+                                            type="secondary"
+                                            status="alt"
+                                            to="https://github.com/PostHog/posthog/issues/new?template=bug_report.yml&labels=bug"
+                                            icon={<IconBug />}
+                                            targetBlank
+                                        >
+                                            Report a bug
                                         </LemonButton>
                                     </li>
                                     <li>


### PR DESCRIPTION
## Summary
Added minimal "Report a bug" button to the support panel alongside the existing "Request a feature"
button.

## Changes
- Added `IconBug` import to `SidePanelSupport.tsx`
- Added new "Report a bug" button that links to GitHub bug report template with proper labels

## Test plan
✅ Frontend builds successfully with the change
✅ "Report a bug" text confirmed in compiled JavaScript bundle
✅ Links to correct GitHub URL:
`https://github.com/PostHog/posthog/issues/new?template=bug_report.yml&labels=bug`
✅ Uses `targetBlank` prop for new tab behavior
✅ Follows exact same pattern as existing "Request a feature" button

## Implementation details
The button was added to `frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx` right above the existing "Request a feature" button in the "Share feedback" section.

## Notes
I inspected the existing support menu implementation, identified the correct GitHub issue
template URL pattern with proper query params. Found the `IconBug` icon already available in the
`@posthog/icons` package. Fixed initial build issues by building the `@posthog/hogvm` dependency.
Used Claude Code to streamline development workflow.

@abigailbramble for review