### PR TITLE
feat: Emit row metrics for batch exports

### DIFF
--- a/products/batch_exports/backend/temporal/batch_exports.py
+++ b/products/batch_exports/backend/temporal/batch_exports.py
@@ -537,10 +537,18 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
             inputs.records_completed if inputs.records_completed is not None else "no",
         )
 
-    await try_produce_run_status_app_metrics(batch_export_run.status, inputs.team_id, inputs.batch_export_id)
+    await try_produce_run_status_app_metrics(
+        batch_export_run.status, inputs.team_id, inputs.batch_export_id, inputs.id, inputs.records_completed or 0
+    )
 
 
-async def try_produce_run_status_app_metrics(status: BatchExportRun.Status | str, team_id: int, batch_export_id: str):
+async def try_produce_run_status_app_metrics(
+    status: BatchExportRun.Status | str,
+    team_id: int,
+    batch_export_id: str,
+    batch_export_run_id: str,
+    rows_exported: int,
+):
     """Attempt to produce batch export run status to app_metrics2.
 
     The metric name and kind will depend on the reported status.
@@ -564,28 +572,44 @@ async def try_produce_run_status_app_metrics(status: BatchExportRun.Status | str
             metric_kind = "failure"
             metric_name = "failed"
 
+    run_metric = json.dumps(
+        {
+            "team_id": team_id,
+            "app_source": "batch_export",
+            "app_source_id": batch_export_id,
+            "count": 1,
+            "metric_kind": metric_kind,
+            "metric_name": metric_name,
+            "timestamp": dt.datetime.now(dt.UTC).strftime("%Y-%m-%d %H:%M:%S"),
+        }
+    ).encode("utf-8")
+    rows_metric = json.dumps(
+        {
+            "team_id": team_id,
+            "app_source": "batch_export",
+            "app_source_id": batch_export_id,
+            "instance_id": batch_export_run_id,
+            "count": rows_exported,
+            "metric_kind": "rows",
+            "metric_name": "rows_exported",
+            "timestamp": dt.datetime.now(dt.UTC).strftime("%Y-%m-%d %H:%M:%S"),
+        }
+    ).encode("utf-8")
+
     async with producer:
-        fut = await producer.send(
-            KAFKA_APP_METRICS2,
-            json.dumps(
-                {
-                    "team_id": team_id,
-                    "app_source": "batch_export",
-                    "app_source_id": batch_export_id,
-                    "count": 1,
-                    "metric_kind": metric_kind,
-                    "metric_name": metric_name,
-                    "timestamp": dt.datetime.now(dt.UTC).strftime("%Y-%m-%d %H:%M:%S"),
-                }
-            ).encode("utf-8"),
-        )
-        try:
-            await fut
-            await producer.flush()
-        except Exception:
-            LOGGER.exception(
-                "Metrics production failed", team_id=team_id, batch_export_id=batch_export_id, metric_kind=metric_kind
-            )
+        for metric in (run_metric, rows_metric):
+            fut = await producer.send(KAFKA_APP_METRICS2, metric)
+
+            try:
+                await fut
+                await producer.flush()
+            except Exception:
+                LOGGER.exception(
+                    "Metrics production failed",
+                    team_id=team_id,
+                    batch_export_id=batch_export_id,
+                    metric_kind=metric_kind,
+                )
 
 
 def configure_default_ssl_context():

--- a/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
@@ -222,8 +222,8 @@ async def read_json_file_from_s3(s3_compatible_client, bucket_name, key) -> list
     return data[0]
 
 
-MetricKind = t.Literal["success", "cancellation", "failure"]
-MetricName = t.Literal["succeeded", "canceled", "failed"]
+MetricKind = t.Literal["success", "cancellation", "failure", "rows"]
+MetricName = t.Literal["succeeded", "canceled", "failed", "rows_exported"]
 ExpectedCount = int
 ExpectedMetricsMap = dict[tuple[MetricKind, MetricName], ExpectedCount]
 
@@ -960,7 +960,11 @@ async def _run_s3_batch_export_workflow(
     elif isinstance(model, BatchExportModel) and model.name == "sessions":
         sort_key = "session_id"
 
-    await assert_metrics_in_clickhouse(clickhouse_client, batch_export_id, {("success", "succeeded"): 1})
+    await assert_metrics_in_clickhouse(
+        clickhouse_client,
+        batch_export_id,
+        {("success", "succeeded"): 1, ("rows", "rows_exported"): run.records_completed},
+    )
 
     await assert_clickhouse_records_in_s3(
         s3_compatible_client=s3_client,

--- a/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
@@ -963,7 +963,7 @@ async def _run_s3_batch_export_workflow(
     await assert_metrics_in_clickhouse(
         clickhouse_client,
         batch_export_id,
-        {("success", "succeeded"): 1, ("rows", "rows_exported"): run.records_completed},
+        {("success", "succeeded"): 1, ("rows", "rows_exported"): run.records_completed or 0},
     )
 
     await assert_clickhouse_records_in_s3(


### PR DESCRIPTION
## Problem

We need row metrics for batch exports.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Extend the existing metrics production function to also handle `rows_exported`.
Extend tests to verify this is tracked correctly.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

S3 tests also verify app_metrics contains a `rows_exported` metric matching `records_completed` in the database.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
