### PR TITLE
feat(experiments): show experiment exposure changes

### DIFF
--- a/frontend/src/scenes/experiments/activity-descriptions/experimentChangeDescription.tsx
+++ b/frontend/src/scenes/experiments/activity-descriptions/experimentChangeDescription.tsx
@@ -135,8 +135,8 @@ export const getExperimentChangeDescription = (
                         }
 
                         return typedAfter?.multiple_variant_handling === 'first_seen'
-                            ? 'changed the variant handling to first seen'
-                            : 'changed the variant handling to exclude from analysis'
+                            ? 'changed the variant handling to "first seen"'
+                            : 'changed the variant handling to "exclude from analysis"'
                     })
                     .with('exposure_config', () => {
                         const afterConfig = typedAfter?.exposure_config

--- a/frontend/src/scenes/experiments/activity-descriptions/experimentChangeDescription.tsx
+++ b/frontend/src/scenes/experiments/activity-descriptions/experimentChangeDescription.tsx
@@ -1,12 +1,15 @@
 import clsx from 'clsx'
+import equal from 'fast-deep-equal'
 import { match } from 'ts-pattern'
 
 import { ActivityChange } from 'lib/components/ActivityLog/humanizeActivity'
 import { dayjs } from 'lib/dayjs'
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { Link } from 'lib/lemon-ui/Link'
 import { CONCLUSION_DISPLAY_CONFIG } from 'scenes/experiments/constants'
 import { urls } from 'scenes/urls'
 
+import type { ExperimentExposureCriteria } from '~/queries/schema/schema-general'
 import { Experiment, ExperimentConclusion } from '~/types'
 
 const ExperimentConclusionTag = ({ conclusion }: { conclusion: ExperimentConclusion }): JSX.Element => (
@@ -29,11 +32,16 @@ export const nameOrLinkToExperiment = (name: string | null, id?: string): JSX.El
 /**
  * we pick the allowed properties, and shoehorn in deleted because it's missing from the type
  */
-type AllowedExperimentFields = Pick<Experiment, 'conclusion' | 'start_date' | 'end_date' | 'metrics'> & {
+type AllowedExperimentFields = Pick<
+    Experiment,
+    'conclusion' | 'start_date' | 'end_date' | 'metrics' | 'exposure_criteria'
+> & {
     deleted: boolean
 }
 
-export const getExperimentChangeDescription = (experimentChange: ActivityChange): string | JSX.Element | null => {
+export const getExperimentChangeDescription = (
+    experimentChange: ActivityChange
+): string | JSX.Element | (string | JSX.Element)[] | null => {
     /**
      * a little type assertion to force field into the allowed experiment fields
      */
@@ -98,6 +106,70 @@ export const getExperimentChangeDescription = (experimentChange: ActivityChange)
             }
 
             return null
+        })
+        .with({ field: 'exposure_criteria' }, ({ before, after }) => {
+            /**
+             * exposure criteria is by default `{filter_test_accounts: true}`,
+             * meaning that we use `feature_flag_called` as the event and
+             * first seen as the varian handling.
+             *
+             * if the experiment has a `null` exposure criteria, a created action is logged.
+             */
+            const typedAfter = after as ExperimentExposureCriteria
+            const typedBefore = before as ExperimentExposureCriteria
+
+            const changes: (string | JSX.Element | null)[] = Object.keys(after || {}).map((key) =>
+                match(key as keyof ExperimentExposureCriteria)
+                    .with('filterTestAccounts', () => {
+                        if (typedAfter?.filterTestAccounts === typedBefore?.filterTestAccounts) {
+                            return null
+                        }
+
+                        return typedAfter?.filterTestAccounts
+                            ? 'added the test account filter'
+                            : 'removed the test account filter'
+                    })
+                    .with('multiple_variant_handling', () => {
+                        if (typedAfter?.multiple_variant_handling === typedBefore?.multiple_variant_handling) {
+                            return null
+                        }
+
+                        return typedAfter?.multiple_variant_handling === 'first_seen'
+                            ? 'changed the variant handling to first seen'
+                            : 'changed the variant handling to exclude from analysis'
+                    })
+                    .with('exposure_config', () => {
+                        const afterConfig = typedAfter?.exposure_config
+                        const beforeConfig = typedBefore?.exposure_config
+
+                        if (equal(afterConfig, beforeConfig)) {
+                            return null
+                        }
+
+                        if (afterConfig) {
+                            return (
+                                <span>
+                                    set the exposure configuration to{' '}
+                                    <LemonTag color="purple">{afterConfig.event}</LemonTag>
+                                </span>
+                            )
+                        }
+                        return null
+                    })
+                    .exhaustive()
+            )
+
+            // Check if exposure_config was removed (returning to default)
+            if (typedBefore?.exposure_config && !typedAfter?.exposure_config) {
+                changes.push(
+                    <span>
+                        set the exposure configuration to the <LemonTag color="purple">$feature_flag_called</LemonTag>{' '}
+                        default
+                    </span>
+                )
+            }
+
+            return changes.filter(Boolean) as (string | JSX.Element)[]
         })
         .otherwise(() => null)
 }

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
@@ -46,6 +46,94 @@ const UnknownAction = ({ logItem }: { logItem: ActivityLogItem }): JSX.Element =
     )
 }
 
