### PR TITLE
feat(max): Avoid adding non blocking exceptions to group summaries

### DIFF
--- a/ee/hogai/graph/session_summaries/test/__snapshots__/test_nodes.ambr
+++ b/ee/hogai/graph/session_summaries/test/__snapshots__/test_nodes.ambr
@@ -23,7 +23,7 @@
   GROUP BY s.session_id
   HAVING ifNull(greater(active_seconds, 8.0), 0)
   ORDER BY start_time DESC
-  LIMIT 201
+  LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
@@ -97,7 +97,7 @@
   GROUP BY s.session_id
   HAVING ifNull(greater(active_seconds, 7.0), 0)
   ORDER BY start_time DESC
-  LIMIT 201
+  LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
@@ -161,7 +161,7 @@
   GROUP BY s.session_id
   HAVING ifNull(greater(active_seconds, 6.0), 0)
   ORDER BY start_time DESC
-  LIMIT 201
+  LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,

--- a/ee/hogai/session_summaries/constants.py
+++ b/ee/hogai/session_summaries/constants.py
@@ -11,7 +11,7 @@ SESSION_SUMMARIES_TEMPERATURE = 0.1  # Reduce hallucinations, but >0 to allow fo
 BASE_LLM_CALL_TIMEOUT_S = 600.0
 
 # Summarization
-MAX_SESSIONS_TO_SUMMARIZE = 200  # Maximum number of sessions to summarize at once
+MAX_SESSIONS_TO_SUMMARIZE = 100  # Maximum number of sessions to summarize at once
 HALLUCINATED_EVENTS_MIN_RATIO = 0.15  # If more than 15% of events in the summary hallucinated, fail the summarization
 # Minimum number of sessions to use group summary logic (find patterns) instead of summarizing them separately
 GROUP_SUMMARIES_MIN_SESSIONS = 5

