### PR TITLE
fix(data-warehouse): Sleep a little bit on every reattempt

### DIFF
--- a/posthog/warehouse/models/table.py
+++ b/posthog/warehouse/models/table.py
@@ -1,4 +1,5 @@
 import csv
+import time
 from datetime import datetime
 from io import StringIO
 from typing import TYPE_CHECKING, Any, Optional, TypeAlias
@@ -210,6 +211,9 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
                             self._safe_expose_ch_error(err)
                         else:
                             raise
+
+                    # Pause execution slightly to not overload clickhouse
+                    time.sleep(2**i)
 
         if result is None or isinstance(result, int):
             raise Exception("No columns types provided by clickhouse in get_columns")


### PR DESCRIPTION
## Problem
- We're occasionally hitting simultaneous clickhouse errors - I think its due to our retry logic

## Changes
- Add a slight backoff sleep to the retry 