### PR TITLE
fix: no project toast errors

### DIFF
--- a/frontend/src/layout/navigation-3000/Navigation.tsx
+++ b/frontend/src/layout/navigation-3000/Navigation.tsx
@@ -10,6 +10,7 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { cn } from 'lib/utils/css-classes'
 import { SceneConfig } from 'scenes/sceneTypes'
+import { teamLogic } from 'scenes/teamLogic'
 
 import { PanelLayout } from '~/layout/panel-layout/PanelLayout'
 
@@ -36,6 +37,7 @@ export function Navigation({
     const mainRef = useRef<HTMLElement>(null)
     const { featureFlags } = useValues(featureFlagLogic)
     const newSceneLayout = featureFlags[FEATURE_FLAGS.NEW_SCENE_LAYOUT]
+    const { currentTeam } = useValues(teamLogic)
 
     if (mode !== 'full') {
         return (
@@ -43,7 +45,7 @@ export function Navigation({
             <div className="Navigation3000 flex-col" style={theme?.mainStyle}>
                 {mode === 'minimal' ? <MinimalNavigation /> : null}
                 <main>{children}</main>
-                <MaxFloatingInput />
+                {currentTeam ? <MaxFloatingInput /> : null}
             </div>
         )
     }
@@ -111,7 +113,7 @@ export function Navigation({
             </main>
             <SidePanel />
             <CommandBar />
-            <MaxFloatingInput />
+            {currentTeam ? <MaxFloatingInput /> : null}
         </div>
     )
 }

--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
@@ -60,16 +60,23 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
             (selectedTab, sidePanelOpen, isCloudOrDev, featureFlags, sceneSidePanelContext, currentTeam) => {
                 const tabs: SidePanelTab[] = []
 
-                if (featureFlags[FEATURE_FLAGS.ARTIFICIAL_HOG] || (sidePanelOpen && selectedTab === SidePanelTab.Max)) {
+                if (
+                    currentTeam &&
+                    (featureFlags[FEATURE_FLAGS.ARTIFICIAL_HOG] || (sidePanelOpen && selectedTab === SidePanelTab.Max))
+                ) {
                     // Show Max if user is already enrolled into beta OR they got a link to Max (even if they haven't enrolled)
                     tabs.push(SidePanelTab.Max)
                 }
-                tabs.push(SidePanelTab.Notebooks)
+                if (currentTeam) {
+                    tabs.push(SidePanelTab.Notebooks)
+                }
                 tabs.push(SidePanelTab.Docs)
                 if (isCloudOrDev) {
                     tabs.push(SidePanelTab.Support)
                 }
-                tabs.push(SidePanelTab.Activity)
+                if (currentTeam) {
+                    tabs.push(SidePanelTab.Activity)
+                }
 
                 if (currentTeam?.created_at) {
                     const teamCreatedAt = dayjs(currentTeam.created_at)
@@ -79,14 +86,20 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
                     }
                 }
 
-                if (featureFlags[FEATURE_FLAGS.DISCUSSIONS]) {
+                if (currentTeam && featureFlags[FEATURE_FLAGS.DISCUSSIONS]) {
                     tabs.push(SidePanelTab.Discussion)
                 }
 
-                if (sceneSidePanelContext.access_control_resource && sceneSidePanelContext.access_control_resource_id) {
+                if (
+                    currentTeam &&
+                    sceneSidePanelContext.access_control_resource &&
+                    sceneSidePanelContext.access_control_resource_id
+                ) {
                     tabs.push(SidePanelTab.AccessControl)
                 }
-                tabs.push(SidePanelTab.Exports)
+                if (currentTeam) {
+                    tabs.push(SidePanelTab.Exports)
+                }
                 tabs.push(SidePanelTab.Settings)
 
                 if (isCloudOrDev) {

--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
@@ -20,6 +20,16 @@ import { sidePanelStateLogic } from './sidePanelStateLogic'
 
 const ALWAYS_EXTRA_TABS = [SidePanelTab.Settings, SidePanelTab.Activity, SidePanelTab.Status, SidePanelTab.Exports]
 
+const TABS_REQUIRING_A_TEAM = [
+    SidePanelTab.Max,
+    SidePanelTab.Notebooks,
+    SidePanelTab.Activity,
+    SidePanelTab.Activation,
+    SidePanelTab.Discussion,
+    SidePanelTab.AccessControl,
+    SidePanelTab.Exports,
+]
+
 export const sidePanelLogic = kea<sidePanelLogicType>([
     path(['scenes', 'navigation', 'sidepanel', 'sidePanelLogic']),
     connect(() => ({
@@ -60,23 +70,16 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
             (selectedTab, sidePanelOpen, isCloudOrDev, featureFlags, sceneSidePanelContext, currentTeam) => {
                 const tabs: SidePanelTab[] = []
 
-                if (
-                    currentTeam &&
-                    (featureFlags[FEATURE_FLAGS.ARTIFICIAL_HOG] || (sidePanelOpen && selectedTab === SidePanelTab.Max))
-                ) {
+                if (featureFlags[FEATURE_FLAGS.ARTIFICIAL_HOG] || (sidePanelOpen && selectedTab === SidePanelTab.Max)) {
                     // Show Max if user is already enrolled into beta OR they got a link to Max (even if they haven't enrolled)
                     tabs.push(SidePanelTab.Max)
                 }
-                if (currentTeam) {
-                    tabs.push(SidePanelTab.Notebooks)
-                }
+                tabs.push(SidePanelTab.Notebooks)
                 tabs.push(SidePanelTab.Docs)
                 if (isCloudOrDev) {
                     tabs.push(SidePanelTab.Support)
                 }
-                if (currentTeam) {
-                    tabs.push(SidePanelTab.Activity)
-                }
+                tabs.push(SidePanelTab.Activity)
 
                 if (currentTeam?.created_at) {
                     const teamCreatedAt = dayjs(currentTeam.created_at)
@@ -86,26 +89,23 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
                     }
                 }
 
-                if (currentTeam && featureFlags[FEATURE_FLAGS.DISCUSSIONS]) {
+                if (featureFlags[FEATURE_FLAGS.DISCUSSIONS]) {
                     tabs.push(SidePanelTab.Discussion)
                 }
 
-                if (
-                    currentTeam &&
-                    sceneSidePanelContext.access_control_resource &&
-                    sceneSidePanelContext.access_control_resource_id
-                ) {
+                if (sceneSidePanelContext.access_control_resource && sceneSidePanelContext.access_control_resource_id) {
                     tabs.push(SidePanelTab.AccessControl)
                 }
-                if (currentTeam) {
-                    tabs.push(SidePanelTab.Exports)
-                }
+                tabs.push(SidePanelTab.Exports)
                 tabs.push(SidePanelTab.Settings)
 
                 if (isCloudOrDev) {
                     tabs.push(SidePanelTab.Status)
                 }
 
+                if (!currentTeam) {
+                    return tabs.filter((tab) => !TABS_REQUIRING_A_TEAM.includes(tab))
+                }
                 return tabs
             },
         ],

--- a/frontend/src/models/dashboardsModel.tsx
+++ b/frontend/src/models/dashboardsModel.tsx
@@ -95,6 +95,11 @@ export const dashboardsModel = kea<dashboardsModelType>([
                         return { count: 0, next: null, previous: null, results: [] }
                     }
 
+                    if (!teamLogic.values.currentTeam) {
+                        // Don't load dashboards when the current team is unavailable to prevent toast errors.
+                        return { count: 0, next: null, previous: null, results: [] }
+                    }
+
                     let apiUrl =
                         url ||
                         `api/environments/${teamLogic.values.currentTeamId}/dashboards/?limit=2000&exclude_generated=true`

--- a/frontend/src/models/dashboardsModel.tsx
+++ b/frontend/src/models/dashboardsModel.tsx
@@ -96,7 +96,6 @@ export const dashboardsModel = kea<dashboardsModelType>([
                     }
 
                     if (!teamLogic.values.currentTeam) {
-                        // Don't load dashboards when the current team is unavailable to prevent toast errors.
                         return { count: 0, next: null, previous: null, results: [] }
                     }
 

--- a/frontend/src/models/groupsModel.ts
+++ b/frontend/src/models/groupsModel.ts
@@ -27,7 +27,6 @@ export const groupsModel = kea<groupsModelType>([
             [] as Array<GroupType>,
             {
                 loadAllGroupTypes: async () => {
-                    // Don't load group types when the current project is unavailable to prevent toast errors
                     if (!values.currentProjectId) {
                         return []
                     }

--- a/frontend/src/models/groupsModel.ts
+++ b/frontend/src/models/groupsModel.ts
@@ -27,6 +27,10 @@ export const groupsModel = kea<groupsModelType>([
             [] as Array<GroupType>,
             {
                 loadAllGroupTypes: async () => {
+                    // Don't load group types when the current project is unavailable to prevent toast errors
+                    if (!values.currentProjectId) {
+                        return []
+                    }
                     return await api.get(`api/projects/${values.currentProjectId}/groups_types`)
                 },
                 updateGroupTypesMetadata: async (payload: Array<GroupType>) => {

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -20,6 +20,7 @@ import { useEffect, useState } from 'react'
 import { commandBarLogic } from 'lib/components/CommandBar/commandBarLogic'
 import { BarStatus } from 'lib/components/CommandBar/types'
 import { FEATURE_FLAGS, TeamMembershipLevel } from 'lib/constants'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { getRelativeNextPath, identifierToHuman } from 'lib/utils'
@@ -698,6 +699,9 @@ export const sceneLogic = kea<sceneLogicType>([
                                 console.warn(
                                     'Project not available and no other projects, redirecting to project creation'
                                 )
+                                lemonToast.error('You do not have access to any projects in this organization', {
+                                    toastId: 'no-projects',
+                                })
                                 router.actions.replace(urls.projectCreateFirst())
                                 return
                             }


### PR DESCRIPTION
## Problem

When a user has no project (e.g., after deleting the only one), dashboardsModel and groupsModel still mount in the layout and try to load data, resulting in 404s and toast errors.

https://github.com/user-attachments/assets/aad88890-6c82-44e0-b119-fce129897dfb

## Changes

- In the side panel, hide buttons requiring project access when no project exists (only Docs, Help, Settings, and Status remain).
- Keep the navbar visible to allow access to Settings.
- Update dashboardsModel and groupsModel to skip data loading if no project is available. 

https://github.com/user-attachments/assets/ae214976-a2a7-4edc-be4a-d845ada61798

## How did you test this code?

Manually tested by deleting a project as a member and as an owner.