--- a/ee/hogai/session_summaries/session_group/patterns.py
+++ b/ee/hogai/session_summaries/session_group/patterns.py
@@ -369,6 +369,9 @@ def combine_patterns_ids_with_events_context(
             event_segment_context = _enrich_pattern_assigned_event_with_session_summary_data(
                 pattern_assigned_event, session_summaries
             )
+            # Skip non-blocking exceptions, allow blocking ones and abandonment (no exception)
+            if event_segment_context.target_event.exception == "non-blocking":
+                continue
             if pattern_id not in pattern_event_ids_mapping:
                 pattern_event_ids_mapping[pattern_id] = []
             pattern_event_ids_mapping[pattern_id].append(event_segment_context)
@@ -412,9 +415,7 @@ def combine_patterns_with_events_context(
         pattern_id = pattern.pattern_id
         pattern_events = pattern_id_to_event_context_mapping.get(int(pattern_id), [])
         if not pattern_events:
-            logger.exception(
-                f"No events found for pattern {pattern_id} when combining patterns with events context: {pattern_id_to_event_context_mapping}"
-            )
+            # Skip patterns if no relevant events were found
             continue
         enriched_pattern = EnrichedSessionGroupSummaryPattern(
             **pattern.model_dump(),

--- a/ee/hogai/session_summaries/session_group/patterns.py
+++ b/ee/hogai/session_summaries/session_group/patterns.py
@@ -350,6 +350,7 @@ def combine_patterns_ids_with_events_context(
 ) -> dict[int, list[PatternAssignedEventSegmentContext]]:
     """Map pattern IDs to enriched event contexts using assignments context."""
     pattern_event_ids_mapping: dict[int, list[PatternAssignedEventSegmentContext]] = {}
+    patterns_with_removed_non_blocking_exceptions = set()
     # Iterate over patterns to which we assigned event ids
     for pattern_id, event_ids in combined_patterns_assignments.items():
         for event_id in event_ids:
@@ -371,10 +372,18 @@ def combine_patterns_ids_with_events_context(
             )
             # Skip non-blocking exceptions, allow blocking ones and abandonment (no exception)
             if event_segment_context.target_event.exception == "non-blocking":
+                patterns_with_removed_non_blocking_exceptions.add(pattern_id)
                 continue
             if pattern_id not in pattern_event_ids_mapping:
                 pattern_event_ids_mapping[pattern_id] = []
             pattern_event_ids_mapping[pattern_id].append(event_segment_context)
+    # If we removed all non-blocking exceptions for some patterns - it's not a failure
+    for pattern_id in patterns_with_removed_non_blocking_exceptions:
+        if pattern_id in pattern_event_ids_mapping:
+            # Avoid touching patterns that have events left even after removing non-blocking exceptions
+            continue
+        # Let's back the patterns we emptied, so we can properly calculate failure ratio
+        pattern_event_ids_mapping[pattern_id] = []
     return pattern_event_ids_mapping
 
 
@@ -411,11 +420,15 @@ def combine_patterns_with_events_context(
 ) -> EnrichedSessionGroupSummaryPatternsList:
     """Attach event context and stats to each extracted pattern."""
     combined_patterns = []
+    non_failed_empty_patterns_count = 0
     for pattern in patterns.patterns:
         pattern_id = pattern.pattern_id
-        pattern_events = pattern_id_to_event_context_mapping.get(int(pattern_id), [])
+        pattern_events = pattern_id_to_event_context_mapping.get(int(pattern_id))
         if not pattern_events:
-            # Skip patterns if no relevant events were found
+            if pattern_events is not None:
+                # If the pattern has not events, but is in the mapping - it's not a failure,
+                # it means we made it empty by removing non-blocking exceptions
+                non_failed_empty_patterns_count += 1
             continue
         enriched_pattern = EnrichedSessionGroupSummaryPattern(
             **pattern.model_dump(),
@@ -424,10 +437,15 @@ def combine_patterns_with_events_context(
         )
         combined_patterns.append(enriched_pattern)
     # If not enough patterns were properly enriched - fail the activity
-    if ceil(len(patterns.patterns) * FAILED_PATTERNS_ENRICHMENT_MIN_RATIO) > len(combined_patterns):
+    minimum_expected_patterns_count = ceil(len(patterns.patterns) * FAILED_PATTERNS_ENRICHMENT_MIN_RATIO)
+    successful_patterns_count = len(combined_patterns) + non_failed_empty_patterns_count
+    failed_patterns_count = len(patterns.patterns) - successful_patterns_count
+    if minimum_expected_patterns_count > successful_patterns_count:
         exception_message = (
             f"Too many patterns failed to enrich with session meta, when summarizing {len(session_ids)} "
-            f"sessions ({logging_session_ids(session_ids)}) for user {user_id}"
+            f"sessions ({logging_session_ids(session_ids)}) for user {user_id}. "
+            f"Input: {len(patterns.patterns)}; success: {successful_patterns_count} "
+            f"(enriched: {len(combined_patterns)}); failure: {failed_patterns_count}"
         )
         logger.exception(exception_message)
         raise ApplicationError(exception_message)

--- a/posthog/temporal/tests/ai/test_summarize_session_group.py
+++ b/posthog/temporal/tests/ai/test_summarize_session_group.py
@@ -512,6 +512,143 @@ async def test_assign_events_to_patterns_threshold_check(
         assert len(result.patterns) == 3  # Should have 3 patterns with events
 
 
+@pytest.mark.asyncio
+async def test_assign_events_to_patterns_filters_non_blocking_exceptions(
+    mocker: MockerFixture,
+    mock_session_id: str,
+    mock_enriched_llm_json_response: dict[str, Any],
+    mock_single_session_summary_inputs: Callable,
+    mock_session_group_summary_of_summaries_inputs: Callable,
+    redis_test_setup: AsyncRedisTestContext,
+    auser: User,
+    ateam: Team,
+):
+    """Test that non-blocking exceptions are filtered out from pattern assignments"""
+    modified_summary_data = dict(mock_enriched_llm_json_response)
+    # Add a non-blocking exception event to the key actions (to skip)
+    modified_summary_data["key_actions"][1]["events"].append(
+        {
+            "description": "Non-blocking error occurred",
+            "abandonment": False,
+            "confusion": False,
+            "exception": "non-blocking",  # This should be filtered out
+            "event_id": "xyz98765",
+            "timestamp": "2025-03-31T18:41:20.000000+00:00",
+            "milliseconds_since_start": 48000,
+            "window_id": "0195ed81-7519-7595-9221-8bb8ddb1fdcc",
+            "current_url": "http://localhost:8010/error",
+            "event": "$exception",
+            "event_type": "error",
+            "event_index": 7,
+            "session_id": mock_session_id,
+            "event_uuid": "00000000-0000-0000-0001-000000000008",
+        }
+    )
+    # Create serializer from modified data
+    modified_serializer = SessionSummarySerializer(data=modified_summary_data)
+    assert modified_serializer.is_valid(), f"Invalid session summary data: {modified_serializer.errors}"
+    # Setup input and store modified session summary in DB
+    session_ids = [mock_session_id]
+    single_session_inputs = [
+        mock_single_session_summary_inputs(session_id, ateam.id, auser.id) for session_id in session_ids
+    ]
+    activity_input = mock_session_group_summary_of_summaries_inputs(single_session_inputs, auser.id, ateam.id)
+    await database_sync_to_async(SingleSessionSummary.objects.add_summary, thread_sensitive=False)(
+        team_id=ateam.id,
+        session_id=mock_session_id,
+        summary=modified_serializer,
+        exception_event_ids=[],
+        extra_summary_context=activity_input.extra_summary_context,
+        created_by=auser,
+    )
+    # Setup Redis with patterns
+    patterns_data = RawSessionGroupSummaryPatternsList(
+        patterns=[
+            {
+                "pattern_id": 1,
+                "pattern_name": "Error Pattern",
+                "pattern_description": "Pattern for error events",
+                "severity": "high",
+                "indicators": ["error", "exception"],
+            },
+            {
+                "pattern_id": 2,
+                "pattern_name": "Confusion Pattern",
+                "pattern_description": "Pattern for user confusion",
+                "severity": "medium",
+                "indicators": ["confusion", "retry"],
+            },
+        ]
+    )
+    _, redis_input_key, _ = get_redis_state_client(
+        key_base=activity_input.redis_key_base,
+        input_label=StateActivitiesEnum.SESSION_GROUP_EXTRACTED_PATTERNS,
+        state_id=generate_state_id_from_session_ids(session_ids),
+    )
+    await redis_test_setup.setup_input_data(
+        _compress_redis_data(patterns_data.model_dump_json()),
+        redis_input_key,
+    )
+    # Create a mock LLM response for pattern assignment
+    patterns_assignment_yaml = """patterns:
+  - pattern_id: 1
+    event_ids: ["mnop3456", "xyz98765"]  # mnop3456 is blocking, xyz98765 is non-blocking
+  - pattern_id: 2
+    event_ids: ["stuv9012"]  # stuv9012 has abandonment"""
+    mock_llm_response = ChatCompletion(
+        id="test_id",
+        model="test_model",
+        object="chat.completion",
+        created=int(datetime.now().timestamp()),
+        choices=[
+            Choice(
+                finish_reason="stop",
+                index=0,
+                message=ChatCompletionMessage(
+                    content=patterns_assignment_yaml,
+                    role="assistant",
+                ),
+            )
+        ],
+    )
+    # Mock LLM calls and Temporal context
+    with (
+        patch("ee.hogai.session_summaries.llm.consume.call_llm") as mock_call_llm,
+        patch("temporalio.activity.info") as mock_activity_info,
+        patch("posthog.temporal.ai.session_summary.activities.patterns.async_connect") as mock_async_connect,
+    ):
+        # Setup mocks
+        mock_activity_info.return_value.workflow_id = "test_workflow_id"
+        mock_activity_info.return_value.workflow_run_id = "test_run_id"
+        # Mock workflow handle for progress updates
+        mock_workflow_handle = AsyncMock()
+        mock_workflow_handle.signal = AsyncMock()
+        mock_temporal_client = AsyncMock()
+        mock_temporal_client.get_workflow_handle = MagicMock(return_value=mock_workflow_handle)
+        mock_async_connect.return_value = mock_temporal_client
+        # Mock LLM call for pattern assignment
+        mock_call_llm.return_value = mock_llm_response
+        # Execute activity
+        result = await assign_events_to_patterns_activity(activity_input)
+    # Assertions
+    assert isinstance(result, EnrichedSessionGroupSummaryPatternsList)
+    # Pattern 1 should only have mnop3456 (blocking, should be included), not xyz98765 (non-blocking, should be skipped)
+    pattern_1 = next((p for p in result.patterns if p.pattern_id == 1), None)
+    assert pattern_1 is not None, "Pattern 1 should exist"
+    assert len(pattern_1.events) == 1, "Pattern 1 should have only 1 event after filtering"
+    assert pattern_1.events[0].target_event.event_id == "mnop3456"
+    assert pattern_1.events[0].target_event.exception == "blocking"
+    # Pattern 2 should have stuv9012 (abandonment, should be included)
+    pattern_2 = next((p for p in result.patterns if p.pattern_id == 2), None)
+    assert pattern_2 is not None, "Pattern 2 should exist"
+    assert len(pattern_2.events) == 1, "Pattern 2 should have 1 event"
+    assert pattern_2.events[0].target_event.event_id == "stuv9012"
+    assert pattern_2.events[0].target_event.abandonment is True
+    # Verify stats reflect only remaining events
+    assert pattern_1.stats.occurences == 1  # Only blocking exception counted
+    assert pattern_2.stats.occurences == 1
+
+
 class TestSummarizeSessionGroupWorkflow:
     @contextmanager
     def execute_test_environment(

--- a/posthog/temporal/tests/ai/test_summarize_session_group.py
+++ b/posthog/temporal/tests/ai/test_summarize_session_group.py
@@ -585,6 +585,7 @@ async def test_assign_events_to_patterns_filters_non_blocking_exceptions(
         input_label=StateActivitiesEnum.SESSION_GROUP_EXTRACTED_PATTERNS,
         state_id=generate_state_id_from_session_ids(session_ids),
     )
+    assert redis_input_key is not None
     await redis_test_setup.setup_input_data(
         _compress_redis_data(patterns_data.model_dump_json()),
         redis_input_key,
@@ -647,6 +648,195 @@ async def test_assign_events_to_patterns_filters_non_blocking_exceptions(
     # Verify stats reflect only remaining events
     assert pattern_1.stats.occurences == 1  # Only blocking exception counted
     assert pattern_2.stats.occurences == 1
+
+
+@pytest.mark.asyncio
+async def test_non_blocking_exceptions_dont_fail_enrichment_ratio(
+    mocker: MockerFixture,
+    mock_session_id: str,
+    mock_enriched_llm_json_response: dict[str, Any],
+    mock_single_session_summary_inputs: Callable,
+    mock_session_group_summary_of_summaries_inputs: Callable,
+    redis_test_setup: AsyncRedisTestContext,
+    auser: User,
+    ateam: Team,
+):
+    """Test that patterns with only non-blocking exceptions don't count as enrichment failures"""
+    # Create a modified session summary with only non-blocking exceptions for some patterns
+    modified_summary_data = dict(mock_enriched_llm_json_response)
+    # Clear existing events and add specific test events
+    modified_summary_data["key_actions"][1]["events"] = [
+        {
+            "description": "Non-blocking error 1",
+            "abandonment": False,
+            "confusion": False,
+            "exception": "non-blocking",
+            "event_id": "nonb0001",
+            "timestamp": "2025-03-31T18:41:20.000000+00:00",
+            "milliseconds_since_start": 48000,
+            "window_id": "0195ed81-7519-7595-9221-8bb8ddb1fdcc",
+            "current_url": "http://localhost:8010/error",
+            "event": "$exception",
+            "event_type": "error",
+            "event_index": 7,
+            "session_id": mock_session_id,
+            "event_uuid": "00000000-0000-0000-0001-000000000008",
+        },
+        {
+            "description": "Non-blocking error 2",
+            "abandonment": False,
+            "confusion": False,
+            "exception": "non-blocking",
+            "event_id": "nonb0002",
+            "timestamp": "2025-03-31T18:41:21.000000+00:00",
+            "milliseconds_since_start": 49000,
+            "window_id": "0195ed81-7519-7595-9221-8bb8ddb1fdcc",
+            "current_url": "http://localhost:8010/error",
+            "event": "$exception",
+            "event_type": "error",
+            "event_index": 8,
+            "session_id": mock_session_id,
+            "event_uuid": "00000000-0000-0000-0001-000000000009",
+        },
+        {
+            "description": "Blocking error",
+            "abandonment": False,
+            "confusion": True,
+            "exception": "blocking",
+            "event_id": "block001",
+            "timestamp": "2025-03-31T18:41:22.000000+00:00",
+            "milliseconds_since_start": 50000,
+            "window_id": "0195ed81-7519-7595-9221-8bb8ddb1fdcc",
+            "current_url": "http://localhost:8010/error",
+            "event": "$exception",
+            "event_type": "error",
+            "event_index": 9,
+            "session_id": mock_session_id,
+            "event_uuid": "00000000-0000-0000-0001-000000000010",
+        },
+    ]
+    # Create serializer from modified data
+    modified_serializer = SessionSummarySerializer(data=modified_summary_data)
+    assert modified_serializer.is_valid(), f"Invalid session summary data: {modified_serializer.errors}"
+    # Setup input
+    session_ids = [mock_session_id]
+    single_session_inputs = [
+        mock_single_session_summary_inputs(session_id, ateam.id, auser.id) for session_id in session_ids
+    ]
+    activity_input = mock_session_group_summary_of_summaries_inputs(single_session_inputs, auser.id, ateam.id)
+    # Store modified session summary in DB
+    await database_sync_to_async(SingleSessionSummary.objects.add_summary, thread_sensitive=False)(
+        team_id=ateam.id,
+        session_id=mock_session_id,
+        summary=modified_serializer,
+        exception_event_ids=[],
+        extra_summary_context=activity_input.extra_summary_context,
+        created_by=auser,
+    )
+    # Setup Redis with 3 patterns
+    patterns_data = RawSessionGroupSummaryPatternsList(
+        patterns=[
+            {
+                "pattern_id": 1,
+                "pattern_name": "Non-blocking Pattern",
+                "pattern_description": "Pattern with only non-blocking exceptions",
+                "severity": "low",
+                "indicators": ["non-blocking"],
+            },
+            {
+                "pattern_id": 2,
+                "pattern_name": "Blocking Pattern",
+                "pattern_description": "Pattern with blocking exceptions",
+                "severity": "high",
+                "indicators": ["blocking"],
+            },
+            {
+                "pattern_id": 3,
+                "pattern_name": "Mixed Pattern",
+                "pattern_description": "Pattern with both types",
+                "severity": "medium",
+                "indicators": ["error"],
+            },
+        ]
+    )
+    _, redis_input_key, _ = get_redis_state_client(
+        key_base=activity_input.redis_key_base,
+        input_label=StateActivitiesEnum.SESSION_GROUP_EXTRACTED_PATTERNS,
+        state_id=generate_state_id_from_session_ids(session_ids),
+    )
+    assert redis_input_key is not None
+    await redis_test_setup.setup_input_data(
+        _compress_redis_data(patterns_data.model_dump_json()),
+        redis_input_key,
+    )
+    # Mock LLM response that assigns events to patterns
+    patterns_assignment_yaml = """patterns:
+  - pattern_id: 1
+    event_ids: ["nonb0001", "nonb0002"]  # Only non-blocking
+  - pattern_id: 2
+    event_ids: ["block001"]  # Only blocking
+  - pattern_id: 3
+    event_ids: ["nonb0001", "block001"]  # Mixed"""
+    mock_llm_response = ChatCompletion(
+        id="test_id",
+        model="test_model",
+        object="chat.completion",
+        created=int(datetime.now().timestamp()),
+        choices=[
+            Choice(
+                finish_reason="stop",
+                index=0,
+                message=ChatCompletionMessage(
+                    content=patterns_assignment_yaml,
+                    role="assistant",
+                ),
+            )
+        ],
+    )
+
+    with (
+        patch("ee.hogai.session_summaries.llm.consume.call_llm") as mock_call_llm,
+        patch("temporalio.activity.info") as mock_activity_info,
+        patch("posthog.temporal.ai.session_summary.activities.patterns.async_connect") as mock_async_connect,
+    ):
+        # Setup mocks
+        mock_activity_info.return_value.workflow_id = "test_workflow_id"
+        mock_activity_info.return_value.workflow_run_id = "test_run_id"
+
+        # Mock workflow handle for progress updates
+        mock_workflow_handle = AsyncMock()
+        mock_workflow_handle.signal = AsyncMock()
+        mock_temporal_client = AsyncMock()
+        mock_temporal_client.get_workflow_handle = MagicMock(return_value=mock_workflow_handle)
+        mock_async_connect.return_value = mock_temporal_client
+
+        # Mock LLM call
+        mock_call_llm.return_value = mock_llm_response
+
+        # Execute activity - should NOT fail despite pattern 1 having no events after filtering
+        result = await assign_events_to_patterns_activity(activity_input)
+
+    # Assertions
+    assert isinstance(result, EnrichedSessionGroupSummaryPatternsList)
+
+    # Pattern 1 should be removed (only non-blocking)
+    pattern_1 = next((p for p in result.patterns if p.pattern_id == 1), None)
+    assert pattern_1 is None, "Pattern 1 with only non-blocking exceptions should be removed"
+
+    # Pattern 2 should exist with blocking exception
+    pattern_2 = next((p for p in result.patterns if p.pattern_id == 2), None)
+    assert pattern_2 is not None, "Pattern 2 should exist"
+    assert len(pattern_2.events) == 1
+    assert pattern_2.events[0].target_event.event_id == "block001"
+
+    # Pattern 3 should have only the blocking exception
+    pattern_3 = next((p for p in result.patterns if p.pattern_id == 3), None)
+    assert pattern_3 is not None, "Pattern 3 should exist"
+    assert len(pattern_3.events) == 1, "Pattern 3 should have only blocking event"
+    assert pattern_3.events[0].target_event.event_id == "block001"
+
+    # Result should have 2 patterns (patterns 2 and 3)
+    assert len(result.patterns) == 2, "Should have 2 patterns with valid events"
 
 
 class TestSummarizeSessionGroupWorkflow:


### PR DESCRIPTION
## Problem

- Non-blocking exceptions (like JS errors that didn't affect the user match) were attached to Session summaries patterns, which led to some examples in the notebook to be meh ("yeah, it happened, so what?")
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Remove non-blocking exceptions from the final notebook
- Reduce max sessions to 100 (as results from 200+ generate too many examples and it OOMs the browser and Max, need to change FE implementation, as even hidden players eat memory, as it seems)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
