### PR TITLE
fix(experiments): don't use full width for metric goal selector

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -307,19 +307,17 @@ export function ExperimentMetricForm({
                 )}
             </div>
             <div>
-                <LemonLabel className="mb-1">Goal</LemonLabel>
+                <LemonLabel className="mb-1">What is the goal for this metric?</LemonLabel>
                 <LemonSelect<ExperimentMetricGoal>
                     value={metric.goal || ExperimentMetricGoal.Increase}
                     onChange={(value) => handleSetMetric({ ...metric, goal: value })}
                     options={[
-                        { value: ExperimentMetricGoal.Increase, label: 'Increase' },
-                        { value: ExperimentMetricGoal.Decrease, label: 'Decrease' },
+                        { value: ExperimentMetricGoal.Increase, label: 'To increase' },
+                        { value: ExperimentMetricGoal.Decrease, label: 'To decrease' },
                     ]}
-                    fullWidth
                 />
                 <div className="text-muted text-sm mt-1">
-                    Choose whether you want this metric to increase or decrease. For example, conversion rates should
-                    increase, while bounce rates should decrease.
+                    For example, conversion rates should increase, while bounce rates should decrease.
                 </div>
             </div>
             <ExperimentMetricConversionWindowFilter metric={metric} handleSetMetric={handleSetMetric} />

--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -307,13 +307,13 @@ export function ExperimentMetricForm({
                 )}
             </div>
             <div>
-                <LemonLabel className="mb-1">What is the goal for this metric?</LemonLabel>
+                <LemonLabel className="mb-1">Goal</LemonLabel>
                 <LemonSelect<ExperimentMetricGoal>
                     value={metric.goal || ExperimentMetricGoal.Increase}
                     onChange={(value) => handleSetMetric({ ...metric, goal: value })}
                     options={[
-                        { value: ExperimentMetricGoal.Increase, label: 'To increase' },
-                        { value: ExperimentMetricGoal.Decrease, label: 'To decrease' },
+                        { value: ExperimentMetricGoal.Increase, label: 'Increase' },
+                        { value: ExperimentMetricGoal.Decrease, label: 'Decrease' },
                     ]}
                 />
                 <div className="text-muted text-sm mt-1">


### PR DESCRIPTION
## Problem
Goal selector uses full width.
<img width="988" height="100" alt="Screenshot 2025-09-02 at 21 30 03" src="https://github.com/user-attachments/assets/6411b87b-81d3-4b89-8f8b-5e534d5a015c" />

## Changes

Only use the width needed to fit the content. Also make the description less wordy.
<img width="973" height="106" alt="Screenshot 2025-09-03 at 17 31 25" src="https://github.com/user-attachments/assets/4fa4a16a-e837-4343-bfe0-27b966578c81" />

## How did you test this code?

- 👀 