### PR TITLE
feat(kafka-deduplicator): CheckpointExporter facet by target partition/store

### DIFF
--- a/rust/kafka-deduplicator/src/checkpoint/export.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/export.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use metrics;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
@@ -8,6 +9,7 @@ use tokio::time;
 use tracing::{debug, error, info, warn};
 
 use super::{CheckpointConfig, CheckpointUploader};
+use crate::kafka::types::Partition;
 use crate::rocksdb::deduplication_store::DeduplicationStore;
 
 const CHECKPOINT_LAST_TIMESTAMP_GAUGE: &str = "checkpoint_last_timestamp";
@@ -16,13 +18,15 @@ const CHECKPOINT_SIZE_HISTOGRAM: &str = "checkpoint_size_bytes";
 const CHECKPOINT_UPLOAD_DURATION_HISTOGRAM: &str = "checkpoint_upload_duration_seconds";
 const CHECKPOINT_ERRORS_COUNTER: &str = "checkpoint_errors_total";
 
+const CHECKPOINT_NAME_PREFIX: &str = "chkpt";
+
 #[derive(Debug)]
 pub struct CheckpointExporter {
     config: CheckpointConfig,
     uploader: Box<dyn CheckpointUploader>,
-    last_checkpoint: Arc<Mutex<Option<Instant>>>,
-    checkpoint_counter: Arc<Mutex<u32>>,
-    is_checkpointing: Arc<Mutex<bool>>,
+    last_checkpoints: Arc<Mutex<HashMap<Partition, Instant>>>,
+    checkpoint_counters: Arc<Mutex<HashMap<Partition, u32>>>,
+    is_checkpointing: Arc<Mutex<HashSet<Partition>>>,
 }
 
 impl CheckpointExporter {
@@ -30,9 +34,9 @@ impl CheckpointExporter {
         Self {
             config,
             uploader,
-            last_checkpoint: Arc::new(Mutex::new(None)),
-            checkpoint_counter: Arc::new(Mutex::new(0)),
-            is_checkpointing: Arc::new(Mutex::new(false)),
+            last_checkpoints: Arc::new(Mutex::new(HashMap::new())),
+            checkpoint_counters: Arc::new(Mutex::new(HashMap::new())),
+            is_checkpointing: Arc::new(Mutex::new(HashSet::new())),
         }
     }
 
@@ -58,22 +62,27 @@ impl CheckpointExporter {
     /// Trigger a checkpoint if one is not already in progress
     pub async fn maybe_checkpoint(&self, store: &DeduplicationStore) -> Result<bool> {
         // Try to acquire the checkpoint lock - if already locked, skip
-        let mut is_checkpointing = self.is_checkpointing.lock().await;
-        if *is_checkpointing {
-            debug!("Checkpoint already in progress, skipping");
-            return Ok(false);
-        }
+        let partition = Partition::new(store.get_topic().to_string(), store.get_partition());
 
-        // Set checkpoint in progress flag
-        *is_checkpointing = true;
-        drop(is_checkpointing); // Release lock early
-
-        let result = self.perform_checkpoint(store).await;
-
-        // Clear checkpoint in progress flag
+        // Attempt to acquire the checkpoint lock or bail if already in flight
         {
             let mut is_checkpointing = self.is_checkpointing.lock().await;
-            *is_checkpointing = false;
+            if is_checkpointing.contains(&partition) {
+                debug!("Checkpoint already in progress, skipping");
+                return Ok(false);
+            }
+            is_checkpointing.insert(partition.clone());
+        }
+
+        // if we got here, the checkpoint is in progress and locked now...
+
+        // TODO(eli): perhaps wrap with panic::catch_unwind here for extra safety unlocking?
+        let result = self.perform_checkpoint(store).await;
+
+        // Atomically clear the checkpoint in progress flag
+        {
+            let mut is_checkpointing = self.is_checkpointing.lock().await;
+            is_checkpointing.remove(&partition);
         }
 
         result.map(|_| true)
@@ -84,13 +93,22 @@ impl CheckpointExporter {
 
         info!("Starting checkpoint creation");
 
+        let partition = Partition::new(store.get_topic().to_string(), store.get_partition());
+
         // Create checkpoint directory with timestamp (microseconds for uniqueness)
-        let timestamp = SystemTime::now()
+        let checkpoint_timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .context("Failed to get current timestamp")?
             .as_micros();
 
-        let checkpoint_name = format!("checkpoint_{timestamp}");
+        // ensure the checkpoint name is unique and lexicographically sortable
+        let checkpoint_name = format!(
+            "{}_{}_{}_{:0>20}",
+            CHECKPOINT_NAME_PREFIX,
+            partition.topic(),
+            partition.partition_number(),
+            checkpoint_timestamp
+        );
         let local_checkpoint_path =
             PathBuf::from(&self.config.local_checkpoint_dir).join(&checkpoint_name);
 
@@ -122,15 +140,22 @@ impl CheckpointExporter {
 
         // Update last checkpoint timestamp
         {
-            let mut last_checkpoint = self.last_checkpoint.lock().await;
-            *last_checkpoint = Some(Instant::now());
-            metrics::gauge!(CHECKPOINT_LAST_TIMESTAMP_GAUGE).set((timestamp / 1_000_000) as f64);
+            let mut last_checkpoints = self.last_checkpoints.lock().await;
+            last_checkpoints.insert(partition.clone(), Instant::now());
+            // TODO(eli): facet (tag) by topic/partition? track Instant here instead of start time?
+            metrics::gauge!(CHECKPOINT_LAST_TIMESTAMP_GAUGE)
+                .set((checkpoint_timestamp / 1_000_000) as f64);
         }
 
         // Determine if this should be a full upload or incremental
-        let mut counter = self.checkpoint_counter.lock().await;
-        *counter += 1;
-        let is_full_upload = *counter % self.config.full_upload_interval == 0;
+        let current_part_counter: u32;
+        {
+            let mut counters = self.checkpoint_counters.lock().await;
+            let result = counters.get(&partition).unwrap_or(&0_u32);
+            current_part_counter = *result;
+            counters.insert(partition.clone(), current_part_counter + 1);
+        }
+        let is_full_upload = current_part_counter % self.config.full_upload_interval == 0;
 
         // Upload to remote storage in background
         if self.uploader.is_available().await {
@@ -173,6 +198,7 @@ impl CheckpointExporter {
                 }
             }
         } else {
+            // TODO(eli): add metric emission for this, it's serious!
             warn!("Uploader not available, checkpoint will remain local only");
         }
 
@@ -224,7 +250,7 @@ impl CheckpointExporter {
             let path = entry.path();
             if path.is_dir() {
                 if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                    if name.starts_with("checkpoint_") {
+                    if name.starts_with(CHECKPOINT_NAME_PREFIX) {
                         checkpoint_dirs.push(path);
                     }
                 }
@@ -253,12 +279,14 @@ impl CheckpointExporter {
     }
 
     /// Get the timestamp of the last checkpoint
-    pub async fn last_checkpoint_timestamp(&self) -> Option<Instant> {
-        *self.last_checkpoint.lock().await
+    pub async fn last_checkpoint_timestamp(&self, partition: &Partition) -> Option<Instant> {
+        let last_checkpoints = self.last_checkpoints.lock().await;
+        last_checkpoints.get(partition).cloned()
     }
 
     /// Check if a checkpoint is currently in progress
-    pub async fn is_checkpointing(&self) -> bool {
-        *self.is_checkpointing.lock().await
+    pub async fn is_checkpointing(&self, partition: &Partition) -> bool {
+        let statuses = self.is_checkpointing.lock().await;
+        statuses.contains(partition)
     }
 }

--- a/rust/kafka-deduplicator/src/checkpoint/export.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/export.rs
@@ -18,7 +18,7 @@ const CHECKPOINT_SIZE_HISTOGRAM: &str = "checkpoint_size_bytes";
 const CHECKPOINT_UPLOAD_DURATION_HISTOGRAM: &str = "checkpoint_upload_duration_seconds";
 const CHECKPOINT_ERRORS_COUNTER: &str = "checkpoint_errors_total";
 
-const CHECKPOINT_NAME_PREFIX: &str = "chkpt";
+pub const CHECKPOINT_NAME_PREFIX: &str = "chkpt";
 
 #[derive(Debug)]
 pub struct CheckpointExporter {
@@ -126,6 +126,8 @@ impl CheckpointExporter {
         // Determine if this should be a full upload or incremental
         let current_part_counter: u32;
         {
+            // TODO(eli): the previous checkpoint metadata should contain the
+            //            associated counter so we don't restart every redeploy
             let mut counters = self.checkpoint_counters.lock().await;
             let result = counters.get(&partition).unwrap_or(&0_u32);
             current_part_counter = *result;

--- a/rust/kafka-deduplicator/tests/checkpoint_tests.rs
+++ b/rust/kafka-deduplicator/tests/checkpoint_tests.rs
@@ -3,7 +3,9 @@ use std::time::Duration;
 use tempfile::TempDir;
 
 use common_types::RawEvent;
-use kafka_deduplicator::checkpoint::{CheckpointConfig, CheckpointExporter, CheckpointUploader};
+use kafka_deduplicator::checkpoint::{
+    export::CHECKPOINT_NAME_PREFIX, CheckpointConfig, CheckpointExporter, CheckpointUploader,
+};
 use kafka_deduplicator::kafka::types::Partition;
 use kafka_deduplicator::rocksdb::deduplication_store::{
     DeduplicationStore, DeduplicationStoreConfig,
@@ -337,7 +339,7 @@ async fn test_checkpoint_skips_when_in_progress() {
     let checkpoint_dirs: std::collections::HashSet<_> = uploaded_files
         .keys()
         .filter_map(|key| {
-            if let Some(start) = key.find("checkpoint_") {
+            if let Some(start) = key.find(CHECKPOINT_NAME_PREFIX) {
                 let end = key[start..].find('/').map(|i| start + i)?;
                 Some(&key[start..end])
             } else {
@@ -425,7 +427,7 @@ async fn test_incremental_vs_full_upload() {
     let exporter = CheckpointExporter::new(config, Box::new(mock_uploader.clone()));
 
     // Perform multiple checkpoints
-    for i in 1..=5 {
+    for i in 0..=5 {
         let result = exporter.maybe_checkpoint(&store).await;
         assert!(
             result.is_ok(),


### PR DESCRIPTION
## Problem
As prep for the `CheckpointManager` to stop flushing (and soon uploading checkpoints) for all partitions at once in a periodic background loop, and start passing particular stores associated with an input partition into a throttled task pool for async checkpointing, we need to make the exporter component aware of multiple stores/partitions.

## Changes
* Iterate on `CheckpointExporter` with main goal of making it partition/store aware
* Minimal test updates related to this iteration

Note: this is broken out from a [larger draft PR](https://github.com/PostHog/posthog/compare/eli.r/kd-full-checkpoint-1?expand=1) aimed at injecting this new functionality into the `CheckpointManager`. Splitting my changes avoids merge conflicts with other in-flight work ([PR](https://github.com/PostHog/posthog/pull/37376), [PR](https://github.com/PostHog/posthog/pull/37492#pullrequestreview-3182265825)) that will land interleaved with mine

## How did you test this code?
Locally an in CI. This iteration doesn't touch live code in the service (yet)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
