### PR TITLE
chore(ix): shortcuts empty banner to teach users how to use it

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -2,7 +2,14 @@ import { BindLogic, useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { RefObject, useEffect, useRef, useState } from 'react'
 
-import { IconCheckbox, IconChevronRight, IconFolderPlus, IconPlusSmall } from '@posthog/icons'
+import {
+    IconCheckbox,
+    IconChevronRight,
+    IconEllipsis,
+    IconFolderPlus,
+    IconPlusSmall,
+    IconShortcut,
+} from '@posthog/icons'
 
 import { moveToLogic } from 'lib/components/FileSystem/MoveTo/moveToLogic'
 import { ResizableElement } from 'lib/components/ResizeElement/ResizeElement'
@@ -133,6 +140,25 @@ export function ProjectTree({
     const canOpenInPostHogTab = !!featureFlags[FEATURE_FLAGS.SCENE_TABS]
     const showFilterDropdown = root === 'project://'
     const showSortDropdown = root === 'project://'
+
+    const treeData: TreeDataItem[] = []
+    if (root === 'shortcuts://' && fullFileSystemFiltered.length === 0) {
+        treeData.push({
+            id: 'products/shortcuts-helper-category',
+            name: 'Example shortcuts',
+            type: 'category',
+            displayName: (
+                <div className="border border-primary text-xs mb-2 font-normal rounded-xs p-1 -mx-1">
+                    Shortcuts are added by pressing{' '}
+                    <IconEllipsis className="size-3 border border-[var(--color-neutral-500)] rounded-xs" />,
+                    side-clicking a panel item, then "Add to shortcuts panel", or inside a app's resources file menu
+                    click <IconShortcut className="size-3 border border-[var(--color-neutral-500)] rounded-xs" />
+                </div>
+            ),
+        })
+    } else {
+        treeData.push(...fullFileSystemFiltered)
+    }
 
     useEffect(() => {
         setPanelTreeRef(treeRef)
@@ -441,7 +467,7 @@ export function ProjectTree({
             ref={treeRef}
             contentRef={mainContentRef as RefObject<HTMLElement>}
             className="px-0 py-1"
-            data={fullFileSystemFiltered}
+            data={treeData}
             mode={onlyTree ? 'tree' : projectTreeMode}
             selectMode={selectMode}
             tableViewKeys={treeTableKeys}

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -151,7 +151,7 @@ export function ProjectTree({
                 <div className="border border-primary text-xs mb-2 font-normal rounded-xs p-1 -mx-1">
                     Shortcuts are added by pressing{' '}
                     <IconEllipsis className="size-3 border border-[var(--color-neutral-500)] rounded-xs" />,
-                    side-clicking a panel item, then "Add to shortcuts panel", or inside a app's resources file menu
+                    side-clicking a panel item, then "Add to shortcuts panel", or inside an app's resources file menu
                     click <IconShortcut className="size-3 border border-[var(--color-neutral-500)] rounded-xs" />
                 </div>
             ),

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -342,7 +342,7 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                             return null
                         }
                         return (
-                            <div key={item.id} className="not-first:mt-3 py-1 pl-2 flex items-center">
+                            <div key={item.id} className="not-first:mt-3 py-1 px-2 flex items-center">
                                 <span className="text-xs font-semibold text-tertiary">{item.displayName}</span>
                             </div>
                         )


### PR DESCRIPTION
## Problem
Shortcuts panel (in nav bar) when empty felt desolate, users may not understand how to use it!

## Changes
Add a small banner to the shortcuts panel when empty teaching users briefly how to use it

![2025-09-03 10 39 32](https://github.com/user-attachments/assets/02dec716-3cba-4af7-a7dd-3eacff614a48)


## How did you test this code?
When empty, it shows the banner,
when not empty, banner is gone, great.