### PR TITLE
fix: add sudo to apt-get commands in deploy script

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -141,8 +141,8 @@ EOF
 
 # Download GeoLite2-City.mmdb if it doesn't exist
 echo "Downloading GeoIP database file"
-apt-get update && 
-apt-get install -y --no-install-recommends curl ca-certificates brotli && 
+sudo apt-get update && 
+sudo apt-get install -y --no-install-recommends curl ca-certificates brotli && 
 mkdir -p ./share && 
 if [ ! -f ./share/GeoLite2-City.mmdb ]; then 
     curl -L 'https://mmdbcdn.posthog.net/' --http1.1 | brotli --decompress --output=./share/GeoLite2-City.mmdb && 


### PR DESCRIPTION
## Problem

`apt-get` commands would fail without sufficient privileges and the script continues to execute.

`set -e` does not abort execution in this case because the commands are "part of any command executed in a `&&` or `||` list except the command following the final `&&` or `||`." I cannot assume if this is intentional or not, so if execution of the script should be aborted on GeoIP database download errors, you may consider applying the following changes instead:

```diff
diff --git a/bin/deploy-hobby b/bin/deploy-hobby
index dc24606a09090..75216777a82f9 100755
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -141,13 +141,13 @@ EOF
 
 # Download GeoLite2-City.mmdb if it doesn't exist
 echo "Downloading GeoIP database file"
-apt-get update && 
-apt-get install -y --no-install-recommends curl ca-certificates brotli && 
-mkdir -p ./share && 
-if [ ! -f ./share/GeoLite2-City.mmdb ]; then 
-    curl -L 'https://mmdbcdn.posthog.net/' --http1.1 | brotli --decompress --output=./share/GeoLite2-City.mmdb && 
-    echo '{\"date\": \"'$(date +%Y-%m-%d)'\"}' > ./share/GeoLite2-City.json; 
-    chmod 644 ./share/GeoLite2-City.mmdb &&
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends curl ca-certificates brotli
+mkdir -p ./share
+if [ ! -f ./share/GeoLite2-City.mmdb ]; then
+    curl -L 'https://mmdbcdn.posthog.net/' --http1.1 | brotli --decompress --output=./share/GeoLite2-City.mmdb
+    echo '{\"date\": \"'$(date +%Y-%m-%d)'\"}' > ./share/GeoLite2-City.json
+    chmod 644 ./share/GeoLite2-City.mmdb
     chmod 644 ./share/GeoLite2-City.json
 fi
 
```

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Add `sudo` to the commands.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Run the script again.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
