### PR TITLE
fix(sql editor): Support changing of variable type for existing variable

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/NewVariableModal.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/NewVariableModal.tsx
@@ -128,7 +128,8 @@ const renderVariableSpecificFields = (
 }
 
 export const NewVariableModal = (): JSX.Element => {
-    const { closeModal, updateVariable, save, openNewVariableModal } = useActions(variableModalLogic)
+    const { closeModal, updateVariable, save, openNewVariableModal, changeTypeExistingVariable } =
+        useActions(variableModalLogic)
     const { isModalOpen, variable, modalType } = useValues(variableModalLogic)
     const { deleteVariable } = useActions(variableDataLogic)
     const title = modalType === 'new' ? `New ${variable.type} variable` : `Editing ${variable.name}`
@@ -193,7 +194,13 @@ export const NewVariableModal = (): JSX.Element => {
                 <LemonField.Pure label="Type" className="gap-1">
                     <LemonSelect
                         value={variable.type}
-                        onChange={(value) => openNewVariableModal(value as VariableType)}
+                        onChange={(value) => {
+                            if (modalType === 'new') {
+                                openNewVariableModal(value as VariableType)
+                            } else {
+                                changeTypeExistingVariable(value as VariableType)
+                            }
+                        }}
                         options={[
                             {
                                 value: 'String',

--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/variableModalLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/variableModalLogic.ts
@@ -90,7 +90,12 @@ export const variableModalLogic = kea<variableModalLogicType>([
     props({ key: '' } as AddVariableLogicProps),
     key((props) => props.key),
     connect(() => ({
-        actions: [variableDataLogic, ['getVariables'], variablesLogic, ['addVariable']],
+        actions: [
+            variableDataLogic,
+            ['getVariables'],
+            variablesLogic,
+            ['addVariable', 'updateVariableValue', 'updateSourceQuery'],
+        ],
     })),
     actions({
         openNewVariableModal: (variableType: VariableType) => ({ variableType }),
@@ -156,8 +161,11 @@ export const variableModalLogic = kea<variableModalLogicType>([
                     actions.addVariable({ variableId: variable.id, code_name: variable.code_name })
                 } else {
                     await api.insightVariables.update(values.variable.id, values.variable)
+                    if (values.variableType !== values.variable.type) {
+                        const { id, default_value } = values.variable
+                        actions.updateVariableValue(id, default_value, false)
+                    }
                 }
-
                 actions.getVariables()
                 actions.closeModal()
             } catch (e: any) {

--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/variableModalLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/variableModalLogic.ts
@@ -90,7 +90,12 @@ export const variableModalLogic = kea<variableModalLogicType>([
     props({ key: '' } as AddVariableLogicProps),
     key((props) => props.key),
     connect(() => ({
-        actions: [variableDataLogic, ['getVariables'], variablesLogic, ['addVariable', 'updateVariableValue']],
+        actions: [
+            variableDataLogic,
+            ['getVariables'],
+            variablesLogic,
+            ['addVariable', 'updateInternalSelectedVariable'],
+        ],
     })),
     actions({
         openNewVariableModal: (variableType: VariableType) => ({ variableType }),
@@ -155,10 +160,12 @@ export const variableModalLogic = kea<variableModalLogicType>([
                     const variable = await api.insightVariables.create(values.variable)
                     actions.addVariable({ variableId: variable.id, code_name: variable.code_name })
                 } else {
-                    await api.insightVariables.update(values.variable.id, values.variable)
+                    const variable = await api.insightVariables.update(values.variable.id, values.variable)
                     if (values.variableType !== values.variable.type) {
-                        const { id, default_value } = values.variable
-                        actions.updateVariableValue(id, default_value, false)
+                        actions.updateInternalSelectedVariable({
+                            variableId: variable.id,
+                            code_name: variable.code_name,
+                        })
                     }
                 }
                 actions.getVariables()

--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/variableModalLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/variableModalLogic.ts
@@ -90,12 +90,7 @@ export const variableModalLogic = kea<variableModalLogicType>([
     props({ key: '' } as AddVariableLogicProps),
     key((props) => props.key),
     connect(() => ({
-        actions: [
-            variableDataLogic,
-            ['getVariables'],
-            variablesLogic,
-            ['addVariable', 'updateVariableValue', 'updateSourceQuery'],
-        ],
+        actions: [variableDataLogic, ['getVariables'], variablesLogic, ['addVariable', 'updateVariableValue']],
     })),
     actions({
         openNewVariableModal: (variableType: VariableType) => ({ variableType }),

--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/variableModalLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/variableModalLogic.ts
@@ -30,6 +30,61 @@ export interface AddVariableLogicProps {
     key: string
 }
 
+const getDefaultVariableForType = (variableType: VariableType): Variable => {
+    if (variableType === 'String') {
+        return {
+            id: '',
+            type: 'String',
+            name: '',
+            default_value: '',
+            code_name: '',
+        } as StringVariable
+    }
+
+    if (variableType === 'Number') {
+        return {
+            id: '',
+            type: 'Number',
+            name: '',
+            default_value: 0,
+            code_name: '',
+        } as NumberVariable
+    }
+
+    if (variableType === 'Boolean') {
+        return {
+            id: '',
+            type: 'Boolean',
+            name: '',
+            default_value: false,
+            code_name: '',
+        } as BooleanVariable
+    }
+
+    if (variableType === 'List') {
+        return {
+            id: '',
+            type: 'List',
+            name: '',
+            values: [],
+            default_value: '',
+            code_name: '',
+        } as ListVariable
+    }
+
+    if (variableType === 'Date') {
+        return {
+            id: '',
+            type: 'Date',
+            name: '',
+            default_value: dayjs().format('YYYY-MM-DD HH:mm:00'),
+            code_name: '',
+        } as DateVariable
+    }
+
+    throw new Error(`Unsupported variable type ${variableType}`)
+}
+
 export const variableModalLogic = kea<variableModalLogicType>([
     path(['queries', 'nodes', 'DataVisualization', 'Components', 'Variables', 'variableLogic']),
     props({ key: '' } as AddVariableLogicProps),
@@ -43,6 +98,7 @@ export const variableModalLogic = kea<variableModalLogicType>([
         closeModal: true,
         updateVariable: (variable: Variable) => ({ variable }),
         save: true,
+        changeTypeExistingVariable: (variableType: VariableType) => ({ variableType }),
     }),
     reducers({
         modalType: [
@@ -72,58 +128,7 @@ export const variableModalLogic = kea<variableModalLogicType>([
             {
                 openExistingVariableModal: (_, { variable }) => ({ ...variable }),
                 openNewVariableModal: (_, { variableType }) => {
-                    if (variableType === 'String') {
-                        return {
-                            id: '',
-                            type: 'String',
-                            name: '',
-                            default_value: '',
-                            code_name: '',
-                        } as StringVariable
-                    }
-
-                    if (variableType === 'Number') {
-                        return {
-                            id: '',
-                            type: 'Number',
-                            name: '',
-                            default_value: 0,
-                            code_name: '',
-                        } as NumberVariable
-                    }
-
-                    if (variableType === 'Boolean') {
-                        return {
-                            id: '',
-                            type: 'Boolean',
-                            name: '',
-                            default_value: false,
-                            code_name: '',
-                        } as BooleanVariable
-                    }
-
-                    if (variableType === 'List') {
-                        return {
-                            id: '',
-                            type: 'List',
-                            name: '',
-                            values: [],
-                            default_value: '',
-                            code_name: '',
-                        } as ListVariable
-                    }
-
-                    if (variableType === 'Date') {
-                        return {
-                            id: '',
-                            type: 'Date',
-                            name: '',
-                            default_value: dayjs().format('YYYY-MM-DD HH:mm:00'),
-                            code_name: '',
-                        } as DateVariable
-                    }
-
-                    throw new Error(`Unsupported variable type ${variableType}`)
+                    return getDefaultVariableForType(variableType)
                 },
                 updateVariable: (state, { variable }) =>
                     ({
@@ -131,6 +136,15 @@ export const variableModalLogic = kea<variableModalLogicType>([
                         ...variable,
                     }) as Variable,
                 closeModal: () => DEFAULT_VARIABLE,
+                changeTypeExistingVariable: (state, { variableType }) => {
+                    const defaultVariable = getDefaultVariableForType(variableType)
+                    return {
+                        ...defaultVariable,
+                        id: state.id,
+                        name: state.name,
+                        code_name: state.code_name,
+                    }
+                },
             },
         ],
     }),

--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/variablesLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/variablesLogic.ts
@@ -59,6 +59,7 @@ export const variablesLogic = kea<variablesLogicType>([
         setEditorQuery: (query: string) => ({ query }),
         updateSourceQuery: true,
         resetVariables: true,
+        updateInternalSelectedVariable: (variable: HogQLVariable) => ({ variable }),
     })),
     propsChanged(({ props, actions, values }, oldProps) => {
         if (oldProps.queryInput !== props.queryInput) {
@@ -110,7 +111,6 @@ export const variablesLogic = kea<variablesLogicType>([
 
                     const variableType = allVariables.find((n) => n.id === variableId)?.type
                     const valueWithType = convertValueToCorrectType(value, variableType ?? 'String')
-
                     const variablesInState = [...state]
                     variablesInState[variableIndex] = {
                         ...variablesInState[variableIndex],
@@ -140,6 +140,18 @@ export const variablesLogic = kea<variablesLogicType>([
                 },
                 resetVariables: () => {
                     return []
+                },
+                updateInternalSelectedVariable: (state, { variable }) => {
+                    const variableIndex = state.findIndex((n) => n.variableId === variable.variableId)
+                    if (variableIndex < 0) {
+                        return state
+                    }
+                    const variablesInState = [...state]
+                    variablesInState[variableIndex] = {
+                        ...variable,
+                    }
+
+                    return variablesInState
                 },
             },
         ],


### PR DESCRIPTION
## Problem

When changing the type of an existing variable, the modal switches to the new variable state:

https://github.com/user-attachments/assets/916a50ad-8c80-407c-a8c7-e63657e1499b

This happens because the `onChange` function that handles the type change has not considered the case where `modalType === 'existing'`:

https://github.com/PostHog/posthog/blob/41c64f291890ef24e78effbad4aaee44fc5e2bac/frontend/src/queries/nodes/DataVisualization/Components/Variables/NewVariableModal.tsx#L194-L196


## Changes

1) Add support for the change of type in an existing variable
2) If the existing variable is added to the insight on the current tab, we update the variable's value to default value.


https://github.com/user-attachments/assets/b7fd2a04-d77b-4125-ac6c-d8c55aff2e78

## Alternative
Updating the type of an existing variable can be a confusing experience especially if the variable is used in many insights.

We can also opt to disable the lemon select that handles the type when `modalType === 'existing'`.

## How did you test this code?

Locally:

1) Go to http://localhost:8010/project/1/sql
2) Create a variable of type 'number'
3) Click on the variable button, a dropdown will appear. Click on the settings icon on the bottom right.
4) A dialog will appear, change the `type` to date
5) Click save

The variable's value should be updated to the date that you set as default

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
