### PR TITLE
SUPPORT SUPERDAY: [WIP/UNTESTED] Add identifier fallback for Customer.io CDP destination

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import React from 'react'
 
-import { IconFeatures, IconHelmet, IconMap } from '@posthog/icons'
+import { IconBug, IconFeatures, IconHelmet, IconMap } from '@posthog/icons'
 import { LemonButton, Link } from '@posthog/lemon-ui'
 
 import { SupportForm } from 'lib/components/Support/SupportForm'
@@ -400,6 +400,17 @@ export function SidePanelSupport(): JSX.Element {
                                             targetBlank
                                         >
                                             Vote on our roadmap
+                                        </LemonButton>
+                                    </li>
+                                    <li>
+                                        <LemonButton
+                                            type="secondary"
+                                            status="alt"
+                                            to="https://github.com/PostHog/posthog/issues/new?template=bug_report.yml&labels=bug"
+                                            icon={<IconBug />}
+                                            targetBlank
+                                        >
+                                            Report a bug
                                         </LemonButton>
                                     </li>
                                     <li>


### PR DESCRIPTION
This addresses issue #26, builds on the approach explored in PR #45 where Customer.io destination skips events from users without email addresses, but for the current CDP destinations system instead of the deprecated plugin (which I tried first mistakenly!).

**This is untested WIP** - working through SuperDay trial quickly to demonstrate the approach. This is just to show the idea and would be the next bit of work I could tackle with proper testing.

Added fallback logic in the HOG code so when the email identifier is empty, it tries person.properties.userId, then cio_id, then distinct_id as fallbacks. Also updated the default identifier_value template to show the fallback chain.

For testing I'd need to verify that Customer.io actually accepts these different identifier types in their API and test with events that have userId but no email, events with cio_id, etc. Would also need to validate the HOG syntax is correct and the fallback logic actually works as expected.

@abigailbramble to review.