### PR TITLE
chore(dashboard): add extra properties to dashboard events

### DIFF
--- a/frontend/src/lib/components/AddToDashboard/addToDashboardModalLogic.ts
+++ b/frontend/src/lib/components/AddToDashboard/addToDashboardModalLogic.ts
@@ -106,7 +106,7 @@ export const addToDashboardModalLogic = kea<addToDashboardModalLogicType>([
                     dashboards: [...(values.insight.dashboards || []), dashboardId],
                 },
                 () => {
-                    actions.reportSavedInsightToDashboard()
+                    actions.reportSavedInsightToDashboard(values.insight, dashboardId)
                     dashboardsModel.actions.tileAddedToDashboard(dashboardId)
                     lemonToast.success('Insight added to dashboard', {
                         button: {
@@ -126,7 +126,7 @@ export const addToDashboardModalLogic = kea<addToDashboardModalLogicType>([
                     ),
                 },
                 () => {
-                    actions.reportRemovedInsightFromDashboard()
+                    actions.reportRemovedInsightFromDashboard(values.insight, dashboardId)
                     lemonToast.success('Insight removed from dashboard')
                 }
             )

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -419,12 +419,12 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportCreatedDashboardFromModal: true,
         reportSavedInsightToDashboard: (
             insight: Partial<QueryBasedInsightModel> | null,
-            dashboard: DashboardType<QueryBasedInsightModel> | null
-        ) => ({ insight, dashboard }),
+            dashboardId: number | null
+        ) => ({ insight, dashboardId }),
         reportRemovedInsightFromDashboard: (
             insight: Partial<QueryBasedInsightModel> | null,
-            dashboard: DashboardType<QueryBasedInsightModel> | null
-        ) => ({ insight, dashboard }),
+            dashboardId: number | null
+        ) => ({ insight, dashboardId }),
         reportSavedInsightTabChanged: (tab: string) => ({ tab }),
         reportSavedInsightFilterUsed: (filterKeys: string[]) => ({ filterKeys }),
         reportSavedInsightLayoutChanged: (layout: string) => ({ layout }),
@@ -931,18 +931,16 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportCreatedDashboardFromModal: async () => {
             posthog.capture('created new dashboard from modal')
         },
-        reportSavedInsightToDashboard: async ({ insight, dashboard }) => {
+        reportSavedInsightToDashboard: async ({ insight, dashboardId }) => {
             posthog.capture('saved insight to dashboard', {
                 insight: sanitizeInsight(insight),
-                dashboard_id: dashboard?.id,
-                dashboard: sanitizeDashboard(dashboard),
+                dashboard_id: dashboardId,
             })
         },
-        reportRemovedInsightFromDashboard: async ({ insight, dashboard }) => {
+        reportRemovedInsightFromDashboard: async ({ insight, dashboardId }) => {
             posthog.capture('removed insight from dashboard', {
                 insight: sanitizeInsight(insight),
-                dashboard_id: dashboard?.id,
-                dashboard: sanitizeDashboard(dashboard),
+                dashboard_id: dashboardId,
             })
         },
         reportInsightsTableCalcToggled: async (payload) => {

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -141,7 +141,7 @@ export function getEventPropertiesForExperiment(experiment: Experiment): object 
     }
 }
 
-function sanitizeInsight(insight: QueryBasedInsightModel | null): object | undefined {
+function sanitizeInsight(insight: Partial<QueryBasedInsightModel> | null): object | undefined {
     if (!insight) {
         return undefined
     }
@@ -167,6 +167,17 @@ function sanitizeTile(tile: DashboardTile<QueryBasedInsightModel> | null): objec
     return {
         ...tile,
         insight: tile.insight ? sanitizeInsight(tile.insight) : undefined,
+    }
+}
+
+function sanitizeDashboard(dashboard: DashboardType<QueryBasedInsightModel> | null): object | null {
+    if (!dashboard) {
+        return null
+    }
+
+    return {
+        ...dashboard,
+        tiles: dashboard.tiles?.map((tile) => sanitizeTile(tile)) || [],
     }
 }
 
@@ -240,7 +251,11 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         ) => ({ action, totalProperties, oldPropertyType, newPropertyType }),
         // insights
         reportInsightCreated: (query: Node | null) => ({ query }),
-        reportInsightSaved: (query: Node | null, isNewInsight: boolean) => ({ query, isNewInsight }),
+        reportInsightSaved: (
+            insight: Partial<QueryBasedInsightModel> | null,
+            query: Node | null,
+            isNewInsight: boolean
+        ) => ({ insight, query, isNewInsight }),
         reportInsightViewed: (
             insightModel: Partial<QueryBasedInsightModel>,
             query: Node | null,
@@ -321,7 +336,11 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             delay,
             lastRefreshed,
         }),
-        reportDashboardModeToggled: (mode: DashboardMode, source: DashboardEventSource | null) => ({ mode, source }),
+        reportDashboardModeToggled: (
+            dashboard: DashboardType<QueryBasedInsightModel> | null,
+            mode: DashboardMode,
+            source: DashboardEventSource | null
+        ) => ({ dashboard, mode, source }),
         reportDashboardRefreshed: (
             dashboardId: number,
             dashboard: DashboardType<QueryBasedInsightModel> | null,
@@ -363,11 +382,16 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             refreshDurationMs,
             individualRefresh,
         }),
-        reportDashboardDateRangeChanged: (dateFrom?: string | Dayjs | null, dateTo?: string | Dayjs | null) => ({
+        reportDashboardDateRangeChanged: (
+            dashboard: DashboardType<QueryBasedInsightModel> | null,
+            dateFrom?: string | Dayjs | null,
+            dateTo?: string | Dayjs | null
+        ) => ({
+            dashboard,
             dateFrom,
             dateTo,
         }),
-        reportDashboardPropertiesChanged: true,
+        reportDashboardPropertiesChanged: (dashboard: DashboardType<QueryBasedInsightModel> | null) => ({ dashboard }),
         reportDashboardPinToggled: (pinned: boolean, source: DashboardEventSource) => ({
             pinned,
             source,
@@ -393,8 +417,14 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportCustomChannelTypeRulesUpdated: (numRules: number) => ({ numRules }),
         reportPropertySelectOpened: true,
         reportCreatedDashboardFromModal: true,
-        reportSavedInsightToDashboard: true,
-        reportRemovedInsightFromDashboard: true,
+        reportSavedInsightToDashboard: (
+            insight: Partial<QueryBasedInsightModel> | null,
+            dashboard: DashboardType<QueryBasedInsightModel> | null
+        ) => ({ insight, dashboard }),
+        reportRemovedInsightFromDashboard: (
+            insight: Partial<QueryBasedInsightModel> | null,
+            dashboard: DashboardType<QueryBasedInsightModel> | null
+        ) => ({ insight, dashboard }),
         reportSavedInsightTabChanged: (tab: string) => ({ tab }),
         reportSavedInsightFilterUsed: (filterKeys: string[]) => ({ filterKeys }),
         reportSavedInsightLayoutChanged: (layout: string) => ({ layout }),
@@ -641,15 +671,16 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
 
             posthog.capture('insight created', sanitizeQuery(query))
         },
-        reportInsightSaved: async ({ query, isNewInsight }) => {
+        reportInsightSaved: async ({ insight, query, isNewInsight }) => {
             // "insight saved" is a proxy for the new insight's results being valuable to the user
             posthog.capture('insight saved', {
                 ...sanitizeQuery(query),
+                insight: sanitizeInsight(insight),
                 is_new_insight: isNewInsight,
             })
         },
         reportInsightViewed: ({ insightModel, query, isFirstLoad, delay }) => {
-            const payload: Record<string, string | number | boolean | undefined> = {
+            const payload: Record<string, any> = {
                 report_delay: delay,
                 is_first_component_load: isFirstLoad,
                 viewer_is_creator:
@@ -659,6 +690,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 is_saved: insightModel.saved,
                 description_length: insightModel.description?.length ?? 0,
                 tags_count: insightModel.tags?.length ?? 0,
+                insight: sanitizeInsight(insightModel),
                 ...sanitizeQuery(query),
             }
 
@@ -678,12 +710,17 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 is_shared,
                 pinned,
                 creation_mode,
+                viewer_is_creator:
+                    dashboard.created_by?.uuid && values.user?.uuid
+                        ? dashboard.created_by?.uuid === values.user?.uuid
+                        : undefined,
                 sample_items_count: 0,
                 item_count: dashboard.tiles?.length || 0,
                 created_by_system: !dashboard.created_by,
                 dashboard_id: id,
                 lastRefreshed: lastRefreshed?.toISOString(),
                 refreshAge: lastRefreshed ? now().diff(lastRefreshed, 'seconds') : undefined,
+                dashboard: sanitizeDashboard(dashboard),
             }
 
             for (const item of dashboard.tiles || []) {
@@ -752,8 +789,13 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 total_properties: totalProperties,
             })
         },
-        reportDashboardModeToggled: async ({ mode, source }) => {
-            posthog.capture('dashboard mode toggled', { mode, source })
+        reportDashboardModeToggled: async ({ dashboard, mode, source }) => {
+            posthog.capture('dashboard mode toggled', {
+                dashboard_id: dashboard?.id,
+                dashboard: sanitizeDashboard(dashboard),
+                mode,
+                source,
+            })
         },
         reportDashboardRefreshed: async ({
             dashboardId,
@@ -765,16 +807,9 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             forceRefresh,
             insightsRefreshedInfo,
         }) => {
-            const sanitizedDashboard = dashboard
-                ? {
-                      ...dashboard,
-                      tiles: dashboard.tiles?.map((tile) => sanitizeTile(tile)) || [],
-                  }
-                : null
-
             posthog.capture(`dashboard refreshed`, {
                 dashboard_id: dashboardId,
-                dashboard: sanitizedDashboard,
+                dashboard: sanitizeDashboard(dashboard),
                 filters,
                 variables,
                 last_refreshed: lastRefreshed?.toString(),
@@ -815,14 +850,19 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 ...sanitizedQuery,
             })
         },
-        reportDashboardDateRangeChanged: async ({ dateFrom, dateTo }) => {
+        reportDashboardDateRangeChanged: async ({ dashboard, dateFrom, dateTo }) => {
             posthog.capture(`dashboard date range changed`, {
+                dashboard_id: dashboard?.id,
+                dashboard: sanitizeDashboard(dashboard),
                 date_from: dateFrom?.toString() || 'Custom',
                 date_to: dateTo?.toString(),
             })
         },
-        reportDashboardPropertiesChanged: async () => {
-            posthog.capture(`dashboard properties changed`)
+        reportDashboardPropertiesChanged: async ({ dashboard }) => {
+            posthog.capture(`dashboard properties changed`, {
+                dashboard_id: dashboard?.id,
+                dashboard: sanitizeDashboard(dashboard),
+            })
         },
         reportDashboardPinToggled: async (payload) => {
             posthog.capture(`dashboard pin toggled`, payload)
@@ -891,11 +931,19 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportCreatedDashboardFromModal: async () => {
             posthog.capture('created new dashboard from modal')
         },
-        reportSavedInsightToDashboard: async () => {
-            posthog.capture('saved insight to dashboard')
+        reportSavedInsightToDashboard: async ({ insight, dashboard }) => {
+            posthog.capture('saved insight to dashboard', {
+                insight: sanitizeInsight(insight),
+                dashboard_id: dashboard?.id,
+                dashboard: sanitizeDashboard(dashboard),
+            })
         },
-        reportRemovedInsightFromDashboard: async () => {
-            posthog.capture('removed insight from dashboard')
+        reportRemovedInsightFromDashboard: async ({ insight, dashboard }) => {
+            posthog.capture('removed insight from dashboard', {
+                insight: sanitizeInsight(insight),
+                dashboard_id: dashboard?.id,
+                dashboard: sanitizeDashboard(dashboard),
+            })
         },
         reportInsightsTableCalcToggled: async (payload) => {
             posthog.capture('insights table calc toggled', payload)

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1593,6 +1593,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 values.dashboard?.persisted_filters?.date_to !== values.effectiveEditBarFilters.date_to
             ) {
                 eventUsageLogic.actions.reportDashboardDateRangeChanged(
+                    values.dashboard,
                     values.effectiveEditBarFilters.date_from,
                     values.effectiveEditBarFilters.date_to
                 )
@@ -1601,7 +1602,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 JSON.stringify(values.dashboard?.persisted_filters?.properties) !==
                 JSON.stringify(values.effectiveEditBarFilters.properties)
             ) {
-                eventUsageLogic.actions.reportDashboardPropertiesChanged()
+                eventUsageLogic.actions.reportDashboardPropertiesChanged(values.dashboard)
             }
         },
         setDashboardMode: async ({ mode, source }) => {
@@ -1640,7 +1641,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
             }
 
             if (mode) {
-                eventUsageLogic.actions.reportDashboardModeToggled(mode, source)
+                eventUsageLogic.actions.reportDashboardModeToggled(values.dashboard, mode, source)
             }
         },
         setAutoRefresh: () => {

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -454,7 +454,7 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
             // and so we shouldn't copy the result from `values.insight` as it might be stale
             const result = savedInsight.result || (values.query ? values.insight.result : null)
             actions.setInsight({ ...savedInsight, result: result }, { fromPersistentApi: true, overrideQuery: true })
-            eventUsageLogic.actions.reportInsightSaved(values.query, insightNumericId === undefined)
+            eventUsageLogic.actions.reportInsightSaved(savedInsight, values.query, insightNumericId === undefined)
             lemonToast.success(`Insight saved${dashboards?.length === 1 ? ' & added to dashboard' : ''}`, {
                 button: {
                     label: 'View Insights list',

--- a/frontend/src/scenes/saved-insights/addSavedInsightsModalLogic.ts
+++ b/frontend/src/scenes/saved-insights/addSavedInsightsModalLogic.ts
@@ -162,7 +162,7 @@ export const addSavedInsightsModalLogic = kea<addSavedInsightsModalLogicType>([
                     lemonToast.success('Insight added to dashboard')
                 }
             } finally {
-                eventUsageLogic.actions.reportSavedInsightToDashboard()
+                eventUsageLogic.actions.reportSavedInsightToDashboard(insight, dashboardId)
                 actions.setDashboardUpdateLoading(insight.id, false)
             }
         },
@@ -182,7 +182,7 @@ export const addSavedInsightsModalLogic = kea<addSavedInsightsModalLogicType>([
                     lemonToast.success('Insight removed from dashboard')
                 }
             } finally {
-                eventUsageLogic.actions.reportRemovedInsightFromDashboard()
+                eventUsageLogic.actions.reportRemovedInsightFromDashboard(insight, dashboardId)
                 actions.setDashboardUpdateLoading(insight.id, false)
             }
         },


### PR DESCRIPTION
## Problem

Most of the tracking events we send from dashboard/insight pages do not include any information on the insight or dashboard itself. Not even an ID.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Adds some extra properties to the events sent from the dashboard and insight.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