+/**
+ * Formats the result from getExperimentChangeDescription into a human-readable string
+ * Handles arrays by joining with commas and "and" for the last item
+ * Adds appropriate preposition (to/for/on) based on the action
+ */
+const humanizeExperimentChange = (
+    result: string | JSX.Element | (string | JSX.Element)[] | null
+): string | JSX.Element | null => {
+    if (result === null) {
+        return null
+    }
+
+    // Helper to determine the right preposition based on the action text
+    const getPreposition = (text: string): string => {
+        if (text.includes('added') || text.includes('set')) {
+            return 'to'
+        }
+        if (text.includes('removed')) {
+            return 'from'
+        }
+        if (text.includes('changed') || text.includes('returned')) {
+            return 'for'
+        }
+        return 'on'
+    }
+
+    if (Array.isArray(result)) {
+        // Filter out null/undefined values
+        const validItems = result.filter(Boolean)
+
+        if (validItems.length === 0) {
+            return null
+        }
+
+        if (validItems.length === 1) {
+            const item = validItems[0]
+            const itemText = typeof item === 'string' ? item : ''
+            const preposition = getPreposition(itemText)
+            return (
+                <span>
+                    {item} {preposition}
+                </span>
+            )
+        }
+
+        // Join with commas and "and" for the last item
+        const lastItem = validItems[validItems.length - 1]
+        const otherItems = validItems.slice(0, -1)
+
+        // Determine preposition based on first item (they should all be similar actions)
+        const firstItemText = typeof otherItems[0] === 'string' ? otherItems[0] : ''
+        const preposition = getPreposition(firstItemText)
+
+        // If all items are strings, return a string
+        const allStrings = validItems.every((item) => typeof item === 'string')
+        if (allStrings) {
+            return `${otherItems.join(', ')} and ${lastItem} ${preposition}`
+        }
+
+        // If mixed or JSX elements, return a span
+        return (
+            <span>
+                {otherItems.map((item, index) => (
+                    <span key={index}>
+                        {item}
+                        {index < otherItems.length - 1 ? ', ' : ' and '}
+                    </span>
+                ))}
+                {lastItem} {preposition}
+            </span>
+        )
+    }
+
+    // Single string or JSX element
+    const itemText = typeof result === 'string' ? result : ''
+    const preposition = getPreposition(itemText)
+
+    if (typeof result === 'string') {
+        return `${result} ${preposition}`
+    }
+
+    return (
+        <span>
+            {result} {preposition}
+        </span>
+    )
+}
+
 export const experimentActivityDescriber = (logItem: ActivityLogItem): HumanizedChange => {
     /**
      * we only have two item types, `shared_metric` or the `null` default for
@@ -144,7 +232,7 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
                               match(updateLogDetail.type)
                                   .with('shared_metric', () => getSharedMetricChangeDescription(change))
                                   .with('holdout', () => getHoldoutChangeDescription(change))
-                                  .otherwise(() => getExperimentChangeDescription(change))
+                                  .otherwise(() => humanizeExperimentChange(getExperimentChangeDescription(change)))
                           )
                           .filter((part) => part !== null)
 

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
@@ -46,6 +46,23 @@ const UnknownAction = ({ logItem }: { logItem: ActivityLogItem }): JSX.Element =
     )
 }
 
+// Helper to determine the right preposition based on the action text
+const getPreposition = (text: string): string => {
+    if (text.includes('added') || text.includes('set')) {
+        return 'to'
+    }
+
+    if (text.includes('removed')) {
+        return 'from'
+    }
+
+    if (text.includes('changed') || text.includes('returned')) {
+        return 'for'
+    }
+
+    return 'on'
+}
+
 /**
  * Formats the result from getExperimentChangeDescription into a human-readable string
  * Handles arrays by joining with commas and "and" for the last item
@@ -56,20 +73,6 @@ const humanizeExperimentChange = (
 ): string | JSX.Element | null => {
     if (result === null) {
         return null
-    }
-
-    // Helper to determine the right preposition based on the action text
-    const getPreposition = (text: string): string => {
-        if (text.includes('added') || text.includes('set')) {
-            return 'to'
-        }
-        if (text.includes('removed')) {
-            return 'from'
-        }
-        if (text.includes('changed') || text.includes('returned')) {
-            return 'for'
-        }
-        return 'on'
     }
 
     if (Array.isArray(result)) {


### PR DESCRIPTION
## Problem

Exposure changes, although logged by the backend, were not displayed or were partially displayed on the activity log. Also, the messaging lacked a clear grammatical structure.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We've added detailed logs of the possible changes to the exposure configuration up to the event level. We can add more detail, but let's evaluate that depending on the feedback we get for this change.

Also, we added a function to improve the grammatical structure of the messages, enhancing the use of connecting words and prepositions.

| Log of exposure configuration changes |
| - |
| <img width="1363" height="315" alt="image" src="https://github.com/user-attachments/assets/10d2c3d6-5d64-4922-9272-be703488db8d" /> |

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/ee0e9c60-5c57-43fa-82fa-2a5fb8430ae6)
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
