### PR TITLE
fix(data-warehouse): Try to get columns multiple times until it works

### DIFF
--- a/posthog/warehouse/models/table.py
+++ b/posthog/warehouse/models/table.py
@@ -180,29 +180,36 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
             # chdb doesn't support parameterized queries
             chdb_query = f"DESCRIBE TABLE (SELECT * FROM {s3_table_func} LIMIT 1)" % quoted_placeholders
 
+            # TODO: upgrade chdb once https://github.com/chdb-io/chdb/issues/342 is actually resolved
             chdb_result = chdb.query(chdb_query, output_format="CSV")
             reader = csv.reader(StringIO(str(chdb_result)))
             result = [tuple(row) for row in reader]
         except Exception as chdb_error:
             capture_exception(chdb_error)
 
-            try:
-                tag_queries(team_id=self.team.pk, table_id=self.id, warehouse_query=True)
+            tag_queries(team_id=self.team.pk, table_id=self.id, warehouse_query=True)
 
-                result = sync_execute(
-                    f"""DESCRIBE TABLE (
-                        SELECT *
-                        FROM {s3_table_func}
-                        LIMIT 1
-                    )""",
-                    args=placeholder_context.values,
-                )
-            except Exception as err:
-                capture_exception(err)
-                if safe_expose_ch_error:
-                    self._safe_expose_ch_error(err)
-                else:
-                    raise
+            # The cluster is a little broken right now, and so this can itermittently fail.
+            # See https://posthog.slack.com/archives/C076R4753Q8/p1756901693184169 for context
+            attempts = 5
+            for i in range(attempts):
+                try:
+                    result = sync_execute(
+                        f"""DESCRIBE TABLE (
+                            SELECT *
+                            FROM {s3_table_func}
+                            LIMIT 1
+                        )""",
+                        args=placeholder_context.values,
+                    )
+                    break
+                except Exception as err:
+                    if i >= attempts - 1:
+                        capture_exception(err)
+                        if safe_expose_ch_error:
+                            self._safe_expose_ch_error(err)
+                        else:
+                            raise
 
         if result is None or isinstance(result, int):
             raise Exception("No columns types provided by clickhouse in get_columns")

--- a/posthog/warehouse/models/table.py
+++ b/posthog/warehouse/models/table.py
@@ -189,7 +189,7 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
 
             tag_queries(team_id=self.team.pk, table_id=self.id, warehouse_query=True)
 
-            # The cluster is a little broken right now, and so this can itermittently fail.
+            # The cluster is a little broken right now, and so this can intermittently fail.
             # See https://posthog.slack.com/archives/C076R4753Q8/p1756901693184169 for context
             attempts = 5
             for i in range(attempts):


### PR DESCRIPTION
## Problem
`deltaLake` queries can intermittently break due to:

```
CHQueryErrorDeltaKernelError
DB::Exception: Received DeltaLake kernel error ObjectStoreError: Error interacting with object store: Generic S3 error: Error performing GET https://s3..amazonaws.com/<bucket>/dlt/.../_delta_log/_last_checkpoint in 2.929744019s, after 10 retries, max_retries: 10, retry_timeout: 180s 
```

Unsure what's causing this, but retrying the query a couple of times works. Some more context here: https://posthog.slack.com/archives/C076R4753Q8/p1756901693184169

## Changes
- Add retry logic to getting columns
