### PR TITLE
fix(dashboards): fix variable overrides from dashboards

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -33,7 +33,7 @@ export function DashboardItems(): JSX.Element {
         refreshStatus,
         itemsLoading,
         effectiveEditBarFilters,
-        urlVariables,
+        effectiveDashboardVariableOverrides,
         temporaryBreakdownColors,
         dataColorThemeId,
     } = useValues(dashboardLogic)
@@ -167,7 +167,7 @@ export function DashboardItems(): JSX.Element {
                                     placement={placement}
                                     loadPriority={smLayout ? smLayout.y * 1000 + smLayout.x : undefined}
                                     filtersOverride={effectiveEditBarFilters}
-                                    variablesOverride={urlVariables}
+                                    variablesOverride={effectiveDashboardVariableOverrides}
                                     // :HACKY: The two props below aren't actually used in the component, but are needed to trigger a re-render
                                     breakdownColorOverride={temporaryBreakdownColors}
                                     dataColorThemeId={dataColorThemeId}


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C045L1VEG87/p1756813384890079

## Changes

The link to the insights page would only have variable overrides from the URL, but not those saved on the dashboard. Changed to use both overrides.

## How did you test this code?

- Tested an insight with a dashboard override
- Tested an insight with a URL override
